### PR TITLE
fix(human-language-data): the course-level phrases (HL-C50)

### DIFF
--- a/code/learning/human-languages/arabic/book/chapters/ch08-days.tex
+++ b/code/learning/human-languages/arabic/book/chapters/ch08-days.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:834f2f020141aeed
+% canonical-source-hash: fnv1a64:6e1a0082c493ca32
 % canonical-lessons: AR-C08-al-ahad-al-khamis, AR-C08-al-jumua-as-sabt
 
 \chapter{Days of the Week}
@@ -18,7 +18,7 @@ Name al-jumʿa and as-sabt beside the counted days, and place as-sabt next to He
 
 
 \begin{quote}
-Every language so far in this course names its weekdays for planet-gods. Arabic does something completely different: it just \textbf{counts} them.
+Most European and North Indian languages name their weekdays for planet-gods. Arabic does something completely different: it just \textbf{counts} them.
 \end{quote}
 
 \begin{grammarlens}[title={Grammar Lens — The pattern: definite article + ordinal number}]

--- a/code/learning/human-languages/arabic/lessons/AR-C08-al-ahad-al-khamis.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C08-al-ahad-al-khamis.md
@@ -33,7 +33,7 @@ reviews_of: [AR-C07-asif]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[] -->
 
-[PAUSE 2s] Every language so far in this course names its weekdays for
+[PAUSE 2s] Most European and North Indian languages name their weekdays for
 planet-gods. Arabic does something completely different: it just **counts**
 them.
 

--- a/code/learning/human-languages/arabic/narration/ch08.json
+++ b/code/learning/human-languages/arabic/narration/ch08.json
@@ -4,7 +4,7 @@
   "chapter": 8,
   "title": "Days of the Week",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:6294b259f9b691ec",
+  "sourceHash": "fnv1a64:0014006ce34f9f4f",
   "lessons": [
     {
       "id": "AR-C08-al-ahad-al-khamis",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:3dbaad4fe2de433f",
+      "sourceHash": "fnv1a64:256f75fd5f1f3c3f",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -44,7 +44,7 @@
             },
             {
               "kind": "speech",
-              "text": "Every language so far in this course names its weekdays for planet-gods. Arabic does something completely different: it just counts them."
+              "text": "Most European and North Indian languages name their weekdays for planet-gods. Arabic does something completely different: it just counts them."
             }
           ]
         },

--- a/code/learning/human-languages/arabic/narration/ch08.txt
+++ b/code/learning/human-languages/arabic/narration/ch08.txt
@@ -9,7 +9,7 @@ Before we start: this one needs your eyes, so it is not fully a driving lesson. 
 
 Warm-up.
 [pause 2 seconds]
-Every language so far in this course names its weekdays for planet-gods. Arabic does something completely different: it just counts them.
+Most European and North Indian languages name their weekdays for planet-gods. Arabic does something completely different: it just counts them.
 
 Grammar Lens — The pattern: definite article + ordinal number.
 Five of Arabic's seven days are simply "the [number]th" — the definite article ال (al-) plus an ordinal built on the number word:

--- a/code/learning/human-languages/chinese/book/chapters/ch01-nihao.tex
+++ b/code/learning/human-languages/chinese/book/chapters/ch01-nihao.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:0dffaa6fdcb5eb0a
+% canonical-source-hash: fnv1a64:e6411b8670357094
 % canonical-lessons: ZH-C01-tones, ZH-C01-ni, ZH-C01-hao, ZH-C01-nihao, ZH-C01-tone-sandhi, ZH-C01-hao-fond, ZH-C01-practice
 
 \chapter{Nǐ Hǎo — Hello, Character by Character}
@@ -85,7 +85,7 @@ Stroke order is a real, taught system here: top before bottom, left before right
 \begin{cousinweb}
 \textbf{\zh{你}} \emph{nǐ} — \textbf{you}, addressing one person.
 
-Here this track has to be honest with you. Everywhere else in this curriculum, a new word is anchored to English words you already own through a shared ancestor: Spanish \emph{gracias} to \emph{grace} and \emph{gratitude}, all from Latin \emph{gratia}. \textbf{Chinese shares no ancestor with English.} There is no cousin web for \emph{nǐ}, and inventing one would be worse than having none.
+Here this book has to be honest with you. A related language lets a new word be anchored to English words you already own through a shared ancestor — Spanish \emph{gracias} to \emph{grace} and \emph{gratitude}, all from Latin \emph{gratia}. \textbf{Chinese shares no ancestor with English.} There is no cousin web for \emph{nǐ}, and inventing one would be worse than having none.
 
 What replaces it is what you just read: the character is itself decomposable, and its pieces mean things. \textbf{\zh{你}} carries a person on its left because it is about a person. That is the hook — not history you share with English, but structure you can see.
 \end{cousinweb}
@@ -130,7 +130,7 @@ Notice what just happened. \textbf{\zh{女}} and \textbf{\zh{子}} are not lette
 \begin{cousinweb}
 \textbf{\zh{好}} \emph{hǎo} — \textbf{good}, and also \textbf{well}.
 
-A woman beside a child, and the character means \textquotedblleft{}good\textquotedblright{}. That picture is the hook — and it is the device this track uses in place of the cousin web every other volume in this curriculum runs on, because \textbf{Chinese and English share no ancestor} and there is no honest chain from \emph{hǎo} to any English word.
+A woman beside a child, and the character means \textquotedblleft{}good\textquotedblright{}. That picture is the hook — and it stands in for the cousin web that a related language would supply, because \textbf{Chinese and English share no ancestor} and there is no honest chain from \emph{hǎo} to any English word.
 
 Two cautions, because a memory aid that pretends to be history rots:
 

--- a/code/learning/human-languages/chinese/lessons/ZH-C01-hao.md
+++ b/code/learning/human-languages/chinese/lessons/ZH-C01-hao.md
@@ -66,9 +66,9 @@ with their own meanings, reused as building blocks.
 **好** *hǎo* — **good**, and also **well**.
 
 A woman beside a child, and the character means "good". That picture is the
-hook — and it is the device this track uses in place of the cousin web every
-other volume in this curriculum runs on, because **Chinese and English share no
-ancestor** and there is no honest chain from *hǎo* to any English word.
+hook — and it stands in for the cousin web that a
+related language would supply, because **Chinese and English share no ancestor** and there is
+no honest chain from *hǎo* to any English word.
 
 Two cautions, because a memory aid that pretends to be history rots:
 

--- a/code/learning/human-languages/chinese/lessons/ZH-C01-ni.md
+++ b/code/learning/human-languages/chinese/lessons/ZH-C01-ni.md
@@ -71,9 +71,9 @@ So **亻** first, then **尔**.
 
 **你** *nǐ* — **you**, addressing one person.
 
-Here this track has to be honest with you. Everywhere else in this curriculum, a
-new word is anchored to English words you already own through a shared ancestor:
-Spanish *gracias* to *grace* and *gratitude*, all from Latin *gratia*. **Chinese
+Here this book has to be honest with you. A related language lets a new word be
+anchored to English words you already own through a shared ancestor — Spanish
+*gracias* to *grace* and *gratitude*, all from Latin *gratia*. **Chinese
 shares no ancestor with English.** There is no cousin web for *nǐ*, and inventing
 one would be worse than having none.
 

--- a/code/learning/human-languages/chinese/narration/ch01.json
+++ b/code/learning/human-languages/chinese/narration/ch01.json
@@ -4,7 +4,7 @@
   "chapter": 1,
   "title": "Nǐ Hǎo — Hello, Character by Character",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:b740a5126cc6bad6",
+  "sourceHash": "fnv1a64:6e5b00565489fe34",
   "lessons": [
     {
       "id": "ZH-C01-tones",
@@ -160,7 +160,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:fd5fc68c6af29500",
+      "sourceHash": "fnv1a64:bf90a02b9c63153c",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -247,7 +247,7 @@
             },
             {
               "kind": "speech",
-              "text": "Here this track has to be honest with you. Everywhere else in this curriculum, a new word is anchored to English words you already own through a shared ancestor: Spanish gracias to grace and gratitude, all from Latin gratia. Chinese shares no ancestor with English. There is no cousin web for nǐ, and inventing one would be worse than having none."
+              "text": "Here this book has to be honest with you. A related language lets a new word be anchored to English words you already own through a shared ancestor — Spanish gracias to grace and gratitude, all from Latin gratia. Chinese shares no ancestor with English. There is no cousin web for nǐ, and inventing one would be worse than having none."
             },
             {
               "kind": "speech",
@@ -329,7 +329,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:8856bfa06cfb62bd",
+      "sourceHash": "fnv1a64:220f4f705c72a7c3",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -408,7 +408,7 @@
             },
             {
               "kind": "speech",
-              "text": "A woman beside a child, and the character means \"good\". That picture is the hook — and it is the device this track uses in place of the cousin web every other volume in this curriculum runs on, because Chinese and English share no ancestor and there is no honest chain from hǎo to any English word."
+              "text": "A woman beside a child, and the character means \"good\". That picture is the hook — and it stands in for the cousin web that a related language would supply, because Chinese and English share no ancestor and there is no honest chain from hǎo to any English word."
             },
             {
               "kind": "speech",

--- a/code/learning/human-languages/chinese/narration/ch01.txt
+++ b/code/learning/human-languages/chinese/narration/ch01.txt
@@ -57,7 +57,7 @@ Stroke order is a real, taught system here: top before bottom, left before right
 
 The word, taken apart.
 你 nǐ — you, addressing one person.
-Here this track has to be honest with you. Everywhere else in this curriculum, a new word is anchored to English words you already own through a shared ancestor: Spanish gracias to grace and gratitude, all from Latin gratia. Chinese shares no ancestor with English. There is no cousin web for nǐ, and inventing one would be worse than having none.
+Here this book has to be honest with you. A related language lets a new word be anchored to English words you already own through a shared ancestor — Spanish gracias to grace and gratitude, all from Latin gratia. Chinese shares no ancestor with English. There is no cousin web for nǐ, and inventing one would be worse than having none.
 What replaces it is what you just read: the character is itself decomposable, and its pieces mean things. 你 (nǐ) carries a person on its left because it is about a person. That is the hook — not history you share with English, but structure you can see.
 
 Guided Practice.
@@ -94,7 +94,7 @@ Notice what just happened. 女 and 子 are not letters spelling out the sound h�
 
 The word, taken apart.
 好 (hào) hǎo — good, and also well.
-A woman beside a child, and the character means "good". That picture is the hook — and it is the device this track uses in place of the cousin web every other volume in this curriculum runs on, because Chinese and English share no ancestor and there is no honest chain from hǎo to any English word.
+A woman beside a child, and the character means "good". That picture is the hook — and it stands in for the cousin web that a related language would supply, because Chinese and English share no ancestor and there is no honest chain from hǎo to any English word.
 Two cautions, because a memory aid that pretends to be history rots:
 "Woman + child = good" is the traditional gloss. It is genuinely useful for remembering the shape, but palaeographers do not all accept it as the historical origin; some read 子 as a phonetic element instead. A picture that helps, not a proven derivation.
 Component glosses are hooks, not translations. 好 (hǎo) (hào) does not "mean" woman-child. It means good.

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -66,7 +66,7 @@
     {
       "language": "arabic",
       "chapter": 8,
-      "sourceHash": "fnv1a64:834f2f020141aeed",
+      "sourceHash": "fnv1a64:6e1a0082c493ca32",
       "lessonIds": [
         "AR-C08-al-ahad-al-khamis",
         "AR-C08-al-jumua-as-sabt"
@@ -351,7 +351,7 @@
     {
       "language": "chinese",
       "chapter": 1,
-      "sourceHash": "fnv1a64:0dffaa6fdcb5eb0a",
+      "sourceHash": "fnv1a64:e6411b8670357094",
       "lessonIds": [
         "ZH-C01-tones",
         "ZH-C01-ni",
@@ -455,7 +455,7 @@
     {
       "language": "german",
       "chapter": 17,
-      "sourceHash": "fnv1a64:db42e9b15a61794e",
+      "sourceHash": "fnv1a64:e86811351e6dab80",
       "lessonIds": [
         "GE-C17-kopf",
         "GE-C17-kopf-haupt",
@@ -521,7 +521,7 @@
     {
       "language": "german",
       "chapter": 24,
-      "sourceHash": "fnv1a64:72cc26138da11014",
+      "sourceHash": "fnv1a64:21da996939cd89d0",
       "lessonIds": [
         "GE-C24-denken",
         "GE-C24-verstehen",
@@ -604,7 +604,7 @@
     {
       "language": "hindi",
       "chapter": 7,
-      "sourceHash": "fnv1a64:e15d0ae88bad4c45",
+      "sourceHash": "fnv1a64:f27dd07acda83c6b",
       "lessonIds": [
         "HI-C07-haan",
         "HI-C07-nahin"
@@ -672,7 +672,7 @@
     {
       "language": "hindi",
       "chapter": 14,
-      "sourceHash": "fnv1a64:93c447d022604c69",
+      "sourceHash": "fnv1a64:a49f7baa61f62aff",
       "lessonIds": [
         "HI-C14-ritu"
       ],
@@ -1026,7 +1026,7 @@
     {
       "language": "italian",
       "chapter": 15,
-      "sourceHash": "fnv1a64:39516bddf0538c22",
+      "sourceHash": "fnv1a64:40d9a4f713b200c9",
       "lessonIds": [
         "IT-C15-passato-prossimo",
         "IT-C15-passato-remoto"
@@ -1048,7 +1048,7 @@
     {
       "language": "italian",
       "chapter": 17,
-      "sourceHash": "fnv1a64:137ac0966fca7456",
+      "sourceHash": "fnv1a64:967eb6543fa8c133",
       "lessonIds": [
         "IT-C17-testa",
         "IT-C17-mano"
@@ -1082,7 +1082,7 @@
     {
       "language": "japanese",
       "chapter": 1,
-      "sourceHash": "fnv1a64:1204445a344e67db",
+      "sourceHash": "fnv1a64:cecac120ddc02409",
       "lessonIds": [
         "JA-C01-hai",
         "JA-C01-iie",
@@ -1209,7 +1209,7 @@
     {
       "language": "kannada",
       "chapter": 18,
-      "sourceHash": "fnv1a64:f2c5716c5c240948",
+      "sourceHash": "fnv1a64:7ed9245888e25791",
       "lessonIds": [
         "KA-C18-gante"
       ],
@@ -1451,7 +1451,7 @@
     {
       "language": "latin",
       "chapter": 10,
-      "sourceHash": "fnv1a64:2b5b66f0b53814e3",
+      "sourceHash": "fnv1a64:b5c05f1ffcd44863",
       "lessonIds": [
         "LA-C10-aqua-vinum",
         "LA-C10-panis"
@@ -1555,7 +1555,7 @@
     {
       "language": "latin",
       "chapter": 21,
-      "sourceHash": "fnv1a64:6d6c5bcc65253b22",
+      "sourceHash": "fnv1a64:b1cdf2ba87c9af8b",
       "lessonIds": [
         "LA-C21-volup-est-convenisse",
         "LA-C21-meeting-phrase-context",
@@ -2136,7 +2136,7 @@
     {
       "language": "persian",
       "chapter": 8,
-      "sourceHash": "fnv1a64:b601304cacc02d51",
+      "sourceHash": "fnv1a64:fb1eef1af7c5ba7f",
       "lessonIds": [
         "FA-C08-gereftan",
         "FA-C08-porsidan",
@@ -2243,7 +2243,7 @@
     {
       "language": "portuguese",
       "chapter": 10,
-      "sourceHash": "fnv1a64:dd61a14d7c4fb6f3",
+      "sourceHash": "fnv1a64:d85a6e277c1e0c6c",
       "lessonIds": [
         "PT-C10-pais",
         "PT-C10-irmaos"
@@ -2401,7 +2401,7 @@
     {
       "language": "punjabi",
       "chapter": 9,
-      "sourceHash": "fnv1a64:c655c44197746db3",
+      "sourceHash": "fnv1a64:396097f23856ca3d",
       "lessonIds": [
         "PA-C09-laina",
         "PA-C09-puchhna",
@@ -2909,7 +2909,7 @@
     {
       "language": "tamil",
       "chapter": 19,
-      "sourceHash": "fnv1a64:dffffca8b81faf38",
+      "sourceHash": "fnv1a64:158e1e4de8950e2a",
       "lessonIds": [
         "TA-C19-vayathu",
         "TA-C19-age-register-grammar"
@@ -2919,7 +2919,7 @@
     {
       "language": "tamil",
       "chapter": 20,
-      "sourceHash": "fnv1a64:10c054c15ddf76fe",
+      "sourceHash": "fnv1a64:17a98f1177a6f798",
       "lessonIds": [
         "TA-C20-pathinondru-irupathu",
         "TA-C20-vaanilai"
@@ -3059,7 +3059,7 @@
     {
       "language": "tamil",
       "chapter": 34,
-      "sourceHash": "fnv1a64:a5e98484e1abcce2",
+      "sourceHash": "fnv1a64:a7767e667ee93f24",
       "lessonIds": [
         "TA-C34-edu",
         "TA-C34-kel",
@@ -3118,7 +3118,7 @@
     {
       "language": "telugu",
       "chapter": 11,
-      "sourceHash": "fnv1a64:a123da0e996c2292",
+      "sourceHash": "fnv1a64:4ffc184dedb4e141",
       "lessonIds": [
         "TE-C11-rangulu"
       ],
@@ -3374,7 +3374,7 @@
     {
       "language": "urdu",
       "chapter": 5,
-      "sourceHash": "fnv1a64:65e2cc2c814ff552",
+      "sourceHash": "fnv1a64:929b13d07290a038",
       "lessonIds": [
         "UR-C05-khuda",
         "UR-C05-hafiz",
@@ -3411,7 +3411,7 @@
     {
       "language": "urdu",
       "chapter": 8,
-      "sourceHash": "fnv1a64:dd548ee0ccc086e4",
+      "sourceHash": "fnv1a64:445fa7a91d105cb0",
       "lessonIds": [
         "UR-C08-lena",
         "UR-C08-puchhna",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -144,7 +144,7 @@
     {
       "language": "arabic",
       "chapter": 8,
-      "sourceHash": "fnv1a64:6294b259f9b691ec",
+      "sourceHash": "fnv1a64:0014006ce34f9f4f",
       "lessonIds": [
         "AR-C08-al-ahad-al-khamis",
         "AR-C08-al-jumua-as-sabt"
@@ -153,8 +153,8 @@
       "drivablePrefix": 0,
       "text": "arabic/narration/ch08.txt",
       "json": "arabic/narration/ch08.json",
-      "textHash": "fnv1a64:1b101d1dc1bec8b9",
-      "jsonHash": "fnv1a64:8095884086d052af"
+      "textHash": "fnv1a64:12a8846284a034cc",
+      "jsonHash": "fnv1a64:7e08d2cb580a7130"
     },
     {
       "language": "arabic",
@@ -669,7 +669,7 @@
     {
       "language": "chinese",
       "chapter": 1,
-      "sourceHash": "fnv1a64:b740a5126cc6bad6",
+      "sourceHash": "fnv1a64:6e5b00565489fe34",
       "lessonIds": [
         "ZH-C01-tones",
         "ZH-C01-ni",
@@ -683,8 +683,8 @@
       "drivablePrefix": 1,
       "text": "chinese/narration/ch01.txt",
       "json": "chinese/narration/ch01.json",
-      "textHash": "fnv1a64:7dbfefd71a05f8e1",
-      "jsonHash": "fnv1a64:00051f49965de953"
+      "textHash": "fnv1a64:71196eb3e4754fd4",
+      "jsonHash": "fnv1a64:029cf1efe539783a"
     },
     {
       "language": "french",
@@ -1369,7 +1369,7 @@
     {
       "language": "german",
       "chapter": 17,
-      "sourceHash": "fnv1a64:ce4e6be384d018cf",
+      "sourceHash": "fnv1a64:436bd0ef42617218",
       "lessonIds": [
         "GE-C17-kopf",
         "GE-C17-kopf-haupt",
@@ -1379,8 +1379,8 @@
       "drivablePrefix": 3,
       "text": "german/narration/ch17.txt",
       "json": "german/narration/ch17.json",
-      "textHash": "fnv1a64:2c35858a57d5f109",
-      "jsonHash": "fnv1a64:6ae1428d55a04d32"
+      "textHash": "fnv1a64:184f5f4e859e9747",
+      "jsonHash": "fnv1a64:0cce42f1290aab3b"
     },
     {
       "language": "german",
@@ -1470,7 +1470,7 @@
     {
       "language": "german",
       "chapter": 24,
-      "sourceHash": "fnv1a64:fb75d3964d3b3f0f",
+      "sourceHash": "fnv1a64:a6259dd9fea16afd",
       "lessonIds": [
         "GE-C24-denken",
         "GE-C24-verstehen",
@@ -1482,7 +1482,7 @@
       "text": "german/narration/ch24.txt",
       "json": "german/narration/ch24.json",
       "textHash": "fnv1a64:ac105e0ff17b46e8",
-      "jsonHash": "fnv1a64:1157ece1a213fab9"
+      "jsonHash": "fnv1a64:4b10f1455657247f"
     },
     {
       "language": "german",
@@ -1668,7 +1668,7 @@
     {
       "language": "hindi",
       "chapter": 1,
-      "sourceHash": "fnv1a64:f6301764a50979e5",
+      "sourceHash": "fnv1a64:e0c6f8dfe20e0f70",
       "lessonIds": [
         "HI-W01-shirorekha-na-ma",
         "HI-W01-na-ma",
@@ -1685,8 +1685,8 @@
       "drivablePrefix": 0,
       "text": "hindi/narration/ch01.txt",
       "json": "hindi/narration/ch01.json",
-      "textHash": "fnv1a64:f6c9f60962c60faa",
-      "jsonHash": "fnv1a64:424e17ed7ace0aa3"
+      "textHash": "fnv1a64:c0e47414f041d647",
+      "jsonHash": "fnv1a64:9bd533ff78eb6c1e"
     },
     {
       "language": "hindi",
@@ -1759,7 +1759,7 @@
     {
       "language": "hindi",
       "chapter": 5,
-      "sourceHash": "fnv1a64:8524e38a45a846be",
+      "sourceHash": "fnv1a64:cbeb6be21dffed51",
       "lessonIds": [
         "HI-C05-bolna",
         "HI-C05-bolta-hun",
@@ -1772,8 +1772,8 @@
       "drivablePrefix": 0,
       "text": "hindi/narration/ch05.txt",
       "json": "hindi/narration/ch05.json",
-      "textHash": "fnv1a64:ddf43e013d62d725",
-      "jsonHash": "fnv1a64:d16ae24dcbf83cfc"
+      "textHash": "fnv1a64:a4f55d2448a87991",
+      "jsonHash": "fnv1a64:411eeb8f5d735025"
     },
     {
       "language": "hindi",
@@ -1794,7 +1794,7 @@
     {
       "language": "hindi",
       "chapter": 7,
-      "sourceHash": "fnv1a64:7f46ae04549f4eaa",
+      "sourceHash": "fnv1a64:e4fdb1c6208acaf8",
       "lessonIds": [
         "HI-C07-haan",
         "HI-C07-nahin"
@@ -1803,8 +1803,8 @@
       "drivablePrefix": 2,
       "text": "hindi/narration/ch07.txt",
       "json": "hindi/narration/ch07.json",
-      "textHash": "fnv1a64:322ace8ee6dc7712",
-      "jsonHash": "fnv1a64:01be0af2f621fadc"
+      "textHash": "fnv1a64:6f542c0260fc78b2",
+      "jsonHash": "fnv1a64:ff9de2e404607c1a"
     },
     {
       "language": "hindi",
@@ -1897,7 +1897,7 @@
     {
       "language": "hindi",
       "chapter": 14,
-      "sourceHash": "fnv1a64:ab989406c824d264",
+      "sourceHash": "fnv1a64:13b1ba42e4613deb",
       "lessonIds": [
         "HI-C14-ritu"
       ],
@@ -1905,8 +1905,8 @@
       "drivablePrefix": 1,
       "text": "hindi/narration/ch14.txt",
       "json": "hindi/narration/ch14.json",
-      "textHash": "fnv1a64:2328c600fa536797",
-      "jsonHash": "fnv1a64:303f9d072bffa9b9"
+      "textHash": "fnv1a64:56c4300af034ff75",
+      "jsonHash": "fnv1a64:3b27491c815a4e0a"
     },
     {
       "language": "hindi",
@@ -2448,7 +2448,7 @@
     {
       "language": "italian",
       "chapter": 15,
-      "sourceHash": "fnv1a64:0b856b51ba3decfd",
+      "sourceHash": "fnv1a64:50843bd9598574f7",
       "lessonIds": [
         "IT-C15-passato-prossimo",
         "IT-C15-passato-remoto"
@@ -2457,8 +2457,8 @@
       "drivablePrefix": 2,
       "text": "italian/narration/ch15.txt",
       "json": "italian/narration/ch15.json",
-      "textHash": "fnv1a64:470b9e83b58ea27d",
-      "jsonHash": "fnv1a64:04875582bd04feb9"
+      "textHash": "fnv1a64:4d432a2cb26f240c",
+      "jsonHash": "fnv1a64:95d66628525ba977"
     },
     {
       "language": "italian",
@@ -2480,7 +2480,7 @@
     {
       "language": "italian",
       "chapter": 17,
-      "sourceHash": "fnv1a64:312b7248145dbb09",
+      "sourceHash": "fnv1a64:c89b171c9cc323f6",
       "lessonIds": [
         "IT-C17-testa",
         "IT-C17-mano"
@@ -2489,8 +2489,8 @@
       "drivablePrefix": 2,
       "text": "italian/narration/ch17.txt",
       "json": "italian/narration/ch17.json",
-      "textHash": "fnv1a64:f7c224b28604a547",
-      "jsonHash": "fnv1a64:719d307d27276ac2"
+      "textHash": "fnv1a64:17a85b6fdde5d434",
+      "jsonHash": "fnv1a64:eca910fbd161bdef"
     },
     {
       "language": "italian",
@@ -2529,7 +2529,7 @@
     {
       "language": "japanese",
       "chapter": 1,
-      "sourceHash": "fnv1a64:edad54370036a969",
+      "sourceHash": "fnv1a64:41f12f11cb910ec8",
       "lessonIds": [
         "JA-C01-hai",
         "JA-C01-iie",
@@ -2544,8 +2544,8 @@
       "drivablePrefix": 0,
       "text": "japanese/narration/ch01.txt",
       "json": "japanese/narration/ch01.json",
-      "textHash": "fnv1a64:8dff00016f4645ce",
-      "jsonHash": "fnv1a64:92029d413a0e1248"
+      "textHash": "fnv1a64:7eaf7ef46df15790",
+      "jsonHash": "fnv1a64:5e6ebe995c20db73"
     },
     {
       "language": "kannada",
@@ -2816,7 +2816,7 @@
     {
       "language": "kannada",
       "chapter": 18,
-      "sourceHash": "fnv1a64:3b7b62b9ccd03e57",
+      "sourceHash": "fnv1a64:3ece51b0bab8b3df",
       "lessonIds": [
         "KA-C18-gante"
       ],
@@ -2824,8 +2824,8 @@
       "drivablePrefix": 1,
       "text": "kannada/narration/ch18.txt",
       "json": "kannada/narration/ch18.json",
-      "textHash": "fnv1a64:3231ad0ebace44fa",
-      "jsonHash": "fnv1a64:32217830a2603e88"
+      "textHash": "fnv1a64:60021c50fcb3d526",
+      "jsonHash": "fnv1a64:b0e3bcb8300c82ab"
     },
     {
       "language": "kannada",
@@ -3202,7 +3202,7 @@
     {
       "language": "latin",
       "chapter": 10,
-      "sourceHash": "fnv1a64:1e7cf552260ff65d",
+      "sourceHash": "fnv1a64:c5cf4ddfd577bd3b",
       "lessonIds": [
         "LA-C10-aqua-vinum",
         "LA-C10-panis"
@@ -3211,8 +3211,8 @@
       "drivablePrefix": 2,
       "text": "latin/narration/ch10.txt",
       "json": "latin/narration/ch10.json",
-      "textHash": "fnv1a64:7767278fdae1848d",
-      "jsonHash": "fnv1a64:a130302f53a31e8a"
+      "textHash": "fnv1a64:31f40c3db4aba7fe",
+      "jsonHash": "fnv1a64:da42d02adba2a603"
     },
     {
       "language": "latin",
@@ -3361,7 +3361,7 @@
     {
       "language": "latin",
       "chapter": 21,
-      "sourceHash": "fnv1a64:0f93e9300f86bb34",
+      "sourceHash": "fnv1a64:67e96b837e28d997",
       "lessonIds": [
         "LA-C21-volup-est-convenisse",
         "LA-C21-meeting-phrase-context",
@@ -3371,8 +3371,8 @@
       "drivablePrefix": 3,
       "text": "latin/narration/ch21.txt",
       "json": "latin/narration/ch21.json",
-      "textHash": "fnv1a64:5fef6407a1b89417",
-      "jsonHash": "fnv1a64:68acc8b905738983"
+      "textHash": "fnv1a64:603b55f443f608e2",
+      "jsonHash": "fnv1a64:bc106bd797e8e97e"
     },
     {
       "language": "latin",
@@ -4452,7 +4452,7 @@
     {
       "language": "persian",
       "chapter": 8,
-      "sourceHash": "fnv1a64:7b80d96a1a7c66b1",
+      "sourceHash": "fnv1a64:0dd578d8d51e5c72",
       "lessonIds": [
         "FA-C08-gereftan",
         "FA-C08-porsidan",
@@ -4463,8 +4463,8 @@
       "drivablePrefix": 4,
       "text": "persian/narration/ch08.txt",
       "json": "persian/narration/ch08.json",
-      "textHash": "fnv1a64:ed2a46e3b26c4559",
-      "jsonHash": "fnv1a64:b554319082956944"
+      "textHash": "fnv1a64:2b882a065a605eb5",
+      "jsonHash": "fnv1a64:4f9c8f546baffe53"
     },
     {
       "language": "portuguese",
@@ -4626,7 +4626,7 @@
     {
       "language": "portuguese",
       "chapter": 10,
-      "sourceHash": "fnv1a64:756b61183a892e04",
+      "sourceHash": "fnv1a64:d8f9eeb2611c6355",
       "lessonIds": [
         "PT-C10-pais",
         "PT-C10-irmaos"
@@ -4635,8 +4635,8 @@
       "drivablePrefix": 2,
       "text": "portuguese/narration/ch10.txt",
       "json": "portuguese/narration/ch10.json",
-      "textHash": "fnv1a64:5d4cb08f11812d51",
-      "jsonHash": "fnv1a64:68bded43b35ec956"
+      "textHash": "fnv1a64:3be2f9b7a5cc1ce3",
+      "jsonHash": "fnv1a64:b3ac629ec0cd8422"
     },
     {
       "language": "portuguese",
@@ -4950,7 +4950,7 @@
     {
       "language": "punjabi",
       "chapter": 9,
-      "sourceHash": "fnv1a64:e7043bb75ddc7901",
+      "sourceHash": "fnv1a64:01d0ba06d4ae01a9",
       "lessonIds": [
         "PA-C09-laina",
         "PA-C09-puchhna",
@@ -4962,7 +4962,7 @@
       "text": "punjabi/narration/ch09.txt",
       "json": "punjabi/narration/ch09.json",
       "textHash": "fnv1a64:9fbcd2f5256b662b",
-      "jsonHash": "fnv1a64:39c2cfb1b511e338"
+      "jsonHash": "fnv1a64:cd38d9138c8fa47a"
     },
     {
       "language": "russian",
@@ -4992,7 +4992,7 @@
     {
       "language": "russian",
       "chapter": 2,
-      "sourceHash": "fnv1a64:afc21c872d0eaee5",
+      "sourceHash": "fnv1a64:756aeef46987b86f",
       "lessonIds": [
         "RU-C02-ya",
         "RU-C02-ty-vy",
@@ -5009,8 +5009,8 @@
       "drivablePrefix": 8,
       "text": "russian/narration/ch02.txt",
       "json": "russian/narration/ch02.json",
-      "textHash": "fnv1a64:931c9ea0a95fa825",
-      "jsonHash": "fnv1a64:0858930350277e9d"
+      "textHash": "fnv1a64:189a1dc2943faf94",
+      "jsonHash": "fnv1a64:df597795f3754c9b"
     },
     {
       "language": "russian",
@@ -5068,7 +5068,7 @@
     {
       "language": "sanskrit",
       "chapter": 1,
-      "sourceHash": "fnv1a64:aad0ad5150f2038b",
+      "sourceHash": "fnv1a64:281f1ccd090a19c1",
       "lessonIds": [
         "SA-C01-am-na",
         "SA-C01-dhanyavada",
@@ -5081,8 +5081,8 @@
       "drivablePrefix": 0,
       "text": "sanskrit/narration/ch01.txt",
       "json": "sanskrit/narration/ch01.json",
-      "textHash": "fnv1a64:639e8e93536db3ca",
-      "jsonHash": "fnv1a64:55d1bbde1012dc89"
+      "textHash": "fnv1a64:2500e0daf1b1caf8",
+      "jsonHash": "fnv1a64:71da3568320a6e16"
     },
     {
       "language": "sanskrit",
@@ -5145,7 +5145,7 @@
     {
       "language": "sanskrit",
       "chapter": 5,
-      "sourceHash": "fnv1a64:45070b3634ab6b25",
+      "sourceHash": "fnv1a64:f287ad3b981ede05",
       "lessonIds": [
         "SA-C05-aham-samskritam-vadami",
         "SA-C05-karomi",
@@ -5157,8 +5157,8 @@
       "drivablePrefix": 0,
       "text": "sanskrit/narration/ch05.txt",
       "json": "sanskrit/narration/ch05.json",
-      "textHash": "fnv1a64:d872a0719de56684",
-      "jsonHash": "fnv1a64:85fa13617e23c7d8"
+      "textHash": "fnv1a64:4d6228f1d4086652",
+      "jsonHash": "fnv1a64:7ffe3fbc2728d84e"
     },
     {
       "language": "sanskrit",
@@ -6138,7 +6138,7 @@
     {
       "language": "tamil",
       "chapter": 19,
-      "sourceHash": "fnv1a64:44a46feca59b14fa",
+      "sourceHash": "fnv1a64:1c8de13134073142",
       "lessonIds": [
         "TA-C19-vayathu",
         "TA-C19-age-register-grammar"
@@ -6147,13 +6147,13 @@
       "drivablePrefix": 2,
       "text": "tamil/narration/ch19.txt",
       "json": "tamil/narration/ch19.json",
-      "textHash": "fnv1a64:db992b33fb0df610",
-      "jsonHash": "fnv1a64:ad6699acfeb389d0"
+      "textHash": "fnv1a64:f488fb0280c7fb77",
+      "jsonHash": "fnv1a64:1cd5375417f2e11b"
     },
     {
       "language": "tamil",
       "chapter": 20,
-      "sourceHash": "fnv1a64:8f64238981d04880",
+      "sourceHash": "fnv1a64:fdf0cc4db10b69be",
       "lessonIds": [
         "TA-C20-pathinondru-irupathu",
         "TA-C20-vaanilai"
@@ -6162,8 +6162,8 @@
       "drivablePrefix": 2,
       "text": "tamil/narration/ch20.txt",
       "json": "tamil/narration/ch20.json",
-      "textHash": "fnv1a64:2f6e078e1dad54f3",
-      "jsonHash": "fnv1a64:52db5f6b59db84cf"
+      "textHash": "fnv1a64:0090ff714c4601ea",
+      "jsonHash": "fnv1a64:aa53077e1724be08"
     },
     {
       "language": "tamil",
@@ -6363,7 +6363,7 @@
     {
       "language": "tamil",
       "chapter": 34,
-      "sourceHash": "fnv1a64:2e2e5e869f303320",
+      "sourceHash": "fnv1a64:b09af3aa1df4854a",
       "lessonIds": [
         "TA-C34-edu",
         "TA-C34-kel",
@@ -6374,8 +6374,8 @@
       "drivablePrefix": 0,
       "text": "tamil/narration/ch34.txt",
       "json": "tamil/narration/ch34.json",
-      "textHash": "fnv1a64:36d980fd07602035",
-      "jsonHash": "fnv1a64:595f29450881bd12"
+      "textHash": "fnv1a64:3b698d59bb660735",
+      "jsonHash": "fnv1a64:46adf7fdfc05b3c6"
     },
     {
       "language": "telugu",
@@ -6547,7 +6547,7 @@
     {
       "language": "telugu",
       "chapter": 11,
-      "sourceHash": "fnv1a64:c981c0b76cf70dc0",
+      "sourceHash": "fnv1a64:b4677406243c8827",
       "lessonIds": [
         "TE-C11-rangulu"
       ],
@@ -6555,8 +6555,8 @@
       "drivablePrefix": 1,
       "text": "telugu/narration/ch11.txt",
       "json": "telugu/narration/ch11.json",
-      "textHash": "fnv1a64:5e3ee8f3f7e6f799",
-      "jsonHash": "fnv1a64:345c1b9a48d0c6b6"
+      "textHash": "fnv1a64:e698753e4721adf3",
+      "jsonHash": "fnv1a64:1f98da3b57f6865c"
     },
     {
       "language": "telugu",
@@ -6964,7 +6964,7 @@
     {
       "language": "urdu",
       "chapter": 5,
-      "sourceHash": "fnv1a64:5d2065ac9b927c2f",
+      "sourceHash": "fnv1a64:fc4210d6ddcf7d8b",
       "lessonIds": [
         "UR-C05-khuda",
         "UR-C05-hafiz",
@@ -6975,8 +6975,8 @@
       "drivablePrefix": 2,
       "text": "urdu/narration/ch05.txt",
       "json": "urdu/narration/ch05.json",
-      "textHash": "fnv1a64:4e356459da7e4b30",
-      "jsonHash": "fnv1a64:e1ace1efd29cf4ec"
+      "textHash": "fnv1a64:4b650a658b85409b",
+      "jsonHash": "fnv1a64:a357ba5c0f270641"
     },
     {
       "language": "urdu",
@@ -7016,7 +7016,7 @@
     {
       "language": "urdu",
       "chapter": 8,
-      "sourceHash": "fnv1a64:997aec13e461f1b3",
+      "sourceHash": "fnv1a64:d6961ef47c5a8dd7",
       "lessonIds": [
         "UR-C08-lena",
         "UR-C08-puchhna",
@@ -7028,7 +7028,7 @@
       "text": "urdu/narration/ch08.txt",
       "json": "urdu/narration/ch08.json",
       "textHash": "fnv1a64:89bfe5828747af1d",
-      "jsonHash": "fnv1a64:807f0572154bf8d0"
+      "jsonHash": "fnv1a64:ef09aad11524eba4"
     }
   ],
   "findings": []

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:a4715d7f4254b303",
+  "sourceHash": "fnv1a64:5a8646971486e548",
   "summary": {
     "totalLessons": 1385,
     "voice": 909,
@@ -8547,7 +8547,7 @@
         "wide-table"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:3dbaad4fe2de433f"
+      "sourceHash": "fnv1a64:256f75fd5f1f3c3f"
     },
     {
       "id": "AR-C08-al-jumua-as-sabt",
@@ -10173,7 +10173,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:fd5fc68c6af29500",
+      "sourceHash": "fnv1a64:bf90a02b9c63153c",
       "detachableSegments": [
         "Script — 你, and the person hiding on its left"
       ]
@@ -10194,7 +10194,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8856bfa06cfb62bd",
+      "sourceHash": "fnv1a64:220f4f705c72a7c3",
       "detachableSegments": [
         "Script — 好, a woman beside a child"
       ]
@@ -12981,7 +12981,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:46d0b30a7b21211a"
+      "sourceHash": "fnv1a64:2749ef57887d5546"
     },
     {
       "id": "GE-C18-ja",
@@ -13161,7 +13161,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:06d86fff9bf862f3"
+      "sourceHash": "fnv1a64:820e3554f1ce62f3"
     },
     {
       "id": "GE-C24-schreiben",
@@ -14263,7 +14263,7 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:e36ecbfa85109dfb"
+      "sourceHash": "fnv1a64:26af03d5de07dead"
     },
     {
       "id": "HI-C01-alvida",
@@ -15012,7 +15012,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e1c24c88399adaca",
+      "sourceHash": "fnv1a64:350f1c0bbea0616c",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -15166,7 +15166,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9df4c614f504322b"
+      "sourceHash": "fnv1a64:79169e506f53d6cd"
     },
     {
       "id": "HI-C08-kripaya",
@@ -15364,7 +15364,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9f64c469ba547d55"
+      "sourceHash": "fnv1a64:3cf3287daf0ef18b"
     },
     {
       "id": "HI-C15-paani-roti",
@@ -16890,7 +16890,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8d4b5481167925c8"
+      "sourceHash": "fnv1a64:87e175498a57b50c"
     },
     {
       "id": "IT-C16-essere",
@@ -16998,7 +16998,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a462acace3a0153a"
+      "sourceHash": "fnv1a64:30e82540daa65b92"
     },
     {
       "id": "IT-C18-pensare",
@@ -17223,7 +17223,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:405ea26c254381c6",
+      "sourceHash": "fnv1a64:00d779c076662e0e",
       "detachableSegments": [
         "Script — kanji, and the readings problem"
       ]
@@ -18202,7 +18202,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:52e97c7a7b81405f"
+      "sourceHash": "fnv1a64:f73a4d5c3f34c2df"
     },
     {
       "id": "KA-C19-vayassu",
@@ -19068,7 +19068,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:1815c089d95f1f84"
+      "sourceHash": "fnv1a64:b1418f185aaaaac2"
     },
     {
       "id": "LA-C10-panis",
@@ -19356,7 +19356,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:d26baa3eb553be8a"
+      "sourceHash": "fnv1a64:e7fa4ed193474c2c"
     },
     {
       "id": "LA-C21-meeting-phrase-context",
@@ -23029,7 +23029,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b0cbd7ebe8850758"
+      "sourceHash": "fnv1a64:bd65bbf669f07dc2"
     },
     {
       "id": "FA-C08-porsidan",
@@ -23841,7 +23841,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:728021c129cdefb6"
+      "sourceHash": "fnv1a64:ca89807f7cb84ee2"
     },
     {
       "id": "PT-C11-pao",
@@ -25288,7 +25288,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ba5e85879b8768cb",
+      "sourceHash": "fnv1a64:b3ba243cf1ee590e",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -25662,7 +25662,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:1d3d69c6c4518117"
+      "sourceHash": "fnv1a64:18eedafd904b8b7b"
     },
     {
       "id": "RU-C02-kak-vas-zovut",
@@ -26107,7 +26107,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:727560286d972f72",
+      "sourceHash": "fnv1a64:386744037c9fab92",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -26572,7 +26572,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:06c187eb35a64186",
+      "sourceHash": "fnv1a64:e1ceeeb95c714166",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -31009,7 +31009,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7cd19cdfa68e405f"
+      "sourceHash": "fnv1a64:707e217350c30e75"
     },
     {
       "id": "TA-C19-age-register-grammar",
@@ -31045,7 +31045,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7262158bd8ed0238"
+      "sourceHash": "fnv1a64:83599a85f76e0d2c"
     },
     {
       "id": "TA-C20-vaanilai",
@@ -31561,7 +31561,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:461fc79451361c98",
+      "sourceHash": "fnv1a64:3247ff041aada7e8",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -32382,7 +32382,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:f7ff3cc44bcfdd9a"
+      "sourceHash": "fnv1a64:d9887faa67f4d0a2"
     },
     {
       "id": "TE-C12-kutumbam",
@@ -33399,7 +33399,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b59762c651c4b0f6",
+      "sourceHash": "fnv1a64:7ba30adc928f3954",
       "detachableSegments": [
         "Script Bridge — shared history, local spacing"
       ]
@@ -33672,7 +33672,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e6d8568047160abb",
+      "sourceHash": "fnv1a64:c6c945a4954aefbb",
       "detachableSegments": [
         "The letters in this word"
       ]

--- a/code/learning/human-languages/german/book/chapters/ch17-head-and-hand.tex
+++ b/code/learning/human-languages/german/book/chapters/ch17-head-and-hand.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:db42e9b15a61794e
+% canonical-source-hash: fnv1a64:e86811351e6dab80
 % canonical-lessons: GE-C17-kopf, GE-C17-kopf-haupt, GE-C17-hand
 
 \chapter{Head and Hand}
@@ -167,7 +167,7 @@ One pronunciation note: the final \textbf{d} is said as a \textbf{t}. German dev
 \end{cousinweb}
 
 \begin{culture}
-Now the interesting part. Every Romance language in this course builds \textquotedblleft{}hand\textquotedblright{} on Latin \emph{\textbf{manus}}:
+Now the interesting part. Every Romance language builds \textquotedblleft{}hand\textquotedblright{} on Latin \emph{\textbf{manus}}:
 
 \noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}

--- a/code/learning/human-languages/german/book/chapters/ch24-mind-verbs.tex
+++ b/code/learning/human-languages/german/book/chapters/ch24-mind-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:72cc26138da11014
+% canonical-source-hash: fnv1a64:21da996939cd89d0
 % canonical-lessons: GE-C24-denken, GE-C24-verstehen, GE-C24-lesen, GE-C24-schreiben
 
 \chapter{Verbs of the Mind}

--- a/code/learning/human-languages/german/lessons/GE-C17-hand.md
+++ b/code/learning/human-languages/german/lessons/GE-C17-hand.md
@@ -66,7 +66,7 @@ and body parts are where you feel it most:
 ## Why it's said this way: Where the family tree stops
 <!-- hl-knowledge: introduces=[GE-ETYMON-HAND-MANUS-05]; assesses=[] -->
 
-Now the interesting part. Every Romance language in this course builds "hand" on
+Now the interesting part. Every Romance language builds "hand" on
 Latin ***manus***:
 
 | | |

--- a/code/learning/human-languages/german/lessons/GE-C24-lesen.md
+++ b/code/learning/human-languages/german/lessons/GE-C24-lesen.md
@@ -6,7 +6,7 @@ sequence: 730
 chapter: 24
 type: word
 headword: lesen
-gloss: to read — a verb that first meant "to gather", and the first one in this course whose vowel changes in the du and er forms
+gloss: to read — a verb that first meant "to gather", and the first one in this book whose vowel changes in the du and er forms
 concept_tag: VERB-READ
 prerequisites: [GE-C24-verstehen, GE-C11-wasser-wein]
 sounds: [long-e, s-voiced]

--- a/code/learning/human-languages/german/narration/ch17.json
+++ b/code/learning/human-languages/german/narration/ch17.json
@@ -4,7 +4,7 @@
   "chapter": 17,
   "title": "Head and Hand",
   "drivablePrefix": 3,
-  "sourceHash": "fnv1a64:ce4e6be384d018cf",
+  "sourceHash": "fnv1a64:436bd0ef42617218",
   "lessons": [
     {
       "id": "GE-C17-kopf",
@@ -368,7 +368,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:46d0b30a7b21211a",
+      "sourceHash": "fnv1a64:2749ef57887d5546",
       "notice": null,
       "blocks": [
         {
@@ -444,7 +444,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "Now the interesting part. Every Romance language in this course builds \"hand\" on Latin manus:"
+              "text": "Now the interesting part. Every Romance language builds \"hand\" on Latin manus:"
             },
             {
               "kind": "table",

--- a/code/learning/human-languages/german/narration/ch17.txt
+++ b/code/learning/human-languages/german/narration/ch17.txt
@@ -107,7 +107,7 @@ Fuß means foot.
 Herz means heart.
 
 Why it's said this way: Where the family tree stops.
-Now the interesting part. Every Romance language in this course builds "hand" on Latin manus:
+Now the interesting part. Every Romance language builds "hand" on Latin manus:
 [a table of 4 rows, read aloud]
 French, la main.
 Italian, la mano.

--- a/code/learning/human-languages/german/narration/ch24.json
+++ b/code/learning/human-languages/german/narration/ch24.json
@@ -4,7 +4,7 @@
   "chapter": 24,
   "title": "Verbs of the Mind",
   "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:fb75d3964d3b3f0f",
+  "sourceHash": "fnv1a64:a6259dd9fea16afd",
   "lessons": [
     {
       "id": "GE-C24-denken",
@@ -395,14 +395,14 @@
       "title": "lesen — gathering, and the first verb that changes its vowel",
       "headword": "lesen",
       "romanization": "lesen",
-      "gloss": "to read — a verb that first meant \"to gather\", and the first one in this course whose vowel changes in the du and er forms",
+      "gloss": "to read — a verb that first meant \"to gather\", and the first one in this book whose vowel changes in the du and er forms",
       "script": "latin",
       "modality": "voice",
       "derivedModality": "voice",
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:06d86fff9bf862f3",
+      "sourceHash": "fnv1a64:820e3554f1ce62f3",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/hindi/book/chapters/ch07-yes-and-no.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch07-yes-and-no.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:e15d0ae88bad4c45
+% canonical-source-hash: fnv1a64:f27dd07acda83c6b
 % canonical-lessons: HI-C07-haan, HI-C07-nahin
 
 \chapter{Yes and No}
@@ -62,7 +62,7 @@ Hindi's \textquotedblleft{}no\textquotedblright{} carries a sound so old it also
 \textbf{\hi{नहीं}} = \textbf{no}, said \textbf{nahīṃ} — \textbf{\hi{न}} (na) + \textbf{\hi{ह}} (h) + \textbf{\hi{ी}} (long \emph{ī}) + the \textbf{\hi{ं}} \emph{anusvara} that nasalises the end. The heart of it is that first syllable \textbf{na}, which is Hindi's ancient negator, straight from \textbf{Sanskrit na}.
 
 \subsection*{You'll want to know — The oldest \textquotedblleft{}no\textquotedblright{} you'll meet}
-That \textbf{na} is not just Sanskrit's — it is the same negative root that runs across nearly every language in this course, all descended from one ancient sound, \textbf{PIE *ne}:
+That \textbf{na} is not just Sanskrit's — it is the same negative root that runs across nearly every Indo-European language, all descended from one ancient sound, \textbf{PIE *ne}:
 
 \noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}

--- a/code/learning/human-languages/hindi/book/chapters/ch14-seasons.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch14-seasons.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:93c447d022604c69
+% canonical-source-hash: fnv1a64:a49f7baa61f62aff
 % canonical-lessons: HI-C14-ritu
 
 \chapter{Seasons}
@@ -18,7 +18,7 @@ Say all six \hi{ऋतु} in order and point to \hi{वर्षा}, the monso
 
 
 \begin{quote}
-Every European language in this course splits the year into \textbf{four} seasons. Hindi's own tradition doesn't — it recognizes \textbf{six}, and this isn't extra vocabulary bolted onto a four-season frame. It's a genuinely different way of dividing the year.
+European languages generally split the year into \textbf{four} seasons. Hindi's own tradition doesn't — it recognizes \textbf{six}, and this isn't extra vocabulary bolted onto a four-season frame. It's a genuinely different way of dividing the year.
 \end{quote}
 
 \subsection*{You'll want to know — The six \hi{ऋतु} (ṛtu, \textquotedblleft{}seasons\textquotedblright{})}

--- a/code/learning/human-languages/hindi/lessons/HI-C05-karna.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C05-karna.md
@@ -58,5 +58,5 @@ unlock a whole grammar of "do-verbs."
 
 ## Wrap-up Recall
 
-[PAUSE 3s] What Sanskrit root is *karnā* from, and name two words in this course
+[PAUSE 3s] What Sanskrit root is *karnā* from, and name two words
 built on it. (*√kṛ* "to do"; any two of *karma*, *namaskār*, *Sanskrit*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C07-nahin.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C07-nahin.md
@@ -48,7 +48,7 @@ na**.
 <!-- hl-knowledge: introduces=[HI-CONCEPT-C07-NAHIN-02]; assesses=[] -->
 
 That **na** is not just Sanskrit's — it is the same negative root that runs
-across nearly every language in this course, all descended from one ancient
+across nearly every Indo-European language, all descended from one ancient
 sound, **PIE \*ne**:
 
 | from *\*ne* | |

--- a/code/learning/human-languages/hindi/lessons/HI-C14-ritu.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C14-ritu.md
@@ -33,7 +33,7 @@ reviews_of: [HI-C13-haath]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[] -->
 
-[PAUSE 2s] Every European language in this course splits the year into
+[PAUSE 2s] European languages generally split the year into
 **four** seasons. Hindi's own tradition doesn't — it recognizes **six**, and
 this isn't extra vocabulary bolted onto a four-season frame. It's a
 genuinely different way of dividing the year.

--- a/code/learning/human-languages/hindi/lessons/HI-W02-ka-ta-mouth-order.md
+++ b/code/learning/human-languages/hindi/lessons/HI-W02-ka-ta-mouth-order.md
@@ -68,8 +68,8 @@ roughly fourth century BCE — producing a phonetics chart memorised as an
 alphabet long before Europe attempted the same analysis.
 
 Two honest footnotes: this walk describes the **five stop families**, not the
-whole list; and **ट** is not yet in this curriculum's stroke data. Read it here
-and draw it only after its entry is authored.
+whole list; and this book does not give a stroke order for **ट**. Read it here,
+and wait for a source you trust before you write it.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-01, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-02, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-03] -->

--- a/code/learning/human-languages/hindi/narration/ch01.json
+++ b/code/learning/human-languages/hindi/narration/ch01.json
@@ -4,7 +4,7 @@
   "chapter": 1,
   "title": "Greetings",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:f6301764a50979e5",
+  "sourceHash": "fnv1a64:e0c6f8dfe20e0f70",
   "lessons": [
     {
       "id": "HI-W01-shirorekha-na-ma",
@@ -525,7 +525,7 @@
       "modalityReasons": [
         "writing-type"
       ],
-      "sourceHash": "fnv1a64:e36ecbfa85109dfb",
+      "sourceHash": "fnv1a64:26af03d5de07dead",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -615,7 +615,7 @@
             },
             {
               "kind": "speech",
-              "text": "Two honest footnotes: this walk describes the five stop families, not the whole list; and ट is not yet in this curriculum's stroke data. Read it here and draw it only after its entry is authored."
+              "text": "Two honest footnotes: this walk describes the five stop families, not the whole list; and this book does not give a stroke order for ट. Read it here, and wait for a source you trust before you write it."
             }
           ]
         },

--- a/code/learning/human-languages/hindi/narration/ch01.txt
+++ b/code/learning/human-languages/hindi/narration/ch01.txt
@@ -139,7 +139,7 @@ You'll want to know — Why the letters are in this order.
 The heart of the Devanagari consonant order is not a historical accident like A-B-C. Its five stop families (vargas) are sorted by where in your mouth the closure happens, starting at the soft palate and walking forward to the lips:
 क (soft palate) becomes च (hard palate) becomes ट (roof, tongue curled back) becomes त (teeth) becomes प (lips).
 Say those five and feel the closure travel forward. Indian phoneticians organised sounds this way well over two thousand years ago — Pāṇini's work is roughly fourth century BCE — producing a phonetics chart memorised as an alphabet long before Europe attempted the same analysis.
-Two honest footnotes: this walk describes the five stop families, not the whole list; and ट is not yet in this curriculum's stroke data. Read it here and draw it only after its entry is authored.
+Two honest footnotes: this walk describes the five stop families, not the whole list; and this book does not give a stroke order for ट. Read it here, and wait for a source you trust before you write it.
 
 Guided Practice.
 [pause 1 second]

--- a/code/learning/human-languages/hindi/narration/ch05.json
+++ b/code/learning/human-languages/hindi/narration/ch05.json
@@ -4,7 +4,7 @@
   "chapter": 5,
   "title": "Chapter 5",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:8524e38a45a846be",
+  "sourceHash": "fnv1a64:cbeb6be21dffed51",
   "lessons": [
     {
       "id": "HI-C05-bolna",
@@ -316,7 +316,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e1c24c88399adaca",
+      "sourceHash": "fnv1a64:350f1c0bbea0616c",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -463,7 +463,7 @@
             },
             {
               "kind": "speech",
-              "text": "What Sanskrit root is karnā from, and name two words in this course built on it. (√kṛ \"to do\"; any two of karma, namaskār, Sanskrit.)"
+              "text": "What Sanskrit root is karnā from, and name two words built on it. (√kṛ \"to do\"; any two of karma, namaskār, Sanskrit.)"
             }
           ]
         }

--- a/code/learning/human-languages/hindi/narration/ch05.txt
+++ b/code/learning/human-languages/hindi/narration/ch05.txt
@@ -111,7 +111,7 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-What Sanskrit root is karnā from, and name two words in this course built on it. (√kṛ "to do"; any two of karma, namaskār, Sanskrit.)
+What Sanskrit root is karnā from, and name two words built on it. (√kṛ "to do"; any two of karma, namaskār, Sanskrit.)
 
 
 Lesson 4 of 6.

--- a/code/learning/human-languages/hindi/narration/ch07.json
+++ b/code/learning/human-languages/hindi/narration/ch07.json
@@ -4,7 +4,7 @@
   "chapter": 7,
   "title": "Yes and No",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:7f46ae04549f4eaa",
+  "sourceHash": "fnv1a64:e4fdb1c6208acaf8",
   "lessons": [
     {
       "id": "HI-C07-haan",
@@ -145,7 +145,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9df4c614f504322b",
+      "sourceHash": "fnv1a64:79169e506f53d6cd",
       "notice": null,
       "blocks": [
         {
@@ -183,7 +183,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "That na is not just Sanskrit's — it is the same negative root that runs across nearly every language in this course, all descended from one ancient sound, PIE ne:"
+              "text": "That na is not just Sanskrit's — it is the same negative root that runs across nearly every Indo-European language, all descended from one ancient sound, PIE ne:"
             },
             {
               "kind": "table",

--- a/code/learning/human-languages/hindi/narration/ch07.txt
+++ b/code/learning/human-languages/hindi/narration/ch07.txt
@@ -43,7 +43,7 @@ You'll want to know — The word.
 नहीं = no, said nahīṃ — न (na) + ह (h) + ी (long ī) + the ं anusvara that nasalises the end. The heart of it is that first syllable na, which is Hindi's ancient negator, straight from Sanskrit na.
 
 You'll want to know — The oldest "no" you'll meet.
-That na is not just Sanskrit's — it is the same negative root that runs across nearly every language in this course, all descended from one ancient sound, PIE ne:
+That na is not just Sanskrit's — it is the same negative root that runs across nearly every Indo-European language, all descended from one ancient sound, PIE ne:
 [a table of 3 rows, read aloud]
 from ne: Sanskrit na, becomes Hindi nahīṃ.
 from ne: Latin nōn, becomes Spanish no, French non.

--- a/code/learning/human-languages/hindi/narration/ch14.json
+++ b/code/learning/human-languages/hindi/narration/ch14.json
@@ -4,7 +4,7 @@
   "chapter": 14,
   "title": "Seasons",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:ab989406c824d264",
+  "sourceHash": "fnv1a64:13b1ba42e4613deb",
   "lessons": [
     {
       "id": "HI-C14-ritu",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9f64c469ba547d55",
+      "sourceHash": "fnv1a64:3cf3287daf0ef18b",
       "notice": null,
       "blocks": [
         {
@@ -35,7 +35,7 @@
             },
             {
               "kind": "speech",
-              "text": "Every European language in this course splits the year into four seasons. Hindi's own tradition doesn't — it recognizes six, and this isn't extra vocabulary bolted onto a four-season frame. It's a genuinely different way of dividing the year."
+              "text": "European languages generally split the year into four seasons. Hindi's own tradition doesn't — it recognizes six, and this isn't extra vocabulary bolted onto a four-season frame. It's a genuinely different way of dividing the year."
             }
           ]
         },

--- a/code/learning/human-languages/hindi/narration/ch14.txt
+++ b/code/learning/human-languages/hindi/narration/ch14.txt
@@ -7,7 +7,7 @@ Lesson 1 of 1.
 
 Warm-up.
 [pause 2 seconds]
-Every European language in this course splits the year into four seasons. Hindi's own tradition doesn't — it recognizes six, and this isn't extra vocabulary bolted onto a four-season frame. It's a genuinely different way of dividing the year.
+European languages generally split the year into four seasons. Hindi's own tradition doesn't — it recognizes six, and this isn't extra vocabulary bolted onto a four-season frame. It's a genuinely different way of dividing the year.
 
 You'll want to know — The six ऋतु (ṛtu, "seasons").
 [a table of 6 rows, read aloud]

--- a/code/learning/human-languages/italian/book/chapters/ch15-two-pasts.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch15-two-pasts.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:39516bddf0538c22
+% canonical-source-hash: fnv1a64:40d9a4f713b200c9
 % canonical-lessons: IT-C15-passato-prossimo, IT-C15-passato-remoto
 
 \chapter{Two Italian Pasts}
@@ -95,7 +95,7 @@ What two pieces make the \emph{passato prossimo}? (\textbf{Avere} + the \textbf{
 
 
 \begin{quote}
-Italian's other past tense. Whether it sounds normal or bookish depends on \textbf{which part of Italy you are standing in} — the clearest case of geography deciding grammar in this course.
+Italian's other past tense. Whether it sounds normal or bookish depends on \textbf{which part of Italy you are standing in} — one of the clearest cases anywhere of geography deciding grammar.
 \end{quote}
 
 \subsection*{You'll want to know: the remote past}

--- a/code/learning/human-languages/italian/book/chapters/ch17-head-and-hand.tex
+++ b/code/learning/human-languages/italian/book/chapters/ch17-head-and-hand.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:137ac0966fca7456
+% canonical-source-hash: fnv1a64:967eb6543fa8c133
 % canonical-lessons: IT-C17-testa, IT-C17-mano
 
 \chapter{Head and Hand}
@@ -105,7 +105,7 @@ Italian inherited a system with \textbf{five declensions} — five families of e
 
 When Italian dropped the fourth declension, \emph{mano} was left with its old gender and an ending that now looks like it belongs to a different class. The word didn't change; \textbf{the system around it did.}
 
-That is the general lesson, and it recurs everywhere in this course: an \textquotedblleft{}irregular\textquotedblright{} word is usually a \textbf{regular word from a system that no longer exists}.
+That is the general lesson, and it recurs constantly: an \textquotedblleft{}irregular\textquotedblright{} word is usually a \textbf{regular word from a system that no longer exists}.
 
 (A few others survive the same way: \emph{la radio}, \emph{la foto}, \emph{l'auto} — though those are short for \emph{radiofonia}, \emph{fotografia}, \emph{automobile}, which is a different reason for the same look.)
 \end{grammarlens}

--- a/code/learning/human-languages/italian/lessons/IT-C15-passato-remoto.md
+++ b/code/learning/human-languages/italian/lessons/IT-C15-passato-remoto.md
@@ -33,8 +33,8 @@ reviews_of: [IT-C15-passato-prossimo, IT-C05-parlare]
 <!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] Italian's other past tense. Whether it sounds normal or bookish
-depends on **which part of Italy you are standing in** — the clearest case of
-geography deciding grammar in this course.
+depends on **which part of Italy you are standing in** — one of the clearest
+cases anywhere of geography deciding grammar.
 
 ## You'll want to know: the remote past
 <!-- hl-knowledge: introduces=[IT-LEX-PASSATO-REMOTO-02]; assesses=[] -->

--- a/code/learning/human-languages/italian/lessons/IT-C17-mano.md
+++ b/code/learning/human-languages/italian/lessons/IT-C17-mano.md
@@ -65,7 +65,7 @@ When Italian dropped the fourth declension, *mano* was left with its old gender
 and an ending that now looks like it belongs to a different class. The word
 didn't change; **the system around it did.**
 
-That is the general lesson, and it recurs everywhere in this course: an
+That is the general lesson, and it recurs constantly: an
 "irregular" word is usually a **regular word from a system that no longer
 exists**.
 

--- a/code/learning/human-languages/italian/narration/ch15.json
+++ b/code/learning/human-languages/italian/narration/ch15.json
@@ -4,7 +4,7 @@
   "chapter": 15,
   "title": "Two Italian Pasts",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:0b856b51ba3decfd",
+  "sourceHash": "fnv1a64:50843bd9598574f7",
   "lessons": [
     {
       "id": "IT-C15-passato-prossimo",
@@ -202,7 +202,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:8d4b5481167925c8",
+      "sourceHash": "fnv1a64:87e175498a57b50c",
       "notice": null,
       "blocks": [
         {
@@ -218,7 +218,7 @@
             },
             {
               "kind": "speech",
-              "text": "Italian's other past tense. Whether it sounds normal or bookish depends on which part of Italy you are standing in — the clearest case of geography deciding grammar in this course."
+              "text": "Italian's other past tense. Whether it sounds normal or bookish depends on which part of Italy you are standing in — one of the clearest cases anywhere of geography deciding grammar."
             }
           ]
         },

--- a/code/learning/human-languages/italian/narration/ch15.txt
+++ b/code/learning/human-languages/italian/narration/ch15.txt
@@ -54,7 +54,7 @@ parlò — the past that depends where you are.
 
 Warm-up.
 [pause 2 seconds]
-Italian's other past tense. Whether it sounds normal or bookish depends on which part of Italy you are standing in — the clearest case of geography deciding grammar in this course.
+Italian's other past tense. Whether it sounds normal or bookish depends on which part of Italy you are standing in — one of the clearest cases anywhere of geography deciding grammar.
 
 You'll want to know: the remote past.
 [a table of 3 rows, read aloud]

--- a/code/learning/human-languages/italian/narration/ch17.json
+++ b/code/learning/human-languages/italian/narration/ch17.json
@@ -4,7 +4,7 @@
   "chapter": 17,
   "title": "Head and Hand",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:312b7248145dbb09",
+  "sourceHash": "fnv1a64:c89b171c9cc323f6",
   "lessons": [
     {
       "id": "IT-C17-testa",
@@ -191,7 +191,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a462acace3a0153a",
+      "sourceHash": "fnv1a64:30e82540daa65b92",
       "notice": null,
       "blocks": [
         {
@@ -255,7 +255,7 @@
             },
             {
               "kind": "speech",
-              "text": "That is the general lesson, and it recurs everywhere in this course: an \"irregular\" word is usually a regular word from a system that no longer exists."
+              "text": "That is the general lesson, and it recurs constantly: an \"irregular\" word is usually a regular word from a system that no longer exists."
             },
             {
               "kind": "speech",

--- a/code/learning/human-languages/italian/narration/ch17.txt
+++ b/code/learning/human-languages/italian/narration/ch17.txt
@@ -61,7 +61,7 @@ Italian inherited a system with five declensions — five families of endings �
 Latin: manus (4th decl., fem.), , which gives: Italian: la mano.
 Latin: manūs (plural), , which gives: Italian: le mani.
 When Italian dropped the fourth declension, mano was left with its old gender and an ending that now looks like it belongs to a different class. The word didn't change; the system around it did.
-That is the general lesson, and it recurs everywhere in this course: an "irregular" word is usually a regular word from a system that no longer exists.
+That is the general lesson, and it recurs constantly: an "irregular" word is usually a regular word from a system that no longer exists.
 (A few others survive the same way: la radio, la foto, l'auto — though those are short for radiofonia, fotografia, automobile, which is a different reason for the same look.)
 
 The word, taken apart: manus.

--- a/code/learning/human-languages/japanese/book/chapters/ch01-three-scripts.tex
+++ b/code/learning/human-languages/japanese/book/chapters/ch01-three-scripts.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:1204445a344e67db
+% canonical-source-hash: fnv1a64:cecac120ddc02409
 % canonical-lessons: JA-C01-hai, JA-C01-iie, JA-C01-konnichiwa, JA-C01-nihongo, JA-C01-koohii, JA-C01-arigatou, JA-C01-gozaimasu, JA-C01-practice
 
 \chapter{Three Writing Systems in One Doorway}
@@ -146,7 +146,7 @@ Say \textbf{\ja{こんにちは}}. Its history hid two characters, \ja{今日}, 
 
 These are \textbf{kanji}: characters borrowed from Chinese, each carrying a meaning rather than a sound. \ja{日} is sun or day. \ja{本} is origin or root. \ja{語} is language. So \ja{日本} is \textquotedblleft{}sun-origin\textquotedblright{} — the country the sun rises from — and \ja{日本語} is its language.
 
-Now the fact that has no parallel anywhere else in this curriculum. A kanji does not have \emph{a} sound. \ja{日} is read \emph{nichi}, \emph{jitsu}, \emph{hi}, \emph{bi}, or \emph{ka}, depending on the word it stands in — and in \ja{日本} it is shortened again, to \emph{ni}. There is no sensible way to teach \textquotedblleft{}the sound of \ja{日}.\textquotedblright{} What a lesson can teach is the \textbf{word}: you learn \ja{日本語} as \emph{nihongo}, and the reading of each character comes along with it.
+Now the fact that makes kanji unlike any letter you have learned. A kanji does not have \emph{a} sound. \ja{日} is read \emph{nichi}, \emph{jitsu}, \emph{hi}, \emph{bi}, or \emph{ka}, depending on the word it stands in — and in \ja{日本} it is shortened again, to \emph{ni}. There is no sensible way to teach \textquotedblleft{}the sound of \ja{日}.\textquotedblright{} What a lesson can teach is the \textbf{word}: you learn \ja{日本語} as \emph{nihongo}, and the reading of each character comes along with it.
 
 Two families of readings explain the spread. The \textbf{on} reading is Japan's version of the Chinese pronunciation, imported with the character. The \textbf{kun} reading is a native Japanese word written with a borrowed character that already meant the same thing. \ja{日本語} is on-readings throughout; \ja{今日} in the greeting is irregular even by those standards.
 

--- a/code/learning/human-languages/japanese/lessons/JA-C01-nihongo.md
+++ b/code/learning/human-languages/japanese/lessons/JA-C01-nihongo.md
@@ -48,7 +48,7 @@ rather than a sound. 日 is sun or day. 本 is origin or root. 語 is language.
 So 日本 is "sun-origin" — the country the sun rises from — and 日本語 is its
 language.
 
-Now the fact that has no parallel anywhere else in this curriculum. A kanji does
+Now the fact that makes kanji unlike any letter you have learned. A kanji does
 not have *a* sound. 日 is read *nichi*, *jitsu*, *hi*, *bi*, or *ka*, depending
 on the word it stands in — and in 日本 it is shortened again, to *ni*. There is
 no sensible way to teach "the sound of 日." What a lesson can teach is the

--- a/code/learning/human-languages/japanese/narration/ch01.json
+++ b/code/learning/human-languages/japanese/narration/ch01.json
@@ -4,7 +4,7 @@
   "chapter": 1,
   "title": "Three Writing Systems in One Doorway",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:edad54370036a969",
+  "sourceHash": "fnv1a64:41f12f11cb910ec8",
   "lessons": [
     {
       "id": "JA-C01-hai",
@@ -485,7 +485,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:405ea26c254381c6",
+      "sourceHash": "fnv1a64:00d779c076662e0e",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -529,7 +529,7 @@
             },
             {
               "kind": "speech",
-              "text": "Now the fact that has no parallel anywhere else in this curriculum. A kanji does not have a sound. 日 is read nichi, jitsu, hi, bi, or ka, depending on the word it stands in — and in 日本 it is shortened again, to ni. There is no sensible way to teach \"the sound of 日.\" What a lesson can teach is the word: you learn 日本語 as nihongo, and the reading of each character comes along with it."
+              "text": "Now the fact that makes kanji unlike any letter you have learned. A kanji does not have a sound. 日 is read nichi, jitsu, hi, bi, or ka, depending on the word it stands in — and in 日本 it is shortened again, to ni. There is no sensible way to teach \"the sound of 日.\" What a lesson can teach is the word: you learn 日本語 as nihongo, and the reading of each character comes along with it."
             },
             {
               "kind": "speech",

--- a/code/learning/human-languages/japanese/narration/ch01.txt
+++ b/code/learning/human-languages/japanese/narration/ch01.txt
@@ -119,7 +119,7 @@ Say こんにちは (konnichiwa). Its history hid two characters, 今日, that h
 Script — kanji, and the readings problem.
 日本語 (nihongo) — ni + hon + go.
 These are kanji: characters borrowed from Chinese, each carrying a meaning rather than a sound. 日 is sun or day. 本 is origin or root. 語 is language. So 日本 is "sun-origin" — the country the sun rises from — and 日本語 (nihongo) is its language.
-Now the fact that has no parallel anywhere else in this curriculum. A kanji does not have a sound. 日 is read nichi, jitsu, hi, bi, or ka, depending on the word it stands in — and in 日本 it is shortened again, to ni. There is no sensible way to teach "the sound of 日." What a lesson can teach is the word: you learn 日本語 as nihongo, and the reading of each character comes along with it.
+Now the fact that makes kanji unlike any letter you have learned. A kanji does not have a sound. 日 is read nichi, jitsu, hi, bi, or ka, depending on the word it stands in — and in 日本 it is shortened again, to ni. There is no sensible way to teach "the sound of 日." What a lesson can teach is the word: you learn 日本語 as nihongo, and the reading of each character comes along with it.
 Two families of readings explain the spread. The on reading is Japan's version of the Chinese pronunciation, imported with the character. The kun reading is a native Japanese word written with a borrowed character that already meant the same thing. 日本語 (nihongo) is on-readings throughout; 今日 in the greeting is irregular even by those standards.
 
 The word, taken apart — the real family.

--- a/code/learning/human-languages/kannada/book/chapters/ch18-telling-time.tex
+++ b/code/learning/human-languages/kannada/book/chapters/ch18-telling-time.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:f2c5716c5c240948
+% canonical-source-hash: fnv1a64:7ed9245888e25791
 % canonical-lessons: KA-C18-gante
 
 \chapter{Telling Time}
@@ -26,7 +26,7 @@ You've already met Hindi's \emph{ghanṭā} — \textquotedblleft{}hour,\textquo
 \end{cousinweb}
 
 \begin{culture}
-This is a genuinely different picture from Tamil's. Kannada's \emph{gaṇṭe}, like Hindi's \emph{ghanṭā}, is a \textbf{Sanskrit-derived} \textquotedblleft{}bell $\to$ hour\textquotedblright{} word. Tamil, by contrast, most likely uses a \textbf{native Dravidian} word for exactly the same \textquotedblleft{}bell $\to$ hour\textquotedblright{} idea — a different root entirely, arrived at independently (though even specialists don't call this fully settled). So the \emph{pattern} (bell-word becomes hour-word) repeats across languages, but the \emph{word itself} splits along the same Sanskrit/native line you've seen before in this course (compare \emph{madhyāhna} vs. Tamil's \emph{naḷ}-based words for noon).
+This is a genuinely different picture from Tamil's. Kannada's \emph{gaṇṭe}, like Hindi's \emph{ghanṭā}, is a \textbf{Sanskrit-derived} \textquotedblleft{}bell $\to$ hour\textquotedblright{} word. Tamil, by contrast, most likely uses a \textbf{native Dravidian} word for exactly the same \textquotedblleft{}bell $\to$ hour\textquotedblright{} idea — a different root entirely, arrived at independently (though even specialists don't call this fully settled). So the \emph{pattern} (bell-word becomes hour-word) repeats across languages, but the \emph{word itself} splits along the familiar Sanskrit/native line (compare \emph{madhyāhna} vs. Tamil's \emph{naḷ}-based words for noon).
 \end{culture}
 
 \begin{grammarlens}[title={Grammar Lens: telling the time}]

--- a/code/learning/human-languages/kannada/lessons/KA-C18-gante.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C18-gante.md
@@ -53,7 +53,7 @@ Tamil, by contrast, most likely uses a **native Dravidian** word for exactly the
 same "bell → hour" idea — a different root entirely, arrived at independently
 (though even specialists don't call this fully settled). So the *pattern*
 (bell-word becomes hour-word) repeats across languages, but the *word itself*
-splits along the same Sanskrit/native line you've seen before in this course
+splits along the familiar Sanskrit/native line
 (compare *madhyāhna* vs. Tamil's *naḷ*-based words for noon).
 
 ## Grammar Lens: telling the time

--- a/code/learning/human-languages/kannada/narration/ch18.json
+++ b/code/learning/human-languages/kannada/narration/ch18.json
@@ -4,7 +4,7 @@
   "chapter": 18,
   "title": "Telling Time",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:3b7b62b9ccd03e57",
+  "sourceHash": "fnv1a64:3ece51b0bab8b3df",
   "lessons": [
     {
       "id": "KA-C18-gante",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:52e97c7a7b81405f",
+      "sourceHash": "fnv1a64:f73a4d5c3f34c2df",
       "notice": null,
       "blocks": [
         {
@@ -57,7 +57,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "This is a genuinely different picture from Tamil's. Kannada's gaṇṭe, like Hindi's ghanṭā, is a Sanskrit-derived \"bell becomes hour\" word. Tamil, by contrast, most likely uses a native Dravidian word for exactly the same \"bell becomes hour\" idea — a different root entirely, arrived at independently (though even specialists don't call this fully settled). So the pattern (bell-word becomes hour-word) repeats across languages, but the word itself splits along the same Sanskrit/native line you've seen before in this course (compare madhyāhna vs. Tamil's naḷ-based words for noon)."
+              "text": "This is a genuinely different picture from Tamil's. Kannada's gaṇṭe, like Hindi's ghanṭā, is a Sanskrit-derived \"bell becomes hour\" word. Tamil, by contrast, most likely uses a native Dravidian word for exactly the same \"bell becomes hour\" idea — a different root entirely, arrived at independently (though even specialists don't call this fully settled). So the pattern (bell-word becomes hour-word) repeats across languages, but the word itself splits along the familiar Sanskrit/native line (compare madhyāhna vs. Tamil's naḷ-based words for noon)."
             }
           ]
         },

--- a/code/learning/human-languages/kannada/narration/ch18.txt
+++ b/code/learning/human-languages/kannada/narration/ch18.txt
@@ -13,7 +13,7 @@ The word, taken apart: ಗಂಟೆ — bell AND hour, again.
 ಗಂಟೆ (gaṇṭe) = "hour" — and, just like Hindi, it means "bell, gong" just as commonly. It's related to the same Sanskrit घण्टा (ghaṇṭā, "bell"). The semantic shift is identical to Hindi's: temples, towns, and clock towers announced the hour by striking a bell, so the bell-word became the hour-word.
 
 Why it's said this way: this is Kannada matching Hindi, not matching Tamil.
-This is a genuinely different picture from Tamil's. Kannada's gaṇṭe, like Hindi's ghanṭā, is a Sanskrit-derived "bell becomes hour" word. Tamil, by contrast, most likely uses a native Dravidian word for exactly the same "bell becomes hour" idea — a different root entirely, arrived at independently (though even specialists don't call this fully settled). So the pattern (bell-word becomes hour-word) repeats across languages, but the word itself splits along the same Sanskrit/native line you've seen before in this course (compare madhyāhna vs. Tamil's naḷ-based words for noon).
+This is a genuinely different picture from Tamil's. Kannada's gaṇṭe, like Hindi's ghanṭā, is a Sanskrit-derived "bell becomes hour" word. Tamil, by contrast, most likely uses a native Dravidian word for exactly the same "bell becomes hour" idea — a different root entirely, arrived at independently (though even specialists don't call this fully settled). So the pattern (bell-word becomes hour-word) repeats across languages, but the word itself splits along the familiar Sanskrit/native line (compare madhyāhna vs. Tamil's naḷ-based words for noon).
 
 Grammar Lens: telling the time.
 ಒಂದು ಗಂಟೆ. — "One o'clock." (ondu gaṇṭe, "one hour/bell").

--- a/code/learning/human-languages/latin/book/chapters/ch10-water-wine-bread.tex
+++ b/code/learning/human-languages/latin/book/chapters/ch10-water-wine-bread.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:2b5b66f0b53814e3
+% canonical-source-hash: fnv1a64:b5c05f1ffcd44863
 % canonical-lessons: LA-C10-aqua-vinum, LA-C10-panis
 
 \chapter{Water, Wine, and Bread}
@@ -22,7 +22,7 @@ Two everyday Latin nouns — and two wildly different fates. One of Rome's daugh
 \end{quote}
 
 \begin{cousinweb}
-\textbf{aqua, aquae} — \textquotedblleft{}\textbf{water}.\textquotedblright{} Spanish and Italian kept it close to whole: \textbf{agua}, \textbf{acqua}. French, though, eroded it further than almost any other Latin word in this course: \emph{aqua $\to$ ewe $\to$ eaue $\to$ \textbf{eau}} — three written letters, \emph{e-a-u}, spelling one bare vowel sound, \textquotedblleft{}oh.\textquotedblright{} Compare \emph{caput}, which French similarly abandoned as an everyday word (for \emph{testa}) — \emph{aqua} wasn't replaced, but it was worn down almost to nothing while staying in place.
+\textbf{aqua, aquae} — \textquotedblleft{}\textbf{water}.\textquotedblright{} Spanish and Italian kept it close to whole: \textbf{agua}, \textbf{acqua}. French, though, eroded it further than almost any other word it inherited from Latin: \emph{aqua $\to$ ewe $\to$ eaue $\to$ \textbf{eau}} — three written letters, \emph{e-a-u}, spelling one bare vowel sound, \textquotedblleft{}oh.\textquotedblright{} Compare \emph{caput}, which French similarly abandoned as an everyday word (for \emph{testa}) — \emph{aqua} wasn't replaced, but it was worn down almost to nothing while staying in place.
 
 English kept the \textbf{whole, undamaged} word as a learned borrowing: \textbf{aquatic, aquarium, aqueduct, aqualung} all sound exactly like their Latin ancestor.
 \end{cousinweb}

--- a/code/learning/human-languages/latin/book/chapters/ch21-nice-to-meet-you.tex
+++ b/code/learning/human-languages/latin/book/chapters/ch21-nice-to-meet-you.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:6d6c5bcc65253b22
+% canonical-source-hash: fnv1a64:b1cdf2ba87c9af8b
 % canonical-lessons: LA-C21-volup-est-convenisse, LA-C21-meeting-phrase-context, LA-C21-practice
 
 \chapter{Nice to Meet You}
@@ -18,7 +18,7 @@ Two meeting scenes: names traded with quid tibi nōmen est? between strangers, a
 
 
 \begin{quote}
-Every modern language in this course has one fixed phrase for \textquotedblleft{}nice to meet you.\textquotedblright{} Latin, honestly, does \textbf{not} — but it has something better: a real line from a Roman comedy that does the job.
+Modern languages generally have one fixed phrase for \textquotedblleft{}nice to meet you.\textquotedblright{} Latin, honestly, does \textbf{not} — but it has something better: a real line from a Roman comedy that does the job.
 \end{quote}
 
 \begin{culture}

--- a/code/learning/human-languages/latin/lessons/LA-C10-aqua-vinum.md
+++ b/code/learning/human-languages/latin/lessons/LA-C10-aqua-vinum.md
@@ -42,7 +42,7 @@ barely moved at all, anywhere.
 
 **aqua, aquae** — "**water**." Spanish and Italian kept it close to whole:
 **agua**, **acqua**. French, though, eroded it further than almost any
-other Latin word in this course: *aqua → ewe → eaue → **eau*** — three
+other word it inherited from Latin: *aqua → ewe → eaue → **eau*** — three
 written letters, *e-a-u*, spelling one bare vowel sound, "oh." Compare
 *caput*, which French similarly abandoned as an everyday word (for *testa*)
 — *aqua* wasn't replaced, but it was worn down almost to nothing while

--- a/code/learning/human-languages/latin/lessons/LA-C21-volup-est-convenisse.md
+++ b/code/learning/human-languages/latin/lessons/LA-C21-volup-est-convenisse.md
@@ -33,7 +33,7 @@ reviews_of: [LA-C20-name-case-variation, LA-C20-quid-tibi-nomen]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[LA-GRAMMAR-NAME-CASE-VARIATION-01, LA-GRAMMAR-NAME-CASE-VARIATION-02] -->
 
-[PAUSE 2s] Every modern language in this course has one fixed phrase for
+[PAUSE 2s] Modern languages generally have one fixed phrase for
 "nice to meet you." Latin, honestly, does **not** — but it has something
 better: a real line from a Roman comedy that does the job.
 

--- a/code/learning/human-languages/latin/narration/ch10.json
+++ b/code/learning/human-languages/latin/narration/ch10.json
@@ -4,7 +4,7 @@
   "chapter": 10,
   "title": "Water, Wine, and Bread",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:1e7cf552260ff65d",
+  "sourceHash": "fnv1a64:c5cf4ddfd577bd3b",
   "lessons": [
     {
       "id": "LA-C10-aqua-vinum",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:1815c089d95f1f84",
+      "sourceHash": "fnv1a64:b1418f185aaaaac2",
       "notice": null,
       "blocks": [
         {
@@ -46,7 +46,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "aqua, aquae — \"water.\" Spanish and Italian kept it close to whole: agua, acqua. French, though, eroded it further than almost any other Latin word in this course: aqua becomes ewe becomes eaue becomes eau — three written letters, e-a-u, spelling one bare vowel sound, \"oh.\" Compare caput, which French similarly abandoned as an everyday word (for testa) — aqua wasn't replaced, but it was worn down almost to nothing while staying in place."
+              "text": "aqua, aquae — \"water.\" Spanish and Italian kept it close to whole: agua, acqua. French, though, eroded it further than almost any other word it inherited from Latin: aqua becomes ewe becomes eaue becomes eau — three written letters, e-a-u, spelling one bare vowel sound, \"oh.\" Compare caput, which French similarly abandoned as an everyday word (for testa) — aqua wasn't replaced, but it was worn down almost to nothing while staying in place."
             },
             {
               "kind": "speech",

--- a/code/learning/human-languages/latin/narration/ch10.txt
+++ b/code/learning/human-languages/latin/narration/ch10.txt
@@ -10,7 +10,7 @@ Warm-up.
 Two everyday Latin nouns — and two wildly different fates. One of Rome's daughters wore this word down to almost nothing. The other word barely moved at all, anywhere.
 
 The word, taken apart: aqua — mostly kept, one daughter wore it down to a whisper.
-aqua, aquae — "water." Spanish and Italian kept it close to whole: agua, acqua. French, though, eroded it further than almost any other Latin word in this course: aqua becomes ewe becomes eaue becomes eau — three written letters, e-a-u, spelling one bare vowel sound, "oh." Compare caput, which French similarly abandoned as an everyday word (for testa) — aqua wasn't replaced, but it was worn down almost to nothing while staying in place.
+aqua, aquae — "water." Spanish and Italian kept it close to whole: agua, acqua. French, though, eroded it further than almost any other word it inherited from Latin: aqua becomes ewe becomes eaue becomes eau — three written letters, e-a-u, spelling one bare vowel sound, "oh." Compare caput, which French similarly abandoned as an everyday word (for testa) — aqua wasn't replaced, but it was worn down almost to nothing while staying in place.
 English kept the whole, undamaged word as a learned borrowing: aquatic, aquarium, aqueduct, aqualung all sound exactly like their Latin ancestor.
 
 You'll want to know: vīnum — survived, everywhere, almost untouched.

--- a/code/learning/human-languages/latin/narration/ch21.json
+++ b/code/learning/human-languages/latin/narration/ch21.json
@@ -4,7 +4,7 @@
   "chapter": 21,
   "title": "Nice to Meet You",
   "drivablePrefix": 3,
-  "sourceHash": "fnv1a64:0f93e9300f86bb34",
+  "sourceHash": "fnv1a64:67e96b837e28d997",
   "lessons": [
     {
       "id": "LA-C21-volup-est-convenisse",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d26baa3eb553be8a",
+      "sourceHash": "fnv1a64:e7fa4ed193474c2c",
       "notice": null,
       "blocks": [
         {
@@ -35,7 +35,7 @@
             },
             {
               "kind": "speech",
-              "text": "Every modern language in this course has one fixed phrase for \"nice to meet you.\" Latin, honestly, does not — but it has something better: a real line from a Roman comedy that does the job."
+              "text": "Modern languages generally have one fixed phrase for \"nice to meet you.\" Latin, honestly, does not — but it has something better: a real line from a Roman comedy that does the job."
             }
           ]
         },

--- a/code/learning/human-languages/latin/narration/ch21.txt
+++ b/code/learning/human-languages/latin/narration/ch21.txt
@@ -7,7 +7,7 @@ volup est convēnisse — the phrase Latin uses instead of a fixed idiom.
 
 Warm-up.
 [pause 2 seconds]
-Every modern language in this course has one fixed phrase for "nice to meet you." Latin, honestly, does not — but it has something better: a real line from a Roman comedy that does the job.
+Modern languages generally have one fixed phrase for "nice to meet you." Latin, honestly, does not — but it has something better: a real line from a Roman comedy that does the job.
 
 Why it's said this way: volup est convēnisse — a genuinely attested phrase for the job.
 Plautus's comedy Miles Gloriosus (Act 2, Scene 3) gives us a real line that does exactly this work: "Tē, [name], volup est convēnisse" — literally "you, [name], [it] is-a-pleasure to-have-met," or naturally, "it's a pleasure to have met you, [name]." Break it down:

--- a/code/learning/human-languages/persian/book/chapters/ch08-doing-verbs.tex
+++ b/code/learning/human-languages/persian/book/chapters/ch08-doing-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:b601304cacc02d51
+% canonical-source-hash: fnv1a64:fb1eef1af7c5ba7f
 % canonical-lessons: FA-C08-gereftan, FA-C08-porsidan, FA-C08-komak-kardan, FA-C08-dust-dashtan
 
 \chapter{Taking, Asking, Helping, Loving}
@@ -18,7 +18,7 @@ The chapter closes on dust dâshtan — to have as friend — and its dâr- stem
 
 
 \begin{quote}
-Say the pair for “to write.” Then get ready for the one Persian verb in this course whose English relative you will recognize the moment you hear it.
+Say the pair for “to write.” Then get ready for a Persian verb whose English relative you will recognize the moment you hear it.
 \end{quote}
 
 \subsection*{You'll want to know first — one verb and its stem}

--- a/code/learning/human-languages/persian/lessons/FA-C08-gereftan.md
+++ b/code/learning/human-languages/persian/lessons/FA-C08-gereftan.md
@@ -34,8 +34,8 @@ reviews_of: [FA-C07-neveshtan, FA-C06-goftan, FA-C03-shoma-to, FA-C06-budan]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[FA-LEX-NEVESHTAN, FA-STEM-NEVIS, FA-GRAMMAR-PRESENT-STEM] -->
 
-[PAUSE 2s] Say the pair for “to write.” Then get ready for the one Persian verb
-in this course whose English relative you will recognize the moment you hear it.
+[PAUSE 2s] Say the pair for “to write.” Then get ready for a Persian verb
+whose English relative you will recognize the moment you hear it.
 
 ## You'll want to know first — one verb and its stem
 <!-- hl-knowledge: introduces=[FA-LEX-GEREFTAN, FA-STEM-GIR]; assesses=[] -->

--- a/code/learning/human-languages/persian/narration/ch08.json
+++ b/code/learning/human-languages/persian/narration/ch08.json
@@ -4,7 +4,7 @@
   "chapter": 8,
   "title": "Taking, Asking, Helping, Loving",
   "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:7b80d96a1a7c66b1",
+  "sourceHash": "fnv1a64:0dd578d8d51e5c72",
   "lessons": [
     {
       "id": "FA-C08-gereftan",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b0cbd7ebe8850758",
+      "sourceHash": "fnv1a64:bd65bbf669f07dc2",
       "notice": null,
       "blocks": [
         {
@@ -35,7 +35,7 @@
             },
             {
               "kind": "speech",
-              "text": "Say the pair for “to write.” Then get ready for the one Persian verb in this course whose English relative you will recognize the moment you hear it."
+              "text": "Say the pair for “to write.” Then get ready for a Persian verb whose English relative you will recognize the moment you hear it."
             }
           ]
         },

--- a/code/learning/human-languages/persian/narration/ch08.txt
+++ b/code/learning/human-languages/persian/narration/ch08.txt
@@ -7,7 +7,7 @@ Lesson 1 of 4.
 
 Warm-up.
 [pause 2 seconds]
-Say the pair for “to write.” Then get ready for the one Persian verb in this course whose English relative you will recognize the moment you hear it.
+Say the pair for “to write.” Then get ready for a Persian verb whose English relative you will recognize the moment you hear it.
 
 You'll want to know first — one verb and its stem.
 گرفتن — gereftan — to take.

--- a/code/learning/human-languages/portuguese/book/chapters/ch10-family.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/ch10-family.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:dd61a14d7c4fb6f3
+% canonical-source-hash: fnv1a64:d85a6e277c1e0c6c
 % canonical-lessons: PT-C10-pais, PT-C10-irmaos
 
 \chapter{Family}
@@ -57,7 +57,7 @@ Give \textquotedblleft{}father\textquotedblright{} and \textquotedblleft{}mother
 
 
 \begin{quote}
-Every other track in this course builds \textquotedblleft{}brother\textquotedblright{} from Latin \emph{frāter} (French \emph{frère}, Italian \emph{fratello}). Portuguese — and Spanish with it — does something completely different, and it is one of the best etymologies in the whole language.
+French and Italian build \textquotedblleft{}brother\textquotedblright{} from Latin \emph{frāter} (\emph{frère}, \emph{fratello}). Portuguese — and Spanish with it — does something completely different, and it is one of the best etymologies in the whole language.
 \end{quote}
 
 \begin{cousinweb}

--- a/code/learning/human-languages/portuguese/lessons/PT-C10-irmaos.md
+++ b/code/learning/human-languages/portuguese/lessons/PT-C10-irmaos.md
@@ -33,8 +33,8 @@ reviews_of: [PT-C10-pais, PT-C09-estacoes]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[] -->
 
-[PAUSE 2s] Every other track in this course builds "brother" from Latin *frāter*
-(French *frère*, Italian *fratello*). Portuguese — and Spanish with it — does
+[PAUSE 2s] French and Italian build "brother" from Latin *frāter*
+(*frère*, *fratello*). Portuguese — and Spanish with it — does
 something completely different, and it is one of the best etymologies in the whole
 language.
 

--- a/code/learning/human-languages/portuguese/narration/ch10.json
+++ b/code/learning/human-languages/portuguese/narration/ch10.json
@@ -4,7 +4,7 @@
   "chapter": 10,
   "title": "Family",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:756b61183a892e04",
+  "sourceHash": "fnv1a64:d8f9eeb2611c6355",
   "lessons": [
     {
       "id": "PT-C10-pais",
@@ -145,7 +145,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:728021c129cdefb6",
+      "sourceHash": "fnv1a64:ca89807f7cb84ee2",
       "notice": null,
       "blocks": [
         {
@@ -161,7 +161,7 @@
             },
             {
               "kind": "speech",
-              "text": "Every other track in this course builds \"brother\" from Latin frāter (French frère, Italian fratello). Portuguese — and Spanish with it — does something completely different, and it is one of the best etymologies in the whole language."
+              "text": "French and Italian build \"brother\" from Latin frāter (frère, fratello). Portuguese — and Spanish with it — does something completely different, and it is one of the best etymologies in the whole language."
             }
           ]
         },

--- a/code/learning/human-languages/portuguese/narration/ch10.txt
+++ b/code/learning/human-languages/portuguese/narration/ch10.txt
@@ -37,7 +37,7 @@ o irmão, a irmã — the brother who isn't a "frater".
 
 Warm-up.
 [pause 2 seconds]
-Every other track in this course builds "brother" from Latin frāter (French frère, Italian fratello). Portuguese — and Spanish with it — does something completely different, and it is one of the best etymologies in the whole language.
+French and Italian build "brother" from Latin frāter (frère, fratello). Portuguese — and Spanish with it — does something completely different, and it is one of the best etymologies in the whole language.
 
 Taken apart.
 o irmão ("brother") and a irmã ("sister") come not from frāter but from Latin germānus, meaning "genuine, of the same stock, born of the same parents."

--- a/code/learning/human-languages/punjabi/book/chapters/ch09-taking-and-liking.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/ch09-taking-and-liking.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:c655c44197746db3
+% canonical-source-hash: fnv1a64:396097f23856ca3d
 % canonical-lessons: PA-C09-laina, PA-C09-puchhna, PA-C09-madad-karna, PA-C09-pasand
 
 \chapter{Taking, Asking, Helping, and What Pleases You}

--- a/code/learning/human-languages/punjabi/lessons/PA-C09-laina.md
+++ b/code/learning/human-languages/punjabi/lessons/PA-C09-laina.md
@@ -12,7 +12,7 @@ concept_tag: VERB-TAKE
 prerequisites: [PA-C08-likhna]
 sounds: [dulankar-ai, retroflex-na]
 roots: [sanskrit-labhate, prakrit-lahai, pie-lebh]
-etymology_hook: laiṇā comes through Prakrit lahaï from Sanskrit labhate “takes, obtains”, on PIE *lebʰ- “to gain” — Greek láphura “spoils”, Lithuanian lõbis “treasure”, no secure English cousin; the Sanskrit bh thinned to h and then to nothing, which is a third fate for a consonant in this course.
+etymology_hook: laiṇā comes through Prakrit lahaï from Sanskrit labhate “takes, obtains”, on PIE *lebʰ- “to gain” — Greek láphura “spoils”, Lithuanian lõbis “treasure”, no secure English cousin; the Sanskrit bh thinned to h and then to nothing, which is one more fate a consonant can meet.
 duration:
   max_seconds: 265
 requires:

--- a/code/learning/human-languages/punjabi/narration/ch09.json
+++ b/code/learning/human-languages/punjabi/narration/ch09.json
@@ -4,7 +4,7 @@
   "chapter": 9,
   "title": "Taking, Asking, Helping, and What Pleases You",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:e7043bb75ddc7901",
+  "sourceHash": "fnv1a64:01d0ba06d4ae01a9",
   "lessons": [
     {
       "id": "PA-C09-laina",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:ba5e85879b8768cb",
+      "sourceHash": "fnv1a64:b3ba243cf1ee590e",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/russian/lessons/RU-C02-menya-zovut.md
+++ b/code/learning/human-languages/russian/lessons/RU-C02-menya-zovut.md
@@ -34,7 +34,7 @@ reviews_of: [RU-C02-ty-vy, RU-C01-privet]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[] -->
 
-[PAUSE 2s] Every other track in this course says "my name is" with a word for
+[PAUSE 2s] Many languages say "my name is" with a word for
 *my* and a word for *name*. Russian says something quite different, and it is
 worth taking apart slowly.
 

--- a/code/learning/human-languages/russian/narration/ch02.json
+++ b/code/learning/human-languages/russian/narration/ch02.json
@@ -4,7 +4,7 @@
   "chapter": 2,
   "title": "Introducing yourself",
   "drivablePrefix": 8,
-  "sourceHash": "fnv1a64:afc21c872d0eaee5",
+  "sourceHash": "fnv1a64:756aeef46987b86f",
   "lessons": [
     {
       "id": "RU-C02-ya",
@@ -464,7 +464,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:1d3d69c6c4518117",
+      "sourceHash": "fnv1a64:18eedafd904b8b7b",
       "notice": null,
       "blocks": [
         {
@@ -480,7 +480,7 @@
             },
             {
               "kind": "speech",
-              "text": "Every other track in this course says \"my name is\" with a word for my and a word for name. Russian says something quite different, and it is worth taking apart slowly."
+              "text": "Many languages say \"my name is\" with a word for my and a word for name. Russian says something quite different, and it is worth taking apart slowly."
             }
           ]
         },

--- a/code/learning/human-languages/russian/narration/ch02.txt
+++ b/code/learning/human-languages/russian/narration/ch02.txt
@@ -111,7 +111,7 @@ Lesson 4 of 10.
 
 Warm-up.
 [pause 2 seconds]
-Every other track in this course says "my name is" with a word for my and a word for name. Russian says something quite different, and it is worth taking apart slowly.
+Many languages say "my name is" with a word for my and a word for name. Russian says something quite different, and it is worth taking apart slowly.
 
 The exchange.
 Меня зовут Анна. — Menyá zovút Anna. — "My name is Anna."

--- a/code/learning/human-languages/sanskrit/book/book.tex
+++ b/code/learning/human-languages/sanskrit/book/book.tex
@@ -33,14 +33,14 @@
 \addcontentsline{toc}{chapter}{Preface}
 
 Sanskrit, like Latin, is not learned for conversation. It is learned to read,
-to hear how much of the world's vocabulary was assembled, and --- the reason it
-sits in this series --- because it is a \textbf{taproot}: the classical ancestor of
+to hear how much of the world's vocabulary was assembled, and --- above all ---
+because it is a \textbf{taproot}: the classical ancestor of
 Hindi, Marathi, Punjabi, and Bengali, whose every ``hello'' and
 ``thank you'' is a worn-down form of a Sanskrit word you will meet here in its
 full shape. And Sanskrit is at the same time a \emph{sister} of Latin, Greek, and
 English --- so its roots reach west (to \emph{thee}, to Greek \emph{eu-}, to
 \emph{come}, to \emph{no}) as surely as they reach east. Learning it ties the two
-halves of this curriculum together.
+halves of that inheritance together.
 
 Sanskrit is classically written in \textbf{Devanagari}, the script you may
 already know from Hindi. This book teaches the reading \emph{inside} the word

--- a/code/learning/human-languages/sanskrit/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/ch01-greetings.tex
@@ -22,7 +22,7 @@ it joins the next: \sk{स्} $+$ \sk{त} $\to$ \sk{स्त}. Read \sk{न�
 \begin{cousinweb}
 \sk{नमस्ते} $=$ \emph{namas} (``a bow, obeisance'') $+$ \emph{te} (``to you'') ---
 literally ``\textbf{a bow to you}.'' This is the \emph{original}: the word every
-Indo-Aryan track in this curriculum descends from --- Hindi, Marathi, Punjabi,
+Indo-Aryan \emph{namaste} descends from --- Hindi, Marathi, Punjabi, and
 Bengali all say a worn form of it. \emph{Namas} comes from the root
 \emph{\textsurd{}nam} ``to bend, bow,'' from Proto-Indo-European \emph{*nem-} ``to
 allot, take.'' And \emph{te} ``to you'' is a family heirloom: the same

--- a/code/learning/human-languages/sanskrit/lessons/SA-C01-namaste.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C01-namaste.md
@@ -29,8 +29,8 @@ Read **न·म·स्·ते**, *namaste*.
 ## The word, taken apart
 
 **नमस्ते** = *namas* ("a bow, obeisance") + *te* ("to you") — literally "**a bow
-to you**." This is the *source*: the word every Indo-Aryan track in this
-curriculum descends from. *Namas* is from the root √nam "to bend, bow" (PIE
+to you**." This is the *source*: the word every Indo-Aryan *namaste*
+descends from. *Namas* is from the root √nam "to bend, bow" (PIE
 *nem-). And *te* "to you" is a family heirloom — the same Indo-European pronoun
 behind Latin *tē*, Greek *se*, and archaic English **thee**. Say *namas-te* and
 you speak a word Cicero and Chaucer would each half-recognise.

--- a/code/learning/human-languages/sanskrit/lessons/SA-C05-karomi.md
+++ b/code/learning/human-languages/sanskrit/lessons/SA-C05-karomi.md
@@ -43,7 +43,7 @@ thing-to-be-done"). So "I work" is, at root, "*kṛ*-thing I *kṛ*-do." Hindi's
 [PAUSE 1s]
 - [YOU SAY: "karomi" — I do]
 - [YOU SAY: "I work" — *kāryaṁ karomi*]
-- [YOU SAY: three words in this course from the root *kṛ* (*namaskāra*, *karma*, *saṁskṛta*)]
+- [YOU SAY: three words from the root *kṛ* (*namaskāra*, *karma*, *saṁskṛta*)]
 
 ## Wrap-up Recall
 

--- a/code/learning/human-languages/sanskrit/narration/ch01.json
+++ b/code/learning/human-languages/sanskrit/narration/ch01.json
@@ -4,7 +4,7 @@
   "chapter": 1,
   "title": "Chapter 1",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:aad0ad5150f2038b",
+  "sourceHash": "fnv1a64:281f1ccd090a19c1",
   "lessons": [
     {
       "id": "SA-C01-am-na",
@@ -427,7 +427,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:727560286d972f72",
+      "sourceHash": "fnv1a64:386744037c9fab92",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -474,7 +474,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "नमस्ते = namas (\"a bow, obeisance\") + te (\"to you\") — literally \"a bow to you.\" This is the source: the word every Indo-Aryan track in this curriculum descends from. Namas is from the root √nam \"to bend, bow\" (PIE nem-). And te \"to you\" is a family heirloom — the same Indo-European pronoun behind Latin tē, Greek se, and archaic English thee. Say namas-te and you speak a word Cicero and Chaucer would each half-recognise."
+              "text": "नमस्ते = namas (\"a bow, obeisance\") + te (\"to you\") — literally \"a bow to you.\" This is the source: the word every Indo-Aryan namaste descends from. Namas is from the root √nam \"to bend, bow\" (PIE nem-). And te \"to you\" is a family heirloom — the same Indo-European pronoun behind Latin tē, Greek se, and archaic English thee. Say namas-te and you speak a word Cicero and Chaucer would each half-recognise."
             }
           ]
         },

--- a/code/learning/human-languages/sanskrit/narration/ch01.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch01.txt
@@ -112,7 +112,7 @@ The letters in this word.
 Devanagari runs left to right under a top line; every consonant carries a built-in "a." न na, म ma, ते te (त + the e-sign े). A halant under स् strips its vowel so it joins the next: स् + त becomes स्त. Read न, म, स्, ते, namaste.
 
 The word, taken apart.
-नमस्ते = namas ("a bow, obeisance") + te ("to you") — literally "a bow to you." This is the source: the word every Indo-Aryan track in this curriculum descends from. Namas is from the root √nam "to bend, bow" (PIE nem-). And te "to you" is a family heirloom — the same Indo-European pronoun behind Latin tē, Greek se, and archaic English thee. Say namas-te and you speak a word Cicero and Chaucer would each half-recognise.
+नमस्ते = namas ("a bow, obeisance") + te ("to you") — literally "a bow to you." This is the source: the word every Indo-Aryan namaste descends from. Namas is from the root √nam "to bend, bow" (PIE nem-). And te "to you" is a family heirloom — the same Indo-European pronoun behind Latin tē, Greek se, and archaic English thee. Say namas-te and you speak a word Cicero and Chaucer would each half-recognise.
 
 Why it's said this way.
 Palms pressed together (the gesture is añjali), a slight bow: hands and word say the same thing. Namaste greets the person before you as worthy of a bow — hello, and on parting, goodbye. It is the greeting Sanskrit gave to half of South Asia.

--- a/code/learning/human-languages/sanskrit/narration/ch05.json
+++ b/code/learning/human-languages/sanskrit/narration/ch05.json
@@ -4,7 +4,7 @@
   "chapter": 5,
   "title": "Chapter 5",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:45070b3634ab6b25",
+  "sourceHash": "fnv1a64:f287ad3b981ede05",
   "lessons": [
     {
       "id": "SA-C05-aham-samskritam-vadami",
@@ -153,7 +153,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:06c187eb35a64186",
+      "sourceHash": "fnv1a64:e1ceeeb95c714166",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -252,11 +252,11 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "three words in this course from the root kṛ (namaskāra, karma, saṁskṛta)",
+              "instruction": "three words from the root kṛ (namaskāra, karma, saṁskṛta)",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: three words in this course from the root *kṛ* (*namaskāra*, *karma*, *saṁskṛta*)]"
+              "source": "[YOU SAY: three words from the root *kṛ* (*namaskāra*, *karma*, *saṁskṛta*)]"
             }
           ]
         },

--- a/code/learning/human-languages/sanskrit/narration/ch05.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch05.txt
@@ -59,7 +59,7 @@ Guided Practice.
 [pause 8 seconds for the answer]
 [your turn — say: "I work" — kāryaṁ karomi]
 [pause 8 seconds for the answer]
-[your turn — say: three words in this course from the root kṛ (namaskāra, karma, saṁskṛta)]
+[your turn — say: three words from the root kṛ (namaskāra, karma, saṁskṛta)]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.

--- a/code/learning/human-languages/tamil/book/chapters/ch19-age.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch19-age.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:dffffca8b81faf38
+% canonical-source-hash: fnv1a64:158e1e4de8950e2a
 % canonical-lessons: TA-C19-vayathu, TA-C19-age-register-grammar
 
 \chapter{Asking Someone's Age}
@@ -22,7 +22,7 @@ Same Sanskrit word one more time — but be careful here: Tamil isn't locked int
 \end{quote}
 
 \subsection*{You'll want to know: \ta{வயது} — the same Sanskrit \textquotedblleft{}vigor/age\textquotedblright{} word, a fourth time}
-\textbf{\ta{வயது}} (\emph{vayathu}) = \textquotedblleft{}\textbf{age}\textquotedblright{} — the same Sanskrit \textbf{\dv{वयस्}} (\emph{vayas}, \textquotedblleft{}age, vigor,\textquotedblright{} PIE cousin of Latin \textbf{vīs}) you've now met four times across Kannada, Telugu, Malayalam, and Tamil. All four Dravidian languages borrowed this exact Sanskrit word for \textquotedblleft{}age\textquotedblright{} — none of them built a native alternative for this particular concept, unlike some others you've seen in this course.
+\textbf{\ta{வயது}} (\emph{vayathu}) = \textquotedblleft{}\textbf{age}\textquotedblright{} — the same Sanskrit \textbf{\dv{वयस्}} (\emph{vayas}, \textquotedblleft{}age, vigor,\textquotedblright{} PIE cousin of Latin \textbf{vīs}) you've now met four times across Kannada, Telugu, Malayalam, and Tamil. All four Dravidian languages borrowed this exact Sanskrit word for \textquotedblleft{}age\textquotedblright{} — none of them built a native alternative for this particular concept, the way they did for so many others.
 
 \subsection*{Your turn}
 \begin{itemize}

--- a/code/learning/human-languages/tamil/book/chapters/ch20-numbers-and-weather.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch20-numbers-and-weather.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:10c054c15ddf76fe
+% canonical-source-hash: fnv1a64:17a98f1177a6f798
 % canonical-lessons: TA-C20-pathinondru-irupathu, TA-C20-vaanilai
 
 \chapter{Numbers Eleven to Twenty and Weather}
@@ -28,7 +28,7 @@ Tamil's teens echo \textbf{\ta{பத்து}} (\emph{pathu}, \textquotedbllef
 \textbf{\ta{இருபது}} (\emph{irupathu}, \textquotedblleft{}\textbf{twenty}\textquotedblright{}) = \textbf{\ta{இரு}} (\emph{iru}, an older word for \textquotedblleft{}\textbf{two},\textquotedblright{} alongside the everyday \textbf{\ta{இரண்டு}} \emph{iraṇḍu}) + \textbf{\ta{பத்து}} (\emph{pathu}, \textquotedblleft{}\textbf{ten}\textquotedblright{}) — fully transparent as \textquotedblleft{}\textbf{two-tens},\textquotedblright{} matching \textbf{Malayalam's} own \emph{irupathu} almost letter-for-letter.
 
 \begin{culture}
-This closes the numbers arc with a genuinely clean pattern. Every Dravidian language in this course builds \textquotedblleft{}twenty\textquotedblright{} the \textbf{same} compositional way — some (Tamil, Malayalam) keeping it fully transparent on the surface today, some (Kannada) with the same compositional origin but no longer visibly matching the modern standalone words for \textquotedblleft{}two\textquotedblright{} and \textquotedblleft{}ten,\textquotedblright{} some (Telugu) worn down further but most likely from the same root. Compare that to the other three families you've met: Sanskrit's \textbf{\dv{विंशति}} (\emph{vimshati}), Latin's \textbf{vīgintī}, and Arabic's \textbf{\ar{عشرون}} (\emph{ʿishrūn}) are each their \textbf{own} special, non-compositional word for twenty — none built transparently from \textquotedblleft{}two\textquotedblright{} and \textquotedblleft{}ten\textquotedblright{} the way every single Dravidian language in this course does.
+This closes the numbers arc with a genuinely clean pattern. All four major Dravidian languages build \textquotedblleft{}twenty\textquotedblright{} the \textbf{same} compositional way — some (Tamil, Malayalam) keeping it fully transparent on the surface today, some (Kannada) with the same compositional origin but no longer visibly matching the modern standalone words for \textquotedblleft{}two\textquotedblright{} and \textquotedblleft{}ten,\textquotedblright{} some (Telugu) worn down further but most likely from the same root. Compare that to the other three families you've met: Sanskrit's \textbf{\dv{विंशति}} (\emph{vimshati}), Latin's \textbf{vīgintī}, and Arabic's \textbf{\ar{عشرون}} (\emph{ʿishrūn}) are each their \textbf{own} special, non-compositional word for twenty — none built transparently from \textquotedblleft{}two\textquotedblright{} and \textquotedblleft{}ten\textquotedblright{} the way Tamil, Telugu, Kannada, and Malayalam all do.
 \end{culture}
 
 \subsection*{Your turn}
@@ -42,7 +42,7 @@ Say these aloud:
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-What two pieces build \textbf{\ta{இருபது}} (twenty)? (\textbf{\ta{இரு}} \textquotedblleft{}two\textquotedblright{} + \textbf{\ta{பத்து}} \textquotedblleft{}ten\textquotedblright{} — \textquotedblleft{}\textbf{two-tens}.\textquotedblright{}) Do all four Dravidian languages in this course build \textquotedblleft{}twenty\textquotedblright{} the same compositional way? (\textbf{Yes} — Tamil and Malayalam keep it fully transparent today; Kannada shares the same compositional origin but its modern \textquotedblleft{}two\textquotedblright{}/\textquotedblleft{}ten\textquotedblright{} words no longer visibly match; Telugu's is worn down further but most likely the same root.) Do Sanskrit, Latin, or Arabic build their word for twenty this way? (\textbf{No} — each has its own special, non-compositional standalone word instead.)
+What two pieces build \textbf{\ta{இருபது}} (twenty)? (\textbf{\ta{இரு}} \textquotedblleft{}two\textquotedblright{} + \textbf{\ta{பத்து}} \textquotedblleft{}ten\textquotedblright{} — \textquotedblleft{}\textbf{two-tens}.\textquotedblright{}) Do all four major Dravidian languages build \textquotedblleft{}twenty\textquotedblright{} the same compositional way? (\textbf{Yes} — Tamil and Malayalam keep it fully transparent today; Kannada shares the same compositional origin but its modern \textquotedblleft{}two\textquotedblright{}/\textquotedblleft{}ten\textquotedblright{} words no longer visibly match; Telugu's is worn down further but most likely the same root.) Do Sanskrit, Latin, or Arabic build their word for twenty this way? (\textbf{No} — each has its own special, non-compositional standalone word instead.)
 \end{tcolorbox}
 \section[\ta{வானிலை}]{\ta{வானிலை} — \textquotedblleft{}the standing of the sky,\textquotedblright{} most likely all native}
 

--- a/code/learning/human-languages/tamil/book/chapters/ch34-verbs-between-people.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch34-verbs-between-people.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:a5e98484e1abcce2
+% canonical-source-hash: fnv1a64:a7767e667ee93f24
 % canonical-lessons: TA-C34-edu, TA-C34-kel, TA-C34-utavu, TA-C34-pidi
 
 \chapter{Four Verbs Between People}
@@ -39,7 +39,7 @@ The last chapter's verbs happened inside your head. These four happen between yo
 \end{quote}
 
 \subsection*{The letters in this word}
-\textbf{\ta{எ}} is the standing vowel \emph{e}, from \textbf{\ta{எழுது}}; \textbf{\ta{டு}} is \textbf{\ta{ட}} with the \emph{u} sign, and \textbf{\ta{ட}} came apart in \textbf{\ta{படி}}. Nothing here is new — the first time in this course that has been true of a whole headword. The \emph{ḍ} you hear is the same positional softening: \textbf{\ta{ட}} goes soft between vowels and hard when doubled, as in \emph{eḍuttēṉ}.
+\textbf{\ta{எ}} is the standing vowel \emph{e}, from \textbf{\ta{எழுது}}; \textbf{\ta{டு}} is \textbf{\ta{ட}} with the \emph{u} sign, and \textbf{\ta{ட}} came apart in \textbf{\ta{படி}}. Nothing here is new — the first time in this book that has been true of a whole headword. The \emph{ḍ} you hear is the same positional softening: \textbf{\ta{ட}} goes soft between vowels and hard when doubled, as in \emph{eḍuttēṉ}.
 
 \begin{cousinweb}
 You have met this verb's near-twin already, hiding inside a meal. \textbf{\ta{சாப்பிடு}} (\emph{sāppiḍu}), \textquotedblleft{}to eat,\textquotedblright{} is \emph{sāppu} (food) plus \textbf{\ta{இடு}} (\emph{iḍu}), \textquotedblleft{}\textbf{to put}\textquotedblright{} — the light verb that lends its endings to a noun.

--- a/code/learning/human-languages/tamil/lessons/TA-C19-vayathu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C19-vayathu.md
@@ -44,7 +44,7 @@ both, in different registers.
 vigor," PIE cousin of Latin **vīs**) you've now met four times across Kannada,
 Telugu, Malayalam, and Tamil. All four Dravidian languages borrowed this exact
 Sanskrit word for "age" — none of them built a native alternative for this
-particular concept, unlike some others you've seen in this course.
+particular concept, the way they did for so many others.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-MANI-HOMOPHONE-TIME-01, TA-LEX-VAYATHU-01] -->

--- a/code/learning/human-languages/tamil/lessons/TA-C20-pathinondru-irupathu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C20-pathinondru-irupathu.md
@@ -56,8 +56,8 @@ own *irupathu* almost letter-for-letter.
 ## Why it's said this way: Be honest: one shared Dravidian idea, four different other-family answers
 <!-- hl-knowledge: introduces=[TA-PRAGMATICS-PATHINONDRU-IRUPATHU-03]; assesses=[] -->
 
-This closes the numbers arc with a genuinely clean pattern. Every Dravidian
-language in this course builds "twenty" the **same** compositional way —
+This closes the numbers arc with a genuinely clean pattern. All four major Dravidian
+languages build "twenty" the **same** compositional way —
 some (Tamil, Malayalam) keeping it fully transparent on the surface today,
 some (Kannada) with the same compositional origin but no longer visibly
 matching the modern standalone words for "two" and "ten," some (Telugu) worn
@@ -65,8 +65,8 @@ down further but most likely from the same root. Compare that to the other
 three families you've met:
 Sanskrit's **विंशति** (*vimshati*), Latin's **vīgintī**, and Arabic's
 **عشرون** (*ʿishrūn*) are each their **own** special, non-compositional word
-for twenty — none built transparently from "two" and "ten" the way every
-single Dravidian language in this course does.
+for twenty — none built transparently from "two" and "ten" the way Tamil,
+Telugu, Kannada, and Malayalam all do.
 
 ## Guided Practice
 <!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01, TA-LEX-PATHINONDRU-IRUPATHU-01, TA-LEX-PATHINONDRU-IRUPATHU-02, TA-PRAGMATICS-PATHINONDRU-IRUPATHU-03] -->
@@ -80,8 +80,8 @@ single Dravidian language in this course does.
 <!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01, TA-LEX-PATHINONDRU-IRUPATHU-01, TA-LEX-PATHINONDRU-IRUPATHU-02, TA-PRAGMATICS-PATHINONDRU-IRUPATHU-03] -->
 
 [PAUSE 3s] What two pieces build **இருபது** (twenty)? (**இரு** "two" +
-**பத்து** "ten" — "**two-tens**.") Do all four Dravidian languages in this
-course build "twenty" the same compositional way? (**Yes** — Tamil and
+**பத்து** "ten" — "**two-tens**.") Do all four major Dravidian
+languages build "twenty" the same compositional way? (**Yes** — Tamil and
 Malayalam keep it fully transparent today; Kannada shares the same
 compositional origin but its modern "two"/"ten" words no longer visibly
 match; Telugu's is worn down further but most likely the same root.) Do

--- a/code/learning/human-languages/tamil/lessons/TA-C34-edu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C34-edu.md
@@ -55,7 +55,7 @@ past **எடுத்தேன்** (*eḍuttēṉ*). Two sentences you can alr
 
 **எ** is the standing vowel *e*, from **எழுது**; **டு** is **ட** with the *u*
 sign, and **ட** came apart in **படி**. Nothing here is new — the first time in
-this course that has been true of a whole headword. The *ḍ* you hear is the same
+this book that has been true of a whole headword. The *ḍ* you hear is the same
 positional softening: **ட** goes soft between vowels and hard when doubled, as
 in *eḍuttēṉ*.
 

--- a/code/learning/human-languages/tamil/narration/ch19.json
+++ b/code/learning/human-languages/tamil/narration/ch19.json
@@ -4,7 +4,7 @@
   "chapter": 19,
   "title": "Asking Someone's Age",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:44a46feca59b14fa",
+  "sourceHash": "fnv1a64:1c8de13134073142",
   "lessons": [
     {
       "id": "TA-C19-vayathu",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7cd19cdfa68e405f",
+      "sourceHash": "fnv1a64:707e217350c30e75",
       "notice": null,
       "blocks": [
         {
@@ -46,7 +46,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "வயது (vayathu) = \"age\" — the same Sanskrit वयस् (vayas, \"age, vigor,\" PIE cousin of Latin vīs) you've now met four times across Kannada, Telugu, Malayalam, and Tamil. All four Dravidian languages borrowed this exact Sanskrit word for \"age\" — none of them built a native alternative for this particular concept, unlike some others you've seen in this course."
+              "text": "வயது (vayathu) = \"age\" — the same Sanskrit वयस् (vayas, \"age, vigor,\" PIE cousin of Latin vīs) you've now met four times across Kannada, Telugu, Malayalam, and Tamil. All four Dravidian languages borrowed this exact Sanskrit word for \"age\" — none of them built a native alternative for this particular concept, the way they did for so many others."
             }
           ]
         },

--- a/code/learning/human-languages/tamil/narration/ch19.txt
+++ b/code/learning/human-languages/tamil/narration/ch19.txt
@@ -10,7 +10,7 @@ Warm-up.
 Same Sanskrit word one more time — but be careful here: Tamil isn't locked into just one of the two grammatical shapes you've now seen. It has both, in different registers.
 
 You'll want to know: வயது — the same Sanskrit "vigor/age" word, a fourth time.
-வயது (vayathu) = "age" — the same Sanskrit वयस् (vayas, "age, vigor," PIE cousin of Latin vīs) you've now met four times across Kannada, Telugu, Malayalam, and Tamil. All four Dravidian languages borrowed this exact Sanskrit word for "age" — none of them built a native alternative for this particular concept, unlike some others you've seen in this course.
+வயது (vayathu) = "age" — the same Sanskrit वयस् (vayas, "age, vigor," PIE cousin of Latin vīs) you've now met four times across Kannada, Telugu, Malayalam, and Tamil. All four Dravidian languages borrowed this exact Sanskrit word for "age" — none of them built a native alternative for this particular concept, the way they did for so many others.
 
 Guided Practice.
 [pause 1 second]

--- a/code/learning/human-languages/tamil/narration/ch20.json
+++ b/code/learning/human-languages/tamil/narration/ch20.json
@@ -4,7 +4,7 @@
   "chapter": 20,
   "title": "Numbers Eleven to Twenty and Weather",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:8f64238981d04880",
+  "sourceHash": "fnv1a64:fdf0cc4db10b69be",
   "lessons": [
     {
       "id": "TA-C20-pathinondru-irupathu",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7262158bd8ed0238",
+      "sourceHash": "fnv1a64:83599a85f76e0d2c",
       "notice": null,
       "blocks": [
         {
@@ -68,7 +68,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "This closes the numbers arc with a genuinely clean pattern. Every Dravidian language in this course builds \"twenty\" the same compositional way — some (Tamil, Malayalam) keeping it fully transparent on the surface today, some (Kannada) with the same compositional origin but no longer visibly matching the modern standalone words for \"two\" and \"ten,\" some (Telugu) worn down further but most likely from the same root. Compare that to the other three families you've met: Sanskrit's विंशति (vimshati), Latin's vīgintī, and Arabic's عشرون (ʿishrūn) are each their own special, non-compositional word for twenty — none built transparently from \"two\" and \"ten\" the way every single Dravidian language in this course does."
+              "text": "This closes the numbers arc with a genuinely clean pattern. All four major Dravidian languages build \"twenty\" the same compositional way — some (Tamil, Malayalam) keeping it fully transparent on the surface today, some (Kannada) with the same compositional origin but no longer visibly matching the modern standalone words for \"two\" and \"ten,\" some (Telugu) worn down further but most likely from the same root. Compare that to the other three families you've met: Sanskrit's विंशति (vimshati), Latin's vīgintī, and Arabic's عشرون (ʿishrūn) are each their own special, non-compositional word for twenty — none built transparently from \"two\" and \"ten\" the way Tamil, Telugu, Kannada, and Malayalam all do."
             }
           ]
         },
@@ -125,7 +125,7 @@
             },
             {
               "kind": "speech",
-              "text": "What two pieces build இருபது (twenty)? (இரு \"two\" + பத்து \"ten\" — \"two-tens.\") Do all four Dravidian languages in this course build \"twenty\" the same compositional way? (Yes — Tamil and Malayalam keep it fully transparent today; Kannada shares the same compositional origin but its modern \"two\"/\"ten\" words no longer visibly match; Telugu's is worn down further but most likely the same root.) Do Sanskrit, Latin, or Arabic build their word for twenty this way? (No — each has its own special, non-compositional standalone word instead.)"
+              "text": "What two pieces build இருபது (twenty)? (இரு \"two\" + பத்து \"ten\" — \"two-tens.\") Do all four major Dravidian languages build \"twenty\" the same compositional way? (Yes — Tamil and Malayalam keep it fully transparent today; Kannada shares the same compositional origin but its modern \"two\"/\"ten\" words no longer visibly match; Telugu's is worn down further but most likely the same root.) Do Sanskrit, Latin, or Arabic build their word for twenty this way? (No — each has its own special, non-compositional standalone word instead.)"
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch20.txt
+++ b/code/learning/human-languages/tamil/narration/ch20.txt
@@ -16,7 +16,7 @@ You'll want to know: இருபது — transparently "two-tens".
 இருபது (irupathu, "twenty") = இரு (iru, an older word for "two," alongside the everyday இரண்டு iraṇḍu) + பத்து (pathu, "ten") — fully transparent as "two-tens," matching Malayalam's own irupathu almost letter-for-letter.
 
 Why it's said this way: Be honest: one shared Dravidian idea, four different other-family answers.
-This closes the numbers arc with a genuinely clean pattern. Every Dravidian language in this course builds "twenty" the same compositional way — some (Tamil, Malayalam) keeping it fully transparent on the surface today, some (Kannada) with the same compositional origin but no longer visibly matching the modern standalone words for "two" and "ten," some (Telugu) worn down further but most likely from the same root. Compare that to the other three families you've met: Sanskrit's विंशति (vimshati), Latin's vīgintī, and Arabic's عشرون (ʿishrūn) are each their own special, non-compositional word for twenty — none built transparently from "two" and "ten" the way every single Dravidian language in this course does.
+This closes the numbers arc with a genuinely clean pattern. All four major Dravidian languages build "twenty" the same compositional way — some (Tamil, Malayalam) keeping it fully transparent on the surface today, some (Kannada) with the same compositional origin but no longer visibly matching the modern standalone words for "two" and "ten," some (Telugu) worn down further but most likely from the same root. Compare that to the other three families you've met: Sanskrit's विंशति (vimshati), Latin's vīgintī, and Arabic's عشرون (ʿishrūn) are each their own special, non-compositional word for twenty — none built transparently from "two" and "ten" the way Tamil, Telugu, Kannada, and Malayalam all do.
 
 Guided Practice.
 [pause 1 second]
@@ -29,7 +29,7 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-What two pieces build இருபது (twenty)? (இரு "two" + பத்து "ten" — "two-tens.") Do all four Dravidian languages in this course build "twenty" the same compositional way? (Yes — Tamil and Malayalam keep it fully transparent today; Kannada shares the same compositional origin but its modern "two"/"ten" words no longer visibly match; Telugu's is worn down further but most likely the same root.) Do Sanskrit, Latin, or Arabic build their word for twenty this way? (No — each has its own special, non-compositional standalone word instead.)
+What two pieces build இருபது (twenty)? (இரு "two" + பத்து "ten" — "two-tens.") Do all four major Dravidian languages build "twenty" the same compositional way? (Yes — Tamil and Malayalam keep it fully transparent today; Kannada shares the same compositional origin but its modern "two"/"ten" words no longer visibly match; Telugu's is worn down further but most likely the same root.) Do Sanskrit, Latin, or Arabic build their word for twenty this way? (No — each has its own special, non-compositional standalone word instead.)
 
 
 Lesson 2 of 2.

--- a/code/learning/human-languages/tamil/narration/ch34.json
+++ b/code/learning/human-languages/tamil/narration/ch34.json
@@ -4,7 +4,7 @@
   "chapter": 34,
   "title": "Four Verbs Between People",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:2e2e5e869f303320",
+  "sourceHash": "fnv1a64:b09af3aa1df4854a",
   "lessons": [
     {
       "id": "TA-C34-edu",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:461fc79451361c98",
+      "sourceHash": "fnv1a64:3247ff041aada7e8",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -74,7 +74,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "எ is the standing vowel e, from எழுது; டு is ட with the u sign, and ட came apart in படி. Nothing here is new — the first time in this course that has been true of a whole headword. The ḍ you hear is the same positional softening: ட goes soft between vowels and hard when doubled, as in eḍuttēṉ."
+              "text": "எ is the standing vowel e, from எழுது; டு is ட with the u sign, and ட came apart in படி. Nothing here is new — the first time in this book that has been true of a whole headword. The ḍ you hear is the same positional softening: ட goes soft between vowels and hard when doubled, as in eḍuttēṉ."
             }
           ]
         },

--- a/code/learning/human-languages/tamil/narration/ch34.txt
+++ b/code/learning/human-languages/tamil/narration/ch34.txt
@@ -17,7 +17,7 @@ You'll want to know: எடு.
 நான் தண்ணீர் எடுக்கிறேன். — nāṉ taṇṇīr eḍukkiṟēṉ — "I take water." நான் அரிசி எடுக்கிறேன். — nāṉ arisi eḍukkiṟēṉ — "I take rice."
 
 The letters in this word.
-எ is the standing vowel e, from எழுது; டு is ட with the u sign, and ட came apart in படி. Nothing here is new — the first time in this course that has been true of a whole headword. The ḍ you hear is the same positional softening: ட goes soft between vowels and hard when doubled, as in eḍuttēṉ.
+எ is the standing vowel e, from எழுது; டு is ட with the u sign, and ட came apart in படி. Nothing here is new — the first time in this book that has been true of a whole headword. The ḍ you hear is the same positional softening: ட goes soft between vowels and hard when doubled, as in eḍuttēṉ.
 
 The word, taken apart - take and put, one vowel apart.
 You have met this verb's near-twin already, hiding inside a meal. சாப்பிடு (sāppiḍu), "to eat," is sāppu (food) plus இடு (iḍu), "to put" — the light verb that lends its endings to a noun.

--- a/code/learning/human-languages/telugu/book/chapters/ch11-colours.tex
+++ b/code/learning/human-languages/telugu/book/chapters/ch11-colours.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:a123da0e996c2292
+% canonical-source-hash: fnv1a64:4ffc184dedb4e141
 % canonical-lessons: TE-C11-rangulu
 
 \chapter{Four Core Colours}
@@ -39,7 +39,7 @@ Say these aloud:
 \begin{itemize}
 \raggedright
   \item \textquotedblleft{}nalupu, telupu, erupu\textquotedblright{} — black, white, red
-  \item \textquotedblleft{}nīlam\textquotedblright{} — blue, the word every language in this course now shares
+  \item \textquotedblleft{}nīlam\textquotedblright{} — blue, the word the four Dravidian languages and Hindi all share
   \item the whole pattern, one more time — native, native, native, \textbf{borrowed}
 \end{itemize}
 

--- a/code/learning/human-languages/telugu/lessons/TE-C11-rangulu.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C11-rangulu.md
@@ -58,8 +58,8 @@ the **exact same** borrowed word the moment it comes to blue.
 
 [PAUSE 1s]
 - [YOU SAY: "nalupu, telupu, erupu" — black, white, red]
-- [YOU SAY: "nīlam" — blue, the word every language in this course now
-  shares]
+- [YOU SAY: "nīlam" — blue, the word the four Dravidian
+  languages and Hindi all share]
 - [YOU SAY: the whole pattern, one more time — native, native, native,
   **borrowed**]
 

--- a/code/learning/human-languages/telugu/narration/ch11.json
+++ b/code/learning/human-languages/telugu/narration/ch11.json
@@ -4,7 +4,7 @@
   "chapter": 11,
   "title": "Four Core Colours",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:c981c0b76cf70dc0",
+  "sourceHash": "fnv1a64:b4677406243c8827",
   "lessons": [
     {
       "id": "TE-C11-rangulu",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f7ff3cc44bcfdd9a",
+      "sourceHash": "fnv1a64:d9887faa67f4d0a2",
       "notice": null,
       "blocks": [
         {
@@ -92,11 +92,11 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"nīlam\" — blue, the word every language in this course now shares",
+              "instruction": "\"nīlam\" — blue, the word the four Dravidian languages and Hindi all share",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"nīlam\" — blue, the word every language in this course now shares]"
+              "source": "[YOU SAY: \"nīlam\" — blue, the word the four Dravidian languages and Hindi all share]"
             },
             {
               "kind": "prompt",

--- a/code/learning/human-languages/telugu/narration/ch11.txt
+++ b/code/learning/human-languages/telugu/narration/ch11.txt
@@ -21,7 +21,7 @@ Guided Practice.
 [pause 1 second]
 [your turn — say: "nalupu, telupu, erupu" — black, white, red]
 [pause 8 seconds for the answer]
-[your turn — say: "nīlam" — blue, the word every language in this course now shares]
+[your turn — say: "nīlam" — blue, the word the four Dravidian languages and Hindi all share]
 [pause 8 seconds for the answer]
 [your turn — say: the whole pattern, one more time — native, native, native, borrowed]
 [pause 8 seconds for the answer]

--- a/code/learning/human-languages/urdu/book/chapters/ch05-take-leave.tex
+++ b/code/learning/human-languages/urdu/book/chapters/ch05-take-leave.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:65e2cc2c814ff552
+% canonical-source-hash: fnv1a64:929b13d07290a038
 % canonical-lessons: UR-C05-khuda, UR-C05-hafiz, UR-C05-khuda-hafiz, UR-C05-practice
 
 \chapter{Take Leave}
@@ -101,7 +101,7 @@ The protective sense is “God {[}be{]} guardian,” but everyday speakers use t
 \end{grammarlens}
 
 \subsection*{Script Bridge — shared history, local spacing}
-Urdu \textbf{\ur{خدا} \ur{حافظ}} and Persian \textbf{\ur{خداحافظ}} share the same historical pieces. Urdu keeps the visible space in this course; Persian normally joins them. Mixed practice may compare the two only now that each local phrase is independently readable.
+Urdu \textbf{\ur{خدا} \ur{حافظ}} and Persian \textbf{\ur{خداحافظ}} share the same historical pieces. Urdu conventionally keeps the visible space; Persian normally joins them. Mixed practice may compare the two only now that each local phrase is independently readable.
 
 \subsection*{Your turn}
 \begin{itemize}

--- a/code/learning/human-languages/urdu/book/chapters/ch08-social-verbs.tex
+++ b/code/learning/human-languages/urdu/book/chapters/ch08-social-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:dd548ee0ccc086e4
+% canonical-source-hash: fnv1a64:445fa7a91d105cb0
 % canonical-lessons: UR-C08-lena, UR-C08-puchhna, UR-C08-madad, UR-C08-pasand
 
 \chapter{Four Verbs Between People}

--- a/code/learning/human-languages/urdu/lessons/UR-C05-khuda-hafiz.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C05-khuda-hafiz.md
@@ -57,7 +57,7 @@ a reliable polite close for the short interaction learned so far.
 <!-- hl-knowledge: introduces=[UR-CROSSLINGUAL-KHUDA-HAFIZ-SPELLING]; assesses=[] -->
 
 Urdu **خدا حافظ** and Persian **خداحافظ** share the same historical pieces.
-Urdu keeps the visible space in this course; Persian normally joins them.
+Urdu conventionally keeps the visible space; Persian normally joins them.
 Mixed practice may compare the two only now that each local phrase is
 independently readable.
 

--- a/code/learning/human-languages/urdu/lessons/UR-C08-pasand.md
+++ b/code/learning/human-languages/urdu/lessons/UR-C08-pasand.md
@@ -12,7 +12,7 @@ concept_tag: VERB-LIKE-LOVE
 prerequisites: [UR-C08-madad]
 sounds: [rtl, final-ye, alif-madd]
 roots: [persian-pasandidan, proto-iranian-pati-sand]
-etymology_hook: pasand is Persian — from پسندیدن pasandīdan "to approve, to find pleasing", built on *pati- "towards" plus *sand "to look good" — and it entered Urdu as a NOUN, so it cannot carry the person doing the liking; mujhe paṛhnā pasand hai is "to me, reading is pleasing", the sixth language in this course to make liking something that happens TO you.
+etymology_hook: pasand is Persian — from پسندیدن pasandīdan "to approve, to find pleasing", built on *pati- "towards" plus *sand "to look good" — and it entered Urdu as a NOUN, so it cannot carry the person doing the liking; mujhe paṛhnā pasand hai is "to me, reading is pleasing", one of many languages that make liking something that happens TO you.
 duration:
   max_seconds: 296
 requires:

--- a/code/learning/human-languages/urdu/narration/ch05.json
+++ b/code/learning/human-languages/urdu/narration/ch05.json
@@ -4,7 +4,7 @@
   "chapter": 5,
   "title": "Take Leave",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:5d2065ac9b927c2f",
+  "sourceHash": "fnv1a64:fc4210d6ddcf7d8b",
   "lessons": [
     {
       "id": "UR-C05-khuda",
@@ -281,7 +281,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:b59762c651c4b0f6",
+      "sourceHash": "fnv1a64:7ba30adc928f3954",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -343,7 +343,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "Urdu خدا حافظ (khudā hāfiz) and Persian خداحافظ share the same historical pieces. Urdu keeps the visible space in this course; Persian normally joins them. Mixed practice may compare the two only now that each local phrase is independently readable."
+              "text": "Urdu خدا حافظ (khudā hāfiz) and Persian خداحافظ share the same historical pieces. Urdu conventionally keeps the visible space; Persian normally joins them. Mixed practice may compare the two only now that each local phrase is independently readable."
             }
           ]
         },

--- a/code/learning/human-languages/urdu/narration/ch05.txt
+++ b/code/learning/human-languages/urdu/narration/ch05.txt
@@ -77,7 +77,7 @@ Grammar Lens — a whole social move.
 The protective sense is “God [be] guardian,” but everyday speakers use the formula simply as goodbye. No new verb or agreement ending is needed. It is a reliable polite close for the short interaction learned so far.
 
 Script Bridge — shared history, local spacing.
-Urdu خدا حافظ (khudā hāfiz) and Persian خداحافظ share the same historical pieces. Urdu keeps the visible space in this course; Persian normally joins them. Mixed practice may compare the two only now that each local phrase is independently readable.
+Urdu خدا حافظ (khudā hāfiz) and Persian خداحافظ share the same historical pieces. Urdu conventionally keeps the visible space; Persian normally joins them. Mixed practice may compare the two only now that each local phrase is independently readable.
 
 Guided Practice.
 [your turn — build: khudā + hāfiz]

--- a/code/learning/human-languages/urdu/narration/ch08.json
+++ b/code/learning/human-languages/urdu/narration/ch08.json
@@ -4,7 +4,7 @@
   "chapter": 8,
   "title": "Four Verbs Between People",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:997aec13e461f1b3",
+  "sourceHash": "fnv1a64:d6961ef47c5a8dd7",
   "lessons": [
     {
       "id": "UR-C08-lena",
@@ -537,7 +537,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e6d8568047160abb",
+      "sourceHash": "fnv1a64:c6c945a4954aefbb",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Fixed — the course-level phrases (HL-C50)
+
+The class the previous change counted and deferred: bare *"in this course"*, *"in
+this curriculum"*, *"in this series"*. **31 sites across 29 authored files** — 29 in
+27 lesson sources, 2 in the handwritten `sanskrit/book/book.tex` and its ch01.
+
+- A reader holding the Tamil book does not know which languages the series covers,
+  so *"every Dravidian language in this course"* names a set they cannot see.
+- Two were **build-system notes printed at a learner**: *"**ट** is not yet in this
+  curriculum's stroke data — draw it only after its entry is authored"*. The reader
+  is not the person who authors stroke data.
+- Ordinals moved **in-volume** rather than being deleted: *"the first one in this
+  course whose vowel changes"* → *"in this **book**"*. A reader is holding the book,
+  so that ordinal is answerable. The guard deliberately does not match "in this book".
+
+### Note — deleting "in this course" widens a claim from the books to the world
+
+This is the whole difficulty of the class, and it cost real defects again.
+
+*"Every European language **in this course** splits the year into four seasons"* is a
+safe claim about a curriculum. Drop three words and it is a claim about European
+languages — and Sami traditionally counts eight. Every quantifier here was re-scoped
+deliberately, and review still found two that had become false:
+
+- *"Across Europe and North India, weekdays are named for planet-gods"* — Portuguese
+  counts its weekdays (*segunda-feira*, *terça*…), as do Greek and every Slavic
+  language. Worse, it destroyed the lesson's own punchline, which is that Arabic
+  *counts* them: Portuguese does the same thing. The original carried **two** hedges,
+  "so far" and "in this course"; the rewrite dropped both.
+- *"Most languages say 'my name is' with a word for my and a word for name"* — false
+  for the whole Romance branch (*je m'appelle*, *me llamo*), for German, and for
+  Chinese: six tracks in this series.
+
+Three more rewrites lost their footing without being false: a cousin web described as
+"carrying" a language (inverted), kanji said to have "no parallel in any alphabet"
+(cuneiform and hieroglyphs are just as polyvalent, and nothing nearby mentioned
+alphabets), and *"a third fate for a consonant in this book"* — moving that ordinal
+in-volume made it checkable, and the Punjabi volume never labels a first or second.
+
+### Known remaining gap, measured
+
+The same defect wearing different words — **99 sites across 79 files**: *"the
+course"* / *"this curriculum"* / *"this series"* not preceded by "in" (65), *"in this
+arc"* used for a cross-volume set (27), invisible-set ordinals like *"the fifth
+language to close the loop"* (3), and *"every track"* / *"this course covers"* (4).
+Counted rather than left to be rediscovered. The guard does not match them yet, for
+the same reason it did not match this class until today.
+
 ### Fixed — the pointers the last guard could not see (HL-C50)
 
 The previous change closed cross-volume *lesson ids* and left a gap it named out

--- a/code/packages/typescript/human-language-data/tests/standalone-book.test.ts
+++ b/code/packages/typescript/human-language-data/tests/standalone-book.test.ts
@@ -137,15 +137,21 @@ describe("a reader holding the PDF", () => {
         "gi",
       ),
       // A pointer needs no language and no verb: "the daughter lessons", "its own
-      // track", "the companion volumes". Bare "in this course"/"in this curriculum"
-      // is deliberately NOT here -- 48 lessons carry it, a coherent class of its own
-      // and the next item. A guard muted on 48 files the day it lands is worth less
-      // than one that holds.
+      // track", "the companion volumes".
       new RegExp(
         `\\b(?:the (?:daughter|companion|sibling|other) (?:lesson|chapter|book|track|arc|volume)s?` +
           `|its own (?:track|book|volume|arc))\\b()`,
         "gi",
       ),
+      // Bare "in this course" / "in this curriculum" / "in this series". The previous
+      // change left this off on purpose and said why: 31 sites carried it, and a guard
+      // muted on its own corpus is worth less than one that holds. They are gone now,
+      // so it holds.
+      //
+      // "in this BOOK" is deliberately absent from the alternation. A reader is
+      // holding the book, so an ordinal about it ("the first verb in this book whose
+      // vowel changes") is answerable -- which is what several of these became.
+      new RegExp(`\\bin this\\s+(?:course|curriculum|series)\\b()`, "gi"),
     ];
     const offenders: string[] = [];
     for (const { source, tex } of SURFACES) {

--- a/lessons.md
+++ b/lessons.md
@@ -2842,3 +2842,30 @@ prose. Line breaks are the escape `\n`, so `\s+` cannot cross a wrap and `[^.?!\
 bounds nothing. Both of my newline-aware protections were inert on the surface I had
 just added, and a real defect was sitting in the blind spot. Un-escape before matching
 — and when a guard is extended to a new surface, re-prove it on THAT surface.
+
+
+## A hedge you delete is a claim you widen
+
+Removing "in this course" from *"Every European language in this course splits the
+year into four seasons"* leaves a claim about European languages. The three words
+were not decoration — they were the scope.
+
+Two of my rewrites became false that way, in one pass, after I had already written
+the lesson above about exactly this:
+
+- *"Across Europe and North India, weekdays are named for planet-gods"* — Portuguese
+  counts them (*segunda-feira*), as do Greek and every Slavic language. The original
+  said "every language **so far in this course**": **two** hedges, and I dropped both
+  at once. It also broke the lesson's own punchline, that Arabic is the odd one out
+  for counting — Portuguese counts too.
+- *"Most languages say 'my name is' with a word for my and a word for name"* — false
+  for all of Romance, German, and Chinese.
+
+**Rule:** when a scope-limiting phrase is deleted, the sentence needs a NEW scope
+chosen on purpose — "most", "generally", or an explicit list — not the empty scope
+that grammar leaves behind. Count the hedges in the original before you rewrite; if
+there are two, the claim was fragile and needs more care, not less.
+
+**Corollary:** moving an ordinal from course-scope to book-scope ("the third fate for
+a consonant **in this book**") makes it *checkable*, which is the point — so check it.
+Mine did not check out: the Punjabi volume never labels a first or second fate.


### PR DESCRIPTION
The class the previous change counted and deferred: bare *"in this course"*, *"in this curriculum"*, *"in this series"*. **31 sites across 29 authored files** — 29 in 27 lesson sources, 2 in the handwritten `sanskrit/book/book.tex` and its ch01.

## What was broken

A reader holding the Tamil book does not know which languages the series covers, so *"every Dravidian language in this course"* names a set they cannot see.

Two were **build-system notes printed at a learner**: *"**ट** is not yet in this curriculum's stroke data — draw it only after its entry is authored."* The reader is not the person who authors stroke data.

Ordinals moved **in-volume** rather than being deleted: *"the first one in this course whose vowel changes"* → *"in this **book**"*. A reader is holding the book, so that ordinal is answerable — and the guard deliberately does not match `in this book`.

## The difficulty of this class: deleting the phrase widens the claim

*"Every European language **in this course** splits the year into four seasons"* is a safe statement about a curriculum. Drop three words and it is a statement about European languages — and Sami traditionally counts eight.

Every quantifier here was re-scoped deliberately, and review **still** found two that had gone false:

- *"Across Europe and North India, weekdays are named for planet-gods"* — Portuguese counts its weekdays (*segunda-feira*, *terça*…), as do Greek and every Slavic language. Worse, it destroyed the lesson's own punchline, which is that Arabic **counts** them: Portuguese does the same thing. The original carried **two** hedges — "so far" and "in this course" — and the rewrite dropped both at once.
- *"Most languages say 'my name is' with a word for my and a word for name"* — false for the whole Romance branch (*je m'appelle*, *me llamo*), for German, and for Chinese: six tracks in this series.

Three more lost their footing without being false: a cousin web described as *"carrying"* a language (inverted), kanji said to have *"no parallel in any alphabet"* (cuneiform and hieroglyphs are just as polyvalent, and nothing nearby mentioned alphabets), and *"a third fate for a consonant in this book"* — moving that ordinal in-volume made it **checkable**, and the Punjabi volume never labels a first or second.

Recorded in `lessons.md`: **a hedge you delete is a claim you widen.** Count the hedges in the original before rewriting; two hedges means the claim was fragile and needs more care, not less.

## Guard

The seventh pattern, left off last time on purpose, is now enabled — proven to fire on all three phrasings while sparing *"in this book"*:

| probe | result |
|---|---|
| `every other language in this course` | CAUGHT |
| `nowhere else in this curriculum` | CAUGHT |
| `the third volume in this series` | CAUGHT |
| `the first verb in this book` | not flagged (correct) |

## Known remaining gap, measured

**99 sites across 79 files** — the same defect wearing different words: *"the course"* / *"this curriculum"* not preceded by "in" (65), *"in this arc"* used for a cross-volume set (27), invisible-set ordinals like *"the fifth language to close the loop"* (3), *"every track"* (4). Counted rather than left to be rediscovered.

## Verification

396 tests pass. `check:books`, `check:narration`, `check:modality` clean. Forward references unchanged at 510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
