### PR TITLE
feat(human-languages): publish coreModality so a driver gets 1,230 lessons (HL-C48)

### DIFF
--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -2,7 +2,7 @@
   "version": 1,
   "algorithm": "fnv1a64",
   "features": {
-    "blockModality": false
+    "blockModality": true
   },
   "policy": {
     "maxLinearisableTableColumns": 3
@@ -7620,7 +7620,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5c3401b074a9ed4b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5c3401b074a9ed4b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C01-as-salamu-alaykum",
@@ -7633,7 +7641,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4cecaf9d8aad4700"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4cecaf9d8aad4700",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C01-marhaba",
@@ -7646,7 +7662,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5d9f80c6fec8c304"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5d9f80c6fec8c304",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C01-masa-al-khayr",
@@ -7659,7 +7683,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:12cfed97a5c22789"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:12cfed97a5c22789",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C01-practice",
@@ -7672,6 +7704,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d17a5272c766dbab"
     },
     {
@@ -7685,7 +7722,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:cb050b6fcf90da8c"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:cb050b6fcf90da8c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C01-salam",
@@ -7698,7 +7743,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:44f0446378253c51"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:44f0446378253c51",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C01-shukran",
@@ -7711,7 +7764,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e4e8e7fe129d4df8"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e4e8e7fe129d4df8",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-W01-abjad-short-vowels",
@@ -7724,6 +7785,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:3e1dd8e526ece3ab"
     },
     {
@@ -7737,6 +7803,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:d975959a53775213"
     },
     {
@@ -7750,6 +7821,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:4be0ee678a21ed83"
     },
     {
@@ -7763,6 +7839,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:c990df30657098d1"
     },
     {
@@ -7777,6 +7858,12 @@
         "writing-type",
         "wide-table"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type",
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:112e88792a30e708"
     },
     {
@@ -7790,6 +7877,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:5a0a95b5fcedbd5f"
     },
     {
@@ -7803,7 +7895,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:2d97705045b6d7b0"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:2d97705045b6d7b0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C02-ii-my",
@@ -7816,7 +7916,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c938ceadba398f9e"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c938ceadba398f9e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C02-ism",
@@ -7829,7 +7937,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:7f07aaa91a92ea81"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7f07aaa91a92ea81",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C02-ismii",
@@ -7842,6 +7958,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:66ae5f617a129840"
     },
     {
@@ -7855,7 +7976,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:dbd1e0cf51386345"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:dbd1e0cf51386345",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C02-maa-ismuka",
@@ -7868,6 +7997,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a98c1b04a4da2876"
     },
     {
@@ -7881,6 +8015,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8f6913bf948bd70b"
     },
     {
@@ -7894,7 +8033,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3e43ab7585f164eb"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3e43ab7585f164eb",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-W04-dots-family-nun-ta",
@@ -7907,6 +8054,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:f5c066d586c0d093"
     },
     {
@@ -7920,6 +8072,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:8e93235a7b7ab596"
     },
     {
@@ -7933,6 +8090,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:b3f5a5be0439833c"
     },
     {
@@ -7947,6 +8109,12 @@
         "writing-type",
         "wide-table"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type",
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:d442889100e30ce8"
     },
     {
@@ -7961,7 +8129,17 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3b2e6ebe41ce9654"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:3b2e6ebe41ce9654",
+      "detachableSegments": [
+        "Script — The hook-and-tail family",
+        "Script — Draw them",
+        "Script — Where you've seen it — خير"
+      ]
     },
     {
       "id": "AR-W08-kaf-and-ra",
@@ -7975,7 +8153,16 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:12066b9d81273cbe"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:12066b9d81273cbe",
+      "detachableSegments": [
+        "Script — ك (kāf) — the angular k",
+        "Script — ر (rā) — the little downward curve that breaks"
+      ]
     },
     {
       "id": "AR-W09-khayr-bikhayr",
@@ -7989,7 +8176,16 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ff8640e312fa8991"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:ff8640e312fa8991",
+      "detachableSegments": [
+        "Script — Assemble خير — right to left",
+        "Script — Then بخير — \"(I'm) well\""
+      ]
     },
     {
       "id": "AR-C03-kayfa",
@@ -8002,6 +8198,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4d4f0429a815bfd9"
     },
     {
@@ -8015,6 +8216,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:017e0b4e62ce2300"
     },
     {
@@ -8028,6 +8234,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:ebca6f2afdb7274d"
     },
     {
@@ -8041,6 +8252,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f3c11bb981abda92"
     },
     {
@@ -8054,6 +8270,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fb4eafd54d45244e"
     },
     {
@@ -8067,6 +8288,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:a84e2262a220a4e9"
     },
     {
@@ -8081,7 +8307,18 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:68477b2c41a68c3a"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:68477b2c41a68c3a",
+      "detachableSegments": [
+        "Script — Draw it",
+        "Script — A third dots-family",
+        "Script — The surprise: ʿayn → O",
+        "Script — Where you've heard it"
+      ]
     },
     {
       "id": "AR-W11-ha-and-ta-marbuta",
@@ -8095,7 +8332,16 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:849de7ad76378728"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:849de7ad76378728",
+      "detachableSegments": [
+        "Script — ه (hāʾ) — the loop that never looks the same",
+        "Script — ة (tāʾ marbūṭa) — the \"tied tāʾ\""
+      ]
     },
     {
       "id": "AR-W12-maa-salama",
@@ -8110,7 +8356,18 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:44b336c3ea8b6fcb"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:44b336c3ea8b6fcb",
+      "detachableSegments": [
+        "Script — Part 1 — مع (maʿa, \"with\")",
+        "Script — Part 2 — السلامة (as-salāma, \"the safety\")",
+        "Script — The root s-l-m, one more time",
+        "Script — Assemble it — right to left"
+      ]
     },
     {
       "id": "AR-C04-maa-with",
@@ -8123,6 +8380,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4d6223a8157e97d3"
     },
     {
@@ -8136,6 +8398,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e310a26b87a53a68"
     },
     {
@@ -8149,6 +8416,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:16d95ec6d2c923e4"
     },
     {
@@ -8162,6 +8434,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c2d7502d85e39eb8"
     },
     {
@@ -8175,6 +8452,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:05c5e1b72f8cf5f3"
     },
     {
@@ -8188,6 +8470,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8c749ad301412efe"
     },
     {
@@ -8201,6 +8488,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c044132d30f8a721"
     },
     {
@@ -8214,6 +8506,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e17fff0e577f02ce"
     },
     {
@@ -8227,6 +8524,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2eb595b74e4f9df5"
     },
     {
@@ -8240,6 +8542,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:3dbaad4fe2de433f"
     },
     {
@@ -8253,6 +8560,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:35460220b0154ce3"
     },
     {
@@ -8266,6 +8578,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c0e830442ac228b5"
     },
     {
@@ -8279,6 +8596,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:326e9d5629639cf6"
     },
     {
@@ -8292,6 +8614,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7ac8641f61451bd9"
     },
     {
@@ -8305,6 +8632,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:46c7c50078e64335"
     },
     {
@@ -8318,6 +8650,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:47bcf37ed366effd"
     },
     {
@@ -8331,6 +8668,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e0adf54a63f55e87"
     },
     {
@@ -8344,6 +8686,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2f49159243716b70"
     },
     {
@@ -8357,6 +8704,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:08dfd74ec767791d"
     },
     {
@@ -8370,6 +8722,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e5051d5567cd25da"
     },
     {
@@ -8383,6 +8740,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0411a0cb0f4f7c11"
     },
     {
@@ -8396,6 +8758,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:42a178bd1fb74be6"
     },
     {
@@ -8409,6 +8776,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8f69cf2d5f5d07d1"
     },
     {
@@ -8422,6 +8794,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b6d43c1a5b4ae6b8"
     },
     {
@@ -8435,6 +8812,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:194e70a900faede5"
     },
     {
@@ -8448,6 +8830,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9a1426dc9c9a2abd"
     },
     {
@@ -8461,6 +8848,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f33045d5cd091570"
     },
     {
@@ -8474,6 +8866,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c39f01d4603699e5"
     },
     {
@@ -8487,6 +8884,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:649e7fa3ce3a0668"
     },
     {
@@ -8500,6 +8902,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0cdff4548a8a9674"
     },
     {
@@ -8513,6 +8920,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0de5d8903cefad89"
     },
     {
@@ -8526,6 +8938,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:dcd7b1cc0fd5a4bc"
     },
     {
@@ -8539,6 +8956,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7f336d22da3abfe2"
     },
     {
@@ -8552,6 +8974,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:20ee1b4f18263d8d"
     },
     {
@@ -8565,6 +8992,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9d60f205ab777646"
     },
     {
@@ -8578,6 +9010,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ce20844fd21afc59"
     },
     {
@@ -8591,6 +9028,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fef39f3ff85a08c5"
     },
     {
@@ -8604,6 +9046,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8ce3988b76cd6848"
     },
     {
@@ -8617,6 +9064,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7474171579a55797"
     },
     {
@@ -8630,7 +9082,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9a1c0dfa08fc8d85"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9a1c0dfa08fc8d85",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C31-qaraa",
@@ -8643,7 +9103,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:048d4affba0e5fc3"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:048d4affba0e5fc3",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C31-saala",
@@ -8656,7 +9124,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9b7f1e1d11e552b5"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9b7f1e1d11e552b5",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C31-kataba",
@@ -8669,7 +9145,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8083a92e55e85f54"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8083a92e55e85f54",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C32-akhadha",
@@ -8682,7 +9166,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ba58f2589a487984"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ba58f2589a487984",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C32-fakkara",
@@ -8695,7 +9187,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c78324b8fddadc52"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c78324b8fddadc52",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C32-saada",
@@ -8708,7 +9208,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:76c015b2e8c3825c"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:76c015b2e8c3825c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "AR-C32-ahabba",
@@ -8721,7 +9229,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:2c4164cd56e38bb1"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:2c4164cd56e38bb1",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C01-achchha",
@@ -8734,7 +9250,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:84972988a9ab9cfe"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:84972988a9ab9cfe",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C01-ashi",
@@ -8747,7 +9271,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3548b8e1e6d8b786"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3548b8e1e6d8b786",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C01-dhonnobad",
@@ -8760,7 +9292,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b6dedebbef9e9c4a"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b6dedebbef9e9c4a",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C01-hyan-na",
@@ -8773,7 +9313,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:d86583f11bfbb6a7"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:d86583f11bfbb6a7",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C01-nomoshkar",
@@ -8786,7 +9334,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:63149e08a09fd266"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:63149e08a09fd266",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C01-practice",
@@ -8799,6 +9355,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a0c79554855f2825"
     },
     {
@@ -8812,7 +9373,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4b0fda4f32ec3fd6"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4b0fda4f32ec3fd6",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C02-amar",
@@ -8825,7 +9394,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a2568d0190f56ea9"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a2568d0190f56ea9",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C02-amar-naam",
@@ -8838,6 +9415,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:51eefb2762daba62"
     },
     {
@@ -8851,7 +9433,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9742adfbc75528a3"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9742adfbc75528a3",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C02-naam",
@@ -8864,7 +9454,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ff4b24b412c6f334"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ff4b24b412c6f334",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C02-practice",
@@ -8877,6 +9475,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:30d98e47cec9efea"
     },
     {
@@ -8890,6 +9493,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:49150302a08d596e"
     },
     {
@@ -8903,7 +9511,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:7ced4161be7a9daf"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7ced4161be7a9daf",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C03-ami",
@@ -8916,7 +9532,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8e68eb4530d5434b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8e68eb4530d5434b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C03-bhalo",
@@ -8929,7 +9553,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:77f8059fd4601afa"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:77f8059fd4601afa",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C03-kemon",
@@ -8942,7 +9574,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:62bb3e5d57aa6659"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:62bb3e5d57aa6659",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C03-kono-bepar-na",
@@ -8955,7 +9595,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:2620bde01fad47a8"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:2620bde01fad47a8",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C03-practice",
@@ -8968,6 +9616,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:55d8c883a5973097"
     },
     {
@@ -8981,7 +9634,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:dc0e1d8dda6194ec"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:dc0e1d8dda6194ec",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C04-abar",
@@ -8994,7 +9655,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bdbcded841cd4265"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:bdbcded841cd4265",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C04-abar-dekha-hobe",
@@ -9007,6 +9676,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:33d3aab992b566ea"
     },
     {
@@ -9020,7 +9694,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b8f661e6e0594a07"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b8f661e6e0594a07",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C04-kal-dekha-hobe",
@@ -9033,7 +9715,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5a5040768b99964e"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5a5040768b99964e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C04-practice",
@@ -9046,6 +9736,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4cfb9c1b606ded5f"
     },
     {
@@ -9059,7 +9754,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:71f11d270c7b77e9"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:71f11d270c7b77e9",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C05-bola",
@@ -9072,7 +9775,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:03bcf22359a87d4e"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:03bcf22359a87d4e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C05-kaj-kora",
@@ -9085,7 +9796,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:88ae3d7246caf29a"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:88ae3d7246caf29a",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C05-practice",
@@ -9098,6 +9817,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:08dee411f79d123f"
     },
     {
@@ -9111,7 +9835,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f1a739ff51404a22"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f1a739ff51404a22",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C06-numbers-1-5",
@@ -9124,6 +9856,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b90d02828e8f4352"
     },
     {
@@ -9137,6 +9874,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:875d94baecd764c8"
     },
     {
@@ -9150,6 +9892,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:02aa3ee59e96b202"
     },
     {
@@ -9163,6 +9910,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:781996d54b057830"
     },
     {
@@ -9176,6 +9928,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4af6db76d104a4ea"
     },
     {
@@ -9189,6 +9946,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fdbc818ec1394d03"
     },
     {
@@ -9202,6 +9964,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9cee0df0ef154a25"
     },
     {
@@ -9215,7 +9982,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:559a663bc15c575f"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:559a663bc15c575f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C08-bojha",
@@ -9228,7 +10003,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:847cbb02cc421259"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:847cbb02cc421259",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C08-pora",
@@ -9241,7 +10024,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:087da54326653038"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:087da54326653038",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C08-lekha",
@@ -9254,7 +10045,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:057ee091c68a66f7"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:057ee091c68a66f7",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C09-neowa",
@@ -9267,7 +10066,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4ab8b306459cb32b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4ab8b306459cb32b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C09-jijnasa-kora",
@@ -9280,7 +10087,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4b3d683c0f08d7a8"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4b3d683c0f08d7a8",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C09-sahajjo-kora",
@@ -9293,7 +10108,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:0b7790c25f7261f4"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0b7790c25f7261f4",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "BN-C09-bhalo-laga",
@@ -9306,7 +10129,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c9aa4582a3ac3bf3"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c9aa4582a3ac3bf3",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ZH-C01-tones",
@@ -9319,6 +10150,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4b569881c35225c0"
     },
     {
@@ -9332,7 +10168,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:fd5fc68c6af29500"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:fd5fc68c6af29500",
+      "detachableSegments": [
+        "Script — 你, and the person hiding on its left"
+      ]
     },
     {
       "id": "ZH-C01-hao",
@@ -9345,7 +10189,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8856bfa06cfb62bd"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8856bfa06cfb62bd",
+      "detachableSegments": [
+        "Script — 好, a woman beside a child"
+      ]
     },
     {
       "id": "ZH-C01-nihao",
@@ -9358,6 +10210,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:33e6c06570cdddcc"
     },
     {
@@ -9371,6 +10228,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:be0bd150e6d245de"
     },
     {
@@ -9384,6 +10246,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4c8bd26e8b670b97"
     },
     {
@@ -9397,6 +10264,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:20a7dc4c3eefeed6"
     },
     {
@@ -9410,6 +10282,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d4daafe747413b56"
     },
     {
@@ -9423,6 +10300,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8fbba17e97a94ac5"
     },
     {
@@ -9436,6 +10318,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:69d03dc70ba43271"
     },
     {
@@ -9449,6 +10336,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d3dacca4d2795c17"
     },
     {
@@ -9462,6 +10354,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e34422e75a8e6a66"
     },
     {
@@ -9475,6 +10372,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8039220a178a1b2e"
     },
     {
@@ -9488,6 +10390,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8a858a28682f1fbe"
     },
     {
@@ -9502,6 +10409,12 @@
         "sight-cue",
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue",
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:e28a45e6e90399d6"
     },
     {
@@ -9515,6 +10428,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5e3bf39b1acbf123"
     },
     {
@@ -9528,6 +10446,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3b4217aedd4a0b2f"
     },
     {
@@ -9541,6 +10464,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e600f732ded9a997"
     },
     {
@@ -9554,6 +10482,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a84b2cf34d70d5d4"
     },
     {
@@ -9567,6 +10500,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c9ff24acde19d23c"
     },
     {
@@ -9580,6 +10518,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c3c423e93b7fd8d7"
     },
     {
@@ -9593,6 +10536,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:768ed915cd4bff65"
     },
     {
@@ -9606,6 +10554,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:221602da2f8434f4"
     },
     {
@@ -9619,6 +10572,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:730fd10466a51177"
     },
     {
@@ -9632,6 +10590,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:be599cea3506cf06"
     },
     {
@@ -9645,6 +10608,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:df4f16f57d7f4668"
     },
     {
@@ -9658,6 +10626,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b847e8c1880ecc27"
     },
     {
@@ -9671,6 +10644,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:4c4319e2d9dc8c2e"
     },
     {
@@ -9684,6 +10662,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7e37666d31fc493a"
     },
     {
@@ -9697,6 +10680,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:27e978bd0dff8c19"
     },
     {
@@ -9710,6 +10698,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0ed8f911f81f5613"
     },
     {
@@ -9723,6 +10716,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d1e3a06b51f0b29c"
     },
     {
@@ -9736,6 +10734,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:09c9c8711a2a7a6a"
     },
     {
@@ -9749,6 +10752,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a2416f192230f13b"
     },
     {
@@ -9762,6 +10770,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:658b24338124089f"
     },
     {
@@ -9775,6 +10788,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d36a604ae3a9cff3"
     },
     {
@@ -9788,6 +10806,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:68bc38c723215615"
     },
     {
@@ -9801,6 +10824,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:39b820a6b7b1e4b1"
     },
     {
@@ -9814,6 +10842,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6eb87bacdc6239d6"
     },
     {
@@ -9827,6 +10860,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:857f79ebbf15c5d7"
     },
     {
@@ -9840,6 +10878,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:b1ecaf14ebba004b"
     },
     {
@@ -9853,6 +10896,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:0f7ca1460edd6157"
     },
     {
@@ -9866,6 +10914,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:13b0ef183fb8ac0b"
     },
     {
@@ -9879,6 +10932,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8ce4da624d5817b9"
     },
     {
@@ -9892,6 +10950,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:1b52b778db2ff0f7"
     },
     {
@@ -9905,6 +10968,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:83b2728615e6a8bd"
     },
     {
@@ -9918,6 +10986,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:aa49383efb48bb90"
     },
     {
@@ -9932,6 +11005,12 @@
         "sight-cue",
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue",
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:513c62c8264deb55"
     },
     {
@@ -9946,6 +11025,12 @@
         "sight-cue",
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue",
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:bdcb67f5105f9909"
     },
     {
@@ -9960,6 +11045,12 @@
         "sight-cue",
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue",
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:5277f68bb1dda755"
     },
     {
@@ -9973,6 +11064,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:06236d3e300701e2"
     },
     {
@@ -9986,6 +11082,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:64d1db65f1168841"
     },
     {
@@ -9999,6 +11100,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:22f7f3eadbc1fe83"
     },
     {
@@ -10012,6 +11118,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2974781db5823913"
     },
     {
@@ -10025,6 +11136,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:27f997cadda7b0cf"
     },
     {
@@ -10038,6 +11154,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ffbb959364731298"
     },
     {
@@ -10051,6 +11172,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ff682d3bb7e27e0f"
     },
     {
@@ -10064,6 +11190,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9f4cdd168e791c5c"
     },
     {
@@ -10077,6 +11208,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ae896345ca74377e"
     },
     {
@@ -10091,6 +11227,12 @@
         "sight-cue",
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue",
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:745c1085c2cc1f62"
     },
     {
@@ -10104,6 +11246,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:930acd145646d7ba"
     },
     {
@@ -10117,6 +11264,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:af7b0b056c6e72bc"
     },
     {
@@ -10130,6 +11282,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:47b88d9a216fdef7"
     },
     {
@@ -10143,6 +11300,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a27218f06597dac4"
     },
     {
@@ -10156,6 +11318,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:8e9f481dabe6b8c4"
     },
     {
@@ -10169,6 +11336,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1f2091d23c533595"
     },
     {
@@ -10182,6 +11354,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:eab30d60d9ceaa02"
     },
     {
@@ -10195,6 +11372,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2ad8553705ea5e8f"
     },
     {
@@ -10208,6 +11390,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:910e09f30c1f4372"
     },
     {
@@ -10221,6 +11408,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ca6ba71da1e4e5b3"
     },
     {
@@ -10234,6 +11426,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:69e73923681c38cb"
     },
     {
@@ -10247,6 +11444,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:51ee660bc823dcc3"
     },
     {
@@ -10260,6 +11462,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4900acc35de80fa8"
     },
     {
@@ -10273,6 +11480,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:cc9c2e7599edddd0"
     },
     {
@@ -10286,6 +11498,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:aadd47afc2c3d2f0"
     },
     {
@@ -10299,6 +11516,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6bf5f14296f59fbe"
     },
     {
@@ -10312,6 +11534,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f23ab8070a06448b"
     },
     {
@@ -10325,6 +11552,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:63e101761a178417"
     },
     {
@@ -10338,6 +11570,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9ad5aa01c0d2c734"
     },
     {
@@ -10351,6 +11588,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:568c8aef59fa16a9"
     },
     {
@@ -10364,6 +11606,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3701a294016bd259"
     },
     {
@@ -10377,6 +11624,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7d3f728249aa2e13"
     },
     {
@@ -10390,6 +11642,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ebc46f670b379245"
     },
     {
@@ -10403,6 +11660,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:85d8360819b5b772"
     },
     {
@@ -10416,6 +11678,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f3d0a8c0b84add36"
     },
     {
@@ -10429,6 +11696,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9c31ea0673fa3e55"
     },
     {
@@ -10442,6 +11714,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f07000fefeb3d091"
     },
     {
@@ -10455,6 +11732,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c75664e4497104d6"
     },
     {
@@ -10468,6 +11750,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fbd99324fd67ea41"
     },
     {
@@ -10481,6 +11768,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:513754e8b498f1ac"
     },
     {
@@ -10494,6 +11786,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:712e97cbb7e062da"
     },
     {
@@ -10507,6 +11804,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:89208bbe2b536b32"
     },
     {
@@ -10520,6 +11822,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8e27f83b4cbae57e"
     },
     {
@@ -10533,6 +11840,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9c2a570d56028e9c"
     },
     {
@@ -10546,6 +11858,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:7212a1c5b8e5d18d"
     },
     {
@@ -10559,6 +11876,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:79105bbc22c09803"
     },
     {
@@ -10572,6 +11894,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:64875806604e97aa"
     },
     {
@@ -10585,6 +11912,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7cf6769d247e4e45"
     },
     {
@@ -10598,6 +11930,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:aebbb094a3522a39"
     },
     {
@@ -10611,6 +11948,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:75645fd51c847743"
     },
     {
@@ -10624,6 +11966,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3dd3c611a81e6cb4"
     },
     {
@@ -10637,6 +11984,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:cc06db614ab8a56b"
     },
     {
@@ -10650,6 +12002,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:cc38318948ace522"
     },
     {
@@ -10663,6 +12020,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e73eeedf80a17a79"
     },
     {
@@ -10676,6 +12038,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6061fcf1c4ce8830"
     },
     {
@@ -10689,6 +12056,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c071790ad9287d04"
     },
     {
@@ -10702,6 +12074,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:78ef6723de639e03"
     },
     {
@@ -10715,6 +12092,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a47d3f6219fcb248"
     },
     {
@@ -10728,6 +12110,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:48aad6df3ed4ede2"
     },
     {
@@ -10741,6 +12128,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:bbb7f015dc775493"
     },
     {
@@ -10754,6 +12146,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9c622b2ea1c89fc0"
     },
     {
@@ -10767,6 +12164,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0ec4a4a2adff25f5"
     },
     {
@@ -10780,6 +12182,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2a5f813dc0845297"
     },
     {
@@ -10793,6 +12200,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9737b1fcb573ffad"
     },
     {
@@ -10806,6 +12218,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:24ef390ee824208c"
     },
     {
@@ -10819,6 +12236,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8dc5e2521c199718"
     },
     {
@@ -10832,6 +12254,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:603d5de9c422f34b"
     },
     {
@@ -10845,6 +12272,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e2e43a680f43b24a"
     },
     {
@@ -10858,6 +12290,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:543133b77d65bee3"
     },
     {
@@ -10871,6 +12308,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:53c74c7dc2bc27f0"
     },
     {
@@ -10884,6 +12326,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:13fb8570c59d5d1c"
     },
     {
@@ -10897,6 +12344,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8db665fdc2105356"
     },
     {
@@ -10910,6 +12362,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:a130c926f83687f6"
     },
     {
@@ -10923,6 +12380,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:57e4243f4d53946f"
     },
     {
@@ -10936,6 +12398,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:02d89a8bc07422d9"
     },
     {
@@ -10949,6 +12416,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a4809a490e2159ca"
     },
     {
@@ -10962,6 +12434,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b692dc8bfe1e4b40"
     },
     {
@@ -10975,6 +12452,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:92a8f484ee09fb92"
     },
     {
@@ -10988,6 +12470,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d41d4ab2725c99dc"
     },
     {
@@ -11001,6 +12488,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:03068b42d443b4fe"
     },
     {
@@ -11014,6 +12506,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:195cf21d12ee7be8"
     },
     {
@@ -11027,6 +12524,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:0b668449ae50e38f"
     },
     {
@@ -11040,6 +12542,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:a531e91aa4bf08b4"
     },
     {
@@ -11053,6 +12560,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:dec34d31bc1fdb7a"
     },
     {
@@ -11066,6 +12578,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0c248766c31bc500"
     },
     {
@@ -11079,6 +12596,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a5e68a19ad335ee0"
     },
     {
@@ -11092,6 +12614,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ef3f0c9ef91d388b"
     },
     {
@@ -11105,6 +12632,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1f24a05df676c375"
     },
     {
@@ -11118,6 +12650,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f9fd37834d482cbd"
     },
     {
@@ -11131,6 +12668,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8a57a69688ac4944"
     },
     {
@@ -11144,6 +12686,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0a795378f02bdfcc"
     },
     {
@@ -11157,6 +12704,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7e9bbbd5638590ba"
     },
     {
@@ -11170,6 +12722,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d65805c696c22eea"
     },
     {
@@ -11184,6 +12741,12 @@
         "sight-cue",
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue",
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:83effc86b2ea8b52"
     },
     {
@@ -11197,6 +12760,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e146ae0153ea6eca"
     },
     {
@@ -11210,6 +12778,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:85b588745f1df6fc"
     },
     {
@@ -11223,6 +12796,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:16cc9ad380a40484"
     },
     {
@@ -11236,6 +12814,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:ac77aad8695d3ee6"
     },
     {
@@ -11249,6 +12832,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2c67e6ffe91b42a5"
     },
     {
@@ -11262,6 +12850,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9037176b3ac1042a"
     },
     {
@@ -11275,6 +12868,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4c7b746e14c133e8"
     },
     {
@@ -11288,6 +12886,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:30c73f516de1fde3"
     },
     {
@@ -11301,6 +12904,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f363f912fec06714"
     },
     {
@@ -11314,6 +12922,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:27f2396af22b0742"
     },
     {
@@ -11327,6 +12940,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3efd11634f5e8898"
     },
     {
@@ -11340,6 +12958,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a043450fec40dee2"
     },
     {
@@ -11353,6 +12976,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:46d0b30a7b21211a"
     },
     {
@@ -11366,6 +12994,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6db290ebf326fdbd"
     },
     {
@@ -11379,6 +13012,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0320e08d92620a31"
     },
     {
@@ -11392,6 +13030,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8aa3db256c553235"
     },
     {
@@ -11405,6 +13048,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7aa6cd0b1c17a61e"
     },
     {
@@ -11418,6 +13066,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:880e01feb51320ea"
     },
     {
@@ -11431,6 +13084,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c326f0bf01024045"
     },
     {
@@ -11444,6 +13102,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9e76b587bcf9af4a"
     },
     {
@@ -11457,6 +13120,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:952056daa67f2430"
     },
     {
@@ -11470,6 +13138,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:73fbcc1325631e99"
     },
     {
@@ -11483,6 +13156,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:06d86fff9bf862f3"
     },
     {
@@ -11496,6 +13174,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:674265d6279ccc47"
     },
     {
@@ -11509,6 +13192,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:659f8d944102c0e7"
     },
     {
@@ -11522,6 +13210,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b37a2e1984bf0f52"
     },
     {
@@ -11535,6 +13228,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ec43afdc6b61f234"
     },
     {
@@ -11548,6 +13246,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6413600515d017a7"
     },
     {
@@ -11561,7 +13264,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6c81ef39a7506b6f"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6c81ef39a7506b6f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C01-aavjo",
@@ -11574,7 +13285,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:876b08b9d022898c"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:876b08b9d022898c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C01-haa-naa",
@@ -11587,7 +13306,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a2be660d94bf9647"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a2be660d94bf9647",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C01-namaste",
@@ -11601,7 +13328,15 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:90098ada701a7ec6"
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:90098ada701a7ec6",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C01-practice",
@@ -11614,6 +13349,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d43324531cc9bef5"
     },
     {
@@ -11628,7 +13368,15 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:8e36192d74166b6c"
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:8e36192d74166b6c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C02-anand",
@@ -11641,7 +13389,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:0ec28b57e91bb066"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0ec28b57e91bb066",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C02-chhe",
@@ -11654,7 +13410,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9421ea8c1eed68ca"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9421ea8c1eed68ca",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C02-maarun",
@@ -11667,7 +13431,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:69923e316ee556fb"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:69923e316ee556fb",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C02-maarun-naam-chhe",
@@ -11680,6 +13452,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:131deb18a89b3213"
     },
     {
@@ -11693,7 +13470,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:45c0fba6f08e5ec3"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:45c0fba6f08e5ec3",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C02-practice",
@@ -11706,6 +13491,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:46d495762ef4f25d"
     },
     {
@@ -11719,7 +13509,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:7b05173babb06dca"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7b05173babb06dca",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C02-tamarun-naam-shun-chhe",
@@ -11732,6 +13530,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:05037cae388d1cb5"
     },
     {
@@ -11745,7 +13548,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ddef50cd33aa95af"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ddef50cd33aa95af",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C03-hun",
@@ -11758,7 +13569,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:11e76b7f4b053d5c"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:11e76b7f4b053d5c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C03-kem",
@@ -11771,7 +13590,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bf5b7526a590d3e1"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:bf5b7526a590d3e1",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C03-majaa",
@@ -11784,7 +13611,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a8f4832b1584963f"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a8f4832b1584963f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C03-practice",
@@ -11797,6 +13632,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2cbc0c298d7b79c6"
     },
     {
@@ -11810,6 +13650,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e015921a087205c8"
     },
     {
@@ -11823,7 +13668,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4b281c51975b08c1"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4b281c51975b08c1",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C04-kaale",
@@ -11836,7 +13689,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1d688df2a4389d1a"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1d688df2a4389d1a",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C04-malishun",
@@ -11849,7 +13710,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:00667abc9913b227"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:00667abc9913b227",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C04-pachha",
@@ -11862,7 +13731,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ed7b37cea503d5c3"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ed7b37cea503d5c3",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C04-pachha-malishun",
@@ -11875,6 +13752,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:722ed898b16425d4"
     },
     {
@@ -11888,6 +13770,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5f7441aa51718c15"
     },
     {
@@ -11901,7 +13788,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a78b0a484e53552b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a78b0a484e53552b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C05-hun-gujarati-bolun-chhun",
@@ -11914,7 +13809,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:dc39a148e0c32c27"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:dc39a148e0c32c27",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C05-kaam-karvun",
@@ -11927,7 +13830,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bc64f6af5ca4e7a5"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:bc64f6af5ca4e7a5",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C05-practice",
@@ -11940,6 +13851,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:930baab2a86c682d"
     },
     {
@@ -11953,7 +13869,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:0776c98caaa4da8c"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0776c98caaa4da8c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C06-numbers-1-5",
@@ -11966,6 +13890,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:efa63868bdf27365"
     },
     {
@@ -11979,6 +13908,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:01b835a278e4ed28"
     },
     {
@@ -11992,6 +13926,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:074c898a263805b4"
     },
     {
@@ -12005,6 +13944,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ac22a70b3f014c43"
     },
     {
@@ -12018,6 +13962,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0a598e9332487ff5"
     },
     {
@@ -12031,6 +13980,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b4e5c4ae025d4ddb"
     },
     {
@@ -12044,6 +13998,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:123451e5d601e80a"
     },
     {
@@ -12057,6 +14016,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0a53c84fae291b0a"
     },
     {
@@ -12070,7 +14034,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ab9bbe40fe19ee9e"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ab9bbe40fe19ee9e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C08-samajvun",
@@ -12083,7 +14055,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e619706cc4866b8e"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e619706cc4866b8e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C08-vanchvun",
@@ -12096,7 +14076,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6a213e7937e89b80"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6a213e7937e89b80",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C08-lakhvun",
@@ -12109,7 +14097,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:cb81bfc0db3e69fa"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:cb81bfc0db3e69fa",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C09-levun",
@@ -12122,7 +14118,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:0b5eb0b51653ba96"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0b5eb0b51653ba96",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C09-puchhvun",
@@ -12135,7 +14139,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b616a00d37b78087"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b616a00d37b78087",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C09-madad-karvi",
@@ -12148,7 +14160,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9b33f51af27e06a4"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9b33f51af27e06a4",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "GU-C09-gamvun",
@@ -12161,7 +14181,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e9696c743f91f3a9"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e9696c743f91f3a9",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-W01-shirorekha-na-ma",
@@ -12175,6 +14203,12 @@
         "writing-type",
         "sight-cue"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type",
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:b5bf3a010b072219"
     },
     {
@@ -12188,6 +14222,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:45827ebdae0b68b3"
     },
     {
@@ -12201,6 +14240,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:bf84e48cdb65d54e"
     },
     {
@@ -12214,6 +14258,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:e36ecbfa85109dfb"
     },
     {
@@ -12227,7 +14276,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:89abbff53db9e06c"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:89abbff53db9e06c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C01-dhanyavad",
@@ -12240,7 +14297,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1ef2eb843b696428"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1ef2eb843b696428",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C01-namaskar",
@@ -12253,7 +14318,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:dd0f0aa5fdb9b145"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:dd0f0aa5fdb9b145",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C01-namaste",
@@ -12266,7 +14339,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:d41848618c702321"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:d41848618c702321",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C01-practice",
@@ -12279,6 +14360,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e06d1360ac7b383d"
     },
     {
@@ -12292,7 +14378,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:49b311784186967c"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:49b311784186967c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-W03-matras-naam",
@@ -12305,6 +14399,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:a2f6742312f65e6a"
     },
     {
@@ -12318,6 +14417,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:a729b2ab4b1ac55e"
     },
     {
@@ -12331,6 +14435,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:957899b91224e536"
     },
     {
@@ -12344,6 +14453,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:3532e6c1694adccf"
     },
     {
@@ -12357,6 +14471,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:26a1cf3645ca2164"
     },
     {
@@ -12371,6 +14490,12 @@
         "writing-type",
         "sight-cue"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type",
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:c5ff75676d1cd255"
     },
     {
@@ -12384,6 +14509,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:94b7be2009ede3a8"
     },
     {
@@ -12397,7 +14527,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:7bf9dd1fbfeaa979"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7bf9dd1fbfeaa979",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C02-aapka-naam-kya-hai",
@@ -12410,6 +14548,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c4f86737591b1807"
     },
     {
@@ -12423,7 +14566,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:373276fb279897f5"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:373276fb279897f5",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C02-khushi",
@@ -12436,6 +14587,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:86c47193cf8000df"
     },
     {
@@ -12449,7 +14605,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:98b5bd2e8efd62f6"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:98b5bd2e8efd62f6",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C02-mera-naam-hai",
@@ -12462,6 +14626,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:90ca854c67ed9189"
     },
     {
@@ -12475,7 +14644,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:eeaa065b35da7455"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:eeaa065b35da7455",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C02-naam",
@@ -12488,7 +14665,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a0371fc3206c766e"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a0371fc3206c766e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C02-practice",
@@ -12501,6 +14686,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:38ed1322267b1ad9"
     },
     {
@@ -12514,7 +14704,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:91c389645b62af66"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:91c389645b62af66",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C03-aapka-swagat-hai",
@@ -12527,7 +14725,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:2f6fac68a084606c"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:2f6fac68a084606c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C03-hun",
@@ -12540,7 +14746,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:75b0ccce17d974e7"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:75b0ccce17d974e7",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C03-kaise",
@@ -12553,7 +14767,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5a680be90e0f885f"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5a680be90e0f885f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C03-main",
@@ -12566,7 +14788,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:aea62ee6b7a4034b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:aea62ee6b7a4034b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C03-practice",
@@ -12579,6 +14809,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5973bc88e55daa61"
     },
     {
@@ -12592,7 +14827,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bff42bea4150f974"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:bff42bea4150f974",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C04-chalta-hun",
@@ -12605,7 +14848,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1bfbb5b02a0d294f"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1bfbb5b02a0d294f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C04-kal-milte-hain",
@@ -12618,7 +14869,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ee0eb7d8e9024f10"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ee0eb7d8e9024f10",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C04-milenge",
@@ -12631,7 +14890,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a70a0ef65533891a"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a70a0ef65533891a",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C04-phir",
@@ -12644,7 +14911,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:aedfba61a69ddd3b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:aedfba61a69ddd3b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C04-phir-milenge",
@@ -12657,6 +14932,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:da855bd5bbd3b332"
     },
     {
@@ -12670,6 +14950,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3f48527045e33a5d"
     },
     {
@@ -12683,7 +14968,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:63443742433fc576"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:63443742433fc576",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C05-bolta-hun",
@@ -12696,6 +14989,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6aed02a1964d754d"
     },
     {
@@ -12709,7 +15007,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e1c24c88399adaca"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e1c24c88399adaca",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C05-main-hindi-bolta-hun",
@@ -12722,7 +15028,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:195fea9e56a29808"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:195fea9e56a29808",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C05-practice",
@@ -12735,6 +15049,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5e71f588a1b47889"
     },
     {
@@ -12749,7 +15068,15 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:222b1446c5932bfd"
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:222b1446c5932bfd",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C06-numbers-1-5",
@@ -12762,6 +15089,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fc316aab6f08c2c1"
     },
     {
@@ -12775,6 +15107,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d80113a6ecd3bbde"
     },
     {
@@ -12788,6 +15125,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b20a5bf68c0e2db5"
     },
     {
@@ -12801,6 +15143,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e19d43f24244f62e"
     },
     {
@@ -12814,6 +15161,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:26289ff3f3503fe7"
     },
     {
@@ -12827,6 +15179,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6611611ca45a2159"
     },
     {
@@ -12840,6 +15197,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:cbf06c6cdc56aa64"
     },
     {
@@ -12853,6 +15215,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:f7cc8ce278f973ce"
     },
     {
@@ -12866,6 +15233,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b1cc093e07662b42"
     },
     {
@@ -12879,6 +15251,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:10613c571f209ea4"
     },
     {
@@ -12892,6 +15269,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0fd29499da36df2b"
     },
     {
@@ -12905,6 +15287,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b2d82d11b91b5eca"
     },
     {
@@ -12918,6 +15305,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e21e48816a8e2a81"
     },
     {
@@ -12931,6 +15323,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:50b7026bd518c80e"
     },
     {
@@ -12944,6 +15341,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:354c67609f0b4649"
     },
     {
@@ -12957,6 +15359,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9f64c469ba547d55"
     },
     {
@@ -12970,6 +15377,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:bdbb462743bbf066"
     },
     {
@@ -12983,6 +15395,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5a00ca773944ed59"
     },
     {
@@ -12996,6 +15413,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b45448090d1af146"
     },
     {
@@ -13009,6 +15431,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:feb6c6d4810251db"
     },
     {
@@ -13022,6 +15449,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0d79970c96a92694"
     },
     {
@@ -13035,6 +15467,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e1f8e0e5e8aa336a"
     },
     {
@@ -13048,6 +15485,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ef9e7b274f925034"
     },
     {
@@ -13061,6 +15503,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:431011ca0063eb4d"
     },
     {
@@ -13074,6 +15521,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8d3379d6b844a796"
     },
     {
@@ -13087,6 +15539,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:df7700b573fce384"
     },
     {
@@ -13100,6 +15557,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:47c46e86a23f8923"
     },
     {
@@ -13113,6 +15575,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9763bc9d616f87fa"
     },
     {
@@ -13126,6 +15593,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:01d9eb13c4005aeb"
     },
     {
@@ -13139,6 +15611,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f09a4eff599a6f0b"
     },
     {
@@ -13152,6 +15629,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9b2bf263fd107dca"
     },
     {
@@ -13165,6 +15647,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:84a06d8d7ba7297e"
     },
     {
@@ -13178,6 +15665,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:358bef2c319bcb67"
     },
     {
@@ -13191,6 +15683,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1312ac6766ba1c4c"
     },
     {
@@ -13204,6 +15701,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:bc2ba2db2a9d977c"
     },
     {
@@ -13217,6 +15719,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a4973a8f414380c6"
     },
     {
@@ -13230,6 +15737,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2f546c9def3a7957"
     },
     {
@@ -13243,6 +15755,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:dd5e73e34d5bb135"
     },
     {
@@ -13256,6 +15773,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:59d547d969da7cee"
     },
     {
@@ -13269,6 +15791,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:34614427f8c8c4ec"
     },
     {
@@ -13282,6 +15809,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b6dca6cd5e0e436f"
     },
     {
@@ -13295,7 +15827,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:fe18b61235e1be5b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:fe18b61235e1be5b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C34-padhna",
@@ -13308,7 +15848,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:868c856e36706e86"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:868c856e36706e86",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C34-likhna",
@@ -13321,7 +15869,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:281996bb41433226"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:281996bb41433226",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C35-lena",
@@ -13334,6 +15890,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e9e64bdec332f5c3"
     },
     {
@@ -13347,7 +15908,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8279a3a4b8c92b74"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8279a3a4b8c92b74",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "HI-C35-madad",
@@ -13360,6 +15929,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:235e467083ddf21d"
     },
     {
@@ -13373,6 +15947,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4625fc75bef6bc43"
     },
     {
@@ -13386,6 +15965,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:bf5ba98deca296b4"
     },
     {
@@ -13399,6 +15983,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4ef4e2a70ce4f96f"
     },
     {
@@ -13412,6 +16001,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4ff5252d6115ac5b"
     },
     {
@@ -13425,6 +16019,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2db996eea27f7291"
     },
     {
@@ -13438,6 +16037,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:24727ed3519a514e"
     },
     {
@@ -13451,6 +16055,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:42abb1bb4b06d812"
     },
     {
@@ -13464,6 +16073,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:51cf1ab986e10d2c"
     },
     {
@@ -13477,6 +16091,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:82dfa21619caa6fc"
     },
     {
@@ -13490,6 +16109,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f8d015596bda6a34"
     },
     {
@@ -13503,6 +16127,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6cbee97bd2d0ce6d"
     },
     {
@@ -13516,6 +16145,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6ee18f6ecb61ad08"
     },
     {
@@ -13529,6 +16163,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:af7966db27fdd5d9"
     },
     {
@@ -13542,6 +16181,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:65cccc833c91609c"
     },
     {
@@ -13555,6 +16199,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7ddc010272df8430"
     },
     {
@@ -13568,6 +16217,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:023ad2836fcaefdf"
     },
     {
@@ -13581,6 +16235,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:cd34da0727862033"
     },
     {
@@ -13594,6 +16253,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6e5af8c6039cec71"
     },
     {
@@ -13607,6 +16271,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6d03fde04d5a9049"
     },
     {
@@ -13620,6 +16289,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:75a8a718c8139813"
     },
     {
@@ -13633,6 +16307,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b1afea564cd5d0cc"
     },
     {
@@ -13646,6 +16325,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:016ae46fa1ec18fd"
     },
     {
@@ -13659,6 +16343,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:23c7fd178ce62749"
     },
     {
@@ -13672,6 +16361,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b0700f74c0056643"
     },
     {
@@ -13685,6 +16379,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:cc941c1f87d03f42"
     },
     {
@@ -13698,6 +16397,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b0173d636bb9ca50"
     },
     {
@@ -13711,6 +16415,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c20e7102d5095a8a"
     },
     {
@@ -13724,6 +16433,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:eaaa02873a656579"
     },
     {
@@ -13737,6 +16451,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:099131cdde7c1d43"
     },
     {
@@ -13750,6 +16469,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c4775635ebb63b52"
     },
     {
@@ -13763,6 +16487,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:bd73f59ecefa85a0"
     },
     {
@@ -13776,6 +16505,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9c5c9c5e244117c4"
     },
     {
@@ -13789,6 +16523,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:304effa7717adae1"
     },
     {
@@ -13803,6 +16542,12 @@
         "sight-cue",
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue",
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:2e3db6f2ef1d7557"
     },
     {
@@ -13816,6 +16561,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:c5f4da1a711d185c"
     },
     {
@@ -13829,6 +16579,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:b8ffb24763d86e84"
     },
     {
@@ -13842,6 +16597,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:9a91f1d6dace1834"
     },
     {
@@ -13855,6 +16615,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:78d97facae92a855"
     },
     {
@@ -13868,6 +16633,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:765c17dfee4ea380"
     },
     {
@@ -13881,6 +16651,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:643084eb40befbc6"
     },
     {
@@ -13894,6 +16669,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:99951bab86392f1e"
     },
     {
@@ -13907,6 +16687,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6373589c2409a1af"
     },
     {
@@ -13920,6 +16705,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6b4dfcef93c43201"
     },
     {
@@ -13933,6 +16723,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d24c93ec00cc8ea7"
     },
     {
@@ -13946,6 +16741,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9dd6ff850d67f4ee"
     },
     {
@@ -13959,6 +16759,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:3a0f27892fd984ce"
     },
     {
@@ -13972,6 +16777,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:1f921aa293716744"
     },
     {
@@ -13985,6 +16795,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d0b6f05b7cd86047"
     },
     {
@@ -13998,6 +16813,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:81b850406f4d7c3f"
     },
     {
@@ -14011,6 +16831,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:b141d3259442a09e"
     },
     {
@@ -14024,6 +16849,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:263c4afa76e9f3db"
     },
     {
@@ -14037,6 +16867,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a7df067937bdc8ef"
     },
     {
@@ -14050,6 +16885,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8d4b5481167925c8"
     },
     {
@@ -14063,6 +16903,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d9680de18280bc9e"
     },
     {
@@ -14076,6 +16921,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:e22b778a121eae21"
     },
     {
@@ -14089,6 +16939,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:ba9428463c194f78"
     },
     {
@@ -14102,6 +16957,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:cf85c351b3611b7a"
     },
     {
@@ -14115,6 +16975,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ad1ac30c6518f022"
     },
     {
@@ -14128,6 +16993,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a462acace3a0153a"
     },
     {
@@ -14141,6 +17011,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b7fe3dd46f267ece"
     },
     {
@@ -14154,6 +17029,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:78085442ef080abe"
     },
     {
@@ -14167,6 +17047,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:54e3ea7bdb0badc0"
     },
     {
@@ -14180,6 +17065,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:bf241d48b4032ad6"
     },
     {
@@ -14193,6 +17083,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a26fc49607ec8fe5"
     },
     {
@@ -14206,6 +17101,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c1a4a8184e67d693"
     },
     {
@@ -14219,6 +17119,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:bbbeb0b530219e69"
     },
     {
@@ -14232,6 +17137,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:659830f6ba3b9926"
     },
     {
@@ -14245,7 +17155,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9e35a70226961635"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9e35a70226961635",
+      "detachableSegments": [
+        "Script — two signs, two beats"
+      ]
     },
     {
       "id": "JA-C01-iie",
@@ -14258,7 +17176,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:48f5d1d0cb381ae2"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:48f5d1d0cb381ae2",
+      "detachableSegments": [
+        "Script — one new sign, three beats"
+      ]
     },
     {
       "id": "JA-C01-konnichiwa",
@@ -14271,7 +17197,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a5f03af3d9b83495"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a5f03af3d9b83495",
+      "detachableSegments": [
+        "Script — four new signs, and one you know"
+      ]
     },
     {
       "id": "JA-C01-nihongo",
@@ -14284,7 +17218,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:405ea26c254381c6"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:405ea26c254381c6",
+      "detachableSegments": [
+        "Script — kanji, and the readings problem"
+      ]
     },
     {
       "id": "JA-C01-koohii",
@@ -14297,7 +17239,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9d562bfdb6016d62"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9d562bfdb6016d62",
+      "detachableSegments": [
+        "Script — katakana, the borrowed-word script"
+      ]
     },
     {
       "id": "JA-C01-arigatou",
@@ -14310,7 +17260,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1ff00726c195b8ce"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1ff00726c195b8ce",
+      "detachableSegments": [
+        "Script — five signs and two small strokes"
+      ]
     },
     {
       "id": "JA-C01-gozaimasu",
@@ -14323,7 +17281,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a6d37ece38604436"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a6d37ece38604436",
+      "detachableSegments": [
+        "Script — five more signs, two of them dakuten"
+      ]
     },
     {
       "id": "JA-C01-practice",
@@ -14336,6 +17302,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fd0c2e1120a75440"
     },
     {
@@ -14350,7 +17321,15 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:035084b4558bdd72"
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:035084b4558bdd72",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C01-haudu",
@@ -14363,7 +17342,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:762cd4edbe26fc8e"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:762cd4edbe26fc8e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C01-illa",
@@ -14376,7 +17363,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5d8cbb19876741f0"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5d8cbb19876741f0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C01-namaskara",
@@ -14389,7 +17384,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3466dc173743e691"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3466dc173743e691",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C01-practice",
@@ -14402,6 +17405,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:cd038c2959d9f124"
     },
     {
@@ -14415,7 +17423,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9aa5a310f9bc828b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9aa5a310f9bc828b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C02-enu",
@@ -14428,7 +17444,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1be9909948d15d65"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1be9909948d15d65",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C02-hesaru",
@@ -14441,7 +17465,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:31cbf4d18c055096"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:31cbf4d18c055096",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C02-nanna",
@@ -14454,7 +17486,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:acd0ca42626d82bc"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:acd0ca42626d82bc",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C02-nanna-hesaru",
@@ -14467,6 +17507,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e51b27c4418575da"
     },
     {
@@ -14480,7 +17525,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:d50a8710b4d9aea6"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:d50a8710b4d9aea6",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C02-nimma-hesaru-enu",
@@ -14493,6 +17546,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:cb5beb5aca69aced"
     },
     {
@@ -14506,6 +17564,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:93db0cc0cb61a43e"
     },
     {
@@ -14519,6 +17582,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9394454c9eb26055"
     },
     {
@@ -14532,7 +17600,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:93437e98f663cb1c"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:93437e98f663cb1c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C03-hege",
@@ -14545,7 +17621,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8b830f9a970ffdec"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8b830f9a970ffdec",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C03-naanu",
@@ -14558,7 +17642,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:58de706b080bec57"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:58de706b080bec57",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C03-niivu-hegiddiira",
@@ -14571,7 +17663,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b4afa9f62df6a322"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b4afa9f62df6a322",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C03-paravaagilla",
@@ -14584,7 +17684,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a41e1b1c079f7f0b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a41e1b1c079f7f0b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C03-practice",
@@ -14597,6 +17705,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d57f4b0e1d1c241e"
     },
     {
@@ -14610,7 +17723,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5424de3b9e5d6cef"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5424de3b9e5d6cef",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C04-hoogu",
@@ -14623,7 +17744,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:30e99c8aa7d1463b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:30e99c8aa7d1463b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C04-matte-sigona",
@@ -14636,7 +17765,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4340dca3b939a451"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4340dca3b939a451",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C04-naale-sigona",
@@ -14649,7 +17786,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9c7fce2e8376967d"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9c7fce2e8376967d",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C04-practice",
@@ -14662,6 +17807,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b97400c0ccd8d1c1"
     },
     {
@@ -14675,7 +17825,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6f539f1993b90d24"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6f539f1993b90d24",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C05-kelasa-maadu",
@@ -14688,7 +17846,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9f1823451187ac5a"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9f1823451187ac5a",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C05-maatanaadu",
@@ -14701,7 +17867,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ea6df29016abfee2"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ea6df29016abfee2",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C05-naanu-kannada-maatanaaduttene",
@@ -14714,7 +17888,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c58b743e977f94c7"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c58b743e977f94c7",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "KA-C05-practice",
@@ -14727,6 +17909,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6c4002fdd5f2263d"
     },
     {
@@ -14740,6 +17927,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:2992f91067cb3eae"
     },
     {
@@ -14753,6 +17945,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:237c518b69f2b256"
     },
     {
@@ -14766,6 +17963,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b6cdaf03c942582b"
     },
     {
@@ -14779,6 +17981,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:073b63668004d352"
     },
     {
@@ -14792,6 +17999,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:ac529c2e35700a68"
     },
     {
@@ -14805,6 +18017,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:a93811ff1388aa1d"
     },
     {
@@ -14818,6 +18035,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:35ace1cd966ef652"
     },
     {
@@ -14831,6 +18053,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:bc906a495b55c8c5"
     },
     {
@@ -14844,6 +18071,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d1cb40574cf48b89"
     },
     {
@@ -14857,6 +18089,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:84a6e74134b1665c"
     },
     {
@@ -14870,6 +18107,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:816ebd1863ce3cc9"
     },
     {
@@ -14883,6 +18125,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:aad2ae9b46cc2f67"
     },
     {
@@ -14896,6 +18143,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4e297f50c05aa28a"
     },
     {
@@ -14909,6 +18161,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:12b347e74d1b8a21"
     },
     {
@@ -14922,6 +18179,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3671dc98e0d34e40"
     },
     {
@@ -14935,6 +18197,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7c3ffdf9f20e84bf"
     },
     {
@@ -14948,6 +18215,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b1ca6627d9b28ecb"
     },
     {
@@ -14961,6 +18233,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2e5f6d95d47961f9"
     },
     {
@@ -14974,6 +18251,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:36b6f5f3c841c2b3"
     },
     {
@@ -14987,6 +18269,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7e629189ef8f7017"
     },
     {
@@ -15000,6 +18287,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:43482806a1544152"
     },
     {
@@ -15013,6 +18305,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b23a67688711dae0"
     },
     {
@@ -15026,6 +18323,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:671996cecd9c3bef"
     },
     {
@@ -15039,6 +18341,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a3df191ed7cba0c0"
     },
     {
@@ -15052,6 +18359,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d399a5e4a2aeb1ca"
     },
     {
@@ -15065,6 +18377,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1466642b866e29ed"
     },
     {
@@ -15078,6 +18395,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:12b4b4c06d6601f7"
     },
     {
@@ -15091,6 +18413,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9dfa68bed3ca815c"
     },
     {
@@ -15104,6 +18431,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2027420fe9dd34a2"
     },
     {
@@ -15117,6 +18449,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:235151969cc736e2"
     },
     {
@@ -15130,6 +18467,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e0ded00331879ba2"
     },
     {
@@ -15143,6 +18485,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:779ab22bcc738f3b"
     },
     {
@@ -15156,6 +18503,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:43af55183ade57ca"
     },
     {
@@ -15169,6 +18521,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2c0e9d9b8cce853a"
     },
     {
@@ -15182,6 +18539,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:24026ebada70e585"
     },
     {
@@ -15195,6 +18557,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fd7c9f20c9d9b7c0"
     },
     {
@@ -15208,6 +18575,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:915fe318d5be9557"
     },
     {
@@ -15221,6 +18593,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7c47bae7fdbedecd"
     },
     {
@@ -15234,6 +18611,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:34fd767aa7d17da1"
     },
     {
@@ -15247,6 +18629,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:35c3f21bb2c8ecf8"
     },
     {
@@ -15260,6 +18647,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:73aa8e5bb7cc81ca"
     },
     {
@@ -15273,6 +18665,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d78f84abda939af4"
     },
     {
@@ -15286,6 +18683,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:14f730987ba4e2f4"
     },
     {
@@ -15299,6 +18701,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fdd0ec6159882e0b"
     },
     {
@@ -15312,6 +18719,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:dc3a533dd64d2208"
     },
     {
@@ -15325,6 +18737,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3ec59e713292cf0c"
     },
     {
@@ -15338,6 +18755,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6c79087ce3c2b815"
     },
     {
@@ -15351,6 +18773,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:aa2584c6cf114f91"
     },
     {
@@ -15364,6 +18791,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d231bd9e9b21af64"
     },
     {
@@ -15377,6 +18809,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4b96f24670e6e04f"
     },
     {
@@ -15391,6 +18828,12 @@
         "sight-cue",
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue",
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:a1d47161206de2cc"
     },
     {
@@ -15404,6 +18847,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:21ca6fade810615a"
     },
     {
@@ -15417,6 +18865,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c27a461435c37855"
     },
     {
@@ -15430,6 +18883,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e1a8a89e50819218"
     },
     {
@@ -15443,6 +18901,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:daa7b2028c9eb763"
     },
     {
@@ -15456,6 +18919,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f2deb3662d1d66b5"
     },
     {
@@ -15469,6 +18937,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8c1374e8b4fd28a5"
     },
     {
@@ -15482,6 +18955,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:469d49d7467b0bd0"
     },
     {
@@ -15495,6 +18973,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e2eb931af67e5883"
     },
     {
@@ -15508,6 +18991,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f740e6f8c7ea0bce"
     },
     {
@@ -15521,6 +19009,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b0d70f698ae3f763"
     },
     {
@@ -15534,6 +19027,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:219a83524eb2f5c6"
     },
     {
@@ -15547,6 +19045,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:01584ac09d4f269c"
     },
     {
@@ -15560,6 +19063,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1815c089d95f1f84"
     },
     {
@@ -15573,6 +19081,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:462d31404139af7b"
     },
     {
@@ -15586,6 +19099,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8829f5644f26d3b8"
     },
     {
@@ -15599,6 +19117,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f34f23b9caa3f5f3"
     },
     {
@@ -15612,6 +19135,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2bedf7362612ade1"
     },
     {
@@ -15625,6 +19153,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c83e9ce7f7f6024d"
     },
     {
@@ -15638,6 +19171,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3ca5b037de5908b4"
     },
     {
@@ -15651,6 +19189,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:752b86d076a6bedf"
     },
     {
@@ -15664,6 +19207,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:08a18400508f061f"
     },
     {
@@ -15677,6 +19225,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fe54b20d871f468e"
     },
     {
@@ -15690,6 +19243,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:cf10924d8df0911e"
     },
     {
@@ -15703,6 +19261,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3eb2b3813eaf89bf"
     },
     {
@@ -15716,6 +19279,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9f0465f604011809"
     },
     {
@@ -15729,6 +19297,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:81aeafc0622aef52"
     },
     {
@@ -15742,6 +19315,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9dd4a51e3b64720c"
     },
     {
@@ -15755,6 +19333,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:25752f46deb4c04b"
     },
     {
@@ -15768,6 +19351,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d26baa3eb553be8a"
     },
     {
@@ -15781,6 +19369,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:11d5e61c195c5fb4"
     },
     {
@@ -15794,6 +19387,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1ecece80fdd47b3c"
     },
     {
@@ -15807,6 +19405,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4746a09ecea844d0"
     },
     {
@@ -15820,6 +19423,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d0c78397121bbbbb"
     },
     {
@@ -15833,6 +19441,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fd20f29edbdaba21"
     },
     {
@@ -15846,6 +19459,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:191337c0bbe191b6"
     },
     {
@@ -15859,6 +19477,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:37381c4bde4b1c99"
     },
     {
@@ -15872,6 +19495,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7e365929d7622073"
     },
     {
@@ -15885,6 +19513,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d347115db770b2b1"
     },
     {
@@ -15898,6 +19531,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:898bf6278c0472bf"
     },
     {
@@ -15911,6 +19549,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:66256ba5a5212e25"
     },
     {
@@ -15924,6 +19567,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c3ed059fad5a5a94"
     },
     {
@@ -15937,6 +19585,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b8b15665b17ab142"
     },
     {
@@ -15950,6 +19603,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a219fd42b0916452"
     },
     {
@@ -15963,6 +19621,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:00242fd2dcaeda95"
     },
     {
@@ -15976,6 +19639,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b6d7a6121f9b4bbc"
     },
     {
@@ -15989,6 +19657,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8a44722fca6b01fc"
     },
     {
@@ -16002,6 +19675,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c506be6271eb4353"
     },
     {
@@ -16015,6 +19693,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1679ce5fe3160f66"
     },
     {
@@ -16028,6 +19711,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3738faa18f82389e"
     },
     {
@@ -16041,6 +19729,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b953d8c26b573452"
     },
     {
@@ -16054,6 +19747,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e0ff6bb656fe9f58"
     },
     {
@@ -16067,6 +19765,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d12f0c2d1c2338a2"
     },
     {
@@ -16080,6 +19783,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:742adb95f89d57d9"
     },
     {
@@ -16093,6 +19801,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:90c7781508ce6776"
     },
     {
@@ -16106,6 +19819,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c9d41fbe1f17b046"
     },
     {
@@ -16119,6 +19837,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:52164a1c1090035b"
     },
     {
@@ -16132,6 +19855,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2b762d17dcef21c2"
     },
     {
@@ -16145,6 +19873,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:051856f3e9c81534"
     },
     {
@@ -16158,6 +19891,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8f212bec0682b367"
     },
     {
@@ -16171,6 +19909,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b5511be9ba3c46d1"
     },
     {
@@ -16184,6 +19927,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:825bf0ef0ce282f8"
     },
     {
@@ -16197,6 +19945,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a0c57712692fe5f1"
     },
     {
@@ -16210,6 +19963,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4d8ae3b70ae202db"
     },
     {
@@ -16223,6 +19981,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1fb29952282581ed"
     },
     {
@@ -16236,6 +19999,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:257e966cc6befa30"
     },
     {
@@ -16249,6 +20017,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c051a21f677da1d1"
     },
     {
@@ -16262,7 +20035,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b5428b9487e2b5ca"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b5428b9487e2b5ca",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C01-illa",
@@ -16275,7 +20056,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a386c9616c67b3e7"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a386c9616c67b3e7",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C01-namaskaram",
@@ -16288,7 +20077,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bd41bd8573b9cfb8"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:bd41bd8573b9cfb8",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C01-nandi",
@@ -16301,7 +20098,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:77fae88f5176850b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:77fae88f5176850b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C01-practice",
@@ -16314,6 +20119,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:5f48e1f8ca2ef8d8"
     },
     {
@@ -16327,7 +20137,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:2cdf31bc9b98e609"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:2cdf31bc9b98e609",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C02-aanu",
@@ -16340,7 +20158,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ff571c00f6d40e5d"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ff571c00f6d40e5d",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C02-enre",
@@ -16353,7 +20179,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:fdf49546f6b2b6ee"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:fdf49546f6b2b6ee",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C02-enre-peru-aanu",
@@ -16366,6 +20200,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:da9f506cea14ae5e"
     },
     {
@@ -16379,7 +20218,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:cd1b34c3574c0c15"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:cd1b34c3574c0c15",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C02-nii-ningal",
@@ -16392,7 +20239,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8df6cc5e645d2578"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8df6cc5e645d2578",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C02-ninre-peru-entaanu",
@@ -16405,6 +20260,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3230de8b1fadd8c3"
     },
     {
@@ -16418,7 +20278,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:fce78214aef0ef35"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:fce78214aef0ef35",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C02-practice",
@@ -16431,6 +20299,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:98fd8347dca89d38"
     },
     {
@@ -16444,6 +20317,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:39689e1d6aa3ebb2"
     },
     {
@@ -16457,7 +20335,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:64cd69a9348bd1f5"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:64cd69a9348bd1f5",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C03-njaan",
@@ -16470,7 +20356,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1c8c8f8f5981e1da"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1c8c8f8f5981e1da",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C03-practice",
@@ -16483,6 +20377,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c2519415de315bed"
     },
     {
@@ -16496,7 +20395,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9eae0087a7a99e4f"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9eae0087a7a99e4f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C03-sukham",
@@ -16509,7 +20416,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5e0de3df6b96aec1"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5e0de3df6b96aec1",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C03-sukhamaano",
@@ -16522,7 +20437,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5c17999601548f76"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5c17999601548f76",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C04-naale-kaanaam",
@@ -16535,7 +20458,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:7f5e2b7fe9218475"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7f5e2b7fe9218475",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C04-pokuka",
@@ -16548,7 +20479,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bd9c0c56fa2d2c9d"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:bd9c0c56fa2d2c9d",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C04-poyi-varaam",
@@ -16561,7 +20500,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:887651ed8d638d32"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:887651ed8d638d32",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C04-practice",
@@ -16574,6 +20521,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7e1ccf228db6f4cc"
     },
     {
@@ -16587,7 +20539,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e9a77070f795c048"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e9a77070f795c048",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C05-joli-ceyyuka",
@@ -16600,7 +20560,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:31d528a76c0bd599"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:31d528a76c0bd599",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C05-njaan-malayalam-samsaarikkunnu",
@@ -16613,7 +20581,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b14fc6b48cd6b91d"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b14fc6b48cd6b91d",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C05-practice",
@@ -16626,6 +20602,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:517f683dbde4de86"
     },
     {
@@ -16639,7 +20620,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1bdbc87303276fc6"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1bdbc87303276fc6",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C05-taamasikkuka",
@@ -16652,7 +20641,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8af0e0a180efa543"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8af0e0a180efa543",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C06-dative-ikku",
@@ -16665,6 +20662,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:494e395d488a3813"
     },
     {
@@ -16678,6 +20680,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:776992a51835cb14"
     },
     {
@@ -16691,6 +20698,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:2a9ed4236164b68a"
     },
     {
@@ -16704,6 +20716,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:fdd67cc65bed0e4b"
     },
     {
@@ -16717,6 +20734,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4520f33cdb069b52"
     },
     {
@@ -16730,6 +20752,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:13a530938d324359"
     },
     {
@@ -16743,6 +20770,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:cac9e52db2cbf656"
     },
     {
@@ -16756,6 +20788,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:62c26eca8d419caa"
     },
     {
@@ -16769,6 +20806,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c8f4b6bd85c63fb9"
     },
     {
@@ -16782,6 +20824,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:188461a9e7b4408b"
     },
     {
@@ -16795,6 +20842,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2987afd1acf6966c"
     },
     {
@@ -16808,6 +20860,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:52093eeffc1197b2"
     },
     {
@@ -16821,6 +20878,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:15853d09bdad6b8a"
     },
     {
@@ -16834,6 +20896,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6da9faf1334b3f22"
     },
     {
@@ -16847,6 +20914,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5e5d3423d223860c"
     },
     {
@@ -16860,6 +20932,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:27f91cf7f0a0d28f"
     },
     {
@@ -16873,6 +20950,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c0edebb4be94b008"
     },
     {
@@ -16886,6 +20968,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6e118e921dd579c5"
     },
     {
@@ -16899,6 +20986,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0ad30d747675aade"
     },
     {
@@ -16912,6 +21004,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1b76808f04d3669a"
     },
     {
@@ -16925,6 +21022,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c30a3f461f13e7c7"
     },
     {
@@ -16938,6 +21040,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c8a896f44b16eafa"
     },
     {
@@ -16951,6 +21058,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c52f31160d246a7e"
     },
     {
@@ -16964,6 +21076,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:53a7d4f15dc6e80c"
     },
     {
@@ -16977,6 +21094,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4fe755af3ecd5b81"
     },
     {
@@ -16990,6 +21112,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b5ee132494024238"
     },
     {
@@ -17003,6 +21130,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1f7e1a50dbcee8a6"
     },
     {
@@ -17016,6 +21148,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f51751154852e81b"
     },
     {
@@ -17029,6 +21166,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e41a549db6c8c832"
     },
     {
@@ -17042,6 +21184,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1243bf8f8bdb38de"
     },
     {
@@ -17055,6 +21202,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:319b9cf0184e41fe"
     },
     {
@@ -17068,6 +21220,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fe01eca3969055a4"
     },
     {
@@ -17081,6 +21238,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:245c8bd9a2c2896c"
     },
     {
@@ -17094,6 +21256,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:062041c5546f2372"
     },
     {
@@ -17107,6 +21274,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ad407ce9fdc26ad9"
     },
     {
@@ -17120,6 +21292,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a9233ede32bd6000"
     },
     {
@@ -17133,6 +21310,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f4391ddcae89fe89"
     },
     {
@@ -17146,6 +21328,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:846fe064460069ca"
     },
     {
@@ -17159,6 +21346,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6808949bcdfecb1d"
     },
     {
@@ -17172,7 +21364,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:080402d8451fbb93"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:080402d8451fbb93",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C33-manassilaakkuka",
@@ -17185,7 +21385,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:cb6bc49224559927"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:cb6bc49224559927",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C33-vaayikkuka",
@@ -17198,7 +21406,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:92ce2dd007bf522e"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:92ce2dd007bf522e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C33-ezhutuka",
@@ -17211,7 +21427,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:af6712cea8fc7fe6"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:af6712cea8fc7fe6",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C34-edukkuka",
@@ -17224,7 +21448,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:0046b0dba1edb3a2"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0046b0dba1edb3a2",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C34-codikkuka",
@@ -17237,7 +21469,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:569391079123b945"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:569391079123b945",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C34-sahaayikkuka",
@@ -17250,7 +21490,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:d850225bac58ea53"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:d850225bac58ea53",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "ML-C34-ishtam",
@@ -17263,7 +21511,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:57160fe267d6d5e7"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:57160fe267d6d5e7",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C01-baram",
@@ -17276,7 +21532,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e8acc6d28293a532"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e8acc6d28293a532",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C01-dhanyavad",
@@ -17289,7 +21553,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:dff856539c02590f"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:dff856539c02590f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C01-ho",
@@ -17302,7 +21574,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1870ccc311c6214e"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1870ccc311c6214e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C01-nahi",
@@ -17315,7 +21595,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:014b65433ef4192f"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:014b65433ef4192f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C01-namaskar",
@@ -17328,7 +21616,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ac1642934e61a0cc"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ac1642934e61a0cc",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C01-practice",
@@ -17341,6 +21637,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9d187e3e6e7555ec"
     },
     {
@@ -17354,7 +21655,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9860ee3897f812f0"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9860ee3897f812f0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C02-aahe",
@@ -17367,7 +21676,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6d76204e5a92182f"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6d76204e5a92182f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C02-anand",
@@ -17380,6 +21697,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:22ea5d99f4a85759"
     },
     {
@@ -17393,7 +21715,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a3a3199a2f631da2"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a3a3199a2f631da2",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C02-majhe",
@@ -17406,7 +21736,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:12147a7db0bc628e"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:12147a7db0bc628e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C02-majhe-naav-aahe",
@@ -17419,6 +21757,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:151eaa22ab083bf1"
     },
     {
@@ -17432,7 +21775,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5c6ccd43c11eba92"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5c6ccd43c11eba92",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C02-practice",
@@ -17445,6 +21796,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:dc477000accbb398"
     },
     {
@@ -17458,7 +21814,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8cd11b308e6ab1df"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8cd11b308e6ab1df",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C02-tumche-naav-kaay-aahe",
@@ -17471,6 +21835,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7762eea32e74fd3b"
     },
     {
@@ -17484,6 +21853,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0cfa2dab83cbbabb"
     },
     {
@@ -17497,7 +21871,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e695d0daa0640a61"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e695d0daa0640a61",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C03-mi",
@@ -17510,7 +21892,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:22844eecb06db04d"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:22844eecb06db04d",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C03-mi-bara-aahe",
@@ -17523,6 +21913,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b379c0ae628e5fbd"
     },
     {
@@ -17536,6 +21931,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:eb7818167410db6b"
     },
     {
@@ -17549,6 +21949,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:086c5a5c922f7887"
     },
     {
@@ -17562,7 +21967,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:d2a93e1d9ba5feca"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:d2a93e1d9ba5feca",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C04-kalji-ghya",
@@ -17575,7 +21988,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:2262fbdb932d7780"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:2262fbdb932d7780",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C04-practice",
@@ -17588,6 +22009,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b2f49ee8ecb088f8"
     },
     {
@@ -17601,7 +22027,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8fee2b0b32a934c4"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8fee2b0b32a934c4",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C04-punha-bhetu",
@@ -17614,6 +22048,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:29ec2b62f0225100"
     },
     {
@@ -17627,7 +22066,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:97e1110a9c571d0b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:97e1110a9c571d0b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C05-bolne",
@@ -17640,7 +22087,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8e3878fbe5f91411"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8e3878fbe5f91411",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C05-kaam-karne",
@@ -17653,7 +22108,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:77068cc88a0a5570"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:77068cc88a0a5570",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C05-mi-marathi-bolto",
@@ -17666,6 +22129,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fb6cd9255ece76d5"
     },
     {
@@ -17679,6 +22147,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:360f39186883773c"
     },
     {
@@ -17693,7 +22166,15 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:a5aee5a710cf9dc8"
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:a5aee5a710cf9dc8",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C06-numbers-1-5",
@@ -17706,6 +22187,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:40777dbcd678a439"
     },
     {
@@ -17719,6 +22205,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c778d912211f1242"
     },
     {
@@ -17732,6 +22223,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0f2ed68a452c17d6"
     },
     {
@@ -17745,6 +22241,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e542d487028acb9f"
     },
     {
@@ -17758,6 +22259,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:452475ec272ca043"
     },
     {
@@ -17771,6 +22277,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a3925dbc1a2bd6f7"
     },
     {
@@ -17784,6 +22295,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2be2ef5168f6ef78"
     },
     {
@@ -17797,6 +22313,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e85044dedb2058a5"
     },
     {
@@ -17810,7 +22331,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6c23c65f9fe81a6b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6c23c65f9fe81a6b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C08-samajne",
@@ -17823,7 +22352,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e0b2f29fcd872001"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e0b2f29fcd872001",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C08-vachne",
@@ -17836,7 +22373,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:81b2b18e933000a0"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:81b2b18e933000a0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C08-lihine",
@@ -17849,7 +22394,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:991573d7718cd4cd"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:991573d7718cd4cd",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C09-ghene",
@@ -17862,7 +22415,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:299d9bbccfef9e23"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:299d9bbccfef9e23",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C09-vicharne",
@@ -17875,7 +22436,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5a822ee9bd20957b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5a822ee9bd20957b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C09-madat-karne",
@@ -17888,7 +22457,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bbc7db2efcf7b1a5"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:bbc7db2efcf7b1a5",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "MR-C09-avadne",
@@ -17901,7 +22478,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9ae117caacb14423"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9ae117caacb14423",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "FA-C01-bale",
@@ -17914,6 +22499,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8cab01c60aea34a5"
     },
     {
@@ -17927,6 +22517,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:831ed1da893de263"
     },
     {
@@ -17940,6 +22535,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c0df8ec253b9b50b"
     },
     {
@@ -17953,6 +22553,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a0e9314f433cb6ab"
     },
     {
@@ -17966,6 +22571,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:aa39932a49590127"
     },
     {
@@ -17979,6 +22589,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:be202b2738d36b7b"
     },
     {
@@ -17992,6 +22607,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:71b3336475de7a57"
     },
     {
@@ -18005,7 +22625,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c28cba7850362b53"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c28cba7850362b53",
+      "detachableSegments": [
+        "Script: the question mark"
+      ]
     },
     {
       "id": "FA-C03-khoshvaghtam",
@@ -18018,6 +22646,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e199c041ce87eb5d"
     },
     {
@@ -18031,6 +22664,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4c3f2d98d0b2ca18"
     },
     {
@@ -18044,6 +22682,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c22ed1da7c4fc7f4"
     },
     {
@@ -18057,6 +22700,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c01f079eced4d640"
     },
     {
@@ -18070,6 +22718,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5be3080680b8c3ff"
     },
     {
@@ -18083,6 +22736,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4122348cafedbcce"
     },
     {
@@ -18096,6 +22754,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:aa215822c6de9bf2"
     },
     {
@@ -18109,6 +22772,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5e86a4c94d35c548"
     },
     {
@@ -18122,6 +22790,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:18cbd8850f1e7748"
     },
     {
@@ -18135,6 +22808,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3ddd0bd9a0cb79db"
     },
     {
@@ -18148,6 +22826,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e68453afbcfac0db"
     },
     {
@@ -18161,6 +22844,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e9a02f25650f2fe7"
     },
     {
@@ -18174,6 +22862,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2648a2da07145fb3"
     },
     {
@@ -18187,6 +22880,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d78d4cf6acd38d82"
     },
     {
@@ -18200,6 +22898,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c7f73b025f73c432"
     },
     {
@@ -18213,6 +22916,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:99d83661901b1619"
     },
     {
@@ -18226,6 +22934,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c9c77c962f6bf2cf"
     },
     {
@@ -18239,6 +22952,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:33e29d0c00d11bff"
     },
     {
@@ -18252,6 +22970,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7411eea71ec35188"
     },
     {
@@ -18265,6 +22988,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:abcd90b516fa7834"
     },
     {
@@ -18278,6 +23006,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:bf84f9553db841c7"
     },
     {
@@ -18291,6 +23024,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b0cbd7ebe8850758"
     },
     {
@@ -18304,6 +23042,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a8dd2150335c86c9"
     },
     {
@@ -18317,6 +23060,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6ce8a795202b003b"
     },
     {
@@ -18330,6 +23078,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:067ad924f3fff5b1"
     },
     {
@@ -18343,6 +23096,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d7a6174cadee47fd"
     },
     {
@@ -18356,6 +23114,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8f8f5773e8d4760e"
     },
     {
@@ -18369,6 +23132,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b326770e399d3ecf"
     },
     {
@@ -18382,6 +23150,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:453359836b8256d1"
     },
     {
@@ -18395,6 +23168,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a99b126926f54064"
     },
     {
@@ -18408,6 +23186,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5b6c01fccdfd47e7"
     },
     {
@@ -18421,6 +23204,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4b869cae6648659d"
     },
     {
@@ -18434,6 +23222,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:eda0c2812ecde1a0"
     },
     {
@@ -18447,6 +23240,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1f3c824ae780a931"
     },
     {
@@ -18460,6 +23258,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:52cbdef0857d72fc"
     },
     {
@@ -18473,6 +23276,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4f94e3dd7241a606"
     },
     {
@@ -18486,6 +23294,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f4a8709237abf25d"
     },
     {
@@ -18499,6 +23312,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fc322bb39b699414"
     },
     {
@@ -18512,6 +23330,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a02e9d4188bd98d6"
     },
     {
@@ -18525,6 +23348,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:86de033159d18fc0"
     },
     {
@@ -18538,6 +23366,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0ded2b44e7c3dc08"
     },
     {
@@ -18551,6 +23384,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:097a53e55e7299bb"
     },
     {
@@ -18564,6 +23402,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:426383f6e63eba27"
     },
     {
@@ -18577,6 +23420,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e37b7cc427686d4f"
     },
     {
@@ -18590,6 +23438,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:19d80603dcf4fd33"
     },
     {
@@ -18603,6 +23456,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:90e51bff189b5067"
     },
     {
@@ -18616,6 +23474,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e036daa989a9b2f7"
     },
     {
@@ -18629,6 +23492,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9b8ef9e56b40ed0a"
     },
     {
@@ -18642,6 +23510,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9830b40389d38856"
     },
     {
@@ -18655,6 +23528,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ac782f096e52d36a"
     },
     {
@@ -18668,6 +23546,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b71370b7fd65a597"
     },
     {
@@ -18681,6 +23564,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3f903540d005c2a3"
     },
     {
@@ -18694,6 +23582,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9142f96e86f2df49"
     },
     {
@@ -18707,6 +23600,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d828ba686501d94c"
     },
     {
@@ -18720,6 +23618,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:14e10194f21a22cd"
     },
     {
@@ -18733,6 +23636,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7cc2b0d894096c3b"
     },
     {
@@ -18746,6 +23654,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:554c9e659dae7732"
     },
     {
@@ -18759,6 +23672,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:594c1134cb80d6c4"
     },
     {
@@ -18772,6 +23690,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:b4daae3921b6de2e"
     },
     {
@@ -18785,6 +23708,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:c0fda7f81e770a79"
     },
     {
@@ -18798,6 +23726,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:e9ed04ba035c46c6"
     },
     {
@@ -18811,6 +23744,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:aa3cae359e8a5ad7"
     },
     {
@@ -18825,6 +23763,12 @@
         "sight-cue",
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue",
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:82df5e19c047fe50"
     },
     {
@@ -18838,6 +23782,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:61f1e8e8650bebd8"
     },
     {
@@ -18851,6 +23800,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f7afb2c35ee6edff"
     },
     {
@@ -18864,6 +23818,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c95ddcf9efd42694"
     },
     {
@@ -18877,6 +23836,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:728021c129cdefb6"
     },
     {
@@ -18890,6 +23854,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:978f1cc1949e0eda"
     },
     {
@@ -18903,6 +23872,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:89864126fd6d8ed4"
     },
     {
@@ -18916,6 +23890,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:e97ba5a3eb90b0f4"
     },
     {
@@ -18929,6 +23908,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:afd007780ea26424"
     },
     {
@@ -18942,6 +23926,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9bff2a85a1efcf44"
     },
     {
@@ -18955,6 +23944,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:62f1d856582b2f75"
     },
     {
@@ -18968,6 +23962,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c6b81a7f8eef85bd"
     },
     {
@@ -18981,6 +23980,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0e1b449764858e32"
     },
     {
@@ -18994,6 +23998,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:04e67acb90f29799"
     },
     {
@@ -19007,6 +24016,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:dc425e1b1bcff9a2"
     },
     {
@@ -19020,6 +24034,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:edbb93f449017570"
     },
     {
@@ -19033,6 +24052,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fdf8381298bfb94b"
     },
     {
@@ -19046,6 +24070,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c97bb700d6b120b4"
     },
     {
@@ -19059,6 +24088,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8a88df5726f51052"
     },
     {
@@ -19072,6 +24106,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ad67a92c860441ca"
     },
     {
@@ -19085,6 +24124,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1b677a14fdff6ebe"
     },
     {
@@ -19098,6 +24142,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:cb7201caca5af86d"
     },
     {
@@ -19111,6 +24160,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b6280fefbd37ea75"
     },
     {
@@ -19124,6 +24178,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:49979a10a3a6ec74"
     },
     {
@@ -19137,6 +24196,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f107891d41421a8e"
     },
     {
@@ -19150,6 +24214,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c8624c9aea28f2ed"
     },
     {
@@ -19163,6 +24232,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5ee9217699dedf09"
     },
     {
@@ -19176,6 +24250,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c977c7d335aaebaf"
     },
     {
@@ -19189,6 +24268,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:00842329cad02770"
     },
     {
@@ -19202,6 +24286,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:022d6eed8b617498"
     },
     {
@@ -19215,6 +24304,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:da9952c537a9bc43"
     },
     {
@@ -19228,6 +24322,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:bcda58e3866b4830"
     },
     {
@@ -19241,6 +24340,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:331c29072a3b115c"
     },
     {
@@ -19254,6 +24358,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:79c7eb13ce008985"
     },
     {
@@ -19267,6 +24376,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b1ae2563d664e109"
     },
     {
@@ -19280,6 +24394,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fd54d3307eb823b6"
     },
     {
@@ -19293,6 +24412,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:346e56012ffc6875"
     },
     {
@@ -19306,7 +24430,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a89b857d7542da98"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a89b857d7542da98",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C01-han-nahin",
@@ -19319,7 +24451,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:711c263e7b6de012"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:711c263e7b6de012",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C01-namaste",
@@ -19332,7 +24472,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:2e52f78d315f8fba"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:2e52f78d315f8fba",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C01-practice",
@@ -19345,6 +24493,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b0d8a58c3deaf7ab"
     },
     {
@@ -19358,7 +24511,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:093c9a80c31e6643"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:093c9a80c31e6643",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C01-shukriya",
@@ -19371,7 +24532,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9d7714fe70dee67b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9d7714fe70dee67b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C02-hai",
@@ -19384,7 +24553,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:922e7239562cb946"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:922e7239562cb946",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C02-khushi",
@@ -19397,7 +24574,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:2d68323af6b51fd6"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:2d68323af6b51fd6",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C02-ki",
@@ -19410,7 +24595,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6fde17101437fdf7"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6fde17101437fdf7",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C02-mera",
@@ -19423,7 +24616,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1750d6e42b415d7f"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1750d6e42b415d7f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C02-mera-naam-hai",
@@ -19436,6 +24637,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6d39215d0cc51e57"
     },
     {
@@ -19449,7 +24655,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6e4f130bce7c66bd"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6e4f130bce7c66bd",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C02-practice",
@@ -19462,6 +24676,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:46c2d78c663c06a3"
     },
     {
@@ -19475,7 +24694,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:af3a545579ee1871"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:af3a545579ee1871",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C02-tuhada-naam-ki-hai",
@@ -19488,6 +24715,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4ba5461017c82525"
     },
     {
@@ -19501,7 +24733,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:fb0615eb3dc5a6d0"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:fb0615eb3dc5a6d0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C03-koi-gall-nahin",
@@ -19514,7 +24754,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:0ffbdb425dfe11b1"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0ffbdb425dfe11b1",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C03-main",
@@ -19527,7 +24775,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:0ab088277790b4ee"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0ab088277790b4ee",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C03-practice",
@@ -19540,6 +24796,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2601e4b885cf4a55"
     },
     {
@@ -19553,7 +24814,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:aeae745d883bd1c5"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:aeae745d883bd1c5",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C03-tusi-kivein-ho",
@@ -19566,6 +24835,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d146aca7ee5de71f"
     },
     {
@@ -19579,7 +24853,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f84a739655088280"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f84a739655088280",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C04-phir",
@@ -19592,7 +24874,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c5e8584e9954c824"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c5e8584e9954c824",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C04-phir-milaange",
@@ -19605,6 +24895,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:47d4e46fef3f9a03"
     },
     {
@@ -19618,6 +24913,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5661e05e766f61d3"
     },
     {
@@ -19631,7 +24931,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ee53d2792100e157"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ee53d2792100e157",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C05-bolna",
@@ -19644,7 +24952,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:307dfe45fa3042e4"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:307dfe45fa3042e4",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C05-kamm-karna",
@@ -19657,7 +24973,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f9467160d95bc6b0"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f9467160d95bc6b0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C05-main-punjabi-bolda-han",
@@ -19670,7 +24994,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f4f87d3d34970a4c"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f4f87d3d34970a4c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C05-practice",
@@ -19683,6 +25015,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:09b5dca7f4ed542c"
     },
     {
@@ -19697,7 +25034,15 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:78cb36385d3494ad"
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:78cb36385d3494ad",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C06-numbers-1-5",
@@ -19710,6 +25055,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:eb013f7b1d01d8f5"
     },
     {
@@ -19723,6 +25073,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ffa41e7a4b0fb099"
     },
     {
@@ -19736,6 +25091,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b885be04f89dedf2"
     },
     {
@@ -19749,6 +25109,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:454611cabf72ba2e"
     },
     {
@@ -19762,6 +25127,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:02948358822be42d"
     },
     {
@@ -19775,6 +25145,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:399aa141195ccd0f"
     },
     {
@@ -19788,6 +25163,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:206f10ac6c1ebf37"
     },
     {
@@ -19801,6 +25181,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:720de68e6041f13e"
     },
     {
@@ -19814,7 +25199,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a9a4fa8645386d68"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a9a4fa8645386d68",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C08-samajhna",
@@ -19827,7 +25220,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:dbc09d98b1506dd6"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:dbc09d98b1506dd6",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C08-parhna",
@@ -19840,7 +25241,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f872b6ca6fea56e6"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f872b6ca6fea56e6",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C08-likhna",
@@ -19853,7 +25262,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6dfd8d54df7e6694"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6dfd8d54df7e6694",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C09-laina",
@@ -19866,7 +25283,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ba5e85879b8768cb"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ba5e85879b8768cb",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C09-puchhna",
@@ -19879,7 +25304,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:64526add00dafcd0"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:64526add00dafcd0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C09-madad-karna",
@@ -19892,7 +25325,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:fe20dd4c14e2913b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:fe20dd4c14e2913b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "PA-C09-pasand",
@@ -19905,7 +25346,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:cf1e6755d4424a40"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:cf1e6755d4424a40",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "RU-C01-da",
@@ -19918,7 +25367,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:fcaf3fa3908abd78"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:fcaf3fa3908abd78",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "RU-C01-net",
@@ -19931,7 +25388,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1bb4f36be79471f9"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1bb4f36be79471f9",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "RU-C01-pozhaluysta",
@@ -19944,7 +25409,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:7022b561af758fe6"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7022b561af758fe6",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "RU-C01-practice",
@@ -19957,6 +25430,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0950a92805f6dabf"
     },
     {
@@ -19970,7 +25448,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8258d0d87859c9ea"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8258d0d87859c9ea",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "RU-C01-spasibo",
@@ -19983,7 +25469,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:007b0e31e887f8eb"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:007b0e31e887f8eb",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "RU-C01-zdravstvuyte",
@@ -19996,7 +25490,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:1129d225cc1a7f6e"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1129d225cc1a7f6e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "RU-W01-false-friends-v-r",
@@ -20009,6 +25511,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:e5923f38dea06429"
     },
     {
@@ -20023,6 +25530,12 @@
         "writing-type",
         "wide-table"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type",
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:e7b121151af172cc"
     },
     {
@@ -20036,6 +25549,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:5d4c98bf9e21742d"
     },
     {
@@ -20049,6 +25567,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:db26ef3c1f7cfb10"
     },
     {
@@ -20062,6 +25585,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:ae0552066fff71d5"
     },
     {
@@ -20075,6 +25603,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:be456798a468e226"
     },
     {
@@ -20088,6 +25621,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:522d7a730d2c32c9"
     },
     {
@@ -20101,6 +25639,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8cb35e836814f02f"
     },
     {
@@ -20114,6 +25657,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1d3d69c6c4518117"
     },
     {
@@ -20127,6 +25675,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ab5c929932a8ce45"
     },
     {
@@ -20140,6 +25693,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c47d172e1777208b"
     },
     {
@@ -20153,6 +25711,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:01a9d848c5acbb2f"
     },
     {
@@ -20166,6 +25729,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:97f4b12fe17053b5"
     },
     {
@@ -20179,6 +25747,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:ee5e553eef015dca"
     },
     {
@@ -20192,6 +25765,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:97d645e1b389a3a3"
     },
     {
@@ -20205,6 +25783,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:14888e9ea4e76480"
     },
     {
@@ -20218,6 +25801,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:50c788897a116d01"
     },
     {
@@ -20231,6 +25819,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:053dfd24401ef0cc"
     },
     {
@@ -20244,6 +25837,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:465d68c6c09ddaf8"
     },
     {
@@ -20257,6 +25855,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b18ddd600f40a6a6"
     },
     {
@@ -20270,6 +25873,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e19ec69e198f3e9d"
     },
     {
@@ -20283,6 +25891,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ab9ee93584dab9d0"
     },
     {
@@ -20296,6 +25909,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fb096ddbe147f336"
     },
     {
@@ -20309,6 +25927,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:abe88d6b3606e545"
     },
     {
@@ -20322,7 +25945,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:0f08ae4c05ca1162"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0f08ae4c05ca1162",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "RU-C05-brat",
@@ -20335,6 +25966,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:cda6615170c3f19a"
     },
     {
@@ -20348,6 +25984,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8ddc0a7207ebb793"
     },
     {
@@ -20361,6 +26002,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b965f8611a96ce2d"
     },
     {
@@ -20374,6 +26020,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ff48a9340aa49fa3"
     },
     {
@@ -20387,7 +26038,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:487c7a73e21f5983"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:487c7a73e21f5983",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C01-dhanyavada",
@@ -20400,7 +26059,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ea7c7dc97c584b3a"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ea7c7dc97c584b3a",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C01-namaskara",
@@ -20414,7 +26081,15 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:a0eb563a777d2f13"
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:a0eb563a777d2f13",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C01-namaste",
@@ -20427,7 +26102,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:727560286d972f72"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:727560286d972f72",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C01-practice",
@@ -20440,6 +26123,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c6eab9947be19d00"
     },
     {
@@ -20453,7 +26141,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:cbf7ca601bf00a4f"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:cbf7ca601bf00a4f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C02-anandah",
@@ -20466,7 +26162,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e8e0fd6673d824d6"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e8e0fd6673d824d6",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C02-asti",
@@ -20479,7 +26183,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9088728915fcc1e6"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9088728915fcc1e6",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C02-bhavan-tvam",
@@ -20492,7 +26204,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5f68b66f9b279a71"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5f68b66f9b279a71",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C02-kim",
@@ -20505,7 +26225,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4e40385ad96c7c3b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4e40385ad96c7c3b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C02-mama",
@@ -20518,7 +26246,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:19cf8b63960c764f"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:19cf8b63960c764f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C02-mama-nama-asti",
@@ -20531,6 +26267,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8cc63cf7c2cc9dfa"
     },
     {
@@ -20544,7 +26285,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:dd8f39ca044c965c"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:dd8f39ca044c965c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C02-tava-nama-kim",
@@ -20557,6 +26306,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d2a2ccc10d3a9ff8"
     },
     {
@@ -20570,7 +26324,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:45944c82838832c8"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:45944c82838832c8",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C03-bhavan-katham-asti",
@@ -20583,6 +26345,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c818ed9314a76d14"
     },
     {
@@ -20596,7 +26363,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:656fec3705a363e8"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:656fec3705a363e8",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C03-kushalam",
@@ -20609,7 +26384,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3fe117d8b3a2e1c0"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3fe117d8b3a2e1c0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C03-na-cinta",
@@ -20622,7 +26405,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3b49148c41bacfa4"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3b49148c41bacfa4",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C03-practice",
@@ -20635,6 +26426,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:852bd85b8bf75efc"
     },
     {
@@ -20648,7 +26444,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b682dedfea2ec53e"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b682dedfea2ec53e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C04-practice",
@@ -20661,6 +26465,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f5da060bdedd7132"
     },
     {
@@ -20674,7 +26483,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ca5312471924cfcf"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ca5312471924cfcf",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C04-punar-darshanaya",
@@ -20687,7 +26504,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c01517255bb7ee88"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c01517255bb7ee88",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C04-shvah",
@@ -20700,7 +26525,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4ded4e8244e80298"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4ded4e8244e80298",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C05-aham-samskritam-vadami",
@@ -20713,7 +26546,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6ce6fe49bf237194"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6ce6fe49bf237194",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C05-karomi",
@@ -20726,7 +26567,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:06c187eb35a64186"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:06c187eb35a64186",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C05-practice",
@@ -20739,6 +26588,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b0788b51b84ec1bc"
     },
     {
@@ -20752,7 +26606,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:dab4cb61ca2e0775"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:dab4cb61ca2e0775",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C05-vasami",
@@ -20765,7 +26627,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:d03f17265b4a3ef7"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:d03f17265b4a3ef7",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "SA-C06-numbers-1-5",
@@ -20779,6 +26649,12 @@
         "sight-cue",
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue",
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:09f36fd41edd6bf6"
     },
     {
@@ -20792,6 +26668,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7bfc7b92461bc6f1"
     },
     {
@@ -20805,6 +26686,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b9ff587c9b04cf7a"
     },
     {
@@ -20818,6 +26704,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:acba716e7ca6b5c4"
     },
     {
@@ -20831,6 +26722,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:625c2624967f0670"
     },
     {
@@ -20844,6 +26740,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:cb62d733b276b4c5"
     },
     {
@@ -20857,6 +26758,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:684286f6f5882df7"
     },
     {
@@ -20870,6 +26776,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7f8841a36a6c95f0"
     },
     {
@@ -20883,6 +26794,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:96cb8ccb4a739c4c"
     },
     {
@@ -20896,6 +26812,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3ab6a3b5b466e409"
     },
     {
@@ -20909,6 +26830,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:df200f517ac15a66"
     },
     {
@@ -20922,6 +26848,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e9af1425f8c25258"
     },
     {
@@ -20935,6 +26866,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:094a75e4cda64eba"
     },
     {
@@ -20948,6 +26884,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4a64f82544bac0de"
     },
     {
@@ -20961,6 +26902,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:79b521b14cf365df"
     },
     {
@@ -20974,6 +26920,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ed8fbaf4e26fa2f5"
     },
     {
@@ -20987,6 +26938,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:519a8f81d87a0669"
     },
     {
@@ -21000,6 +26956,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7a030311d9732cc3"
     },
     {
@@ -21013,6 +26974,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c959c6ba3261a30f"
     },
     {
@@ -21026,6 +26992,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:59f7bf775dcbb156"
     },
     {
@@ -21039,6 +27010,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6ae2661f94e4c312"
     },
     {
@@ -21052,6 +27028,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0d06f61a8fc5db24"
     },
     {
@@ -21065,6 +27046,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:29d0935f9ac06644"
     },
     {
@@ -21078,6 +27064,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:14e6566acb24a098"
     },
     {
@@ -21091,6 +27082,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d4d84d98a193ba01"
     },
     {
@@ -21104,6 +27100,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6bfa680323927fc9"
     },
     {
@@ -21117,6 +27118,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:db422486bc275583"
     },
     {
@@ -21130,6 +27136,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:353f6913cbc25361"
     },
     {
@@ -21143,6 +27154,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e2292f4fb7e20251"
     },
     {
@@ -21156,6 +27172,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:27e54c87738449da"
     },
     {
@@ -21169,6 +27190,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b256de03c573917b"
     },
     {
@@ -21182,6 +27208,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:15d4ae4f57ab020b"
     },
     {
@@ -21195,6 +27226,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ccef862fda339570"
     },
     {
@@ -21208,6 +27244,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e1ccfd229de2a3fd"
     },
     {
@@ -21221,6 +27262,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a68e3b11f451f46b"
     },
     {
@@ -21234,6 +27280,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:466a23d3a98e138a"
     },
     {
@@ -21248,7 +27299,15 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:7061ae42743cb58d"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:7061ae42743cb58d",
+      "detachableSegments": [
+        "Script — the upside-down opener"
+      ]
     },
     {
       "id": "ES-C03-familia-qu",
@@ -21261,6 +27320,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:eb66f372cf2b6887"
     },
     {
@@ -21274,6 +27338,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d63e1dc84f6301ca"
     },
     {
@@ -21287,6 +27356,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:165a5c83e387b09c"
     },
     {
@@ -21300,6 +27374,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6858d837f3aca63a"
     },
     {
@@ -21313,6 +27392,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a318581b4ba64bb9"
     },
     {
@@ -21326,6 +27410,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:18b77f42953215fc"
     },
     {
@@ -21339,6 +27428,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f5e3fa74cf594ffc"
     },
     {
@@ -21352,6 +27446,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3b8ebf50aed6457a"
     },
     {
@@ -21365,6 +27464,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a0b65487b5a73d41"
     },
     {
@@ -21378,6 +27482,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ad2c2ef9af54d91e"
     },
     {
@@ -21391,6 +27500,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4b38ddebc1627ccf"
     },
     {
@@ -21404,6 +27518,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8bb8f60531308827"
     },
     {
@@ -21417,6 +27536,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9041b6c5d8c595ae"
     },
     {
@@ -21430,6 +27554,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:af6610ef4fcc2317"
     },
     {
@@ -21444,7 +27573,15 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:0a154ad329459672"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:0a154ad329459672",
+      "detachableSegments": [
+        "Script — shape and stroke"
+      ]
     },
     {
       "id": "ES-W01-tilde-diacritica",
@@ -21457,6 +27594,11 @@
       "reasons": [
         "writing-type"
       ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:00c35b0e1c97c4c6"
     },
     {
@@ -21471,7 +27613,15 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f9ec537631d2b099"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:f9ec537631d2b099",
+      "detachableSegments": [
+        "Script — how to write it"
+      ]
     },
     {
       "id": "ES-W02-enye-formas",
@@ -21485,7 +27635,15 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f42bf3408df4a291"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:f42bf3408df4a291",
+      "detachableSegments": [
+        "Script — the two forms"
+      ]
     },
     {
       "id": "ES-W03-inverted",
@@ -21499,7 +27657,15 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4b185ff5be127741"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:4b185ff5be127741",
+      "detachableSegments": [
+        "Script — the two opening marks"
+      ]
     },
     {
       "id": "ES-W03-question-span",
@@ -21513,7 +27679,15 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:cc42e88629ebdfaf"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:cc42e88629ebdfaf",
+      "detachableSegments": [
+        "Script — bracket the spoken span"
+      ]
     },
     {
       "id": "ES-C04-practice",
@@ -21526,6 +27700,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:95b7ff61b4e942fd"
     },
     {
@@ -21539,6 +27718,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1efab3e6e2d1971f"
     },
     {
@@ -21552,6 +27736,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0373a9248796f3f9"
     },
     {
@@ -21565,6 +27754,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8a9a3573eb8c6a3e"
     },
     {
@@ -21578,6 +27772,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:67d43bf4b728ac2e"
     },
     {
@@ -21591,6 +27790,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a6a61bd22ad29bc9"
     },
     {
@@ -21604,6 +27808,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c022f19f780530c4"
     },
     {
@@ -21617,6 +27826,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:bb6a1ec725b3062b"
     },
     {
@@ -21630,6 +27844,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4b96d615a4e56676"
     },
     {
@@ -21643,6 +27862,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f66d4757e7f825f2"
     },
     {
@@ -21656,6 +27880,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f0eaf961627f631b"
     },
     {
@@ -21670,6 +27899,12 @@
         "sight-cue",
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue",
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:d62ffbd226de0824"
     },
     {
@@ -21683,6 +27918,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:97af627f6454e1eb"
     },
     {
@@ -21696,6 +27936,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a0caa17d21e7026e"
     },
     {
@@ -21709,6 +27954,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3419ebdf7bb7ba3f"
     },
     {
@@ -21722,6 +27972,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:359d617ceb162fa6"
     },
     {
@@ -21735,6 +27990,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6a403bb27ffc266d"
     },
     {
@@ -21748,6 +28008,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1cc22b5309fcdd0c"
     },
     {
@@ -21761,6 +28026,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:2c5c24910d6f4117"
     },
     {
@@ -21774,6 +28044,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:320be51b027d8215"
     },
     {
@@ -21787,6 +28062,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0b1c08a502f1f2b5"
     },
     {
@@ -21800,6 +28080,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b10d4559c743a03d"
     },
     {
@@ -21813,6 +28098,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:1a9b0f692c3ce186"
     },
     {
@@ -21826,6 +28116,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b46d43b715b1eab9"
     },
     {
@@ -21839,6 +28134,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ed0886a860ddd794"
     },
     {
@@ -21852,6 +28152,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:41443319609fc232"
     },
     {
@@ -21865,6 +28170,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c8e8c4495c46b9fb"
     },
     {
@@ -21878,6 +28188,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:933eafd23ceb4124"
     },
     {
@@ -21891,6 +28206,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f6c1102f99e48dfb"
     },
     {
@@ -21904,6 +28224,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:079927285e2d7c12"
     },
     {
@@ -21917,6 +28242,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7d7dc85d231765fe"
     },
     {
@@ -21930,6 +28260,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:e1ee931ddaf78a6d"
     },
     {
@@ -21943,6 +28278,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:1a1ac8d5f28b64da"
     },
     {
@@ -21956,6 +28296,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:97e7c19bbe741eda"
     },
     {
@@ -21969,6 +28314,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2efae4f60d605d59"
     },
     {
@@ -21982,6 +28332,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:c16ec47331e0c841"
     },
     {
@@ -21995,6 +28350,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e10c22caf5db30ed"
     },
     {
@@ -22008,6 +28368,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:544fa5d83e0f113f"
     },
     {
@@ -22021,6 +28386,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d5319cef387b6b17"
     },
     {
@@ -22034,6 +28404,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8b3b70b2c52e51a2"
     },
     {
@@ -22047,6 +28422,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:93e91c4220c73ee9"
     },
     {
@@ -22060,6 +28440,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:af92d49c34d3eda3"
     },
     {
@@ -22073,6 +28458,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0c31a56e74c2d5ee"
     },
     {
@@ -22086,6 +28476,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4b8ca2a96fcd9236"
     },
     {
@@ -22099,6 +28494,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:17afaf4786688193"
     },
     {
@@ -22112,6 +28512,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fe2365102528f58f"
     },
     {
@@ -22125,6 +28530,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:c049d52a0fb55326"
     },
     {
@@ -22138,6 +28548,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fe496f4ed5343157"
     },
     {
@@ -22151,6 +28566,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c3cbc4d6fcbeaafc"
     },
     {
@@ -22164,6 +28584,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:2497b5ca46b70d45"
     },
     {
@@ -22177,6 +28602,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4f976b4d96ae28b3"
     },
     {
@@ -22190,6 +28620,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:cd3da96c84d6e042"
     },
     {
@@ -22203,6 +28638,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:15ba2316d6c80667"
     },
     {
@@ -22216,6 +28656,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:29f4924f1b0065d6"
     },
     {
@@ -22229,6 +28674,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:62a3242726961642"
     },
     {
@@ -22242,6 +28692,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:4b3fcf24c86f0c33"
     },
     {
@@ -22255,6 +28710,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e20f599f8e6f29be"
     },
     {
@@ -22268,6 +28728,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:9c3bcc2a62e8957e"
     },
     {
@@ -22281,6 +28746,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f180bd5fc945e341"
     },
     {
@@ -22294,6 +28764,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:75f5252fcaca8439"
     },
     {
@@ -22307,6 +28782,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6938e0da50515712"
     },
     {
@@ -22320,6 +28800,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:e9f899c42d6b76bd"
     },
     {
@@ -22333,6 +28818,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a530fffb868e2f93"
     },
     {
@@ -22346,6 +28836,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:91ce99547c890c02"
     },
     {
@@ -22359,6 +28854,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b2b0bb94c5c6820f"
     },
     {
@@ -22372,6 +28872,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:befb2b16944dd31a"
     },
     {
@@ -22385,6 +28890,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:cc5849df9cf29fbb"
     },
     {
@@ -22398,6 +28908,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:37bc14318be96308"
     },
     {
@@ -22411,6 +28926,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:24c74260689cfbb0"
     },
     {
@@ -22424,6 +28944,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8a5116ada01886a3"
     },
     {
@@ -22437,6 +28962,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8a556331081027e6"
     },
     {
@@ -22450,6 +28980,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:29a5021c7eb66506"
     },
     {
@@ -22463,6 +28998,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:57ff016d1d7798be"
     },
     {
@@ -22476,6 +29016,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b17f3a4bbf08b693"
     },
     {
@@ -22489,6 +29034,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d9bf248186007d54"
     },
     {
@@ -22502,6 +29052,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1edebc53ccdc91db"
     },
     {
@@ -22515,6 +29070,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:10316f8fbdca5ef8"
     },
     {
@@ -22528,6 +29088,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:2daae3fceeab7c1f"
     },
     {
@@ -22541,6 +29106,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:539054e0683b301c"
     },
     {
@@ -22554,6 +29124,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:db51bf774d990900"
     },
     {
@@ -22567,6 +29142,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c6fe8636baaf2417"
     },
     {
@@ -22580,6 +29160,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:95fcef898178289a"
     },
     {
@@ -22593,6 +29178,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:93ee0709ae2c9910"
     },
     {
@@ -22606,6 +29196,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:351e499d442f0d1f"
     },
     {
@@ -22619,6 +29214,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c679f98885675be4"
     },
     {
@@ -22632,6 +29232,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:16e1370ac5e837cb"
     },
     {
@@ -22645,6 +29250,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1d23fe41ce429e33"
     },
     {
@@ -22658,6 +29268,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c30685b9a391edd2"
     },
     {
@@ -22671,6 +29286,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:3b1b0233f9810058"
     },
     {
@@ -22684,6 +29304,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:af75f70992f67934"
     },
     {
@@ -22697,6 +29322,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6254dc7ee5085423"
     },
     {
@@ -22710,6 +29340,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:652a27f226793cb3"
     },
     {
@@ -22723,6 +29358,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5b5026e865212425"
     },
     {
@@ -22736,6 +29376,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b3bfe0b28d5bddf9"
     },
     {
@@ -22749,6 +29394,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:829c80cb6c072acc"
     },
     {
@@ -22762,6 +29412,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:287d2a03bb8678d5"
     },
     {
@@ -22775,6 +29430,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:465eaf6ee7b3b25d"
     },
     {
@@ -22788,6 +29448,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:51189e6ba928a1c4"
     },
     {
@@ -22801,6 +29466,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d051928bb9223bdb"
     },
     {
@@ -22814,6 +29484,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7ae87a0614eb6409"
     },
     {
@@ -22827,6 +29502,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:236f8af21463cfb4"
     },
     {
@@ -22840,6 +29520,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:aec387ce76b2b2ff"
     },
     {
@@ -22853,6 +29538,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b321d2286569f3f5"
     },
     {
@@ -22866,6 +29556,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a433c43d4631a50d"
     },
     {
@@ -22879,6 +29574,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a19f46a025249f81"
     },
     {
@@ -22892,6 +29592,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0d33a8da6aadbc9d"
     },
     {
@@ -22905,6 +29610,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:04f892f1e8481ab5"
     },
     {
@@ -22918,6 +29628,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:070edf4c229dd975"
     },
     {
@@ -22931,6 +29646,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f9fce5111b86e152"
     },
     {
@@ -22944,6 +29664,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:70b642cd35202bfe"
     },
     {
@@ -22957,6 +29682,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:734e9cd53f6a9bc3"
     },
     {
@@ -22970,6 +29700,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c5b2f574d22b44eb"
     },
     {
@@ -22983,6 +29718,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8a9e95416ea42c5e"
     },
     {
@@ -22996,6 +29736,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:076b246ba782b686"
     },
     {
@@ -23011,7 +29756,16 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:52e873e570e7a21e"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type",
+        "sight-cue"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:52e873e570e7a21e",
+      "detachableSegments": [
+        "Script you'll notice: The script is the shape of its writing surface"
+      ]
     },
     {
       "id": "TA-W01-abugida-va-ka",
@@ -23025,7 +29779,17 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a2fe0a66292e2a3b"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:a2fe0a66292e2a3b",
+      "detachableSegments": [
+        "Script you'll notice: The vowel you get for free",
+        "Script you'll notice: வ — \"va\"",
+        "Script you'll notice: க — \"ka\""
+      ]
     },
     {
       "id": "TA-W02-ma-retroflex-na",
@@ -23039,7 +29803,16 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6ce88d858a0ad284"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:6ce88d858a0ad284",
+      "detachableSegments": [
+        "Script you'll notice: ம",
+        "Script you'll notice: ண"
+      ]
     },
     {
       "id": "TA-W02-three-ns",
@@ -23053,7 +29826,15 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:0a6a4e9cd2c74425"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:0a6a4e9cd2c74425",
+      "detachableSegments": [
+        "Script you'll notice: The backward walk"
+      ]
     },
     {
       "id": "TA-W03-pulli-vanakkam",
@@ -23068,7 +29849,16 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:9d8862d16c87f51c"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:9d8862d16c87f51c",
+      "detachableSegments": [
+        "Script you'll notice: The puḷḷi",
+        "Script you'll notice: What Tamil does *not* do"
+      ]
     },
     {
       "id": "TA-W03-write-vanakkam",
@@ -23082,7 +29872,15 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:19ea78f7643992a1"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:19ea78f7643992a1",
+      "detachableSegments": [
+        "Script you'll notice: Build the word"
+      ]
     },
     {
       "id": "TA-W04-vowel-signs-nandri",
@@ -23096,7 +29894,16 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:0396b3f438d3d484"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:0396b3f438d3d484",
+      "detachableSegments": [
+        "Script you'll notice: The two remaining n's",
+        "Script you'll notice: ற — \"ṟa\", the hard r"
+      ]
     },
     {
       "id": "TA-W04-i-sign-write-nandri",
@@ -23110,7 +29917,16 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:fc6618acb28f2b17"
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:fc6618acb28f2b17",
+      "detachableSegments": [
+        "Script you'll notice: The first vowel sign",
+        "Script you'll notice: Assemble நன்றி"
+      ]
     },
     {
       "id": "TA-C01-aam",
@@ -23124,7 +29940,15 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:5971b60f9445ebba"
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:5971b60f9445ebba",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C01-illai",
@@ -23137,7 +29961,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:eb7d4be5afd2b4a8"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:eb7d4be5afd2b4a8",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C01-nandri",
@@ -23150,7 +29982,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e3b598578abbeee7"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e3b598578abbeee7",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C01-nandri-family-register",
@@ -23163,6 +30003,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1b71da01982a1c62"
     },
     {
@@ -23176,6 +30021,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9fc5ad0e85df4288"
     },
     {
@@ -23189,7 +30039,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8abff912866c6ae0"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8abff912866c6ae0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C01-vanakkam",
@@ -23202,7 +30060,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4c4fa4af1fcb85dd"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4c4fa4af1fcb85dd",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C01-vanakkam-family-register",
@@ -23215,6 +30081,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:22c3d53d824d6cd4"
     },
     {
@@ -23228,7 +30099,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a21db6ae59748a32"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a21db6ae59748a32",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C02-en-peyar",
@@ -23241,6 +30120,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:0fa6e13aeee02146"
     },
     {
@@ -23254,7 +30138,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:25fcc38dc3c7e5ad"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:25fcc38dc3c7e5ad",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C02-magizhcci",
@@ -23267,6 +30159,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c3bc57954e56329f"
     },
     {
@@ -23280,7 +30177,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:777a927ff6b68192"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:777a927ff6b68192",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C02-peyar",
@@ -23293,7 +30198,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f21262c05a8174ac"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f21262c05a8174ac",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C02-practice",
@@ -23306,6 +30219,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:460dd2935bc8810b"
     },
     {
@@ -23319,6 +30237,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fd46f23f443298d1"
     },
     {
@@ -23332,7 +30255,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:115a665d0b5ae3db"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:115a665d0b5ae3db",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C03-eppadi-irukkirirgal",
@@ -23345,7 +30276,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:54b96e84af48f100"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:54b96e84af48f100",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C03-naan",
@@ -23358,7 +30297,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bf125d1e56b58ba0"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:bf125d1e56b58ba0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C03-nalam",
@@ -23371,7 +30318,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:7085a36204532448"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7085a36204532448",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C03-paravayillai",
@@ -23384,7 +30339,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:706b526524e2e1ab"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:706b526524e2e1ab",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C03-practice",
@@ -23397,6 +30360,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:38559b2a97d4823f"
     },
     {
@@ -23410,7 +30378,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:2bd30145a8a3485b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:2bd30145a8a3485b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C04-naalai",
@@ -23423,7 +30399,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:46d7d64986982553"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:46d7d64986982553",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C04-po",
@@ -23436,7 +30420,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:99257b30e11fb454"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:99257b30e11fb454",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C04-poy-varugiren",
@@ -23449,7 +30441,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f14e5eedd7053032"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f14e5eedd7053032",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C04-practice",
@@ -23462,6 +30462,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:65bb3e5878370184"
     },
     {
@@ -23475,7 +30480,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:42a739df1441cc91"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:42a739df1441cc91",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C05-pesu",
@@ -23488,7 +30501,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5667a5594c84050d"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5667a5594c84050d",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C05-practice",
@@ -23501,6 +30522,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:13bb1c850f393572"
     },
     {
@@ -23514,7 +30540,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9853bbbff15ebc67"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9853bbbff15ebc67",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C05-velai-sey",
@@ -23527,7 +30561,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ca5c5c9223f2aab4"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ca5c5c9223f2aab4",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C06-dative-ukku",
@@ -23540,6 +30582,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:80d96e6884624d7c"
     },
     {
@@ -23553,6 +30600,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4284bfb529666b68"
     },
     {
@@ -23566,6 +30618,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5ac4c3bda06796be"
     },
     {
@@ -23579,6 +30636,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2918677f2a6352d0"
     },
     {
@@ -23592,6 +30654,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:abb924eead9ea4ef"
     },
     {
@@ -23605,6 +30672,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:43c348a1c52641ce"
     },
     {
@@ -23619,6 +30691,12 @@
         "sight-cue",
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue",
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:4ddc2af168d07ed1"
     },
     {
@@ -23632,6 +30710,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:74ab19978e0308e0"
     },
     {
@@ -23645,6 +30728,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b64c5bd7dd10f8eb"
     },
     {
@@ -23658,7 +30746,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:11ca8536d913b3ec"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:11ca8536d913b3ec",
+      "detachableSegments": [
+        "Script you'll notice: Read the join in செய்து"
+      ]
     },
     {
       "id": "TA-C09-mannikkavum",
@@ -23671,6 +30767,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d90c27fb2d5e0c93"
     },
     {
@@ -23684,7 +30785,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:63705a2b1437e7b4"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:63705a2b1437e7b4",
+      "detachableSegments": [
+        "Script you'll notice: Read ன்னி"
+      ]
     },
     {
       "id": "TA-C10-vaara-kizhamai",
@@ -23697,6 +30806,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d6deae3e70e1cb8b"
     },
     {
@@ -23710,6 +30824,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:57cc7e3f10c4a1d8"
     },
     {
@@ -23723,6 +30842,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d83e9a64372df884"
     },
     {
@@ -23736,6 +30860,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:29bbeb31bbfd6439"
     },
     {
@@ -23749,6 +30878,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:694c78bf15e7787a"
     },
     {
@@ -23762,6 +30896,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:46646101ede78b4e"
     },
     {
@@ -23775,6 +30914,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5c9c8e831599839e"
     },
     {
@@ -23788,6 +30932,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:49f6e1ca6f73b6d4"
     },
     {
@@ -23801,6 +30950,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c43444f3c116f991"
     },
     {
@@ -23814,6 +30968,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7edef22adf32f80f"
     },
     {
@@ -23827,6 +30986,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f5c848b349d8fe58"
     },
     {
@@ -23840,6 +31004,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7cd19cdfa68e405f"
     },
     {
@@ -23853,6 +31022,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:15d09bbc0d429868"
     },
     {
@@ -23866,6 +31040,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7262158bd8ed0238"
     },
     {
@@ -23879,6 +31058,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d7b6f1dddb46cfde"
     },
     {
@@ -23892,6 +31076,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1dd35c7accb9a520"
     },
     {
@@ -23905,6 +31094,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a16121a6959da941"
     },
     {
@@ -23918,6 +31112,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:77b519193dd4561d"
     },
     {
@@ -23931,6 +31130,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:be8dbaeab3323246"
     },
     {
@@ -23944,6 +31148,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c5945153902f2494"
     },
     {
@@ -23957,6 +31166,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b660a38234786f74"
     },
     {
@@ -23970,6 +31184,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:03301eb9bd9795c0"
     },
     {
@@ -23983,6 +31202,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0f4e1927b3bee8aa"
     },
     {
@@ -23996,6 +31220,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:34c59d75dd71e3e4"
     },
     {
@@ -24009,6 +31238,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c8b7ae0842bacb6d"
     },
     {
@@ -24022,6 +31256,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b28557a764c08bb8"
     },
     {
@@ -24035,6 +31274,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2e0fef18cdf187fb"
     },
     {
@@ -24048,6 +31292,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8fc0fa5050220196"
     },
     {
@@ -24061,6 +31310,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e605d22d0c8038e0"
     },
     {
@@ -24074,6 +31328,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:40bdf24325c6deef"
     },
     {
@@ -24087,6 +31346,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0f94f0e85cdff5f4"
     },
     {
@@ -24100,6 +31364,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d66cfc3bade90237"
     },
     {
@@ -24113,6 +31382,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:19f2c25a59f0f982"
     },
     {
@@ -24126,6 +31400,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6d11abac17fa8c52"
     },
     {
@@ -24139,6 +31418,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:bb3c1c1696795fe0"
     },
     {
@@ -24152,6 +31436,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:39ea79380f0de2f5"
     },
     {
@@ -24165,6 +31454,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:43e3caa79eab7344"
     },
     {
@@ -24178,7 +31472,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bec4abda60466215"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:bec4abda60466215",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C33-puri",
@@ -24191,7 +31493,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:33fe6b5286b65e12"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:33fe6b5286b65e12",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C33-padi",
@@ -24204,7 +31514,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:2c0a727552358fa4"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:2c0a727552358fa4",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C33-ezhutu",
@@ -24217,7 +31535,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3a36a9291ceaaf55"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3a36a9291ceaaf55",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C34-edu",
@@ -24230,7 +31556,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:461fc79451361c98"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:461fc79451361c98",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C34-kel",
@@ -24243,7 +31577,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5a4741225dff9092"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5a4741225dff9092",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C34-utavu",
@@ -24256,7 +31598,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:cbacf37334d54ef5"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:cbacf37334d54ef5",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TA-C34-pidi",
@@ -24269,6 +31619,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1480cdf0e8dbdd75"
     },
     {
@@ -24282,7 +31637,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:02c7e53b73ee6c0f"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:02c7e53b73ee6c0f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C01-dhanyavadamulu",
@@ -24296,7 +31659,15 @@
         "script-block",
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:00aabcd9866ae9f2"
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:00aabcd9866ae9f2",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C01-ledu",
@@ -24309,7 +31680,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:fa3ba3d6439ce271"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:fa3ba3d6439ce271",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C01-namaskaram",
@@ -24322,7 +31701,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:86c4ca28846a9629"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:86c4ca28846a9629",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C01-practice",
@@ -24335,6 +31722,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:54e10d121ebdf0e1"
     },
     {
@@ -24348,7 +31740,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:563edf856ad232b4"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:563edf856ad232b4",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C02-emiti",
@@ -24361,7 +31761,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c24865d86c900c57"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c24865d86c900c57",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C02-mii-peru-emiti",
@@ -24374,6 +31782,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e6f916bbadd82ce2"
     },
     {
@@ -24387,7 +31800,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:66506069a92e1306"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:66506069a92e1306",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C02-naa-peru",
@@ -24400,6 +31821,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:efa61e58af98b59d"
     },
     {
@@ -24413,7 +31839,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:354cf9f77192856b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:354cf9f77192856b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C02-peru",
@@ -24426,7 +31860,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:282c8e00b4bab667"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:282c8e00b4bab667",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C02-practice",
@@ -24439,6 +31881,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:12280a991b01ad5a"
     },
     {
@@ -24452,6 +31899,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7d919f075065847b"
     },
     {
@@ -24465,7 +31917,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:921926f70cd68931"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:921926f70cd68931",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C03-elaa",
@@ -24478,7 +31938,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:290d6f92cdec1fa7"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:290d6f92cdec1fa7",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C03-miiru-elaa-unnaaru",
@@ -24491,7 +31959,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:cdaadb9998d4dc78"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:cdaadb9998d4dc78",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C03-nenu",
@@ -24504,7 +31980,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c9f149c5d962518f"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c9f149c5d962518f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C03-paravaaledu",
@@ -24517,7 +32001,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4f0cfb3134d69cfb"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4f0cfb3134d69cfb",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C03-practice",
@@ -24530,6 +32022,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b0ba2ac8f4f5a194"
     },
     {
@@ -24543,7 +32040,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:515fec85b9e97e7c"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:515fec85b9e97e7c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C04-practice",
@@ -24556,6 +32061,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e4a7c80ad0a0c8f1"
     },
     {
@@ -24569,7 +32079,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f241961853fa1fdd"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f241961853fa1fdd",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C04-velli-vastaanu",
@@ -24582,7 +32100,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:7a4b023ba6421195"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7a4b023ba6421195",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C04-vellu",
@@ -24595,7 +32121,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:662e875342cd06a1"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:662e875342cd06a1",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C05-maatlaadu",
@@ -24608,7 +32142,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8d053f228fb6653b"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8d053f228fb6653b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C05-nenu-telugu-maatlaadataanu",
@@ -24621,7 +32163,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b49ca03d60180860"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b49ca03d60180860",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C05-pani-ceyu",
@@ -24634,7 +32184,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:eaa29c2ebacac405"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:eaa29c2ebacac405",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C05-practice",
@@ -24647,6 +32205,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7a2239c5402cad44"
     },
     {
@@ -24660,7 +32223,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:26e4f178d9a9f193"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:26e4f178d9a9f193",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C06-dative-ku",
@@ -24673,6 +32244,11 @@
       "reasons": [
         "sight-cue"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "sight-cue"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:c99fd7445630aabe"
     },
     {
@@ -24686,6 +32262,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ea0900ad7d7e9e5a"
     },
     {
@@ -24700,7 +32281,15 @@
         "script-block",
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:d4f724de2a90e484"
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:d4f724de2a90e484",
+      "detachableSegments": [
+        "Script you'll notice: A Telugu shape to notice"
+      ]
     },
     {
       "id": "TE-C07-numbers-6-10",
@@ -24713,6 +32302,11 @@
       "reasons": [
         "wide-table"
       ],
+      "coreModality": "sight",
+      "coreReasons": [
+        "wide-table"
+      ],
+      "coreDrivable": false,
       "sourceHash": "fnv1a64:ad0f0d5bb46a0ef3"
     },
     {
@@ -24726,7 +32320,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b2afdcd482b62280"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b2afdcd482b62280",
+      "detachableSegments": [
+        "Script you'll notice: Sound & structure point"
+      ]
     },
     {
       "id": "TE-C09-kshaminchandi",
@@ -24739,6 +32341,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0bcd75b57925d88b"
     },
     {
@@ -24752,6 +32359,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fca7ffd433cc3894"
     },
     {
@@ -24765,6 +32377,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:442aa8558e8036cc"
     },
     {
@@ -24778,6 +32395,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:468849cfa4cd8161"
     },
     {
@@ -24791,6 +32413,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fcf0942176d96b7c"
     },
     {
@@ -24804,6 +32431,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:570ed576366fdc7d"
     },
     {
@@ -24817,6 +32449,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:39c73acb4c328246"
     },
     {
@@ -24830,6 +32467,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7a76dcd7ba1e054e"
     },
     {
@@ -24843,6 +32485,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ed422a8d56752cf5"
     },
     {
@@ -24856,6 +32503,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:46fbe5e7dd9ad73b"
     },
     {
@@ -24869,6 +32521,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:38cdddf1d35e0de1"
     },
     {
@@ -24882,6 +32539,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8b15c534e755f7c6"
     },
     {
@@ -24895,6 +32557,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:37d9dac6f11c147a"
     },
     {
@@ -24908,6 +32575,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:56928232f37805f9"
     },
     {
@@ -24921,6 +32593,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b0fe9f377036d9b9"
     },
     {
@@ -24934,6 +32611,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2a2be619494004e7"
     },
     {
@@ -24947,6 +32629,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:767a5519fcd55de6"
     },
     {
@@ -24960,6 +32647,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:b4f4970ab0dab434"
     },
     {
@@ -24973,6 +32665,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:e273374a80112cc8"
     },
     {
@@ -24986,6 +32683,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:d9da980866e3cf48"
     },
     {
@@ -24999,6 +32701,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:8eab8bc48df8486f"
     },
     {
@@ -25012,6 +32719,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:586b3a016969c36f"
     },
     {
@@ -25025,6 +32737,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:9c2387e268aedf0e"
     },
     {
@@ -25038,6 +32755,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5f0f648bad51261c"
     },
     {
@@ -25051,6 +32773,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:031882d937ae89d3"
     },
     {
@@ -25064,6 +32791,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:95e0e0d8d44e097c"
     },
     {
@@ -25077,6 +32809,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:401c8466d0d772aa"
     },
     {
@@ -25090,6 +32827,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:6260299ebab73314"
     },
     {
@@ -25103,6 +32845,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f997d974ba724d80"
     },
     {
@@ -25116,6 +32863,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:dd2e98eb6ddba616"
     },
     {
@@ -25129,6 +32881,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1413881a1d5ae10c"
     },
     {
@@ -25142,7 +32899,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:eee1e6ebe3bfa28a"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:eee1e6ebe3bfa28a",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C33-artham-cesuko",
@@ -25155,7 +32920,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4daba41c708acffd"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4daba41c708acffd",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C33-caduvu",
@@ -25168,7 +32941,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:20ac8b067d2dafd7"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:20ac8b067d2dafd7",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C33-raayu",
@@ -25181,7 +32962,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:34579995b467114e"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:34579995b467114e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C34-tiisuko",
@@ -25194,7 +32983,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b912560c856ff200"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b912560c856ff200",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C34-adugu",
@@ -25207,7 +33004,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:17905a0b5febb5f8"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:17905a0b5febb5f8",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C34-sahayam-ceyu",
@@ -25220,7 +33025,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3bc08fd14c6ec50c"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3bc08fd14c6ec50c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C34-ishtam",
@@ -25233,7 +33046,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:43e769d702413130"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:43e769d702413130",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "UR-C01-ji-han",
@@ -25246,6 +33067,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:a50644718ff79815"
     },
     {
@@ -25259,6 +33085,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:62f6a8f345192f8a"
     },
     {
@@ -25272,6 +33103,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:56bcf932b70c0520"
     },
     {
@@ -25285,6 +33121,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c9d290fdc45f48d1"
     },
     {
@@ -25298,6 +33139,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c9b79da0c62dcb0a"
     },
     {
@@ -25311,6 +33157,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:ccaa2c3c41a8cd7e"
     },
     {
@@ -25324,6 +33175,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c5a55d9c52ca2ac6"
     },
     {
@@ -25337,7 +33193,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:33f50c2a33ff9ab5"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:33f50c2a33ff9ab5",
+      "detachableSegments": [
+        "Script: the question mark"
+      ]
     },
     {
       "id": "UR-C03-khushi-hui",
@@ -25350,6 +33214,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c9a50b04d3fe8bea"
     },
     {
@@ -25363,6 +33232,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:7db9fff12a5c9fe7"
     },
     {
@@ -25376,6 +33250,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:fba07a89de0f4ae3"
     },
     {
@@ -25389,6 +33268,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:4670924e6b5cd7a8"
     },
     {
@@ -25402,6 +33286,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:5f7eda2808e6faec"
     },
     {
@@ -25415,6 +33304,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:37b78208f52d826d"
     },
     {
@@ -25428,6 +33322,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:f80175164da896d5"
     },
     {
@@ -25441,6 +33340,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:c50547e514646ca2"
     },
     {
@@ -25454,6 +33358,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:dbaf59b34e5d5a38"
     },
     {
@@ -25467,6 +33376,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:24ecfe4c657e30a2"
     },
     {
@@ -25480,7 +33394,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b59762c651c4b0f6"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b59762c651c4b0f6",
+      "detachableSegments": [
+        "Script Bridge — shared history, local spacing"
+      ]
     },
     {
       "id": "UR-C05-practice",
@@ -25493,6 +33415,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:447fa1578ed99c7f"
     },
     {
@@ -25506,6 +33433,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2cb8964dab7062d5"
     },
     {
@@ -25519,6 +33451,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:0b42ee061c919368"
     },
     {
@@ -25532,6 +33469,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:042409b1029d7da3"
     },
     {
@@ -25545,6 +33487,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:581ece084faa7e89"
     },
     {
@@ -25558,6 +33505,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:2af8f0d723bc7015"
     },
     {
@@ -25571,7 +33523,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c7c0b17b326a93a8"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c7c0b17b326a93a8",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "UR-C07-samajhna",
@@ -25584,7 +33544,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5f458cfe9dc330c7"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5f458cfe9dc330c7",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "UR-C07-parhna",
@@ -25597,7 +33565,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:46d1b7a5d0208a4f"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:46d1b7a5d0208a4f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "UR-C07-likhna",
@@ -25610,7 +33586,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:77a2c90d40b58230"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:77a2c90d40b58230",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "UR-C08-lena",
@@ -25623,7 +33607,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6cff3b5bf832d114"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6cff3b5bf832d114",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "UR-C08-puchhna",
@@ -25636,7 +33628,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:86d649f6d61cbefd"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:86d649f6d61cbefd",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "UR-C08-madad",
@@ -25649,6 +33649,11 @@
       "reasons": [
         "no-visual-dependency"
       ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
       "sourceHash": "fnv1a64:1f13a27d19ff7f06"
     },
     {
@@ -25662,7 +33667,15 @@
       "reasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e6d8568047160abb"
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e6d8568047160abb",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     }
   ],
   "findings": []

--- a/code/packages/typescript/human-language-data/src/modality-manifest.ts
+++ b/code/packages/typescript/human-language-data/src/modality-manifest.ts
@@ -138,6 +138,46 @@ export interface ModalityManifestLesson {
   drivable: boolean;
   /** Which derivation rules fired, in order — why this lesson is labelled as it is. */
   reasons: ModalityReasonCode[];
+  /**
+   * The channel the lesson needs once its DETACHABLE blocks are set aside — today the
+   * inline-letters `script` section and any `writing` section. By construction never
+   * stronger than {@link modality}.
+   *
+   * This is the key the header promised and the manifest never emitted, which is the
+   * whole reason it is being added now. Ten authoring waves put honest
+   * `## The letters in this word` sections into eighteen tracks; every one of those
+   * lessons derives `modality: sight` and `coreModality: voice`, and with no
+   * `coreModality` published, a consumer had no way to tell "needs eyes throughout"
+   * from "needs eyes only for a section a fluent reader skims". Four separate tracks
+   * reported their new chapters as undrivable on that basis, and two agents reached
+   * opposite conclusions about the cause.
+   *
+   * Read it as `entry.coreModality ?? entry.modality`, which is correct against both
+   * old and new builds — and branch on `features.blockModality` if you want to know
+   * which you are holding.
+   */
+  coreModality: Modality;
+  /** Rules that fired for the core, in derivation order. */
+  coreReasons: ModalityReasonCode[];
+  /**
+   * `coreModality === "voice"` — the OPT-IN filter, beside the conservative `drivable`.
+   *
+   * Both are published on purpose. `drivable` stays exactly what it always was: the
+   * strongest channel anywhere in the lesson, so a consumer that never learns about
+   * detachable blocks keeps producing a correct, merely pessimistic driving edition
+   * forever. `coreDrivable` is what a renderer that CAN set a section aside should
+   * read. Nothing about `drivable` moves in this change; that is the compatibility
+   * promise this file's header makes, and switching it would break every consumer
+   * that trusted it.
+   */
+  coreDrivable: boolean;
+  /**
+   * Titles of the sections a hands-free renderer may set aside, in body order.
+   *
+   * Emitted only when non-empty. This is what makes `coreDrivable` auditable rather
+   * than asserted: a reader can see WHICH sections were discounted and disagree.
+   */
+  detachableSegments?: string[];
   /** Fingerprint of the lesson AST this row was derived from. */
   sourceHash: string;
   /** Present only when the author wrote an explicit `modality:`. */
@@ -304,8 +344,17 @@ function manifestLesson(entry: LessonModality, sourceHash: string): ModalityMani
     derived: entry.derived,
     drivable: entry.modality === "voice",
     reasons: entry.reasons,
+    coreModality: entry.coreModality,
+    coreReasons: entry.coreReasons,
+    coreDrivable: entry.coreModality === "voice",
     sourceHash,
   };
+  // Omitted rather than emitted empty, for the same reason as the override fields
+  // below: most lessons have no detachable section, and `"detachableSegments": []`
+  // on a thousand rows is noise a reader must learn to skip.
+  if (entry.detachableSegments.length > 0) {
+    row.detachableSegments = entry.detachableSegments;
+  }
   // The three override fields are omitted rather than emitted empty. They apply to a
   // handful of lessons out of 1,096, and `"authoredReason": ""` a thousand times over
   // is noise every reader must learn to skip. Absent means "the author said nothing",
@@ -429,8 +478,11 @@ export function buildModalityManifest(
   return {
     version: MODALITY_MANIFEST_VERSION,
     algorithm: "fnv1a64",
-    // Flipped to true by HL-C41, in the same change that starts emitting block rows.
-    features: { blockModality: false },
+    // True as of HL-C48: every row now carries `coreModality`, `coreReasons`,
+    // `coreDrivable`, and `detachableSegments` where it has any. The flag was honest
+    // while it was false — the data genuinely was not emitted — and flipping it
+    // without emitting the data would have been the actual bug.
+    features: { blockModality: true },
     policy: { maxLinearisableTableColumns },
     sourceHash: modalityCorpusHash(lessons),
     summary: {

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -383,13 +383,60 @@ describe("chapter rollups", () => {
 // Forward compatibility with block-level modality (HL-C41)
 // ---------------------------------------------------------------------------
 
-describe("room for block-level modality", () => {
-  it("declares that this build carries whole-lesson modality only", () => {
+describe("block-level modality", () => {
+  it("declares that this build carries core modality beside the whole-lesson answer", () => {
     // A capability flag, not a version bump: block modality is strictly additional
     // information, so both kinds of manifest stay version 1 and both answer the
     // driving question correctly.
-    expect(buildModalityManifest([]).features).toEqual({ blockModality: false });
+    //
+    // False until HL-C48 — and honestly so. The flag says "this build carries block
+    // data", and the build did not: no row emitted `coreModality` at all. Flipping the
+    // flag without emitting the data would have been the real bug, and reading the flag
+    // as "which field does `drivable` use" was a misreading that cost five waves of
+    // treating a missing feature as a design tension.
+    expect(buildModalityManifest([]).features).toEqual({ blockModality: true });
     expect(buildModalityManifest([]).version).toBe(1);
+  });
+
+  it("publishes the core answer WITHOUT moving the conservative one", () => {
+    // The compatibility promise this file's header makes, asserted rather than trusted.
+    // A lesson whose only visual dependency is an inline-letters section still reports
+    // `modality: sight` and `drivable: false` — a consumer that never learns about
+    // detachable blocks is unaffected by this change — while `coreModality`/
+    // `coreDrivable` say what a renderer that CAN set that section aside should do.
+    const manifest = buildModalityManifest([
+      lesson({
+        id: "ES-C01-a",
+        body: "## Warm-up\n\nSay it aloud.\n\n## The letters in this word\n\nThe first is round.",
+      }),
+    ]);
+    const row = manifest.lessons[0]!;
+    expect(row.modality).toBe("sight");
+    expect(row.drivable).toBe(false);
+    expect(row.coreModality).toBe("voice");
+    expect(row.coreDrivable).toBe(true);
+    // Auditable, not asserted: a reader can see which section was discounted.
+    expect(row.detachableSegments).toEqual(["The letters in this word"]);
+  });
+
+  it("omits detachableSegments entirely when a lesson has none", () => {
+    // Same reasoning as the override fields: most lessons have no detachable section,
+    // and an empty array on a thousand rows is noise every reader must skip.
+    const row = buildModalityManifest([lesson({ id: "ES-C01-a" })]).lessons[0]!;
+    expect(row).not.toHaveProperty("detachableSegments");
+    expect(row.coreModality).toBe("voice");
+  });
+
+  it("never lets the core answer be stronger than the whole-lesson one", () => {
+    // The structural invariant. `coreModality` is derived from a SUBSET of the blocks,
+    // so it can only ever be weaker or equal. If this ever fails, the derivation has a
+    // bug that would hand a driver a lesson needing a pen.
+    const { lessons } = loadEverything();
+    const order = { voice: 0, sight: 1, pen: 2 } as const;
+    for (const row of buildModalityManifest(lessons).lessons) {
+      expect(order[row.coreModality]).toBeLessThanOrEqual(order[row.modality]);
+      if (row.coreDrivable) expect(row.coreModality).toBe("voice");
+    }
   });
 
   it("keeps `modality` the conservative whole-lesson answer a naive reader can trust", () => {


### PR DESCRIPTION
The manifest header has promised `coreModality` since HL08 and **never emitted it**. Every row carried `modality` — the strongest channel needed *anywhere* in the lesson — and nothing else, so a consumer could not tell *"needs eyes throughout"* from *"needs eyes only for a section a fluent reader skims"*.

Ten authoring waves made that gap expensive. Eighteen tracks now carry honest `## The letters in this word` sections; every one of those lessons derives `modality: sight` and `coreModality: voice`. **Four tracks reported their new chapters as undrivable because of it**, and two agents reached opposite conclusions about the cause — one blaming detachability, one finding the flag. Direct measurement settled it: the derivation was always right, the *publication* was missing.

```
drivable (conservative)     909
coreDrivable (opt-in)     1,230 of 1,385 = 89%
321 of the 423 `sight` lessons are core-drivable
```

## What this deliberately does NOT do

**`modality` and `drivable` do not move.** This file's header promises that `modality` keeps its meaning permanently, and that a consumer which never learns about detachable blocks keeps producing a correct — merely pessimistic — driving edition forever, *because a driver offered too little is never handed a pen at 70mph*.

I had planned to switch `drivable` to the core answer. Reading the header showed that would break the documented compatibility contract. The fix is **additive**, exactly as that header specifies: read `entry.coreModality ?? entry.modality`, and branch on `features.blockModality` to know which build you hold.

## What each row gains

```json
"modality": "sight",  "drivable": false,          ← unchanged
"coreModality": "voice", "coreDrivable": true,    ← new
"detachableSegments": ["The letters in this word"]
```

`detachableSegments` is what makes the claim **auditable rather than asserted** — a reader can see which sections were discounted and disagree. `features.blockModality` flips to true *in the same change that emits the data*; it was honest while false, and flipping it alone would have been the actual bug.

## Tests

Four new, including the **structural invariant** that `coreModality` is never stronger than `modality`, asserted across the whole corpus. If that ever fails, the derivation would be handing a driver a lesson that needs a pen.

- **919 tests pass** (396 human-language-data + 523 language-ladder), default timeouts.
- `check:modality`, `check:books`, `check:narration` all clean.

## Security review — passed, first round

It traced both concerns rather than waving them through: `detachableSegments` titles reach disk only via `JSON.stringify` (escapes quotes, backslashes, control chars — no heading can forge sibling keys), and the optional-key emission is deterministic (fixed insertion point, parse-order array, pure integer predicate; no clock, RNG, locale formatting, or `readdirSync` ordering), so `check:modality` cannot flap across platforms.

**⚠️ Note for future consumers:** no renderer reads `detachableSegments` yet. The first one must **HTML-escape before DOM insertion** and **LaTeX-escape `\ { } $ & # ^ _ ~ %` before any `\section{}`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)