### PR TITLE
fix(human-languages): the book no longer sends its reader into a git checkout (HL-C50)

### DIFF
--- a/code/learning/human-languages/arabic/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/arabic/book/chapters/ch01-greetings.tex
@@ -4,7 +4,7 @@
 The Arabic greetings --- and, taught through them, how to read the Arabic
 script and how the three-consonant \textbf{root} builds nearly every word. Each
 lesson introduces the letters its word needs, so you learn to read the word and
-understand it at once. \emph{Practice lessons: \texttt{lessons/AR-C01-*.md}.}
+understand it at once.
 
 \section*{Three facts about the script, and one about the roots}
 

--- a/code/learning/human-languages/arabic/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/arabic/book/chapters/ch02-introductions.tex
@@ -10,7 +10,7 @@ saying you're glad to meet them:
 \end{center}
 
 Built from Chapter~1's letters and roots, each piece taken apart, then
-assembled. \emph{Practice lessons: \texttt{lessons/AR-C02-*.md}.}
+assembled.
 
 \section{\ar{اسم} \emph{(ism)} --- ``name''}
 \label{lesson:ism}

--- a/code/learning/human-languages/bengali/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch01-greetings.tex
@@ -4,7 +4,6 @@
 The Bengali greetings --- and, taught through them, how to read the Bengali
 script and the one sound-shift that turns every Sanskrit word into something
 recognisably \emph{Bengali}. Each lesson introduces the letters its word needs.
-\emph{Practice lessons: \texttt{lessons/BN-C01-*.md}.}
 
 \section{\bn{নমস্কার} \emph{(n\^{o}moshkar)} --- ``hello''}
 \label{lesson:nomoshkar}

--- a/code/learning/human-languages/bengali/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch02-introductions.tex
@@ -10,7 +10,7 @@ saying you're glad to meet them:
 \end{center}
 
 Built the same way as the greetings --- each piece taken apart, its letters and
-root, then assembled. \emph{Practice lessons: \texttt{lessons/BN-C02-*.md}.}
+root, then assembled.
 
 \section{\bn{নাম} \emph{(n\=am)} --- ``name,'' a word older than Europe}
 \label{lesson:naam}

--- a/code/learning/human-languages/bengali/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch03-responding.tex
@@ -9,8 +9,6 @@ time, Bengali brings back a verb ``to be'':
 \bn{আমি ভালো আছি}, \bn{ধন্যবাদ।} \quad(\emph{\=ami bh\=alo \=achhi, dh\^{o}nnobad} --- ``I'm well, thank you.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/BN-C03-*.md}.}
-
 \section{\bn{কেমন} \emph{(k\=emon)} --- ``how,'' another of the k- questions}
 \label{lesson:kemon}
 

--- a/code/learning/human-languages/bengali/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch04-farewells.tex
@@ -8,8 +8,6 @@ fuller, everyday form:
 \bn{আবার দেখা হবে!} \quad(\emph{\=ab\=ar d\ae{}kh\=a h\^{o}be} --- ``We'll meet again!'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/BN-C04-*.md}.}
-
 \section{\bn{আবার} \emph{(\=ab\=ar)} --- ``again''}
 \label{lesson:abar}
 

--- a/code/learning/human-languages/bengali/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch05-first-verbs.tex
@@ -8,8 +8,6 @@ Bengali conjugates them:
 \bn{আমি বাংলা বলি।} \quad(\emph{\=ami b\=angl\=a b\^{o}li} --- ``I speak Bengali.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/BN-C05-*.md}.}
-
 \section{\bn{বলা} \emph{(b\^{o}l\=a)} --- ``to speak,'' your first full verb}
 \label{lesson:bola}
 

--- a/code/learning/human-languages/chinese/book/book.tex
+++ b/code/learning/human-languages/chinese/book/book.tex
@@ -19,9 +19,6 @@
   {\large Adhithya Rajasekaran\par}
   \vfill
   {\large Starter edition --- seven short lessons in one cumulative chapter.\par}
-  \vspace{1cm}
-  {\large Companion practice lessons live alongside this book at\\
-  \texttt{code/learning/human-languages/chinese/lessons/}\par}
   \vspace{2cm}
   {\normalsize
     Copyright \copyright\ Adhithya Rajasekaran. Licensed under
@@ -76,12 +73,10 @@ substitute.
 \chapter*{Sources for this starter edition}
 \addcontentsline{toc}{chapter}{Sources for this starter edition}
 
-Character shapes, components, and stroke order follow the inventory in
-\texttt{data/scripts/chinese.json}, whose stroke orders are marked authoritative
-because Chinese stroke order is a standardised taught system rather than a
-convention. Codepoint and glyph references are to the
+Character shapes, components, and stroke order follow this project's curated
+character inventory, whose stroke orders are marked authoritative because Chinese
+stroke order is a standardised taught system rather than a convention. Codepoint and glyph references are to the
 \href{https://www.unicode.org/charts/PDF/U4E00.pdf}{Unicode CJK Unified
-Ideographs chart}. The companion Markdown lessons carry the inline citations and
-are the canonical short-practice source for this edition.
+Ideographs chart}.
 
 \end{document}

--- a/code/learning/human-languages/french/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/french/book/chapters/ch01-greetings.tex
@@ -6,8 +6,7 @@ for ``day,'' ``evening,'' ``night,'' and the gender machine that decides their
 endings. French and Spanish are both daughters of Latin; where a French word
 and its Spanish cousin split from one Latin root, both appear here, because the
 \emph{difference} between them is often the lesson --- and the text supplies
-the Spanish word whether or not you have met it before. \emph{Practice lessons:
-\texttt{lessons/FR-C01-*.md}.}
+the Spanish word whether or not you have met it before.
 
 \section{\emph{salut} --- ``hi,'' a wish for your health}
 \label{lesson:salut}

--- a/code/learning/human-languages/french/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/french/book/chapters/ch02-introductions.tex
@@ -12,7 +12,7 @@ saying you're glad to meet them:
 \end{center}
 
 We build it the same way as the greetings: each piece taken apart first, then
-assembled. \emph{Practice lessons: \texttt{lessons/FR-C02-*.md}.}
+assembled.
 
 \section{\emph{je} --- ``I,'' the smallest word you own}
 \label{lesson:je}

--- a/code/learning/human-languages/french/book/chapters/ch03-how-are-you.tex
+++ b/code/learning/human-languages/french/book/chapters/ch03-how-are-you.tex
@@ -13,8 +13,6 @@ asking how someone is doing. French asks that last question with a verb of
 
 Each piece is taken apart first, then assembled.
 
-\emph{Practice lessons: \nolinkurl{lessons/FR-C03-*.md}.}
-
 \section{\emph{merci} --- ``thank you,'' and it means \emph{mercy}}
 \label{lesson:merci}
 

--- a/code/learning/human-languages/french/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/french/book/chapters/ch04-farewells.tex
@@ -10,8 +10,6 @@ and a small family of soft ones, all built the same way --- the preposition
 --- \`{A} demain, Chlo\'{e}. Au revoir!
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/FR-C04-*.md}.}
-
 \section{\emph{au revoir} --- ``goodbye,'' i.e. ``until we see each other again''}
 \label{lesson:au-revoir}
 

--- a/code/learning/human-languages/french/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/french/book/chapters/ch05-first-verbs.tex
@@ -5,7 +5,7 @@ Until now you have assembled fixed phrases. This chapter hands you a
 \emph{pattern} instead: the regular \emph{-er} verbs, the largest verb family in
 French by a wide margin. Learn the one template and thousands of verbs come with
 it --- and with it you build your first sentence that nobody handed you
-pre-made. \emph{Practice lessons: \texttt{lessons/FR-C05-*.md}.}
+pre-made.
 
 \section{\emph{parler} --- ``to speak,'' the model \emph{-er} verb}
 \label{lesson:parler}

--- a/code/learning/human-languages/french/book/chapters/ch06-numbers-1-10.tex
+++ b/code/learning/human-languages/french/book/chapters/ch06-numbers-1-10.tex
@@ -4,7 +4,6 @@
 Numbers are the most-reused words in any language, and French --- like its
 sibling Spanish --- inherited them almost unchanged from Latin. So you already
 half-know them from English, and a \emph{Spanish twin} stands beside each one.
-\emph{Practice lessons: \texttt{lessons/FR-C06-*.md}.}
 
 \section{\emph{un, deux, trois, quatre, cinq} --- counting to five}
 \label{lesson:nombres-1-5}

--- a/code/learning/human-languages/french/book/chapters/ch07-days.tex
+++ b/code/learning/human-languages/french/book/chapters/ch07-days.tex
@@ -4,7 +4,6 @@
 The seven-day week is one of humanity's oldest inheritances, and its day-names
 are a map of the sky: the Romans named each day for a planet-god. French kept
 that map almost intact --- and then religion overwrote the last two.
-\emph{Practice lessons: \texttt{lessons/FR-C07-*.md}.}
 
 \section{\emph{lundi} to \emph{vendredi} --- the planets of the week}
 \label{lesson:jours-1}

--- a/code/learning/human-languages/french/book/chapters/ch08-time.tex
+++ b/code/learning/human-languages/french/book/chapters/ch08-time.tex
@@ -4,7 +4,6 @@
 With your numbers in hand, you can tell the time. It takes one key word,
 \emph{heure} (``hour''), plus two hours that refuse a number and take a name
 instead: \emph{midi} and \emph{minuit}.
-\emph{Practice lessons: \texttt{lessons/FR-C08-*.md}.}
 
 \section{\emph{heure} --- the hour, and telling the time}
 \label{lesson:heure}

--- a/code/learning/human-languages/french/book/chapters/ch09-months-seasons.tex
+++ b/code/learning/human-languages/french/book/chapters/ch09-months-seasons.tex
@@ -3,8 +3,7 @@
 
 The French calendar is a procession of Roman gods and emperors, carried almost
 unchanged out of Latin --- and the four seasons are four small Latin poems about
-heat, sleep, and first things. \emph{Practice lessons:
-\nolinkurl{lessons/FR-C09-*.md}.}
+heat, sleep, and first things.
 
 \section{\emph{les mois} --- the calendar's gods and Caesars}
 \label{lesson:mois}

--- a/code/learning/human-languages/french/book/chapters/ch10-family.tex
+++ b/code/learning/human-languages/french/book/chapters/ch10-family.tex
@@ -4,7 +4,6 @@
 Four words --- father, mother, brother, sister --- and every one of them is
 among the oldest words we can reconstruct, older than Latin, older than Rome.
 Each is also a key to a whole shelf of English vocabulary.
-\emph{Practice lessons: \texttt{lessons/FR-C10-*.md}.}
 
 \section{\emph{le p\`{e}re}, \emph{la m\`{e}re} --- the oldest words in the family}
 \label{lesson:parents}

--- a/code/learning/human-languages/french/book/chapters/ch11-food.tex
+++ b/code/learning/human-languages/french/book/chapters/ch11-food.tex
@@ -3,8 +3,7 @@
 
 Food at last --- and three words that sit at the centre of the French table.
 One of them hides the loveliest word-story in English; another is the most
-worn-down word French ever took from Latin. \emph{Practice lessons:
-\texttt{lessons/FR-C11-*.md}.}
+worn-down word French ever took from Latin.
 
 \section{\emph{le pain} --- bread, and the people you share it with}
 \label{lesson:pain}

--- a/code/learning/human-languages/french/book/chapters/ch12-numbers-11-20.tex
+++ b/code/learning/human-languages/french/book/chapters/ch12-numbers-11-20.tex
@@ -3,8 +3,7 @@
 
 The French teens are not built the way you would guess. Six of them came out of
 Latin already welded together; then, at exactly seventeen, the language changes
-its mind in front of you. \emph{Practice lessons:
-\nolinkurl{lessons/FR-C12-*.md}.}
+its mind in front of you.
 
 \section[\emph{onze} to \emph{seize}]{\emph{onze} $\to$ \emph{seize} --- six numbers welded together}
 \label{lesson:nombres-11-16}

--- a/code/learning/human-languages/french/book/chapters/ch13-colours.tex
+++ b/code/learning/human-languages/french/book/chapters/ch13-colours.tex
@@ -4,7 +4,7 @@
 Four basic colours --- \emph{noir}, \emph{blanc}, \emph{rouge}, \emph{bleu} ---
 and a surprise inside them: half of them are not Latin at all. Two walked down
 from Rome; two walked in from the Germanic north, against the usual direction of
-traffic. \emph{Practice lessons: \texttt{lessons/FR-C13-*.md}.}
+traffic.
 
 \section{\emph{noir}, \emph{blanc} --- one inherited, one borrowed}
 \label{lesson:noir-blanc}

--- a/code/learning/human-languages/french/book/chapters/ch14-avoir-age.tex
+++ b/code/learning/human-languages/french/book/chapters/ch14-avoir-age.tex
@@ -3,8 +3,7 @@
 
 The verb French leans on hardest, and the first thing it lets you say that
 English cannot say the same way: your age. French does not \emph{be} twenty ---
-it \emph{has} twenty years. \emph{Practice lessons:
-\texttt{lessons/FR-C14-*.md}.}
+it \emph{has} twenty years.
 
 \section{\emph{avoir} --- ``to have''}
 \label{lesson:avoir}

--- a/code/learning/human-languages/french/book/chapters/ch15-passe-compose.tex
+++ b/code/learning/human-languages/french/book/chapters/ch15-passe-compose.tex
@@ -3,8 +3,7 @@
 
 French's everyday past tense is built out of \emph{avoir} --- and it began life
 not as a tense at all, but as a sentence about \emph{possessing} something. Then
-we meet the older past it pushed out of the language. \emph{Practice lessons:
-\texttt{lessons/FR-C15-*.md}.}
+we meet the older past it pushed out of the language.
 
 \section{\emph{j'ai parl\'{e}} --- the past built from ``have''}
 \label{lesson:passe-compose}

--- a/code/learning/human-languages/french/book/chapters/ch16-etre.tex
+++ b/code/learning/human-languages/french/book/chapters/ch16-etre.tex
@@ -3,8 +3,7 @@
 
 The partner of \emph{avoir}, and the most irregular verb in the language --- for
 a reason worth knowing. Then the small group of verbs that refuse \emph{avoir}
-in the past and take \emph{\^{e}tre} instead. \emph{Practice lessons:
-\texttt{lessons/FR-C16-*.md}.}
+in the past and take \emph{\^{e}tre} instead.
 
 \section{\emph{\^{e}tre} --- ``to be''}
 \label{lesson:etre}

--- a/code/learning/human-languages/german/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/german/book/chapters/ch01-greetings.tex
@@ -5,7 +5,7 @@ The German greetings, built from their pieces --- a word for ``good,'' the
 day-parts, and the three-gender article system. Because German and English
 are siblings, most words are direct cousins, reshaped by the High German
 Consonant Shift; where it helps, Spanish and French stand alongside for
-contrast. \emph{Practice lessons: \texttt{lessons/GE-C01-*.md}.}
+contrast.
 
 \section{\emph{hallo} --- ``hi,'' a real cousin this time}
 \label{lesson:hallo}

--- a/code/learning/human-languages/german/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/german/book/chapters/ch02-introductions.tex
@@ -13,7 +13,7 @@ saying you're glad to meet them:
 
 Built the same way as the greetings: each piece taken apart first, then
 assembled --- and, because German is English's sibling, most pieces are direct
-English cousins. \emph{Practice lessons: \texttt{lessons/GE-C02-*.md}.}
+English cousins.
 
 \section{\emph{ich} --- ``I,'' the same ancient word as Latin \emph{ego}}
 \label{lesson:ich}

--- a/code/learning/human-languages/german/book/chapters/ch03-how-are-you.tex
+++ b/code/learning/human-languages/german/book/chapters/ch03-how-are-you.tex
@@ -5,7 +5,7 @@ Having given your name, you ask after the other person --- and German asks it
 with a verb of \emph{motion}: \emph{wie geht es dir?}, ``how goes it to you?''
 Around that question sit the two courtesies that hold every conversation
 together, \emph{danke} and \emph{bitte}, each of which turns out to be an
-English word in disguise. \emph{Practice lessons: \texttt{lessons/GE-C03-*.md}.}
+English word in disguise.
 
 \section{\emph{danke} --- ``thank you,'' which is really ``I think of you''}
 \label{lesson:danke}

--- a/code/learning/human-languages/german/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/german/book/chapters/ch04-farewells.tex
@@ -4,7 +4,7 @@
 You can open a German conversation; now close it. German parts formally with a
 promise to \emph{see each other again}, casually with a word that has travelled
 across three languages, and softly with \emph{bis\ldots} --- ``until\ldots'' ---
-plus a word for time. \emph{Practice lessons: \texttt{lessons/GE-C04-*.md}.}
+plus a word for time.
 
 \section{\emph{auf Wiedersehen} --- ``goodbye,'' i.e.\ ``till we see again''}
 \label{lesson:auf-wiedersehen}

--- a/code/learning/human-languages/german/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/german/book/chapters/ch05-first-verbs.tex
@@ -5,7 +5,6 @@ Until now you have assembled fixed phrases. This chapter hands you the machine
 itself: the regular German verb, whose endings you learn once and then apply to
 thousands of words. Three verbs --- \emph{wohnen}, \emph{machen}, \emph{lernen}
 --- and then your first sentence built from parts nobody handed you.
-\emph{Practice lessons: \texttt{lessons/GE-C05-*.md}.}
 
 \section{\emph{wohnen} --- ``to live,'' and the regular German verb}
 \label{lesson:wohnen}

--- a/code/learning/human-languages/german/book/chapters/ch06-numbers-1-10.tex
+++ b/code/learning/human-languages/german/book/chapters/ch06-numbers-1-10.tex
@@ -5,7 +5,6 @@ Here is where German feels \emph{closer to English than any Romance language
 does}. German's numbers are not borrowed from Latin --- they are German's own
 Germanic words, and they are the near-twins of English \emph{one, two, three,
 four, five}. One sound-law explains every difference.
-\emph{Practice lessons: \texttt{lessons/GE-C06-*.md}.}
 
 \section{\emph{eins, zwei, drei, vier, f\"{u}nf} --- counting to five}
 \label{lesson:zahlen-1-5}

--- a/code/learning/human-languages/german/book/chapters/ch07-days.tex
+++ b/code/learning/human-languages/german/book/chapters/ch07-days.tex
@@ -5,7 +5,6 @@ Just as with the numbers, German goes its \textbf{Germanic} way here --- and
 lands right next to English. The Romans named the weekdays for planet-gods
 (\emph{Mars, Mercury, Jupiter, Venus}); the Germanic peoples swapped in
 \emph{their own} gods, and German and English inherited that same set.
-\emph{Practice lessons: \texttt{lessons/GE-C07-*.md}.}
 
 \section{\emph{Montag} to \emph{Freitag} --- the gods of the Germanic week}
 \label{lesson:wochentage-1}

--- a/code/learning/human-languages/german/book/chapters/ch08-time.tex
+++ b/code/learning/human-languages/german/book/chapters/ch08-time.tex
@@ -5,7 +5,6 @@ Something new happens here. German's numbers were homegrown (\emph{eins,
 zwei}), and its weekdays were Germanic gods (\emph{Donnerstag}). But its word
 for the \textbf{clock} --- \textbf{Uhr} --- is borrowed from Latin, while noon
 and midnight swing back to native German.
-\emph{Practice lessons: \texttt{lessons/GE-C08-*.md}.}
 
 \section{\emph{Uhr} --- the clock, and a Roman word in the German day}
 \label{lesson:uhr}

--- a/code/learning/human-languages/german/book/chapters/ch09-months-seasons.tex
+++ b/code/learning/human-languages/german/book/chapters/ch09-months-seasons.tex
@@ -5,7 +5,6 @@ The German year is built from two different quarries. Its twelve
 \emph{months} were carried north from Rome, name and all; its four
 \emph{seasons} are homegrown Germanic, one of them the twin of English
 \textbf{harvest}. This chapter walks both halves and shows where the seam runs.
-\emph{Practice lessons: \texttt{lessons/GE-C09-*.md}.}
 
 \section{\emph{die Monate} --- Rome's calendar in German}
 \label{lesson:monate}

--- a/code/learning/human-languages/german/book/chapters/ch10-family.tex
+++ b/code/learning/human-languages/german/book/chapters/ch10-family.tex
@@ -5,7 +5,6 @@ The months were Latin tourists. Family is the opposite story: German's words
 for father, mother, brother and sister were never borrowed --- they are
 inherited, and they are blood cousins of the English ones. Along the way they
 put a famous sound-law on display.
-\emph{Practice lessons: \nolinkurl{lessons/GE-C10-*.md}.}
 
 \section{\emph{der Vater}, \emph{die Mutter} --- the pair that proves Grimm's law}
 \label{lesson:eltern}

--- a/code/learning/human-languages/german/book/chapters/ch11-food.tex
+++ b/code/learning/human-languages/german/book/chapters/ch11-food.tex
@@ -4,7 +4,7 @@
 Three words from the table, and three different histories. Two of them German
 speakers have always had; one of them Rome carried north together with the
 plant it came from. On the way, the last of German's three genders finally
-appears. \emph{Practice lessons: \texttt{lessons/GE-C11-*.md}.}
+appears.
 
 \section{\emph{das Brot} --- bread, and the third gender}
 \label{lesson:brot}

--- a/code/learning/human-languages/german/book/chapters/ch12-numbers-11-20.tex
+++ b/code/learning/human-languages/german/book/chapters/ch12-numbers-11-20.tex
@@ -5,7 +5,6 @@ Why are English \emph{eleven} and \emph{twelve} so strange? Why not ``oneteen,
 twoteen''? German has the same oddity. Because the two languages are Germanic
 twins, learning one \emph{explains} the other. At thirteen, both settle into a
 rule that never breaks.
-\emph{Practice lessons: \texttt{lessons/GE-C12-*.md}.}
 
 \section{\emph{elf} und \emph{zw\"{o}lf} --- ``one left over,'' ``two left over''}
 \label{lesson:elf-zwoelf}

--- a/code/learning/human-languages/german/book/chapters/ch13-colours.tex
+++ b/code/learning/human-languages/german/book/chapters/ch13-colours.tex
@@ -5,7 +5,6 @@ Four colours --- \emph{schwarz}, \emph{wei\ss{}}, \emph{rot}, \emph{blau} ---
 and a small surprise inside them. German's colour words are all home-grown
 Germanic, with no Latin borrowed in; and two of them travelled the other way,
 out of Germanic and into the Romance languages.
-\emph{Practice lessons: \texttt{lessons/GE-C13-*.md}.}
 
 \section{\emph{schwarz}, \emph{wei\ss{}} --- black and white, and the word German lent away}
 \label{lesson:schwarz-weiss}

--- a/code/learning/human-languages/german/book/chapters/ch14-haben-alter.tex
+++ b/code/learning/human-languages/german/book/chapters/ch14-haben-alter.tex
@@ -4,7 +4,6 @@
 German's workhorse verb \emph{haben}, ``to have'' --- which hides the best false
 cognate in the whole course --- and then the one everyday sentence where German
 \emph{refuses} to use it, siding with English against every Romance sister.
-\emph{Practice lessons: \texttt{lessons/GE-C14-*.md}.}
 
 \section{\emph{haben} --- ``to have,'' the twin of English \emph{have}}
 \label{lesson:haben}

--- a/code/learning/human-languages/german/book/chapters/ch15-perfekt.tex
+++ b/code/learning/human-languages/german/book/chapters/ch15-perfekt.tex
@@ -5,7 +5,6 @@ German has two ways of talking about the past: the \emph{Perfekt}, built from
 \emph{haben} plus a wrapped-up participle, and the \emph{Pr\"{a}teritum}, a
 single word with a \emph{-te} on the end. They mean the same thing. What
 separates them is where you are and whether you are writing.
-\emph{Practice lessons: \texttt{lessons/GE-C15-*.md}.}
 
 \section{\emph{ich habe gesagt} --- the past built from ``have''}
 \label{lesson:perfekt}

--- a/code/learning/human-languages/german/book/chapters/ch16-sein.tex
+++ b/code/learning/human-languages/german/book/chapters/ch16-sein.tex
@@ -5,7 +5,6 @@
 verb in German, because it is not really one verb at all but three ancient ones
 sharing a paradigm. Then the second half of the past tense: the family of verbs
 that builds its perfect on \emph{sein} instead of \emph{haben}.
-\emph{Practice lessons: \texttt{lessons/GE-C16-*.md}.}
 
 \section{\emph{sein} --- ``to be,'' three verbs under one roof}
 \label{lesson:sein}

--- a/code/learning/human-languages/gujarati/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch01-greetings.tex
@@ -3,7 +3,7 @@
 
 The Gujarati greetings --- and, taught through them, how to read a script that is
 Devanagari's sister, but bareheaded. Each lesson introduces the letters its word
-needs. \emph{Practice lessons: \texttt{lessons/GU-C01-*.md}.}
+needs.
 
 \section{\gu{નમસ્તે} \emph{(namaste)} --- ``hello,'' and a script with no ceiling}
 \label{lesson:namaste}

--- a/code/learning/human-languages/gujarati/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch02-introductions.tex
@@ -9,8 +9,6 @@ saying you're glad to meet them:
 \gu{તમારું નામ શું છે}? \quad(\emph{tam\=arũ n\=am shũ chhe} --- ``What is your name?'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/GU-C02-*.md}.}
-
 \section{\gu{નામ} \emph{(n\=am)} --- ``name,'' a word older than Europe}
 \label{lesson:naam}
 

--- a/code/learning/human-languages/gujarati/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch03-responding.tex
@@ -8,8 +8,6 @@ For most Gujaratis this is the real everyday hello:
 \gu{હું મજામાં છું}, \gu{આભાર}. \quad(\emph{hũ maj\=am\=a\d{m} chhũ, \=abh\=ar} --- ``I'm well, thank you.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/GU-C03-*.md}.}
-
 \section{\gu{કેમ} \emph{(kem)} --- ``how,'' a proper k- question}
 \label{lesson:kem}
 

--- a/code/learning/human-languages/gujarati/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch04-farewells.tex
@@ -8,8 +8,6 @@ explicit companion:
 \gu{પાછા મળીશું}! \quad(\emph{p\=achh\=a ma\d{l}\=\i shũ} --- ``We'll meet again!'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/GU-C04-*.md}.}
-
 \section{\gu{પાછા} \emph{(p\=achh\=a)} --- ``again, back''}
 \label{lesson:pachha}
 

--- a/code/learning/human-languages/gujarati/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/ch05-first-verbs.tex
@@ -7,8 +7,6 @@ Until now, ``to be.'' Now verbs that \emph{act} --- and sentences that move:
 \gu{હું ગુજરાતી બોલું છું}. \quad(\emph{hũ gujar\=at\=\i\ bolũ chhũ} --- ``I speak Gujarati.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/GU-C05-*.md}.}
-
 \section{\gu{બોલવું} \emph{(bolvũ)} --- ``to speak,'' your first full verb}
 \label{lesson:bolvun}
 

--- a/code/learning/human-languages/hindi/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch01-greetings.tex
@@ -4,7 +4,7 @@
 The Hindi greetings --- and, taught through them, how to read Devanagari and
 Hindi's double inheritance (Sanskrit and Perso-Arabic). Each lesson introduces
 the letters its word needs, so you learn to read the word and understand it at
-once. \emph{Practice lessons: \texttt{lessons/HI-C01-*.md}.}
+once.
 
 \section{\hi{नमस्ते} \emph{(namaste)} --- ``I bow to you''}
 \label{lesson:namaste}

--- a/code/learning/human-languages/hindi/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch02-introductions.tex
@@ -10,7 +10,7 @@ saying you're glad to meet them:
 \end{center}
 
 Built the same way as the greetings --- each piece taken apart, its letters and
-its root, then assembled. \emph{Practice lessons: \texttt{lessons/HI-C02-*.md}.}
+its root, then assembled.
 
 \section{\hi{नाम} \emph{(n\=am)} --- ``name,'' a word older than Europe}
 \label{lesson:naam}

--- a/code/learning/human-languages/hindi/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch03-responding.tex
@@ -11,8 +11,6 @@ answering, how someone is:
 
 Every atom traced, then assembled.
 
-\emph{Practice lessons:} \texttt{lessons/HI-C03-*.md}.
-
 \section{\hi{कैसे} \emph{(kaise)} --- ``how,'' another of the k- questions}
 \label{lesson:kaise}
 

--- a/code/learning/human-languages/hindi/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch04-farewells.tex
@@ -8,8 +8,6 @@ more warmly --- with a promise to meet again:
 \hi{फिर मिलेंगे!} \quad(\emph{phir milenge} --- ``We'll meet again!'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/HI-C04-*.md}.}
-
 \section{\hi{फिर} \emph{(phir)} --- ``again''}
 \label{lesson:phir}
 

--- a/code/learning/human-languages/hindi/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch05-first-verbs.tex
@@ -7,8 +7,6 @@ Until now, ``to be.'' Now verbs that \emph{act} --- and sentences that move:
 \hi{मैं हिंदी बोलता हूँ।} \quad(\emph{mai\d{m} hind\=\i\ bolt\=a h\=u\d{m}} --- ``I speak Hindi.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/HI-C05-*.md}.}
-
 \section{\hi{बोलना} \emph{(boln\=a)} --- ``to speak,'' your first full verb}
 \label{lesson:bolna}
 

--- a/code/learning/human-languages/italian/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch01-greetings.tex
@@ -4,7 +4,6 @@
 The Italian greetings, built from their pieces --- a word for ``good,'' the
 day-parts, the article that carries gender, and the most famous ``hello'' in
 the world. Each word is taken apart to its root and its English cousins.
-\emph{Practice lessons: \texttt{lessons/IT-C01-*.md}.}
 
 \section{\emph{ciao} --- ``hi,'' and the word that means ``I am your slave''}
 \label{lesson:ciao}

--- a/code/learning/human-languages/japanese/book/book.tex
+++ b/code/learning/human-languages/japanese/book/book.tex
@@ -20,9 +20,6 @@
   {\large Adhithya Rajasekaran\par}
   \vfill
   {\large Starter edition --- eight short lessons in one cumulative chapter.\par}
-  \vspace{1cm}
-  {\large Companion practice lessons live alongside this book at\\
-  \texttt{code/learning/human-languages/japanese/lessons/}\par}
   \vspace{2cm}
   {\normalsize
     Copyright \copyright\ Adhithya Rajasekaran. Licensed under

--- a/code/learning/human-languages/kannada/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch01-greetings.tex
@@ -4,8 +4,7 @@
 The Kannada greetings and the words that oil a first conversation --- and,
 taught through them, how to read the Kannada script and how Kannada sits inside
 the Dravidian family. Each lesson introduces the letters its word needs, so you
-learn to read the word and understand it at once. \emph{Practice lessons:
-\texttt{lessons/KA-C01-*.md}.}
+learn to read the word and understand it at once.
 
 \section{\kn{ನಮಸ್ಕಾರ} \emph{(namaskāra)} --- ``greetings,'' a making of a bow}
 \label{lesson:namaskara}

--- a/code/learning/human-languages/kannada/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch02-introductions.tex
@@ -10,7 +10,7 @@ saying you're glad to meet them:
 \end{center}
 
 Built the same way as the greetings --- each piece taken apart, its letters and
-its root, then assembled. \emph{Practice lessons: \texttt{lessons/KA-C02-*.md}.}
+its root, then assembled.
 
 \section{\kn{ಹೆಸರು} \emph{(hesaru)} --- ``name,'' and the \emph{p}-to-\emph{h} shift}
 \label{lesson:hesaru}

--- a/code/learning/human-languages/kannada/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch03-responding.tex
@@ -9,8 +9,6 @@ Dravidian verb ``to be'':
 \kn{ನಾನು ಚೆನ್ನಾಗಿದ್ದೇನೆ, ಧನ್ಯವಾದ.} \quad(\emph{n\=anu cenn\=agidd\=ene, dhanyav\=ada} --- ``I'm well, thank you.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/KA-C03-*.md}.}
-
 \section{\kn{ಹೇಗೆ} \emph{(h\=ege)} --- ``how,'' another of the \=e- questions}
 \label{lesson:hege}
 

--- a/code/learning/human-languages/kannada/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch04-farewells.tex
@@ -8,8 +8,6 @@ promises to return:
 \kn{ಹೋಗಿ ಬರುತ್ತೇನೆ.} \quad(\emph{h\=ogi barutt\=ene} --- ``I'll go and come back.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/KA-C04-*.md}.}
-
 \section{\kn{ಹೋಗು} \emph{(h\=ogu)} --- ``go,'' and \kn{ಬಾ} (come)}
 \label{lesson:hoogu}
 

--- a/code/learning/human-languages/kannada/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch05-first-verbs.tex
@@ -8,8 +8,6 @@ Kannada's sentences begin to move:
 \kn{ನಾನು ಕನ್ನಡ ಮಾತನಾಡುತ್ತೇನೆ.} \quad(\emph{n\=anu kanna\d{d}a m\=atan\=a\d{d}utt\=ene} --- ``I speak Kannada.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/KA-C05-*.md}.}
-
 \section{\kn{ಮಾತನಾಡು} \emph{(m\=atan\=a\d{d}u)} --- ``to speak,'' your first full verb}
 \label{lesson:maatanaadu}
 

--- a/code/learning/human-languages/latin/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/latin/book/chapters/ch01-greetings.tex
@@ -6,8 +6,7 @@ a \textbf{taproot}: these five salutations are the ancestors of the greetings yo
 met in Spanish, Italian, French, and Portuguese, \emph{and} the etymons of a
 surprising slice of English's polite vocabulary. Learn \emph{valē} and you have
 already half-learned \emph{value}, \emph{valid}, and \emph{prevail}. Each lesson
-introduces the sounds its word needs. \emph{Practice lessons:
-\texttt{lessons/LA-C01-*.md}.}
+introduces the sounds its word needs.
 
 \section{\textit{salv\=e} / \textit{salv\=ete} --- ``hello'' (be well)}
 \label{lesson:salve}

--- a/code/learning/human-languages/malayalam/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch01-greetings.tex
@@ -4,8 +4,7 @@
 The Malayalam greetings and the words that oil a first conversation --- and,
 taught through them, how to read the Malayalam script and how Malayalam sits
 inside the Dravidian family. Each lesson introduces the letters its word needs,
-so you learn to read the word and understand it at once. \emph{Practice
-lessons: \texttt{lessons/ML-C01-*.md}.}
+so you learn to read the word and understand it at once.
 
 \section{\ml{നമസ്കാരം} \emph{(namaskāram)} --- ``greetings,'' a making of a bow}
 \label{lesson:namaskaram}

--- a/code/learning/human-languages/malayalam/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch02-introductions.tex
@@ -10,7 +10,7 @@ saying you're glad to meet them:
 \end{center}
 
 Built the same way as the greetings --- each piece taken apart, its letters and
-its root, then assembled. \emph{Practice lessons: \texttt{lessons/ML-C02-*.md}.}
+its root, then assembled.
 
 \section{\ml{പേര്} \emph{(p\=eru)} --- ``name,'' the native Dravidian word}
 \label{lesson:peru}

--- a/code/learning/human-languages/malayalam/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch03-responding.tex
@@ -9,8 +9,6 @@ its sisters, asks it with a real verb ``to be'':
 \ml{സുഖമാണ്, നന്ദി.} \quad(\emph{sukham\=a\d{n}\u{u}, nandi} --- ``I'm well, thank you.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/ML-C03-*.md}.}
-
 \section{\ml{എങ്ങനെ} \emph{(e\.{n}\.{n}ane)} --- ``how,'' another of the e- questions}
 \label{lesson:engane}
 

--- a/code/learning/human-languages/malayalam/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch04-farewells.tex
@@ -8,8 +8,6 @@ promises to return:
 \ml{പോയി വരാം.} \quad(\emph{p\=oyi var\=a\d{m}} --- ``I'll go and come back.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/ML-C04-*.md}.}
-
 \section{\ml{പോകുക} \emph{(p\=okuka)} --- ``to go,'' and \ml{വരിക} (to come)}
 \label{lesson:pokuka}
 

--- a/code/learning/human-languages/malayalam/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/ch05-first-verbs.tex
@@ -8,8 +8,6 @@ astonishingly simple thing about Malayalam grammar:
 \ml{ഞാൻ മലയാളം സംസാരിക്കുന്നു.} \quad(\emph{ñ\=aṉ malay\=a\d{l}a\d{m} sa\d{m}s\=arikkunnu} --- ``I speak Malayalam.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/ML-C05-*.md}.}
-
 \section{\ml{സംസാരിക്കുക} \emph{(sa\d{m}s\=arikkuka)} --- ``to speak,'' your first full verb}
 \label{lesson:samsaarikkuka}
 

--- a/code/learning/human-languages/marathi/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch01-greetings.tex
@@ -3,8 +3,7 @@
 
 The Marathi greetings --- and, taught through them, how to read the Devanagari
 script and what makes Marathi its own language, not a dialect of Hindi. Each
-lesson introduces the letters its word needs. \emph{Practice lessons:
-\texttt{lessons/MR-C01-*.md}.}
+lesson introduces the letters its word needs.
 
 \section{\mr{नमस्कार} \emph{(namask\=ar)} --- ``greetings''}
 \label{lesson:namaskar}

--- a/code/learning/human-languages/marathi/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch02-introductions.tex
@@ -9,8 +9,6 @@ saying you are glad to meet them:
 \mr{तुमचं नाव काय आहे?} \quad(\emph{tumch\d{m} n\=av k\=ay \=ahe} --- ``What is your name?'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/MR-C02-*.md}.}
-
 \section{\mr{नाव} \emph{(n\=av)} --- ``name,'' a word older than Europe}
 \label{lesson:naav}
 

--- a/code/learning/human-languages/marathi/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch03-responding.tex
@@ -8,8 +8,6 @@ The everyday exchange after hello:
 \mr{मी बरा आहे, धन्यवाद.} \quad(\emph{m\=\i\ bar\=a \=ahe, dhanyav\=ad} --- ``I'm well, thank you.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/MR-C03-*.md}.}
-
 \section{\mr{कसा} / \mr{कशी} / \mr{कसं} \emph{(kas\=a / ka\'{s}\=\i\ / kas\d{m})} --- ``how''}
 \label{lesson:kasa}
 

--- a/code/learning/human-languages/marathi/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch04-farewells.tex
@@ -8,8 +8,6 @@ explicit companion:
 \mr{पुन्हा भेटू!} \quad(\emph{punh\=a bhe\d{t}\=u} --- ``We'll meet again!'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/MR-C04-*.md}.}
-
 \section{\mr{पुन्हा} \emph{(punh\=a)} --- ``again''}
 \label{lesson:punha}
 

--- a/code/learning/human-languages/marathi/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/marathi/book/chapters/ch05-first-verbs.tex
@@ -8,8 +8,6 @@ Until now, verbs of \emph{being} and \emph{meeting}. Now verbs that \emph{act}
 \mr{मी मराठी बोलतो.} \quad(\emph{m\=\i\ mar\=a\d{t}h\=\i\ bolto} --- ``I speak Marathi.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/MR-C05-*.md}.}
-
 \section{\mr{बोलणे} \emph{(bol\d{n}e)} --- ``to speak,'' your first full verb}
 \label{lesson:bolne}
 

--- a/code/learning/human-languages/persian/book/chapters/ch01-greetings-and-responses.tex
+++ b/code/learning/human-languages/persian/book/chapters/ch01-greetings-and-responses.tex
@@ -4,8 +4,7 @@
 This chapter builds one miniature exchange in dependency order: greet, thank,
 answer yes, answer no. Four short expressions are enough to establish the
 direction of the script, joining, one non-joining letter, omitted short vowels,
-and the contrast between borrowed and inherited vocabulary. Companion lessons:
-\texttt{FA-C01-*.md}.
+and the contrast between borrowed and inherited vocabulary.
 
 \section{\texorpdfstring{\fa{سلام}}{salam} \emph{(sal\^am)} --- hello through peace}
 

--- a/code/learning/human-languages/persian/book/chapters/ch02-give-your-name.tex
+++ b/code/learning/human-languages/persian/book/chapters/ch02-give-your-name.tex
@@ -2,8 +2,7 @@
 \label{ch:persian-name}
 
 The first chapter supplied social moves. This one adds a single sentence and a
-single grammar idea: Persian's linking vowel, \emph{ezafe}. Companion lesson:
-\texttt{FA-C02-esm-e-man.md}.
+single grammar idea: Persian's linking vowel, \emph{ezafe}.
 
 \section{\texorpdfstring{\fa{اسم من ... است}}{esm-e man ... ast}
   \emph{(esm-e man ... ast)} --- my name is ...}

--- a/code/learning/human-languages/portuguese/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch01-greetings.tex
@@ -4,7 +4,7 @@
 The Portuguese greetings, built from their pieces --- a word for ``good,'' the
 day-parts, the article that carries gender, and a ``thank you'' that changes
 with \emph{who is speaking}. Each word is taken apart to its root and its
-English cousins. \emph{Practice lessons: \texttt{lessons/PT-C01-*.md}.}
+English cousins.
 
 \section{\emph{ol\'{a}} --- ``hi''}
 \label{lesson:ola}

--- a/code/learning/human-languages/punjabi/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch01-greetings.tex
@@ -3,8 +3,7 @@
 
 The Punjabi greetings --- and, taught through them, how to read the Gurmukhi
 script and the two faiths and two vocabularies that meet in Punjabi. Each lesson
-introduces the letters its word needs. \emph{Practice lessons:
-\texttt{lessons/PA-C01-*.md}.}
+introduces the letters its word needs.
 
 \section{\pa{ਸਤਿ ਸ੍ਰੀ ਅਕਾਲ} \emph{(sat sr\=\i\ ak\=al)} --- the Sikh greeting}
 \label{lesson:sat-sri-akal}

--- a/code/learning/human-languages/punjabi/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch02-introductions.tex
@@ -10,7 +10,7 @@ saying you're glad to meet them:
 \end{center}
 
 Built the same way as the greetings --- each piece taken apart, its letters and
-root, then assembled. \emph{Practice lessons: \texttt{lessons/PA-C02-*.md}.}
+root, then assembled.
 
 \section{\pa{ਨਾਂ} \emph{(n\=a\d{m})} --- ``name,'' a word older than Europe}
 \label{lesson:naam}

--- a/code/learning/human-languages/punjabi/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch03-responding.tex
@@ -8,8 +8,6 @@ After the name comes the exchange everyone actually has:
 \pa{ਮੈਂ ਠੀਕ ਹਾਂ, ਧੰਨਵਾਦ।} \quad(\emph{mai\d{m} \d{t}h\=\i k h\=a\d{m}, dhannav\=ad} --- ``I'm fine, thank you.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/PA-C03-*.md}.}
-
 \section{\pa{ਕਿਵੇਂ} \emph{(kiv\=e\d{m})} --- ``how,'' another of the k- questions}
 \label{lesson:kivein}
 

--- a/code/learning/human-languages/punjabi/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch04-farewells.tex
@@ -8,8 +8,6 @@ which doubles as a goodbye. Real days end more warmly:
 \pa{ਫਿਰ ਮਿਲਾਂਗੇ!} \quad(\emph{phir mil\=a\d{m}ge} --- ``We'll meet again!'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/PA-C04-*.md}.}
-
 \section{\pa{ਫਿਰ} \emph{(phir)} --- ``again''}
 \label{lesson:phir}
 

--- a/code/learning/human-languages/punjabi/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch05-first-verbs.tex
@@ -7,8 +7,6 @@ Until now, ``to be.'' Now verbs that \emph{act} --- and sentences that move:
 \pa{ਮੈਂ ਪੰਜਾਬੀ ਬੋਲਦਾ ਹਾਂ।} \quad(\emph{mai\d{m} panj\=ab\=\i\ bold\=a h\=a\d{m}} --- ``I speak Punjabi.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/PA-C05-*.md}.}
-
 \section{\pa{ਬੋਲਣਾ} \emph{(bol\d{n}\=a)} --- ``to speak,'' your first full verb}
 \label{lesson:bolna}
 

--- a/code/learning/human-languages/russian/book/chapters/ch01-greetings-and-courtesy.tex
+++ b/code/learning/human-languages/russian/book/chapters/ch01-greetings-and-courtesy.tex
@@ -3,7 +3,7 @@
 
 This chapter grows a complete courtesy exchange from six expressions. Cyrillic
 arrives inside each word, starting with the four letters that most often fool a
-Latin-alphabet reader. Companion lessons: \texttt{RU-C01-*.md}.
+Latin-alphabet reader.
 
 \section{\texorpdfstring{\ru{привет}}{privet} \emph{(priv\'et)} --- informal hello}
 

--- a/code/learning/human-languages/russian/book/chapters/ch02-introducing-yourself.tex
+++ b/code/learning/human-languages/russian/book/chapters/ch02-introducing-yourself.tex
@@ -3,8 +3,7 @@
 
 The first chapter supplied courtesy moves. This chapter adds pronouns, one
 naming construction, its matching question, and a complete first conversation.
-Case appears only through the forms the exchange needs. Companion lessons:
-\texttt{RU-C02-*.md}.
+Case appears only through the forms the exchange needs.
 
 \section{\texorpdfstring{\ru{я}}{ya} \emph{(ya)} --- I}
 

--- a/code/learning/human-languages/sanskrit/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch01-greetings.tex
@@ -6,7 +6,7 @@ whole curriculum. Every ``thank you'' and ``hello'' in the Hindi, Marathi,
 Punjabi, and Bengali tracks points back here; and Sanskrit is at the same time a
 \emph{sister} of Latin, Greek, and English, so its words reach west as well as
 east. Each lesson introduces the letters and the Sanskrit-specific reading its
-word needs. \emph{Practice lessons: \texttt{lessons/SA-C01-*.md}.}
+word needs.
 
 \section{\sk{नमस्ते} \emph{(namaste)} --- ``I bow to you''}
 \label{lesson:namaste}

--- a/code/learning/human-languages/sanskrit/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch02-introductions.tex
@@ -9,8 +9,6 @@ Now a first real exchange --- and, since this is Sanskrit, each atom is the
 \sk{तव नाम किम्?} \quad(\emph{tava n\=ama kim} --- ``What is your name?'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/SA-C02-*.md}.}
-
 \section{\sk{नाम} \emph{(n\=ama)} --- ``name,'' the source of a word half the world shares}
 \label{lesson:nama}
 

--- a/code/learning/human-languages/sanskrit/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch03-responding.tex
@@ -9,8 +9,6 @@ whose forms fathered English \emph{am} and \emph{is}:
 \sk{अहं कुशली अस्मि, धन्यवादः।} \quad(\emph{aha\d{m} ku\'{s}al\=\i\ asmi, dhanyav\=ada\d{h}} --- ``I am well, thank you.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/SA-C03-*.md}.}
-
 \section{\sk{कथम्} \emph{(katham)} --- ``how,'' another of the ka- questions}
 \label{lesson:katham}
 

--- a/code/learning/human-languages/sanskrit/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch04-farewells.tex
@@ -8,8 +8,6 @@ and promises a seeing to come:
 \sk{पुनर्दर्शनाय।} \quad(\emph{punar-dar\'{s}an\=aya} --- ``Until we meet again.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/SA-C04-*.md}.}
-
 \section{\sk{गच्छामि} \emph{(gacch\=ami)} --- ``I go'' (taking leave)}
 \label{lesson:gacchami}
 

--- a/code/learning/human-languages/sanskrit/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch05-first-verbs.tex
@@ -8,8 +8,6 @@ the Sanskrit verb: it counts to \textbf{three}.
 \sk{अहं संस्कृतं वदामि।} \quad(\emph{aha\d{m} sa\d{m}sk\d{r}ta\d{m} vad\=ami} --- ``I speak Sanskrit.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/SA-C05-*.md}.}
-
 \section{\sk{वदामि} \emph{(vad\=ami)} --- ``I speak,'' and the Sanskrit verb}
 \label{lesson:vadami}
 

--- a/code/learning/human-languages/spanish/book/chapters/ch07-er-ir-verbs.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch07-er-ir-verbs.tex
@@ -5,7 +5,7 @@ Spanish has exactly three verb families, and you have already met one of them.
 This chapter hands you the other two --- \emph{-er} and \emph{-ir} --- which
 turn out to be almost the same as each other. Then it gives you two question
 words, so that for the first time you can \emph{ask} something and understand
-the answer. \emph{Practice lessons: \texttt{lessons/ES-C07-*.md}.}
+the answer.
 
 \section{\emph{comer} --- ``to eat,'' and the second verb family}
 \label{lesson:comer}

--- a/code/learning/human-languages/spanish/book/chapters/ch08-numbers-and-age.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch08-numbers-and-age.tex
@@ -5,7 +5,7 @@ Numbers are the most reused words in any language, and Spanish counts almost
 exactly the way Latin did --- which means each one planted an English word you
 can lean on. Then one irregular verb, \emph{tener} (``to have''), turns those
 numbers into your age: in Spanish you don't \emph{be} twenty, you \emph{have}
-twenty years. \emph{Practice lessons: \texttt{lessons/ES-C08-*.md}.}
+twenty years.
 
 \section{\emph{uno, dos, tres, cuatro, cinco} --- counting to five}
 \label{lesson:numeros-1-5}

--- a/code/learning/human-languages/spanish/book/chapters/ch09-ser-y-estar.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch09-ser-y-estar.tex
@@ -4,7 +4,7 @@
 Spanish has \emph{two} verbs where English has one. This chapter finally meets
 the second one, \emph{ser}, and settles the famous question of when to use
 which --- a choice that is not arbitrary at all, but written into the two Latin
-roots. \emph{Practice lessons: \texttt{lessons/ES-C09-*.md}.}
+roots.
 
 \section{\emph{ser} --- ``to be,'' the \emph{essential} kind}
 \label{lesson:ser}

--- a/code/learning/human-languages/spanish/book/chapters/ch10-ir-y-futuro.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch10-ir-y-futuro.tex
@@ -4,7 +4,7 @@
 Three new powers: you can \emph{go} somewhere, you can talk about the
 \emph{future}, and you can say \emph{whose} something is. The future comes
 almost free --- Spanish builds tomorrow out of the verb ``to go,'' exactly as
-English does. \emph{Practice lessons: \texttt{lessons/ES-C10-*.md}.}
+English does.
 
 \section{\emph{ir} --- ``to go,'' stitched from three verbs}
 \label{lesson:ir}

--- a/code/learning/human-languages/spanish/book/chapters/ch11-stem-changes.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch11-stem-changes.tex
@@ -5,7 +5,6 @@ Two power-verbs --- \emph{querer} (``to want'') and \emph{poder} (``can'') ---
 crack their own vowels when you conjugate them. This chapter shows why: one
 ancient sound-law, two vowels, and a boot-shaped pattern you can predict. It
 closes with \emph{nuestro}, ``our,'' which carries the very same crack.
-\emph{Practice lessons: \texttt{lessons/ES-C11-*.md}.}
 
 \section[querer --- ``to want,'' and the e-to-ie crack]
   {\emph{querer} --- ``to want,'' and the \emph{e}$\to$\emph{ie} crack}

--- a/code/learning/human-languages/spanish/book/chapters/ch12-yo-go-verbs.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch12-yo-go-verbs.tex
@@ -5,7 +5,6 @@ Two workhorse verbs --- one for \emph{doing} and \emph{making}, one for
 \emph{saying} --- and the strange little club they belong to, where the ``I''
 form grows a hard \emph{g} out of nowhere. Learn the club once and six of the
 language's most-used verbs stop being surprises.
-\emph{Practice lessons: \texttt{lessons/ES-C12-*.md}.}
 
 \section{\emph{hacer} --- ``to do / to make,'' and the \emph{yo}-form that grows a \emph{g}}
 \label{lesson:hacer}

--- a/code/learning/human-languages/spanish/book/chapters/ch13-completing-go-club.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch13-completing-go-club.tex
@@ -5,7 +5,6 @@ Three verbs remain in the small club of Spanish verbs whose \emph{I} form grows
 an extra \textbf{g}: \emph{pongo}, \emph{salgo}, \emph{vengo}. They hide a
 Latin ``place'' root, a Latin ``leap'' root, and a Latin ``come'' root --- and
 the last of them stacks \emph{two} irregularities at once.
-\emph{Practice lessons: \texttt{lessons/ES-C13-*.md}.}
 
 \section{\emph{poner} --- ``to put,'' and the club gains a member}
 \label{lesson:poner}

--- a/code/learning/human-languages/spanish/book/chapters/ch14-preterite.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch14-preterite.tex
@@ -6,7 +6,6 @@ into ``what happened'': the \textbf{preterite}, Spanish's everyday past. It
 opens with the strangest fact in the language --- ``I was'' and ``I went'' are
 the same word --- and closes with a pattern that covers thousands of verbs and
 hangs on a single accent mark.
-\emph{Practice lessons: \texttt{lessons/ES-C14-*.md}.}
 
 \section{\emph{fui} --- the past arrives, and two verbs become one}
 \label{lesson:ser-ir-preterite}

--- a/code/learning/human-languages/spanish/book/chapters/ch15-completing-preterite.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch15-completing-preterite.tex
@@ -5,7 +5,6 @@ The past tense finishes here. The \emph{-er} and \emph{-ir} verbs hand you a gif
 --- one set of endings for two conjugations --- and then a handful of very old
 verbs pull the stress backwards and drop their accents entirely. One question
 sorts all of them: where does the stress land?
-\emph{Practice lessons: \texttt{lessons/ES-C15-*.md}.}
 
 \section{\emph{com\'{i}}, \emph{viv\'{i}} --- two conjugations become one}
 \label{lesson:comer-vivir-preterite}

--- a/code/learning/human-languages/spanish/book/chapters/ch16-imperfect.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch16-imperfect.tex
@@ -5,7 +5,6 @@ One past tense says a thing finished; this one says a thing was
 \emph{going on}. It is also the most regular tense in the language, with exactly
 three irregular verbs in the whole of Spanish --- and then one genuinely new
 distinction to learn to think in.
-\emph{Practice lessons: \texttt{lessons/ES-C16-*.md}.}
 
 \section{\emph{hablaba}, \emph{com\'{i}a} --- the past that kept going}
 \label{lesson:imperfecto}

--- a/code/learning/human-languages/spanish/book/chapters/ch17-future-conditional.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch17-future-conditional.tex
@@ -4,7 +4,7 @@
 Two whole tenses built from a single trick: glue an infinitive to the verb
 ``to have.'' Use the present of ``have'' and you get the future; use its past
 and you get ``would.'' One machine, one part swapped, and a seam you can still
-see. \emph{Practice lessons: \texttt{lessons/ES-C17-*.md}.}
+see.
 
 \section{\emph{hablar\'{e}} --- the future, welded shut}
 \label{lesson:futuro}

--- a/code/learning/human-languages/spanish/book/chapters/ch18-subjunctive.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch18-subjunctive.tex
@@ -5,7 +5,7 @@ Every verb form so far has \emph{asserted} something. This chapter opens the
 other door: a whole second set of endings reserved for what is wanted, doubted,
 hoped for --- for what has not happened and may never happen. It is built by one
 small trick, triggered by one simple test, and its name means ``joined
-underneath.'' \emph{Practice lessons: \texttt{lessons/ES-C18-*.md}.}
+underneath.''
 
 \section{\emph{hable}, \emph{coma}, \emph{viva} --- building the present subjunctive}
 \label{lesson:subjuntivo}

--- a/code/learning/human-languages/tamil/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch01-greetings.tex
@@ -4,8 +4,7 @@
 The Tamil greetings and the words that oil a first conversation --- and,
 taught through them, how to read the Tamil script and how Tamil sits inside
 the Dravidian family. Each lesson introduces the letters its word needs, so
-you learn to read the word and understand it at once. \emph{Practice lessons:
-\texttt{lessons/TA-C01-*.md}.}
+you learn to read the word and understand it at once.
 
 \section{\ta{வணக்கம்} \emph{(vaṇakkam)} --- ``greetings,'' a small act of respect}
 \label{lesson:vanakkam}

--- a/code/learning/human-languages/tamil/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch02-introductions.tex
@@ -11,7 +11,7 @@ saying you're glad to meet them:
 
 Built the same way as the greetings --- each piece taken apart, its letters and
 its root, then assembled. And here the roots run \emph{native}: this is where
-Tamil is most itself. \emph{Practice lessons: \texttt{lessons/TA-C02-*.md}.}
+Tamil is most itself.
 
 \section{\ta{பெயர்} \emph{(peyar)} --- ``name,'' and where the family is \emph{not} Indo-European}
 \label{lesson:peyar}

--- a/code/learning/human-languages/tamil/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch03-responding.tex
@@ -9,8 +9,6 @@ time, Tamil reaches for a verb ``to be'':
 \ta{நான் நலமாக இருக்கிறேன்.} \quad(\emph{n\=a\d{n} nalam\=aga irukki\d{r}\=e\d{n}} --- ``I'm well.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/TA-C03-*.md}.}
-
 \section{\ta{எப்படி} \emph{(eppa\d{t}i)} --- ``how,'' another of the e- questions}
 \label{lesson:eppadi}
 

--- a/code/learning/human-languages/tamil/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch04-farewells.tex
@@ -8,8 +8,6 @@ English ears --- ``I'll go and \emph{come back}'':
 \ta{போய் வருகிறேன்.} \quad(\emph{p\=oy varugi\d{r}\=e\d{n}} --- ``I'll go and come back.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/TA-C04-*.md}.}
-
 \section{\ta{போ} \emph{(p\=o)} --- ``go,'' and \ta{வா} (come)}
 \label{lesson:po}
 

--- a/code/learning/human-languages/tamil/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch05-first-verbs.tex
@@ -8,8 +8,6 @@ sentences begin to move:
 \ta{நான் தமிழ் பேசுகிறேன்.} \quad(\emph{n\=a\d{n} tami\d{l} p\=esugi\d{r}\=e\d{n}} --- ``I speak Tamil.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/TA-C05-*.md}.}
-
 \section{\ta{பேசு} \emph{(p\=esu)} --- ``to speak,'' your first full verb}
 \label{lesson:pesu}
 

--- a/code/learning/human-languages/telugu/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch01-greetings.tex
@@ -4,8 +4,7 @@
 The Telugu greetings and the words that oil a first conversation --- and,
 taught through them, how to read the Telugu script and how Telugu sits inside
 the Dravidian family. Each lesson introduces the letters its word needs, so you
-learn to read the word and understand it at once. \emph{Practice lessons:
-\texttt{lessons/TE-C01-*.md}.}
+learn to read the word and understand it at once.
 
 \section{\te{నమస్కారం} \emph{(namaskāram)} --- ``greetings''}
 \label{lesson:namaskaram}

--- a/code/learning/human-languages/telugu/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch02-introductions.tex
@@ -10,7 +10,7 @@ saying you're glad to meet them:
 \end{center}
 
 Built the same way as the greetings --- each piece taken apart, its letters and
-its root, then assembled. \emph{Practice lessons: \texttt{lessons/TE-C02-*.md}.}
+its root, then assembled.
 
 \section{\te{పేరు} \emph{(p\=eru)} --- ``name,'' the native Dravidian word}
 \label{lesson:peru}

--- a/code/learning/human-languages/telugu/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch03-responding.tex
@@ -9,8 +9,6 @@ time, a Telugu verb ``to be'':
 \te{నేను బాగున్నాను, ధన్యవాదములు.} \quad(\emph{n\=enu b\=agunn\=anu, dhanyav\=adamulu} --- ``I'm well, thank you.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/TE-C03-*.md}.}
-
 \section{\te{ఎలా} \emph{(el\=a)} --- ``how,'' another of the e- questions}
 \label{lesson:elaa}
 

--- a/code/learning/human-languages/telugu/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch04-farewells.tex
@@ -8,8 +8,6 @@ promises to return:
 \te{వెళ్ళి వస్తాను.} \quad(\emph{ve\d{l}\d{l}i vast\=anu} --- ``I'll go and come back.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/TE-C04-*.md}.}
-
 \section{\te{వెళ్ళు} \emph{(ve\d{l}\d{l}u)} --- ``go,'' and \te{వచ్చు} (come)}
 \label{lesson:vellu}
 

--- a/code/learning/human-languages/telugu/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch05-first-verbs.tex
@@ -8,8 +8,6 @@ sentences begin to move:
 \te{నేను తెలుగు మాట్లాడతాను.} \quad(\emph{n\=enu telugu m\=a\d{t}l\=a\d{d}at\=anu} --- ``I speak Telugu.'')
 \end{center}
 
-\emph{Practice lessons: \texttt{lessons/TE-C05-*.md}.}
-
 \section{\te{మాట్లాడు} \emph{(m\=a\d{t}l\=a\d{d}u)} --- ``to speak,'' your first full verb}
 \label{lesson:maatlaadu}
 

--- a/code/learning/human-languages/urdu/book/chapters/ch01-greetings-and-responses.tex
+++ b/code/learning/human-languages/urdu/book/chapters/ch01-greetings-and-responses.tex
@@ -4,7 +4,7 @@
 This chapter builds one miniature exchange in dependency order: greet, thank,
 answer yes, answer no. Four short expressions establish right-to-left reading,
 joining, omitted short vowels, long vowels, respectful \emph{j\={i}}, and one
-Urdu nasal sign. Companion lessons: \texttt{UR-C01-*.md}.
+Urdu nasal sign.
 
 \section{\texorpdfstring{\ur{سلام}}{salam} \emph{(sal\={a}m)} --- hello through peace}
 

--- a/code/learning/human-languages/urdu/book/chapters/ch02-give-your-name.tex
+++ b/code/learning/human-languages/urdu/book/chapters/ch02-give-your-name.tex
@@ -2,8 +2,7 @@
 \label{ch:urdu-name}
 
 The first chapter supplied social moves. This one adds one sentence and one
-word-order fact: Urdu places the present copula at the end. Companion lesson:
-\texttt{UR-C02-mera-naam.md}.
+word-order fact: Urdu places the present copula at the end.
 
 \section{\texorpdfstring{\ur{میرا نام ... ہے}}{mera nam ... hai} --- my name is ...}
 

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Fixed — the book no longer sends its reader into a git checkout (HL-C50)
+
+- **105 handwritten chapters printed a repo path at somebody holding a PDF**:
+  *"Practice lessons: `lessons/AR-C01-*.md`"* (99) and *"Companion lesson:
+  `FA-C02-esm-e-man.md`"* (6). `book-cli.ts` already stated the principle — "a reader
+  holding the PDF cannot follow a link into a Git repository" — and drops relative
+  links for exactly this reason. The handwritten chapters had never been held to it.
+- **The worst instance was on a title page, and a chapter-only check could not see
+  it.** Japanese and Chinese printed *"Companion practice lessons live alongside this
+  book at `code/learning/human-languages/japanese/lessons/`"* on the **title page** —
+  more prominent than any chapter clause. `loadBookCorpus` records `entrypoint` as a
+  path and never reads it, so the first version of the guard test passed green while
+  the defect sat on page one. The test now reads `book.tex` too.
+- Chinese's printed "Sources" backmatter also cited `data/scripts/chinese.json` by
+  repo path and sent the reader to "the companion Markdown lessons". The source is
+  now named without the path, and the dangling pointer is gone.
+- Zero generated files touched: 416 chapters, 311 generated, 105 modified — the
+  intersection is empty, and the change set is exactly the complete set of handwritten
+  chapters.
+- The guard covers **all** chapters including generated ones, so it is a regression
+  test on the generator too, not only on handwritten prose.
+
 ### Added — Russian chapter 3 gets the capability it never had
 
 - It was the **only generated chapter with no opening**, because `russian/chapters.json`

--- a/code/packages/typescript/human-language-data/tests/standalone-book.test.ts
+++ b/code/packages/typescript/human-language-data/tests/standalone-book.test.ts
@@ -1,0 +1,47 @@
+// HL-C50 — the book is a standalone artifact. See HL09 §8.
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { defaultCurriculumRoot, loadBookCorpus } from "../src/loader.js";
+
+const BOOKS = loadBookCorpus().books;
+
+// Chapters AND the book shell. `loadBookCorpus` records `entrypoint` as a path and
+// never reads it, so a test over `book.chapters` alone passes green while the TITLE
+// PAGE prints a repo path — which is exactly what Japanese and Chinese were doing,
+// more prominently than any chapter clause.
+const CHAPTERS = [
+  ...BOOKS.flatMap((book) =>
+    book.chapters.map((chapter) => ({ source: chapter.source, tex: chapter.tex })),
+  ),
+  ...BOOKS.map((book) => ({
+    source: book.entrypoint,
+    tex: readFileSync(join(defaultCurriculumRoot(), book.entrypoint), "utf8"),
+  })),
+];
+
+describe("a reader holding the PDF", () => {
+  it("is never sent to a file in the git repository", () => {
+    // 99 chapters ended a paragraph with "Practice lessons: lessons/AR-C01-*.md".
+    // That sentence is addressed to somebody with a checkout. `book-cli.ts` already
+    // states the principle — "a reader holding the PDF cannot follow a link into a
+    // Git repository" — and drops relative links for exactly this reason; the
+    // handwritten chapters had never been held to it.
+    const offenders = CHAPTERS.filter(({ tex }) =>
+      /lessons\/[A-Z]{2}-C\d|(?:Practice|Companion)\s+(?:practice\s+)?lessons?:?/.test(tex),
+    ).map(({ source }) => source);
+    expect(offenders).toEqual([]);
+  });
+
+  it("is never pointed at a path in the curriculum tree at all", () => {
+    // Broader than the line that prompted this: any `lessons/`, `curriculum.json`,
+    // `chapters.json` or `.md` path printed to a reader is the same mistake.
+    const offenders = CHAPTERS.filter(({ tex }) =>
+      /\\(?:texttt|nolinkurl|path)\{[^}]*(?:lessons\/|\.md|chapters\.json|curriculum\.json)[^}]*\}/.test(
+        tex,
+      ),
+    ).map(({ source }) => source);
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
**105 handwritten chapters printed a repo path at somebody holding a PDF.**

> …whether or not you have met it before. *Practice lessons: `lessons/FR-C01-*.md`.*

`book-cli.ts` already states the principle — *"a reader holding the PDF cannot follow a link into a Git repository"* — and drops relative links for exactly this reason. The handwritten chapters had never been held to it.

## The worst instance was on a title page, and my first guard couldn't see it

Japanese and Chinese printed this on the **title page**:

> Companion practice lessons live alongside this book at
> `code/learning/human-languages/japanese/lessons/`

More prominent than any chapter clause. `loadBookCorpus` records `entrypoint` as a *path* and never reads its contents, so my test over `book.chapters` **passed green while the defect sat on page one.** Pre-push review caught it.

The test now reads `book.tex` too, and I verified it fails when the pointer is reintroduced — it named `japanese/book/book.tex` — then passes again once removed.

Chinese's printed "Sources" backmatter also cited `data/scripts/chinese.json` by repo path and sent the reader to "the companion Markdown lessons". The source is named without the path now.

## Two regex mistakes of my own

Both caught by asserting on the **goal** rather than a proxy:

1. **Alternation order** let the first branch consume `\emph{Practice lessons:}` and *strand* the `\texttt{lessons/HI-C03-*.md}` after it.
2. My first assertion checked for the words `"Practice lesson"` — which *had* been removed — instead of for the **path**, which survived. It passed on a file it had just damaged.

Asserting on `lessons/[A-Z]{2}-C\d` found both immediately.

## Review confirmed clean

- **No prose damaged**: exactly one removed span per file, **zero non-whitespace insertions** across all 105. Every removal leaves a sentence ending in a period.
- **Structurally intact**: braces and `\begin`/`\end` balanced in all 105, per-file brace deltas *identical* to `origin/main`, and the structural token sequence (`\section`, `\chapter`, `\label`, …) byte-identical old vs new. Nothing structural was consumed.
- **Nothing over-removed**: all five removed shapes are repo pointers. Legitimate `\texttt{}` uses — pronunciation rule ids like `\texttt{vowel-e-german}` — untouched, and the guard's regex requires a path *inside* the braces so it won't fire on them.
- **Zero generated files touched**: 416 chapters, 311 generated, 105 modified — empty intersection, and the change set is exactly the complete set of handwritten chapters.

The guard covers **all** chapters including generated ones, so it's a regression test on the generator too, not only on handwritten prose.

## Still open for HL-C50

No track has a glossary, index or answer key; 5 of 22 lack a pronunciation appendix; and 6 chapters make dangling cross-track references ("the same wearing-down the Hindi track shows"). Those are separate slices.

## Verification

390 tests pass; `check:books`, `check:modality`, `check:narration` and the validator all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)