### PR TITLE
feat(human-languages): author the Russian chapter 3 capability

### DIFF
--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -2269,7 +2269,7 @@
     {
       "language": "russian",
       "chapter": 3,
-      "sourceHash": "fnv1a64:d2fa252939f19e6f",
+      "sourceHash": "fnv1a64:92f0da71e90f84b4",
       "lessonIds": [
         "RU-C03-byt",
         "RU-C03-zhit",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -4824,8 +4824,8 @@
       "drivablePrefix": 6,
       "text": "russian/narration/ch03.txt",
       "json": "russian/narration/ch03.json",
-      "textHash": "fnv1a64:26e2130882173b36",
-      "jsonHash": "fnv1a64:3539c96c585e851f"
+      "textHash": "fnv1a64:cc09c5dfc5ca4314",
+      "jsonHash": "fnv1a64:b7849f4e1cf0c345"
     },
     {
       "language": "russian",

--- a/code/learning/human-languages/russian/book/chapters/ch03-first-verbs.tex
+++ b/code/learning/human-languages/russian/book/chapters/ch03-first-verbs.tex
@@ -1,9 +1,15 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:d2fa252939f19e6f
+% canonical-source-hash: fnv1a64:92f0da71e90f84b4
 % canonical-lessons: RU-C03-byt, RU-C03-zhit, RU-C03-znat, RU-C03-govorit, RU-C03-videt, RU-C03-idti
 
 \chapter{Six Verbs, and the One You Never Say}
 \label{ch:russian-first-verbs}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can say what I do in Russian with six everyday verbs — \ru{быть}, \ru{жить}, \ru{знать}, \ru{говорить}, \ru{видеть}, \ru{идти} — put each of them in the \ru{я} form, negate one with \ru{не}, and say a sentence like «\ru{Я} — \ru{Анна}» the way Russian does, by leaving the verb out entirely.}
+
+Say \ru{иду} — «I am going», one trip, right now — and hear why Russian splits going-there-once from going-there-often, a distinction English carries in tone and Russian carries in the verb itself. Then place \ru{идти} against the two verb families the chapter has been sorting, and meet the \ru{го}- that English also inherited in go / went.
+\end{chapteropening}
 
 \section[byt']{\ru{быть} — \textquotedblleft{}to be\textquotedblright{}}
 

--- a/code/learning/human-languages/russian/chapters.json
+++ b/code/learning/human-languages/russian/chapters.json
@@ -30,6 +30,29 @@
       }
     },
     {
+      "chapter": 3,
+      "title": "Six Verbs, and the One You Never Say",
+      "label": "ch:russian-first-verbs",
+      "canDo": "I can say what I do in Russian with six everyday verbs — быть, жить, знать, говорить, видеть, идти — put each of them in the я form, negate one with не, and say a sentence like «Я — Анна» the way Russian does, by leaving the verb out entirely.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "RU-C03-idti",
+        "kind": "task",
+        "summary": "Say иду — «I am going», one trip, right now — and hear why Russian splits going-there-once from going-there-often, a distinction English carries in tone and Russian carries in the verb itself. Then place идти against the two verb families the chapter has been sorting, and meet the го- that English also inherited in go / went.",
+        "assesses": [
+          "RU-LEX-YA",
+          "RU-GRAMMAR-PRESENT-FIRST-PERSON-U",
+          "RU-GRAMMAR-TWO-VERB-FAMILIES",
+          "RU-LEX-IDTI",
+          "RU-GRAMMAR-MOTION-ONE-WAY-VS-HABITUAL",
+          "RU-ETYMON-IDTI-GO-WENT"
+        ],
+        "note": "Chapter 3 has no terminal practice lesson, so the payoff is the last lesson by sequence; it assesses 6 of the chapter's 18 atoms, below the 0.5 representativeness floor. A dedicated payoff lesson would close that, per HL-C25."
+      }
+    },
+    {
       "chapter": 4,
       "title": "Verbs of the Mind and the Page",
       "label": "ch:russian-verbs-of-the-mind",

--- a/code/learning/human-languages/russian/narration/ch03.json
+++ b/code/learning/human-languages/russian/narration/ch03.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "russian",
   "chapter": 3,
-  "title": "Chapter 3",
+  "title": "Six Verbs, and the One You Never Say",
   "drivablePrefix": 6,
   "sourceHash": "fnv1a64:d2fa252939f19e6f",
   "lessons": [

--- a/code/learning/human-languages/russian/narration/ch03.txt
+++ b/code/learning/human-languages/russian/narration/ch03.txt
@@ -1,4 +1,4 @@
-Russian, chapter 3: Chapter 3.
+Russian, chapter 3: Six Verbs, and the One You Never Say.
 6 lessons. All 6 can be done entirely by ear.
 
 

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — Russian chapter 3 gets the capability it never had
+
+- It was the **only generated chapter with no opening**, because `russian/chapters.json`
+  had entries for chapters 2, 4 and 5 and skipped 3. The book could not describe a
+  chapter the ledger did not know about.
+- `canDo` names what the chapter title already promised — *"Six Verbs, and the One You
+  Never Say"* — which is `быть`: Russian drops the present-tense copula, so the verb is
+  learned in order **not** to say it.
+- The payoff is `RU-C03-idti`, and every atom in its `assesses` list is taken from that
+  lesson's own block directives. None is invented, and none is borrowed from a lesson
+  that does not assess it.
+- **It is an honest, declared regression on one metric.** The chapter has no terminal
+  practice lesson, so the payoff is the last lesson by sequence and assesses 6 of 18
+  atoms — below the 0.5 representativeness floor, taking the corpus 24 → **25**. That is
+  recorded in the chapter's own non-printed `payoff.note` and pinned with its reason. A
+  chapter with an opening and a thin payoff is better than one with neither; HL-C25
+  exists to author real payoff lessons.
+- Corpus: declared chapters 317 → **318**, chapters without a capability 99 → **98**.
+  Every generated chapter now has an opening, so the chapter-intro test's by-name
+  exception list is empty — and it is still a by-name check, not a count, so a future
+  chapter without a capability is named rather than silently tolerated.
+
 ### Fixed — a chapter's fingerprint now covers the capability the book prints
 
 - `canonicalChapterHash` covered lessons only, so `chapters.json` was **invisible to

--- a/code/packages/typescript/human-language-data/tests/chapter-intro.test.ts
+++ b/code/packages/typescript/human-language-data/tests/chapter-intro.test.ts
@@ -42,8 +42,10 @@ describe("the chapter opening", () => {
       expect(match).not.toBeNull();
       expect(hasCapability(match![1]!, Number(match![2]))).toBe(false);
     }
-    // Russian chapter 3 is the whole of the debt today.
-    expect(withoutOpening).toEqual(["russian/book/chapters/ch03-first-verbs.tex"]);
+    // Zero, since russian chapter 3 gained its capability. The by-name assertion
+    // above is what keeps this honest: it does not merely count, it requires that any
+    // chapter without an opening genuinely has no capability to build one from.
+    expect(withoutOpening).toEqual([]);
   });
 
   it("never points at another track of this course", () => {

--- a/code/packages/typescript/human-language-data/tests/chapters.test.ts
+++ b/code/packages/typescript/human-language-data/tests/chapters.test.ts
@@ -226,13 +226,21 @@ describe("corpus snapshot", () => {
     // holds at 98. A new chapter that shipped without a `canDo`/`payoff` would have
     // pushed the debt to 99, which is exactly what this trio is here to catch.
     expect(report.summary.bookChapters).toBe(416);
-    expect(report.summary.declaredChapters).toBe(317);
-    expect(report.summary.chaptersWithoutCapability).toBe(99);
+    // 317 -> 318 when russian chapter 3 gained a capability. It was the only
+    // generated chapter with no HL05 entry, so it was also the only generated chapter
+    // the book could not give an opening to.
+    expect(report.summary.declaredChapters).toBe(318);
+    expect(report.summary.chaptersWithoutCapability).toBe(98);
     expect(report.summary.payoffsNotClosed).toBe(0);
     expect(report.summary.unknownPayoffLessons).toBe(0);
     expect(report.summary.titleDrift).toBe(0);
     expect(report.summary.duplicateChapters).toBe(0);
-    expect(report.summary.payoffsNotRepresentative).toBe(24);
+    // 24 -> 25 with russian chapter 3. Its payoff is the last lesson by sequence --
+    // the chapter has no terminal practice lesson -- so it assesses 6 of 18 atoms,
+    // below the 0.5 floor. That is recorded in the chapter's own `payoff.note` and is
+    // a deliberate trade: a chapter with an opening and a thin payoff is better than
+    // one with neither, and HL-C25 exists to author real payoff lessons.
+    expect(report.summary.payoffsNotRepresentative).toBe(25);
   });
 
   it("names the tracks whose chapter debt is already zero", () => {


### PR DESCRIPTION
Russian ch3 was the **only generated chapter with no opening** — `russian/chapters.json` had entries for chapters 2, 4 and 5 and skipped 3. The book can't describe a chapter the ledger doesn't know about.

```latex
\textbf{By the end of this chapter:} \emph{I can say what I do in Russian with six
everyday verbs — \ru{быть}, \ru{жить}, \ru{знать}, \ru{говорить}, \ru{видеть},
\ru{идти} — put each of them in the \ru{я} form, negate one with \ru{не}, and say a
sentence like «\ru{Я} — \ru{Анна}» the way Russian does, by leaving the verb out entirely.}
```

The `canDo` names what the chapter title already promised — *"Six Verbs, and the One You Never Say"* — which is `быть`. Russian drops the present-tense copula, so that verb is learned in order **not** to say it.

Every atom in the payoff's `assesses` list comes from `RU-C03-idti`'s own block directives. None invented, none borrowed from a lesson that doesn't assess it.

## One metric gets worse, declared rather than hidden

The chapter has no terminal practice lesson, so the payoff is the last lesson by sequence and assesses **6 of 18 atoms** — below the 0.5 representativeness floor. Corpus goes 24 → **25**.

That's recorded in the chapter's own non-printed `payoff.note` and pinned in the test *with its reason*, so it reads as a declared trade rather than drift. A chapter with an opening and a thin payoff is better than one with neither, and HL-C25 exists to author real payoff lessons.

## Corpus movement

| | before | after |
|---|---|---|
| declared chapters | 317 | **318** |
| chapters without a capability | 99 | **98** |
| generated chapters without an opening | 1 | **0** |
| payoffs below the representativeness floor | 24 | **25** |

The chapter-intro test's exception list is now empty — and it's still a **by-name** check rather than a count, so a future chapter without a capability gets named instead of silently tolerated.

## Verification

388 tests pass; `check:books`, `check:modality`, `check:narration` and the validator all clean. The Cyrillic is correctly wrapped in `\ru{}` by the script-run renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)