### PR TITLE
refactor(human-languages): renumber Spanish sequences onto a clean 10-spaced run

### DIFF
--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -2178,7 +2178,7 @@
     {
       "language": "spanish",
       "chapter": 3,
-      "sourceHash": "fnv1a64:42fbffb8f2c9ee65",
+      "sourceHash": "fnv1a64:c33320f1373d714f",
       "lessonIds": [
         "ES-C03-me",
         "ES-C03-llamar",
@@ -2200,7 +2200,7 @@
     {
       "language": "spanish",
       "chapter": 4,
-      "sourceHash": "fnv1a64:5410c6a8b2635804",
+      "sourceHash": "fnv1a64:725d6b137377bf9c",
       "lessonIds": [
         "ES-C04-gracias",
         "ES-C04-de-nada",
@@ -2223,7 +2223,7 @@
     {
       "language": "spanish",
       "chapter": 5,
-      "sourceHash": "fnv1a64:9914574b6e231c0f",
+      "sourceHash": "fnv1a64:cff622156693b783",
       "lessonIds": [
         "ES-C05-adios",
         "ES-C05-hasta",
@@ -2238,7 +2238,7 @@
     {
       "language": "spanish",
       "chapter": 6,
-      "sourceHash": "fnv1a64:4450428fd5374b11",
+      "sourceHash": "fnv1a64:4fe3507a54682e0b",
       "lessonIds": [
         "ES-C06-cafe",
         "ES-C06-por-favor",
@@ -2255,7 +2255,7 @@
     {
       "language": "spanish",
       "chapter": 19,
-      "sourceHash": "fnv1a64:348146303665aa93",
+      "sourceHash": "fnv1a64:26065bd139568e43",
       "lessonIds": [
         "ES-C19-si",
         "ES-C19-no"
@@ -2265,7 +2265,7 @@
     {
       "language": "spanish",
       "chapter": 20,
-      "sourceHash": "fnv1a64:ff8b8576d2795748",
+      "sourceHash": "fnv1a64:eb8a28c91366131e",
       "lessonIds": [
         "ES-C20-lo-siento",
         "ES-C20-perdon"
@@ -2275,7 +2275,7 @@
     {
       "language": "spanish",
       "chapter": 21,
-      "sourceHash": "fnv1a64:9f1f17a520fa7add",
+      "sourceHash": "fnv1a64:cbada3c250a98194",
       "lessonIds": [
         "ES-C21-lunes-viernes",
         "ES-C21-sabado-domingo"
@@ -2285,7 +2285,7 @@
     {
       "language": "spanish",
       "chapter": 22,
-      "sourceHash": "fnv1a64:8bfd3dca44e35355",
+      "sourceHash": "fnv1a64:7ce9af6cb50c3202",
       "lessonIds": [
         "ES-C22-negro-blanco",
         "ES-C22-blanco-germanico",
@@ -2297,7 +2297,7 @@
     {
       "language": "spanish",
       "chapter": 23,
-      "sourceHash": "fnv1a64:65f7e89fb2452174",
+      "sourceHash": "fnv1a64:55d2e4bd397961e0",
       "lessonIds": [
         "ES-C23-padre-madre",
         "ES-C23-hermano-hermana",
@@ -2308,7 +2308,7 @@
     {
       "language": "spanish",
       "chapter": 24,
-      "sourceHash": "fnv1a64:cb85e3f2de32dd93",
+      "sourceHash": "fnv1a64:d9335133eebe69c2",
       "lessonIds": [
         "ES-C24-cabeza",
         "ES-C24-mano"
@@ -2318,7 +2318,7 @@
     {
       "language": "spanish",
       "chapter": 25,
-      "sourceHash": "fnv1a64:b76c71606e7c1944",
+      "sourceHash": "fnv1a64:ce540eb8329698ee",
       "lessonIds": [
         "ES-C25-las-estaciones"
       ],
@@ -2327,7 +2327,7 @@
     {
       "language": "spanish",
       "chapter": 26,
-      "sourceHash": "fnv1a64:7d92244aefd55f9c",
+      "sourceHash": "fnv1a64:adcb64dbcc088e9f",
       "lessonIds": [
         "ES-C26-agua",
         "ES-C26-vino",
@@ -2338,7 +2338,7 @@
     {
       "language": "spanish",
       "chapter": 27,
-      "sourceHash": "fnv1a64:3c0241436ecab0b0",
+      "sourceHash": "fnv1a64:1221fb0b96f61360",
       "lessonIds": [
         "ES-C27-los-meses"
       ],
@@ -2347,7 +2347,7 @@
     {
       "language": "spanish",
       "chapter": 28,
-      "sourceHash": "fnv1a64:67c5930a2b05b153",
+      "sourceHash": "fnv1a64:ab0e2305d98d0480",
       "lessonIds": [
         "ES-C28-mediodia-medianoche"
       ],
@@ -2356,7 +2356,7 @@
     {
       "language": "spanish",
       "chapter": 29,
-      "sourceHash": "fnv1a64:ba45be8faf01ca69",
+      "sourceHash": "fnv1a64:2a23e6b112a7d818",
       "lessonIds": [
         "ES-C29-la-hora"
       ],
@@ -2365,7 +2365,7 @@
     {
       "language": "spanish",
       "chapter": 30,
-      "sourceHash": "fnv1a64:87388bb3aea1cfc8",
+      "sourceHash": "fnv1a64:6148ab69b50fe394",
       "lessonIds": [
         "ES-C30-el-tiempo",
         "ES-C30-hace-calor",
@@ -2376,7 +2376,7 @@
     {
       "language": "spanish",
       "chapter": 31,
-      "sourceHash": "fnv1a64:b65e81d19628893e",
+      "sourceHash": "fnv1a64:96d1c45d4a4ca6a3",
       "lessonIds": [
         "ES-C31-once-quince",
         "ES-C31-dieciseis-diecinueve",
@@ -2388,7 +2388,7 @@
     {
       "language": "spanish",
       "chapter": 32,
-      "sourceHash": "fnv1a64:e38a946a84daf051",
+      "sourceHash": "fnv1a64:d1283505847604c8",
       "lessonIds": [
         "ES-C32-gato",
         "ES-C32-perro"
@@ -2398,7 +2398,7 @@
     {
       "language": "spanish",
       "chapter": 33,
-      "sourceHash": "fnv1a64:9997a29a09400b47",
+      "sourceHash": "fnv1a64:1193d6388479368f",
       "lessonIds": [
         "ES-C33-verde",
         "ES-C33-amarillo"
@@ -2408,7 +2408,7 @@
     {
       "language": "spanish",
       "chapter": 34,
-      "sourceHash": "fnv1a64:bc65a341cf39fbb6",
+      "sourceHash": "fnv1a64:64748b10c5f453b4",
       "lessonIds": [
         "ES-C34-pensar",
         "ES-C34-entender",
@@ -2420,7 +2420,7 @@
     {
       "language": "spanish",
       "chapter": 35,
-      "sourceHash": "fnv1a64:28a0602c608252cb",
+      "sourceHash": "fnv1a64:e3c93cbb0c057188",
       "lessonIds": [
         "ES-C35-tomar",
         "ES-C35-preguntar",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -4794,7 +4794,7 @@
     {
       "language": "spanish",
       "chapter": 3,
-      "sourceHash": "fnv1a64:42fbffb8f2c9ee65",
+      "sourceHash": "fnv1a64:c33320f1373d714f",
       "lessonIds": [
         "ES-C03-me",
         "ES-C03-llamar",
@@ -4816,12 +4816,12 @@
       "text": "spanish/narration/ch03.txt",
       "json": "spanish/narration/ch03.json",
       "textHash": "fnv1a64:00bde6030183469f",
-      "jsonHash": "fnv1a64:a00379a8b39cc2ff"
+      "jsonHash": "fnv1a64:c29d79f342b13592"
     },
     {
       "language": "spanish",
       "chapter": 4,
-      "sourceHash": "fnv1a64:5410c6a8b2635804",
+      "sourceHash": "fnv1a64:725d6b137377bf9c",
       "lessonIds": [
         "ES-C04-gracias",
         "ES-C04-de-nada",
@@ -4844,12 +4844,12 @@
       "text": "spanish/narration/ch04.txt",
       "json": "spanish/narration/ch04.json",
       "textHash": "fnv1a64:d77eae07976375e3",
-      "jsonHash": "fnv1a64:859fd756327a299c"
+      "jsonHash": "fnv1a64:761156245d3e9a8e"
     },
     {
       "language": "spanish",
       "chapter": 5,
-      "sourceHash": "fnv1a64:9914574b6e231c0f",
+      "sourceHash": "fnv1a64:cff622156693b783",
       "lessonIds": [
         "ES-C05-adios",
         "ES-C05-hasta",
@@ -4864,12 +4864,12 @@
       "text": "spanish/narration/ch05.txt",
       "json": "spanish/narration/ch05.json",
       "textHash": "fnv1a64:fc65d60a2f48a712",
-      "jsonHash": "fnv1a64:7723e57f03e57ab5"
+      "jsonHash": "fnv1a64:d72d4762f1592d9d"
     },
     {
       "language": "spanish",
       "chapter": 6,
-      "sourceHash": "fnv1a64:4450428fd5374b11",
+      "sourceHash": "fnv1a64:4fe3507a54682e0b",
       "lessonIds": [
         "ES-C06-cafe",
         "ES-C06-por-favor",
@@ -4886,7 +4886,7 @@
       "text": "spanish/narration/ch06.txt",
       "json": "spanish/narration/ch06.json",
       "textHash": "fnv1a64:0fe1565dd6c60f60",
-      "jsonHash": "fnv1a64:ce7e670927dba398"
+      "jsonHash": "fnv1a64:f7ff2d8a3d1df76f"
     },
     {
       "language": "spanish",
@@ -4910,7 +4910,7 @@
     {
       "language": "spanish",
       "chapter": 8,
-      "sourceHash": "fnv1a64:f96b7bbd0ab4daba",
+      "sourceHash": "fnv1a64:04ed5b71dcd6ef10",
       "lessonIds": [
         "ES-C08-numeros-1-5",
         "ES-C08-numeros-6-10",
@@ -4923,12 +4923,12 @@
       "text": "spanish/narration/ch08.txt",
       "json": "spanish/narration/ch08.json",
       "textHash": "fnv1a64:ece3418c7e272d33",
-      "jsonHash": "fnv1a64:e40b9465d8e7e51a"
+      "jsonHash": "fnv1a64:5001c1540a854594"
     },
     {
       "language": "spanish",
       "chapter": 9,
-      "sourceHash": "fnv1a64:a145296a95911d1d",
+      "sourceHash": "fnv1a64:31ecfffb1213f2bb",
       "lessonIds": [
         "ES-C09-ser",
         "ES-C09-ser-vs-estar",
@@ -4941,12 +4941,12 @@
       "text": "spanish/narration/ch09.txt",
       "json": "spanish/narration/ch09.json",
       "textHash": "fnv1a64:04f0dba79a2d6484",
-      "jsonHash": "fnv1a64:9a960078fc7671da"
+      "jsonHash": "fnv1a64:4cd102dabf9ae5c8"
     },
     {
       "language": "spanish",
       "chapter": 10,
-      "sourceHash": "fnv1a64:3341e73c1c7419bf",
+      "sourceHash": "fnv1a64:dee01cb1d828b806",
       "lessonIds": [
         "ES-C10-ir",
         "ES-C10-ir-a-futuro",
@@ -4958,12 +4958,12 @@
       "text": "spanish/narration/ch10.txt",
       "json": "spanish/narration/ch10.json",
       "textHash": "fnv1a64:ce35d1302b956038",
-      "jsonHash": "fnv1a64:2bd9acfb02103a58"
+      "jsonHash": "fnv1a64:4b43320727903be0"
     },
     {
       "language": "spanish",
       "chapter": 11,
-      "sourceHash": "fnv1a64:1845998478b152fa",
+      "sourceHash": "fnv1a64:69ad78a547a85c5d",
       "lessonIds": [
         "ES-C11-querer",
         "ES-C11-poder",
@@ -4976,12 +4976,12 @@
       "text": "spanish/narration/ch11.txt",
       "json": "spanish/narration/ch11.json",
       "textHash": "fnv1a64:75272d4b7e853a6d",
-      "jsonHash": "fnv1a64:363daed3a2daef7f"
+      "jsonHash": "fnv1a64:f58ccaa1f7bb5f6a"
     },
     {
       "language": "spanish",
       "chapter": 12,
-      "sourceHash": "fnv1a64:1e748551bb813072",
+      "sourceHash": "fnv1a64:ab04c43bed11cbe9",
       "lessonIds": [
         "ES-C12-hacer",
         "ES-C12-decir",
@@ -4993,12 +4993,12 @@
       "text": "spanish/narration/ch12.txt",
       "json": "spanish/narration/ch12.json",
       "textHash": "fnv1a64:a5d51f2b6d65e588",
-      "jsonHash": "fnv1a64:08762128a4a2f721"
+      "jsonHash": "fnv1a64:7095f6c76900e946"
     },
     {
       "language": "spanish",
       "chapter": 13,
-      "sourceHash": "fnv1a64:a4e20b412d6537ba",
+      "sourceHash": "fnv1a64:9012955fa6cf35df",
       "lessonIds": [
         "ES-C13-poner",
         "ES-C13-salir",
@@ -5010,12 +5010,12 @@
       "text": "spanish/narration/ch13.txt",
       "json": "spanish/narration/ch13.json",
       "textHash": "fnv1a64:06cdf215fd3994c6",
-      "jsonHash": "fnv1a64:0f3fd7134e6b7b0d"
+      "jsonHash": "fnv1a64:7f2cfcef656d8694"
     },
     {
       "language": "spanish",
       "chapter": 14,
-      "sourceHash": "fnv1a64:7b5d1287654f2e62",
+      "sourceHash": "fnv1a64:a39884d4aea7bb13",
       "lessonIds": [
         "ES-C14-ser-ir-preterite",
         "ES-C14-hablar-preterite",
@@ -5026,12 +5026,12 @@
       "text": "spanish/narration/ch14.txt",
       "json": "spanish/narration/ch14.json",
       "textHash": "fnv1a64:fb0503a6309245f7",
-      "jsonHash": "fnv1a64:776aab14f68423ae"
+      "jsonHash": "fnv1a64:164243cedea6db6c"
     },
     {
       "language": "spanish",
       "chapter": 15,
-      "sourceHash": "fnv1a64:bf95b4776eb920c1",
+      "sourceHash": "fnv1a64:6a0d0566d7c228af",
       "lessonIds": [
         "ES-C15-comer-vivir-preterite",
         "ES-C15-preterite-fuertes",
@@ -5042,12 +5042,12 @@
       "text": "spanish/narration/ch15.txt",
       "json": "spanish/narration/ch15.json",
       "textHash": "fnv1a64:5cb5f5dcfab199e1",
-      "jsonHash": "fnv1a64:323b69f022616375"
+      "jsonHash": "fnv1a64:638a91584525e000"
     },
     {
       "language": "spanish",
       "chapter": 16,
-      "sourceHash": "fnv1a64:30eaac9352ed3655",
+      "sourceHash": "fnv1a64:82ec9c67f1912a73",
       "lessonIds": [
         "ES-C16-imperfecto",
         "ES-C16-tres-irregulares",
@@ -5058,12 +5058,12 @@
       "text": "spanish/narration/ch16.txt",
       "json": "spanish/narration/ch16.json",
       "textHash": "fnv1a64:1aff743d44d8e988",
-      "jsonHash": "fnv1a64:8dc5202beae56582"
+      "jsonHash": "fnv1a64:8d75afe5fb51fb7f"
     },
     {
       "language": "spanish",
       "chapter": 17,
-      "sourceHash": "fnv1a64:e4705d94e1f467da",
+      "sourceHash": "fnv1a64:987d104372c450ad",
       "lessonIds": [
         "ES-C17-futuro",
         "ES-C17-condicional",
@@ -5075,12 +5075,12 @@
       "text": "spanish/narration/ch17.txt",
       "json": "spanish/narration/ch17.json",
       "textHash": "fnv1a64:892ec53d74d0c99f",
-      "jsonHash": "fnv1a64:b59af381ba6f993c"
+      "jsonHash": "fnv1a64:413aa32d9b925357"
     },
     {
       "language": "spanish",
       "chapter": 18,
-      "sourceHash": "fnv1a64:056b353dce315e5a",
+      "sourceHash": "fnv1a64:611f103a3f18023d",
       "lessonIds": [
         "ES-C18-subjuntivo",
         "ES-C18-inherited-subjunctive-stems",
@@ -5098,12 +5098,12 @@
       "text": "spanish/narration/ch18.txt",
       "json": "spanish/narration/ch18.json",
       "textHash": "fnv1a64:03ab81aeb4513484",
-      "jsonHash": "fnv1a64:487e60f44c9bb0fd"
+      "jsonHash": "fnv1a64:b0408cff584385b6"
     },
     {
       "language": "spanish",
       "chapter": 19,
-      "sourceHash": "fnv1a64:348146303665aa93",
+      "sourceHash": "fnv1a64:26065bd139568e43",
       "lessonIds": [
         "ES-C19-si",
         "ES-C19-no"
@@ -5113,12 +5113,12 @@
       "text": "spanish/narration/ch19.txt",
       "json": "spanish/narration/ch19.json",
       "textHash": "fnv1a64:373eb04704da5d1a",
-      "jsonHash": "fnv1a64:b95ca3f9cd49bc31"
+      "jsonHash": "fnv1a64:27952257134980f1"
     },
     {
       "language": "spanish",
       "chapter": 20,
-      "sourceHash": "fnv1a64:ff8b8576d2795748",
+      "sourceHash": "fnv1a64:eb8a28c91366131e",
       "lessonIds": [
         "ES-C20-lo-siento",
         "ES-C20-perdon"
@@ -5128,12 +5128,12 @@
       "text": "spanish/narration/ch20.txt",
       "json": "spanish/narration/ch20.json",
       "textHash": "fnv1a64:d3d1b961d9af447f",
-      "jsonHash": "fnv1a64:52cec2c27e192e38"
+      "jsonHash": "fnv1a64:f7225eeedbcf1b08"
     },
     {
       "language": "spanish",
       "chapter": 21,
-      "sourceHash": "fnv1a64:9f1f17a520fa7add",
+      "sourceHash": "fnv1a64:cbada3c250a98194",
       "lessonIds": [
         "ES-C21-lunes-viernes",
         "ES-C21-sabado-domingo"
@@ -5143,12 +5143,12 @@
       "text": "spanish/narration/ch21.txt",
       "json": "spanish/narration/ch21.json",
       "textHash": "fnv1a64:8fa545c195a8cf42",
-      "jsonHash": "fnv1a64:816ced95b40ba5af"
+      "jsonHash": "fnv1a64:f987152cd9d48e0f"
     },
     {
       "language": "spanish",
       "chapter": 22,
-      "sourceHash": "fnv1a64:8bfd3dca44e35355",
+      "sourceHash": "fnv1a64:7ce9af6cb50c3202",
       "lessonIds": [
         "ES-C22-negro-blanco",
         "ES-C22-blanco-germanico",
@@ -5160,12 +5160,12 @@
       "text": "spanish/narration/ch22.txt",
       "json": "spanish/narration/ch22.json",
       "textHash": "fnv1a64:48c95ca0a73360fd",
-      "jsonHash": "fnv1a64:12ed168a4e5a214c"
+      "jsonHash": "fnv1a64:f2a65d0d4ff96b77"
     },
     {
       "language": "spanish",
       "chapter": 23,
-      "sourceHash": "fnv1a64:65f7e89fb2452174",
+      "sourceHash": "fnv1a64:55d2e4bd397961e0",
       "lessonIds": [
         "ES-C23-padre-madre",
         "ES-C23-hermano-hermana",
@@ -5176,12 +5176,12 @@
       "text": "spanish/narration/ch23.txt",
       "json": "spanish/narration/ch23.json",
       "textHash": "fnv1a64:44b20880358e76b4",
-      "jsonHash": "fnv1a64:d308b850bd19c904"
+      "jsonHash": "fnv1a64:80c227f58129c040"
     },
     {
       "language": "spanish",
       "chapter": 24,
-      "sourceHash": "fnv1a64:cb85e3f2de32dd93",
+      "sourceHash": "fnv1a64:d9335133eebe69c2",
       "lessonIds": [
         "ES-C24-cabeza",
         "ES-C24-mano"
@@ -5191,12 +5191,12 @@
       "text": "spanish/narration/ch24.txt",
       "json": "spanish/narration/ch24.json",
       "textHash": "fnv1a64:3d084cec190d9646",
-      "jsonHash": "fnv1a64:1b204fa0495b9691"
+      "jsonHash": "fnv1a64:bb977ebeee944ae6"
     },
     {
       "language": "spanish",
       "chapter": 25,
-      "sourceHash": "fnv1a64:b76c71606e7c1944",
+      "sourceHash": "fnv1a64:ce540eb8329698ee",
       "lessonIds": [
         "ES-C25-las-estaciones"
       ],
@@ -5205,12 +5205,12 @@
       "text": "spanish/narration/ch25.txt",
       "json": "spanish/narration/ch25.json",
       "textHash": "fnv1a64:a7f8d8342dcdd68e",
-      "jsonHash": "fnv1a64:74675c7acefe4159"
+      "jsonHash": "fnv1a64:152a3cc2a807b18d"
     },
     {
       "language": "spanish",
       "chapter": 26,
-      "sourceHash": "fnv1a64:7d92244aefd55f9c",
+      "sourceHash": "fnv1a64:adcb64dbcc088e9f",
       "lessonIds": [
         "ES-C26-agua",
         "ES-C26-vino",
@@ -5221,12 +5221,12 @@
       "text": "spanish/narration/ch26.txt",
       "json": "spanish/narration/ch26.json",
       "textHash": "fnv1a64:4649f822f1228737",
-      "jsonHash": "fnv1a64:869fc11353ae6348"
+      "jsonHash": "fnv1a64:d1179c594fdc6d29"
     },
     {
       "language": "spanish",
       "chapter": 27,
-      "sourceHash": "fnv1a64:3c0241436ecab0b0",
+      "sourceHash": "fnv1a64:1221fb0b96f61360",
       "lessonIds": [
         "ES-C27-los-meses"
       ],
@@ -5235,12 +5235,12 @@
       "text": "spanish/narration/ch27.txt",
       "json": "spanish/narration/ch27.json",
       "textHash": "fnv1a64:2d8fab2bcd81b688",
-      "jsonHash": "fnv1a64:3ee26af86c362f10"
+      "jsonHash": "fnv1a64:fe254af83249e07c"
     },
     {
       "language": "spanish",
       "chapter": 28,
-      "sourceHash": "fnv1a64:67c5930a2b05b153",
+      "sourceHash": "fnv1a64:ab0e2305d98d0480",
       "lessonIds": [
         "ES-C28-mediodia-medianoche"
       ],
@@ -5249,12 +5249,12 @@
       "text": "spanish/narration/ch28.txt",
       "json": "spanish/narration/ch28.json",
       "textHash": "fnv1a64:e5eadefe71d560b9",
-      "jsonHash": "fnv1a64:dc8b5ba712cadb27"
+      "jsonHash": "fnv1a64:3db2a89a02adea71"
     },
     {
       "language": "spanish",
       "chapter": 29,
-      "sourceHash": "fnv1a64:ba45be8faf01ca69",
+      "sourceHash": "fnv1a64:2a23e6b112a7d818",
       "lessonIds": [
         "ES-C29-la-hora"
       ],
@@ -5263,12 +5263,12 @@
       "text": "spanish/narration/ch29.txt",
       "json": "spanish/narration/ch29.json",
       "textHash": "fnv1a64:da1165b7f8d6a489",
-      "jsonHash": "fnv1a64:24943f084afe140a"
+      "jsonHash": "fnv1a64:223a6b85005a967d"
     },
     {
       "language": "spanish",
       "chapter": 30,
-      "sourceHash": "fnv1a64:87388bb3aea1cfc8",
+      "sourceHash": "fnv1a64:6148ab69b50fe394",
       "lessonIds": [
         "ES-C30-el-tiempo",
         "ES-C30-hace-calor",
@@ -5279,12 +5279,12 @@
       "text": "spanish/narration/ch30.txt",
       "json": "spanish/narration/ch30.json",
       "textHash": "fnv1a64:4386a7e736d47f4b",
-      "jsonHash": "fnv1a64:aa631de9d29865db"
+      "jsonHash": "fnv1a64:9cc36ea225f02e11"
     },
     {
       "language": "spanish",
       "chapter": 31,
-      "sourceHash": "fnv1a64:b65e81d19628893e",
+      "sourceHash": "fnv1a64:96d1c45d4a4ca6a3",
       "lessonIds": [
         "ES-C31-once-quince",
         "ES-C31-dieciseis-diecinueve",
@@ -5296,12 +5296,12 @@
       "text": "spanish/narration/ch31.txt",
       "json": "spanish/narration/ch31.json",
       "textHash": "fnv1a64:448c3f3bf59984a8",
-      "jsonHash": "fnv1a64:ceb7c48a5458ec27"
+      "jsonHash": "fnv1a64:983d0543637ad86f"
     },
     {
       "language": "spanish",
       "chapter": 32,
-      "sourceHash": "fnv1a64:e38a946a84daf051",
+      "sourceHash": "fnv1a64:d1283505847604c8",
       "lessonIds": [
         "ES-C32-gato",
         "ES-C32-perro"
@@ -5311,12 +5311,12 @@
       "text": "spanish/narration/ch32.txt",
       "json": "spanish/narration/ch32.json",
       "textHash": "fnv1a64:8838c20927bac752",
-      "jsonHash": "fnv1a64:415988d4a2cc300c"
+      "jsonHash": "fnv1a64:e9df23e339ff0cc1"
     },
     {
       "language": "spanish",
       "chapter": 33,
-      "sourceHash": "fnv1a64:9997a29a09400b47",
+      "sourceHash": "fnv1a64:1193d6388479368f",
       "lessonIds": [
         "ES-C33-verde",
         "ES-C33-amarillo"
@@ -5326,12 +5326,12 @@
       "text": "spanish/narration/ch33.txt",
       "json": "spanish/narration/ch33.json",
       "textHash": "fnv1a64:5ed8cdd9a10a4418",
-      "jsonHash": "fnv1a64:0ae2b7b200d055da"
+      "jsonHash": "fnv1a64:e448039b92c024cf"
     },
     {
       "language": "spanish",
       "chapter": 34,
-      "sourceHash": "fnv1a64:bc65a341cf39fbb6",
+      "sourceHash": "fnv1a64:64748b10c5f453b4",
       "lessonIds": [
         "ES-C34-pensar",
         "ES-C34-entender",
@@ -5343,12 +5343,12 @@
       "text": "spanish/narration/ch34.txt",
       "json": "spanish/narration/ch34.json",
       "textHash": "fnv1a64:2d75c3da112d51d1",
-      "jsonHash": "fnv1a64:fc61c94ae274afde"
+      "jsonHash": "fnv1a64:b13d29fd942028c4"
     },
     {
       "language": "spanish",
       "chapter": 35,
-      "sourceHash": "fnv1a64:28a0602c608252cb",
+      "sourceHash": "fnv1a64:e3c93cbb0c057188",
       "lessonIds": [
         "ES-C35-tomar",
         "ES-C35-preguntar",
@@ -5360,7 +5360,7 @@
       "text": "spanish/narration/ch35.txt",
       "json": "spanish/narration/ch35.json",
       "textHash": "fnv1a64:40df7ff1ff550a48",
-      "jsonHash": "fnv1a64:ed88066cad003d3f"
+      "jsonHash": "fnv1a64:768d75640e6ad386"
     },
     {
       "language": "tamil",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:1978364c3cd21f06",
+  "sourceHash": "fnv1a64:a2a56c534299bf00",
   "summary": {
     "totalLessons": 1249,
     "voice": 848,
@@ -19191,19 +19191,6 @@
       "id": "ES-C03-tu-usted-register",
       "language": "spanish",
       "chapter": 3,
-      "sequence": 165,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:9cae1a32ffd9d433"
-    },
-    {
-      "id": "ES-C03-usted-origin",
-      "language": "spanish",
-      "chapter": 3,
       "sequence": 170,
       "modality": "voice",
       "derived": "voice",
@@ -19211,10 +19198,10 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:313935a54432e2fc"
+      "sourceHash": "fnv1a64:4e4c276351c8a68d"
     },
     {
-      "id": "ES-C03-como",
+      "id": "ES-C03-usted-origin",
       "language": "spanish",
       "chapter": 3,
       "sequence": 180,
@@ -19224,13 +19211,26 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9e4ea930fecfcd0b"
+      "sourceHash": "fnv1a64:a68e3b11f451f46b"
+    },
+    {
+      "id": "ES-C03-como",
+      "language": "spanish",
+      "chapter": 3,
+      "sequence": 190,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:466a23d3a98e138a"
     },
     {
       "id": "ES-C03-como-acento",
       "language": "spanish",
       "chapter": 3,
-      "sequence": 185,
+      "sequence": 200,
       "modality": "pen",
       "derived": "pen",
       "drivable": false,
@@ -19238,49 +19238,23 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bec544478750ac13"
+      "sourceHash": "fnv1a64:7061ae42743cb58d"
     },
     {
       "id": "ES-C03-familia-qu",
       "language": "spanish",
       "chapter": 3,
-      "sequence": 190,
+      "sequence": 210,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
       "reasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:b17345e50849e2c0"
+      "sourceHash": "fnv1a64:eb66f372cf2b6887"
     },
     {
       "id": "ES-C03-se-llama",
-      "language": "spanish",
-      "chapter": 3,
-      "sequence": 200,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:5e44303bdf967b34"
-    },
-    {
-      "id": "ES-C03-como-se-llama",
-      "language": "spanish",
-      "chapter": 3,
-      "sequence": 210,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:15d93f753535461a"
-    },
-    {
-      "id": "ES-C03-mucho",
       "language": "spanish",
       "chapter": 3,
       "sequence": 220,
@@ -19290,10 +19264,10 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:0eb31d27e344bac8"
+      "sourceHash": "fnv1a64:d63e1dc84f6301ca"
     },
     {
-      "id": "ES-C03-gusto",
+      "id": "ES-C03-como-se-llama",
       "language": "spanish",
       "chapter": 3,
       "sequence": 230,
@@ -19303,10 +19277,10 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:dab0f8222a757a9f"
+      "sourceHash": "fnv1a64:8579507a71fa8de4"
     },
     {
-      "id": "ES-C03-practice",
+      "id": "ES-C03-mucho",
       "language": "spanish",
       "chapter": 3,
       "sequence": 240,
@@ -19316,12 +19290,12 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:15726c67051588f6"
+      "sourceHash": "fnv1a64:6858d837f3aca63a"
     },
     {
-      "id": "ES-C04-gracias",
+      "id": "ES-C03-gusto",
       "language": "spanish",
-      "chapter": 4,
+      "chapter": 3,
       "sequence": 250,
       "modality": "voice",
       "derived": "voice",
@@ -19329,12 +19303,12 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:3969444c81af8bce"
+      "sourceHash": "fnv1a64:a318581b4ba64bb9"
     },
     {
-      "id": "ES-C04-de-nada",
+      "id": "ES-C03-practice",
       "language": "spanish",
-      "chapter": 4,
+      "chapter": 3,
       "sequence": 260,
       "modality": "voice",
       "derived": "voice",
@@ -19342,10 +19316,10 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5e5c913f2118ae08"
+      "sourceHash": "fnv1a64:18b77f42953215fc"
     },
     {
-      "id": "ES-C04-estar",
+      "id": "ES-C04-gracias",
       "language": "spanish",
       "chapter": 4,
       "sequence": 270,
@@ -19355,23 +19329,10 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c48ba479e91735af"
+      "sourceHash": "fnv1a64:f5e3fa74cf594ffc"
     },
     {
-      "id": "ES-C04-estar-estado",
-      "language": "spanish",
-      "chapter": 4,
-      "sequence": 275,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:c75d3f1d85a3378b"
-    },
-    {
-      "id": "ES-C04-como-esta",
+      "id": "ES-C04-de-nada",
       "language": "spanish",
       "chapter": 4,
       "sequence": 280,
@@ -19381,10 +19342,10 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d1b2bd3bf645f43d"
+      "sourceHash": "fnv1a64:3b8ebf50aed6457a"
     },
     {
-      "id": "ES-C04-como-estas-register",
+      "id": "ES-C04-estar",
       "language": "spanish",
       "chapter": 4,
       "sequence": 290,
@@ -19394,10 +19355,10 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5ac43b43f055da36"
+      "sourceHash": "fnv1a64:a0b65487b5a73d41"
     },
     {
-      "id": "ES-C04-regular",
+      "id": "ES-C04-estar-estado",
       "language": "spanish",
       "chapter": 4,
       "sequence": 300,
@@ -19407,10 +19368,10 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9f76e8eda46d6c3b"
+      "sourceHash": "fnv1a64:ad2c2ef9af54d91e"
     },
     {
-      "id": "ES-C04-y",
+      "id": "ES-C04-como-esta",
       "language": "spanish",
       "chapter": 4,
       "sequence": 310,
@@ -19420,65 +19381,49 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a061efc60a36db8d"
+      "sourceHash": "fnv1a64:4b38ddebc1627ccf"
     },
     {
-      "id": "ES-W01-acento",
+      "id": "ES-C04-como-estas-register",
       "language": "spanish",
       "chapter": 4,
       "sequence": 320,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "writing-type",
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:baf8f0bf2acd2bcd"
+      "sourceHash": "fnv1a64:ec2185a3c64d23ae"
     },
     {
-      "id": "ES-W01-tilde-diacritica",
+      "id": "ES-C04-regular",
       "language": "spanish",
       "chapter": 4,
       "sequence": 330,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "writing-type"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:dc1796509ac801d3"
+      "sourceHash": "fnv1a64:9041b6c5d8c595ae"
     },
     {
-      "id": "ES-W02-enye",
+      "id": "ES-C04-y",
       "language": "spanish",
       "chapter": 4,
       "sequence": 340,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "writing-type",
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:54a1f5e3da8c51f6"
+      "sourceHash": "fnv1a64:bf5cf5002e53d936"
     },
     {
-      "id": "ES-W02-enye-formas",
-      "language": "spanish",
-      "chapter": 4,
-      "sequence": 345,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:50764998caf80a44"
-    },
-    {
-      "id": "ES-W03-inverted",
+      "id": "ES-W01-acento",
       "language": "spanish",
       "chapter": 4,
       "sequence": 350,
@@ -19489,10 +19434,10 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f2bf58f0935c07cd"
+      "sourceHash": "fnv1a64:0a154ad329459672"
     },
     {
-      "id": "ES-W03-question-span",
+      "id": "ES-W01-tilde-diacritica",
       "language": "spanish",
       "chapter": 4,
       "sequence": 360,
@@ -19500,67 +19445,70 @@
       "derived": "pen",
       "drivable": false,
       "reasons": [
+        "writing-type"
+      ],
+      "sourceHash": "fnv1a64:fcfbb52aee30c7f8"
+    },
+    {
+      "id": "ES-W02-enye",
+      "language": "spanish",
+      "chapter": 4,
+      "sequence": 370,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:99b94711b2c0d896"
+      "sourceHash": "fnv1a64:f9ec537631d2b099"
+    },
+    {
+      "id": "ES-W02-enye-formas",
+      "language": "spanish",
+      "chapter": 4,
+      "sequence": 380,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:f42bf3408df4a291"
+    },
+    {
+      "id": "ES-W03-inverted",
+      "language": "spanish",
+      "chapter": 4,
+      "sequence": 390,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:4b185ff5be127741"
+    },
+    {
+      "id": "ES-W03-question-span",
+      "language": "spanish",
+      "chapter": 4,
+      "sequence": 400,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:5df9c6a05264f0ad"
     },
     {
       "id": "ES-C04-practice",
       "language": "spanish",
       "chapter": 4,
-      "sequence": 370,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:4755fc6507f6e1a2"
-    },
-    {
-      "id": "ES-C05-adios",
-      "language": "spanish",
-      "chapter": 5,
-      "sequence": 380,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:6a680cbb31975a8e"
-    },
-    {
-      "id": "ES-C05-hasta",
-      "language": "spanish",
-      "chapter": 5,
-      "sequence": 390,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:2fa83bf6f818d032"
-    },
-    {
-      "id": "ES-C05-hasta-limits",
-      "language": "spanish",
-      "chapter": 5,
-      "sequence": 400,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:671f64f069058b1a"
-    },
-    {
-      "id": "ES-C05-hasta-luego",
-      "language": "spanish",
-      "chapter": 5,
       "sequence": 410,
       "modality": "voice",
       "derived": "voice",
@@ -19568,10 +19516,10 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c7c6ad01ee274beb"
+      "sourceHash": "fnv1a64:95b7ff61b4e942fd"
     },
     {
-      "id": "ES-C05-hasta-manana",
+      "id": "ES-C05-adios",
       "language": "spanish",
       "chapter": 5,
       "sequence": 420,
@@ -19581,10 +19529,10 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:cfc7945c70776255"
+      "sourceHash": "fnv1a64:1efab3e6e2d1971f"
     },
     {
-      "id": "ES-C05-hasta-pronto",
+      "id": "ES-C05-hasta",
       "language": "spanish",
       "chapter": 5,
       "sequence": 430,
@@ -19594,10 +19542,10 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:54f0024553c75758"
+      "sourceHash": "fnv1a64:0373a9248796f3f9"
     },
     {
-      "id": "ES-C05-practice",
+      "id": "ES-C05-hasta-limits",
       "language": "spanish",
       "chapter": 5,
       "sequence": 440,
@@ -19607,12 +19555,12 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:cd27f0a890b9511f"
+      "sourceHash": "fnv1a64:8a9a3573eb8c6a3e"
     },
     {
-      "id": "ES-C06-cafe",
+      "id": "ES-C05-hasta-luego",
       "language": "spanish",
-      "chapter": 6,
+      "chapter": 5,
       "sequence": 450,
       "modality": "voice",
       "derived": "voice",
@@ -19620,12 +19568,12 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f25db04ee0f884da"
+      "sourceHash": "fnv1a64:77d7a5f501080017"
     },
     {
-      "id": "ES-C06-por-favor",
+      "id": "ES-C05-hasta-manana",
       "language": "spanish",
-      "chapter": 6,
+      "chapter": 5,
       "sequence": 460,
       "modality": "voice",
       "derived": "voice",
@@ -19633,12 +19581,12 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:3ac312a5638b2595"
+      "sourceHash": "fnv1a64:a6a61bd22ad29bc9"
     },
     {
-      "id": "ES-C06-hablar",
+      "id": "ES-C05-hasta-pronto",
       "language": "spanish",
-      "chapter": 6,
+      "chapter": 5,
       "sequence": 470,
       "modality": "voice",
       "derived": "voice",
@@ -19646,26 +19594,12 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ec974cf7795b5dea"
+      "sourceHash": "fnv1a64:512b57b48ebad954"
     },
     {
-      "id": "ES-C06-ar-presente",
+      "id": "ES-C05-practice",
       "language": "spanish",
-      "chapter": 6,
-      "sequence": 475,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "sight-cue",
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:16c2c3aaca0bd5c9"
-    },
-    {
-      "id": "ES-C06-trabajar",
-      "language": "spanish",
-      "chapter": 6,
+      "chapter": 5,
       "sequence": 480,
       "modality": "voice",
       "derived": "voice",
@@ -19673,10 +19607,10 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:87e1da307dcee2f5"
+      "sourceHash": "fnv1a64:bb6a1ec725b3062b"
     },
     {
-      "id": "ES-C06-estudiar",
+      "id": "ES-C06-cafe",
       "language": "spanish",
       "chapter": 6,
       "sequence": 490,
@@ -19686,10 +19620,10 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e41c7eebc5f12c68"
+      "sourceHash": "fnv1a64:4b96d615a4e56676"
     },
     {
-      "id": "ES-C06-espanol",
+      "id": "ES-C06-por-favor",
       "language": "spanish",
       "chapter": 6,
       "sequence": 500,
@@ -19699,23 +19633,10 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:96238d0438890a16"
+      "sourceHash": "fnv1a64:f66d4757e7f825f2"
     },
     {
-      "id": "ES-C06-hablo-espanol",
-      "language": "spanish",
-      "chapter": 6,
-      "sequence": 505,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:5bc0c2715a5aa607"
-    },
-    {
-      "id": "ES-C06-practice",
+      "id": "ES-C06-hablar",
       "language": "spanish",
       "chapter": 6,
       "sequence": 510,
@@ -19725,7 +19646,86 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e76d3d2926c9d2bb"
+      "sourceHash": "fnv1a64:f0eaf961627f631b"
+    },
+    {
+      "id": "ES-C06-ar-presente",
+      "language": "spanish",
+      "chapter": 6,
+      "sequence": 520,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "sight-cue",
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:d62ffbd226de0824"
+    },
+    {
+      "id": "ES-C06-trabajar",
+      "language": "spanish",
+      "chapter": 6,
+      "sequence": 530,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:045c7903c73d446d"
+    },
+    {
+      "id": "ES-C06-estudiar",
+      "language": "spanish",
+      "chapter": 6,
+      "sequence": 540,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:a0caa17d21e7026e"
+    },
+    {
+      "id": "ES-C06-espanol",
+      "language": "spanish",
+      "chapter": 6,
+      "sequence": 550,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:3419ebdf7bb7ba3f"
+    },
+    {
+      "id": "ES-C06-hablo-espanol",
+      "language": "spanish",
+      "chapter": 6,
+      "sequence": 560,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:359d617ceb162fa6"
+    },
+    {
+      "id": "ES-C06-practice",
+      "language": "spanish",
+      "chapter": 6,
+      "sequence": 570,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:5688a6936f544445"
     },
     {
       "id": "ES-C07-beber",
@@ -19809,903 +19809,6 @@
       "id": "ES-C08-numeros-1-5",
       "language": "spanish",
       "chapter": 8,
-      "sequence": 524,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:d0ad0f4bf00e9dd5"
-    },
-    {
-      "id": "ES-C08-numeros-6-10",
-      "language": "spanish",
-      "chapter": 8,
-      "sequence": 526,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:31bbfdae30ea5829"
-    },
-    {
-      "id": "ES-C08-tener",
-      "language": "spanish",
-      "chapter": 8,
-      "sequence": 528,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:d7ac3ca77bc32f7f"
-    },
-    {
-      "id": "ES-C08-cuantos-anos",
-      "language": "spanish",
-      "chapter": 8,
-      "sequence": 530,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:fcb5f16ab501160a"
-    },
-    {
-      "id": "ES-C08-practice",
-      "language": "spanish",
-      "chapter": 8,
-      "sequence": 532,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:6c650d67ce5cb460"
-    },
-    {
-      "id": "ES-C09-ser",
-      "language": "spanish",
-      "chapter": 9,
-      "sequence": 534,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:06810f2823517346"
-    },
-    {
-      "id": "ES-C09-ser-vs-estar",
-      "language": "spanish",
-      "chapter": 9,
-      "sequence": 536,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:2e697cd43b1008d8"
-    },
-    {
-      "id": "ES-C09-soy-de",
-      "language": "spanish",
-      "chapter": 9,
-      "sequence": 538,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:9d827a379647bb01"
-    },
-    {
-      "id": "ES-C09-esta-en",
-      "language": "spanish",
-      "chapter": 9,
-      "sequence": 540,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "sight-cue"
-      ],
-      "sourceHash": "fnv1a64:c4741a1391c9dd4e"
-    },
-    {
-      "id": "ES-C09-practice",
-      "language": "spanish",
-      "chapter": 9,
-      "sequence": 542,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "sight-cue"
-      ],
-      "sourceHash": "fnv1a64:bb563dc466711e9c"
-    },
-    {
-      "id": "ES-C10-ir",
-      "language": "spanish",
-      "chapter": 10,
-      "sequence": 544,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:a112992448d98155"
-    },
-    {
-      "id": "ES-C10-ir-a-futuro",
-      "language": "spanish",
-      "chapter": 10,
-      "sequence": 546,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:593eb56d09a903d9"
-    },
-    {
-      "id": "ES-C10-mi-tu-su",
-      "language": "spanish",
-      "chapter": 10,
-      "sequence": 548,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:9e0132e713e2e689"
-    },
-    {
-      "id": "ES-C10-practice",
-      "language": "spanish",
-      "chapter": 10,
-      "sequence": 550,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:6e9314985eb5ba8d"
-    },
-    {
-      "id": "ES-C11-querer",
-      "language": "spanish",
-      "chapter": 11,
-      "sequence": 552,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:5431d0644d171e4a"
-    },
-    {
-      "id": "ES-C11-poder",
-      "language": "spanish",
-      "chapter": 11,
-      "sequence": 554,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:2d66abfcc957b70d"
-    },
-    {
-      "id": "ES-C11-stem-changes",
-      "language": "spanish",
-      "chapter": 11,
-      "sequence": 556,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:c7b9e4b8437c58d5"
-    },
-    {
-      "id": "ES-C11-nuestro",
-      "language": "spanish",
-      "chapter": 11,
-      "sequence": 558,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:7a0ac7c6de92c18d"
-    },
-    {
-      "id": "ES-C11-practice",
-      "language": "spanish",
-      "chapter": 11,
-      "sequence": 560,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:76a65b2d1bd68da7"
-    },
-    {
-      "id": "ES-C12-hacer",
-      "language": "spanish",
-      "chapter": 12,
-      "sequence": 562,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:4eaa4375ddf5ddc9"
-    },
-    {
-      "id": "ES-C12-decir",
-      "language": "spanish",
-      "chapter": 12,
-      "sequence": 564,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:72edb388d5667454"
-    },
-    {
-      "id": "ES-C12-yo-go",
-      "language": "spanish",
-      "chapter": 12,
-      "sequence": 566,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:676f366bba630168"
-    },
-    {
-      "id": "ES-C12-practice",
-      "language": "spanish",
-      "chapter": 12,
-      "sequence": 568,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:5cd89031d88c7419"
-    },
-    {
-      "id": "ES-C13-poner",
-      "language": "spanish",
-      "chapter": 13,
-      "sequence": 570,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "sight-cue"
-      ],
-      "sourceHash": "fnv1a64:4a6d21b6e5842518"
-    },
-    {
-      "id": "ES-C13-salir",
-      "language": "spanish",
-      "chapter": 13,
-      "sequence": 572,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:6e1368dae4cebfe2"
-    },
-    {
-      "id": "ES-C13-venir",
-      "language": "spanish",
-      "chapter": 13,
-      "sequence": 574,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:aabd87fb7c1c7eae"
-    },
-    {
-      "id": "ES-C13-practice",
-      "language": "spanish",
-      "chapter": 13,
-      "sequence": 576,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "sight-cue"
-      ],
-      "sourceHash": "fnv1a64:c38441962b855240"
-    },
-    {
-      "id": "ES-C14-ser-ir-preterite",
-      "language": "spanish",
-      "chapter": 14,
-      "sequence": 578,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:5cb98853f54215d7"
-    },
-    {
-      "id": "ES-C14-hablar-preterite",
-      "language": "spanish",
-      "chapter": 14,
-      "sequence": 580,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:99d2ac9cf71ade02"
-    },
-    {
-      "id": "ES-C14-practice",
-      "language": "spanish",
-      "chapter": 14,
-      "sequence": 582,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:eefb1d965f836b28"
-    },
-    {
-      "id": "ES-C15-comer-vivir-preterite",
-      "language": "spanish",
-      "chapter": 15,
-      "sequence": 584,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:c4492b031d93a760"
-    },
-    {
-      "id": "ES-C15-preterite-fuertes",
-      "language": "spanish",
-      "chapter": 15,
-      "sequence": 586,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:1bf08f09f5512a0b"
-    },
-    {
-      "id": "ES-C15-practice",
-      "language": "spanish",
-      "chapter": 15,
-      "sequence": 588,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:84f421ddf990bd02"
-    },
-    {
-      "id": "ES-C16-imperfecto",
-      "language": "spanish",
-      "chapter": 16,
-      "sequence": 590,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:a7934411170c064f"
-    },
-    {
-      "id": "ES-C16-tres-irregulares",
-      "language": "spanish",
-      "chapter": 16,
-      "sequence": 592,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:f0aeca46b35f7ba0"
-    },
-    {
-      "id": "ES-C16-practice",
-      "language": "spanish",
-      "chapter": 16,
-      "sequence": 594,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:8ea9920b4d1ad6c4"
-    },
-    {
-      "id": "ES-C17-futuro",
-      "language": "spanish",
-      "chapter": 17,
-      "sequence": 596,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:2a1bea9375fca1f7"
-    },
-    {
-      "id": "ES-C17-condicional",
-      "language": "spanish",
-      "chapter": 17,
-      "sequence": 598,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:b700b8e082384c9b"
-    },
-    {
-      "id": "ES-C17-practice",
-      "language": "spanish",
-      "chapter": 17,
-      "sequence": 600,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:2b4102bf168727e5"
-    },
-    {
-      "id": "ES-C17-future-guessing",
-      "language": "spanish",
-      "chapter": 17,
-      "sequence": 602,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:5527b162c3ab4fe8"
-    },
-    {
-      "id": "ES-C18-subjuntivo",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": 604,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:256303072a07e4d8"
-    },
-    {
-      "id": "ES-C18-inherited-subjunctive-stems",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": 606,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:9406fc796546d74a"
-    },
-    {
-      "id": "ES-C18-subjunctive-outliers",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": 608,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:87910704c052914f"
-    },
-    {
-      "id": "ES-C18-subjunctive-name",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": 610,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:40f17ef5d07b402a"
-    },
-    {
-      "id": "ES-C18-quiero-que",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": 612,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:5a5c6b962d384dee"
-    },
-    {
-      "id": "ES-C18-wanting-clause-trap",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": 614,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:2eedce6d8fb2c565"
-    },
-    {
-      "id": "ES-C18-ojala",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": 616,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:7a5cbefcd831a467"
-    },
-    {
-      "id": "ES-C18-practice",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": 618,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:d42894546917da8b"
-    },
-    {
-      "id": "ES-C18-practice-subjects",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": 620,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:e009f00a2d88fe2f"
-    },
-    {
-      "id": "ES-C18-practice-mood",
-      "language": "spanish",
-      "chapter": 18,
-      "sequence": 622,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:2bdbd831a0781532"
-    },
-    {
-      "id": "ES-C19-si",
-      "language": "spanish",
-      "chapter": 19,
-      "sequence": 640,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:df0f47319db22908"
-    },
-    {
-      "id": "ES-C19-no",
-      "language": "spanish",
-      "chapter": 19,
-      "sequence": 650,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:41b35806ec2b71a5"
-    },
-    {
-      "id": "ES-C20-lo-siento",
-      "language": "spanish",
-      "chapter": 20,
-      "sequence": 660,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:00ce4359ea93afdf"
-    },
-    {
-      "id": "ES-C20-perdon",
-      "language": "spanish",
-      "chapter": 20,
-      "sequence": 665,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:4a10e72821bf26fc"
-    },
-    {
-      "id": "ES-C21-lunes-viernes",
-      "language": "spanish",
-      "chapter": 21,
-      "sequence": 670,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:71d96a3f4b87cafa"
-    },
-    {
-      "id": "ES-C21-sabado-domingo",
-      "language": "spanish",
-      "chapter": 21,
-      "sequence": 680,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "wide-table"
-      ],
-      "sourceHash": "fnv1a64:f271345272c76bb1"
-    },
-    {
-      "id": "ES-C22-negro-blanco",
-      "language": "spanish",
-      "chapter": 22,
-      "sequence": 690,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:92bf0940d0b819db"
-    },
-    {
-      "id": "ES-C22-blanco-germanico",
-      "language": "spanish",
-      "chapter": 22,
-      "sequence": 695,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:81d42eb28a9defb2"
-    },
-    {
-      "id": "ES-C22-rojo",
-      "language": "spanish",
-      "chapter": 22,
-      "sequence": 700,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:c07fa5ee06564a7b"
-    },
-    {
-      "id": "ES-C22-azul",
-      "language": "spanish",
-      "chapter": 22,
-      "sequence": 705,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:de00a30ead1a50c7"
-    },
-    {
-      "id": "ES-C23-padre-madre",
-      "language": "spanish",
-      "chapter": 23,
-      "sequence": 710,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:7616d50a73e80fc3"
-    },
-    {
-      "id": "ES-C23-hermano-hermana",
-      "language": "spanish",
-      "chapter": 23,
-      "sequence": 720,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:ab984fb1e7d9fb5c"
-    },
-    {
-      "id": "ES-C23-hermano-hache",
-      "language": "spanish",
-      "chapter": 23,
-      "sequence": 725,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:baea4dd12bea235e"
-    },
-    {
-      "id": "ES-C24-cabeza",
-      "language": "spanish",
-      "chapter": 24,
-      "sequence": 730,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:1ca9e2018cf8fbe1"
-    },
-    {
-      "id": "ES-C24-mano",
-      "language": "spanish",
-      "chapter": 24,
-      "sequence": 740,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:9ebd83a6bc67002a"
-    },
-    {
-      "id": "ES-C25-las-estaciones",
-      "language": "spanish",
-      "chapter": 25,
-      "sequence": 750,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:8188afe380d53ba6"
-    },
-    {
-      "id": "ES-C26-agua",
-      "language": "spanish",
-      "chapter": 26,
-      "sequence": 760,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:396cd87e02e45696"
-    },
-    {
-      "id": "ES-C26-vino",
-      "language": "spanish",
-      "chapter": 26,
-      "sequence": 765,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:d8403ab5884125cd"
-    },
-    {
-      "id": "ES-C26-pan",
-      "language": "spanish",
-      "chapter": 26,
-      "sequence": 770,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:34fd005c9eaee292"
-    },
-    {
-      "id": "ES-C27-los-meses",
-      "language": "spanish",
-      "chapter": 27,
       "sequence": 780,
       "modality": "voice",
       "derived": "voice",
@@ -20713,12 +19816,12 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:2a00cef600dd4a76"
+      "sourceHash": "fnv1a64:b46d43b715b1eab9"
     },
     {
-      "id": "ES-C28-mediodia-medianoche",
+      "id": "ES-C08-numeros-6-10",
       "language": "spanish",
-      "chapter": 28,
+      "chapter": 8,
       "sequence": 790,
       "modality": "voice",
       "derived": "voice",
@@ -20726,12 +19829,12 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f3bd9875be93e05a"
+      "sourceHash": "fnv1a64:ed0886a860ddd794"
     },
     {
-      "id": "ES-C29-la-hora",
+      "id": "ES-C08-tener",
       "language": "spanish",
-      "chapter": 29,
+      "chapter": 8,
       "sequence": 800,
       "modality": "voice",
       "derived": "voice",
@@ -20739,12 +19842,12 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:dc8bd714712b7c60"
+      "sourceHash": "fnv1a64:41443319609fc232"
     },
     {
-      "id": "ES-C30-el-tiempo",
+      "id": "ES-C08-cuantos-anos",
       "language": "spanish",
-      "chapter": 30,
+      "chapter": 8,
       "sequence": 810,
       "modality": "voice",
       "derived": "voice",
@@ -20752,38 +19855,12 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f7b78397a0e28684"
+      "sourceHash": "fnv1a64:c8e8c4495c46b9fb"
     },
     {
-      "id": "ES-C30-hace-calor",
+      "id": "ES-C08-practice",
       "language": "spanish",
-      "chapter": 30,
-      "sequence": 813,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:079d6db94cc41834"
-    },
-    {
-      "id": "ES-C30-llueve",
-      "language": "spanish",
-      "chapter": 30,
-      "sequence": 816,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:a3eb437013dc1d29"
-    },
-    {
-      "id": "ES-C31-once-quince",
-      "language": "spanish",
-      "chapter": 31,
+      "chapter": 8,
       "sequence": 820,
       "modality": "voice",
       "derived": "voice",
@@ -20791,51 +19868,12 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:16abdfd4edd4cbc2"
+      "sourceHash": "fnv1a64:933eafd23ceb4124"
     },
     {
-      "id": "ES-C31-dieciseis-diecinueve",
+      "id": "ES-C09-ser",
       "language": "spanish",
-      "chapter": 31,
-      "sequence": 823,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:43f7c733f16124f2"
-    },
-    {
-      "id": "ES-C31-teens-latinos",
-      "language": "spanish",
-      "chapter": 31,
-      "sequence": 825,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:425127755f16b3ae"
-    },
-    {
-      "id": "ES-C31-veinte",
-      "language": "spanish",
-      "chapter": 31,
-      "sequence": 827,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:6ebd22e653465428"
-    },
-    {
-      "id": "ES-C32-gato",
-      "language": "spanish",
-      "chapter": 32,
+      "chapter": 9,
       "sequence": 830,
       "modality": "voice",
       "derived": "voice",
@@ -20843,51 +19881,25 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:1ea0f80b5f1d8597"
+      "sourceHash": "fnv1a64:f6c1102f99e48dfb"
     },
     {
-      "id": "ES-C32-perro",
+      "id": "ES-C09-ser-vs-estar",
       "language": "spanish",
-      "chapter": 32,
-      "sequence": 835,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:875f6739e1b5c41b"
-    },
-    {
-      "id": "ES-C33-verde",
-      "language": "spanish",
-      "chapter": 33,
+      "chapter": 9,
       "sequence": 840,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "wide-table"
       ],
-      "sourceHash": "fnv1a64:36b56916259af11e"
+      "sourceHash": "fnv1a64:079927285e2d7c12"
     },
     {
-      "id": "ES-C33-amarillo",
+      "id": "ES-C09-soy-de",
       "language": "spanish",
-      "chapter": 33,
-      "sequence": 845,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:ae70fb1bf5810c09"
-    },
-    {
-      "id": "ES-C34-pensar",
-      "language": "spanish",
-      "chapter": 34,
+      "chapter": 9,
       "sequence": 850,
       "modality": "voice",
       "derived": "voice",
@@ -20895,77 +19907,38 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c34f771fc63fa6da"
+      "sourceHash": "fnv1a64:7d7dc85d231765fe"
     },
     {
-      "id": "ES-C34-entender",
+      "id": "ES-C09-esta-en",
       "language": "spanish",
-      "chapter": 34,
-      "sequence": 855,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:265e5fbe219438c0"
-    },
-    {
-      "id": "ES-C34-leer",
-      "language": "spanish",
-      "chapter": 34,
+      "chapter": 9,
       "sequence": 860,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "sight-cue"
       ],
-      "sourceHash": "fnv1a64:fe730e9bf319e028"
+      "sourceHash": "fnv1a64:e1ee931ddaf78a6d"
     },
     {
-      "id": "ES-C34-escribir",
+      "id": "ES-C09-practice",
       "language": "spanish",
-      "chapter": 34,
-      "sequence": 865,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:c4ff55a994a886be"
-    },
-    {
-      "id": "ES-C35-tomar",
-      "language": "spanish",
-      "chapter": 35,
+      "chapter": 9,
       "sequence": 870,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "sight-cue"
       ],
-      "sourceHash": "fnv1a64:7f64cbe9c19a04ac"
+      "sourceHash": "fnv1a64:1a1ac8d5f28b64da"
     },
     {
-      "id": "ES-C35-preguntar",
+      "id": "ES-C10-ir",
       "language": "spanish",
-      "chapter": 35,
-      "sequence": 875,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:4f6bdcdc76c54e70"
-    },
-    {
-      "id": "ES-C35-ayudar",
-      "language": "spanish",
-      "chapter": 35,
+      "chapter": 10,
       "sequence": 880,
       "modality": "voice",
       "derived": "voice",
@@ -20973,20 +19946,1047 @@
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d33da6ef3a522438"
+      "sourceHash": "fnv1a64:97e7c19bbe741eda"
     },
     {
-      "id": "ES-C35-gustar",
+      "id": "ES-C10-ir-a-futuro",
       "language": "spanish",
-      "chapter": 35,
-      "sequence": 885,
+      "chapter": 10,
+      "sequence": 890,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
       "reasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:99ebd45c298ca198"
+      "sourceHash": "fnv1a64:2efae4f60d605d59"
+    },
+    {
+      "id": "ES-C10-mi-tu-su",
+      "language": "spanish",
+      "chapter": 10,
+      "sequence": 900,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:c16ec47331e0c841"
+    },
+    {
+      "id": "ES-C10-practice",
+      "language": "spanish",
+      "chapter": 10,
+      "sequence": 910,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:e10c22caf5db30ed"
+    },
+    {
+      "id": "ES-C11-querer",
+      "language": "spanish",
+      "chapter": 11,
+      "sequence": 920,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:544fa5d83e0f113f"
+    },
+    {
+      "id": "ES-C11-poder",
+      "language": "spanish",
+      "chapter": 11,
+      "sequence": 930,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:d5319cef387b6b17"
+    },
+    {
+      "id": "ES-C11-stem-changes",
+      "language": "spanish",
+      "chapter": 11,
+      "sequence": 940,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:8b3b70b2c52e51a2"
+    },
+    {
+      "id": "ES-C11-nuestro",
+      "language": "spanish",
+      "chapter": 11,
+      "sequence": 950,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:93e91c4220c73ee9"
+    },
+    {
+      "id": "ES-C11-practice",
+      "language": "spanish",
+      "chapter": 11,
+      "sequence": 960,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:af92d49c34d3eda3"
+    },
+    {
+      "id": "ES-C12-hacer",
+      "language": "spanish",
+      "chapter": 12,
+      "sequence": 970,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:0c31a56e74c2d5ee"
+    },
+    {
+      "id": "ES-C12-decir",
+      "language": "spanish",
+      "chapter": 12,
+      "sequence": 980,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:4b8ca2a96fcd9236"
+    },
+    {
+      "id": "ES-C12-yo-go",
+      "language": "spanish",
+      "chapter": 12,
+      "sequence": 990,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:17afaf4786688193"
+    },
+    {
+      "id": "ES-C12-practice",
+      "language": "spanish",
+      "chapter": 12,
+      "sequence": 1000,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:fe2365102528f58f"
+    },
+    {
+      "id": "ES-C13-poner",
+      "language": "spanish",
+      "chapter": 13,
+      "sequence": 1010,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:c049d52a0fb55326"
+    },
+    {
+      "id": "ES-C13-salir",
+      "language": "spanish",
+      "chapter": 13,
+      "sequence": 1020,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:fe496f4ed5343157"
+    },
+    {
+      "id": "ES-C13-venir",
+      "language": "spanish",
+      "chapter": 13,
+      "sequence": 1030,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:c3cbc4d6fcbeaafc"
+    },
+    {
+      "id": "ES-C13-practice",
+      "language": "spanish",
+      "chapter": 13,
+      "sequence": 1040,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:2497b5ca46b70d45"
+    },
+    {
+      "id": "ES-C14-ser-ir-preterite",
+      "language": "spanish",
+      "chapter": 14,
+      "sequence": 1050,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:4f976b4d96ae28b3"
+    },
+    {
+      "id": "ES-C14-hablar-preterite",
+      "language": "spanish",
+      "chapter": 14,
+      "sequence": 1060,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:cd3da96c84d6e042"
+    },
+    {
+      "id": "ES-C14-practice",
+      "language": "spanish",
+      "chapter": 14,
+      "sequence": 1070,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:15ba2316d6c80667"
+    },
+    {
+      "id": "ES-C15-comer-vivir-preterite",
+      "language": "spanish",
+      "chapter": 15,
+      "sequence": 1080,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:29f4924f1b0065d6"
+    },
+    {
+      "id": "ES-C15-preterite-fuertes",
+      "language": "spanish",
+      "chapter": 15,
+      "sequence": 1090,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:62a3242726961642"
+    },
+    {
+      "id": "ES-C15-practice",
+      "language": "spanish",
+      "chapter": 15,
+      "sequence": 1100,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:4b3fcf24c86f0c33"
+    },
+    {
+      "id": "ES-C16-imperfecto",
+      "language": "spanish",
+      "chapter": 16,
+      "sequence": 1110,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:e20f599f8e6f29be"
+    },
+    {
+      "id": "ES-C16-tres-irregulares",
+      "language": "spanish",
+      "chapter": 16,
+      "sequence": 1120,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:9c3bcc2a62e8957e"
+    },
+    {
+      "id": "ES-C16-practice",
+      "language": "spanish",
+      "chapter": 16,
+      "sequence": 1130,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:f180bd5fc945e341"
+    },
+    {
+      "id": "ES-C17-futuro",
+      "language": "spanish",
+      "chapter": 17,
+      "sequence": 1140,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:75f5252fcaca8439"
+    },
+    {
+      "id": "ES-C17-condicional",
+      "language": "spanish",
+      "chapter": 17,
+      "sequence": 1150,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:6938e0da50515712"
+    },
+    {
+      "id": "ES-C17-practice",
+      "language": "spanish",
+      "chapter": 17,
+      "sequence": 1160,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:e9f899c42d6b76bd"
+    },
+    {
+      "id": "ES-C17-future-guessing",
+      "language": "spanish",
+      "chapter": 17,
+      "sequence": 1170,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:a530fffb868e2f93"
+    },
+    {
+      "id": "ES-C18-subjuntivo",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 1180,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:91ce99547c890c02"
+    },
+    {
+      "id": "ES-C18-inherited-subjunctive-stems",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 1190,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:b2b0bb94c5c6820f"
+    },
+    {
+      "id": "ES-C18-subjunctive-outliers",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 1200,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:befb2b16944dd31a"
+    },
+    {
+      "id": "ES-C18-subjunctive-name",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 1210,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:cc5849df9cf29fbb"
+    },
+    {
+      "id": "ES-C18-quiero-que",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 1220,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:37bc14318be96308"
+    },
+    {
+      "id": "ES-C18-wanting-clause-trap",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 1230,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:24c74260689cfbb0"
+    },
+    {
+      "id": "ES-C18-ojala",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 1240,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:8a5116ada01886a3"
+    },
+    {
+      "id": "ES-C18-practice",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 1250,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:8a556331081027e6"
+    },
+    {
+      "id": "ES-C18-practice-subjects",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 1260,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:29a5021c7eb66506"
+    },
+    {
+      "id": "ES-C18-practice-mood",
+      "language": "spanish",
+      "chapter": 18,
+      "sequence": 1270,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:57ff016d1d7798be"
+    },
+    {
+      "id": "ES-C19-si",
+      "language": "spanish",
+      "chapter": 19,
+      "sequence": 1280,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:b17f3a4bbf08b693"
+    },
+    {
+      "id": "ES-C19-no",
+      "language": "spanish",
+      "chapter": 19,
+      "sequence": 1290,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:d9bf248186007d54"
+    },
+    {
+      "id": "ES-C20-lo-siento",
+      "language": "spanish",
+      "chapter": 20,
+      "sequence": 1300,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:1edebc53ccdc91db"
+    },
+    {
+      "id": "ES-C20-perdon",
+      "language": "spanish",
+      "chapter": 20,
+      "sequence": 1310,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:10316f8fbdca5ef8"
+    },
+    {
+      "id": "ES-C21-lunes-viernes",
+      "language": "spanish",
+      "chapter": 21,
+      "sequence": 1320,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:2daae3fceeab7c1f"
+    },
+    {
+      "id": "ES-C21-sabado-domingo",
+      "language": "spanish",
+      "chapter": 21,
+      "sequence": 1330,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "wide-table"
+      ],
+      "sourceHash": "fnv1a64:539054e0683b301c"
+    },
+    {
+      "id": "ES-C22-negro-blanco",
+      "language": "spanish",
+      "chapter": 22,
+      "sequence": 1340,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:db51bf774d990900"
+    },
+    {
+      "id": "ES-C22-blanco-germanico",
+      "language": "spanish",
+      "chapter": 22,
+      "sequence": 1350,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:c6fe8636baaf2417"
+    },
+    {
+      "id": "ES-C22-rojo",
+      "language": "spanish",
+      "chapter": 22,
+      "sequence": 1360,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:95fcef898178289a"
+    },
+    {
+      "id": "ES-C22-azul",
+      "language": "spanish",
+      "chapter": 22,
+      "sequence": 1370,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:93ee0709ae2c9910"
+    },
+    {
+      "id": "ES-C23-padre-madre",
+      "language": "spanish",
+      "chapter": 23,
+      "sequence": 1380,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:351e499d442f0d1f"
+    },
+    {
+      "id": "ES-C23-hermano-hermana",
+      "language": "spanish",
+      "chapter": 23,
+      "sequence": 1390,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:c679f98885675be4"
+    },
+    {
+      "id": "ES-C23-hermano-hache",
+      "language": "spanish",
+      "chapter": 23,
+      "sequence": 1400,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:16e1370ac5e837cb"
+    },
+    {
+      "id": "ES-C24-cabeza",
+      "language": "spanish",
+      "chapter": 24,
+      "sequence": 1410,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:1d23fe41ce429e33"
+    },
+    {
+      "id": "ES-C24-mano",
+      "language": "spanish",
+      "chapter": 24,
+      "sequence": 1420,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:c30685b9a391edd2"
+    },
+    {
+      "id": "ES-C25-las-estaciones",
+      "language": "spanish",
+      "chapter": 25,
+      "sequence": 1430,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:3b1b0233f9810058"
+    },
+    {
+      "id": "ES-C26-agua",
+      "language": "spanish",
+      "chapter": 26,
+      "sequence": 1440,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:af75f70992f67934"
+    },
+    {
+      "id": "ES-C26-vino",
+      "language": "spanish",
+      "chapter": 26,
+      "sequence": 1450,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:6254dc7ee5085423"
+    },
+    {
+      "id": "ES-C26-pan",
+      "language": "spanish",
+      "chapter": 26,
+      "sequence": 1460,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:652a27f226793cb3"
+    },
+    {
+      "id": "ES-C27-los-meses",
+      "language": "spanish",
+      "chapter": 27,
+      "sequence": 1470,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:5b5026e865212425"
+    },
+    {
+      "id": "ES-C28-mediodia-medianoche",
+      "language": "spanish",
+      "chapter": 28,
+      "sequence": 1480,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:b3bfe0b28d5bddf9"
+    },
+    {
+      "id": "ES-C29-la-hora",
+      "language": "spanish",
+      "chapter": 29,
+      "sequence": 1490,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:829c80cb6c072acc"
+    },
+    {
+      "id": "ES-C30-el-tiempo",
+      "language": "spanish",
+      "chapter": 30,
+      "sequence": 1500,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:287d2a03bb8678d5"
+    },
+    {
+      "id": "ES-C30-hace-calor",
+      "language": "spanish",
+      "chapter": 30,
+      "sequence": 1510,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:465eaf6ee7b3b25d"
+    },
+    {
+      "id": "ES-C30-llueve",
+      "language": "spanish",
+      "chapter": 30,
+      "sequence": 1520,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:51189e6ba928a1c4"
+    },
+    {
+      "id": "ES-C31-once-quince",
+      "language": "spanish",
+      "chapter": 31,
+      "sequence": 1530,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:d051928bb9223bdb"
+    },
+    {
+      "id": "ES-C31-dieciseis-diecinueve",
+      "language": "spanish",
+      "chapter": 31,
+      "sequence": 1540,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:7ae87a0614eb6409"
+    },
+    {
+      "id": "ES-C31-teens-latinos",
+      "language": "spanish",
+      "chapter": 31,
+      "sequence": 1550,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:236f8af21463cfb4"
+    },
+    {
+      "id": "ES-C31-veinte",
+      "language": "spanish",
+      "chapter": 31,
+      "sequence": 1560,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:aec387ce76b2b2ff"
+    },
+    {
+      "id": "ES-C32-gato",
+      "language": "spanish",
+      "chapter": 32,
+      "sequence": 1570,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:b321d2286569f3f5"
+    },
+    {
+      "id": "ES-C32-perro",
+      "language": "spanish",
+      "chapter": 32,
+      "sequence": 1580,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:a433c43d4631a50d"
+    },
+    {
+      "id": "ES-C33-verde",
+      "language": "spanish",
+      "chapter": 33,
+      "sequence": 1590,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:a19f46a025249f81"
+    },
+    {
+      "id": "ES-C33-amarillo",
+      "language": "spanish",
+      "chapter": 33,
+      "sequence": 1600,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:0d33a8da6aadbc9d"
+    },
+    {
+      "id": "ES-C34-pensar",
+      "language": "spanish",
+      "chapter": 34,
+      "sequence": 1610,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:04f892f1e8481ab5"
+    },
+    {
+      "id": "ES-C34-entender",
+      "language": "spanish",
+      "chapter": 34,
+      "sequence": 1620,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:070edf4c229dd975"
+    },
+    {
+      "id": "ES-C34-leer",
+      "language": "spanish",
+      "chapter": 34,
+      "sequence": 1630,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:f9fce5111b86e152"
+    },
+    {
+      "id": "ES-C34-escribir",
+      "language": "spanish",
+      "chapter": 34,
+      "sequence": 1640,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:70b642cd35202bfe"
+    },
+    {
+      "id": "ES-C35-tomar",
+      "language": "spanish",
+      "chapter": 35,
+      "sequence": 1650,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:734e9cd53f6a9bc3"
+    },
+    {
+      "id": "ES-C35-preguntar",
+      "language": "spanish",
+      "chapter": 35,
+      "sequence": 1660,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:c5b2f574d22b44eb"
+    },
+    {
+      "id": "ES-C35-ayudar",
+      "language": "spanish",
+      "chapter": 35,
+      "sequence": 1670,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:8a9e95416ea42c5e"
+    },
+    {
+      "id": "ES-C35-gustar",
+      "language": "spanish",
+      "chapter": 35,
+      "sequence": 1680,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:076b246ba782b686"
     },
     {
       "id": "TA-W01-curves-va-ka",

--- a/code/learning/human-languages/spanish/book/chapters/ch03-introductions.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch03-introductions.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:42fbffb8f2c9ee65
+% canonical-source-hash: fnv1a64:c33320f1373d714f
 % canonical-lessons: ES-C03-me, ES-C03-llamar, ES-C03-me-llamo, ES-C03-tu-usted, ES-C03-tu-usted-register, ES-C03-usted-origin, ES-C03-como, ES-C03-como-acento, ES-C03-familia-qu, ES-C03-se-llama, ES-C03-como-se-llama, ES-C03-mucho, ES-C03-gusto, ES-C03-practice
 
 \chapter{Introducing Yourself}

--- a/code/learning/human-languages/spanish/book/chapters/ch04-how-are-you.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch04-how-are-you.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:5410c6a8b2635804
+% canonical-source-hash: fnv1a64:725d6b137377bf9c
 % canonical-lessons: ES-C04-gracias, ES-C04-de-nada, ES-C04-estar, ES-C04-estar-estado, ES-C04-como-esta, ES-C04-como-estas-register, ES-C04-regular, ES-C04-y, ES-W01-acento, ES-W01-tilde-diacritica, ES-W02-enye, ES-W02-enye-formas, ES-W03-inverted, ES-W03-question-span, ES-C04-practice
 
 \chapter{How Are You?}

--- a/code/learning/human-languages/spanish/book/chapters/ch05-farewells.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch05-farewells.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:9914574b6e231c0f
+% canonical-source-hash: fnv1a64:cff622156693b783
 % canonical-lessons: ES-C05-adios, ES-C05-hasta, ES-C05-hasta-limits, ES-C05-hasta-luego, ES-C05-hasta-manana, ES-C05-hasta-pronto, ES-C05-practice
 
 \chapter{Farewells}

--- a/code/learning/human-languages/spanish/book/chapters/ch06-first-verbs.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch06-first-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:4450428fd5374b11
+% canonical-source-hash: fnv1a64:4fe3507a54682e0b
 % canonical-lessons: ES-C06-cafe, ES-C06-por-favor, ES-C06-hablar, ES-C06-ar-presente, ES-C06-trabajar, ES-C06-estudiar, ES-C06-espanol, ES-C06-hablo-espanol, ES-C06-practice
 
 \chapter{The First Verbs}

--- a/code/learning/human-languages/spanish/book/chapters/ch19-yes-and-no.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch19-yes-and-no.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:348146303665aa93
+% canonical-source-hash: fnv1a64:26065bd139568e43
 % canonical-lessons: ES-C19-si, ES-C19-no
 
 \chapter{Yes and No}

--- a/code/learning/human-languages/spanish/book/chapters/ch20-lo-siento.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch20-lo-siento.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:ff8b8576d2795748
+% canonical-source-hash: fnv1a64:eb8a28c91366131e
 % canonical-lessons: ES-C20-lo-siento, ES-C20-perdon
 
 \chapter{Lo Siento}

--- a/code/learning/human-languages/spanish/book/chapters/ch21-days-of-the-week.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch21-days-of-the-week.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:9f1f17a520fa7add
+% canonical-source-hash: fnv1a64:cbada3c250a98194
 % canonical-lessons: ES-C21-lunes-viernes, ES-C21-sabado-domingo
 
 \chapter{Days of the Week}

--- a/code/learning/human-languages/spanish/book/chapters/ch22-black-white-red-blue.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch22-black-white-red-blue.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:8bfd3dca44e35355
+% canonical-source-hash: fnv1a64:7ce9af6cb50c3202
 % canonical-lessons: ES-C22-negro-blanco, ES-C22-blanco-germanico, ES-C22-rojo, ES-C22-azul
 
 \chapter{Black, White, Red, and Blue}

--- a/code/learning/human-languages/spanish/book/chapters/ch23-family.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch23-family.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:65f7e89fb2452174
+% canonical-source-hash: fnv1a64:55d2e4bd397961e0
 % canonical-lessons: ES-C23-padre-madre, ES-C23-hermano-hermana, ES-C23-hermano-hache
 
 \chapter{Parents and Siblings}

--- a/code/learning/human-languages/spanish/book/chapters/ch24-head-and-hand.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch24-head-and-hand.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:cb85e3f2de32dd93
+% canonical-source-hash: fnv1a64:d9335133eebe69c2
 % canonical-lessons: ES-C24-cabeza, ES-C24-mano
 
 \chapter{Head and Hand}

--- a/code/learning/human-languages/spanish/book/chapters/ch25-seasons.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch25-seasons.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:b76c71606e7c1944
+% canonical-source-hash: fnv1a64:ce540eb8329698ee
 % canonical-lessons: ES-C25-las-estaciones
 
 \chapter{The Seasons}

--- a/code/learning/human-languages/spanish/book/chapters/ch26-water-wine-bread.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch26-water-wine-bread.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:7d92244aefd55f9c
+% canonical-source-hash: fnv1a64:adcb64dbcc088e9f
 % canonical-lessons: ES-C26-agua, ES-C26-vino, ES-C26-pan
 
 \chapter{Water, Wine, and Bread}

--- a/code/learning/human-languages/spanish/book/chapters/ch27-months.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch27-months.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:3c0241436ecab0b0
+% canonical-source-hash: fnv1a64:1221fb0b96f61360
 % canonical-lessons: ES-C27-los-meses
 
 \chapter{The Months}

--- a/code/learning/human-languages/spanish/book/chapters/ch28-noon-midnight.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch28-noon-midnight.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:67c5930a2b05b153
+% canonical-source-hash: fnv1a64:ab0e2305d98d0480
 % canonical-lessons: ES-C28-mediodia-medianoche
 
 \chapter{Noon and Midnight}

--- a/code/learning/human-languages/spanish/book/chapters/ch29-telling-time.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch29-telling-time.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:ba45be8faf01ca69
+% canonical-source-hash: fnv1a64:2a23e6b112a7d818
 % canonical-lessons: ES-C29-la-hora
 
 \chapter{Telling Time}

--- a/code/learning/human-languages/spanish/book/chapters/ch30-weather.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch30-weather.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:87388bb3aea1cfc8
+% canonical-source-hash: fnv1a64:6148ab69b50fe394
 % canonical-lessons: ES-C30-el-tiempo, ES-C30-hace-calor, ES-C30-llueve
 
 \chapter{The Weather}

--- a/code/learning/human-languages/spanish/book/chapters/ch31-numbers-11-20.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch31-numbers-11-20.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:b65e81d19628893e
+% canonical-source-hash: fnv1a64:96d1c45d4a4ca6a3
 % canonical-lessons: ES-C31-once-quince, ES-C31-dieciseis-diecinueve, ES-C31-teens-latinos, ES-C31-veinte
 
 \chapter{Numbers Eleven to Twenty}

--- a/code/learning/human-languages/spanish/book/chapters/ch32-dog-and-cat.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch32-dog-and-cat.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:e38a946a84daf051
+% canonical-source-hash: fnv1a64:d1283505847604c8
 % canonical-lessons: ES-C32-gato, ES-C32-perro
 
 \chapter{Dog and Cat}

--- a/code/learning/human-languages/spanish/book/chapters/ch33-green-and-yellow.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch33-green-and-yellow.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:9997a29a09400b47
+% canonical-source-hash: fnv1a64:1193d6388479368f
 % canonical-lessons: ES-C33-verde, ES-C33-amarillo
 
 \chapter{Green and Yellow}

--- a/code/learning/human-languages/spanish/book/chapters/ch34-verbs-of-the-mind.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch34-verbs-of-the-mind.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:bc65a341cf39fbb6
+% canonical-source-hash: fnv1a64:64748b10c5f453b4
 % canonical-lessons: ES-C34-pensar, ES-C34-entender, ES-C34-leer, ES-C34-escribir
 
 \chapter{Four Verbs of the Mind}

--- a/code/learning/human-languages/spanish/book/chapters/ch35-take-ask-help.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch35-take-ask-help.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:28a0602c608252cb
+% canonical-source-hash: fnv1a64:e3c93cbb0c057188
 % canonical-lessons: ES-C35-tomar, ES-C35-preguntar, ES-C35-ayudar, ES-C35-gustar
 
 \chapter{Taking, Asking, Helping — and the Backwards Verb}

--- a/code/learning/human-languages/spanish/lessons/ES-C03-como-acento.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-como-acento.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C03-como-acento
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 185
+sequence: 200
 chapter: 3
 type: writing
 headword: ¿cómo?

--- a/code/learning/human-languages/spanish/lessons/ES-C03-como-se-llama.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-como-se-llama.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C03-como-se-llama
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 210
+sequence: 230
 chapter: 3
 type: word
 headword: ¿cómo se llama usted?

--- a/code/learning/human-languages/spanish/lessons/ES-C03-como.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-como.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C03-como
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 180
+sequence: 190
 chapter: 3
 type: word
 headword: cómo

--- a/code/learning/human-languages/spanish/lessons/ES-C03-familia-qu.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-familia-qu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C03-familia-qu
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 190
+sequence: 210
 chapter: 3
 type: etymology
 headword: qu-

--- a/code/learning/human-languages/spanish/lessons/ES-C03-gusto.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-gusto.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C03-gusto
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 230
+sequence: 250
 chapter: 3
 type: word
 headword: mucho gusto

--- a/code/learning/human-languages/spanish/lessons/ES-C03-mucho.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-mucho.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C03-mucho
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 220
+sequence: 240
 chapter: 3
 type: word
 headword: mucho

--- a/code/learning/human-languages/spanish/lessons/ES-C03-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-practice.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C03-practice
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 240
+sequence: 260
 chapter: 3
 type: practice-mix
 headword: (practice)

--- a/code/learning/human-languages/spanish/lessons/ES-C03-se-llama.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-se-llama.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C03-se-llama
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 200
+sequence: 220
 chapter: 3
 type: word
 headword: se llama

--- a/code/learning/human-languages/spanish/lessons/ES-C03-tu-usted-register.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-tu-usted-register.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C03-tu-usted-register
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 165
+sequence: 170
 chapter: 3
 type: word
 headword: tú o usted

--- a/code/learning/human-languages/spanish/lessons/ES-C03-usted-origin.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C03-usted-origin.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C03-usted-origin
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 170
+sequence: 180
 chapter: 3
 type: etymology
 headword: vuestra merced → usted

--- a/code/learning/human-languages/spanish/lessons/ES-C04-como-esta.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-como-esta.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C04-como-esta
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 280
+sequence: 310
 chapter: 4
 type: phrase
 headword: ¿cómo está usted?

--- a/code/learning/human-languages/spanish/lessons/ES-C04-como-estas-register.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-como-estas-register.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C04-como-estas-register
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 290
+sequence: 320
 chapter: 4
 type: grammar
 headword: ¿cómo está usted? / ¿cómo estás?

--- a/code/learning/human-languages/spanish/lessons/ES-C04-de-nada.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-de-nada.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C04-de-nada
 spine_node: SPINE-COURTESY-THANK
-sequence: 260
+sequence: 280
 chapter: 4
 type: phrase
 headword: de nada

--- a/code/learning/human-languages/spanish/lessons/ES-C04-estar-estado.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-estar-estado.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C04-estar-estado
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 275
+sequence: 300
 chapter: 4
 type: word
 headword: estás / está

--- a/code/learning/human-languages/spanish/lessons/ES-C04-estar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-estar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C04-estar
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 270
+sequence: 290
 chapter: 4
 type: word
 headword: estar

--- a/code/learning/human-languages/spanish/lessons/ES-C04-gracias.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-gracias.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C04-gracias
 spine_node: SPINE-COURTESY-THANK
-sequence: 250
+sequence: 270
 chapter: 4
 type: word
 headword: gracias

--- a/code/learning/human-languages/spanish/lessons/ES-C04-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-practice.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C04-practice
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 370
+sequence: 410
 chapter: 4
 type: practice-mix
 headword: (practice)

--- a/code/learning/human-languages/spanish/lessons/ES-C04-regular.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-regular.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C04-regular
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 300
+sequence: 330
 chapter: 4
 type: word
 headword: regular

--- a/code/learning/human-languages/spanish/lessons/ES-C04-y.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C04-y.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C04-y
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 310
+sequence: 340
 chapter: 4
 type: word
 headword: y / ¿y tú?

--- a/code/learning/human-languages/spanish/lessons/ES-C05-adios.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-adios.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C05-adios
 spine_node: SPINE-TAKE-LEAVE
-sequence: 380
+sequence: 420
 chapter: 5
 type: word
 headword: adiós

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-limits.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-limits.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C05-hasta-limits
 spine_node: SPINE-TAKE-LEAVE
-sequence: 400
+sequence: 440
 chapter: 5
 type: grammar
 headword: hasta aquí / hasta la noche

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-luego.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-luego.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C05-hasta-luego
 spine_node: SPINE-TAKE-LEAVE
-sequence: 410
+sequence: 450
 chapter: 5
 type: phrase
 headword: hasta luego

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-manana.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-manana.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C05-hasta-manana
 spine_node: SPINE-TAKE-LEAVE
-sequence: 420
+sequence: 460
 chapter: 5
 type: phrase
 headword: hasta mañana

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta-pronto.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta-pronto.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C05-hasta-pronto
 spine_node: SPINE-TAKE-LEAVE
-sequence: 430
+sequence: 470
 chapter: 5
 type: phrase
 headword: hasta pronto

--- a/code/learning/human-languages/spanish/lessons/ES-C05-hasta.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-hasta.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C05-hasta
 spine_node: SPINE-TAKE-LEAVE
-sequence: 390
+sequence: 430
 chapter: 5
 type: word
 headword: hasta

--- a/code/learning/human-languages/spanish/lessons/ES-C05-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C05-practice.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C05-practice
 spine_node: SPINE-TAKE-LEAVE
-sequence: 440
+sequence: 480
 chapter: 5
 type: practice-mix
 headword: (practice)

--- a/code/learning/human-languages/spanish/lessons/ES-C06-ar-presente.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-ar-presente.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C06-ar-presente
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 475
+sequence: 520
 chapter: 6
 type: word
 headword: hablo, hablas, habla

--- a/code/learning/human-languages/spanish/lessons/ES-C06-cafe.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-cafe.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C06-cafe
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 450
+sequence: 490
 chapter: 6
 type: word
 headword: café

--- a/code/learning/human-languages/spanish/lessons/ES-C06-espanol.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-espanol.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C06-espanol
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 500
+sequence: 550
 chapter: 6
 type: word
 headword: español

--- a/code/learning/human-languages/spanish/lessons/ES-C06-estudiar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-estudiar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C06-estudiar
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 490
+sequence: 540
 chapter: 6
 type: word
 headword: estudiar

--- a/code/learning/human-languages/spanish/lessons/ES-C06-hablar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-hablar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C06-hablar
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 470
+sequence: 510
 chapter: 6
 type: word
 headword: hablar

--- a/code/learning/human-languages/spanish/lessons/ES-C06-hablo-espanol.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-hablo-espanol.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C06-hablo-espanol
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 505
+sequence: 560
 chapter: 6
 type: phrase
 headword: Hablo español

--- a/code/learning/human-languages/spanish/lessons/ES-C06-por-favor.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-por-favor.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C06-por-favor
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 460
+sequence: 500
 chapter: 6
 type: phrase
 headword: por favor

--- a/code/learning/human-languages/spanish/lessons/ES-C06-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-practice.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C06-practice
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 510
+sequence: 570
 chapter: 6
 type: practice-mix
 headword: (practice)

--- a/code/learning/human-languages/spanish/lessons/ES-C06-trabajar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C06-trabajar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C06-trabajar
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 480
+sequence: 530
 chapter: 6
 type: word
 headword: trabajar

--- a/code/learning/human-languages/spanish/lessons/ES-C08-cuantos-anos.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C08-cuantos-anos.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C08-cuantos-anos
 chapter: 8
-sequence: 530
+sequence: 810
 type: phrase
 headword: ¿Cuántos años tienes?
 gloss: how old are you? (literally "how many years do you have?")

--- a/code/learning/human-languages/spanish/lessons/ES-C08-numeros-1-5.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C08-numeros-1-5.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C08-numeros-1-5
 chapter: 8
-sequence: 524
+sequence: 780
 type: word
 headword: uno, dos, tres, cuatro, cinco
 gloss: the numbers 1–5

--- a/code/learning/human-languages/spanish/lessons/ES-C08-numeros-6-10.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C08-numeros-6-10.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C08-numeros-6-10
 chapter: 8
-sequence: 526
+sequence: 790
 type: word
 headword: seis, siete, ocho, nueve, diez
 gloss: the numbers 6–10 (and the months hidden in them)

--- a/code/learning/human-languages/spanish/lessons/ES-C08-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C08-practice.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C08-practice
 chapter: 8
-sequence: 532
+sequence: 820
 type: practice-mix
 headword: (practice)
 gloss: counting, having, and telling your age

--- a/code/learning/human-languages/spanish/lessons/ES-C08-tener.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C08-tener.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C08-tener
 chapter: 8
-sequence: 528
+sequence: 800
 type: word
 headword: tener
 gloss: to have (your first irregular / stem-changing verb)

--- a/code/learning/human-languages/spanish/lessons/ES-C09-esta-en.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-esta-en.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C09-esta-en
 chapter: 9
-sequence: 540
+sequence: 860
 type: phrase
 headword: está en…
 gloss: "is in/at…" — location always takes estar

--- a/code/learning/human-languages/spanish/lessons/ES-C09-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-practice.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C09-practice
 chapter: 9
-sequence: 542
+sequence: 870
 type: practice-mix
 headword: (practice)
 gloss: drilling the ser / estar split

--- a/code/learning/human-languages/spanish/lessons/ES-C09-ser-vs-estar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-ser-vs-estar.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C09-ser-vs-estar
 chapter: 9
-sequence: 536
+sequence: 840
 type: phrase
 headword: ser vs estar
 gloss: the two "to be" verbs, contrasted — essence vs state

--- a/code/learning/human-languages/spanish/lessons/ES-C09-ser.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-ser.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C09-ser
 chapter: 9
-sequence: 534
+sequence: 830
 type: word
 headword: ser
 gloss: to be (identity — permanent, essential)

--- a/code/learning/human-languages/spanish/lessons/ES-C09-soy-de.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C09-soy-de.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C09-soy-de
 chapter: 9
-sequence: 538
+sequence: 850
 type: phrase
 headword: soy de…
 gloss: "I'm from…" — origin and identity take ser

--- a/code/learning/human-languages/spanish/lessons/ES-C10-ir-a-futuro.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C10-ir-a-futuro.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C10-ir-a-futuro
 chapter: 10
-sequence: 546
+sequence: 890
 type: phrase
 headword: voy a + infinitive
 gloss: the near future — "I'm going to…"

--- a/code/learning/human-languages/spanish/lessons/ES-C10-ir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C10-ir.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C10-ir
 chapter: 10
-sequence: 544
+sequence: 880
 type: word
 headword: ir
 gloss: to go (the most irregular Spanish verb — three Latin verbs in one)

--- a/code/learning/human-languages/spanish/lessons/ES-C10-mi-tu-su.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C10-mi-tu-su.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C10-mi-tu-su
 chapter: 10
-sequence: 548
+sequence: 900
 type: word
 headword: mi, tu, su
 gloss: my, your, his/her/your-formal (the possessives)

--- a/code/learning/human-languages/spanish/lessons/ES-C10-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C10-practice.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C10-practice
 chapter: 10
-sequence: 550
+sequence: 910
 type: practice-mix
 headword: (practice)
 gloss: going places, the near future, and whose things

--- a/code/learning/human-languages/spanish/lessons/ES-C11-nuestro.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-nuestro.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C11-nuestro
 chapter: 11
-sequence: 558
+sequence: 950
 type: word
 headword: nuestro
 gloss: our (and vuestro, "your"-plural) — the possessive that agrees fully

--- a/code/learning/human-languages/spanish/lessons/ES-C11-poder.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-poder.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C11-poder
 chapter: 11
-sequence: 554
+sequence: 930
 type: word
 headword: poder
 gloss: to be able / can — a stem-changing verb, o→ue

--- a/code/learning/human-languages/spanish/lessons/ES-C11-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-practice.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C11-practice
 chapter: 11
-sequence: 560
+sequence: 960
 type: practice-mix
 headword: (practice)
 gloss: wanting, being able, and the stem-change boot

--- a/code/learning/human-languages/spanish/lessons/ES-C11-querer.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-querer.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C11-querer
 chapter: 11
-sequence: 552
+sequence: 920
 type: word
 headword: querer
 gloss: to want (and to love) — a stem-changing verb, e→ie

--- a/code/learning/human-languages/spanish/lessons/ES-C11-stem-changes.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C11-stem-changes.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C11-stem-changes
 chapter: 11
-sequence: 556
+sequence: 940
 type: phrase
 headword: e→ie, o→ue
 gloss: the stem-change patterns, side by side — the "boot"

--- a/code/learning/human-languages/spanish/lessons/ES-C12-decir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-decir.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C12-decir
 chapter: 12
-sequence: 564
+sequence: 980
 type: word
 headword: decir
 gloss: to say / to tell — doubly irregular, digo + e→i

--- a/code/learning/human-languages/spanish/lessons/ES-C12-hacer.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-hacer.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C12-hacer
 chapter: 12
-sequence: 562
+sequence: 970
 type: word
 headword: hacer
 gloss: to do / to make — an irregular yo-form, hago

--- a/code/learning/human-languages/spanish/lessons/ES-C12-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-practice.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C12-practice
 chapter: 12
-sequence: 568
+sequence: 1000
 type: practice-mix
 headword: (practice)
 gloss: doing, making, saying — hacer, decir, and the -go club

--- a/code/learning/human-languages/spanish/lessons/ES-C12-yo-go.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C12-yo-go.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C12-yo-go
 chapter: 12
-sequence: 566
+sequence: 990
 type: phrase
 headword: -go
 gloss: the "-go" verbs — a small club whose yo-form ends in -go

--- a/code/learning/human-languages/spanish/lessons/ES-C13-poner.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-poner.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C13-poner
 chapter: 13
-sequence: 570
+sequence: 1010
 type: word
 headword: poner
 gloss: to put / to place — a -go yo-form, pongo

--- a/code/learning/human-languages/spanish/lessons/ES-C13-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-practice.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C13-practice
 chapter: 13
-sequence: 576
+sequence: 1040
 type: practice-mix
 headword: (practice)
 gloss: the whole -go club, complete — tengo, hago, digo, pongo, salgo, vengo

--- a/code/learning/human-languages/spanish/lessons/ES-C13-salir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-salir.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C13-salir
 chapter: 13
-sequence: 572
+sequence: 1020
 type: word
 headword: salir
 gloss: to leave / to go out — a -go yo-form, salgo, from a root that means "to leap"

--- a/code/learning/human-languages/spanish/lessons/ES-C13-venir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C13-venir.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C13-venir
 chapter: 13
-sequence: 574
+sequence: 1030
 type: word
 headword: venir
 gloss: to come — doubly irregular, vengo + e→ie, completing the -go club

--- a/code/learning/human-languages/spanish/lessons/ES-C14-hablar-preterite.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C14-hablar-preterite.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C14-hablar-preterite
 chapter: 14
-sequence: 580
+sequence: 1060
 type: word
 headword: hablé
 gloss: the regular -ar preterite — hablé, hablaste, habló — and why the accent matters

--- a/code/learning/human-languages/spanish/lessons/ES-C14-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C14-practice.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C14-practice
 chapter: 14
-sequence: 582
+sequence: 1070
 type: practice-mix
 headword: (practice)
 gloss: past vs present — fui, hablé, and the forms that look the same

--- a/code/learning/human-languages/spanish/lessons/ES-C14-ser-ir-preterite.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C14-ser-ir-preterite.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C14-ser-ir-preterite
 chapter: 14
-sequence: 578
+sequence: 1050
 type: word
 headword: fui
 gloss: the preterite (past) — and the astonishing fact that "I was" and "I went" are the same word

--- a/code/learning/human-languages/spanish/lessons/ES-C15-comer-vivir-preterite.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C15-comer-vivir-preterite.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C15-comer-vivir-preterite
 chapter: 15
-sequence: 584
+sequence: 1080
 type: word
 headword: comí, viví
 gloss: the regular -er/-ir preterite — where two conjugations collapse into one

--- a/code/learning/human-languages/spanish/lessons/ES-C15-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C15-practice.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C15-practice
 chapter: 15
-sequence: 588
+sequence: 1100
 type: practice-mix
 headword: (practice)
 gloss: the whole preterite — -ar, -er/-ir, and strong, told apart by where the stress lands

--- a/code/learning/human-languages/spanish/lessons/ES-C15-preterite-fuertes.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C15-preterite-fuertes.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C15-preterite-fuertes
 chapter: 15
-sequence: 586
+sequence: 1090
 type: word
 headword: tuve, hice, estuve
 gloss: the strong preterites — where the stress moves off the ending and the accent disappears

--- a/code/learning/human-languages/spanish/lessons/ES-C16-imperfecto.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C16-imperfecto.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C16-imperfecto
 chapter: 16
-sequence: 590
+sequence: 1110
 type: word
 headword: hablaba, comía
 gloss: the imperfect — the past that kept going, and the most regular tense in Spanish

--- a/code/learning/human-languages/spanish/lessons/ES-C16-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C16-practice.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C16-practice
 chapter: 16
-sequence: 594
+sequence: 1130
 type: practice-mix
 headword: (practice)
 gloss: preterite vs imperfect — the distinction English doesn't grammatically make

--- a/code/learning/human-languages/spanish/lessons/ES-C16-tres-irregulares.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C16-tres-irregulares.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C16-tres-irregulares
 chapter: 16
-sequence: 592
+sequence: 1120
 type: word
 headword: era, iba, veía
 gloss: the only three irregular imperfects in the entire language

--- a/code/learning/human-languages/spanish/lessons/ES-C17-condicional.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C17-condicional.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C17-condicional
 chapter: 17
-sequence: 598
+sequence: 1150
 type: word
 headword: hablaría
 gloss: the conditional — the same weld, using the imperfect of haber instead

--- a/code/learning/human-languages/spanish/lessons/ES-C17-future-guessing.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C17-future-guessing.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C17-future-guessing
 chapter: 17
-sequence: 602
+sequence: 1170
 type: grammar
 headword: serán las tres
 gloss: the future can express a present guess, and the conditional can express a past guess

--- a/code/learning/human-languages/spanish/lessons/ES-C17-futuro.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C17-futuro.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C17-futuro
 chapter: 17
-sequence: 596
+sequence: 1140
 type: word
 headword: hablaré
 gloss: the future — a compound tense that welded itself shut

--- a/code/learning/human-languages/spanish/lessons/ES-C17-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C17-practice.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C17-practice
 chapter: 17
-sequence: 600
+sequence: 1160
 type: practice-mix
 headword: (practice)
 gloss: the ten irregular stems that serve both future and conditional

--- a/code/learning/human-languages/spanish/lessons/ES-C18-inherited-subjunctive-stems.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-inherited-subjunctive-stems.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C18-inherited-subjunctive-stems
 chapter: 18
-sequence: 606
+sequence: 1190
 type: grammar
 headword: tenga, diga, haga; quiera, pueda
 gloss: irregular yo stems and stressed stem changes carry into the subjunctive automatically

--- a/code/learning/human-languages/spanish/lessons/ES-C18-ojala.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-ojala.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C18-ojala
 chapter: 18
-sequence: 616
+sequence: 1240
 type: etymology
 headword: ojalá
 gloss: a wish-word borrowed from Andalusi Arabic that triggers the subjunctive without que or a main verb

--- a/code/learning/human-languages/spanish/lessons/ES-C18-practice-mood.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-practice-mood.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C18-practice-mood
 chapter: 18
-sequence: 622
+sequence: 1270
 type: practice-mix
 headword: fact or wish?
 gloss: choosing indicative versus subjunctive and hearing the opposite-vowel contrast

--- a/code/learning/human-languages/spanish/lessons/ES-C18-practice-subjects.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-practice-subjects.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C18-practice-subjects
 chapter: 18
-sequence: 620
+sequence: 1260
 type: practice-mix
 headword: one subject or two?
 gloss: choosing infinitive versus que plus subjunctive after wanting

--- a/code/learning/human-languages/spanish/lessons/ES-C18-practice.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-practice.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C18-practice
 chapter: 18
-sequence: 618
+sequence: 1250
 type: practice-mix
 headword: "Chapter 18 practice"
 gloss: "drilling the vowel flip and inherited stems"

--- a/code/learning/human-languages/spanish/lessons/ES-C18-quiero-que.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-quiero-que.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C18-quiero-que
 chapter: 18
-sequence: 612
+sequence: 1220
 type: phrase
 headword: quiero que…
 gloss: "what triggers the subjunctive — one subject wanting another to act"

--- a/code/learning/human-languages/spanish/lessons/ES-C18-subjunctive-name.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-subjunctive-name.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C18-subjunctive-name
 chapter: 18
-sequence: 610
+sequence: 1210
 type: etymology
 headword: subjuntivo
 gloss: joined underneath — a mood named for its grammatical position in a subordinate clause

--- a/code/learning/human-languages/spanish/lessons/ES-C18-subjunctive-outliers.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-subjunctive-outliers.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C18-subjunctive-outliers
 chapter: 18
-sequence: 608
+sequence: 1200
 type: grammar
 headword: sea, vaya, sepa, haya; esté
 gloss: four forms must be learned outright, while estar keeps a regular stem with exceptional stress

--- a/code/learning/human-languages/spanish/lessons/ES-C18-subjuntivo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-subjuntivo.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C18-subjuntivo
 chapter: 18
-sequence: 604
+sequence: 1180
 type: word
 headword: hable, coma, viva
 gloss: "the regular present subjunctive — built from the yo form, with the vowel flipped"

--- a/code/learning/human-languages/spanish/lessons/ES-C18-wanting-clause-trap.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C18-wanting-clause-trap.md
@@ -1,7 +1,7 @@
 ---
 id: ES-C18-wanting-clause-trap
 chapter: 18
-sequence: 614
+sequence: 1230
 type: grammar
 headword: quiero que hables / quiero hablarte
 gloss: Spanish requires a full clause for a second subject after wanting, but permits object plus infinitive with perception and causation

--- a/code/learning/human-languages/spanish/lessons/ES-C19-no.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C19-no.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C19-no
 spine_node: SPINE-RESPOND-BASIC
-sequence: 650
+sequence: 1290
 chapter: 19
 type: word
 headword: no

--- a/code/learning/human-languages/spanish/lessons/ES-C19-si.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C19-si.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C19-si
 spine_node: SPINE-RESPOND-BASIC
-sequence: 640
+sequence: 1280
 chapter: 19
 type: word
 headword: sí

--- a/code/learning/human-languages/spanish/lessons/ES-C20-lo-siento.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C20-lo-siento.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C20-lo-siento
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 660
+sequence: 1300
 chapter: 20
 type: phrase
 headword: lo siento

--- a/code/learning/human-languages/spanish/lessons/ES-C20-perdon.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C20-perdon.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C20-perdon
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 665
+sequence: 1310
 chapter: 20
 type: phrase
 headword: perdón

--- a/code/learning/human-languages/spanish/lessons/ES-C21-lunes-viernes.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C21-lunes-viernes.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C21-lunes-viernes
 spine_node: SPINE-TIME-OF-DAY
-sequence: 670
+sequence: 1320
 chapter: 21
 type: word
 headword: lunes, martes, miércoles, jueves, viernes

--- a/code/learning/human-languages/spanish/lessons/ES-C21-sabado-domingo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C21-sabado-domingo.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C21-sabado-domingo
 spine_node: SPINE-TIME-OF-DAY
-sequence: 680
+sequence: 1330
 chapter: 21
 type: word
 headword: sábado, domingo

--- a/code/learning/human-languages/spanish/lessons/ES-C22-azul.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C22-azul.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C22-azul
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 705
+sequence: 1370
 chapter: 22
 type: word
 headword: azul

--- a/code/learning/human-languages/spanish/lessons/ES-C22-blanco-germanico.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C22-blanco-germanico.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C22-blanco-germanico
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 695
+sequence: 1350
 chapter: 22
 type: etymology
 headword: blanco ← *blank

--- a/code/learning/human-languages/spanish/lessons/ES-C22-negro-blanco.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C22-negro-blanco.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C22-negro-blanco
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 690
+sequence: 1340
 chapter: 22
 type: word
 headword: negro, blanco

--- a/code/learning/human-languages/spanish/lessons/ES-C22-rojo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C22-rojo.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C22-rojo
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 700
+sequence: 1360
 chapter: 22
 type: word
 headword: rojo

--- a/code/learning/human-languages/spanish/lessons/ES-C23-hermano-hache.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C23-hermano-hache.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C23-hermano-hache
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 725
+sequence: 1400
 chapter: 23
 type: etymology
 headword: hermano ← *ermano*

--- a/code/learning/human-languages/spanish/lessons/ES-C23-hermano-hermana.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C23-hermano-hermana.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C23-hermano-hermana
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 720
+sequence: 1390
 chapter: 23
 type: word
 headword: el hermano, la hermana

--- a/code/learning/human-languages/spanish/lessons/ES-C23-padre-madre.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C23-padre-madre.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C23-padre-madre
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 710
+sequence: 1380
 chapter: 23
 type: word
 headword: el padre, la madre

--- a/code/learning/human-languages/spanish/lessons/ES-C24-cabeza.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C24-cabeza.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C24-cabeza
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 730
+sequence: 1410
 chapter: 24
 type: word
 headword: la cabeza

--- a/code/learning/human-languages/spanish/lessons/ES-C24-mano.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C24-mano.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C24-mano
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 740
+sequence: 1420
 chapter: 24
 type: word
 headword: la mano

--- a/code/learning/human-languages/spanish/lessons/ES-C25-las-estaciones.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C25-las-estaciones.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C25-las-estaciones
 spine_node: SPINE-TIME-OF-DAY
-sequence: 750
+sequence: 1430
 chapter: 25
 type: word
 headword: la primavera, el verano, el otoño, el invierno

--- a/code/learning/human-languages/spanish/lessons/ES-C26-agua.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C26-agua.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C26-agua
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 760
+sequence: 1440
 chapter: 26
 type: word
 headword: el agua

--- a/code/learning/human-languages/spanish/lessons/ES-C26-pan.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C26-pan.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C26-pan
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 770
+sequence: 1460
 chapter: 26
 type: word
 headword: el pan

--- a/code/learning/human-languages/spanish/lessons/ES-C26-vino.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C26-vino.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C26-vino
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 765
+sequence: 1450
 chapter: 26
 type: word
 headword: el vino

--- a/code/learning/human-languages/spanish/lessons/ES-C27-los-meses.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C27-los-meses.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C27-los-meses
 spine_node: SPINE-TIME-OF-DAY
-sequence: 780
+sequence: 1470
 chapter: 27
 type: word
 headword: los meses

--- a/code/learning/human-languages/spanish/lessons/ES-C28-mediodia-medianoche.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C28-mediodia-medianoche.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C28-mediodia-medianoche
 spine_node: SPINE-TIME-OF-DAY
-sequence: 790
+sequence: 1480
 chapter: 28
 type: word
 headword: mediodía, medianoche

--- a/code/learning/human-languages/spanish/lessons/ES-C29-la-hora.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C29-la-hora.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C29-la-hora
 spine_node: SPINE-TIME-OF-DAY
-sequence: 800
+sequence: 1490
 chapter: 29
 type: word
 headword: la hora

--- a/code/learning/human-languages/spanish/lessons/ES-C30-el-tiempo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C30-el-tiempo.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C30-el-tiempo
 spine_node: SPINE-TIME-OF-DAY
-sequence: 810
+sequence: 1500
 chapter: 30
 type: word
 headword: el tiempo

--- a/code/learning/human-languages/spanish/lessons/ES-C30-hace-calor.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C30-hace-calor.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C30-hace-calor
 spine_node: SPINE-TIME-OF-DAY
-sequence: 813
+sequence: 1510
 chapter: 30
 type: phrase
 headword: hace calor, hace frío, hace sol

--- a/code/learning/human-languages/spanish/lessons/ES-C30-llueve.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C30-llueve.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C30-llueve
 spine_node: SPINE-TIME-OF-DAY
-sequence: 816
+sequence: 1520
 chapter: 30
 type: phrase
 headword: llueve

--- a/code/learning/human-languages/spanish/lessons/ES-C31-dieciseis-diecinueve.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C31-dieciseis-diecinueve.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C31-dieciseis-diecinueve
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 823
+sequence: 1540
 chapter: 31
 type: word
 headword: dieciséis — diecinueve

--- a/code/learning/human-languages/spanish/lessons/ES-C31-once-quince.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C31-once-quince.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C31-once-quince
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 820
+sequence: 1530
 chapter: 31
 type: word
 headword: once — quince

--- a/code/learning/human-languages/spanish/lessons/ES-C31-teens-latinos.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C31-teens-latinos.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C31-teens-latinos
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 825
+sequence: 1550
 chapter: 31
 type: etymology
 headword: duodēvīgintī, ūndēvīgintī

--- a/code/learning/human-languages/spanish/lessons/ES-C31-veinte.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C31-veinte.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C31-veinte
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 827
+sequence: 1560
 chapter: 31
 type: word
 headword: veinte

--- a/code/learning/human-languages/spanish/lessons/ES-C32-gato.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C32-gato.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C32-gato
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 830
+sequence: 1570
 chapter: 32
 type: word
 headword: gato

--- a/code/learning/human-languages/spanish/lessons/ES-C32-perro.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C32-perro.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C32-perro
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 835
+sequence: 1580
 chapter: 32
 type: word
 headword: perro

--- a/code/learning/human-languages/spanish/lessons/ES-C33-amarillo.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C33-amarillo.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C33-amarillo
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 845
+sequence: 1600
 chapter: 33
 type: word
 headword: amarillo

--- a/code/learning/human-languages/spanish/lessons/ES-C33-verde.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C33-verde.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C33-verde
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 840
+sequence: 1590
 chapter: 33
 type: word
 headword: verde

--- a/code/learning/human-languages/spanish/lessons/ES-C34-entender.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C34-entender.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C34-entender
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 855
+sequence: 1620
 chapter: 34
 type: word
 headword: entender

--- a/code/learning/human-languages/spanish/lessons/ES-C34-escribir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C34-escribir.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C34-escribir
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 865
+sequence: 1640
 chapter: 34
 type: word
 headword: escribir

--- a/code/learning/human-languages/spanish/lessons/ES-C34-leer.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C34-leer.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C34-leer
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 860
+sequence: 1630
 chapter: 34
 type: word
 headword: leer

--- a/code/learning/human-languages/spanish/lessons/ES-C34-pensar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C34-pensar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C34-pensar
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 850
+sequence: 1610
 chapter: 34
 type: word
 headword: pensar

--- a/code/learning/human-languages/spanish/lessons/ES-C35-ayudar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C35-ayudar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C35-ayudar
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 880
+sequence: 1670
 chapter: 35
 type: word
 headword: ayudar

--- a/code/learning/human-languages/spanish/lessons/ES-C35-gustar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C35-gustar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C35-gustar
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 885
+sequence: 1680
 chapter: 35
 type: word
 headword: gustar

--- a/code/learning/human-languages/spanish/lessons/ES-C35-preguntar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C35-preguntar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C35-preguntar
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 875
+sequence: 1660
 chapter: 35
 type: word
 headword: preguntar

--- a/code/learning/human-languages/spanish/lessons/ES-C35-tomar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C35-tomar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-C35-tomar
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 870
+sequence: 1650
 chapter: 35
 type: word
 headword: tomar

--- a/code/learning/human-languages/spanish/lessons/ES-W01-acento.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W01-acento.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-W01-acento
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 320
+sequence: 350
 chapter: 4
 type: writing
 headword: "á é í ó ú"

--- a/code/learning/human-languages/spanish/lessons/ES-W01-tilde-diacritica.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W01-tilde-diacritica.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-W01-tilde-diacritica
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 330
+sequence: 360
 chapter: 4
 type: writing
 headword: "el / él"

--- a/code/learning/human-languages/spanish/lessons/ES-W02-enye-formas.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W02-enye-formas.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-W02-enye-formas
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 345
+sequence: 380
 chapter: 4
 type: writing
 headword: mañana, español

--- a/code/learning/human-languages/spanish/lessons/ES-W02-enye.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W02-enye.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-W02-enye
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 340
+sequence: 370
 chapter: 4
 type: writing
 headword: "ñ"

--- a/code/learning/human-languages/spanish/lessons/ES-W03-inverted.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W03-inverted.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-W03-inverted
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 350
+sequence: 390
 chapter: 4
 type: writing
 headword: "¿ ¡"

--- a/code/learning/human-languages/spanish/lessons/ES-W03-question-span.md
+++ b/code/learning/human-languages/spanish/lessons/ES-W03-question-span.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: ES-W03-question-span
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 360
+sequence: 400
 chapter: 4
 type: writing
 headword: "Roberto, ¿cómo estás?"

--- a/code/learning/human-languages/spanish/narration/ch03.json
+++ b/code/learning/human-languages/spanish/narration/ch03.json
@@ -4,7 +4,7 @@
   "chapter": 3,
   "title": "Introducing Yourself",
   "drivablePrefix": 7,
-  "sourceHash": "fnv1a64:42fbffb8f2c9ee65",
+  "sourceHash": "fnv1a64:c33320f1373d714f",
   "lessons": [
     {
       "id": "ES-C03-me",
@@ -528,7 +528,7 @@
     },
     {
       "id": "ES-C03-tu-usted-register",
-      "sequence": 165,
+      "sequence": 170,
       "title": "tú or usted — a choice you have to make every time",
       "headword": "tú o usted",
       "romanization": "tú o usted",
@@ -539,7 +539,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9cae1a32ffd9d433",
+      "sourceHash": "fnv1a64:4e4c276351c8a68d",
       "notice": null,
       "blocks": [
         {
@@ -678,7 +678,7 @@
     },
     {
       "id": "ES-C03-usted-origin",
-      "sequence": 170,
+      "sequence": 180,
       "title": "vuestra merced becomes usted — respect compressed into one word",
       "headword": "vuestra merced → usted",
       "romanization": "vuestra merced → usted",
@@ -689,7 +689,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:313935a54432e2fc",
+      "sourceHash": "fnv1a64:a68e3b11f451f46b",
       "notice": null,
       "blocks": [
         {
@@ -807,7 +807,7 @@
     },
     {
       "id": "ES-C03-como",
-      "sequence": 180,
+      "sequence": 190,
       "title": "cómo — \"how,\" your first question word",
       "headword": "cómo",
       "romanization": "cómo",
@@ -818,7 +818,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9e4ea930fecfcd0b",
+      "sourceHash": "fnv1a64:466a23d3a98e138a",
       "notice": null,
       "blocks": [
         {
@@ -934,7 +934,7 @@
     },
     {
       "id": "ES-C03-como-acento",
-      "sequence": 185,
+      "sequence": 200,
       "title": "¿cómo? — the two marks that say \"this is a question\"",
       "headword": "¿cómo?",
       "romanization": "¿cómo?",
@@ -946,7 +946,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bec544478750ac13",
+      "sourceHash": "fnv1a64:7061ae42743cb58d",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -1094,7 +1094,7 @@
     },
     {
       "id": "ES-C03-familia-qu",
-      "sequence": 190,
+      "sequence": 210,
       "title": "The qu- question family — one ancient pattern, many clues",
       "headword": "qu-",
       "romanization": "qu-",
@@ -1105,7 +1105,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:b17345e50849e2c0",
+      "sourceHash": "fnv1a64:eb66f372cf2b6887",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -1237,7 +1237,7 @@
     },
     {
       "id": "ES-C03-se-llama",
-      "sequence": 200,
+      "sequence": 220,
       "title": "se llama — the reflexive that fits usted",
       "headword": "se llama",
       "romanization": "se llama",
@@ -1248,7 +1248,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5e44303bdf967b34",
+      "sourceHash": "fnv1a64:d63e1dc84f6301ca",
       "notice": null,
       "blocks": [
         {
@@ -1406,7 +1406,7 @@
     },
     {
       "id": "ES-C03-como-se-llama",
-      "sequence": 210,
+      "sequence": 230,
       "title": "¿cómo se llama usted? — assembling the question, and answering it",
       "headword": "¿cómo se llama usted?",
       "romanization": "¿cómo se llama usted?",
@@ -1417,7 +1417,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:15d93f753535461a",
+      "sourceHash": "fnv1a64:8579507a71fa8de4",
       "notice": null,
       "blocks": [
         {
@@ -1551,7 +1551,7 @@
     },
     {
       "id": "ES-C03-mucho",
-      "sequence": 220,
+      "sequence": 240,
       "title": "mucho — \"much,\" and a sound-change you've already seen",
       "headword": "mucho",
       "romanization": "mucho",
@@ -1562,7 +1562,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:0eb31d27e344bac8",
+      "sourceHash": "fnv1a64:6858d837f3aca63a",
       "notice": null,
       "blocks": [
         {
@@ -1673,7 +1673,7 @@
     },
     {
       "id": "ES-C03-gusto",
-      "sequence": 230,
+      "sequence": 250,
       "title": "gusto becomes mucho gusto — \"much pleasure\"",
       "headword": "mucho gusto",
       "romanization": "mucho gusto",
@@ -1684,7 +1684,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:dab0f8222a757a9f",
+      "sourceHash": "fnv1a64:a318581b4ba64bb9",
       "notice": null,
       "blocks": [
         {
@@ -1809,7 +1809,7 @@
     },
     {
       "id": "ES-C03-practice",
-      "sequence": 240,
+      "sequence": 260,
       "title": "Practice — introducing yourself",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -1820,7 +1820,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:15726c67051588f6",
+      "sourceHash": "fnv1a64:18b77f42953215fc",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch04.json
+++ b/code/learning/human-languages/spanish/narration/ch04.json
@@ -4,11 +4,11 @@
   "chapter": 4,
   "title": "How Are You?",
   "drivablePrefix": 8,
-  "sourceHash": "fnv1a64:5410c6a8b2635804",
+  "sourceHash": "fnv1a64:725d6b137377bf9c",
   "lessons": [
     {
       "id": "ES-C04-gracias",
-      "sequence": 250,
+      "sequence": 270,
       "title": "gracias — \"thank you,\" and a whole family of English words",
       "headword": "gracias",
       "romanization": "gracias",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:3969444c81af8bce",
+      "sourceHash": "fnv1a64:f5e3fa74cf594ffc",
       "notice": null,
       "blocks": [
         {
@@ -149,7 +149,7 @@
     },
     {
       "id": "ES-C04-de-nada",
-      "sequence": 260,
+      "sequence": 280,
       "title": "de nada — \"you're welcome,\" or \"it was nothing\"",
       "headword": "de nada",
       "romanization": "de nada",
@@ -160,7 +160,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5e5c913f2118ae08",
+      "sourceHash": "fnv1a64:3b8ebf50aed6457a",
       "notice": null,
       "blocks": [
         {
@@ -281,7 +281,7 @@
     },
     {
       "id": "ES-C04-estar",
-      "sequence": 270,
+      "sequence": 290,
       "title": "estar — \"to be,\" the standing kind",
       "headword": "estar",
       "romanization": "estar",
@@ -292,7 +292,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c48ba479e91735af",
+      "sourceHash": "fnv1a64:a0b65487b5a73d41",
       "notice": null,
       "blocks": [
         {
@@ -410,7 +410,7 @@
     },
     {
       "id": "ES-C04-estar-estado",
-      "sequence": 275,
+      "sequence": 300,
       "title": "estás / está — the two forms, and what they are for",
       "headword": "estás / está",
       "romanization": "estás / está",
@@ -421,7 +421,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c75d3f1d85a3378b",
+      "sourceHash": "fnv1a64:ad2c2ef9af54d91e",
       "notice": null,
       "blocks": [
         {
@@ -565,7 +565,7 @@
     },
     {
       "id": "ES-C04-como-esta",
-      "sequence": 280,
+      "sequence": 310,
       "title": "¿cómo está usted? — \"how are you?\"",
       "headword": "¿cómo está usted?",
       "romanization": "¿cómo está usted?",
@@ -576,7 +576,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d1b2bd3bf645f43d",
+      "sourceHash": "fnv1a64:4b38ddebc1627ccf",
       "notice": null,
       "blocks": [
         {
@@ -675,7 +675,7 @@
     },
     {
       "id": "ES-C04-como-estas-register",
-      "sequence": 290,
+      "sequence": 320,
       "title": "¿cómo está usted? / ¿cómo estás? — choose the register",
       "headword": "¿cómo está usted? / ¿cómo estás?",
       "romanization": "¿cómo está usted? / ¿cómo estás?",
@@ -686,7 +686,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5ac43b43f055da36",
+      "sourceHash": "fnv1a64:ec2185a3c64d23ae",
       "notice": null,
       "blocks": [
         {
@@ -800,7 +800,7 @@
     },
     {
       "id": "ES-C04-regular",
-      "sequence": 300,
+      "sequence": 330,
       "title": "regular / más o menos — the honest \"so-so\"",
       "headword": "regular",
       "romanization": "regular",
@@ -811,7 +811,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9f76e8eda46d6c3b",
+      "sourceHash": "fnv1a64:9041b6c5d8c595ae",
       "notice": null,
       "blocks": [
         {
@@ -965,7 +965,7 @@
     },
     {
       "id": "ES-C04-y",
-      "sequence": 310,
+      "sequence": 340,
       "title": "y / ¿y tú? — pass the question back",
       "headword": "y / ¿y tú?",
       "romanization": "y / ¿y tú?",
@@ -976,7 +976,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a061efc60a36db8d",
+      "sourceHash": "fnv1a64:bf5cf5002e53d936",
       "notice": null,
       "blocks": [
         {
@@ -1091,7 +1091,7 @@
     },
     {
       "id": "ES-W01-acento",
-      "sequence": 320,
+      "sequence": 350,
       "title": "á é í ó ú — the acute accent, and the two jobs it does",
       "headword": "á é í ó ú",
       "romanization": "á é í ó ú",
@@ -1103,7 +1103,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:baf8f0bf2acd2bcd",
+      "sourceHash": "fnv1a64:0a154ad329459672",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -1228,7 +1228,7 @@
     },
     {
       "id": "ES-W01-tilde-diacritica",
-      "sequence": 330,
+      "sequence": 360,
       "title": "el or él? — the accent as a meaning label",
       "headword": "el / él",
       "romanization": "el / él",
@@ -1239,7 +1239,7 @@
       "modalityReasons": [
         "writing-type"
       ],
-      "sourceHash": "fnv1a64:dc1796509ac801d3",
+      "sourceHash": "fnv1a64:fcfbb52aee30c7f8",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -1356,7 +1356,7 @@
     },
     {
       "id": "ES-W02-enye",
-      "sequence": 340,
+      "sequence": 370,
       "title": "ñ — the letter that remembers a doubled n",
       "headword": "ñ",
       "romanization": "ñ",
@@ -1368,7 +1368,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:54a1f5e3da8c51f6",
+      "sourceHash": "fnv1a64:f9ec537631d2b099",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -1503,7 +1503,7 @@
     },
     {
       "id": "ES-W02-enye-formas",
-      "sequence": 345,
+      "sequence": 380,
       "title": "mañana, español — the ñ in the words you are about to need",
       "headword": "mañana, español",
       "romanization": "mañana, español",
@@ -1515,7 +1515,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:50764998caf80a44",
+      "sourceHash": "fnv1a64:f42bf3408df4a291",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -1631,7 +1631,7 @@
     },
     {
       "id": "ES-W03-inverted",
-      "sequence": 350,
+      "sequence": 390,
       "title": "¿ ¡ — the marks that open a question",
       "headword": "¿ ¡",
       "romanization": "¿ ¡",
@@ -1643,7 +1643,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f2bf58f0935c07cd",
+      "sourceHash": "fnv1a64:4b185ff5be127741",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -1759,7 +1759,7 @@
     },
     {
       "id": "ES-W03-question-span",
-      "sequence": 360,
+      "sequence": 400,
       "title": "Where does ¿ begin? — bracket the spoken span",
       "headword": "Roberto, ¿cómo estás?",
       "romanization": "Roberto, ¿cómo estás?",
@@ -1771,7 +1771,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:99b94711b2c0d896",
+      "sourceHash": "fnv1a64:5df9c6a05264f0ad",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -1909,7 +1909,7 @@
     },
     {
       "id": "ES-C04-practice",
-      "sequence": 370,
+      "sequence": 410,
       "title": "Practice — \"how are you?\", start to finish",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -1920,7 +1920,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:4755fc6507f6e1a2",
+      "sourceHash": "fnv1a64:95b7ff61b4e942fd",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch05.json
+++ b/code/learning/human-languages/spanish/narration/ch05.json
@@ -4,11 +4,11 @@
   "chapter": 5,
   "title": "Farewells",
   "drivablePrefix": 7,
-  "sourceHash": "fnv1a64:9914574b6e231c0f",
+  "sourceHash": "fnv1a64:cff622156693b783",
   "lessons": [
     {
       "id": "ES-C05-adios",
-      "sequence": 380,
+      "sequence": 420,
       "title": "adiós — \"goodbye,\" or \"to God\"",
       "headword": "adiós",
       "romanization": "adiós",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6a680cbb31975a8e",
+      "sourceHash": "fnv1a64:1efab3e6e2d1971f",
       "notice": null,
       "blocks": [
         {
@@ -161,7 +161,7 @@
     },
     {
       "id": "ES-C05-hasta",
-      "sequence": 390,
+      "sequence": 430,
       "title": "hasta — \"until,\" and Spain's Arabic centuries",
       "headword": "hasta",
       "romanization": "hasta",
@@ -172,7 +172,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:2fa83bf6f818d032",
+      "sourceHash": "fnv1a64:0373a9248796f3f9",
       "notice": null,
       "blocks": [
         {
@@ -286,7 +286,7 @@
     },
     {
       "id": "ES-C05-hasta-limits",
-      "sequence": 400,
+      "sequence": 440,
       "title": "hasta aquí / hasta la noche — point to the limit",
       "headword": "hasta aquí / hasta la noche",
       "romanization": "hasta aquí / hasta la noche",
@@ -297,7 +297,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:671f64f069058b1a",
+      "sourceHash": "fnv1a64:8a9a3573eb8c6a3e",
       "notice": null,
       "blocks": [
         {
@@ -405,7 +405,7 @@
     },
     {
       "id": "ES-C05-hasta-luego",
-      "sequence": 410,
+      "sequence": 450,
       "title": "hasta luego — the everyday \"see you later\"",
       "headword": "hasta luego",
       "romanization": "hasta luego",
@@ -416,7 +416,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c7c6ad01ee274beb",
+      "sourceHash": "fnv1a64:77d7a5f501080017",
       "notice": null,
       "blocks": [
         {
@@ -561,7 +561,7 @@
     },
     {
       "id": "ES-C05-hasta-manana",
-      "sequence": 420,
+      "sequence": 460,
       "title": "hasta mañana — \"see you tomorrow\" (and the ñ returns)",
       "headword": "hasta mañana",
       "romanization": "hasta mañana",
@@ -572,7 +572,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:cfc7945c70776255",
+      "sourceHash": "fnv1a64:a6a61bd22ad29bc9",
       "notice": null,
       "blocks": [
         {
@@ -698,7 +698,7 @@
     },
     {
       "id": "ES-C05-hasta-pronto",
-      "sequence": 430,
+      "sequence": 470,
       "title": "hasta pronto — \"see you soon\"",
       "headword": "hasta pronto",
       "romanization": "hasta pronto",
@@ -709,7 +709,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:54f0024553c75758",
+      "sourceHash": "fnv1a64:512b57b48ebad954",
       "notice": null,
       "blocks": [
         {
@@ -854,7 +854,7 @@
     },
     {
       "id": "ES-C05-practice",
-      "sequence": 440,
+      "sequence": 480,
       "title": "Practice — saying goodbye",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -865,7 +865,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:cd27f0a890b9511f",
+      "sourceHash": "fnv1a64:bb6a1ec725b3062b",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch06.json
+++ b/code/learning/human-languages/spanish/narration/ch06.json
@@ -4,11 +4,11 @@
   "chapter": 6,
   "title": "The First Verbs",
   "drivablePrefix": 3,
-  "sourceHash": "fnv1a64:4450428fd5374b11",
+  "sourceHash": "fnv1a64:4fe3507a54682e0b",
   "lessons": [
     {
       "id": "ES-C06-cafe",
-      "sequence": 450,
+      "sequence": 490,
       "title": "café — coffee, and a place to drink it",
       "headword": "café",
       "romanization": "café",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f25db04ee0f884da",
+      "sourceHash": "fnv1a64:4b96d615a4e56676",
       "notice": null,
       "blocks": [
         {
@@ -126,7 +126,7 @@
     },
     {
       "id": "ES-C06-por-favor",
-      "sequence": 460,
+      "sequence": 500,
       "title": "por favor — \"please,\" i.e. \"for a favour\"",
       "headword": "por favor",
       "romanization": "por favor",
@@ -137,7 +137,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:3ac312a5638b2595",
+      "sourceHash": "fnv1a64:f66d4757e7f825f2",
       "notice": null,
       "blocks": [
         {
@@ -275,7 +275,7 @@
     },
     {
       "id": "ES-C06-hablar",
-      "sequence": 470,
+      "sequence": 510,
       "title": "hablar — \"to speak,\" which used to mean \"to tell tales\"",
       "headword": "hablar",
       "romanization": "hablar",
@@ -286,7 +286,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ec974cf7795b5dea",
+      "sourceHash": "fnv1a64:f0eaf961627f631b",
       "notice": null,
       "blocks": [
         {
@@ -405,7 +405,7 @@
     },
     {
       "id": "ES-C06-ar-presente",
-      "sequence": 475,
+      "sequence": 520,
       "title": "hablo, hablas, habla — one ending swap, three sentences",
       "headword": "hablo, hablas, habla",
       "romanization": "hablo, hablas, habla",
@@ -417,7 +417,7 @@
         "sight-cue",
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:16c2c3aaca0bd5c9",
+      "sourceHash": "fnv1a64:d62ffbd226de0824",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -557,7 +557,7 @@
     },
     {
       "id": "ES-C06-trabajar",
-      "sequence": 480,
+      "sequence": 530,
       "title": "trabajar — \"to work,\" and it once meant torture",
       "headword": "trabajar",
       "romanization": "trabajar",
@@ -568,7 +568,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:87e1da307dcee2f5",
+      "sourceHash": "fnv1a64:045c7903c73d446d",
       "notice": null,
       "blocks": [
         {
@@ -721,7 +721,7 @@
     },
     {
       "id": "ES-C06-estudiar",
-      "sequence": 490,
+      "sequence": 540,
       "title": "estudiar — \"to study,\" and the eagerness inside it",
       "headword": "estudiar",
       "romanization": "estudiar",
@@ -732,7 +732,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e41c7eebc5f12c68",
+      "sourceHash": "fnv1a64:a0caa17d21e7026e",
       "notice": null,
       "blocks": [
         {
@@ -889,7 +889,7 @@
     },
     {
       "id": "ES-C06-espanol",
-      "sequence": 500,
+      "sequence": 550,
       "title": "español — the word for the language",
       "headword": "español",
       "romanization": "español",
@@ -900,7 +900,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:96238d0438890a16",
+      "sourceHash": "fnv1a64:3419ebdf7bb7ba3f",
       "notice": null,
       "blocks": [
         {
@@ -1004,7 +1004,7 @@
     },
     {
       "id": "ES-C06-hablo-espanol",
-      "sequence": 505,
+      "sequence": 560,
       "title": "Hablo español — your first real sentence",
       "headword": "Hablo español",
       "romanization": "Hablo español",
@@ -1015,7 +1015,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5bc0c2715a5aa607",
+      "sourceHash": "fnv1a64:359d617ceb162fa6",
       "notice": null,
       "blocks": [
         {
@@ -1146,7 +1146,7 @@
     },
     {
       "id": "ES-C06-practice",
-      "sequence": 510,
+      "sequence": 570,
       "title": "Practice — making sentences with -ar verbs",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -1157,7 +1157,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e76d3d2926c9d2bb",
+      "sourceHash": "fnv1a64:5688a6936f544445",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch08.json
+++ b/code/learning/human-languages/spanish/narration/ch08.json
@@ -4,11 +4,11 @@
   "chapter": 8,
   "title": "Chapter 8",
   "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:f96b7bbd0ab4daba",
+  "sourceHash": "fnv1a64:04ed5b71dcd6ef10",
   "lessons": [
     {
       "id": "ES-C08-numeros-1-5",
-      "sequence": 524,
+      "sequence": 780,
       "title": "uno, dos, tres, cuatro, cinco — counting to five",
       "headword": "uno, dos, tres, cuatro, cinco",
       "romanization": "uno, dos, tres, cuatro, cinco",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d0ad0f4bf00e9dd5",
+      "sourceHash": "fnv1a64:b46d43b715b1eab9",
       "notice": null,
       "blocks": [
         {
@@ -154,7 +154,7 @@
     },
     {
       "id": "ES-C08-numeros-6-10",
-      "sequence": 526,
+      "sequence": 790,
       "title": "seis, siete, ocho, nueve, diez — and the calendar's secret",
       "headword": "seis, siete, ocho, nueve, diez",
       "romanization": "seis, siete, ocho, nueve, diez",
@@ -165,7 +165,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:31bbfdae30ea5829",
+      "sourceHash": "fnv1a64:ed0886a860ddd794",
       "notice": null,
       "blocks": [
         {
@@ -308,7 +308,7 @@
     },
     {
       "id": "ES-C08-tener",
-      "sequence": 528,
+      "sequence": 800,
       "title": "tener — \"to have,\" your first irregular verb",
       "headword": "tener",
       "romanization": "tener",
@@ -319,7 +319,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d7ac3ca77bc32f7f",
+      "sourceHash": "fnv1a64:41443319609fc232",
       "notice": null,
       "blocks": [
         {
@@ -466,7 +466,7 @@
     },
     {
       "id": "ES-C08-cuantos-anos",
-      "sequence": 530,
+      "sequence": 810,
       "title": "¿Cuántos años tienes? — \"how old are you?\"",
       "headword": "¿Cuántos años tienes?",
       "romanization": "¿Cuántos años tienes?",
@@ -477,7 +477,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:fcb5f16ab501160a",
+      "sourceHash": "fnv1a64:c8e8c4495c46b9fb",
       "notice": null,
       "blocks": [
         {
@@ -597,7 +597,7 @@
     },
     {
       "id": "ES-C08-practice",
-      "sequence": 532,
+      "sequence": 820,
       "title": "Practice — numbers, having, and age",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -608,7 +608,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6c650d67ce5cb460",
+      "sourceHash": "fnv1a64:933eafd23ceb4124",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch09.json
+++ b/code/learning/human-languages/spanish/narration/ch09.json
@@ -4,11 +4,11 @@
   "chapter": 9,
   "title": "Chapter 9",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:a145296a95911d1d",
+  "sourceHash": "fnv1a64:31ecfffb1213f2bb",
   "lessons": [
     {
       "id": "ES-C09-ser",
-      "sequence": 534,
+      "sequence": 830,
       "title": "ser — \"to be,\" the essential kind",
       "headword": "ser",
       "romanization": "ser",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:06810f2823517346",
+      "sourceHash": "fnv1a64:f6c1102f99e48dfb",
       "notice": null,
       "blocks": [
         {
@@ -170,7 +170,7 @@
     },
     {
       "id": "ES-C09-ser-vs-estar",
-      "sequence": 536,
+      "sequence": 840,
       "title": "ser vs estar — essence vs state",
       "headword": "ser vs estar",
       "romanization": "ser vs estar",
@@ -181,7 +181,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:2e697cd43b1008d8",
+      "sourceHash": "fnv1a64:079927285e2d7c12",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -354,7 +354,7 @@
     },
     {
       "id": "ES-C09-soy-de",
-      "sequence": 538,
+      "sequence": 850,
       "title": "soy de… — saying where you're from",
       "headword": "soy de…",
       "romanization": "soy de…",
@@ -365,7 +365,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9d827a379647bb01",
+      "sourceHash": "fnv1a64:7d7dc85d231765fe",
       "notice": null,
       "blocks": [
         {
@@ -499,7 +499,7 @@
     },
     {
       "id": "ES-C09-esta-en",
-      "sequence": 540,
+      "sequence": 860,
       "title": "está en… — saying where something is",
       "headword": "está en…",
       "romanization": "está en…",
@@ -510,7 +510,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:c4741a1391c9dd4e",
+      "sourceHash": "fnv1a64:e1ee931ddaf78a6d",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -661,7 +661,7 @@
     },
     {
       "id": "ES-C09-practice",
-      "sequence": 542,
+      "sequence": 870,
       "title": "Practice — ser or estar?",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -672,7 +672,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:bb563dc466711e9c",
+      "sourceHash": "fnv1a64:1a1ac8d5f28b64da",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/spanish/narration/ch10.json
+++ b/code/learning/human-languages/spanish/narration/ch10.json
@@ -4,11 +4,11 @@
   "chapter": 10,
   "title": "Chapter 10",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:3341e73c1c7419bf",
+  "sourceHash": "fnv1a64:dee01cb1d828b806",
   "lessons": [
     {
       "id": "ES-C10-ir",
-      "sequence": 544,
+      "sequence": 880,
       "title": "ir — \"to go,\" stitched from three verbs",
       "headword": "ir",
       "romanization": "ir",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a112992448d98155",
+      "sourceHash": "fnv1a64:97e7c19bbe741eda",
       "notice": null,
       "blocks": [
         {
@@ -181,7 +181,7 @@
     },
     {
       "id": "ES-C10-ir-a-futuro",
-      "sequence": 546,
+      "sequence": 890,
       "title": "voy a + infinitive — the \"going-to\" future",
       "headword": "voy a + infinitive",
       "romanization": "voy a + infinitive",
@@ -192,7 +192,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:593eb56d09a903d9",
+      "sourceHash": "fnv1a64:2efae4f60d605d59",
       "notice": null,
       "blocks": [
         {
@@ -316,7 +316,7 @@
     },
     {
       "id": "ES-C10-mi-tu-su",
-      "sequence": 548,
+      "sequence": 900,
       "title": "mi, tu, su — my, your, his/her",
       "headword": "mi, tu, su",
       "romanization": "mi, tu, su",
@@ -327,7 +327,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:9e0132e713e2e689",
+      "sourceHash": "fnv1a64:c16ec47331e0c841",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -478,7 +478,7 @@
     },
     {
       "id": "ES-C10-practice",
-      "sequence": 550,
+      "sequence": 910,
       "title": "Practice — ir, the near future, and possessives",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -489,7 +489,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6e9314985eb5ba8d",
+      "sourceHash": "fnv1a64:e10c22caf5db30ed",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch11.json
+++ b/code/learning/human-languages/spanish/narration/ch11.json
@@ -4,11 +4,11 @@
   "chapter": 11,
   "title": "Chapter 11",
   "drivablePrefix": 5,
-  "sourceHash": "fnv1a64:1845998478b152fa",
+  "sourceHash": "fnv1a64:69ad78a547a85c5d",
   "lessons": [
     {
       "id": "ES-C11-querer",
-      "sequence": 552,
+      "sequence": 920,
       "title": "querer — \"to want,\" and the e becomes ie crack again",
       "headword": "querer",
       "romanization": "querer",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5431d0644d171e4a",
+      "sourceHash": "fnv1a64:544fa5d83e0f113f",
       "notice": null,
       "blocks": [
         {
@@ -162,7 +162,7 @@
     },
     {
       "id": "ES-C11-poder",
-      "sequence": 554,
+      "sequence": 930,
       "title": "poder — \"to be able,\" and the o becomes ue crack",
       "headword": "poder",
       "romanization": "poder",
@@ -173,7 +173,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:2d66abfcc957b70d",
+      "sourceHash": "fnv1a64:d5319cef387b6b17",
       "notice": null,
       "blocks": [
         {
@@ -335,7 +335,7 @@
     },
     {
       "id": "ES-C11-stem-changes",
-      "sequence": 556,
+      "sequence": 940,
       "title": "e becomes ie and o becomes ue — one rule, two vowels",
       "headword": "e→ie, o→ue",
       "romanization": "e→ie, o→ue",
@@ -346,7 +346,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c7b9e4b8437c58d5",
+      "sourceHash": "fnv1a64:8b3b70b2c52e51a2",
       "notice": null,
       "blocks": [
         {
@@ -486,7 +486,7 @@
     },
     {
       "id": "ES-C11-nuestro",
-      "sequence": 558,
+      "sequence": 950,
       "title": "nuestro — \"our,\" the possessive that agrees fully",
       "headword": "nuestro",
       "romanization": "nuestro",
@@ -497,7 +497,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7a0ac7c6de92c18d",
+      "sourceHash": "fnv1a64:93e91c4220c73ee9",
       "notice": null,
       "blocks": [
         {
@@ -622,7 +622,7 @@
     },
     {
       "id": "ES-C11-practice",
-      "sequence": 560,
+      "sequence": 960,
       "title": "Practice — querer, poder, and the boot",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -633,7 +633,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:76a65b2d1bd68da7",
+      "sourceHash": "fnv1a64:af92d49c34d3eda3",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch12.json
+++ b/code/learning/human-languages/spanish/narration/ch12.json
@@ -4,11 +4,11 @@
   "chapter": 12,
   "title": "Chapter 12",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:1e748551bb813072",
+  "sourceHash": "fnv1a64:ab04c43bed11cbe9",
   "lessons": [
     {
       "id": "ES-C12-hacer",
-      "sequence": 562,
+      "sequence": 970,
       "title": "hacer — \"to do / to make,\" and the yo-form that grows a g",
       "headword": "hacer",
       "romanization": "hacer",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:4eaa4375ddf5ddc9",
+      "sourceHash": "fnv1a64:0c31a56e74c2d5ee",
       "notice": null,
       "blocks": [
         {
@@ -171,7 +171,7 @@
     },
     {
       "id": "ES-C12-decir",
-      "sequence": 564,
+      "sequence": 980,
       "title": "decir — \"to say,\" the verb with two irregularities at once",
       "headword": "decir",
       "romanization": "decir",
@@ -182,7 +182,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:72edb388d5667454",
+      "sourceHash": "fnv1a64:4b8ca2a96fcd9236",
       "notice": null,
       "blocks": [
         {
@@ -333,7 +333,7 @@
     },
     {
       "id": "ES-C12-yo-go",
-      "sequence": 566,
+      "sequence": 990,
       "title": "The \"-go\" club — one irregular corner, many verbs",
       "headword": "-go",
       "romanization": "-go",
@@ -344,7 +344,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:676f366bba630168",
+      "sourceHash": "fnv1a64:17afaf4786688193",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -473,7 +473,7 @@
     },
     {
       "id": "ES-C12-practice",
-      "sequence": 568,
+      "sequence": 1000,
       "title": "Practice — hacer, decir, and the -go club",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -484,7 +484,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5cd89031d88c7419",
+      "sourceHash": "fnv1a64:fe2365102528f58f",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch13.json
+++ b/code/learning/human-languages/spanish/narration/ch13.json
@@ -4,11 +4,11 @@
   "chapter": 13,
   "title": "Chapter 13",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:a4e20b412d6537ba",
+  "sourceHash": "fnv1a64:9012955fa6cf35df",
   "lessons": [
     {
       "id": "ES-C13-poner",
-      "sequence": 570,
+      "sequence": 1010,
       "title": "poner — \"to put,\" and the club gains a member",
       "headword": "poner",
       "romanization": "poner",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:4a6d21b6e5842518",
+      "sourceHash": "fnv1a64:c049d52a0fb55326",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -169,7 +169,7 @@
     },
     {
       "id": "ES-C13-salir",
-      "sequence": 572,
+      "sequence": 1020,
       "title": "salir — \"to go out,\" from a verb that meant \"to leap\"",
       "headword": "salir",
       "romanization": "salir",
@@ -180,7 +180,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6e1368dae4cebfe2",
+      "sourceHash": "fnv1a64:fe496f4ed5343157",
       "notice": null,
       "blocks": [
         {
@@ -312,7 +312,7 @@
     },
     {
       "id": "ES-C13-venir",
-      "sequence": 574,
+      "sequence": 1030,
       "title": "venir — \"to come,\" the last club member, cracked and g-grown",
       "headword": "venir",
       "romanization": "venir",
@@ -323,7 +323,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:aabd87fb7c1c7eae",
+      "sourceHash": "fnv1a64:c3cbc4d6fcbeaafc",
       "notice": null,
       "blocks": [
         {
@@ -473,7 +473,7 @@
     },
     {
       "id": "ES-C13-practice",
-      "sequence": 576,
+      "sequence": 1040,
       "title": "Practice — the -go club, complete",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -484,7 +484,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:c38441962b855240",
+      "sourceHash": "fnv1a64:2497b5ca46b70d45",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/spanish/narration/ch14.json
+++ b/code/learning/human-languages/spanish/narration/ch14.json
@@ -4,11 +4,11 @@
   "chapter": 14,
   "title": "Chapter 14",
   "drivablePrefix": 3,
-  "sourceHash": "fnv1a64:7b5d1287654f2e62",
+  "sourceHash": "fnv1a64:a39884d4aea7bb13",
   "lessons": [
     {
       "id": "ES-C14-ser-ir-preterite",
-      "sequence": 578,
+      "sequence": 1050,
       "title": "fui — the past tense arrives, and two verbs become one",
       "headword": "fui",
       "romanization": "fui",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5cb98853f54215d7",
+      "sourceHash": "fnv1a64:4f976b4d96ae28b3",
       "notice": null,
       "blocks": [
         {
@@ -161,7 +161,7 @@
     },
     {
       "id": "ES-C14-hablar-preterite",
-      "sequence": 580,
+      "sequence": 1060,
       "title": "hablé — the regular past, built on an accent",
       "headword": "hablé",
       "romanization": "hablé",
@@ -172,7 +172,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:99d2ac9cf71ade02",
+      "sourceHash": "fnv1a64:cd3da96c84d6e042",
       "notice": null,
       "blocks": [
         {
@@ -314,7 +314,7 @@
     },
     {
       "id": "ES-C14-practice",
-      "sequence": 582,
+      "sequence": 1070,
       "title": "Practice — the preterite, past against present",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -325,7 +325,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:eefb1d965f836b28",
+      "sourceHash": "fnv1a64:15ba2316d6c80667",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch15.json
+++ b/code/learning/human-languages/spanish/narration/ch15.json
@@ -4,11 +4,11 @@
   "chapter": 15,
   "title": "Chapter 15",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:bf95b4776eb920c1",
+  "sourceHash": "fnv1a64:6a0d0566d7c228af",
   "lessons": [
     {
       "id": "ES-C15-comer-vivir-preterite",
-      "sequence": 584,
+      "sequence": 1080,
       "title": "comí, viví — two conjugations become one",
       "headword": "comí, viví",
       "romanization": "comí, viví",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c4492b031d93a760",
+      "sourceHash": "fnv1a64:29f4924f1b0065d6",
       "notice": null,
       "blocks": [
         {
@@ -167,7 +167,7 @@
     },
     {
       "id": "ES-C15-preterite-fuertes",
-      "sequence": 586,
+      "sequence": 1090,
       "title": "tuve, hice, estuve — the strong preterites",
       "headword": "tuve, hice, estuve",
       "romanization": "tuve, hice, estuve",
@@ -178,7 +178,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:1bf08f09f5512a0b",
+      "sourceHash": "fnv1a64:62a3242726961642",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -357,7 +357,7 @@
     },
     {
       "id": "ES-C15-practice",
-      "sequence": 588,
+      "sequence": 1100,
       "title": "Practice — three families, one question",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -368,7 +368,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:84f421ddf990bd02",
+      "sourceHash": "fnv1a64:4b3fcf24c86f0c33",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/spanish/narration/ch16.json
+++ b/code/learning/human-languages/spanish/narration/ch16.json
@@ -4,11 +4,11 @@
   "chapter": 16,
   "title": "Chapter 16",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:30eaac9352ed3655",
+  "sourceHash": "fnv1a64:82ec9c67f1912a73",
   "lessons": [
     {
       "id": "ES-C16-imperfecto",
-      "sequence": 590,
+      "sequence": 1110,
       "title": "hablaba, comía — the past that kept going",
       "headword": "hablaba, comía",
       "romanization": "hablaba, comía",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a7934411170c064f",
+      "sourceHash": "fnv1a64:e20f599f8e6f29be",
       "notice": null,
       "blocks": [
         {
@@ -195,7 +195,7 @@
     },
     {
       "id": "ES-C16-tres-irregulares",
-      "sequence": 592,
+      "sequence": 1120,
       "title": "era, iba, veía — all three of them",
       "headword": "era, iba, veía",
       "romanization": "era, iba, veía",
@@ -206,7 +206,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:f0aeca46b35f7ba0",
+      "sourceHash": "fnv1a64:9c3bcc2a62e8957e",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -378,7 +378,7 @@
     },
     {
       "id": "ES-C16-practice",
-      "sequence": 594,
+      "sequence": 1130,
       "title": "Practice — two pasts, one choice",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -389,7 +389,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:8ea9920b4d1ad6c4",
+      "sourceHash": "fnv1a64:f180bd5fc945e341",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch17.json
+++ b/code/learning/human-languages/spanish/narration/ch17.json
@@ -4,11 +4,11 @@
   "chapter": 17,
   "title": "Chapter 17",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:e4705d94e1f467da",
+  "sourceHash": "fnv1a64:987d104372c450ad",
   "lessons": [
     {
       "id": "ES-C17-futuro",
-      "sequence": 596,
+      "sequence": 1140,
       "title": "hablaré — the future, welded shut",
       "headword": "hablaré",
       "romanization": "hablaré",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:2a1bea9375fca1f7",
+      "sourceHash": "fnv1a64:75f5252fcaca8439",
       "notice": null,
       "blocks": [
         {
@@ -220,7 +220,7 @@
     },
     {
       "id": "ES-C17-condicional",
-      "sequence": 598,
+      "sequence": 1150,
       "title": "hablaría — the same weld, one tense over",
       "headword": "hablaría",
       "romanization": "hablaría",
@@ -231,7 +231,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b700b8e082384c9b",
+      "sourceHash": "fnv1a64:6938e0da50515712",
       "notice": null,
       "blocks": [
         {
@@ -414,7 +414,7 @@
     },
     {
       "id": "ES-C17-practice",
-      "sequence": 600,
+      "sequence": 1160,
       "title": "Practice — ten stems, two tenses",
       "headword": "(practice)",
       "romanization": "(practice)",
@@ -425,7 +425,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:2b4102bf168727e5",
+      "sourceHash": "fnv1a64:e9f899c42d6b76bd",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -597,7 +597,7 @@
     },
     {
       "id": "ES-C17-future-guessing",
-      "sequence": 602,
+      "sequence": 1170,
       "title": "serán las tres — future form, present guess",
       "headword": "serán las tres",
       "romanization": "serán las tres",
@@ -608,7 +608,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5527b162c3ab4fe8",
+      "sourceHash": "fnv1a64:a530fffb868e2f93",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch18.json
+++ b/code/learning/human-languages/spanish/narration/ch18.json
@@ -4,11 +4,11 @@
   "chapter": 18,
   "title": "Chapter 18",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:056b353dce315e5a",
+  "sourceHash": "fnv1a64:611f103a3f18023d",
   "lessons": [
     {
       "id": "ES-C18-subjuntivo",
-      "sequence": 604,
+      "sequence": 1180,
       "title": "hable, coma, viva — the subjunctive",
       "headword": "hable, coma, viva",
       "romanization": "hable, coma, viva",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:256303072a07e4d8",
+      "sourceHash": "fnv1a64:91ce99547c890c02",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -175,7 +175,7 @@
     },
     {
       "id": "ES-C18-inherited-subjunctive-stems",
-      "sequence": 606,
+      "sequence": 1190,
       "title": "tenga, diga, quiera — old irregularities come free",
       "headword": "tenga, diga, haga; quiera, pueda",
       "romanization": "tenga, diga, haga; quiera, pueda",
@@ -186,7 +186,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9406fc796546d74a",
+      "sourceHash": "fnv1a64:b2b0bb94c5c6820f",
       "notice": null,
       "blocks": [
         {
@@ -329,7 +329,7 @@
     },
     {
       "id": "ES-C18-subjunctive-outliers",
-      "sequence": 608,
+      "sequence": 1200,
       "title": "sea, vaya, sepa, haya; esté — where the shortcut stops",
       "headword": "sea, vaya, sepa, haya; esté",
       "romanization": "sea, vaya, sepa, haya; esté",
@@ -340,7 +340,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:87910704c052914f",
+      "sourceHash": "fnv1a64:befb2b16944dd31a",
       "notice": null,
       "blocks": [
         {
@@ -466,7 +466,7 @@
     },
     {
       "id": "ES-C18-subjunctive-name",
-      "sequence": 610,
+      "sequence": 1210,
       "title": "subjuntivo — \"joined underneath\"",
       "headword": "subjuntivo",
       "romanization": "subjuntivo",
@@ -477,7 +477,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:40f17ef5d07b402a",
+      "sourceHash": "fnv1a64:cc5849df9cf29fbb",
       "notice": null,
       "blocks": [
         {
@@ -560,7 +560,7 @@
     },
     {
       "id": "ES-C18-quiero-que",
-      "sequence": 612,
+      "sequence": 1220,
       "title": "quiero que… — making the subjunctive appear",
       "headword": "quiero que…",
       "romanization": "quiero que…",
@@ -571,7 +571,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5a5c6b962d384dee",
+      "sourceHash": "fnv1a64:37bc14318be96308",
       "notice": null,
       "blocks": [
         {
@@ -732,7 +732,7 @@
     },
     {
       "id": "ES-C18-wanting-clause-trap",
-      "sequence": 614,
+      "sequence": 1230,
       "title": "quiero que hables — do not smuggle in a subject",
       "headword": "quiero que hables / quiero hablarte",
       "romanization": "quiero que hables / quiero hablarte",
@@ -743,7 +743,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:2eedce6d8fb2c565",
+      "sourceHash": "fnv1a64:24c74260689cfbb0",
       "notice": null,
       "blocks": [
         {
@@ -842,7 +842,7 @@
     },
     {
       "id": "ES-C18-ojala",
-      "sequence": 616,
+      "sequence": 1240,
       "title": "ojalá — a wish borrowed whole",
       "headword": "ojalá",
       "romanization": "ojalá",
@@ -853,7 +853,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7a5cbefcd831a467",
+      "sourceHash": "fnv1a64:8a5116ada01886a3",
       "notice": null,
       "blocks": [
         {
@@ -951,7 +951,7 @@
     },
     {
       "id": "ES-C18-practice",
-      "sequence": 618,
+      "sequence": 1250,
       "title": "Chapter 18 practice — fact or wish?",
       "headword": "Chapter 18 practice",
       "romanization": "Chapter 18 practice",
@@ -962,7 +962,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d42894546917da8b",
+      "sourceHash": "fnv1a64:8a556331081027e6",
       "notice": null,
       "blocks": [
         {
@@ -1052,7 +1052,7 @@
     },
     {
       "id": "ES-C18-practice-subjects",
-      "sequence": 620,
+      "sequence": 1260,
       "title": "Practice — one subject or two?",
       "headword": "one subject or two?",
       "romanization": "one subject or two?",
@@ -1063,7 +1063,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e009f00a2d88fe2f",
+      "sourceHash": "fnv1a64:29a5021c7eb66506",
       "notice": null,
       "blocks": [
         {
@@ -1159,7 +1159,7 @@
     },
     {
       "id": "ES-C18-practice-mood",
-      "sequence": 622,
+      "sequence": 1270,
       "title": "Practice — fact or wish?",
       "headword": "fact or wish?",
       "romanization": "fact or wish?",
@@ -1170,7 +1170,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:2bdbd831a0781532",
+      "sourceHash": "fnv1a64:57ff016d1d7798be",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch19.json
+++ b/code/learning/human-languages/spanish/narration/ch19.json
@@ -4,11 +4,11 @@
   "chapter": 19,
   "title": "Yes and No",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:348146303665aa93",
+  "sourceHash": "fnv1a64:26065bd139568e43",
   "lessons": [
     {
       "id": "ES-C19-si",
-      "sequence": 640,
+      "sequence": 1280,
       "title": "sí — yes",
       "headword": "sí",
       "romanization": "sí",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:df0f47319db22908",
+      "sourceHash": "fnv1a64:b17f3a4bbf08b693",
       "notice": null,
       "blocks": [
         {
@@ -156,7 +156,7 @@
     },
     {
       "id": "ES-C19-no",
-      "sequence": 650,
+      "sequence": 1290,
       "title": "no — no / not",
       "headword": "no",
       "romanization": "no",
@@ -167,7 +167,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:41b35806ec2b71a5",
+      "sourceHash": "fnv1a64:d9bf248186007d54",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch20.json
+++ b/code/learning/human-languages/spanish/narration/ch20.json
@@ -4,11 +4,11 @@
   "chapter": 20,
   "title": "Lo Siento",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:ff8b8576d2795748",
+  "sourceHash": "fnv1a64:eb8a28c91366131e",
   "lessons": [
     {
       "id": "ES-C20-lo-siento",
-      "sequence": 660,
+      "sequence": 1300,
       "title": "lo siento — \"I'm sorry,\" i.e. \"I feel it\"",
       "headword": "lo siento",
       "romanization": "lo siento",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:00ce4359ea93afdf",
+      "sourceHash": "fnv1a64:1edebc53ccdc91db",
       "notice": null,
       "blocks": [
         {
@@ -119,7 +119,7 @@
     },
     {
       "id": "ES-C20-perdon",
-      "sequence": 665,
+      "sequence": 1310,
       "title": "perdón — the sorry that asks for something back",
       "headword": "perdón",
       "romanization": "perdón",
@@ -130,7 +130,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:4a10e72821bf26fc",
+      "sourceHash": "fnv1a64:10316f8fbdca5ef8",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch21.json
+++ b/code/learning/human-languages/spanish/narration/ch21.json
@@ -4,11 +4,11 @@
   "chapter": 21,
   "title": "Days of the Week",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:9f1f17a520fa7add",
+  "sourceHash": "fnv1a64:cbada3c250a98194",
   "lessons": [
     {
       "id": "ES-C21-lunes-viernes",
-      "sequence": 670,
+      "sequence": 1320,
       "title": "lunes to viernes — the planets of the week, worn down",
       "headword": "lunes, martes, miércoles, jueves, viernes",
       "romanization": "lunes, martes, miércoles, jueves, viernes",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:71d96a3f4b87cafa",
+      "sourceHash": "fnv1a64:2daae3fceeab7c1f",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -153,7 +153,7 @@
     },
     {
       "id": "ES-C21-sabado-domingo",
-      "sequence": 680,
+      "sequence": 1330,
       "title": "sábado and domingo — the week's religious edge",
       "headword": "sábado, domingo",
       "romanization": "sábado, domingo",
@@ -164,7 +164,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:f271345272c76bb1",
+      "sourceHash": "fnv1a64:539054e0683b301c",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/spanish/narration/ch22.json
+++ b/code/learning/human-languages/spanish/narration/ch22.json
@@ -4,11 +4,11 @@
   "chapter": 22,
   "title": "Black, White, Red, and Blue",
   "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:8bfd3dca44e35355",
+  "sourceHash": "fnv1a64:7ce9af6cb50c3202",
   "lessons": [
     {
       "id": "ES-C22-negro-blanco",
-      "sequence": 690,
+      "sequence": 1340,
       "title": "negro, blanco — two colours, and one of their histories",
       "headword": "negro, blanco",
       "romanization": "negro, blanco",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:92bf0940d0b819db",
+      "sourceHash": "fnv1a64:db51bf774d990900",
       "notice": null,
       "blocks": [
         {
@@ -130,7 +130,7 @@
     },
     {
       "id": "ES-C22-blanco-germanico",
-      "sequence": 695,
+      "sequence": 1350,
       "title": "blanco — the colour Spanish did not inherit",
       "headword": "blanco ← *blank",
       "romanization": "blanco ← *blank",
@@ -141,7 +141,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:81d42eb28a9defb2",
+      "sourceHash": "fnv1a64:c6fe8636baaf2417",
       "notice": null,
       "blocks": [
         {
@@ -283,7 +283,7 @@
     },
     {
       "id": "ES-C22-rojo",
-      "sequence": 700,
+      "sequence": 1360,
       "title": "rojo — the same family as red, by a different branch",
       "headword": "rojo",
       "romanization": "rojo",
@@ -294,7 +294,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c07fa5ee06564a7b",
+      "sourceHash": "fnv1a64:95fcef898178289a",
       "notice": null,
       "blocks": [
         {
@@ -394,7 +394,7 @@
     },
     {
       "id": "ES-C22-azul",
-      "sequence": 705,
+      "sequence": 1370,
       "title": "azul — a stone from Afghanistan, in your everyday vocabulary",
       "headword": "azul",
       "romanization": "azul",
@@ -405,7 +405,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:de00a30ead1a50c7",
+      "sourceHash": "fnv1a64:93ee0709ae2c9910",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch23.json
+++ b/code/learning/human-languages/spanish/narration/ch23.json
@@ -4,11 +4,11 @@
   "chapter": 23,
   "title": "Parents and Siblings",
   "drivablePrefix": 3,
-  "sourceHash": "fnv1a64:65f7e89fb2452174",
+  "sourceHash": "fnv1a64:55d2e4bd397961e0",
   "lessons": [
     {
       "id": "ES-C23-padre-madre",
-      "sequence": 710,
+      "sequence": 1380,
       "title": "el padre, la madre — among the oldest words there are",
       "headword": "el padre, la madre",
       "romanization": "el padre, la madre",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7616d50a73e80fc3",
+      "sourceHash": "fnv1a64:351e499d442f0d1f",
       "notice": null,
       "blocks": [
         {
@@ -144,7 +144,7 @@
     },
     {
       "id": "ES-C23-hermano-hermana",
-      "sequence": 720,
+      "sequence": 1390,
       "title": "el hermano, la hermana — brother and sister, from a different word entirely",
       "headword": "el hermano, la hermana",
       "romanization": "el hermano, la hermana",
@@ -155,7 +155,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ab984fb1e7d9fb5c",
+      "sourceHash": "fnv1a64:c679f98885675be4",
       "notice": null,
       "blocks": [
         {
@@ -278,7 +278,7 @@
     },
     {
       "id": "ES-C23-hermano-hache",
-      "sequence": 725,
+      "sequence": 1400,
       "title": "the h in hermano — a letter that was never spoken",
       "headword": "hermano ← *ermano*",
       "romanization": "hermano ← *ermano*",
@@ -289,7 +289,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:baea4dd12bea235e",
+      "sourceHash": "fnv1a64:16e1370ac5e837cb",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch24.json
+++ b/code/learning/human-languages/spanish/narration/ch24.json
@@ -4,11 +4,11 @@
   "chapter": 24,
   "title": "Head and Hand",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:cb85e3f2de32dd93",
+  "sourceHash": "fnv1a64:d9335133eebe69c2",
   "lessons": [
     {
       "id": "ES-C24-cabeza",
-      "sequence": 730,
+      "sequence": 1410,
       "title": "la cabeza — \"the head\"",
       "headword": "la cabeza",
       "romanization": "la cabeza",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:1ca9e2018cf8fbe1",
+      "sourceHash": "fnv1a64:1d23fe41ce429e33",
       "notice": null,
       "blocks": [
         {
@@ -157,7 +157,7 @@
     },
     {
       "id": "ES-C24-mano",
-      "sequence": 740,
+      "sequence": 1420,
       "title": "la mano — \"the hand\"",
       "headword": "la mano",
       "romanization": "la mano",
@@ -168,7 +168,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9ebd83a6bc67002a",
+      "sourceHash": "fnv1a64:c30685b9a391edd2",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch25.json
+++ b/code/learning/human-languages/spanish/narration/ch25.json
@@ -4,11 +4,11 @@
   "chapter": 25,
   "title": "The Seasons",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:b76c71606e7c1944",
+  "sourceHash": "fnv1a64:ce540eb8329698ee",
   "lessons": [
     {
       "id": "ES-C25-las-estaciones",
-      "sequence": 750,
+      "sequence": 1430,
       "title": "la primavera, el verano, el otoño, el invierno — three plain, one surprising",
       "headword": "la primavera, el verano, el otoño, el invierno",
       "romanization": "la primavera, el verano, el otoño, el invierno",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:8188afe380d53ba6",
+      "sourceHash": "fnv1a64:3b1b0233f9810058",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch26.json
+++ b/code/learning/human-languages/spanish/narration/ch26.json
@@ -4,11 +4,11 @@
   "chapter": 26,
   "title": "Water, Wine, and Bread",
   "drivablePrefix": 3,
-  "sourceHash": "fnv1a64:7d92244aefd55f9c",
+  "sourceHash": "fnv1a64:adcb64dbcc088e9f",
   "lessons": [
     {
       "id": "ES-C26-agua",
-      "sequence": 760,
+      "sequence": 1440,
       "title": "el agua — water, and an article that is not what it looks like",
       "headword": "el agua",
       "romanization": "el agua",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:396cd87e02e45696",
+      "sourceHash": "fnv1a64:af75f70992f67934",
       "notice": null,
       "blocks": [
         {
@@ -149,7 +149,7 @@
     },
     {
       "id": "ES-C26-vino",
-      "sequence": 765,
+      "sequence": 1450,
       "title": "el vino — one word, three separate arrivals in English",
       "headword": "el vino",
       "romanization": "el vino",
@@ -160,7 +160,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d8403ab5884125cd",
+      "sourceHash": "fnv1a64:6254dc7ee5085423",
       "notice": null,
       "blocks": [
         {
@@ -265,7 +265,7 @@
     },
     {
       "id": "ES-C26-pan",
-      "sequence": 770,
+      "sequence": 1460,
       "title": "el pan — bread, and the friend who shares it",
       "headword": "el pan",
       "romanization": "el pan",
@@ -276,7 +276,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:34fd005c9eaee292",
+      "sourceHash": "fnv1a64:652a27f226793cb3",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch27.json
+++ b/code/learning/human-languages/spanish/narration/ch27.json
@@ -4,11 +4,11 @@
   "chapter": 27,
   "title": "The Months",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:3c0241436ecab0b0",
+  "sourceHash": "fnv1a64:1221fb0b96f61360",
   "lessons": [
     {
       "id": "ES-C27-los-meses",
-      "sequence": 780,
+      "sequence": 1470,
       "title": "los meses — the calendar's gods and Caesars",
       "headword": "los meses",
       "romanization": "los meses",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:2a00cef600dd4a76",
+      "sourceHash": "fnv1a64:5b5026e865212425",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch28.json
+++ b/code/learning/human-languages/spanish/narration/ch28.json
@@ -4,11 +4,11 @@
   "chapter": 28,
   "title": "Noon and Midnight",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:67c5930a2b05b153",
+  "sourceHash": "fnv1a64:ab0e2305d98d0480",
   "lessons": [
     {
       "id": "ES-C28-mediodia-medianoche",
-      "sequence": 790,
+      "sequence": 1480,
       "title": "mediodía, medianoche — noon and midnight, spelled out in full",
       "headword": "mediodía, medianoche",
       "romanization": "mediodía, medianoche",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f3bd9875be93e05a",
+      "sourceHash": "fnv1a64:b3bfe0b28d5bddf9",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch29.json
+++ b/code/learning/human-languages/spanish/narration/ch29.json
@@ -4,11 +4,11 @@
   "chapter": 29,
   "title": "Telling Time",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:ba45be8faf01ca69",
+  "sourceHash": "fnv1a64:2a23e6b112a7d818",
   "lessons": [
     {
       "id": "ES-C29-la-hora",
-      "sequence": 800,
+      "sequence": 1490,
       "title": "la hora — Spanish's barely-changed Latin hour",
       "headword": "la hora",
       "romanization": "la hora",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:dc8bd714712b7c60",
+      "sourceHash": "fnv1a64:829c80cb6c072acc",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch30.json
+++ b/code/learning/human-languages/spanish/narration/ch30.json
@@ -4,11 +4,11 @@
   "chapter": 30,
   "title": "The Weather",
   "drivablePrefix": 3,
-  "sourceHash": "fnv1a64:87388bb3aea1cfc8",
+  "sourceHash": "fnv1a64:6148ab69b50fe394",
   "lessons": [
     {
       "id": "ES-C30-el-tiempo",
-      "sequence": 810,
+      "sequence": 1500,
       "title": "el tiempo — one word doing two jobs",
       "headword": "el tiempo",
       "romanization": "el tiempo",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f7b78397a0e28684",
+      "sourceHash": "fnv1a64:287d2a03bb8678d5",
       "notice": null,
       "blocks": [
         {
@@ -119,7 +119,7 @@
     },
     {
       "id": "ES-C30-hace-calor",
-      "sequence": 813,
+      "sequence": 1510,
       "title": "hace calor, hace frío, hace sol — the weather Spanish makes",
       "headword": "hace calor, hace frío, hace sol",
       "romanization": "hace calor, hace frío, hace sol",
@@ -130,7 +130,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:079d6db94cc41834",
+      "sourceHash": "fnv1a64:465eaf6ee7b3b25d",
       "notice": null,
       "blocks": [
         {
@@ -242,7 +242,7 @@
     },
     {
       "id": "ES-C30-llueve",
-      "sequence": 816,
+      "sequence": 1520,
       "title": "llueve — the one weather word that will not join hacer",
       "headword": "llueve",
       "romanization": "llueve",
@@ -253,7 +253,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a3eb437013dc1d29",
+      "sourceHash": "fnv1a64:51189e6ba928a1c4",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch31.json
+++ b/code/learning/human-languages/spanish/narration/ch31.json
@@ -4,11 +4,11 @@
   "chapter": 31,
   "title": "Numbers Eleven to Twenty",
   "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:b65e81d19628893e",
+  "sourceHash": "fnv1a64:96d1c45d4a4ca6a3",
   "lessons": [
     {
       "id": "ES-C31-once-quince",
-      "sequence": 820,
+      "sequence": 1530,
       "title": "once — quince: five words with a seam you can no longer see",
       "headword": "once — quince",
       "romanization": "once — quince",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:16abdfd4edd4cbc2",
+      "sourceHash": "fnv1a64:d051928bb9223bdb",
       "notice": null,
       "blocks": [
         {
@@ -122,7 +122,7 @@
     },
     {
       "id": "ES-C31-dieciseis-diecinueve",
-      "sequence": 823,
+      "sequence": 1540,
       "title": "dieciséis — diecinueve: where the seam reopens",
       "headword": "dieciséis — diecinueve",
       "romanization": "dieciséis — diecinueve",
@@ -133,7 +133,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:43f7c733f16124f2",
+      "sourceHash": "fnv1a64:7ae87a0614eb6409",
       "notice": null,
       "blocks": [
         {
@@ -270,7 +270,7 @@
     },
     {
       "id": "ES-C31-teens-latinos",
-      "sequence": 825,
+      "sequence": 1550,
       "title": "duodēvīgintī — the quirk Spanish threw away",
       "headword": "duodēvīgintī, ūndēvīgintī",
       "romanization": "duodēvīgintī, ūndēvīgintī",
@@ -281,7 +281,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:425127755f16b3ae",
+      "sourceHash": "fnv1a64:236f8af21463cfb4",
       "notice": null,
       "blocks": [
         {
@@ -397,7 +397,7 @@
     },
     {
       "id": "ES-C31-veinte",
-      "sequence": 827,
+      "sequence": 1560,
       "title": "veinte — the number the teens were counting toward",
       "headword": "veinte",
       "romanization": "veinte",
@@ -408,7 +408,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6ebd22e653465428",
+      "sourceHash": "fnv1a64:aec387ce76b2b2ff",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch32.json
+++ b/code/learning/human-languages/spanish/narration/ch32.json
@@ -4,11 +4,11 @@
   "chapter": 32,
   "title": "Dog and Cat",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:e38a946a84daf051",
+  "sourceHash": "fnv1a64:d1283505847604c8",
   "lessons": [
     {
       "id": "ES-C32-gato",
-      "sequence": 830,
+      "sequence": 1570,
       "title": "gato — the word that travelled with the animal",
       "headword": "gato",
       "romanization": "gato",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:1ea0f80b5f1d8597",
+      "sourceHash": "fnv1a64:b321d2286569f3f5",
       "notice": null,
       "blocks": [
         {
@@ -119,7 +119,7 @@
     },
     {
       "id": "ES-C32-perro",
-      "sequence": 835,
+      "sequence": 1580,
       "title": "perro — the word nobody can explain",
       "headword": "perro",
       "romanization": "perro",
@@ -130,7 +130,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:875f6739e1b5c41b",
+      "sourceHash": "fnv1a64:a433c43d4631a50d",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch33.json
+++ b/code/learning/human-languages/spanish/narration/ch33.json
@@ -4,11 +4,11 @@
   "chapter": 33,
   "title": "Green and Yellow",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:9997a29a09400b47",
+  "sourceHash": "fnv1a64:1193d6388479368f",
   "lessons": [
     {
       "id": "ES-C33-verde",
-      "sequence": 840,
+      "sequence": 1590,
       "title": "verde — the colour named after being alive",
       "headword": "verde",
       "romanization": "verde",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:36b56916259af11e",
+      "sourceHash": "fnv1a64:a19f46a025249f81",
       "notice": null,
       "blocks": [
         {
@@ -119,7 +119,7 @@
     },
     {
       "id": "ES-C33-amarillo",
-      "sequence": 845,
+      "sequence": 1600,
       "title": "amarillo — the colour that started as a taste",
       "headword": "amarillo",
       "romanization": "amarillo",
@@ -130,7 +130,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ae70fb1bf5810c09",
+      "sourceHash": "fnv1a64:0d33a8da6aadbc9d",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch34.json
+++ b/code/learning/human-languages/spanish/narration/ch34.json
@@ -4,11 +4,11 @@
   "chapter": 34,
   "title": "Four Verbs of the Mind",
   "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:bc65a341cf39fbb6",
+  "sourceHash": "fnv1a64:64748b10c5f453b4",
   "lessons": [
     {
       "id": "ES-C34-pensar",
-      "sequence": 850,
+      "sequence": 1610,
       "title": "pensar — \"to think\", and it started out meaning \"to weigh\"",
       "headword": "pensar",
       "romanization": "pensar",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c34f771fc63fa6da",
+      "sourceHash": "fnv1a64:04f892f1e8481ab5",
       "notice": null,
       "blocks": [
         {
@@ -190,7 +190,7 @@
     },
     {
       "id": "ES-C34-entender",
-      "sequence": 855,
+      "sequence": 1620,
       "title": "entender — \"to understand\", built out of stretching",
       "headword": "entender",
       "romanization": "entender",
@@ -201,7 +201,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:265e5fbe219438c0",
+      "sourceHash": "fnv1a64:070edf4c229dd975",
       "notice": null,
       "blocks": [
         {
@@ -372,7 +372,7 @@
     },
     {
       "id": "ES-C34-leer",
-      "sequence": 860,
+      "sequence": 1630,
       "title": "leer — \"to read\", and before that, \"to gather\"",
       "headword": "leer",
       "romanization": "leer",
@@ -383,7 +383,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:fe730e9bf319e028",
+      "sourceHash": "fnv1a64:f9fce5111b86e152",
       "notice": null,
       "blocks": [
         {
@@ -551,7 +551,7 @@
     },
     {
       "id": "ES-C34-escribir",
-      "sequence": 865,
+      "sequence": 1640,
       "title": "escribir — \"to write\", which once meant \"to scratch\"",
       "headword": "escribir",
       "romanization": "escribir",
@@ -562,7 +562,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c4ff55a994a886be",
+      "sourceHash": "fnv1a64:70b642cd35202bfe",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/spanish/narration/ch35.json
+++ b/code/learning/human-languages/spanish/narration/ch35.json
@@ -4,11 +4,11 @@
   "chapter": 35,
   "title": "Taking, Asking, Helping — and the Backwards Verb",
   "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:28a0602c608252cb",
+  "sourceHash": "fnv1a64:e3c93cbb0c057188",
   "lessons": [
     {
       "id": "ES-C35-tomar",
-      "sequence": 870,
+      "sequence": 1650,
       "title": "tomar — \"to take\", and nobody knows where it came from",
       "headword": "tomar",
       "romanization": "tomar",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7f64cbe9c19a04ac",
+      "sourceHash": "fnv1a64:734e9cd53f6a9bc3",
       "notice": null,
       "blocks": [
         {
@@ -158,7 +158,7 @@
     },
     {
       "id": "ES-C35-preguntar",
-      "sequence": 875,
+      "sequence": 1660,
       "title": "preguntar — \"to ask\", by sounding the water with a pole",
       "headword": "preguntar",
       "romanization": "preguntar",
@@ -169,7 +169,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:4f6bdcdc76c54e70",
+      "sourceHash": "fnv1a64:c5b2f574d22b44eb",
       "notice": null,
       "blocks": [
         {
@@ -326,7 +326,7 @@
     },
     {
       "id": "ES-C35-ayudar",
-      "sequence": 880,
+      "sequence": 1670,
       "title": "ayudar — \"to help\", and it is English \"aid\" in disguise",
       "headword": "ayudar",
       "romanization": "ayudar",
@@ -337,7 +337,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d33da6ef3a522438",
+      "sourceHash": "fnv1a64:8a9e95416ea42c5e",
       "notice": null,
       "blocks": [
         {
@@ -508,7 +508,7 @@
     },
     {
       "id": "ES-C35-gustar",
-      "sequence": 885,
+      "sequence": 1680,
       "title": "gustar — the verb that runs backwards",
       "headword": "gustar",
       "romanization": "gustar",
@@ -519,7 +519,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:99ebd45c298ca198",
+      "sourceHash": "fnv1a64:076b246ba782b686",
       "notice": null,
       "blocks": [
         {

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Changed — Spanish's `sequence` numbers are renumbered on a clean 10-spaced run
+
+- Every one of Spanish's 148 sequenced lessons is renumbered to **10, 20, 30 … 1680**,
+  in the same reading order it already had. **Relative order is unchanged**, and so
+  is every measurement derived from it: forward prerequisites 5, forward reviews 6,
+  forward references 99, atoms 199/102. Byte-identical answers, different integers.
+- **Why it needed doing.** HL09 step 2 had to fit chapters 7–18 into the 129 integers
+  between 510 (chapter 6's end) and 640 (chapter 19's start), because chapters 19–33
+  were already sequenced at 640–845. That forced a spacing of **2**. Gap census before:
+  51 gaps of 2, 33 of 5, and a scattering of 3s and 4s. After: **147 gaps, every one of
+  them 10.**
+- **Chapter 7 now has room.** Its six lessons are still unsequenced pending the owner's
+  ruling on their order, but the renumbering reserves **210 numbers — 21 slots — between
+  chapter 6 and chapter 8** for six lessons plus the splits they will need. Previously
+  the gap was 10, which would have forced a second renumber the moment chapter 7 landed.
+- Safe by construction, and verified rather than assumed: the security review of #10047
+  confirmed **nothing consumes a sequence's absolute value** — every comparison in
+  `ramp.ts`, `book.ts`, `modality.ts`, `hash.ts` is relative, and the only absolute
+  predicate is `curriculum.ts`'s `Number.isInteger(sequence) && sequence > 0`. The values
+  are persisted verbatim into three generated artifacts, so this is a regeneration event,
+  and the byte-exact `--check` CLIs fail loudly rather than silently on a stale one.
+- Diff shape confirms the claim: lesson files changed **only** in their `sequence:` line,
+  and the 21 regenerated book chapters changed **only** in their `canonical-source-hash`
+  comment. No rendered content moved.
+
 ### Changed — Spanish has a declared reading order (HL09 step 2)
 
 - 50 Spanish lessons across chapters 8–18 gain a `sequence:`, recovered from


### PR DESCRIPTION
Follow-up to #10047, which I flagged there as a known remainder.

## Why

HL09 step 2 had to fit chapters 7–18 into the **129 integers** between 510 (chapter 6's end) and 640 (chapter 19's start) — chapters 19–33 were already sequenced at 640–845. That forced a spacing of **2**, which is almost no insertion room in a track HL09 sizes at *thousands* of lessons.

| gap size | before | after |
|---|---|---|
| 2 | 51 | 0 |
| 3–5 | 38 | 0 |
| **10** | 56 | **147 (all of them)** |

## Relative order is unchanged

All 148 sequenced lessons are renumbered to 10, 20, 30 … 1680 **in the order they already had**. Every derived measurement is identical before and after:

```
forward prerequisites  5      forward reviews  6
forward references    99      atoms   199 taught / 102 never revisited
```

Byte-identical answers, different integers.

## Chapter 7 now has room

Its six lessons stay unsequenced pending your ruling on their order, but this reserves **210 numbers — 21 slots — between chapters 6 and 8**, for six lessons plus the splits they'll need. The gap was previously **10**, which would have forced a second renumber the moment chapter 7 landed.

## Safety — verified, not assumed

#10047's security review already answered this exact question: **nothing consumes a sequence's absolute value.** Every comparison in `ramp.ts`, `book.ts`, `modality.ts` and `hash.ts` is relative; the only absolute predicate is `curriculum.ts`'s `Number.isInteger(sequence) && sequence > 0`. The values *are* persisted verbatim into three generated artifacts, so this is a regeneration event — and the byte-exact `--check` CLIs fail **loudly** on a stale artifact, never silently.

The diff shape confirms the claim:
- lesson files changed **only** in their `sequence:` line (verified structurally — zero other +/- lines)
- the 21 regenerated book chapters changed **only** in their `canonical-source-hash` comment. **No rendered content moved.**

## Verification

369 tests pass; modality, narration and book `--check` all clean; validator 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)