### PR TITLE
feat(human-languages): a track must EARN a level, not touch one (HL09 §3.1)

### DIFF
--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,59 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — a track must EARN a level, not touch one (HL09 §3.1)
+
+- Add `src/level-gate.ts`. The gap report now publishes two numbers per track where
+  it published one:
+
+      levels: 650 pre-A1, 297 A1, 186 A2; 148 unmapped (88% placed)
+      levels ATTAINED (HL09 §3.1): none; 22 tracks touch a level they have not attained
+
+- **This is the gate that would have caught "Spanish reaches A2".** Nothing lied:
+  `TrackLevelCoverage.reach` is documented as *the highest level this track has any
+  lesson at*, and that was true. The mistake was letting a number that means
+  **touches** be read as **means**. One lesson pointing at one A2 node moves `reach`;
+  it is nowhere near enough to sit the exam.
+- `touches` keeps the old meaning. `attained` is the highest level where all four
+  §3.1 criteria hold at that level **and every level below**: every spine node
+  realized, cumulative vocabulary met, no lesson over the atom budget, every atom
+  revisited twice. **Zero of 22 tracks have attained even pre-A1.**
+- Spanish is *in progress at pre-A1*: **44 distinct headwords at or below pre-A1
+  against a 300 target** (shortfall 256), plus 92 atoms revisited fewer than twice.
+- **Every criterion is scoped "at or below the level", and getting that wrong was the
+  first version of this module committing the exact error it exists to catch.** The
+  initial implementation measured whole-track vocabulary (Spanish 138) against a
+  per-level cumulative target, and applied the atom-budget and reinforcement criteria
+  track-wide — so Hindi's single over-budget lesson, which sits *above* pre-A1, blocked
+  pre-A1, making criterion 3 unfalsifiable at the bottom of the ladder. Security review
+  caught it; the honest pre-A1 vocabulary is **44**, not 138.
+- Criterion 4 counts atoms revisited **fewer than twice**, per §3.1 — not "never
+  revisited". The looser reading hid 51 of Spanish's 141 failures.
+- Vocabulary counts only `CONTENT_TYPES` lessons. Counting every lesson type credited
+  drill titles and grammar labels as vocabulary — `(practice)`, `qu-`, `fact or wish?` —
+  25 of Spanish's 138.
+- A level with **no authored spine nodes fails** criterion 1 rather than passing it
+  vacuously. `spine.json` has zero B1-C2 nodes, and "no node is unrealized" is not
+  "every node is realized" — the same touches-vs-means error, one level up.
+- **Failures name the criterion and the shortfall**, not a bare `false` — a boolean
+  would move the argument rather than settle it. `vocabulary: teaches 138 distinct
+  headwords against 300 for pre-A1, shortfall 162`.
+- The gate stops at the **first** failing level, because the criteria are cumulative:
+  a level above a failing one is unreachable by definition.
+- Vocabulary targets live in `LEVEL_VOCABULARY` and are **editorial** per §10 —
+  conventional working figures for CEFR receptive vocabulary, not a claim about any
+  awarding body's syllabus. They are named so a failure can cite what it was measured
+  against.
+- Absent, not empty, when the caller supplies no policy: *not measured* and *attained
+  nothing* are opposite facts, and a test pins that distinction.
+
+### Fixed — the CLI had never once printed the level figures
+
+- `report-cli` never passed `curricula` or `spine` to `buildCurriculumGapReport`, so
+  the `levels` section has been silently absent from every CLI run since HL-C10
+  shipped it. Both `levels` and the new gate now render. The section existed, was
+  tested, and was invisible to anyone reading the report.
+
 ### Changed — 17 R1 reinforcement windows closed in Spanish chapters 3-6 (HL09 step 3)
 
 - Records practice the lessons **already do**. 17 atoms across 11 lessons gain an entry

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -105,6 +105,28 @@ modality.tracks[0].chapters[0];        // { drivablePrefix: 5, firstNonVoiceLess
 deriveLessonModality(lessons[0]).reasons; // ["wide-table"] — why it needs eyes
 ```
 
+### Attaining a level, versus touching one (HL09 §3.1)
+
+```ts
+import { runLevelGate } from "@coding-adventures/human-language-data";
+
+const gate = runLevelGate({ lessons, levels, curricula, spine, ramp, continuity });
+gate.tracks.find((t) => t.language === "spanish");
+// { touches: "A2", attained: null, inProgressAt: "pre-A1", vocabulary: 113,
+//   blockers: [{ criterion: "vocabulary", shortfall: 256,
+//               detail: "teaches 44 distinct headwords at or below pre-A1, against 300" }, …] }
+```
+
+`touches` is the highest level any lesson **sits at** — one lesson pointing at one A2
+node is enough to move it. `attained` is the highest level where all four §3.1 criteria
+hold, here and below: spine nodes realized, cumulative vocabulary met, no lesson over
+the atom budget, every atom revisited twice. Every criterion is scoped **at or below
+the level** — Spanish teaches 113 headwords in total but only **44** at or below
+pre-A1, and it is the 44 the gate judges.
+
+**Zero of 22 tracks have attained even pre-A1.** That gap between the two numbers is
+what let "Spanish reaches A2" stand on fourteen present-tense lessons.
+
 ### Continuity — does the course have a memory of itself? (HL09)
 
 The ramp budgets measure how big each **step** is. This measures whether the steps

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -219,6 +219,13 @@ export {
   type TrackContinuity,
   type WindowName,
 } from "./continuity.js";
+export {
+  runLevelGate,
+  LEVEL_VOCABULARY,
+  type LevelGateReport,
+  type TrackLevelAttainment,
+  type LevelBlocker,
+} from "./level-gate.js";
 export { runValidate } from "./cli.js";
 export { runCurriculumGapReport } from "./report-cli.js";
 export { generatedBookOutputs, runBookGeneration } from "./book-cli.js";

--- a/code/packages/typescript/human-language-data/src/level-gate.ts
+++ b/code/packages/typescript/human-language-data/src/level-gate.ts
@@ -1,0 +1,292 @@
+// What it takes to CLAIM a level — HL09 §3.1.
+//
+// The gap report said Spanish "reached A2". The project owner, who has sat A2
+// examinations, did not believe it, and was right by a factor of about seven:
+// 178 distinct words against the ~1,000-1,500 A2 asks for, fourteen lessons all
+// realizing a single spine node, and only the present tense taught.
+//
+// Nothing lied. `TrackLevelCoverage.reach` is documented as "the highest level
+// this track has any lesson at", and that was true. The mistake was letting a
+// number that means TOUCHES be read as MEANS. One lesson pointed at one A2 node
+// is enough to move `reach`; it is nowhere near enough to sit the exam.
+//
+// So this module computes a second, stricter number and reports both. `touches`
+// keeps the old meaning. `attained` is the highest level where all four HL09 §3.1
+// criteria hold, at that level AND every level below it:
+//
+//   1. every spine node at the level is realized by some path segment,
+//   2. the track teaches at least the level's cumulative vocabulary,
+//   3. no lesson at or below the level exceeds the new-atom budget, and
+//   4. every atom at or below the level is revisited at least twice.
+//
+// A track that fails any of them is "in progress at X", never "reached X", and
+// the report says WHICH criterion failed and by how much — a bare `false` would
+// just move the argument rather than settle it.
+
+import type { CefrLevel, LevelSummary } from "./levels.js";
+import { CEFR_LEVELS, levelRank, lessonSpineNodes } from "./levels.js";
+import { CONTENT_TYPES } from "./constants.js";
+import type { ContinuityReport } from "./continuity.js";
+import type { RampReport } from "./ramp.js";
+import type { ParsedLesson } from "./parse.js";
+import type { CurriculumSpine, LanguageCurriculum } from "./types.js";
+
+/**
+ * Cumulative vocabulary a level asks for, in distinct taught headwords.
+ *
+ * EDITORIAL, per HL09 §10 — these are the conventional working figures for CEFR
+ * receptive vocabulary size, not a claim about any awarding body's published
+ * syllabus. They are recorded here rather than inlined so that a track's failure
+ * can name the number it was measured against.
+ */
+export const LEVEL_VOCABULARY: Record<CefrLevel, number> = {
+  "pre-A1": 300,
+  A1: 600,
+  A2: 1200,
+  B1: 2500,
+  B2: 4000,
+  C1: 8000,
+  C2: 16000,
+};
+
+/** Which of the four criteria a level failed, and by how much. */
+export interface LevelBlocker {
+  criterion: "spine-nodes" | "vocabulary" | "atom-budget" | "reinforcement";
+  detail: string;
+  /** How far short the track is, in the criterion's own units. */
+  shortfall: number;
+}
+
+export interface TrackLevelAttainment {
+  language: string;
+  /** Highest level any lesson SITS at. The old `reach` — touches, not means. */
+  touches: CefrLevel | null;
+  /** Highest level meeting every §3.1 criterion, here and below. Usually lower. */
+  attained: CefrLevel | null;
+  /** The level the track is working on: one above `attained`. */
+  inProgressAt: CefrLevel | null;
+  /** Why `inProgressAt` is not yet attained. Empty only when the ladder is complete. */
+  blockers: LevelBlocker[];
+  /** Distinct headwords the track teaches at ANY level — context, not the criterion. */
+  vocabulary: number;
+}
+
+export interface LevelGateReport {
+  vocabularyTargets: Record<CefrLevel, number>;
+  tracks: TrackLevelAttainment[];
+  summary: {
+    /** Tracks whose `touches` overstates their `attained` — the bug this exists for. */
+    tracksOverstating: number;
+    /** Tracks that have attained anything at all. */
+    tracksWithAnyLevel: number;
+    /** Per level, how many tracks STOP at it — attaining a level implies those below. */
+    attainedByLevel: Record<CefrLevel, number>;
+  };
+}
+
+export interface LevelGateInput {
+  lessons: ParsedLesson[];
+  levels: LevelSummary;
+  curricula: LanguageCurriculum[];
+  spine: CurriculumSpine;
+  ramp: RampReport;
+  continuity: ContinuityReport;
+}
+
+/**
+ * Distinct headwords a set of lessons teaches — criterion 2's measurement.
+ *
+ * Restricted to CONTENT_TYPES (`word`/`phrase`). Without that filter the count
+ * picks up drill titles and grammar labels as though they were vocabulary —
+ * `(practice)`, `qu-`, `fact or wish?`, `chapter 18 practice` — which inflated
+ * Spanish by 25 of 138. `constants.ts` already says those types carry "a
+ * session/orthography label, not a cross-language concept"; counting them toward a
+ * vocabulary target is exactly the kind of number-means-something-else this module
+ * exists to stop.
+ */
+function vocabularyOf(lessons: ParsedLesson[]): number {
+  const words = new Set<string>();
+  for (const lesson of lessons) {
+    if (!CONTENT_TYPES.has(lesson.realization.type)) continue;
+    const headword = (lesson.realization.headword ?? "").trim().toLowerCase();
+    if (headword) words.add(headword);
+  }
+  return words.size;
+}
+
+/** Run the HL09 §3.1 gate over every track. */
+export function runLevelGate(input: LevelGateInput): LevelGateReport {
+  const { lessons, levels, curricula, spine, ramp, continuity } = input;
+
+  // Spine nodes per level, and the segments that realize them.
+  const nodesByLevel = new Map<CefrLevel, string[]>();
+  for (const node of spine.nodes) {
+    const level = node.stage as CefrLevel;
+    if (!CEFR_LEVELS.includes(level)) continue;
+    const list = nodesByLevel.get(level) ?? [];
+    list.push(node.id);
+    nodesByLevel.set(level, list);
+  }
+
+  const realizedByTrack = new Map<string, Set<string>>();
+  for (const curriculum of curricula) {
+    const realized = new Set<string>();
+    for (const segment of curriculum.path ?? []) {
+      // A segment with no lessons is a declared gap, not a realization — the
+      // ledgers use `segments: []` with `omits` to record exactly that.
+      if ((segment.lessons ?? []).length > 0 && segment.spine_node) {
+        realized.add(segment.spine_node);
+      }
+    }
+    realizedByTrack.set(curriculum.language, realized);
+  }
+
+  const lessonsByTrack = new Map<string, ParsedLesson[]>();
+  for (const lesson of lessons) {
+    const list = lessonsByTrack.get(lesson.language) ?? [];
+    list.push(lesson);
+    lessonsByTrack.set(lesson.language, list);
+  }
+
+  // Every criterion is scoped "at or below the level", per §3.1. That needs a
+  // lesson -> level map, and building it is the difference between a gate that
+  // measures attainment and one that measures the whole track against a per-level
+  // target — the same touches-vs-means confusion this module exists to end.
+  const spineNodes = lessonSpineNodes(curricula);
+  const stageOf = new Map<string, CefrLevel>();
+  for (const node of spine.nodes) {
+    const stage = node.stage as CefrLevel;
+    if (CEFR_LEVELS.includes(stage)) stageOf.set(node.id, stage);
+  }
+  const levelOfLesson = new Map<string, CefrLevel>();
+  for (const lesson of lessons) {
+    const node = spineNodes.get(lesson.realization.lessonId);
+    const stage = node ? stageOf.get(node) : undefined;
+    if (stage) levelOfLesson.set(lesson.realization.lessonId, stage);
+  }
+  /**
+   * Is this lesson at or below `ceiling`?
+   *
+   * A lesson no spine node claims is NOT counted toward any level. `levels.ts` makes
+   * the same call for the book filter, and for the same reason: crediting unplaced
+   * material toward a level is how a ramp stops being one.
+   */
+  const atOrBelow = (lessonId: string, ceiling: CefrLevel): boolean => {
+    const level = levelOfLesson.get(lessonId);
+    return level !== undefined && levelRank(level) <= levelRank(ceiling);
+  };
+
+  const attainedByLevel = Object.fromEntries(
+    CEFR_LEVELS.map((level) => [level, 0]),
+  ) as Record<CefrLevel, number>;
+  const tracks: TrackLevelAttainment[] = [];
+
+  for (const coverage of levels.tracks) {
+    const language = coverage.language;
+    const trackLessons = lessonsByTrack.get(language) ?? [];
+    const realized = realizedByTrack.get(language) ?? new Set<string>();
+    // Reported for context: everything the track teaches, at any level.
+    const vocabulary = vocabularyOf(trackLessons);
+    const rampViolations = ramp.lessons.filter((v) => v.language === language);
+    const underReinforced = continuity.reinforcement.filter((d) => d.language === language);
+
+    let attained: CefrLevel | null = null;
+    let inProgressAt: CefrLevel | null = null;
+    let blockers: LevelBlocker[] = [];
+
+    for (const level of CEFR_LEVELS) {
+      const failures: LevelBlocker[] = [];
+
+      const nodes = nodesByLevel.get(level) ?? [];
+      if (nodes.length === 0) {
+        // "No node is unrealized" is not "every node is realized". spine.json has
+        // zero B1-C2 nodes, so without this those levels would pass criterion 1 on
+        // no evidence whatsoever — the touches-vs-means error, one level up.
+        failures.push({
+          criterion: "spine-nodes",
+          detail: `no ${level} spine nodes are authored, so ${level} cannot be attained`,
+          shortfall: 1,
+        });
+      } else {
+        const missing = nodes.filter((id) => !realized.has(id));
+        if (missing.length > 0) {
+          failures.push({
+            criterion: "spine-nodes",
+            detail: `${missing.length} of ${nodes.length} ${level} spine node(s) unrealized: ${missing.slice(0, 4).join(", ")}${missing.length > 4 ? "…" : ""}`,
+            shortfall: missing.length,
+          });
+        }
+      }
+
+      const target = LEVEL_VOCABULARY[level];
+      const atLevel = vocabularyOf(
+        trackLessons.filter((l) => atOrBelow(l.realization.lessonId, level)),
+      );
+      if (atLevel < target) {
+        failures.push({
+          criterion: "vocabulary",
+          detail: `teaches ${atLevel} distinct headwords at or below ${level}, against ${target}`,
+          shortfall: target - atLevel,
+        });
+      }
+
+      const overBudget = rampViolations.filter((v) => atOrBelow(v.lessonId, level));
+      if (overBudget.length > 0) {
+        failures.push({
+          criterion: "atom-budget",
+          detail: `${overBudget.length} lesson(s) at or below ${level} exceed the new-atom budget`,
+          shortfall: overBudget.length,
+        });
+      }
+
+      // §3.1 asks for TWO revisits, so `revisits < 2` — not `=== 0`. Measuring
+      // zero-revisit atoms only would have hidden 51 of Spanish's 141 failures.
+      const thin = underReinforced.filter(
+        (d) => d.revisits < 2 && atOrBelow(d.introducedBy, level),
+      );
+      if (thin.length > 0) {
+        failures.push({
+          criterion: "reinforcement",
+          detail: `${thin.length} atom(s) at or below ${level} are revisited fewer than twice`,
+          shortfall: thin.length,
+        });
+      }
+
+      if (failures.length === 0) {
+        attained = level;
+        continue;
+      }
+      // The first level that fails is the one in progress; everything above it is
+      // unreachable by definition, since the criteria are cumulative.
+      inProgressAt = level;
+      blockers = failures;
+      break;
+    }
+
+    if (attained) attainedByLevel[attained] += 1;
+
+    tracks.push({
+      language,
+      touches: coverage.reach,
+      attained,
+      inProgressAt,
+      blockers,
+      vocabulary,
+    });
+  }
+
+  tracks.sort((a, b) => a.language.localeCompare(b.language));
+  return {
+    vocabularyTargets: { ...LEVEL_VOCABULARY },
+    tracks,
+    summary: {
+      tracksOverstating: tracks.filter(
+        (t) =>
+          t.touches !== null &&
+          (t.attained === null || levelRank(t.touches) > levelRank(t.attained)),
+      ).length,
+      tracksWithAnyLevel: tracks.filter((t) => t.attained !== null).length,
+      attainedByLevel,
+    },
+  };
+}

--- a/code/packages/typescript/human-language-data/src/report-cli.ts
+++ b/code/packages/typescript/human-language-data/src/report-cli.ts
@@ -39,7 +39,7 @@ export function runCurriculumGapReport(args = process.argv.slice(2)): number {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     return 2;
   }
-  const { registry, lessons, books } = loadEverything(options.root);
+  const { registry, lessons, books, curricula, spine } = loadEverything(options.root);
   // The report's drivable percentages and the committed narration export must be
   // computed at the same table width, or the report will advertise a car-friendly
   // corpus the export cannot actually deliver. One policy file, read by both.
@@ -53,6 +53,11 @@ export function runCurriculumGapReport(args = process.argv.slice(2)): number {
     // ledgers can never be measured against different files.
     trackChapters: loadTrackChapters(options.root),
     chapterPolicy: loadChapterPolicy(options.root),
+    // Without these the `levels` section and the HL09 §3.1 level gate are both
+    // silently absent — which is how the CLI managed to never once print the level
+    // figures after HL-C10 shipped them.
+    curricula,
+    spine,
   });
   const json = `${JSON.stringify(report, null, 2)}\n`;
   const text = renderCurriculumGapReport(report);

--- a/code/packages/typescript/human-language-data/src/report.ts
+++ b/code/packages/typescript/human-language-data/src/report.ts
@@ -3,6 +3,7 @@ import { runChapterGates, type ChapterGateReport } from "./chapters.js";
 import { CEFR_LEVELS, summarizeLevels, type LevelSummary } from "./levels.js";
 import { measureRamp, type RampReport } from "./ramp.js";
 import { measureContinuity, type ContinuityReport } from "./continuity.js";
+import { runLevelGate, type LevelGateReport } from "./level-gate.js";
 import type {
   BookCorpus,
   ChapterPolicy,
@@ -178,6 +179,13 @@ export interface CurriculumGapReport {
    * order, reinforcement and forward references are all properties of the lessons.
    */
   continuity: ContinuityReport;
+  /**
+   * HL09 §3.1 — what it takes to CLAIM a level, as opposed to touch one.
+   *
+   * Present only when levels, ramp and continuity were all computed, since the
+   * gate needs all four criteria. Absent is "not measured", never "not attained".
+   */
+  levelGate?: LevelGateReport;
   modality: ModalitySummary;
 }
 
@@ -489,6 +497,10 @@ export function buildCurriculumGapReport(input: CurriculumGapReportInput): Curri
   // its own script, so unlike the chapter gates this does not wait on the ledgers.
   const ramp = input.chapterPolicy ? measureRamp(lessons, input.chapterPolicy) : undefined;
   const continuity = measureContinuity(lessons);
+  const levelGate =
+    levels && ramp && input.curricula && input.spine
+      ? runLevelGate({ lessons, levels, curricula: input.curricula, spine: input.spine, ramp, continuity })
+      : undefined;
 
   const chapterGates =
     input.trackChapters && input.chapterPolicy
@@ -550,6 +562,7 @@ export function buildCurriculumGapReport(input: CurriculumGapReportInput): Curri
     levels,
     ramp,
     continuity,
+    levelGate,
     modality,
   };
 }
@@ -599,6 +612,14 @@ export function renderCurriculumGapReport(report: CurriculumGapReport): string {
         .map(([name, count]) => `${name} ${count}`)
         .join(", "),
     `forward references: ${report.continuity.summary.forwardReferences} uses of material a later lesson teaches`,
+    ...(report.levelGate
+      ? [
+          `levels ATTAINED (HL09 §3.1): ${CEFR_LEVELS.filter((l) => report.levelGate!.summary.attainedByLevel[l] > 0)
+            .map((l) => `${report.levelGate!.summary.attainedByLevel[l]} tracks at ${l}`)
+            .join(", ") || "none"}; ` +
+            `${report.levelGate!.summary.tracksOverstating} track(s) touch a level they have not attained`,
+        ]
+      : []),
     ...(report.chapters
       ? [
           `${report.chapters.summary.chaptersWithoutCapability} of ${report.chapters.summary.bookChapters} book chapters without an HL05 capability; ` +

--- a/code/packages/typescript/human-language-data/tests/level-gate.test.ts
+++ b/code/packages/typescript/human-language-data/tests/level-gate.test.ts
@@ -1,0 +1,149 @@
+// HL09 §3.1 — what it takes to CLAIM a level. See src/level-gate.ts for why.
+
+import { describe, expect, it } from "vitest";
+import { loadEverything, loadChapterPolicy, loadTrackChapters } from "../src/loader.js";
+import { buildCurriculumGapReport } from "../src/report.js";
+import { LEVEL_VOCABULARY, runLevelGate } from "../src/level-gate.js";
+import { summarizeLevels } from "../src/levels.js";
+import { measureRamp } from "../src/ramp.js";
+import { measureContinuity } from "../src/continuity.js";
+
+function realReport() {
+  const e = loadEverything();
+  return buildCurriculumGapReport({
+    registry: e.registry,
+    lessons: e.lessons,
+    books: e.books,
+    curricula: e.curricula,
+    spine: e.spine,
+    trackChapters: loadTrackChapters(),
+    chapterPolicy: loadChapterPolicy(),
+  });
+}
+
+describe("the gate that would have caught the A2 claim", () => {
+  it("separates what a track TOUCHES from what it has ATTAINED", () => {
+    const gate = realReport().levelGate!;
+    const spanish = gate.tracks.find((t) => t.language === "spanish")!;
+
+    // The number that misled: one lesson pointing at one A2 node moves `touches`.
+    expect(spanish.touches).toBe("A2");
+    // The number that does not: Spanish has not met even pre-A1's criteria.
+    expect(spanish.attained).toBeNull();
+    expect(spanish.inProgressAt).toBe("pre-A1");
+  });
+
+  it("reports every track as overstating, which is the finding", () => {
+    // All 22 tracks touch a level none of them has attained. That is not 22 bugs —
+    // it is one measurement having been read as another for the whole project.
+    const gate = realReport().levelGate!;
+    expect(gate.summary.tracksOverstating).toBe(22);
+    expect(gate.summary.tracksWithAnyLevel).toBe(0);
+    for (const level of Object.values(gate.summary.attainedByLevel)) {
+      expect(level).toBe(0);
+    }
+  });
+
+  it("names which criterion failed and by how much, not just that one did", () => {
+    const gate = realReport().levelGate!;
+    const spanish = gate.tracks.find((t) => t.language === "spanish")!;
+    const vocab = spanish.blockers.find((b) => b.criterion === "vocabulary")!;
+
+    // A bare `false` would move the argument rather than settle it.
+    expect(vocab.detail).toContain(String(LEVEL_VOCABULARY["pre-A1"]));
+    expect(spanish.blockers.map((b) => b.criterion)).toContain("reinforcement");
+
+    // The criterion counts vocabulary AT OR BELOW the level, not the whole track.
+    // Spanish teaches 113 headwords in total but only 44 at or below pre-A1, so the
+    // shortfall is 256, not 187. Measuring the whole track against a per-level target
+    // was the first version of this module committing the very error it exists to
+    // catch — a number meaning "everything taught" published against one meaning
+    // "by the end of pre-A1".
+    expect(vocab.shortfall).toBe(256);
+    expect(spanish.vocabulary).toBe(113);
+    expect(vocab.shortfall).toBeGreaterThan(LEVEL_VOCABULARY["pre-A1"] - spanish.vocabulary);
+  });
+
+  it("scopes the atom budget to the level, so a high lesson cannot block a low one", () => {
+    // Hindi has one over-budget lesson, and it sits ABOVE pre-A1. Before the criteria
+    // were level-scoped it blocked pre-A1 anyway, which made criterion 3 unfalsifiable
+    // at the bottom of the ladder for every track.
+    const gate = realReport().levelGate!;
+    const hindi = gate.tracks.find((t) => t.language === "hindi")!;
+    expect(hindi.inProgressAt).toBe("pre-A1");
+    expect(hindi.blockers.map((b) => b.criterion)).not.toContain("atom-budget");
+  });
+
+  it("refuses a level with no authored spine nodes instead of passing it vacuously", () => {
+    // spine.json has zero B1-C2 nodes. "No node is unrealized" is not "every node is
+    // realized" — without this, those levels passed criterion 1 on no evidence.
+    const e = loadEverything();
+    const gate = runLevelGate({
+      lessons: e.lessons,
+      levels: summarizeLevels(e.lessons, e.curricula, e.spine),
+      curricula: e.curricula,
+      spine: e.spine,
+      ramp: measureRamp(e.lessons, loadChapterPolicy()),
+      continuity: measureContinuity(e.lessons),
+    });
+    // No track reaches B1, so assert the rule directly on the spine instead.
+    const authored = new Set(e.spine.nodes.map((n) => n.stage));
+    expect(authored.has("B1")).toBe(false);
+    expect(gate.tracks.every((t) => t.attained === null || t.attained !== "B1")).toBe(true);
+  });
+
+  it("stops at the FIRST failing level, because the criteria are cumulative", () => {
+    const gate = realReport().levelGate!;
+    for (const track of gate.tracks) {
+      // You cannot be in progress at two levels at once, and a level above a failing
+      // one is unreachable by definition.
+      if (track.inProgressAt !== null) expect(track.blockers.length).toBeGreaterThan(0);
+      if (track.attained === null) expect(track.inProgressAt).toBe("pre-A1");
+    }
+  });
+});
+
+describe("the criteria themselves", () => {
+  it("passes a level only when all four hold", () => {
+    // A synthetic track that satisfies nothing must attain nothing, and must name
+    // every criterion it failed rather than the first one.
+    const e = loadEverything();
+    const levels = summarizeLevels(e.lessons, e.curricula, e.spine);
+    const ramp = measureRamp(e.lessons, loadChapterPolicy());
+    const continuity = measureContinuity(e.lessons);
+    const gate = runLevelGate({
+      lessons: e.lessons,
+      levels,
+      curricula: e.curricula,
+      spine: e.spine,
+      ramp,
+      continuity,
+    });
+    const worst = gate.tracks.find((t) => t.blockers.length >= 3);
+    expect(worst).toBeDefined();
+    expect(new Set(worst!.blockers.map((b) => b.criterion)).size).toBe(
+      worst!.blockers.length,
+    );
+  });
+
+  it("keeps the vocabulary targets ascending, since they are cumulative", () => {
+    const values = Object.values(LEVEL_VOCABULARY);
+    for (let i = 1; i < values.length; i += 1) {
+      expect(values[i]!).toBeGreaterThan(values[i - 1]!);
+    }
+  });
+
+  it("is absent, not empty, when the caller supplied no policy", () => {
+    // "Not measured" and "attained nothing" are opposite facts. A consumer that
+    // passes no chapter policy must not see a report claiming zero attainment.
+    const e = loadEverything();
+    const report = buildCurriculumGapReport({
+      registry: e.registry,
+      lessons: e.lessons,
+      books: e.books,
+      curricula: e.curricula,
+      spine: e.spine,
+    });
+    expect(report.levelGate).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The gap report said Spanish "reached A2". You didn't believe it, and you were right. **Nothing lied** — `TrackLevelCoverage.reach` is documented as *"the highest level this track has any lesson at"*, and that was true. The mistake was letting a number meaning **touches** be read as **means**. One lesson pointing at one A2 node moves `reach`; it's nowhere near enough to sit the exam.

The report now publishes both:

```
levels: 650 pre-A1, 297 A1, 186 A2; 148 unmapped (88% placed)
levels ATTAINED (HL09 §3.1): none; 22 tracks touch a level they have not attained
```

`attained` requires all four §3.1 criteria at that level **and every level below**: spine nodes realized, cumulative vocabulary met, no lesson over the atom budget, every atom revisited twice.

**Zero of 22 tracks have attained even pre-A1.** Spanish is in progress at pre-A1 with **44 headwords at or below that level against a target of 300**, and 92 atoms revisited fewer than twice.

## The first version committed the exact error it exists to catch

Security review caught this before push, and it's worth stating plainly. My initial implementation:

- measured **whole-track** vocabulary (Spanish 138) against a **per-level cumulative** target
- applied the atom-budget and reinforcement criteria **track-wide**, so Hindi's single over-budget lesson — which sits *above* pre-A1 — blocked pre-A1, making criterion 3 unfalsifiable at the bottom of the ladder for every track

That is precisely the touches-vs-means confusion the module was written to end, reproduced inside the module. Every criterion is now scoped "at or below the level" as §3.1 says. The honest Spanish pre-A1 vocabulary is **44, not 138** — a 3× difference in the direction that falsely blesses.

Three further corrections from the same review:

| | was | now |
|---|---|---|
| criterion 4 threshold | "never revisited" | **"fewer than twice"** per spec — the loose reading hid 51 of Spanish's 141 failures |
| vocabulary population | every lesson type | **`CONTENT_TYPES` only** — drill titles and grammar labels were being counted as words (`(practice)`, `qu-`, `fact or wish?`): 25 of Spanish's 138 |
| level with no spine nodes | passed vacuously | **fails** — `spine.json` has zero B1–C2 nodes, and "no node is unrealized" is not "every node is realized" |

## Design notes

- Failures **name the criterion and the shortfall**, never a bare boolean — a boolean would move the argument rather than settle it.
- The gate stops at the **first** failing level; the criteria are cumulative, so a level above a failing one is unreachable by definition.
- `LEVEL_VOCABULARY` is **editorial** per §10 — conventional CEFR working figures, not a claim about any awarding body's syllabus — and is named so a failure can cite what it was measured against.
- Absent, not empty, when no policy is supplied: *not measured* and *attained nothing* are opposite facts, pinned by a test.
- `vocabularyTargets` is copied rather than aliased, so a consumer can't mutate the module global.

## Also fixed: the CLI had never printed the level figures

`report-cli` never passed `curricula` or `spine`, so the `levels` section has been **silently absent from every CLI run since HL-C10 shipped it**. It existed, was tested, and was invisible to anyone actually reading the report.

## Verification

378 tests pass; validator 0 errors; coverage 94.7%, `level-gate.ts` at 94.8%. New tests pin the level-scoping directly — one asserts Hindi's high over-budget lesson does *not* block pre-A1, which is the regression that would silently return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)