### PR TITLE
feat(human-languages): the everyday verbs — hear, sleep, sit, stand (HL-C49)

### DIFF
--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -101,9 +101,9 @@ edition is authored.
 
 | Language | Family / script | Status |
 |---|---|---|
-| [Spanish](./spanish/README.md) | Romance / Latin | Pilot — Chapters 1-3 authored (lessons + book); ~30 lessons |
-| [French](./french/README.md) | Romance / Latin | Chapters 1-2 authored (lessons + book) |
-| [German](./german/README.md) | Germanic / Latin | Chapters 1-2 authored (lessons + book) |
+| [Spanish](./spanish/README.md) | Romance / Latin | Reference track — Chapters 1–37 authored; 162 lessons; 29 of the 40 core verbs |
+| [French](./french/README.md) | Romance / Latin | Chapters 1–27 authored; 89 lessons; 22 of the 40 core verbs |
+| [German](./german/README.md) | Germanic / Latin | Chapters 1–27 authored; 92 lessons; 22 of the 40 core verbs |
 | [Italian](./italian/README.md) | Romance / Latin | Chapters 1–17 authored; Chapters 2–17 canonical/generated for app + book |
 | [Portuguese](./portuguese/README.md) | Romance / Latin | Chapter 1 (Greetings) authored (lessons + book) |
 | [Arabic](./arabic/README.md) | Semitic / Arabic (vendored font) | Chapters 1–30 authored; Chapters 3–30 canonical/generated for app + book; first track to realize core `VERB-*` concepts and the first to reach A2 |
@@ -116,7 +116,7 @@ edition is authored.
 | [Kannada](./kannada/README.md) | Dravidian / Kannada (vendored font) | Chapters 1-2 authored (lessons + book) |
 | [Telugu](./telugu/README.md) | Dravidian / Telugu (vendored font) | Chapters 1-2 authored (lessons + book) |
 | [Malayalam](./malayalam/README.md) | Dravidian / Malayalam (vendored font) | Chapters 1–31 authored; Chapters 6–31 canonical/generated for app + book |
-| [Latin](./latin/README.md) | Italic / Latin (**taproot**) | Chapters 1–36 authored; Chapters 2–36 canonical/generated for app + book |
+| [Latin](./latin/README.md) | Italic / Latin (**taproot**) | Chapters 1–41 authored; 81 lessons; 24 of the 40 core verbs |
 | [Sanskrit](./sanskrit/README.md) | Indo-Aryan / Devanagari (**taproot**) | Chapters 1–9 authored (lessons + book; Chapters 6–9 canonical/generated) |
 | [Russian](./russian/README.md) | Slavic / Cyrillic | Chapters 1–5 authored (lessons + book; Chapters 3–5 canonical/generated). Chapters 4–5 are the eight core verbs; aspect is named, not finished |
 | [Persian](./persian/README.md) | Iranian / Perso-Arabic | Eight authored shared-spine chapters; 33 canonical lessons, including thirteen core verbs |

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -214,6 +214,20 @@
       "output": "spanish/book/chapters/ch35-take-ask-help.tex"
     },
     {
+      "language": "spanish",
+      "chapter": 36,
+      "title": "Hearing, Sleeping, Walking, Running",
+      "label": "ch:spanish-hear-sleep-walk-run",
+      "output": "spanish/book/chapters/ch36-hear-sleep-walk-run.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 37,
+      "title": "Opening, Closing, Sitting Down, Standing Up",
+      "label": "ch:spanish-open-close-sit-stand",
+      "output": "spanish/book/chapters/ch37-open-close-sit-stand.tex"
+    },
+    {
       "language": "italian",
       "chapter": 2,
       "title": "How Are You?",

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -538,6 +538,20 @@
       "output": "french/book/chapters/ch25-verbs-of-the-mind.tex"
     },
     {
+      "language": "french",
+      "chapter": 26,
+      "title": "Hearing, Sleeping, Walking, Running",
+      "label": "ch:fr-hearing-sleeping-walking-running",
+      "output": "french/book/chapters/ch26-hearing-sleeping-walking-running.tex"
+    },
+    {
+      "language": "french",
+      "chapter": 27,
+      "title": "Sitting, Standing, Opening, Closing",
+      "label": "ch:fr-sitting-standing-opening-closing",
+      "output": "french/book/chapters/ch27-sitting-standing-opening-closing.tex"
+    },
+    {
       "language": "german",
       "chapter": 17,
       "title": "Head and Hand",

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -601,6 +601,20 @@
       "output": "german/book/chapters/ch25-doing-verbs.tex"
     },
     {
+      "language": "german",
+      "chapter": 26,
+      "title": "Sitting, Standing, Sleeping, Hearing",
+      "label": "ch:ge-still-verbs",
+      "output": "german/book/chapters/ch26-still-verbs.tex"
+    },
+    {
+      "language": "german",
+      "chapter": 27,
+      "title": "Going, Running, Opening, Closing",
+      "label": "ch:ge-moving-verbs",
+      "output": "german/book/chapters/ch27-moving-verbs.tex"
+    },
+    {
       "language": "telugu",
       "chapter": 6,
       "title": "Case Endings and Dative Subjects",

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -2275,6 +2275,20 @@
       "output": "latin/book/chapters/ch39-doing-verbs.tex"
     },
     {
+      "language": "latin",
+      "chapter": 40,
+      "title": "Hearing, Sleeping, Sitting, Standing",
+      "label": "ch:la-sense-and-posture-verbs",
+      "output": "latin/book/chapters/ch40-sense-and-posture-verbs.tex"
+    },
+    {
+      "language": "latin",
+      "chapter": 41,
+      "title": "Walking, Running, Opening, Closing",
+      "label": "ch:la-motion-verbs",
+      "output": "latin/book/chapters/ch41-motion-verbs.tex"
+    },
+    {
       "language": "bengali",
       "chapter": 6,
       "title": "Numbers One to Five",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -1743,6 +1743,30 @@
       "tex": "latin/book/chapters/ch39-doing-verbs.tex"
     },
     {
+      "language": "latin",
+      "chapter": 40,
+      "sourceHash": "fnv1a64:1cddd2598214fb8f",
+      "lessonIds": [
+        "LA-C40-audio",
+        "LA-C40-dormio",
+        "LA-C40-sedeo",
+        "LA-C40-sto"
+      ],
+      "tex": "latin/book/chapters/ch40-sense-and-posture-verbs.tex"
+    },
+    {
+      "language": "latin",
+      "chapter": 41,
+      "sourceHash": "fnv1a64:2b002dc26979c3db",
+      "lessonIds": [
+        "LA-C41-ambulo",
+        "LA-C41-curro",
+        "LA-C41-aperio",
+        "LA-C41-claudo"
+      ],
+      "tex": "latin/book/chapters/ch41-motion-verbs.tex"
+    },
+    {
       "language": "malayalam",
       "chapter": 6,
       "sourceHash": "fnv1a64:681af808b81537e1",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -2780,6 +2780,30 @@
       "tex": "spanish/book/chapters/ch35-take-ask-help.tex"
     },
     {
+      "language": "spanish",
+      "chapter": 36,
+      "sourceHash": "fnv1a64:3e6206d3d514062c",
+      "lessonIds": [
+        "ES-C36-oir",
+        "ES-C36-dormir",
+        "ES-C36-caminar",
+        "ES-C36-correr"
+      ],
+      "tex": "spanish/book/chapters/ch36-hear-sleep-walk-run.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 37,
+      "sourceHash": "fnv1a64:60ab3e2d720ff3b6",
+      "lessonIds": [
+        "ES-C37-abrir",
+        "ES-C37-cerrar",
+        "ES-C37-sentarse",
+        "ES-C37-levantarse"
+      ],
+      "tex": "spanish/book/chapters/ch37-open-close-sit-stand.tex"
+    },
+    {
       "language": "tamil",
       "chapter": 6,
       "sourceHash": "fnv1a64:8cb1982f517a21f4",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -453,6 +453,30 @@
       "tex": "french/book/chapters/ch25-verbs-of-the-mind.tex"
     },
     {
+      "language": "french",
+      "chapter": 26,
+      "sourceHash": "fnv1a64:8fceb055d3841a03",
+      "lessonIds": [
+        "FR-C26-entendre",
+        "FR-C26-dormir",
+        "FR-C26-marcher",
+        "FR-C26-courir"
+      ],
+      "tex": "french/book/chapters/ch26-hearing-sleeping-walking-running.tex"
+    },
+    {
+      "language": "french",
+      "chapter": 27,
+      "sourceHash": "fnv1a64:92921437a691bade",
+      "lessonIds": [
+        "FR-C27-sasseoir",
+        "FR-C27-se-lever",
+        "FR-C27-ouvrir",
+        "FR-C27-fermer"
+      ],
+      "tex": "french/book/chapters/ch27-sitting-standing-opening-closing.tex"
+    },
+    {
       "language": "german",
       "chapter": 17,
       "sourceHash": "fnv1a64:db42e9b15a61794e",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -543,6 +543,30 @@
       "tex": "german/book/chapters/ch25-doing-verbs.tex"
     },
     {
+      "language": "german",
+      "chapter": 26,
+      "sourceHash": "fnv1a64:3241b07fef4da498",
+      "lessonIds": [
+        "GE-C26-sitzen",
+        "GE-C26-stehen",
+        "GE-C26-schlafen",
+        "GE-C26-hoeren"
+      ],
+      "tex": "german/book/chapters/ch26-still-verbs.tex"
+    },
+    {
+      "language": "german",
+      "chapter": 27,
+      "sourceHash": "fnv1a64:3da3cdbab9f0f237",
+      "lessonIds": [
+        "GE-C27-gehen",
+        "GE-C27-laufen",
+        "GE-C27-oeffnen",
+        "GE-C27-schliessen"
+      ],
+      "tex": "german/book/chapters/ch27-moving-verbs.tex"
+    },
+    {
       "language": "gujarati",
       "chapter": 6,
       "sourceHash": "fnv1a64:e37450b34f66cad3",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -1502,6 +1502,40 @@
       "jsonHash": "fnv1a64:b87fdce5ee07ace4"
     },
     {
+      "language": "german",
+      "chapter": 26,
+      "sourceHash": "fnv1a64:9f1e817b7beec48a",
+      "lessonIds": [
+        "GE-C26-sitzen",
+        "GE-C26-stehen",
+        "GE-C26-schlafen",
+        "GE-C26-hoeren"
+      ],
+      "voiceLessons": 4,
+      "drivablePrefix": 4,
+      "text": "german/narration/ch26.txt",
+      "json": "german/narration/ch26.json",
+      "textHash": "fnv1a64:85ffccdf04545476",
+      "jsonHash": "fnv1a64:2987171e016b5ded"
+    },
+    {
+      "language": "german",
+      "chapter": 27,
+      "sourceHash": "fnv1a64:983170162f81dec0",
+      "lessonIds": [
+        "GE-C27-gehen",
+        "GE-C27-laufen",
+        "GE-C27-oeffnen",
+        "GE-C27-schliessen"
+      ],
+      "voiceLessons": 4,
+      "drivablePrefix": 4,
+      "text": "german/narration/ch27.txt",
+      "json": "german/narration/ch27.json",
+      "textHash": "fnv1a64:0a4a47ca028ceec3",
+      "jsonHash": "fnv1a64:a78be525eda88662"
+    },
+    {
       "language": "gujarati",
       "chapter": 1,
       "sourceHash": "fnv1a64:08fb66dea407c28f",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -1093,6 +1093,40 @@
       "jsonHash": "fnv1a64:c65dc68905adcf6c"
     },
     {
+      "language": "french",
+      "chapter": 26,
+      "sourceHash": "fnv1a64:eac4adb1915b9a9d",
+      "lessonIds": [
+        "FR-C26-entendre",
+        "FR-C26-dormir",
+        "FR-C26-marcher",
+        "FR-C26-courir"
+      ],
+      "voiceLessons": 4,
+      "drivablePrefix": 4,
+      "text": "french/narration/ch26.txt",
+      "json": "french/narration/ch26.json",
+      "textHash": "fnv1a64:9bbe1f0d826a66e8",
+      "jsonHash": "fnv1a64:4926cfd1e165d33d"
+    },
+    {
+      "language": "french",
+      "chapter": 27,
+      "sourceHash": "fnv1a64:ac5b1968b18e6213",
+      "lessonIds": [
+        "FR-C27-sasseoir",
+        "FR-C27-se-lever",
+        "FR-C27-ouvrir",
+        "FR-C27-fermer"
+      ],
+      "voiceLessons": 4,
+      "drivablePrefix": 4,
+      "text": "french/narration/ch27.txt",
+      "json": "french/narration/ch27.json",
+      "textHash": "fnv1a64:966f43db626e03d4",
+      "jsonHash": "fnv1a64:47b757ea26d32acd"
+    },
+    {
       "language": "german",
       "chapter": 1,
       "sourceHash": "fnv1a64:3eb0a576892fbc9e",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -5839,6 +5839,40 @@
       "jsonHash": "fnv1a64:768d75640e6ad386"
     },
     {
+      "language": "spanish",
+      "chapter": 36,
+      "sourceHash": "fnv1a64:0e305c37e6fc9666",
+      "lessonIds": [
+        "ES-C36-oir",
+        "ES-C36-dormir",
+        "ES-C36-caminar",
+        "ES-C36-correr"
+      ],
+      "voiceLessons": 4,
+      "drivablePrefix": 4,
+      "text": "spanish/narration/ch36.txt",
+      "json": "spanish/narration/ch36.json",
+      "textHash": "fnv1a64:124d529f278a8ab0",
+      "jsonHash": "fnv1a64:d958feb10ede2f28"
+    },
+    {
+      "language": "spanish",
+      "chapter": 37,
+      "sourceHash": "fnv1a64:3899f6300550ff70",
+      "lessonIds": [
+        "ES-C37-abrir",
+        "ES-C37-cerrar",
+        "ES-C37-sentarse",
+        "ES-C37-levantarse"
+      ],
+      "voiceLessons": 4,
+      "drivablePrefix": 4,
+      "text": "spanish/narration/ch37.txt",
+      "json": "spanish/narration/ch37.json",
+      "textHash": "fnv1a64:5b9393ae9965262b",
+      "jsonHash": "fnv1a64:ca00d1b6d278148f"
+    },
+    {
       "language": "tamil",
       "chapter": 1,
       "sourceHash": "fnv1a64:b80adea0055c5306",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -3644,6 +3644,40 @@
       "jsonHash": "fnv1a64:14e45d70f6ad1110"
     },
     {
+      "language": "latin",
+      "chapter": 40,
+      "sourceHash": "fnv1a64:ae6b9b154fb369b2",
+      "lessonIds": [
+        "LA-C40-audio",
+        "LA-C40-dormio",
+        "LA-C40-sedeo",
+        "LA-C40-sto"
+      ],
+      "voiceLessons": 4,
+      "drivablePrefix": 4,
+      "text": "latin/narration/ch40.txt",
+      "json": "latin/narration/ch40.json",
+      "textHash": "fnv1a64:2bf91d5f96e991a3",
+      "jsonHash": "fnv1a64:878d418f6161f77a"
+    },
+    {
+      "language": "latin",
+      "chapter": 41,
+      "sourceHash": "fnv1a64:fe69dc2b788501fe",
+      "lessonIds": [
+        "LA-C41-ambulo",
+        "LA-C41-curro",
+        "LA-C41-aperio",
+        "LA-C41-claudo"
+      ],
+      "voiceLessons": 4,
+      "drivablePrefix": 4,
+      "text": "latin/narration/ch41.txt",
+      "json": "latin/narration/ch41.json",
+      "textHash": "fnv1a64:789a7ac18d00e297",
+      "jsonHash": "fnv1a64:a650ca85c6e504a4"
+    },
+    {
       "language": "malayalam",
       "chapter": 1,
       "sourceHash": "fnv1a64:bfb1a1a7a0f1d6f8",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,18 +7,18 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:52a1932143b668c3",
+  "sourceHash": "fnv1a64:6f5a49c26bc8ed38",
   "summary": {
-    "totalLessons": 1385,
-    "voice": 909,
+    "totalLessons": 1393,
+    "voice": 917,
     "sight": 423,
     "pen": 53,
-    "drivableLessons": 909,
+    "drivableLessons": 917,
     "drivablePercent": 66,
     "trackCount": 22,
-    "chapterCount": 434,
-    "drivablePrefixTotal": 726,
-    "fullyDrivableChapters": 289,
+    "chapterCount": 436,
+    "drivablePrefixTotal": 734,
+    "fullyDrivableChapters": 291,
     "unstartableChapters": 108,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
@@ -1188,12 +1188,12 @@
     },
     {
       "language": "german",
-      "lessonCount": 84,
-      "voice": 73,
+      "lessonCount": 92,
+      "voice": 81,
       "sight": 8,
       "pen": 3,
-      "drivablePercent": 87,
-      "drivablePrefixTotal": 68,
+      "drivablePercent": 88,
+      "drivablePrefixTotal": 76,
       "modalities": [
         "voice",
         "sight",
@@ -1645,6 +1645,44 @@
             "GE-C25-fragen",
             "GE-C25-helfen",
             "GE-C25-moegen-lieben"
+          ]
+        },
+        {
+          "chapter": 26,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "GE-C26-sitzen",
+            "GE-C26-stehen",
+            "GE-C26-schlafen",
+            "GE-C26-hoeren"
+          ]
+        },
+        {
+          "chapter": 27,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "GE-C27-gehen",
+            "GE-C27-laufen",
+            "GE-C27-oeffnen",
+            "GE-C27-schliessen"
           ]
         }
       ]
@@ -13252,6 +13290,150 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:6413600515d017a7"
+    },
+    {
+      "id": "GE-C26-sitzen",
+      "language": "german",
+      "chapter": 26,
+      "sequence": 790,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:afb92dd9ac5c4a8b"
+    },
+    {
+      "id": "GE-C26-stehen",
+      "language": "german",
+      "chapter": 26,
+      "sequence": 800,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c5502f60549c0f38"
+    },
+    {
+      "id": "GE-C26-schlafen",
+      "language": "german",
+      "chapter": 26,
+      "sequence": 810,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ecd66be4bbd05f73"
+    },
+    {
+      "id": "GE-C26-hoeren",
+      "language": "german",
+      "chapter": 26,
+      "sequence": 820,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5f32d7202016c02e"
+    },
+    {
+      "id": "GE-C27-gehen",
+      "language": "german",
+      "chapter": 27,
+      "sequence": 830,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9cfcead00ceeff1c"
+    },
+    {
+      "id": "GE-C27-laufen",
+      "language": "german",
+      "chapter": 27,
+      "sequence": 840,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b7282b0745a98b5d"
+    },
+    {
+      "id": "GE-C27-oeffnen",
+      "language": "german",
+      "chapter": 27,
+      "sequence": 850,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6077fbe3623e96ba"
+    },
+    {
+      "id": "GE-C27-schliessen",
+      "language": "german",
+      "chapter": 27,
+      "sequence": 860,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7fbdf7b45126355b"
     },
     {
       "id": "GU-C01-aabhaar",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,18 +7,18 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:6f5a49c26bc8ed38",
+  "sourceHash": "fnv1a64:32426636845369e5",
   "summary": {
-    "totalLessons": 1393,
-    "voice": 917,
+    "totalLessons": 1417,
+    "voice": 941,
     "sight": 423,
     "pen": 53,
-    "drivableLessons": 917,
+    "drivableLessons": 941,
     "drivablePercent": 66,
     "trackCount": 22,
-    "chapterCount": 436,
-    "drivablePrefixTotal": 734,
-    "fullyDrivableChapters": 291,
+    "chapterCount": 442,
+    "drivablePrefixTotal": 758,
+    "fullyDrivableChapters": 297,
     "unstartableChapters": 108,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
@@ -743,12 +743,12 @@
     },
     {
       "language": "french",
-      "lessonCount": 81,
-      "voice": 66,
+      "lessonCount": 89,
+      "voice": 74,
       "sight": 12,
       "pen": 3,
-      "drivablePercent": 81,
-      "drivablePrefixTotal": 50,
+      "drivablePercent": 83,
+      "drivablePrefixTotal": 58,
       "modalities": [
         "voice",
         "sight",
@@ -1182,6 +1182,44 @@
             "FR-C25-penser",
             "FR-C25-lire",
             "FR-C25-ecrire"
+          ]
+        },
+        {
+          "chapter": 26,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "FR-C26-entendre",
+            "FR-C26-dormir",
+            "FR-C26-marcher",
+            "FR-C26-courir"
+          ]
+        },
+        {
+          "chapter": 27,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "FR-C27-sasseoir",
+            "FR-C27-se-lever",
+            "FR-C27-ouvrir",
+            "FR-C27-fermer"
           ]
         }
       ]
@@ -3367,12 +3405,12 @@
     },
     {
       "language": "latin",
-      "lessonCount": 73,
-      "voice": 70,
+      "lessonCount": 81,
+      "voice": 78,
       "sight": 3,
       "pen": 0,
       "drivablePercent": 96,
-      "drivablePrefixTotal": 69,
+      "drivablePrefixTotal": 77,
       "modalities": [
         "voice",
         "sight"
@@ -4029,6 +4067,44 @@
             "LA-C39-rogo",
             "LA-C39-adiuvo",
             "LA-C39-amo"
+          ]
+        },
+        {
+          "chapter": 40,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "LA-C40-audio",
+            "LA-C40-dormio",
+            "LA-C40-sedeo",
+            "LA-C40-sto"
+          ]
+        },
+        {
+          "chapter": 41,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "LA-C41-ambulo",
+            "LA-C41-curro",
+            "LA-C41-aperio",
+            "LA-C41-claudo"
           ]
         }
       ]
@@ -5720,12 +5796,12 @@
     },
     {
       "language": "spanish",
-      "lessonCount": 154,
-      "voice": 129,
+      "lessonCount": 162,
+      "voice": 137,
       "sight": 18,
       "pen": 7,
-      "drivablePercent": 84,
-      "drivablePrefixTotal": 99,
+      "drivablePercent": 85,
+      "drivablePrefixTotal": 107,
       "modalities": [
         "voice",
         "sight",
@@ -6365,6 +6441,44 @@
             "ES-C35-preguntar",
             "ES-C35-ayudar",
             "ES-C35-gustar"
+          ]
+        },
+        {
+          "chapter": 36,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "ES-C36-oir",
+            "ES-C36-dormir",
+            "ES-C36-caminar",
+            "ES-C36-correr"
+          ]
+        },
+        {
+          "chapter": 37,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "ES-C37-abrir",
+            "ES-C37-cerrar",
+            "ES-C37-sentarse",
+            "ES-C37-levantarse"
           ]
         }
       ]
@@ -8477,7 +8591,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c2d7502d85e39eb8"
+      "sourceHash": "fnv1a64:e69d598f6d1990e8"
     },
     {
       "id": "AR-C04-practice",
@@ -8585,7 +8699,7 @@
         "wide-table"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:3dbaad4fe2de433f"
+      "sourceHash": "fnv1a64:256f75fd5f1f3c3f"
     },
     {
       "id": "AR-C08-al-jumua-as-sabt",
@@ -8837,7 +8951,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b6d43c1a5b4ae6b8"
+      "sourceHash": "fnv1a64:25835c3671e986bc"
     },
     {
       "id": "AR-C19-wahid-khamsa",
@@ -8873,7 +8987,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9a1426dc9c9a2abd"
+      "sourceHash": "fnv1a64:7e829f5fd5ea8d75"
     },
     {
       "id": "AR-C21-kalb-qitt",
@@ -8891,7 +9005,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:f33045d5cd091570"
+      "sourceHash": "fnv1a64:5c58ecb89a42a062"
     },
     {
       "id": "AR-C22-akhdar-asfar",
@@ -8945,7 +9059,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:0cdff4548a8a9674"
+      "sourceHash": "fnv1a64:bbf0d19361870582"
     },
     {
       "id": "AR-C25-yawm",
@@ -8999,7 +9113,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7f336d22da3abfe2"
+      "sourceHash": "fnv1a64:2df88df161fba6d1"
     },
     {
       "id": "AR-C28-dhahaba",
@@ -9314,7 +9428,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:3548b8e1e6d8b786",
+      "sourceHash": "fnv1a64:6a2efd84816feecc",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -9335,7 +9449,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b6dedebbef9e9c4a",
+      "sourceHash": "fnv1a64:46d50e117712ba2c",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -9377,7 +9491,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:63149e08a09fd266",
+      "sourceHash": "fnv1a64:d1f13ec389f3ef0c",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -9458,7 +9572,7 @@
         "sight-cue"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:51eefb2762daba62"
+      "sourceHash": "fnv1a64:07277492546379d2"
     },
     {
       "id": "BN-C02-ki",
@@ -10211,7 +10325,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:fd5fc68c6af29500",
+      "sourceHash": "fnv1a64:bf90a02b9c63153c",
       "detachableSegments": [
         "Script — 你, and the person hiding on its left"
       ]
@@ -10232,7 +10346,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8856bfa06cfb62bd",
+      "sourceHash": "fnv1a64:220f4f705c72a7c3",
       "detachableSegments": [
         "Script — 好, a woman beside a child"
       ]
@@ -10759,7 +10873,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:d1e3a06b51f0b29c"
+      "sourceHash": "fnv1a64:a67f465814030d42"
     },
     {
       "id": "FR-C03-merci",
@@ -11595,7 +11709,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:63e101761a178417"
+      "sourceHash": "fnv1a64:128c25861fdc9bbf"
     },
     {
       "id": "FR-C22-chien-chat",
@@ -11776,6 +11890,150 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:c75664e4497104d6"
+    },
+    {
+      "id": "FR-C26-entendre",
+      "language": "french",
+      "chapter": 26,
+      "sequence": 790,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:2fcffc50b4c530f1"
+    },
+    {
+      "id": "FR-C26-dormir",
+      "language": "french",
+      "chapter": 26,
+      "sequence": 800,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8ac859110ce4c654"
+    },
+    {
+      "id": "FR-C26-marcher",
+      "language": "french",
+      "chapter": 26,
+      "sequence": 810,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:97bc8031093782ab"
+    },
+    {
+      "id": "FR-C26-courir",
+      "language": "french",
+      "chapter": 26,
+      "sequence": 820,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:06b9e4a83df44973"
+    },
+    {
+      "id": "FR-C27-sasseoir",
+      "language": "french",
+      "chapter": 27,
+      "sequence": 830,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:22351bcb8b4bd18e"
+    },
+    {
+      "id": "FR-C27-se-lever",
+      "language": "french",
+      "chapter": 27,
+      "sequence": 840,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c7f80390b7695f21"
+    },
+    {
+      "id": "FR-C27-ouvrir",
+      "language": "french",
+      "chapter": 27,
+      "sequence": 850,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9520fc80bfc81ee2"
+    },
+    {
+      "id": "FR-C27-fermer",
+      "language": "french",
+      "chapter": 27,
+      "sequence": 860,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b24800fffba8e018"
     },
     {
       "id": "GE-C01-abend",
@@ -12333,7 +12591,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:543133b77d65bee3"
+      "sourceHash": "fnv1a64:2e55d77a4ab3c56b"
     },
     {
       "id": "GE-C04-bis-spater",
@@ -12803,7 +13061,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e146ae0153ea6eca"
+      "sourceHash": "fnv1a64:c066fb5de47769ca"
     },
     {
       "id": "GE-C13-schwarz-weiss",
@@ -12965,7 +13223,7 @@
         "sight-cue"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:27f2396af22b0742"
+      "sourceHash": "fnv1a64:290823f98679e2c6"
     },
     {
       "id": "GE-C17-kopf",
@@ -13019,7 +13277,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:46d0b30a7b21211a"
+      "sourceHash": "fnv1a64:2749ef57887d5546"
     },
     {
       "id": "GE-C18-ja",
@@ -13199,7 +13457,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:06d86fff9bf862f3"
+      "sourceHash": "fnv1a64:820e3554f1ce62f3"
     },
     {
       "id": "GE-C24-schreiben",
@@ -14445,7 +14703,7 @@
         "writing-type"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:e36ecbfa85109dfb"
+      "sourceHash": "fnv1a64:26af03d5de07dead"
     },
     {
       "id": "HI-C01-alvida",
@@ -14912,7 +15170,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:2f6fac68a084606c",
+      "sourceHash": "fnv1a64:553885ef8fce1ee2",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -15056,7 +15314,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ee0eb7d8e9024f10",
+      "sourceHash": "fnv1a64:f9d45fa8e08e7d18",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -15194,7 +15452,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e1c24c88399adaca",
+      "sourceHash": "fnv1a64:350f1c0bbea0616c",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -15348,7 +15606,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:26289ff3f3503fe7"
+      "sourceHash": "fnv1a64:79169e506f53d6cd"
     },
     {
       "id": "HI-C08-kripaya",
@@ -15546,7 +15804,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9f64c469ba547d55"
+      "sourceHash": "fnv1a64:3cf3287daf0ef18b"
     },
     {
       "id": "HI-C15-paani-roti",
@@ -15726,7 +15984,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:df7700b573fce384"
+      "sourceHash": "fnv1a64:7654234c3bf74681"
     },
     {
       "id": "HI-C23-kutta-billi",
@@ -15744,7 +16002,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:47c46e86a23f8923"
+      "sourceHash": "fnv1a64:1e4f97628c48b9b1"
     },
     {
       "id": "HI-C23-billi-history",
@@ -16350,7 +16608,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:af7966db27fdd5d9"
+      "sourceHash": "fnv1a64:12dbb54d4f03c1e3"
     },
     {
       "id": "IT-C02-come-stai",
@@ -17072,7 +17330,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8d4b5481167925c8"
+      "sourceHash": "fnv1a64:87e175498a57b50c"
     },
     {
       "id": "IT-C16-essere",
@@ -17162,7 +17420,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ad1ac30c6518f022"
+      "sourceHash": "fnv1a64:ec786a73bf664872"
     },
     {
       "id": "IT-C17-mano",
@@ -17180,7 +17438,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a462acace3a0153a"
+      "sourceHash": "fnv1a64:30e82540daa65b92"
     },
     {
       "id": "IT-C18-pensare",
@@ -17405,7 +17663,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:405ea26c254381c6",
+      "sourceHash": "fnv1a64:00d779c076662e0e",
       "detachableSegments": [
         "Script — kanji, and the readings problem"
       ]
@@ -17592,7 +17850,7 @@
         "wide-table"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:cd038c2959d9f124"
+      "sourceHash": "fnv1a64:990f8bed0464b050"
     },
     {
       "id": "KA-C01-sari",
@@ -17610,7 +17868,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9aa5a310f9bc828b",
+      "sourceHash": "fnv1a64:805a095b1041dc57",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -18384,7 +18642,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7c3ffdf9f20e84bf"
+      "sourceHash": "fnv1a64:f73a4d5c3f34c2df"
     },
     {
       "id": "KA-C19-vayassu",
@@ -18402,7 +18660,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b1ca6627d9b28ecb"
+      "sourceHash": "fnv1a64:e3ad4ab4ba5f1858"
     },
     {
       "id": "KA-C20-hannondu-ippattu",
@@ -18456,7 +18714,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7e629189ef8f7017"
+      "sourceHash": "fnv1a64:bfd9603009a0b0c5"
     },
     {
       "id": "KA-C22-hasiru-haladi",
@@ -18474,7 +18732,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:43482806a1544152"
+      "sourceHash": "fnv1a64:6b4ce584accf6c2a"
     },
     {
       "id": "KA-C23-dina",
@@ -19016,7 +19274,7 @@
         "wide-table"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:a1d47161206de2cc"
+      "sourceHash": "fnv1a64:d29f71d351fbc066"
     },
     {
       "id": "LA-C02-numbers-6-10",
@@ -19250,7 +19508,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:1815c089d95f1f84"
+      "sourceHash": "fnv1a64:b1418f185aaaaac2"
     },
     {
       "id": "LA-C10-panis",
@@ -19286,7 +19544,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8829f5644f26d3b8"
+      "sourceHash": "fnv1a64:767b2688a9fef140"
     },
     {
       "id": "LA-C12-medius-dies-nox",
@@ -19538,7 +19796,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:d26baa3eb553be8a"
+      "sourceHash": "fnv1a64:e7fa4ed193474c2c"
     },
     {
       "id": "LA-C21-meeting-phrase-context",
@@ -19592,7 +19850,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:4746a09ecea844d0"
+      "sourceHash": "fnv1a64:58b50d89a5634ac8"
     },
     {
       "id": "LA-C23-nihil-est",
@@ -19736,7 +19994,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:66256ba5a5212e25"
+      "sourceHash": "fnv1a64:227678274c9d90e1"
     },
     {
       "id": "LA-C31-mane",
@@ -20207,6 +20465,150 @@
       "sourceHash": "fnv1a64:c051a21f677da1d1"
     },
     {
+      "id": "LA-C40-audio",
+      "language": "latin",
+      "chapter": 40,
+      "sequence": 800,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7857a70e4ef5dbec"
+    },
+    {
+      "id": "LA-C40-dormio",
+      "language": "latin",
+      "chapter": 40,
+      "sequence": 810,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3478cf58bd29876f"
+    },
+    {
+      "id": "LA-C40-sedeo",
+      "language": "latin",
+      "chapter": 40,
+      "sequence": 820,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1f6f7d06cae484ef"
+    },
+    {
+      "id": "LA-C40-sto",
+      "language": "latin",
+      "chapter": 40,
+      "sequence": 830,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a9e7c0df7dfd7fca"
+    },
+    {
+      "id": "LA-C41-ambulo",
+      "language": "latin",
+      "chapter": 41,
+      "sequence": 840,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:d622fafe7bc4956d"
+    },
+    {
+      "id": "LA-C41-curro",
+      "language": "latin",
+      "chapter": 41,
+      "sequence": 850,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:bc6edcf40433f26f"
+    },
+    {
+      "id": "LA-C41-aperio",
+      "language": "latin",
+      "chapter": 41,
+      "sequence": 860,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:06626b6294c4415e"
+    },
+    {
+      "id": "LA-C41-claudo",
+      "language": "latin",
+      "chapter": 41,
+      "sequence": 870,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e7fda89b85277a5e"
+    },
+    {
       "id": "ML-C01-athe",
       "language": "malayalam",
       "chapter": 1,
@@ -20603,7 +21005,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:5e0de3df6b96aec1",
+      "sourceHash": "fnv1a64:edfd9838cfc6c07f",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -20624,7 +21026,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:5c17999601548f76",
+      "sourceHash": "fnv1a64:f7048cc0cbaacda2",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -21083,7 +21485,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:6da9faf1334b3f22"
+      "sourceHash": "fnv1a64:7d243c4083456d88"
     },
     {
       "id": "ML-C17-paathira",
@@ -21191,7 +21593,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:1b76808f04d3669a"
+      "sourceHash": "fnv1a64:e2c8e98f67490f7e"
     },
     {
       "id": "ML-C22-paccha-manja",
@@ -21263,7 +21665,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:53a7d4f15dc6e80c"
+      "sourceHash": "fnv1a64:3aa52d9e621d242e"
     },
     {
       "id": "ML-C24-native-night-words",
@@ -21299,7 +21701,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b5ee132494024238"
+      "sourceHash": "fnv1a64:39130dc31be628cc"
     },
     {
       "id": "ML-C26-raavile",
@@ -23211,7 +23613,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b0cbd7ebe8850758"
+      "sourceHash": "fnv1a64:bd65bbf669f07dc2"
     },
     {
       "id": "FA-C08-porsidan",
@@ -24023,7 +24425,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:728021c129cdefb6"
+      "sourceHash": "fnv1a64:ca89807f7cb84ee2"
     },
     {
       "id": "PT-C11-pao",
@@ -25470,7 +25872,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ba5e85879b8768cb",
+      "sourceHash": "fnv1a64:b3ba243cf1ee590e",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -25844,7 +26246,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:1d3d69c6c4518117"
+      "sourceHash": "fnv1a64:18eedafd904b8b7b"
     },
     {
       "id": "RU-C02-kak-vas-zovut",
@@ -26289,7 +26691,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:727560286d972f72",
+      "sourceHash": "fnv1a64:386744037c9fab92",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -26754,7 +27156,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:06c187eb35a64186",
+      "sourceHash": "fnv1a64:e1ceeeb95c714166",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -26837,7 +27239,7 @@
         "wide-table"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:09f36fd41edd6bf6"
+      "sourceHash": "fnv1a64:d11d09bd8e57ad00"
     },
     {
       "id": "SA-C06-number-cognates",
@@ -29926,6 +30328,150 @@
       "sourceHash": "fnv1a64:076b246ba782b686"
     },
     {
+      "id": "ES-C36-oir",
+      "language": "spanish",
+      "chapter": 36,
+      "sequence": 1690,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:95c8c58081d9ca9c"
+    },
+    {
+      "id": "ES-C36-dormir",
+      "language": "spanish",
+      "chapter": 36,
+      "sequence": 1700,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:23270a43f8e6de20"
+    },
+    {
+      "id": "ES-C36-caminar",
+      "language": "spanish",
+      "chapter": 36,
+      "sequence": 1710,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e8a248a22b872d8c"
+    },
+    {
+      "id": "ES-C36-correr",
+      "language": "spanish",
+      "chapter": 36,
+      "sequence": 1720,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7f6e36b48265ebc3"
+    },
+    {
+      "id": "ES-C37-abrir",
+      "language": "spanish",
+      "chapter": 37,
+      "sequence": 1730,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f0a0b0104cc7285b"
+    },
+    {
+      "id": "ES-C37-cerrar",
+      "language": "spanish",
+      "chapter": 37,
+      "sequence": 1740,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8d8eec3b9af68c5b"
+    },
+    {
+      "id": "ES-C37-sentarse",
+      "language": "spanish",
+      "chapter": 37,
+      "sequence": 1750,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:07fa41c64388469a"
+    },
+    {
+      "id": "ES-C37-levantarse",
+      "language": "spanish",
+      "chapter": 37,
+      "sequence": 1760,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:12daf97af771d3c5"
+    },
+    {
       "id": "TA-W01-curves-va-ka",
       "language": "tamil",
       "chapter": 1,
@@ -30954,7 +31500,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:d90c27fb2d5e0c93"
+      "sourceHash": "fnv1a64:b6af60ab308e7049"
     },
     {
       "id": "TA-C09-sorry-register",
@@ -30993,7 +31539,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:d6deae3e70e1cb8b"
+      "sourceHash": "fnv1a64:7d4d6526c887f8d7"
     },
     {
       "id": "TA-C11-nirangal",
@@ -31011,7 +31557,7 @@
         "sight-cue"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:57cc7e3f10c4a1d8"
+      "sourceHash": "fnv1a64:442d28ae6ba4719a"
     },
     {
       "id": "TA-C12-kudumbam",
@@ -31065,7 +31611,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:694c78bf15e7787a"
+      "sourceHash": "fnv1a64:555129c6b521a26a"
     },
     {
       "id": "TA-C15-thanneer-arisi",
@@ -31191,7 +31737,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7cd19cdfa68e405f"
+      "sourceHash": "fnv1a64:707e217350c30e75"
     },
     {
       "id": "TA-C19-age-register-grammar",
@@ -31227,7 +31773,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7262158bd8ed0238"
+      "sourceHash": "fnv1a64:83599a85f76e0d2c"
     },
     {
       "id": "TA-C20-vaanilai",
@@ -31245,7 +31791,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:d7b6f1dddb46cfde"
+      "sourceHash": "fnv1a64:e976c1dcd9de69f6"
     },
     {
       "id": "TA-C21-naay-poonai",
@@ -31299,7 +31845,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:77b519193dd4561d"
+      "sourceHash": "fnv1a64:ad1a9f6edfca5d2b"
     },
     {
       "id": "TA-C23-day-family-register",
@@ -31335,7 +31881,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c5945153902f2494"
+      "sourceHash": "fnv1a64:32036d5e65c5aec1"
     },
     {
       "id": "TA-C24-night-register-darkness",
@@ -31443,7 +31989,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b28557a764c08bb8"
+      "sourceHash": "fnv1a64:0568dee970d8dc36"
     },
     {
       "id": "TA-C28-afternoon-boundary",
@@ -31743,7 +32289,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:461fc79451361c98",
+      "sourceHash": "fnv1a64:3247ff041aada7e8",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -31909,7 +32455,7 @@
         "wide-table"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:54e10d121ebdf0e1"
+      "sourceHash": "fnv1a64:95fea69b15a25359"
     },
     {
       "id": "TE-C01-sare",
@@ -32564,7 +33110,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:442aa8558e8036cc"
+      "sourceHash": "fnv1a64:d9887faa67f4d0a2"
     },
     {
       "id": "TE-C12-kutumbam",
@@ -32708,7 +33254,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:38cdddf1d35e0de1"
+      "sourceHash": "fnv1a64:93863a8dc7d95c43"
     },
     {
       "id": "TE-C20-padakondu-iravai",
@@ -32726,7 +33272,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8b15c534e755f7c6"
+      "sourceHash": "fnv1a64:e884cbd15de39796"
     },
     {
       "id": "TE-C20-vatavaranam",
@@ -32924,7 +33470,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9c2387e268aedf0e"
+      "sourceHash": "fnv1a64:477b79f35bf246ca"
     },
     {
       "id": "TE-C31-subha-madhyahnam",
@@ -33491,7 +34037,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:37b78208f52d826d"
+      "sourceHash": "fnv1a64:b3f0baedf26298f9"
     },
     {
       "id": "UR-C04-main-thik-hun",
@@ -33581,7 +34127,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b59762c651c4b0f6",
+      "sourceHash": "fnv1a64:7ba30adc928f3954",
       "detachableSegments": [
         "Script Bridge — shared history, local spacing"
       ]
@@ -33854,7 +34400,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e6d8568047160abb",
+      "sourceHash": "fnv1a64:c6c945a4954aefbb",
       "detachableSegments": [
         "The letters in this word"
       ]

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,18 +7,18 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:52a1932143b668c3",
+  "sourceHash": "fnv1a64:923e0671dc2d5da0",
   "summary": {
-    "totalLessons": 1385,
-    "voice": 909,
+    "totalLessons": 1393,
+    "voice": 917,
     "sight": 423,
     "pen": 53,
-    "drivableLessons": 909,
+    "drivableLessons": 917,
     "drivablePercent": 66,
     "trackCount": 22,
-    "chapterCount": 434,
-    "drivablePrefixTotal": 726,
-    "fullyDrivableChapters": 289,
+    "chapterCount": 436,
+    "drivablePrefixTotal": 734,
+    "fullyDrivableChapters": 291,
     "unstartableChapters": 108,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
@@ -5682,12 +5682,12 @@
     },
     {
       "language": "spanish",
-      "lessonCount": 154,
-      "voice": 129,
+      "lessonCount": 162,
+      "voice": 137,
       "sight": 18,
       "pen": 7,
-      "drivablePercent": 84,
-      "drivablePrefixTotal": 99,
+      "drivablePercent": 85,
+      "drivablePrefixTotal": 107,
       "modalities": [
         "voice",
         "sight",
@@ -6327,6 +6327,44 @@
             "ES-C35-preguntar",
             "ES-C35-ayudar",
             "ES-C35-gustar"
+          ]
+        },
+        {
+          "chapter": 36,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "ES-C36-oir",
+            "ES-C36-dormir",
+            "ES-C36-caminar",
+            "ES-C36-correr"
+          ]
+        },
+        {
+          "chapter": 37,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "ES-C37-abrir",
+            "ES-C37-cerrar",
+            "ES-C37-sentarse",
+            "ES-C37-levantarse"
           ]
         }
       ]
@@ -29742,6 +29780,150 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:076b246ba782b686"
+    },
+    {
+      "id": "ES-C36-oir",
+      "language": "spanish",
+      "chapter": 36,
+      "sequence": 1690,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:95c8c58081d9ca9c"
+    },
+    {
+      "id": "ES-C36-dormir",
+      "language": "spanish",
+      "chapter": 36,
+      "sequence": 1700,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:23270a43f8e6de20"
+    },
+    {
+      "id": "ES-C36-caminar",
+      "language": "spanish",
+      "chapter": 36,
+      "sequence": 1710,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e8a248a22b872d8c"
+    },
+    {
+      "id": "ES-C36-correr",
+      "language": "spanish",
+      "chapter": 36,
+      "sequence": 1720,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7f6e36b48265ebc3"
+    },
+    {
+      "id": "ES-C37-abrir",
+      "language": "spanish",
+      "chapter": 37,
+      "sequence": 1730,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f0a0b0104cc7285b"
+    },
+    {
+      "id": "ES-C37-cerrar",
+      "language": "spanish",
+      "chapter": 37,
+      "sequence": 1740,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8d8eec3b9af68c5b"
+    },
+    {
+      "id": "ES-C37-sentarse",
+      "language": "spanish",
+      "chapter": 37,
+      "sequence": 1750,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:07fa41c64388469a"
+    },
+    {
+      "id": "ES-C37-levantarse",
+      "language": "spanish",
+      "chapter": 37,
+      "sequence": 1760,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:12daf97af771d3c5"
     },
     {
       "id": "TA-W01-curves-va-ka",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,18 +7,18 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:52a1932143b668c3",
+  "sourceHash": "fnv1a64:8aff5a9628c8adf6",
   "summary": {
-    "totalLessons": 1385,
-    "voice": 909,
+    "totalLessons": 1393,
+    "voice": 917,
     "sight": 423,
     "pen": 53,
-    "drivableLessons": 909,
+    "drivableLessons": 917,
     "drivablePercent": 66,
     "trackCount": 22,
-    "chapterCount": 434,
-    "drivablePrefixTotal": 726,
-    "fullyDrivableChapters": 289,
+    "chapterCount": 436,
+    "drivablePrefixTotal": 734,
+    "fullyDrivableChapters": 291,
     "unstartableChapters": 108,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
@@ -743,12 +743,12 @@
     },
     {
       "language": "french",
-      "lessonCount": 81,
-      "voice": 66,
+      "lessonCount": 89,
+      "voice": 74,
       "sight": 12,
       "pen": 3,
-      "drivablePercent": 81,
-      "drivablePrefixTotal": 50,
+      "drivablePercent": 83,
+      "drivablePrefixTotal": 58,
       "modalities": [
         "voice",
         "sight",
@@ -1182,6 +1182,44 @@
             "FR-C25-penser",
             "FR-C25-lire",
             "FR-C25-ecrire"
+          ]
+        },
+        {
+          "chapter": 26,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "FR-C26-entendre",
+            "FR-C26-dormir",
+            "FR-C26-marcher",
+            "FR-C26-courir"
+          ]
+        },
+        {
+          "chapter": 27,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "FR-C27-sasseoir",
+            "FR-C27-se-lever",
+            "FR-C27-ouvrir",
+            "FR-C27-fermer"
           ]
         }
       ]
@@ -11738,6 +11776,150 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:c75664e4497104d6"
+    },
+    {
+      "id": "FR-C26-entendre",
+      "language": "french",
+      "chapter": 26,
+      "sequence": 790,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:2fcffc50b4c530f1"
+    },
+    {
+      "id": "FR-C26-dormir",
+      "language": "french",
+      "chapter": 26,
+      "sequence": 800,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8ac859110ce4c654"
+    },
+    {
+      "id": "FR-C26-marcher",
+      "language": "french",
+      "chapter": 26,
+      "sequence": 810,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:97bc8031093782ab"
+    },
+    {
+      "id": "FR-C26-courir",
+      "language": "french",
+      "chapter": 26,
+      "sequence": 820,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:06b9e4a83df44973"
+    },
+    {
+      "id": "FR-C27-sasseoir",
+      "language": "french",
+      "chapter": 27,
+      "sequence": 830,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:22351bcb8b4bd18e"
+    },
+    {
+      "id": "FR-C27-se-lever",
+      "language": "french",
+      "chapter": 27,
+      "sequence": 840,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c7f80390b7695f21"
+    },
+    {
+      "id": "FR-C27-ouvrir",
+      "language": "french",
+      "chapter": 27,
+      "sequence": 850,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9520fc80bfc81ee2"
+    },
+    {
+      "id": "FR-C27-fermer",
+      "language": "french",
+      "chapter": 27,
+      "sequence": 860,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b24800fffba8e018"
     },
     {
       "id": "GE-C01-abend",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,18 +7,18 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:52a1932143b668c3",
+  "sourceHash": "fnv1a64:8a810f17ef39dd1f",
   "summary": {
-    "totalLessons": 1385,
-    "voice": 909,
+    "totalLessons": 1393,
+    "voice": 917,
     "sight": 423,
     "pen": 53,
-    "drivableLessons": 909,
+    "drivableLessons": 917,
     "drivablePercent": 66,
     "trackCount": 22,
-    "chapterCount": 434,
-    "drivablePrefixTotal": 726,
-    "fullyDrivableChapters": 289,
+    "chapterCount": 436,
+    "drivablePrefixTotal": 734,
+    "fullyDrivableChapters": 291,
     "unstartableChapters": 108,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
@@ -3329,12 +3329,12 @@
     },
     {
       "language": "latin",
-      "lessonCount": 73,
-      "voice": 70,
+      "lessonCount": 81,
+      "voice": 78,
       "sight": 3,
       "pen": 0,
       "drivablePercent": 96,
-      "drivablePrefixTotal": 69,
+      "drivablePrefixTotal": 77,
       "modalities": [
         "voice",
         "sight"
@@ -3991,6 +3991,44 @@
             "LA-C39-rogo",
             "LA-C39-adiuvo",
             "LA-C39-amo"
+          ]
+        },
+        {
+          "chapter": 40,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "LA-C40-audio",
+            "LA-C40-dormio",
+            "LA-C40-sedeo",
+            "LA-C40-sto"
+          ]
+        },
+        {
+          "chapter": 41,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "LA-C41-ambulo",
+            "LA-C41-curro",
+            "LA-C41-aperio",
+            "LA-C41-claudo"
           ]
         }
       ]
@@ -20023,6 +20061,150 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:c051a21f677da1d1"
+    },
+    {
+      "id": "LA-C40-audio",
+      "language": "latin",
+      "chapter": 40,
+      "sequence": 800,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7857a70e4ef5dbec"
+    },
+    {
+      "id": "LA-C40-dormio",
+      "language": "latin",
+      "chapter": 40,
+      "sequence": 810,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3478cf58bd29876f"
+    },
+    {
+      "id": "LA-C40-sedeo",
+      "language": "latin",
+      "chapter": 40,
+      "sequence": 820,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1f6f7d06cae484ef"
+    },
+    {
+      "id": "LA-C40-sto",
+      "language": "latin",
+      "chapter": 40,
+      "sequence": 830,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a9e7c0df7dfd7fca"
+    },
+    {
+      "id": "LA-C41-ambulo",
+      "language": "latin",
+      "chapter": 41,
+      "sequence": 840,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:d622fafe7bc4956d"
+    },
+    {
+      "id": "LA-C41-curro",
+      "language": "latin",
+      "chapter": 41,
+      "sequence": 850,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:bc6edcf40433f26f"
+    },
+    {
+      "id": "LA-C41-aperio",
+      "language": "latin",
+      "chapter": 41,
+      "sequence": 860,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:06626b6294c4415e"
+    },
+    {
+      "id": "LA-C41-claudo",
+      "language": "latin",
+      "chapter": 41,
+      "sequence": 870,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e7fda89b85277a5e"
     },
     {
       "id": "ML-C01-athe",

--- a/code/learning/human-languages/french/CHANGELOG.md
+++ b/code/learning/human-languages/french/CHANGELOG.md
@@ -1,5 +1,100 @@
 # Changelog
 
+## Eight verbs no track had ever taught — 2026-08-07
+
+- Authored **Chapters 26 and 27**: eight canonical verb concepts that **no
+  track in the corpus realised** before this tranche. One verb per lesson,
+  gone deep, `concept_tag` verbatim:
+
+  | Lesson | Concept | Verb |
+  |---|---|---|
+  | `FR-C26-entendre` | `VERB-HEAR` | entendre |
+  | `FR-C26-dormir` | `VERB-SLEEP` | dormir |
+  | `FR-C26-marcher` | `VERB-WALK` | marcher |
+  | `FR-C26-courir` | `VERB-RUN` | courir |
+  | `FR-C27-sasseoir` | `VERB-SIT` | s'asseoir |
+  | `FR-C27-se-lever` | `VERB-STAND` | se lever / debout |
+  | `FR-C27-ouvrir` | `VERB-OPEN` | ouvrir |
+  | `FR-C27-fermer` | `VERB-CLOSE` | fermer |
+
+  French goes from **14 of the 40** core verbs to **22 of 40** (35% → 55%), the
+  deepest verb coverage in the corpus. The corpus-wide `universallyMissing`
+  list — concepts nobody teaches — falls from 15 to 7.
+- **Two chapters, not one.** Eight one-verb lessons introduce twenty-two atoms
+  against a per-chapter budget of twelve. Split, Chapter 26 introduces **11**
+  and Chapter 27 introduces **11**, so the ramp report finds **zero** lesson or
+  chapter violations for either and the corpus totals hold at 40 and 25.
+- ***entendre*** gets the tranche's signature block, and the framing is
+  corrected against the record. It is Latin *intendere*, "**to stretch
+  toward**" — English's **intend** is the plainest survival — but the "hear"
+  sense is **not** a late arrival: it is attested from the oldest French texts
+  (c. 1050), alongside attending, understanding and intending. What changed
+  later is that the others fell away as *ouïr* (← *audīre*) wore out, leaving
+  them in *entendu*, *s'entendre* "to get along" and *l'entente*. English kept
+  the *audīre* family instead. Three mind-verbs, three body pictures:
+  *comprendre* grasps, *penser* weighs, *entendre* stretches.
+- **Reflexive body positions, honestly taught.** *S'asseoir* ships with **two**
+  accepted paradigms; the lesson teaches the *-ie-* series whole and marks the
+  *-oi-* singulars as ordinary speech whose plurals (*assoyons*, *assoyez*) are
+  much rarer in France, rather than presenting the two as symmetric. *Je suis
+  assis* is separated from *je m'assieds* as state against movement. And French
+  has **no single verb** for "to stand": the movement is *se lever*, the state
+  is *être debout* — *de* + *bout*, "on end."
+- **The conjugation trap is named.** *Ouvrir* ends in *-ir* and takes *-er*
+  endings, the same set as *marcher*; *fermer* owns them outright, so the two
+  opposites drill as one pair.
+- **Every uncertain link is marked uncertain.** *Marcher*'s origin is left
+  **unsettled** between Frankish **markōn* and Latin *marcus* "a hammer";
+  English *march* is secure (a borrowing *from* French) while English *mark* is
+  a relative **only if** the Frankish account holds, and *la marche*
+  "borderland" is flagged as a separate arrival from the Germanic noun. The
+  **dormouse** is named as **folk etymology** — the story needs an Anglo-Norman
+  word nobody has found. Latin *carrus* (→ *car*, *cargo*) is a **Gaulish
+  loan** sharing *currere*'s root, not a form built from it. English *butt* is
+  a **loan back out of French**, not a Germanic cousin of *bout*; the cousin by
+  descent is **beat**. *Ouvrir* is *aperīre* **reshaped** on its antonym,
+  "probably" — not a blend of two unrelated verbs. And *farm* ← *firmāre* is
+  given as the mainstream account with Old English *feorm* named as
+  interference.
+- **Reinforcement at two cadences (HL09 §7).** Every lesson practises atoms
+  from the **one to three lessons immediately before it**, across the chapter
+  seam — the only cadence that can close the R1 window, since a chapter-end
+  payoff is out of range for the chapter's opening material. On top of that,
+  each payoff reaches several chapters back: `FR-C26-courir` uses *courir*'s
+  hard *c* to re-earn why *canis* became *chien* (Ch.22), and runs *il fait
+  chaud* / *il pleut* (Ch.21) and *ne … pas* (Ch.18) against the new verbs;
+  `FR-C27-fermer` opens and closes *la main* (Ch.17), closes because *il pleut*
+  (Ch.21), and asks in both registers before apologising (Ch.19, Ch.20).
+  Measured: **eleven** French atoms that nothing had ever revisited now are —
+  `FR-ETYMON-CHIEN-03`, `FR-ETYMON-CHAT-05`, `FR-ETYMON-MAINTENIR-05`,
+  `FR-SOUND-MAIN-03`, `FR-GRAMMAR-IL-FAIT-03`, `FR-LEX-IL-PLEUT-04`,
+  `FR-GRAMMAR-NEGATION-04`, `FR-LEX-DESOLE-02`, `FR-PRAGMATICS-SORRY-04`,
+  `FR-ETYMON-COMPRENDRE-02`, `FR-ETYMON-PENSER-05`. French's
+  `atomsNeverRevisited` falls **33 → 25** while its atoms rise **54 → 76**.
+  Two of the tranche's own atoms remain unrevisited — `FR-ETYMON-COURIR-11`
+  and `FR-ETYMON-LEVER-05` — and that is recorded, not padded away.
+- **Payoffs clear the floor on their own merits**: Chapter 26 assesses **9 of
+  11** of its atoms (0.82), Chapter 27 **8 of 11** (0.73), both well above the
+  0.5 representativeness floor, with no `assesses` list padded.
+- **One pre-existing defect became visible and is not hidden.**
+  `FR-C16-passe-compose-etre` drills the learner on *Marcher, courir, nager* and
+  *danser* as movement verbs that take *avoir* — none of which the track taught.
+  Two of those four are now taught, ten chapters later, so the continuity report
+  reports two new forward references (corpus 510 → 512). The earlier lesson was
+  left alone: deleting the words would move the number without fixing the
+  defect, which is that a Chapter 16 grammar lesson has no taught movement verb
+  to point at.
+- All eight lessons are schema v2 and modality `voice`: both chapters are
+  4-of-4 drivable, there is no table anywhere in them, and the six present-tense
+  forms are always a spoken bullet list. Effective durations **295–299 s**
+  against the 300 s ceiling.
+- Wiring: `curriculum.json` gains `FR-PATH-024`, a third `SPINE-SAY-WHAT-I-DO`
+  segment carrying all eight in reading order, and the eight concepts drop out
+  of that node's `omits` (28 → 20). `chapters.json`, `core/book-generation.json`,
+  `book.tex`, the generated ch26/ch27 TeX and the ch26/ch27 narration follow.
+  The French book compiles with XeLaTeX at **134 pages** (was 114) with zero
+  `Missing character` warnings and zero overfull or underfull boxes.
+
 ## Eight more core verbs, split across two chapters — 2026-08-07
 
 - Authored **Chapters 24 and 25**: the eight canonical verb concepts Spanish,

--- a/code/learning/human-languages/french/README.md
+++ b/code/learning/human-languages/french/README.md
@@ -58,10 +58,14 @@ between the two Latin daughters can become the lesson:
 - **Chapter 24 — Taking, Asking, Helping, Loving**: *prendre*, *demander*,
   *aider*, *aimer*.
 - **Chapter 25 — Verbs of the Mind**: *comprendre*, *penser*, *lire*, *écrire*.
+- **Chapter 26 — Hearing, Sleeping, Walking, Running**: *entendre*, *dormir*,
+  *marcher*, *courir*.
+- **Chapter 27 — Sitting, Standing, Opening, Closing**: *s'asseoir*, *se lever* /
+  *debout*, *ouvrir*, *fermer*.
 
-**All twenty-five chapters are authored and in the book (114 pages).**
+**All twenty-seven chapters are authored and in the book (134 pages).**
 
-### The verb tranche (Chapters 24–25)
+### The first verb tranche (Chapters 24–25)
 
 Eight canonical core verbs, one per lesson, taking French from **6 of the 40**
 shared core verbs to **14 of 40**. Each of the eight is already taught by
@@ -82,6 +86,44 @@ and "love," and adding *bien* to it makes it **weaker** (*je t'aime bien* is
 how you turn someone down); *demander* is a false friend and means plain
 "ask," never English's forceful "demand."
 
+### The second verb tranche (Chapters 26–27)
+
+Eight more canonical core verbs, one per lesson, taking French from **14 of the
+40** shared core verbs to **22 of 40** — the deepest coverage in the corpus.
+These eight were realised by **no track anywhere** before this tranche, so the
+concept ids `VERB-HEAR`, `VERB-SLEEP`, `VERB-WALK`, `VERB-RUN`, `VERB-SIT`,
+`VERB-STAND`, `VERB-OPEN` and `VERB-CLOSE` come off the corpus-wide
+"nobody teaches this" list.
+
+Split two-by-two for the same reason as the first tranche: eight one-verb
+lessons introduce twenty-two atoms against a chapter budget of twelve. Chapter
+26 introduces eleven and Chapter 27 introduces eleven, so both land inside
+budget and each carries its own capability and payoff.
+
+Four things this pair of chapters can say that the earlier ones could not:
+
+- ***entendre*** is Latin *intendere*, "**to stretch toward**" — the same verb
+  English kept as **intend**. From the oldest French texts it already covers
+  hearing, attending, understanding and intending all at once; what happened
+  later is that the other senses fell away as *ouïr* (← *audīre*) wore out, and
+  they survive only in *entendu*, *s'entendre* "to get along" and *l'entente*.
+  English took the *audīre* family instead — *audio*, *audience*, *audible*.
+- **the body-position verbs are reflexive**, and ***s'asseoir*** ships with
+  **two** accepted paradigms (*je m'assieds* and *je m'assois*). The lesson
+  teaches the *-ie-* series whole and marks the *-oi-* singulars as ordinary
+  speech whose plurals are much rarer, rather than pretending the two are
+  symmetric.
+- **French has no single verb for "to stand."** The movement is ***se lever***
+  and the state is ***être debout***, which is *de* + *bout*, "**on end**."
+- ***ouvrir*** ends in *-ir* and takes ***-er*** endings, the same set as
+  *marcher*; ***fermer*** owns them outright, so the two opposites drill as one
+  pair.
+
+And two useful everyday facts land here: *ça marche* means "that works, fine,
+deal," and *fermer* is Latin *firmāre* — a French door is not shut but **made
+firm**, the same verb that gave Italian *fermare* "to stop" and Spanish
+*firmar* "to sign."
+
 ---
 
 ## For contributors
@@ -96,7 +138,7 @@ language.
 finish a chapter, and names the lesson that proves it. It is authored intent —
 no validator may rewrite it.
 
-**Nine of twenty-five chapters are authored: 17–25.** Those are exactly the
+**Eleven of twenty-seven chapters are authored: 17–27.** Those are exactly the
 chapters whose lessons have been migrated to schema version 2 and so declare
 real knowledge atoms. Chapters 1–16 are still schema v1 and carry no
 `practises.knowledge`, so a payoff written for them could only assess invented
@@ -117,8 +159,10 @@ actually assesses, floored at 0.5 by `core/chapter-policy.json`:
 | 23 Green and Yellow | `FR-C23-vert-jaune` | 5 / 5 = 1.00 |
 | 24 Taking, Asking, Helping, Loving | `FR-C24-aimer` | 7 / 11 = 0.64 |
 | 25 Verbs of the Mind | `FR-C25-ecrire` | 6 / 9 = 0.67 |
+| 26 Hearing, Sleeping, Walking, Running | `FR-C26-courir` | 9 / 11 = 0.82 |
+| 27 Sitting, Standing, Opening, Closing | `FR-C27-fermer` | 8 / 11 = 0.73 |
 
-Chapters 17, 18, 24 and 25 have **no terminal consolidation lesson**, so their
+Chapters 17, 18 and 24–27 have **no terminal consolidation lesson**, so their
 payoff is the last lesson by `sequence`. Chapter 18 still clears the floor
 because *non* reassesses *oui*; Chapter 17 sits exactly on it. No `assesses`
 list is padded — a shortfall is a signal that the chapter needs a real practice
@@ -135,6 +179,26 @@ which is not decoration, since *manuscript* is *manus* + *scrībere* — plus
 that had never been revisited by anything now are**: `FR-LEX-MAIN-02`,
 `FR-ETYMON-MAIN-04`, `FR-LEX-CHIEN-02`, `FR-LEX-CHAT-04`, `FR-LEX-PLEASE-02`,
 `FR-GRAMMAR-PLEASE-REGISTER-04`, `FR-LEX-NON-02` and `FR-SOUND-NON-03`.
+
+Chapters 26 and 27 reach back at **two** cadences rather than one. Every lesson
+practises atoms from the **one to three lessons immediately before it**, across
+the chapter seam — which is the only cadence that can close HL09's R1 window
+(n+1 … n+3), because a chapter-*end* payoff is out of range for everything the
+chapter opened with. On top of that, each payoff reaches several chapters back:
+`FR-C26-courir` uses *courir*'s hard *c* to re-earn why *canis* became *chien*
+(Chapter 22), and runs *il fait chaud* / *il pleut* (Chapter 21) and *ne … pas*
+(Chapter 18) against the new verbs; `FR-C27-fermer` opens and closes *la main*
+(Chapter 17), closes because *il pleut* (Chapter 21), and asks in both registers
+before apologising (Chapters 19 and 20).
+
+Measured effect: **eleven more French atoms that nothing had ever revisited now
+are** — `FR-ETYMON-CHIEN-03`, `FR-ETYMON-CHAT-05`, `FR-ETYMON-MAINTENIR-05`,
+`FR-SOUND-MAIN-03`, `FR-GRAMMAR-IL-FAIT-03`, `FR-LEX-IL-PLEUT-04`,
+`FR-GRAMMAR-NEGATION-04`, `FR-LEX-DESOLE-02`, `FR-PRAGMATICS-SORRY-04`,
+`FR-ETYMON-COMPRENDRE-02` and `FR-ETYMON-PENSER-05`. French's
+`atomsNeverRevisited` falls 33 → 25 while its atom count rises 54 → 76. Two of
+the tranche's own new atoms are still unrevisited — `FR-ETYMON-COURIR-11` and
+`FR-ETYMON-LEVER-05` — and that is recorded rather than papered over.
 
 ## Files
 

--- a/code/learning/human-languages/french/book/book.tex
+++ b/code/learning/human-languages/french/book/book.tex
@@ -101,6 +101,8 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch23-green-and-yellow}
 \input{chapters/ch24-taking-asking-helping-loving}
 \input{chapters/ch25-verbs-of-the-mind}
+\input{chapters/ch26-hearing-sleeping-walking-running}
+\input{chapters/ch27-sitting-standing-opening-closing}
 
 
 \backmatter

--- a/code/learning/human-languages/french/book/chapters/ch26-hearing-sleeping-walking-running.tex
+++ b/code/learning/human-languages/french/book/chapters/ch26-hearing-sleeping-walking-running.tex
@@ -1,0 +1,304 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:8fceb055d3841a03
+% canonical-lessons: FR-C26-entendre, FR-C26-dormir, FR-C26-marcher, FR-C26-courir
+
+\chapter{Hearing, Sleeping, Walking, Running}
+\label{ch:fr-hearing-sleeping-walking-running}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can say that I hear, sleep, walk and run in French, use ça marche for \textquotedblleft{}that works,\textquotedblright{} and say why entendre carries English's intend inside it while the Latin verb for hearing ended up in English instead.}
+
+Run the chapter's four verbs together with je — j'entends, je dors, je marche, je cours — then use courir's spelling to settle why canis became chien while currere stayed hard at the front: the ca- shift only ever struck c before a. Reaches back past the chapter to le chien and its palatalization from Chapter 22, le chat from the same chapter, il fait chaud and il pleut from Chapter 21, and the ne … pas negation from Chapter 18.
+\end{chapteropening}
+
+\section[entendre]{entendre — \textquotedblleft{}to hear,\textquotedblright{} and the stretching inside it}
+
+\label{lesson:FR-C26-entendre}
+
+
+
+\begin{quote}
+You can think and understand. Now the ear — and French's word for it is English's \emph{intend}.
+\end{quote}
+
+\subsection*{You'll want to know: the word}
+\begin{quote}
+\textbf{entendre} — to hear. Two nasal \emph{an} sounds in a row, then the \emph{-dre} of \emph{prendre}: say it \emph{ahn-TAHN-druh}.
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{J'entends le chien.} — I hear the dog.
+\end{quote}
+
+The \emph{-ds} of \emph{j'entends} is silent, as in \emph{je prends}.
+
+\begin{grammarlens}[title={Grammar Lens: the nasal that stays put}]
+\emph{Prendre}'s nasal dies in the plural. \emph{Entendre} looks like its twin and does the opposite — the stem never moves:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{j'entends} — \emph{jahn-TAHN}
+  \item \textbf{tu entends} — \emph{ahn-TAHN}
+  \item \textbf{il entend} — \emph{ahn-TAHN} (three identical to the ear)
+  \item \textbf{nous entendons} — \emph{ahn-tahn-DOHN}, nasal still there
+  \item \textbf{vous entendez} — \emph{ahn-tahn-DAY}
+  \item \textbf{ils entendent} — \emph{ahn-TAHND}
+\end{itemize}
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{entendre} $\leftarrow$ Latin \textbf{intendere} — \textbf{in-} \textquotedblleft{}toward\textquotedblright{} plus \textbf{tendere}, \textquotedblleft{}\textbf{to stretch}.\textquotedblright{} To \emph{intendere} was to stretch a thing out and aim it: a bowstring, a journey, your attention. English kept the family — \textbf{intend}, plainest of them, plus \textbf{intent}, \textbf{intense}, \textbf{tension}, a \textbf{tent} (a stretched skin), \textbf{extend} and \textbf{pretend}.
+
+Set your three mind-verbs together: French pictures each as a different thing the body does.
+
+\begin{itemize}
+\raggedright
+  \item \textbf{comprendre} — to \textbf{grasp together}, built on \emph{prendre}.
+  \item \textbf{penser} — to \textbf{weigh}, from \emph{pēnsāre}.
+  \item \textbf{entendre} — to \textbf{stretch toward}.
+\end{itemize}
+\end{cousinweb}
+
+\begin{culture}
+From its oldest French records \emph{entendre} already covers a span at once: to hear, to attend, to understand, to intend. Nothing arrived late. What happened since is that the other senses fell away and hearing took the word outright — because Latin's verb for hearing, \textbf{audīre}, wore down in French to \emph{ouïr} and stopped being usable. English kept that family instead: \textbf{audio}, \textbf{audience}, \textbf{audible}, \textbf{audition}.
+
+The abandoned senses survive in phrases French never rebuilt:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{entendu} — \textquotedblleft{}understood,\textquotedblright{} \textquotedblleft{}agreed.\textquotedblright{}
+  \item \textbf{s'entendre} — to hear one another, and so to \textbf{get along}.
+  \item \textbf{l'entente} — an understanding between parties, borrowed into English whole in \emph{Entente Cordiale}.
+\end{itemize}
+
+So the two languages split one Latin pair: French hears with the verb English uses for intending, and English hears with the verb French let go.
+\end{culture}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}entendre\textquotedblright{} — \emph{ahn-TAHN-druh}, two nasals
+  \item \textquotedblleft{}j'entends le chien\textquotedblright{}
+  \item \textquotedblleft{}nous prenons\textquotedblright{} then \textquotedblleft{}nous entendons\textquotedblright{} — one flattens, one holds
+  \item \textquotedblleft{}j'écris, je comprends, j'entends\textquotedblright{}
+  \item the three pictures — stretching, grasping, weighing
+  \item \textquotedblleft{}intend, tension, tent\textquotedblright{} — all a stretching
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say \textquotedblleft{}I hear the dog\textquotedblright{} and \textquotedblleft{}we hear.\textquotedblright{} (\emph{J'entends le chien. Nous entendons} — and unlike \emph{nous prenons}, nothing flattens.) What did \emph{intendere} mean, and which English verb is its plainest survival? (\textbf{To stretch toward}; \textbf{intend}.) Why did French hand hearing to this verb? (Latin's \emph{audīre} wore down to \emph{ouïr} and fell out of use — English kept the \emph{audīre} words instead.) What does \emph{s'entendre} mean? (\textbf{To get along}.)
+\end{tcolorbox}
+\section[dormir]{dormir — \textquotedblleft{}to sleep,\textquotedblright{} and the room named after it}
+
+\label{lesson:FR-C26-dormir}
+
+
+
+\begin{quote}
+After a verb that changed jobs, here is one that never changed. \emph{Dormir} is Latin's word for sleeping, handed on almost untouched — and it hides one trap.
+\end{quote}
+
+\subsection*{You'll want to know: the word}
+\begin{quote}
+\textbf{dormir} — to sleep. Said \emph{dor-MEER}, with the throaty French \textbf{r} in the middle and at the end.
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{Le chat dort.} — The cat is sleeping.
+\end{quote}
+
+French has no separate \textquotedblleft{}is sleeping\textquotedblright{} form. \emph{Il dort} covers both \textquotedblleft{}he sleeps\textquotedblright{} and \textquotedblleft{}he is sleeping\textquotedblright{}; the plain present does all the work.
+
+\begin{grammarlens}[title={Grammar Lens: the m that goes missing}]
+The stem is \emph{dorm-}, and in the singular French throws the \textbf{m} away. Listen for where it comes back:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{je dors} — \emph{dor}
+  \item \textbf{tu dors} — \emph{dor}
+  \item \textbf{il dort} — \emph{dor} (three identical, the \emph{m} gone)
+  \item \textbf{nous dormons} — \emph{dor-MOHN}, and there it is
+  \item \textbf{vous dormez} — \emph{dor-MAY}
+  \item \textbf{ils dorment} — \emph{DORM}
+\end{itemize}
+
+One rule, and you have the whole verb: singular loses the last stem consonant, plural gets it back. A small family of \emph{-ir} verbs shares the shape, so learning it once is worth more than one verb.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{dormir} $\leftarrow$ Latin \textbf{dormīre}, \textquotedblleft{}to sleep.\textquotedblright{} Spanish kept \emph{dormir}, Italian \emph{dormire}, Portuguese \emph{dormir} — the verb crossed into its daughter languages untouched, which is rarer than it sounds. English has no inherited descendant; it borrowed the family later, through French:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{dormitory} $\leftarrow$ \emph{dormītōrium}, a sleeping place; French wore the identical word down to \textbf{dortoir}.
+  \item \textbf{dormant} — Old French \emph{dormant}, \textquotedblleft{}sleeping\textquotedblright{}; a dormant volcano is asleep.
+  \item \textbf{dormer} — a roof window, from Old French \emph{dormeor}, because the room behind it was where you slept.
+\end{itemize}
+
+And an honest stop. The \textbf{dormouse} looks like the best cousin of the lot and is not one. The story needs an Anglo-Norman word for \textquotedblleft{}sleeper\textquotedblright{} that nobody has found in a text, and \emph{dormouse}'s real origin is unknown. A guess in circulation, not an etymology.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}dormir\textquotedblright{} — \emph{dor-MEER}, throaty \emph{r}
+  \item \textquotedblleft{}je dors\textquotedblright{} then \textquotedblleft{}nous dormons\textquotedblright{} — the \emph{m} vanishes, then returns
+  \item \textquotedblleft{}le chat dort\textquotedblright{} — the cat, the travelling word out of Egypt
+  \item \textquotedblleft{}j'entends le chat\textquotedblright{} then \textquotedblleft{}le chat dort\textquotedblright{}
+  \item \textquotedblleft{}dormir, dormitory, dormant\textquotedblright{} — one Latin verb, borrowed back
+  \item \textquotedblleft{}je comprends\textquotedblright{} then \textquotedblleft{}je dors\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say \textquotedblleft{}the cat is sleeping\textquotedblright{} and \textquotedblleft{}we sleep.\textquotedblright{} (\emph{Le chat dort. Nous dormons} — the \emph{m} is silent in the singular and audible in the plural.) Where does \emph{dormitory} come from? (Latin \emph{dormītōrium}, \textquotedblleft{}a \textbf{sleeping place}\textquotedblright{} — and French wore the same word down to \emph{dortoir}.) Is the \textbf{dormouse} in this family? (\textbf{No} — that is folk etymology; the word's real origin is unknown.) And \emph{chat} — an inherited Latin word, or a traveller? (\textbf{A traveller}, from \emph{cattus}, moving with the cat itself out of Egypt.)
+\end{tcolorbox}
+\section[marcher]{marcher — \textquotedblleft{}to walk,\textquotedblright{} and the step hiding inside French negation}
+
+\label{lesson:FR-C26-marcher}
+
+
+
+\begin{quote}
+You can hear and you can sleep. Now move. This verb does a second job too, used dozens of times a day.
+\end{quote}
+
+\subsection*{You'll want to know: the word}
+\begin{quote}
+\textbf{marcher} — to walk. Said \emph{mar-SHAY}: the \emph{-er} is a clean \emph{ay}, and the \emph{ch} is \emph{sh}, never \emph{k}.
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{Je marche.} — I walk.
+\end{quote}
+
+After \emph{dormir}'s vanishing \emph{m}, this one asks nothing: an ordinary \textbf{-er} verb. \emph{Je marche, tu marches, il marche, nous marchons, vous marchez, ils marchent} — four of the six sound identical, just \emph{marsh}.
+
+\begin{culture}
+\emph{Marcher} is also the everyday verb for a thing \textbf{working}. A machine, a plan, an arrangement: if it functions, it walks.
+
+\begin{quote}
+\textbf{Ça marche.} — \textquotedblleft{}That works.\textquotedblright{} Also \textquotedblleft{}Fine,\textquotedblright{} \textquotedblleft{}Deal,\textquotedblright{} \textquotedblleft{}Sounds good.\textquotedblright{} \textbf{Ça ne marche pas.} — \textquotedblleft{}That doesn't work.\textquotedblright{}
+\end{quote}
+
+There is your \emph{ne … pas} from the answer-word \emph{non}, round a real verb at last. And \emph{ça marche} alone is an agreement, two words long.
+
+\emph{Entendre} once held several jobs and shed all but hearing. \emph{Marcher} holds two right now.
+\end{culture}
+
+\begin{cousinweb}
+Here the honest answer is that nobody is certain. Old French \emph{marchier} first meant \textquotedblleft{}\textbf{to trample, to tread on},\textquotedblright{} and two accounts compete:
+
+\begin{itemize}
+\raggedright
+  \item Frankish \textbf{markōn}, \textquotedblleft{}to mark, to press a step in\textquotedblright{} — preferred by most reference works.
+  \item Late Latin \emph{marcāre}, from \textbf{marcus}, \textquotedblleft{}\textbf{a hammer}\textquotedblright{} — a blow and a tread being one motion.
+\end{itemize}
+
+Three consequences, in falling order of certainty:
+
+\begin{itemize}
+\raggedright
+  \item English \textbf{march}, the verb, is borrowed straight \textbf{from} \emph{marcher}. Secure whichever origin is right.
+  \item English \textbf{mark} is Germanic, from Old English \emph{mearc}. A relative \textbf{only if} the Frankish account holds — conditional, not a fact.
+  \item French \textbf{la marche}, a borderland, with \textbf{marquis} and German \textbf{margrave}, comes from the Germanic \textbf{noun} \emph{marka}, \textquotedblleft{}boundary\textquotedblright{} — a separate arrival.
+\end{itemize}
+
+And one cousin you own already. The \textbf{pas} in \emph{ne … pas} began as Latin \emph{passus}, \textquotedblleft{}\textbf{a step}.\textquotedblright{} \emph{Je ne marche pas} is, underneath, \textquotedblleft{}I do not walk a step.\textquotedblright{}
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}marcher\textquotedblright{} — \emph{mar-SHAY}, \emph{sh} not \emph{k}
+  \item \textquotedblleft{}je marche\textquotedblright{} then \textquotedblleft{}nous marchons\textquotedblright{}
+  \item \textquotedblleft{}ça marche\textquotedblright{} — that works, that's fine
+  \item \textquotedblleft{}non\textquotedblright{}, then \textquotedblleft{}je ne marche pas\textquotedblright{} — and \emph{pas} is a \textbf{step}
+  \item \textquotedblleft{}j'entends, je dors, je marche\textquotedblright{}
+  \item \textquotedblleft{}nous dormons, nous marchons\textquotedblright{} — one stem shifts, one never does
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say \textquotedblleft{}I walk\textquotedblright{} and \textquotedblleft{}that works.\textquotedblright{} (\emph{Je marche. Ça marche}.) What are the two competing origins? (Frankish \textbf{markōn\emph{, \textquotedblleft{}to press a step in,\textquotedblright{} or Latin }marcus\emph{, \textquotedblleft{}\textbf{a hammer}.\textquotedblright{} Genuinely unsettled.) Which English word is certainly related, and which only might be? (\textbf{March}, borrowed straight from }marcher\emph{; \textbf{mark} only if the Frankish account is right.) What did }pas\emph{ mean before it meant \textquotedblleft{}not\textquotedblright{}? (\textbf{A step}.)}}
+\end{tcolorbox}
+\section[courir]{courir — \textquotedblleft{}to run,\textquotedblright{} and why it is not \emph{chourir}}
+
+\label{lesson:FR-C26-courir}
+
+
+
+\begin{quote}
+Hearing, sleeping, walking — and now the fastest of the four. Its Latin root is one of the busiest in English, and its spelling settles a question the dog raised.
+\end{quote}
+
+\subsection*{You'll want to know: the word}
+\begin{quote}
+\textbf{courir} — to run. Said \emph{koo-REER}, throaty at both \emph{r}s.
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{Le chien court.} — The dog runs.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: the same endings, a different stem}]
+\emph{Courir} takes \emph{dormir}'s singular endings — \textbf{-s, -s, -t}, all silent:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{je cours} — \emph{koor}
+  \item \textbf{tu cours} — \emph{koor}
+  \item \textbf{il court} — \emph{koor}
+  \item \textbf{nous courons} — \emph{koo-ROHN}
+  \item \textbf{vous courez} — \emph{koo-RAY}
+  \item \textbf{ils courent} — \emph{KOOR}
+\end{itemize}
+
+But the resemblance stops there. \emph{Dormir} \textbf{sheds} a consonant in the singular: \emph{dorm-} becomes \emph{dor-}. \emph{Courir} sheds nothing — its stem \emph{cour-} has nothing spare to lose.
+\end{grammarlens}
+
+\begin{cousinweb}
+\emph{Marcher} left a choice between a Frankish verb and a Latin hammer. This one leaves none. \textbf{courir} $\leftarrow$ Latin \textbf{currere}, \textquotedblleft{}to run,\textquotedblright{} which English mined harder than almost any other verb:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{current} and \textbf{currency} both run; a \textbf{cursor} runs across a screen; a \textbf{course} is a run, a \textbf{corridor} a running-place.
+  \item \textbf{courier}, one who runs; \textbf{curriculum}, literally \textquotedblleft{}\textbf{a running}.\textquotedblright{}
+  \item \textbf{concur}, run together; \textbf{occur}, run up against; \textbf{excursion}.
+\end{itemize}
+
+Now the spelling question. \emph{Chien} came from \emph{canis}, and its \textbf{c} turned into \textbf{ch} — the shift that made \emph{champ} and \emph{chanter}. So why is this verb not \emph{chourir}? Because that shift only struck \textbf{c} before \textbf{a}. \emph{Currere} had \textbf{c} before \textbf{u}, untouched, so the \emph{k} survived. One rule, two regular outcomes.
+
+One honest limit. Latin \textbf{carrus}, \textquotedblleft{}wagon,\textquotedblright{} gave English \textbf{car} and \textbf{cargo}, and descends from the same very old root. But Latin borrowed \emph{carrus} from Gaulish: a cousin by another road, not a word built out of \emph{currere}.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item the chapter's four with \emph{je} — \textquotedblleft{}j'entends, je dors, je marche, je cours\textquotedblright{}
+  \item \textquotedblleft{}le chien court\textquotedblright{} then \textquotedblleft{}le chat dort\textquotedblright{}
+  \item \textquotedblleft{}il fait chaud, je cours\textquotedblright{}
+  \item \textquotedblleft{}il pleut, je ne cours pas\textquotedblright{}
+  \item \textquotedblleft{}je dors, nous dormons\textquotedblright{} then \textquotedblleft{}je cours, nous courons\textquotedblright{} — one sheds
+  \item \textquotedblleft{}chien\textquotedblright{} then \textquotedblleft{}courir\textquotedblright{} — \emph{ch} before \emph{a}, \emph{k} before \emph{u}
+  \item \textquotedblleft{}current, course, courier, curriculum\textquotedblright{} — every one a running
+  \item \textquotedblleft{}ça marche\textquotedblright{} — the agreement, two words
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say the chapter's four verbs with \emph{je}. (\emph{J'entends, je dors, je marche, je cours}.) What does \textbf{curriculum} literally mean? (\textbf{A running} — from \emph{currere}.) Why did \emph{canis} become \emph{chien} while \emph{currere} stayed hard? (The shift only hit \textbf{c} before \textbf{a}.) Which of the four began as a \textbf{stretching}? (\emph{\textbf{Entendre}} — \emph{intendere}, to stretch toward.) Now: \textquotedblleft{}the dog runs\textquotedblright{} and \textquotedblleft{}it is hot.\textquotedblright{} (\emph{Le chien court. Il fait chaud}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/french/book/chapters/ch27-sitting-standing-opening-closing.tex
+++ b/code/learning/human-languages/french/book/chapters/ch27-sitting-standing-opening-closing.tex
@@ -1,0 +1,298 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:92921437a691bade
+% canonical-lessons: FR-C27-sasseoir, FR-C27-se-lever, FR-C27-ouvrir, FR-C27-fermer
+
+\chapter{Sitting, Standing, Opening, Closing}
+\label{ch:fr-sitting-standing-opening-closing}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can sit down, get up, open and close in French, hold both accepted paradigms of s'asseoir apart, say why French needs two pieces — se lever and debout — where English has one verb \textquotedblleft{}to stand,\textquotedblright{} and know that ouvrir takes marcher's endings despite its -ir spelling.}
+
+Say the chapter's four with je — je m'assieds, je me lève, j'ouvre, je ferme — drill ouvrir and fermer as one pair now that both carry the same endings, and take fermer apart into firmāre, 'to make firm', the verb that gave Italian fermare 'to stop' and Spanish firmar 'to sign'. Reaches back past the chapter to open and close la main from Chapter 17, to close because il pleut from Chapter 21, and to ask in both registers and then apologise, from Chapters 19 and 20.
+\end{chapteropening}
+
+\section[s'asseoir]{s'asseoir — \textquotedblleft{}to sit down,\textquotedblright{} a verb you do to yourself}
+
+\label{lesson:FR-C27-sasseoir}
+
+
+
+\begin{quote}
+You have walked and you have run. Now stop. French does not say \textquotedblleft{}I sit\textquotedblright{} — it says \textquotedblleft{}\textbf{I seat myself},\textquotedblright{} and that extra word is one you own.
+\end{quote}
+
+\subsection*{You'll want to know: the word}
+\begin{quote}
+\textbf{s'asseoir} — to sit down. Said \emph{sah-SWAHR}.
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{Je m'assieds.} — I sit down. Said \emph{juh mah-SYAY}.
+\end{quote}
+
+The \textbf{m'} is the \emph{me} inside \emph{je m'appelle}: French treats sitting as something you do \textbf{to yourself}, so the pronoun is not optional.
+
+Keep two ideas apart. \emph{S'asseoir} is the \textbf{movement}, lowering yourself into a chair. \textbf{Je suis assis} is the \textbf{state} after it, \textquotedblleft{}I am seated.\textquotedblright{} English lets \emph{sit} cover both; French makes you choose.
+
+\begin{grammarlens}[title={Grammar Lens: one verb, two accepted sets}]
+The only verb in the course with \textbf{two} correct answers, both in dictionaries. Learn this series whole:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{je m'assieds} — \emph{mah-SYAY}
+  \item \textbf{tu t'assieds} — \emph{tah-SYAY}
+  \item \textbf{il s'assied} — \emph{sah-SYAY} (three identical to the ear)
+  \item \textbf{nous nous asseyons} — \emph{noo-zah-say-YOHN}
+  \item \textbf{vous vous asseyez} — \emph{voo-zah-say-YAY}
+  \item \textbf{ils s'asseyent} — \emph{sah-SAY}
+\end{itemize}
+
+Then recognise the rival singulars \textbf{je m'assois, tu t'assois, il s'assoit} — ordinary spoken French. Their plurals (\emph{assoyons, assoyez}) are much rarer in France, so the series above is the safer one to own. Since 1990 the infinitive may also be spelled \textbf{s'assoir}. Nothing here is wrong; the language never chose.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{s'asseoir} $\leftarrow$ Vulgar Latin \textbf{adsedēre}, a remaking of Classical \textbf{adsidēre} — \textbf{ad-} \textquotedblleft{}at\textquotedblright{} plus \textbf{sedēre}, \textquotedblleft{}\textbf{to sit}.\textquotedblright{} Latin had built the compound; French only wore it down. And \emph{sedēre} is everywhere in English:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{sedentary}, sitting work; a \textbf{session}, \textquotedblleft{}a sitting\textquotedblright{}; \textbf{sediment}, what sits at the bottom.
+  \item \textbf{reside}, sit back; \textbf{preside} and \textbf{president}, sitting in front; \textbf{assiduous}, sitting at a task.
+  \item \textbf{siege} — an army sitting down before a city; \textbf{possess}, \textbf{obsess}, \textbf{subsidy}.
+  \item A bishop's \textbf{see} is his \emph{sedēs}, his \textbf{seat}.
+\end{itemize}
+
+\emph{Dormir} English only borrowed. This root it owns from birth too: \textbf{sit}, \textbf{seat} and \textbf{settle} come down the Germanic road from the same source.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}s'asseoir\textquotedblright{} — \emph{sah-SWAHR}
+  \item \textquotedblleft{}je m'assieds\textquotedblright{} then \textquotedblleft{}nous nous asseyons\textquotedblright{}
+  \item \textquotedblleft{}je m'appelle\textquotedblright{} then \textquotedblleft{}je m'assieds\textquotedblright{} — the same little \emph{m'}
+  \item \textquotedblleft{}je m'assieds\textquotedblright{} then \textquotedblleft{}je suis assis\textquotedblright{} — movement, then state
+  \item \textquotedblleft{}je marche, je cours, je m'assieds, je dors\textquotedblright{}
+  \item \textquotedblleft{}j'entends\textquotedblright{} — the ear needs no chair
+  \item \textquotedblleft{}sedentary, session, siege\textquotedblright{} — every one a sitting
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say \textquotedblleft{}I sit down\textquotedblright{} and \textquotedblleft{}we sit down.\textquotedblright{} (\emph{Je m'assieds. Nous nous asseyons}.) Why is the pronoun there? (French sits you \textbf{yourself} down — the same \emph{m'} as in \emph{je m'appelle}.) What is a \textbf{siege}, literally? (\textbf{A sitting} — an army sitting down before a city.) Which English words are cousins of \emph{sedēre} by birth rather than borrowing? (\textbf{Sit}, \textbf{seat}, \textbf{settle}.) Now the pair: \textquotedblleft{}je cours\textquotedblright{} and \textquotedblleft{}je dors.\textquotedblright{}
+\end{tcolorbox}
+\section[se lever, debout]{se lever, debout — standing, which French says in two pieces}
+
+\label{lesson:FR-C27-se-lever}
+
+
+
+\begin{quote}
+You sat down. Getting up is harder, because French has \textbf{no single verb} for \textquotedblleft{}to stand.\textquotedblright{} It splits the idea in two.
+\end{quote}
+
+\subsection*{You'll want to know: the movement}
+\begin{quote}
+\textbf{se lever} — to get up, to rise. Said \emph{suh luh-VAY}.
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{Je me lève.} — I get up. Said \emph{juh muh LEV}.
+\end{quote}
+
+Reflexive, as \emph{s'asseoir} is: you raise \textbf{yourself}. After that verb's two paradigms this is a relief — an ordinary \textbf{-er} verb with one habit. Silent ending, and the \emph{e} takes a \textbf{grave accent}; spoken ending, and it flattens:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{je me lève} — \emph{LEV}
+  \item \textbf{tu te lèves} — \emph{LEV}
+  \item \textbf{il se lève} — \emph{LEV}
+  \item \textbf{nous nous levons} — \emph{luh-VOHN}, flat
+  \item \textbf{vous vous levez} — \emph{luh-VAY}, flat
+  \item \textbf{ils se lèvent} — \emph{LEV}
+\end{itemize}
+
+\subsection*{You'll want to know: the state}
+\begin{quote}
+\textbf{debout} — standing, upright. Said \emph{duh-BOO}.
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{Je suis debout.} — I am standing.
+\end{quote}
+
+\emph{Se lever} is the \textbf{movement}, \emph{debout} the \textbf{state} — the split between sitting down and being seated. \emph{Debout} is no verb: attach it to \emph{être}.
+
+And it is transparent once opened: \textbf{de} + \textbf{bout}, \textquotedblleft{}\textbf{on end}.\textquotedblright{} A \emph{bout} is a tip or end, so standing is being set on your end. French did once have a plain verb for standing, \emph{ester}; it survives only in a courtroom phrase, which is why the language builds this from pieces.
+
+\begin{cousinweb}
+\textbf{lever} $\leftarrow$ Latin \textbf{levāre}, \textquotedblleft{}to raise\textquotedblright{} — built on \textbf{levis}, \textquotedblleft{}\textbf{light in weight}.\textquotedblright{} To raise a thing is to lighten it. Hence \textbf{elevate}, \textbf{elevator}, \textbf{levitate}, \textbf{levity}; a \textbf{lever}, which lightens a load; \textbf{alleviate}, \textbf{relieve}, \textbf{relief}; \textbf{leaven}.
+
+So two of this course's verbs come from one corner of Roman thought. \emph{Penser} is \emph{pēnsāre}, \textquotedblleft{}\textbf{to weigh}\textquotedblright{}; \emph{lever} is \emph{levāre}, \textquotedblleft{}to make \textbf{light}.\textquotedblright{} Thinking weighs, rising un-weighs, and \emph{sedēre} just sits there.
+
+One correction. \textbf{Bout} comes from \emph{bouter}, \textquotedblleft{}to strike,\textquotedblright{} taken from Frankish — and its English relative by \textbf{descent} is \textbf{beat}. \emph{Butt} looks closer but is a later \textbf{borrowing} back out of French.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}se lever\textquotedblright{} — \emph{suh luh-VAY}
+  \item \textquotedblleft{}je me lève\textquotedblright{} then \textquotedblleft{}nous nous levons\textquotedblright{} — sharp, then flat
+  \item \textquotedblleft{}je m'assieds\textquotedblright{} then \textquotedblleft{}je me lève\textquotedblright{} — down, then up
+  \item \textquotedblleft{}je suis debout\textquotedblright{} — the state, on \emph{être}
+  \item \textquotedblleft{}je me lève et je cours\textquotedblright{}
+  \item \textquotedblleft{}je pense\textquotedblright{} then \textquotedblleft{}je me lève\textquotedblright{} — weighing, then lightening
+  \item \textquotedblleft{}elevate, lever, relief\textquotedblright{} — all a raising
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say \textquotedblleft{}I get up\textquotedblright{} and \textquotedblleft{}we get up.\textquotedblright{} (\emph{Je me lève. Nous nous levons} — the accent appears only when the ending is silent.) How does French say \textquotedblleft{}I am standing\textquotedblright{}? (\emph{\textbf{Je suis debout}} — a state pinned to \emph{être}, not a verb, and \emph{debout} is \emph{de} + \emph{bout}, \textquotedblleft{}\textbf{on end}.\textquotedblright{}) \emph{Penser} came from weighing; what does \emph{lever} come from? (\emph{\textbf{Levis}}, \textquotedblleft{}\textbf{light in weight}\textquotedblright{}.) And the opposite movement? (\emph{Je m'assieds}.)
+\end{tcolorbox}
+\section[ouvrir]{ouvrir — \textquotedblleft{}to open,\textquotedblright{} an -ir verb wearing -er endings}
+
+\label{lesson:FR-C27-ouvrir}
+
+
+
+\begin{quote}
+You can sit and rise. Now the hand from Chapter 17. This verb is French conjugation's small trap: spelled like one family, behaving like another.
+\end{quote}
+
+\subsection*{You'll want to know: the word}
+\begin{quote}
+\textbf{ouvrir} — to open. Said \emph{oo-VREER}.
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{J'ouvre la main.} — I open my hand.
+\end{quote}
+
+French says \emph{la main} where English says \textquotedblleft{}my hand\textquotedblright{}; with your own body the article does the work. And listen to that nasal — \emph{pain}, \emph{main} — the same \emph{-ain} you have been making since the bread.
+
+\begin{grammarlens}[title={Grammar Lens: the endings it should not have}]
+\emph{Ouvrir} ends in \textbf{-ir}, so you would expect it to run like \emph{dormir}. It does not. It takes the endings of \textbf{marcher}, an \emph{-er} verb, exactly:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{j'ouvre} — \emph{JOOVR}
+  \item \textbf{tu ouvres} — \emph{OOVR}
+  \item \textbf{il ouvre} — \emph{OOVR}
+  \item \textbf{nous ouvrons} — \emph{oo-VROHN}
+  \item \textbf{vous ouvrez} — \emph{oo-VRAY}
+  \item \textbf{ils ouvrent} — \emph{OOVR}
+\end{itemize}
+
+Four identical to the ear, \emph{nous} and \emph{vous} audible: the shape of \emph{je marche, nous marchons}. A small group of \emph{-ir} verbs does this, and \emph{ouvrir} is the one you meet most. The spelling promises one thing; listen to what the verb does.
+\end{grammarlens}
+
+\begin{cousinweb}
+Latin's verb for opening was \textbf{aperīre}, which \emph{ouvrir} does not look much like — because the word was remodelled on the way into popular Latin \textbf{operīre}. The likeliest cause is the pull of its own opposite, \emph{cooperīre}, \textquotedblleft{}to cover,\textquotedblright{} which became French \textbf{couvrir}. Opening and covering ended up rhyming and have stayed matched since. The meaning stayed \emph{aperīre}'s; only the shape moved.
+
+English collected both ends:
+
+\begin{itemize}
+\raggedright
+  \item from \emph{aperīre} — an \textbf{aperture}; an \textbf{aperitif}, the drink that \textbf{opens} a meal.
+  \item from Old French \emph{ovrir} — \textbf{overt}, its past participle \textquotedblleft{}opened,\textquotedblright{} and \textbf{overture}, \emph{ouverture}.
+  \item from the covering half — \textbf{curfew}, Old French \emph{cuevrefeu}, \textquotedblleft{}\textbf{cover-fire},\textquotedblright{} the bell that said to bank the hearth.
+\end{itemize}
+
+Set that beside the hand. \emph{Maintenir} is \emph{manū tenēre}, \textquotedblleft{}\textbf{to hold in the hand}\textquotedblright{} — and \emph{ouvrir la main} releases that grip.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}ouvrir\textquotedblright{} — \emph{oo-VREER}
+  \item \textquotedblleft{}j'ouvre la main\textquotedblright{} — and hear \emph{pain}, \emph{main}
+  \item \textquotedblleft{}je marche, nous marchons\textquotedblright{} then \textquotedblleft{}j'ouvre, nous ouvrons\textquotedblright{} — one shape
+  \item \textquotedblleft{}je m'assieds, je me lève, j'ouvre la main\textquotedblright{}
+  \item \textquotedblleft{}je suis debout et j'ouvre la main\textquotedblright{}
+  \item \textquotedblleft{}maintenir\textquotedblright{} then \textquotedblleft{}ouvrir\textquotedblright{} — holding in the hand, then letting go
+  \item \textquotedblleft{}aperture, aperitif, overt, overture\textquotedblright{} — every one an opening
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say \textquotedblleft{}I open my hand\textquotedblright{} and \textquotedblleft{}we open.\textquotedblright{} (\emph{J'ouvre la main. Nous ouvrons}.) Which endings does \emph{ouvrir} borrow, despite its spelling? (The \textbf{-er} set — \emph{marcher}'s.) What is an \textbf{aperitif}, literally? (\textbf{The opener} — the drink that opens a meal.) Why does \emph{ouvrir} not look like Latin \emph{aperīre}? (It was \textbf{reshaped} to match its own opposite, the verb for covering.)
+\end{tcolorbox}
+\section[fermer]{fermer — \textquotedblleft{}to close,\textquotedblright{} which in French means \textquotedblleft{}to make firm\textquotedblright{}}
+
+\label{lesson:FR-C27-fermer}
+
+
+
+\begin{quote}
+The last of the four, and the opposite of the one before it. French chose an unexpected picture: to close a thing is to make it \textbf{firm}.
+\end{quote}
+
+\subsection*{You'll want to know: the word}
+\begin{quote}
+\textbf{fermer} — to close. Said \emph{fer-MAY}.
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{Je ferme la main.} — I close my hand. \textbf{Il pleut. Je ferme.} — It's raining. I'm closing up.
+\end{quote}
+
+A regular \textbf{-er} verb: \emph{je ferme, tu fermes, il ferme, nous fermons, vous fermez, ils ferment}.
+
+\begin{grammarlens}[title={Grammar Lens: two opposites, one set of endings}]
+\emph{Ouvrir} borrowed the \emph{-er} endings against its own spelling. \emph{Fermer} owns them outright. So the two opposites conjugate in step, and drill as one pair:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{j'ouvre} / \textbf{je ferme}
+  \item \textbf{nous ouvrons} / \textbf{nous fermons}
+  \item \textbf{ils ouvrent} / \textbf{ils ferment}
+\end{itemize}
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{fermer} $\leftarrow$ Latin \textbf{firmāre}, \textquotedblleft{}to make firm,\textquotedblright{} from \textbf{firmus}, \textquotedblleft{}\textbf{firm}.\textquotedblright{} A Roman door was not closed, it was \textbf{secured}. English took the adjective and left the verb: \textbf{firm}, \textbf{affirm}, \textbf{confirm}, \textbf{infirm} and the \textbf{infirmary}, the \textbf{firmament} — the sky as a solid vault.
+
+Probably also \textbf{farm}. Old French \emph{ferme} meant a \textbf{fixed rent}, from Medieval Latin \emph{firma}, \textquotedblleft{}a fixed payment,\textquotedblright{} so a farm began as a lease and not a field. Etymologists call this history a confused one, because Old English \emph{feorm}, \textquotedblleft{}food-rent,\textquotedblright{} sat nearby and may have pulled on it. Likely, not clean.
+
+The best part is the split. One Latin verb, three languages, three jobs:
+
+\begin{itemize}
+\raggedright
+  \item French \textbf{fermer} — to \textbf{close}.
+  \item Italian \textbf{fermare} — to \textbf{stop}.
+  \item Spanish \textbf{firmar} — to \textbf{sign}, because a signature makes a paper firm.
+\end{itemize}
+
+And Spanish and Portuguese do not close with this verb at all. Their words come from Latin's \textbf{bolt}. So French shuts a door by making it solid while its neighbours slide a bar across.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}fermer\textquotedblright{} — \emph{fer-MAY}
+  \item \textquotedblleft{}j'ouvre la main\textquotedblright{} then \textquotedblleft{}je ferme la main\textquotedblright{}
+  \item the chapter's four — \textquotedblleft{}je m'assieds, je me lève, j'ouvre, je ferme\textquotedblright{}
+  \item \textquotedblleft{}je suis debout et je ferme\textquotedblright{}
+  \item \textquotedblleft{}il pleut, je ferme\textquotedblright{}
+  \item \textquotedblleft{}vous fermez, s'il vous plaît\textquotedblright{} then \textquotedblleft{}tu fermes, s'il te plaît\textquotedblright{} — formal, then familiar
+  \item \textquotedblleft{}je suis désolé, je ferme\textquotedblright{} — the apology before the refusal
+  \item \textquotedblleft{}fermer, firm, affirm, confirm\textquotedblright{} — all a making-firm
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say the chapter's four with \emph{je}. (\emph{Je m'assieds, je me lève, j'ouvre, je ferme}.) What did \emph{firmāre} mean, and what is a French door doing when it closes? (\textbf{Making firm} — being \textbf{secured}, not barred.) One Latin verb, three languages: Italian and Spanish? (\emph{Fermare}, \textquotedblleft{}to \textbf{stop}\textquotedblright{}; \emph{firmar}, \textquotedblleft{}to \textbf{sign}\textquotedblright{}.) Now close politely in both registers, then apologise. (\emph{Vous fermez, s'il vous plaît. Tu fermes, s'il te plaît. Je suis désolé}.) And the hand? (\emph{J'ouvre la main, je ferme la main}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/french/chapters.json
+++ b/code/learning/human-languages/french/chapters.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "language": "french",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only Chapters 17-25 are authored — they are the French chapters whose lessons have been migrated to schema version 2 and therefore declare real knowledge atoms. Chapters 1-16 are still schema v1: their lessons carry no practises.knowledge, so any payoff written for them would assess invented atoms. Their absence here is real, measurable debt and must not be papered over with placeholders. Chapter 17's payoff sits exactly at the 0.5 representativeness floor and Chapters 17-18 have no terminal practice lesson at all; both facts are recorded per chapter below rather than hidden by padding assesses. Chapters 24 and 25 likewise have no terminal practice-mix, so their payoff is the chapter's last lesson by sequence — which is where the recombination and wrap-up recall actually live, and where each of the two reaches back past its own chapter to re-practise atoms taught earlier in the track (HL09 §7).",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only Chapters 17-27 are authored — they are the French chapters whose lessons have been migrated to schema version 2 and therefore declare real knowledge atoms. Chapters 1-16 are still schema v1: their lessons carry no practises.knowledge, so any payoff written for them would assess invented atoms. Their absence here is real, measurable debt and must not be papered over with placeholders. Chapter 17's payoff sits exactly at the 0.5 representativeness floor and Chapters 17-18 have no terminal practice lesson at all; both facts are recorded per chapter below rather than hidden by padding assesses. Chapters 24 through 27 likewise have no terminal practice-mix, so their payoff is the chapter's last lesson by sequence — which is where the recombination and wrap-up recall actually live, and where each of the two reaches back past its own chapter to re-practise atoms taught earlier in the track (HL09 §7).",
   "chapters": [
     {
       "chapter": 17,
@@ -194,6 +194,67 @@
           "FR-ETYMON-MAIN-04",
           "FR-LEX-PRENDRE-01",
           "FR-LEX-AIMER-09"
+        ]
+      }
+    },
+    {
+      "chapter": 26,
+      "title": "Hearing, Sleeping, Walking, Running",
+      "label": "ch:fr-hearing-sleeping-walking-running",
+      "canDo": "I can say that I hear, sleep, walk and run in French, use ça marche for \"that works,\" and say why entendre carries English's intend inside it while the Latin verb for hearing ended up in English instead.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "FR-C26-courir",
+        "kind": "task",
+        "summary": "Run the chapter's four verbs together with je — j'entends, je dors, je marche, je cours — then use courir's spelling to settle why canis became chien while currere stayed hard at the front: the ca- shift only ever struck c before a. Reaches back past the chapter to le chien and its palatalization from Chapter 22, le chat from the same chapter, il fait chaud and il pleut from Chapter 21, and the ne … pas negation from Chapter 18.",
+        "assesses": [
+          "FR-LEX-COURIR-10",
+          "FR-ETYMON-COURIR-11",
+          "FR-LEX-MARCHER-07",
+          "FR-ETYMON-MARCHER-08",
+          "FR-SEMANTICS-MARCHER-WORK-09",
+          "FR-LEX-DORMIR-04",
+          "FR-GRAMMAR-DORMIR-STEM-06",
+          "FR-LEX-ENTENDRE-01",
+          "FR-ETYMON-ENTENDRE-02",
+          "FR-GRAMMAR-NEGATION-04",
+          "FR-LEX-CHIEN-02",
+          "FR-ETYMON-CHIEN-03",
+          "FR-LEX-CHAT-04",
+          "FR-LEX-IL-PLEUT-04",
+          "FR-GRAMMAR-IL-FAIT-03"
+        ]
+      }
+    },
+    {
+      "chapter": 27,
+      "title": "Sitting, Standing, Opening, Closing",
+      "label": "ch:fr-sitting-standing-opening-closing",
+      "canDo": "I can sit down, get up, open and close in French, hold both accepted paradigms of s'asseoir apart, say why French needs two pieces — se lever and debout — where English has one verb \"to stand,\" and know that ouvrir takes marcher's endings despite its -ir spelling.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "FR-C27-fermer",
+        "kind": "task",
+        "summary": "Say the chapter's four with je — je m'assieds, je me lève, j'ouvre, je ferme — drill ouvrir and fermer as one pair now that both carry the same endings, and take fermer apart into firmāre, 'to make firm', the verb that gave Italian fermare 'to stop' and Spanish firmar 'to sign'. Reaches back past the chapter to open and close la main from Chapter 17, to close because il pleut from Chapter 21, and to ask in both registers and then apologise, from Chapters 19 and 20.",
+        "assesses": [
+          "FR-LEX-FERMER-10",
+          "FR-ETYMON-FERMER-11",
+          "FR-LEX-OUVRIR-07",
+          "FR-ETYMON-OUVRIR-08",
+          "FR-GRAMMAR-OUVRIR-ER-ENDINGS-09",
+          "FR-LEX-LEVER-04",
+          "FR-LEX-DEBOUT-06",
+          "FR-LEX-ASSEOIR-01",
+          "FR-LEX-MAIN-02",
+          "FR-LEX-PLEASE-02",
+          "FR-GRAMMAR-PLEASE-REGISTER-04",
+          "FR-LEX-DESOLE-02",
+          "FR-PRAGMATICS-SORRY-04",
+          "FR-LEX-IL-PLEUT-04"
         ]
       }
     }

--- a/code/learning/human-languages/french/curriculum.json
+++ b/code/learning/human-languages/french/curriculum.json
@@ -287,6 +287,23 @@
       "before": [],
       "inline": [],
       "after": []
+    },
+    {
+      "id": "FR-PATH-024",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "FR-C26-entendre",
+        "FR-C26-dormir",
+        "FR-C26-marcher",
+        "FR-C26-courir",
+        "FR-C27-sasseoir",
+        "FR-C27-se-lever",
+        "FR-C27-ouvrir",
+        "FR-C27-fermer"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
     }
   ],
   "spine": {
@@ -403,7 +420,8 @@
         "FR-PATH-014",
         "FR-PATH-016",
         "FR-PATH-017",
-        "FR-PATH-023"
+        "FR-PATH-023",
+        "FR-PATH-024"
       ],
       "omits": [
         "VERB-INFINITIVE",
@@ -412,7 +430,6 @@
         "VERB-COME",
         "VERB-SAY",
         "VERB-SEE",
-        "VERB-HEAR",
         "VERB-KNOW",
         "VERB-LEARN",
         "VERB-CAN",
@@ -422,18 +439,11 @@
         "VERB-PUT",
         "VERB-EAT",
         "VERB-DRINK",
-        "VERB-SLEEP",
         "VERB-PLAY",
-        "VERB-WALK",
-        "VERB-RUN",
-        "VERB-SIT",
-        "VERB-STAND",
         "VERB-WAIT",
         "VERB-ANSWER",
         "VERB-MEET",
-        "VERB-BUY",
-        "VERB-OPEN",
-        "VERB-CLOSE"
+        "VERB-BUY"
       ],
       "relocates": {}
     },

--- a/code/learning/human-languages/french/lessons/FR-C26-courir.md
+++ b/code/learning/human-languages/french/lessons/FR-C26-courir.md
@@ -1,0 +1,105 @@
+---
+schema_version: 2
+id: FR-C26-courir
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 820
+chapter: 26
+type: word
+headword: courir
+gloss: to run — Latin currere, the root under current, course, courier and curriculum, and the verb that shows why chien palatalized its c and courir did not
+concept_tag: VERB-RUN
+prerequisites: [FR-C26-marcher, FR-C22-chien-chat, FR-C21-le-temps]
+sounds: [r-uvular, silent-final]
+roots: [latin-currere]
+etymology_hook: "courir ← Latin currere 'to run' → current, currency, cursor, course, courier, corridor, curriculum ('a running'), concur, occur, recur, incur, excursion, precursor — and Latin carrus 'wagon' (→ car, carry, cargo) is a Gaulish loanword from the same ancient root, NOT a form built from currere"
+duration:
+  max_seconds: 297
+requires:
+  knowledge: [FR-LEX-MARCHER-07, FR-ETYMON-MARCHER-08, FR-SEMANTICS-MARCHER-WORK-09, FR-LEX-DORMIR-04, FR-GRAMMAR-DORMIR-STEM-06, FR-LEX-ENTENDRE-01, FR-ETYMON-ENTENDRE-02, FR-GRAMMAR-NEGATION-04, FR-LEX-CHIEN-02, FR-ETYMON-CHIEN-03, FR-LEX-CHAT-04, FR-LEX-IL-PLEUT-04, FR-GRAMMAR-IL-FAIT-03]
+introduces:
+  knowledge: [FR-LEX-COURIR-10, FR-ETYMON-COURIR-11]
+practises:
+  knowledge: [FR-LEX-COURIR-10, FR-ETYMON-COURIR-11, FR-LEX-MARCHER-07, FR-ETYMON-MARCHER-08, FR-SEMANTICS-MARCHER-WORK-09, FR-LEX-DORMIR-04, FR-GRAMMAR-DORMIR-STEM-06, FR-LEX-ENTENDRE-01, FR-ETYMON-ENTENDRE-02, FR-GRAMMAR-NEGATION-04, FR-LEX-CHIEN-02, FR-ETYMON-CHIEN-03, FR-LEX-CHAT-04, FR-LEX-IL-PLEUT-04, FR-GRAMMAR-IL-FAIT-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [FR-C26-marcher, FR-C26-dormir, FR-C26-entendre, FR-C22-chien-chat, FR-C21-le-temps, FR-C18-non]
+---
+
+# courir — "to run," and why it is not *chourir*
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-MARCHER-07, FR-LEX-DORMIR-04, FR-LEX-ENTENDRE-01] -->
+
+[PAUSE 2s] Hearing, sleeping, walking — and now the fastest of the four. Its
+Latin root is one of the busiest in English, and its spelling settles a question
+the dog raised.
+
+## You'll want to know: the word
+<!-- hl-knowledge: introduces=[FR-LEX-COURIR-10]; assesses=[FR-LEX-CHIEN-02] -->
+
+> **courir** — to run. Said *koo-REER*, throaty at both *r*s.
+>
+> **Le chien court.** — The dog runs.
+
+## Grammar Lens: the same endings, a different stem
+<!-- hl-knowledge: introduces=[]; assesses=[FR-GRAMMAR-DORMIR-STEM-06, FR-LEX-COURIR-10] -->
+
+*Courir* takes *dormir*'s singular endings — **-s, -s, -t**, all silent:
+
+- **je cours** — *koor*
+- **tu cours** — *koor*
+- **il court** — *koor*
+- **nous courons** — *koo-ROHN*
+- **vous courez** — *koo-RAY*
+- **ils courent** — *KOOR*
+
+But the resemblance stops there. *Dormir* **sheds** a consonant in the
+singular: *dorm-* becomes *dor-*. *Courir* sheds nothing — its stem *cour-* has
+nothing spare to lose.
+
+## The word, taken apart: currere
+<!-- hl-knowledge: introduces=[FR-ETYMON-COURIR-11]; assesses=[FR-ETYMON-CHIEN-03, FR-ETYMON-MARCHER-08] -->
+
+*Marcher* left a choice between a Frankish verb and a Latin hammer. This one
+leaves none. **courir** ← Latin **currere**, "to run," which English mined
+harder than almost any other verb:
+
+- **current** and **currency** both run; a **cursor** runs across a screen; a
+  **course** is a run, a **corridor** a running-place.
+- **courier**, one who runs; **curriculum**, literally "**a running**."
+- **concur**, run together; **occur**, run up against; **excursion**.
+
+Now the spelling question. *Chien* came from *canis*, and its **c** turned into
+**ch** — the shift that made *champ* and *chanter*. So why is this verb not
+*chourir*? Because that shift only struck **c** before **a**. *Currere* had **c**
+before **u**, untouched, so the *k* survived. One rule, two regular outcomes.
+
+One honest limit. Latin **carrus**, "wagon," gave English **car** and **cargo**,
+and descends from the same very old root. But Latin borrowed *carrus* from
+Gaulish: a cousin by another road, not a word built out of *currere*.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-COURIR-10, FR-ETYMON-COURIR-11, FR-LEX-MARCHER-07, FR-ETYMON-MARCHER-08, FR-SEMANTICS-MARCHER-WORK-09, FR-LEX-DORMIR-04, FR-GRAMMAR-DORMIR-STEM-06, FR-LEX-ENTENDRE-01, FR-ETYMON-ENTENDRE-02, FR-GRAMMAR-NEGATION-04, FR-LEX-CHIEN-02, FR-ETYMON-CHIEN-03, FR-LEX-CHAT-04, FR-LEX-IL-PLEUT-04, FR-GRAMMAR-IL-FAIT-03] -->
+
+[PAUSE 1s]
+- [YOU SAY: the chapter's four with *je* — "j'entends, je dors, je marche, je cours"]
+- [YOU SAY: "le chien court" then "le chat dort"]
+- [YOU SAY: "il fait chaud, je cours"]
+- [YOU SAY: "il pleut, je ne cours pas"]
+- [YOU SAY: "je dors, nous dormons" then "je cours, nous courons" — one sheds]
+- [YOU SAY: "chien" then "courir" — *ch* before *a*, *k* before *u*]
+- [YOU SAY: "current, course, courier, curriculum" — every one a running]
+- [YOU SAY: "ça marche" — the agreement, two words]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-COURIR-10, FR-ETYMON-COURIR-11, FR-LEX-MARCHER-07, FR-LEX-DORMIR-04, FR-LEX-ENTENDRE-01, FR-ETYMON-ENTENDRE-02, FR-ETYMON-CHIEN-03, FR-LEX-CHIEN-02, FR-GRAMMAR-IL-FAIT-03] -->
+
+[PAUSE 3s] Say the chapter's four verbs with *je*. (*J'entends, je dors, je
+marche, je cours*.) What does **curriculum** literally mean? (**A running** —
+from *currere*.) Why did *canis* become *chien* while *currere* stayed hard?
+(The shift only hit **c** before **a**.) Which of the four began as a
+**stretching**? (***Entendre*** — *intendere*, to stretch toward.) Now: "the dog
+runs" and "it is hot." (*Le chien court. Il fait chaud*.)

--- a/code/learning/human-languages/french/lessons/FR-C26-dormir.md
+++ b/code/learning/human-languages/french/lessons/FR-C26-dormir.md
@@ -1,0 +1,107 @@
+---
+schema_version: 2
+id: FR-C26-dormir
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 800
+chapter: 26
+type: word
+headword: dormir
+gloss: to sleep — Latin dormīre, unchanged in French, and the source of dormitory and dormant, though not of the dormouse
+concept_tag: VERB-SLEEP
+prerequisites: [FR-C26-entendre, FR-C22-chien-chat]
+sounds: [r-uvular, silent-final]
+roots: [latin-dormire]
+etymology_hook: "dormir ← Latin dormīre 'to sleep', inherited unchanged → dormitory, dormant, dormer window (← Old French dormeor, 'a sleeping room') — but NOT dormouse, whose resemblance is folk etymology resting on an Anglo-Norman word nobody has found"
+duration:
+  max_seconds: 298
+requires:
+  knowledge: [FR-LEX-ENTENDRE-01, FR-LEX-CHAT-04, FR-ETYMON-CHAT-05, FR-LEX-COMPRENDRE-01]
+introduces:
+  knowledge: [FR-LEX-DORMIR-04, FR-ETYMON-DORMIR-05, FR-GRAMMAR-DORMIR-STEM-06]
+practises:
+  knowledge: [FR-LEX-DORMIR-04, FR-ETYMON-DORMIR-05, FR-GRAMMAR-DORMIR-STEM-06, FR-LEX-ENTENDRE-01, FR-LEX-CHAT-04, FR-ETYMON-CHAT-05, FR-LEX-COMPRENDRE-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [FR-C26-entendre, FR-C22-chien-chat, FR-C25-comprendre]
+---
+
+# dormir — "to sleep," and the room named after it
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-ENTENDRE-01] -->
+
+[PAUSE 2s] After a verb that changed jobs, here is one that never changed.
+*Dormir* is Latin's word for sleeping, handed on almost untouched — and it hides
+one trap.
+
+## You'll want to know: the word
+<!-- hl-knowledge: introduces=[FR-LEX-DORMIR-04]; assesses=[FR-LEX-CHAT-04] -->
+
+> **dormir** — to sleep. Said *dor-MEER*, with the throaty French **r** in the
+> middle and at the end.
+>
+> **Le chat dort.** — The cat is sleeping.
+
+French has no separate "is sleeping" form. *Il dort* covers both "he sleeps" and
+"he is sleeping"; the plain present does all the work.
+
+## Grammar Lens: the m that goes missing
+<!-- hl-knowledge: introduces=[FR-GRAMMAR-DORMIR-STEM-06]; assesses=[FR-LEX-DORMIR-04] -->
+
+The stem is *dorm-*, and in the singular French throws the **m** away. Listen
+for where it comes back:
+
+- **je dors** — *dor*
+- **tu dors** — *dor*
+- **il dort** — *dor* (three identical, the *m* gone)
+- **nous dormons** — *dor-MOHN*, and there it is
+- **vous dormez** — *dor-MAY*
+- **ils dorment** — *DORM*
+
+One rule, and you have the whole verb: singular loses the last stem consonant,
+plural gets it back. A small family of *-ir* verbs shares the shape, so learning
+it once is worth more than one verb.
+
+## The word, taken apart: dormīre
+<!-- hl-knowledge: introduces=[FR-ETYMON-DORMIR-05]; assesses=[] -->
+
+**dormir** ← Latin **dormīre**, "to sleep." Spanish kept *dormir*, Italian
+*dormire*, Portuguese *dormir* — the verb crossed into its daughter languages
+untouched, which is rarer than it sounds. English has no inherited descendant;
+it borrowed the family later, through French:
+
+- **dormitory** ← *dormītōrium*, a sleeping place; French wore the identical
+  word down to **dortoir**.
+- **dormant** — Old French *dormant*, "sleeping"; a dormant volcano is asleep.
+- **dormer** — a roof window, from Old French *dormeor*, because the room behind
+  it was where you slept.
+
+And an honest stop. The **dormouse** looks like the best cousin of the lot and
+is not one. The story needs an Anglo-Norman word for "sleeper" that nobody has
+found in a text, and *dormouse*'s real origin is unknown. A guess in
+circulation, not an etymology.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-DORMIR-04, FR-ETYMON-DORMIR-05, FR-GRAMMAR-DORMIR-STEM-06, FR-LEX-ENTENDRE-01, FR-LEX-CHAT-04, FR-ETYMON-CHAT-05, FR-LEX-COMPRENDRE-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: "dormir" — *dor-MEER*, throaty *r*]
+- [YOU SAY: "je dors" then "nous dormons" — the *m* vanishes, then returns]
+- [YOU SAY: "le chat dort" — the cat, the travelling word out of Egypt]
+- [YOU SAY: "j'entends le chat" then "le chat dort"]
+- [YOU SAY: "dormir, dormitory, dormant" — one Latin verb, borrowed back]
+- [YOU SAY: "je comprends" then "je dors"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-DORMIR-04, FR-ETYMON-DORMIR-05, FR-GRAMMAR-DORMIR-STEM-06, FR-LEX-CHAT-04, FR-ETYMON-CHAT-05] -->
+
+[PAUSE 3s] Say "the cat is sleeping" and "we sleep." (*Le chat dort. Nous
+dormons* — the *m* is silent in the singular and audible in the plural.) Where
+does *dormitory* come from? (Latin *dormītōrium*, "a **sleeping place**" — and
+French wore the same word down to *dortoir*.) Is the **dormouse** in this
+family? (**No** — that is folk etymology; the word's real origin is unknown.)
+And *chat* — an inherited Latin word, or a traveller? (**A traveller**, from
+*cattus*, moving with the cat itself out of Egypt.)

--- a/code/learning/human-languages/french/lessons/FR-C26-entendre.md
+++ b/code/learning/human-languages/french/lessons/FR-C26-entendre.md
@@ -1,0 +1,117 @@
+---
+schema_version: 2
+id: FR-C26-entendre
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 790
+chapter: 26
+type: word
+headword: entendre
+gloss: to hear — from a Latin verb meaning "to stretch toward," so English's intend is its closest surviving cousin, and French still keeps the older sense in entendu and s'entendre
+concept_tag: VERB-HEAR
+prerequisites: [FR-C25-ecrire, FR-C25-comprendre]
+sounds: [nasal-an, silent-final]
+roots: [latin-intendere]
+etymology_hook: "entendre ← Latin intendere, in- 'toward' + tendere 'to stretch' → intend, intent, intense, intention, tension, tent, extend, pretend, tendency — French narrowed the verb onto hearing as ouïr (← audīre) wore away, leaving the older sense in entendu 'agreed', s'entendre 'to get along' and l'entente"
+duration:
+  max_seconds: 298
+requires:
+  knowledge: [FR-LEX-COMPRENDRE-01, FR-ETYMON-COMPRENDRE-02, FR-GRAMMAR-PRENDRE-STEM-03, FR-LEX-PENSER-04, FR-ETYMON-PENSER-05, FR-LEX-ECRIRE-08, FR-LEX-CHIEN-02]
+introduces:
+  knowledge: [FR-LEX-ENTENDRE-01, FR-ETYMON-ENTENDRE-02, FR-SEMANTICS-ENTENDRE-SPREAD-03]
+practises:
+  knowledge: [FR-LEX-ENTENDRE-01, FR-ETYMON-ENTENDRE-02, FR-SEMANTICS-ENTENDRE-SPREAD-03, FR-LEX-COMPRENDRE-01, FR-ETYMON-COMPRENDRE-02, FR-GRAMMAR-PRENDRE-STEM-03, FR-LEX-PENSER-04, FR-ETYMON-PENSER-05, FR-LEX-ECRIRE-08, FR-LEX-CHIEN-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [FR-C25-ecrire, FR-C25-penser, FR-C25-comprendre, FR-C24-prendre, FR-C22-chien-chat]
+---
+
+# entendre — "to hear," and the stretching inside it
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-COMPRENDRE-01, FR-LEX-PENSER-04] -->
+
+[PAUSE 2s] You can think and understand. Now the ear — and French's word for it
+is English's *intend*.
+
+## You'll want to know: the word
+<!-- hl-knowledge: introduces=[FR-LEX-ENTENDRE-01]; assesses=[FR-LEX-CHIEN-02] -->
+
+> **entendre** — to hear. Two nasal *an* sounds in a row, then the *-dre* of
+> *prendre*: say it *ahn-TAHN-druh*.
+>
+> **J'entends le chien.** — I hear the dog.
+
+The *-ds* of *j'entends* is silent, as in *je prends*.
+
+## Grammar Lens: the nasal that stays put
+<!-- hl-knowledge: introduces=[]; assesses=[FR-GRAMMAR-PRENDRE-STEM-03, FR-LEX-ENTENDRE-01] -->
+
+*Prendre*'s nasal dies in the plural. *Entendre* looks like its twin and does
+the opposite — the stem never moves:
+
+- **j'entends** — *jahn-TAHN*
+- **tu entends** — *ahn-TAHN*
+- **il entend** — *ahn-TAHN* (three identical to the ear)
+- **nous entendons** — *ahn-tahn-DOHN*, nasal still there
+- **vous entendez** — *ahn-tahn-DAY*
+- **ils entendent** — *ahn-TAHND*
+
+## The word, taken apart: a stretching
+<!-- hl-knowledge: introduces=[FR-ETYMON-ENTENDRE-02]; assesses=[FR-ETYMON-COMPRENDRE-02, FR-ETYMON-PENSER-05] -->
+
+**entendre** ← Latin **intendere** — **in-** "toward" plus **tendere**, "**to
+stretch**." To *intendere* was to stretch a thing out and aim it: a bowstring, a
+journey, your attention. English kept the family — **intend**, plainest of them,
+plus **intent**, **intense**, **tension**, a **tent** (a stretched skin),
+**extend** and **pretend**.
+
+Set your three mind-verbs together: French pictures each as a different thing
+the body does.
+
+- **comprendre** — to **grasp together**, built on *prendre*.
+- **penser** — to **weigh**, from *pēnsāre*.
+- **entendre** — to **stretch toward**.
+
+## Why it's said this way: the sense that took over
+<!-- hl-knowledge: introduces=[FR-SEMANTICS-ENTENDRE-SPREAD-03]; assesses=[FR-LEX-ENTENDRE-01, FR-LEX-COMPRENDRE-01] -->
+
+From its oldest French records *entendre* already covers a span at once: to
+hear, to attend, to understand, to intend. Nothing arrived late. What happened
+since is that the other senses fell away and hearing took the word outright —
+because Latin's verb for hearing, **audīre**, wore down in French to *ouïr* and
+stopped being usable. English kept that family instead: **audio**, **audience**,
+**audible**, **audition**.
+
+The abandoned senses survive in phrases French never rebuilt:
+
+- **entendu** — "understood," "agreed."
+- **s'entendre** — to hear one another, and so to **get along**.
+- **l'entente** — an understanding between parties, borrowed into English whole
+  in *Entente Cordiale*.
+
+So the two languages split one Latin pair: French hears with the verb English
+uses for intending, and English hears with the verb French let go.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-ENTENDRE-01, FR-ETYMON-ENTENDRE-02, FR-SEMANTICS-ENTENDRE-SPREAD-03, FR-LEX-COMPRENDRE-01, FR-ETYMON-COMPRENDRE-02, FR-GRAMMAR-PRENDRE-STEM-03, FR-LEX-PENSER-04, FR-ETYMON-PENSER-05, FR-LEX-ECRIRE-08, FR-LEX-CHIEN-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: "entendre" — *ahn-TAHN-druh*, two nasals]
+- [YOU SAY: "j'entends le chien"]
+- [YOU SAY: "nous prenons" then "nous entendons" — one flattens, one holds]
+- [YOU SAY: "j'écris, je comprends, j'entends"]
+- [YOU SAY: the three pictures — stretching, grasping, weighing]
+- [YOU SAY: "intend, tension, tent" — all a stretching]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-ENTENDRE-01, FR-ETYMON-ENTENDRE-02, FR-SEMANTICS-ENTENDRE-SPREAD-03, FR-LEX-COMPRENDRE-01, FR-GRAMMAR-PRENDRE-STEM-03] -->
+
+[PAUSE 3s] Say "I hear the dog" and "we hear." (*J'entends le chien. Nous
+entendons* — and unlike *nous prenons*, nothing flattens.) What did *intendere*
+mean, and which English verb is its plainest survival? (**To stretch toward**;
+**intend**.) Why did French hand hearing to this verb? (Latin's *audīre* wore
+down to *ouïr* and fell out of use — English kept the *audīre* words instead.)
+What does *s'entendre* mean? (**To get along**.)

--- a/code/learning/human-languages/french/lessons/FR-C26-marcher.md
+++ b/code/learning/human-languages/french/lessons/FR-C26-marcher.md
@@ -1,0 +1,109 @@
+---
+schema_version: 2
+id: FR-C26-marcher
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 810
+chapter: 26
+type: word
+headword: marcher
+gloss: to walk — and also to work, so ça marche is the most useful two words in the chapter; its own origin is genuinely unsettled between a Frankish verb and a Latin hammer
+concept_tag: VERB-WALK
+prerequisites: [FR-C26-dormir, FR-C18-non]
+sounds: [er-ending, r-uvular]
+roots: [frankish-markon]
+etymology_hook: "marcher — origin unsettled: most accounts give Frankish *markōn 'to mark, to press a step in', a competing one gives Late Latin marcāre ← marcus 'hammer'; English march (the verb) is a secure borrowing FROM marcher, while English mark is its relative only if the Frankish account holds, and la marche 'borderland' (→ marquis, margrave) is a separate arrival from the Germanic noun marka"
+duration:
+  max_seconds: 298
+requires:
+  knowledge: [FR-LEX-DORMIR-04, FR-LEX-ENTENDRE-01, FR-SEMANTICS-ENTENDRE-SPREAD-03, FR-LEX-NON-02, FR-GRAMMAR-NEGATION-04, FR-GRAMMAR-DORMIR-STEM-06]
+introduces:
+  knowledge: [FR-LEX-MARCHER-07, FR-ETYMON-MARCHER-08, FR-SEMANTICS-MARCHER-WORK-09]
+practises:
+  knowledge: [FR-LEX-MARCHER-07, FR-ETYMON-MARCHER-08, FR-SEMANTICS-MARCHER-WORK-09, FR-LEX-DORMIR-04, FR-LEX-ENTENDRE-01, FR-SEMANTICS-ENTENDRE-SPREAD-03, FR-LEX-NON-02, FR-GRAMMAR-NEGATION-04, FR-GRAMMAR-DORMIR-STEM-06]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [FR-C26-dormir, FR-C26-entendre, FR-C18-non]
+---
+
+# marcher — "to walk," and the step hiding inside French negation
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-DORMIR-04, FR-LEX-ENTENDRE-01] -->
+
+[PAUSE 2s] You can hear and you can sleep. Now move. This verb does a second job
+too, used dozens of times a day.
+
+## You'll want to know: the word
+<!-- hl-knowledge: introduces=[FR-LEX-MARCHER-07]; assesses=[FR-GRAMMAR-DORMIR-STEM-06] -->
+
+> **marcher** — to walk. Said *mar-SHAY*: the *-er* is a clean *ay*, and the
+> *ch* is *sh*, never *k*.
+>
+> **Je marche.** — I walk.
+
+After *dormir*'s vanishing *m*, this one asks nothing: an ordinary **-er** verb.
+*Je marche, tu marches, il marche, nous marchons, vous marchez, ils marchent* —
+four of the six sound identical, just *marsh*.
+
+## Why it's said this way: ça marche
+<!-- hl-knowledge: introduces=[FR-SEMANTICS-MARCHER-WORK-09]; assesses=[FR-LEX-MARCHER-07, FR-LEX-NON-02, FR-GRAMMAR-NEGATION-04, FR-SEMANTICS-ENTENDRE-SPREAD-03] -->
+
+*Marcher* is also the everyday verb for a thing **working**. A machine, a plan,
+an arrangement: if it functions, it walks.
+
+> **Ça marche.** — "That works." Also "Fine," "Deal," "Sounds good."
+> **Ça ne marche pas.** — "That doesn't work."
+
+There is your *ne … pas* from the answer-word *non*, round a real verb at last.
+And *ça marche* alone is an agreement, two words long.
+
+*Entendre* once held several jobs and shed all but hearing. *Marcher* holds two
+right now.
+
+## The word, taken apart: a step, or a hammer
+<!-- hl-knowledge: introduces=[FR-ETYMON-MARCHER-08]; assesses=[FR-GRAMMAR-NEGATION-04] -->
+
+Here the honest answer is that nobody is certain. Old French *marchier* first
+meant "**to trample, to tread on**," and two accounts compete:
+
+- Frankish **markōn**, "to mark, to press a step in" — preferred by most
+  reference works.
+- Late Latin *marcāre*, from **marcus**, "**a hammer**" — a blow and a tread
+  being one motion.
+
+Three consequences, in falling order of certainty:
+
+- English **march**, the verb, is borrowed straight **from** *marcher*. Secure
+  whichever origin is right.
+- English **mark** is Germanic, from Old English *mearc*. A relative **only if**
+  the Frankish account holds — conditional, not a fact.
+- French **la marche**, a borderland, with **marquis** and German **margrave**,
+  comes from the Germanic **noun** *marka*, "boundary" — a separate arrival.
+
+And one cousin you own already. The **pas** in *ne … pas* began as Latin
+*passus*, "**a step**." *Je ne marche pas* is, underneath, "I do not walk a
+step."
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-MARCHER-07, FR-ETYMON-MARCHER-08, FR-SEMANTICS-MARCHER-WORK-09, FR-LEX-DORMIR-04, FR-LEX-ENTENDRE-01, FR-SEMANTICS-ENTENDRE-SPREAD-03, FR-LEX-NON-02, FR-GRAMMAR-NEGATION-04, FR-GRAMMAR-DORMIR-STEM-06] -->
+
+[PAUSE 1s]
+- [YOU SAY: "marcher" — *mar-SHAY*, *sh* not *k*]
+- [YOU SAY: "je marche" then "nous marchons"]
+- [YOU SAY: "ça marche" — that works, that's fine]
+- [YOU SAY: "non", then "je ne marche pas" — and *pas* is a **step**]
+- [YOU SAY: "j'entends, je dors, je marche"]
+- [YOU SAY: "nous dormons, nous marchons" — one stem shifts, one never does]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-MARCHER-07, FR-ETYMON-MARCHER-08, FR-SEMANTICS-MARCHER-WORK-09, FR-GRAMMAR-NEGATION-04] -->
+
+[PAUSE 3s] Say "I walk" and "that works." (*Je marche. Ça marche*.) What are the
+two competing origins? (Frankish **markōn*, "to press a step in," or Latin
+*marcus*, "**a hammer**." Genuinely unsettled.) Which English
+word is certainly related, and which only might be? (**March**, borrowed
+straight from *marcher*; **mark** only if the Frankish account is right.) What
+did *pas* mean before it meant "not"? (**A step**.)

--- a/code/learning/human-languages/french/lessons/FR-C27-fermer.md
+++ b/code/learning/human-languages/french/lessons/FR-C27-fermer.md
@@ -1,0 +1,105 @@
+---
+schema_version: 2
+id: FR-C27-fermer
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 860
+chapter: 27
+type: word
+headword: fermer
+gloss: to close — from Latin firmāre, "to make firm," so a French door is not shut but made fast; the same verb gave Italian "to stop" and Spanish "to sign"
+concept_tag: VERB-CLOSE
+prerequisites: [FR-C27-ouvrir, FR-C19-sil-vous-plait, FR-C20-je-suis-desole, FR-C21-le-temps]
+sounds: [er-ending, r-uvular]
+roots: [latin-firmare]
+etymology_hook: "fermer ← Latin firmāre 'to make firm, to strengthen' ← firmus → firm, affirm, confirm, infirm, infirmary, firmament — and probably English farm, via Old French ferme 'a fixed rent'; the same Latin verb gave Italian fermare 'to stop' and Spanish firmar 'to sign', while Spanish cerrar and Portuguese fechar are 'bolt' verbs from somewhere else entirely"
+duration:
+  max_seconds: 298
+requires:
+  knowledge: [FR-LEX-OUVRIR-07, FR-ETYMON-OUVRIR-08, FR-GRAMMAR-OUVRIR-ER-ENDINGS-09, FR-LEX-LEVER-04, FR-LEX-DEBOUT-06, FR-LEX-ASSEOIR-01, FR-LEX-MAIN-02, FR-LEX-PLEASE-02, FR-GRAMMAR-PLEASE-REGISTER-04, FR-LEX-DESOLE-02, FR-PRAGMATICS-SORRY-04, FR-LEX-IL-PLEUT-04]
+introduces:
+  knowledge: [FR-LEX-FERMER-10, FR-ETYMON-FERMER-11]
+practises:
+  knowledge: [FR-LEX-FERMER-10, FR-ETYMON-FERMER-11, FR-LEX-OUVRIR-07, FR-ETYMON-OUVRIR-08, FR-GRAMMAR-OUVRIR-ER-ENDINGS-09, FR-LEX-LEVER-04, FR-LEX-DEBOUT-06, FR-LEX-ASSEOIR-01, FR-LEX-MAIN-02, FR-LEX-PLEASE-02, FR-GRAMMAR-PLEASE-REGISTER-04, FR-LEX-DESOLE-02, FR-PRAGMATICS-SORRY-04, FR-LEX-IL-PLEUT-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [FR-C27-ouvrir, FR-C27-se-lever, FR-C27-sasseoir, FR-C21-le-temps, FR-C20-je-suis-desole, FR-C19-sil-vous-plait, FR-C17-main]
+---
+
+# fermer — "to close," which in French means "to make firm"
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-OUVRIR-07, FR-LEX-ASSEOIR-01, FR-LEX-LEVER-04] -->
+
+[PAUSE 2s] The last of the four, and the opposite of the one before it. French
+chose an unexpected picture: to close a thing is to make it **firm**.
+
+## You'll want to know: the word
+<!-- hl-knowledge: introduces=[FR-LEX-FERMER-10]; assesses=[FR-LEX-MAIN-02, FR-LEX-IL-PLEUT-04] -->
+
+> **fermer** — to close. Said *fer-MAY*.
+>
+> **Je ferme la main.** — I close my hand. **Il pleut. Je ferme.** — It's
+> raining. I'm closing up.
+
+A regular **-er** verb: *je ferme, tu fermes, il ferme, nous fermons, vous
+fermez, ils ferment*.
+
+## Grammar Lens: two opposites, one set of endings
+<!-- hl-knowledge: introduces=[]; assesses=[FR-GRAMMAR-OUVRIR-ER-ENDINGS-09, FR-LEX-FERMER-10, FR-LEX-OUVRIR-07] -->
+
+*Ouvrir* borrowed the *-er* endings against its own spelling. *Fermer* owns them
+outright. So the two opposites conjugate in step, and drill as one pair:
+
+- **j'ouvre** / **je ferme**
+- **nous ouvrons** / **nous fermons**
+- **ils ouvrent** / **ils ferment**
+
+## The word, taken apart: making it firm
+<!-- hl-knowledge: introduces=[FR-ETYMON-FERMER-11]; assesses=[FR-ETYMON-OUVRIR-08] -->
+
+**fermer** ← Latin **firmāre**, "to make firm," from **firmus**, "**firm**." A
+Roman door was not closed, it was **secured**. English took the adjective and
+left the verb: **firm**, **affirm**, **confirm**, **infirm** and the
+**infirmary**, the **firmament** — the sky as a solid vault.
+
+Probably also **farm**. Old French *ferme* meant a **fixed rent**, from Medieval
+Latin *firma*, "a fixed payment," so a farm began as a lease and not a field.
+Etymologists call this history a confused one, because Old English *feorm*,
+"food-rent," sat nearby and may have pulled on it. Likely, not clean.
+
+The best part is the split. One Latin verb, three languages, three jobs:
+
+- French **fermer** — to **close**.
+- Italian **fermare** — to **stop**.
+- Spanish **firmar** — to **sign**, because a signature makes a paper firm.
+
+And Spanish and Portuguese do not close with this verb at all. Their words come
+from Latin's **bolt**. So French shuts a door by making it solid while its
+neighbours slide a bar across.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-FERMER-10, FR-ETYMON-FERMER-11, FR-LEX-OUVRIR-07, FR-ETYMON-OUVRIR-08, FR-GRAMMAR-OUVRIR-ER-ENDINGS-09, FR-LEX-LEVER-04, FR-LEX-DEBOUT-06, FR-LEX-ASSEOIR-01, FR-LEX-MAIN-02, FR-LEX-PLEASE-02, FR-GRAMMAR-PLEASE-REGISTER-04, FR-LEX-DESOLE-02, FR-PRAGMATICS-SORRY-04, FR-LEX-IL-PLEUT-04] -->
+
+[PAUSE 1s]
+- [YOU SAY: "fermer" — *fer-MAY*]
+- [YOU SAY: "j'ouvre la main" then "je ferme la main"]
+- [YOU SAY: the chapter's four — "je m'assieds, je me lève, j'ouvre, je ferme"]
+- [YOU SAY: "je suis debout et je ferme"]
+- [YOU SAY: "il pleut, je ferme"]
+- [YOU SAY: "vous fermez, s'il vous plaît" then "tu fermes, s'il te plaît" — formal, then familiar]
+- [YOU SAY: "je suis désolé, je ferme" — the apology before the refusal]
+- [YOU SAY: "fermer, firm, affirm, confirm" — all a making-firm]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-FERMER-10, FR-ETYMON-FERMER-11, FR-LEX-OUVRIR-07, FR-LEX-ASSEOIR-01, FR-LEX-LEVER-04, FR-LEX-DEBOUT-06, FR-LEX-PLEASE-02, FR-LEX-DESOLE-02, FR-LEX-MAIN-02] -->
+
+[PAUSE 3s] Say the chapter's four with *je*. (*Je m'assieds, je me lève,
+j'ouvre, je ferme*.) What did *firmāre* mean, and what is a French door doing
+when it closes? (**Making firm** — being **secured**, not barred.) One Latin
+verb, three languages: Italian and Spanish? (*Fermare*, "to **stop**"; *firmar*,
+"to **sign**".) Now close politely in both registers, then apologise. (*Vous
+fermez, s'il vous plaît. Tu fermes, s'il te plaît. Je suis désolé*.) And the
+hand? (*J'ouvre la main, je ferme la main*.)

--- a/code/learning/human-languages/french/lessons/FR-C27-ouvrir.md
+++ b/code/learning/human-languages/french/lessons/FR-C27-ouvrir.md
@@ -1,0 +1,109 @@
+---
+schema_version: 2
+id: FR-C27-ouvrir
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 850
+chapter: 27
+type: word
+headword: ouvrir
+gloss: to open — an -ir verb that takes -er endings, from a Latin verb reshaped to look like its own opposite, and the source of English overt and overture
+concept_tag: VERB-OPEN
+prerequisites: [FR-C27-se-lever, FR-C17-main]
+sounds: [r-uvular, nasal-ain]
+roots: [latin-aperire]
+etymology_hook: "ouvrir ← popular Latin operīre, a reshaping of Classical aperīre 'to open' — probably pulled into that shape by its own opposite cooperīre 'to cover' (→ couvrir) → aperture, aperitif ('the opener' of a meal), and through Old French ovrir the English words overt and overture"
+duration:
+  max_seconds: 296
+requires:
+  knowledge: [FR-LEX-LEVER-04, FR-LEX-DEBOUT-06, FR-LEX-ASSEOIR-01, FR-LEX-MARCHER-07, FR-LEX-MAIN-02, FR-SOUND-MAIN-03, FR-ETYMON-MAINTENIR-05]
+introduces:
+  knowledge: [FR-LEX-OUVRIR-07, FR-ETYMON-OUVRIR-08, FR-GRAMMAR-OUVRIR-ER-ENDINGS-09]
+practises:
+  knowledge: [FR-LEX-OUVRIR-07, FR-ETYMON-OUVRIR-08, FR-GRAMMAR-OUVRIR-ER-ENDINGS-09, FR-LEX-LEVER-04, FR-LEX-DEBOUT-06, FR-LEX-ASSEOIR-01, FR-LEX-MARCHER-07, FR-LEX-MAIN-02, FR-SOUND-MAIN-03, FR-ETYMON-MAINTENIR-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [FR-C27-se-lever, FR-C27-sasseoir, FR-C26-marcher, FR-C17-main]
+---
+
+# ouvrir — "to open," an -ir verb wearing -er endings
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-ASSEOIR-01, FR-LEX-LEVER-04] -->
+
+[PAUSE 2s] You can sit and rise. Now the hand from Chapter 17. This verb is
+French conjugation's small trap: spelled like one family, behaving like
+another.
+
+## You'll want to know: the word
+<!-- hl-knowledge: introduces=[FR-LEX-OUVRIR-07]; assesses=[FR-LEX-MAIN-02, FR-SOUND-MAIN-03] -->
+
+> **ouvrir** — to open. Said *oo-VREER*.
+>
+> **J'ouvre la main.** — I open my hand.
+
+French says *la main* where English says "my hand"; with your own body the
+article does the work. And listen to that nasal — *pain*, *main* — the same
+*-ain* you have been making since the bread.
+
+## Grammar Lens: the endings it should not have
+<!-- hl-knowledge: introduces=[FR-GRAMMAR-OUVRIR-ER-ENDINGS-09]; assesses=[FR-LEX-OUVRIR-07, FR-LEX-MARCHER-07] -->
+
+*Ouvrir* ends in **-ir**, so you would expect it to run like *dormir*. It does
+not. It takes the endings of **marcher**, an *-er* verb, exactly:
+
+- **j'ouvre** — *JOOVR*
+- **tu ouvres** — *OOVR*
+- **il ouvre** — *OOVR*
+- **nous ouvrons** — *oo-VROHN*
+- **vous ouvrez** — *oo-VRAY*
+- **ils ouvrent** — *OOVR*
+
+Four identical to the ear, *nous* and *vous* audible: the shape of *je marche,
+nous marchons*. A small group of *-ir* verbs does this, and *ouvrir* is the one
+you meet most. The spelling promises one thing; listen to what the verb does.
+
+## The word, taken apart: reshaped by its own opposite
+<!-- hl-knowledge: introduces=[FR-ETYMON-OUVRIR-08]; assesses=[FR-ETYMON-MAINTENIR-05] -->
+
+Latin's verb for opening was **aperīre**, which *ouvrir* does not look much
+like — because the word was remodelled on the way into popular Latin
+**operīre**. The likeliest cause is the pull of its own opposite, *cooperīre*,
+"to cover," which became French **couvrir**. Opening and covering ended up
+rhyming and have stayed matched since. The meaning stayed *aperīre*'s; only the
+shape moved.
+
+English collected both ends:
+
+- from *aperīre* — an **aperture**; an **aperitif**, the drink that **opens** a
+  meal.
+- from Old French *ovrir* — **overt**, its past participle "opened," and
+  **overture**, *ouverture*.
+- from the covering half — **curfew**, Old French *cuevrefeu*, "**cover-fire**,"
+  the bell that said to bank the hearth.
+
+Set that beside the hand. *Maintenir* is *manū tenēre*, "**to hold in the
+hand**" — and *ouvrir la main* releases that grip.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-OUVRIR-07, FR-ETYMON-OUVRIR-08, FR-GRAMMAR-OUVRIR-ER-ENDINGS-09, FR-LEX-LEVER-04, FR-LEX-DEBOUT-06, FR-LEX-ASSEOIR-01, FR-LEX-MARCHER-07, FR-LEX-MAIN-02, FR-SOUND-MAIN-03, FR-ETYMON-MAINTENIR-05] -->
+
+[PAUSE 1s]
+- [YOU SAY: "ouvrir" — *oo-VREER*]
+- [YOU SAY: "j'ouvre la main" — and hear *pain*, *main*]
+- [YOU SAY: "je marche, nous marchons" then "j'ouvre, nous ouvrons" — one shape]
+- [YOU SAY: "je m'assieds, je me lève, j'ouvre la main"]
+- [YOU SAY: "je suis debout et j'ouvre la main"]
+- [YOU SAY: "maintenir" then "ouvrir" — holding in the hand, then letting go]
+- [YOU SAY: "aperture, aperitif, overt, overture" — every one an opening]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-OUVRIR-07, FR-ETYMON-OUVRIR-08, FR-GRAMMAR-OUVRIR-ER-ENDINGS-09, FR-LEX-MAIN-02, FR-LEX-MARCHER-07] -->
+
+[PAUSE 3s] Say "I open my hand" and "we open." (*J'ouvre la main. Nous
+ouvrons*.) Which endings does *ouvrir* borrow, despite its spelling? (The
+**-er** set — *marcher*'s.) What is an **aperitif**, literally? (**The opener**
+— the drink that opens a meal.) Why does *ouvrir* not look like Latin *aperīre*?
+(It was **reshaped** to match its own opposite, the verb for covering.)

--- a/code/learning/human-languages/french/lessons/FR-C27-sasseoir.md
+++ b/code/learning/human-languages/french/lessons/FR-C27-sasseoir.md
@@ -1,0 +1,110 @@
+---
+schema_version: 2
+id: FR-C27-sasseoir
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 830
+chapter: 27
+type: word
+headword: s'asseoir
+gloss: to sit down — a verb you do to yourself, from Latin sedēre, and the one French verb that ships with two accepted sets of forms
+concept_tag: VERB-SIT
+prerequisites: [FR-C26-courir]
+sounds: [r-uvular, silent-final]
+roots: [latin-sedere]
+etymology_hook: "s'asseoir ← Vulgar Latin adsedēre, a remaking of Classical adsidēre (ad- 'at' + sedēre 'to sit') → sedentary, session ('a sitting'), sediment, reside, preside, president, assiduous, siege, possess, obsess, subsidy, supersede, dissident, insidious, and a bishop's see (← sedēs 'a seat') — and English sit, seat and settle are genuine Germanic cousins from the same ancient root"
+duration:
+  max_seconds: 298
+requires:
+  knowledge: [FR-LEX-COURIR-10, FR-LEX-MARCHER-07, FR-LEX-DORMIR-04, FR-ETYMON-DORMIR-05, FR-LEX-ENTENDRE-01]
+introduces:
+  knowledge: [FR-LEX-ASSEOIR-01, FR-ETYMON-ASSEOIR-02, FR-GRAMMAR-ASSEOIR-TWO-STEMS-03]
+practises:
+  knowledge: [FR-LEX-ASSEOIR-01, FR-ETYMON-ASSEOIR-02, FR-GRAMMAR-ASSEOIR-TWO-STEMS-03, FR-LEX-COURIR-10, FR-LEX-MARCHER-07, FR-LEX-DORMIR-04, FR-ETYMON-DORMIR-05, FR-LEX-ENTENDRE-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [FR-C26-courir, FR-C26-marcher, FR-C26-dormir, FR-C26-entendre]
+---
+
+# s'asseoir — "to sit down," a verb you do to yourself
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-MARCHER-07, FR-LEX-COURIR-10] -->
+
+[PAUSE 2s] You have walked and you have run. Now stop. French does not say "I
+sit" — it says "**I seat myself**," and that extra word is one you own.
+
+## You'll want to know: the word
+<!-- hl-knowledge: introduces=[FR-LEX-ASSEOIR-01]; assesses=[] -->
+
+> **s'asseoir** — to sit down. Said *sah-SWAHR*.
+>
+> **Je m'assieds.** — I sit down. Said *juh mah-SYAY*.
+
+The **m'** is the *me* inside *je m'appelle*: French treats sitting as something
+you do **to yourself**, so the pronoun is not optional.
+
+Keep two ideas apart. *S'asseoir* is the **movement**, lowering yourself into a
+chair. **Je suis assis** is the **state** after it, "I am seated." English lets
+*sit* cover both; French makes you choose.
+
+## Grammar Lens: one verb, two accepted sets
+<!-- hl-knowledge: introduces=[FR-GRAMMAR-ASSEOIR-TWO-STEMS-03]; assesses=[FR-LEX-ASSEOIR-01] -->
+
+The only verb in the course with **two** correct answers, both in dictionaries.
+Learn this series whole:
+
+- **je m'assieds** — *mah-SYAY*
+- **tu t'assieds** — *tah-SYAY*
+- **il s'assied** — *sah-SYAY* (three identical to the ear)
+- **nous nous asseyons** — *noo-zah-say-YOHN*
+- **vous vous asseyez** — *voo-zah-say-YAY*
+- **ils s'asseyent** — *sah-SAY*
+
+Then recognise the rival singulars **je m'assois, tu
+t'assois, il s'assoit** — ordinary spoken French. Their plurals (*assoyons,
+assoyez*) are much rarer in France, so the series above is the safer one to own.
+Since 1990 the infinitive may also be spelled **s'assoir**. Nothing here is
+wrong; the language never chose.
+
+## The word, taken apart: sedēre
+<!-- hl-knowledge: introduces=[FR-ETYMON-ASSEOIR-02]; assesses=[FR-ETYMON-DORMIR-05] -->
+
+**s'asseoir** ← Vulgar Latin **adsedēre**, a remaking of Classical **adsidēre**
+— **ad-** "at" plus **sedēre**, "**to sit**." Latin had built the compound;
+French only wore it down. And *sedēre* is everywhere in English:
+
+- **sedentary**, sitting work; a **session**, "a sitting"; **sediment**, what
+  sits at the bottom.
+- **reside**, sit back; **preside** and **president**, sitting in front;
+  **assiduous**, sitting at a task.
+- **siege** — an army sitting down before a city; **possess**, **obsess**,
+  **subsidy**.
+- A bishop's **see** is his *sedēs*, his **seat**.
+
+*Dormir* English only borrowed. This root it owns from birth too: **sit**,
+**seat** and **settle** come down the Germanic road from the same source.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-ASSEOIR-01, FR-ETYMON-ASSEOIR-02, FR-GRAMMAR-ASSEOIR-TWO-STEMS-03, FR-LEX-COURIR-10, FR-LEX-MARCHER-07, FR-LEX-DORMIR-04, FR-ETYMON-DORMIR-05, FR-LEX-ENTENDRE-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: "s'asseoir" — *sah-SWAHR*]
+- [YOU SAY: "je m'assieds" then "nous nous asseyons"]
+- [YOU SAY: "je m'appelle" then "je m'assieds" — the same little *m'*]
+- [YOU SAY: "je m'assieds" then "je suis assis" — movement, then state]
+- [YOU SAY: "je marche, je cours, je m'assieds, je dors"]
+- [YOU SAY: "j'entends" — the ear needs no chair]
+- [YOU SAY: "sedentary, session, siege" — every one a sitting]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-ASSEOIR-01, FR-ETYMON-ASSEOIR-02, FR-GRAMMAR-ASSEOIR-TWO-STEMS-03, FR-LEX-DORMIR-04, FR-LEX-COURIR-10] -->
+
+[PAUSE 3s] Say "I sit down" and "we sit down." (*Je m'assieds. Nous nous
+asseyons*.) Why is the pronoun there? (French sits you **yourself** down — the
+same *m'* as in *je m'appelle*.) What is a **siege**, literally? (**A sitting**
+— an army sitting down before a city.) Which English words are cousins of
+*sedēre* by birth rather than borrowing? (**Sit**, **seat**, **settle**.) Now
+the pair: "je cours" and "je dors."

--- a/code/learning/human-languages/french/lessons/FR-C27-se-lever.md
+++ b/code/learning/human-languages/french/lessons/FR-C27-se-lever.md
@@ -1,0 +1,108 @@
+---
+schema_version: 2
+id: FR-C27-se-lever
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 840
+chapter: 27
+type: word
+headword: se lever, debout
+gloss: to stand — French has no single verb for it, so the movement is se lever ("to lighten yourself") and the state is être debout, literally "on end"
+concept_tag: VERB-STAND
+prerequisites: [FR-C27-sasseoir, FR-C25-penser]
+sounds: [vowel-e-grave, er-ending]
+roots: [latin-levare, frankish-botan]
+etymology_hook: "lever ← Latin levāre 'to raise, to lighten' ← levis 'light in weight' → elevate, elevator, lever, levity, levitate, alleviate, relieve, relief, relevant, leaven, levy; debout is de + bout, 'on end', and bout comes from bouter 'to strike, to push' ← Frankish *bōtan, whose English cousin by descent is beat"
+duration:
+  max_seconds: 298
+requires:
+  knowledge: [FR-LEX-ASSEOIR-01, FR-ETYMON-ASSEOIR-02, FR-GRAMMAR-ASSEOIR-TWO-STEMS-03, FR-LEX-COURIR-10, FR-LEX-PENSER-04, FR-ETYMON-PENSER-05]
+introduces:
+  knowledge: [FR-LEX-LEVER-04, FR-ETYMON-LEVER-05, FR-LEX-DEBOUT-06]
+practises:
+  knowledge: [FR-LEX-LEVER-04, FR-ETYMON-LEVER-05, FR-LEX-DEBOUT-06, FR-LEX-ASSEOIR-01, FR-ETYMON-ASSEOIR-02, FR-GRAMMAR-ASSEOIR-TWO-STEMS-03, FR-LEX-COURIR-10, FR-LEX-PENSER-04, FR-ETYMON-PENSER-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [FR-C27-sasseoir, FR-C26-courir, FR-C25-penser]
+---
+
+# se lever, debout — standing, which French says in two pieces
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-ASSEOIR-01] -->
+
+[PAUSE 2s] You sat down. Getting up is harder, because French has **no single
+verb** for "to stand." It splits the idea in two.
+
+## You'll want to know: the movement
+<!-- hl-knowledge: introduces=[FR-LEX-LEVER-04]; assesses=[FR-GRAMMAR-ASSEOIR-TWO-STEMS-03] -->
+
+> **se lever** — to get up, to rise. Said *suh luh-VAY*.
+>
+> **Je me lève.** — I get up. Said *juh muh LEV*.
+
+Reflexive, as *s'asseoir* is: you raise **yourself**. After that verb's two
+paradigms this is a relief — an ordinary **-er** verb with one habit. Silent
+ending, and the *e* takes a **grave accent**; spoken ending, and it flattens:
+
+- **je me lève** — *LEV*
+- **tu te lèves** — *LEV*
+- **il se lève** — *LEV*
+- **nous nous levons** — *luh-VOHN*, flat
+- **vous vous levez** — *luh-VAY*, flat
+- **ils se lèvent** — *LEV*
+
+## You'll want to know: the state
+<!-- hl-knowledge: introduces=[FR-LEX-DEBOUT-06]; assesses=[FR-LEX-LEVER-04] -->
+
+> **debout** — standing, upright. Said *duh-BOO*.
+>
+> **Je suis debout.** — I am standing.
+
+*Se lever* is the **movement**, *debout* the **state** — the split between
+sitting down and being seated. *Debout* is no verb: attach it to *être*.
+
+And it is transparent once opened: **de** + **bout**, "**on end**." A *bout* is
+a tip or end, so standing is being set on your end. French did once have a
+plain verb for standing, *ester*; it survives only in a courtroom phrase, which
+is why the language builds this from pieces.
+
+## The word, taken apart: lightness
+<!-- hl-knowledge: introduces=[FR-ETYMON-LEVER-05]; assesses=[FR-ETYMON-PENSER-05, FR-ETYMON-ASSEOIR-02] -->
+
+**lever** ← Latin **levāre**, "to raise" — built on **levis**, "**light in
+weight**." To raise a thing is to lighten it. Hence **elevate**,
+**elevator**, **levitate**, **levity**; a **lever**, which lightens a load;
+**alleviate**, **relieve**, **relief**; **leaven**.
+
+So two of this course's verbs come from one corner of Roman thought. *Penser*
+is *pēnsāre*, "**to weigh**"; *lever* is *levāre*, "to make **light**." Thinking
+weighs, rising un-weighs, and *sedēre* just sits there.
+
+One correction. **Bout** comes from *bouter*, "to strike," taken from Frankish —
+and its English relative by **descent** is **beat**. *Butt* looks closer but is
+a later **borrowing** back out of French.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-LEVER-04, FR-ETYMON-LEVER-05, FR-LEX-DEBOUT-06, FR-LEX-ASSEOIR-01, FR-ETYMON-ASSEOIR-02, FR-GRAMMAR-ASSEOIR-TWO-STEMS-03, FR-LEX-COURIR-10, FR-LEX-PENSER-04, FR-ETYMON-PENSER-05] -->
+
+[PAUSE 1s]
+- [YOU SAY: "se lever" — *suh luh-VAY*]
+- [YOU SAY: "je me lève" then "nous nous levons" — sharp, then flat]
+- [YOU SAY: "je m'assieds" then "je me lève" — down, then up]
+- [YOU SAY: "je suis debout" — the state, on *être*]
+- [YOU SAY: "je me lève et je cours"]
+- [YOU SAY: "je pense" then "je me lève" — weighing, then lightening]
+- [YOU SAY: "elevate, lever, relief" — all a raising]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-LEVER-04, FR-ETYMON-LEVER-05, FR-LEX-DEBOUT-06, FR-LEX-ASSEOIR-01, FR-ETYMON-PENSER-05] -->
+
+[PAUSE 3s] Say "I get up" and "we get up." (*Je me lève. Nous nous levons* — the
+accent appears only when the ending is silent.) How does French say "I am
+standing"? (***Je suis debout*** — a state pinned to *être*, not a verb, and
+*debout* is *de* + *bout*, "**on end**.") *Penser* came from weighing; what does
+*lever* come from? (***Levis***, "**light in weight**".) And the opposite
+movement? (*Je m'assieds*.)

--- a/code/learning/human-languages/french/narration/ch26.json
+++ b/code/learning/human-languages/french/narration/ch26.json
@@ -1,0 +1,852 @@
+{
+  "version": 1,
+  "language": "french",
+  "chapter": 26,
+  "title": "Hearing, Sleeping, Walking, Running",
+  "drivablePrefix": 4,
+  "sourceHash": "fnv1a64:eac4adb1915b9a9d",
+  "lessons": [
+    {
+      "id": "FR-C26-entendre",
+      "sequence": 790,
+      "title": "entendre — \"to hear,\" and the stretching inside it",
+      "headword": "entendre",
+      "romanization": "entendre",
+      "gloss": "to hear — from a Latin verb meaning \"to stretch toward,\" so English's intend is its closest surviving cousin, and French still keeps the older sense in entendu and s'entendre",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:2fcffc50b4c530f1",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You can think and understand. Now the ear — and French's word for it is English's intend."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: the word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "entendre — to hear. Two nasal an sounds in a row, then the -dre of prendre: say it ahn-TAHN-druh. J'entends le chien. — I hear the dog."
+            },
+            {
+              "kind": "speech",
+              "text": "The -ds of j'entends is silent, as in je prends."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: the nasal that stays put",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Prendre's nasal dies in the plural. Entendre looks like its twin and does the opposite — the stem never moves:"
+            },
+            {
+              "kind": "speech",
+              "text": "j'entends — jahn-TAHN."
+            },
+            {
+              "kind": "speech",
+              "text": "tu entends — ahn-TAHN."
+            },
+            {
+              "kind": "speech",
+              "text": "il entend — ahn-TAHN (three identical to the ear)."
+            },
+            {
+              "kind": "speech",
+              "text": "nous entendons — ahn-tahn-DOHN, nasal still there."
+            },
+            {
+              "kind": "speech",
+              "text": "vous entendez — ahn-tahn-DAY."
+            },
+            {
+              "kind": "speech",
+              "text": "ils entendent — ahn-TAHND."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: a stretching",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "entendre from Latin intendere — in- \"toward\" plus tendere, \"to stretch.\" To intendere was to stretch a thing out and aim it: a bowstring, a journey, your attention. English kept the family — intend, plainest of them, plus intent, intense, tension, a tent (a stretched skin), extend and pretend."
+            },
+            {
+              "kind": "speech",
+              "text": "Set your three mind-verbs together: French pictures each as a different thing the body does."
+            },
+            {
+              "kind": "speech",
+              "text": "comprendre — to grasp together, built on prendre."
+            },
+            {
+              "kind": "speech",
+              "text": "penser — to weigh, from pēnsāre."
+            },
+            {
+              "kind": "speech",
+              "text": "entendre — to stretch toward."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way: the sense that took over",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "From its oldest French records entendre already covers a span at once: to hear, to attend, to understand, to intend. Nothing arrived late. What happened since is that the other senses fell away and hearing took the word outright — because Latin's verb for hearing, audīre, wore down in French to ouïr and stopped being usable. English kept that family instead: audio, audience, audible, audition."
+            },
+            {
+              "kind": "speech",
+              "text": "The abandoned senses survive in phrases French never rebuilt:"
+            },
+            {
+              "kind": "speech",
+              "text": "entendu — \"understood,\" \"agreed.\""
+            },
+            {
+              "kind": "speech",
+              "text": "s'entendre — to hear one another, and so to get along."
+            },
+            {
+              "kind": "speech",
+              "text": "l'entente — an understanding between parties, borrowed into English whole in Entente Cordiale."
+            },
+            {
+              "kind": "speech",
+              "text": "So the two languages split one Latin pair: French hears with the verb English uses for intending, and English hears with the verb French let go."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"entendre\" — ahn-TAHN-druh, two nasals",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"entendre\" — *ahn-TAHN-druh*, two nasals]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"j'entends le chien\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"j'entends le chien\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"nous prenons\" then \"nous entendons\" — one flattens, one holds",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"nous prenons\" then \"nous entendons\" — one flattens, one holds]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"j'écris, je comprends, j'entends\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"j'écris, je comprends, j'entends\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three pictures — stretching, grasping, weighing",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three pictures — stretching, grasping, weighing]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"intend, tension, tent\" — all a stretching",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"intend, tension, tent\" — all a stretching]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say \"I hear the dog\" and \"we hear.\" (J'entends le chien. Nous entendons — and unlike nous prenons, nothing flattens.) What did intendere mean, and which English verb is its plainest survival? (To stretch toward; intend.) Why did French hand hearing to this verb? (Latin's audīre wore down to ouïr and fell out of use — English kept the audīre words instead.) What does s'entendre mean? (To get along.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "FR-C26-dormir",
+      "sequence": 800,
+      "title": "dormir — \"to sleep,\" and the room named after it",
+      "headword": "dormir",
+      "romanization": "dormir",
+      "gloss": "to sleep — Latin dormīre, unchanged in French, and the source of dormitory and dormant, though not of the dormouse",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:8ac859110ce4c654",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "After a verb that changed jobs, here is one that never changed. Dormir is Latin's word for sleeping, handed on almost untouched — and it hides one trap."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: the word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "dormir — to sleep. Said dor-MEER, with the throaty French r in the middle and at the end. Le chat dort. — The cat is sleeping."
+            },
+            {
+              "kind": "speech",
+              "text": "French has no separate \"is sleeping\" form. Il dort covers both \"he sleeps\" and \"he is sleeping\"; the plain present does all the work."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: the m that goes missing",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The stem is dorm-, and in the singular French throws the m away. Listen for where it comes back:"
+            },
+            {
+              "kind": "speech",
+              "text": "je dors — dor."
+            },
+            {
+              "kind": "speech",
+              "text": "tu dors — dor."
+            },
+            {
+              "kind": "speech",
+              "text": "il dort — dor (three identical, the m gone)."
+            },
+            {
+              "kind": "speech",
+              "text": "nous dormons — dor-MOHN, and there it is."
+            },
+            {
+              "kind": "speech",
+              "text": "vous dormez — dor-MAY."
+            },
+            {
+              "kind": "speech",
+              "text": "ils dorment — DORM."
+            },
+            {
+              "kind": "speech",
+              "text": "One rule, and you have the whole verb: singular loses the last stem consonant, plural gets it back. A small family of -ir verbs shares the shape, so learning it once is worth more than one verb."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: dormīre",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "dormir from Latin dormīre, \"to sleep.\" Spanish kept dormir, Italian dormire, Portuguese dormir — the verb crossed into its daughter languages untouched, which is rarer than it sounds. English has no inherited descendant; it borrowed the family later, through French:"
+            },
+            {
+              "kind": "speech",
+              "text": "dormitory from dormītōrium, a sleeping place; French wore the identical word down to dortoir."
+            },
+            {
+              "kind": "speech",
+              "text": "dormant — Old French dormant, \"sleeping\"; a dormant volcano is asleep."
+            },
+            {
+              "kind": "speech",
+              "text": "dormer — a roof window, from Old French dormeor, because the room behind it was where you slept."
+            },
+            {
+              "kind": "speech",
+              "text": "And an honest stop. The dormouse looks like the best cousin of the lot and is not one. The story needs an Anglo-Norman word for \"sleeper\" that nobody has found in a text, and dormouse's real origin is unknown. A guess in circulation, not an etymology."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"dormir\" — dor-MEER, throaty r",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"dormir\" — *dor-MEER*, throaty *r*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je dors\" then \"nous dormons\" — the m vanishes, then returns",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je dors\" then \"nous dormons\" — the *m* vanishes, then returns]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"le chat dort\" — the cat, the travelling word out of Egypt",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"le chat dort\" — the cat, the travelling word out of Egypt]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"j'entends le chat\" then \"le chat dort\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"j'entends le chat\" then \"le chat dort\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"dormir, dormitory, dormant\" — one Latin verb, borrowed back",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"dormir, dormitory, dormant\" — one Latin verb, borrowed back]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je comprends\" then \"je dors\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je comprends\" then \"je dors\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say \"the cat is sleeping\" and \"we sleep.\" (Le chat dort. Nous dormons — the m is silent in the singular and audible in the plural.) Where does dormitory come from? (Latin dormītōrium, \"a sleeping place\" — and French wore the same word down to dortoir.) Is the dormouse in this family? (No — that is folk etymology; the word's real origin is unknown.) And chat — an inherited Latin word, or a traveller? (A traveller, from cattus, moving with the cat itself out of Egypt.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "FR-C26-marcher",
+      "sequence": 810,
+      "title": "marcher — \"to walk,\" and the step hiding inside French negation",
+      "headword": "marcher",
+      "romanization": "marcher",
+      "gloss": "to walk — and also to work, so ça marche is the most useful two words in the chapter; its own origin is genuinely unsettled between a Frankish verb and a Latin hammer",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:97bc8031093782ab",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You can hear and you can sleep. Now move. This verb does a second job too, used dozens of times a day."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: the word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "marcher — to walk. Said mar-SHAY: the -er is a clean ay, and the ch is sh, never k. Je marche. — I walk."
+            },
+            {
+              "kind": "speech",
+              "text": "After dormir's vanishing m, this one asks nothing: an ordinary -er verb. Je marche, tu marches, il marche, nous marchons, vous marchez, ils marchent — four of the six sound identical, just marsh."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way: ça marche",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Marcher is also the everyday verb for a thing working. A machine, a plan, an arrangement: if it functions, it walks."
+            },
+            {
+              "kind": "speech",
+              "text": "Ça marche. — \"That works.\" Also \"Fine,\" \"Deal,\" \"Sounds good.\" Ça ne marche pas. — \"That doesn't work.\""
+            },
+            {
+              "kind": "speech",
+              "text": "There is your ne … pas from the answer-word non, round a real verb at last. And ça marche alone is an agreement, two words long."
+            },
+            {
+              "kind": "speech",
+              "text": "Entendre once held several jobs and shed all but hearing. Marcher holds two right now."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: a step, or a hammer",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Here the honest answer is that nobody is certain. Old French marchier first meant \"to trample, to tread on,\" and two accounts compete:"
+            },
+            {
+              "kind": "speech",
+              "text": "Frankish markōn, \"to mark, to press a step in\" — preferred by most reference works."
+            },
+            {
+              "kind": "speech",
+              "text": "Late Latin marcāre, from marcus, \"a hammer\" — a blow and a tread being one motion."
+            },
+            {
+              "kind": "speech",
+              "text": "Three consequences, in falling order of certainty:"
+            },
+            {
+              "kind": "speech",
+              "text": "English march, the verb, is borrowed straight from marcher. Secure whichever origin is right."
+            },
+            {
+              "kind": "speech",
+              "text": "English mark is Germanic, from Old English mearc. A relative only if the Frankish account holds — conditional, not a fact."
+            },
+            {
+              "kind": "speech",
+              "text": "French la marche, a borderland, with marquis and German margrave, comes from the Germanic noun marka, \"boundary\" — a separate arrival."
+            },
+            {
+              "kind": "speech",
+              "text": "And one cousin you own already. The pas in ne … pas began as Latin passus, \"a step.\" Je ne marche pas is, underneath, \"I do not walk a step.\""
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"marcher\" — mar-SHAY, sh not k",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"marcher\" — *mar-SHAY*, *sh* not *k*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je marche\" then \"nous marchons\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je marche\" then \"nous marchons\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ça marche\" — that works, that's fine",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ça marche\" — that works, that's fine]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"non\", then \"je ne marche pas\" — and pas is a step",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"non\", then \"je ne marche pas\" — and *pas* is a **step**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"j'entends, je dors, je marche\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"j'entends, je dors, je marche\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"nous dormons, nous marchons\" — one stem shifts, one never does",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"nous dormons, nous marchons\" — one stem shifts, one never does]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say \"I walk\" and \"that works.\" (Je marche. Ça marche.) What are the two competing origins? (Frankish markōn, \"to press a step in,\" or Latin marcus, \"a hammer.\" Genuinely unsettled.) Which English word is certainly related, and which only might be? (March, borrowed straight from marcher; mark only if the Frankish account is right.) What did pas mean before it meant \"not\"? (A step.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "FR-C26-courir",
+      "sequence": 820,
+      "title": "courir — \"to run,\" and why it is not chourir",
+      "headword": "courir",
+      "romanization": "courir",
+      "gloss": "to run — Latin currere, the root under current, course, courier and curriculum, and the verb that shows why chien palatalized its c and courir did not",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:06b9e4a83df44973",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Hearing, sleeping, walking — and now the fastest of the four. Its Latin root is one of the busiest in English, and its spelling settles a question the dog raised."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: the word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "courir — to run. Said koo-REER, throaty at both rs. Le chien court. — The dog runs."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: the same endings, a different stem",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Courir takes dormir's singular endings — -s, -s, -t, all silent:"
+            },
+            {
+              "kind": "speech",
+              "text": "je cours — koor."
+            },
+            {
+              "kind": "speech",
+              "text": "tu cours — koor."
+            },
+            {
+              "kind": "speech",
+              "text": "il court — koor."
+            },
+            {
+              "kind": "speech",
+              "text": "nous courons — koo-ROHN."
+            },
+            {
+              "kind": "speech",
+              "text": "vous courez — koo-RAY."
+            },
+            {
+              "kind": "speech",
+              "text": "ils courent — KOOR."
+            },
+            {
+              "kind": "speech",
+              "text": "But the resemblance stops there. Dormir sheds a consonant in the singular: dorm- becomes dor-. Courir sheds nothing — its stem cour- has nothing spare to lose."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: currere",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Marcher left a choice between a Frankish verb and a Latin hammer. This one leaves none. courir from Latin currere, \"to run,\" which English mined harder than almost any other verb:"
+            },
+            {
+              "kind": "speech",
+              "text": "current and currency both run; a cursor runs across a screen; a course is a run, a corridor a running-place."
+            },
+            {
+              "kind": "speech",
+              "text": "courier, one who runs; curriculum, literally \"a running.\""
+            },
+            {
+              "kind": "speech",
+              "text": "concur, run together; occur, run up against; excursion."
+            },
+            {
+              "kind": "speech",
+              "text": "Now the spelling question. Chien came from canis, and its c turned into ch — the shift that made champ and chanter. So why is this verb not chourir? Because that shift only struck c before a. Currere had c before u, untouched, so the k survived. One rule, two regular outcomes."
+            },
+            {
+              "kind": "speech",
+              "text": "One honest limit. Latin carrus, \"wagon,\" gave English car and cargo, and descends from the same very old root. But Latin borrowed carrus from Gaulish: a cousin by another road, not a word built out of currere."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the chapter's four with je — \"j'entends, je dors, je marche, je cours\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the chapter's four with *je* — \"j'entends, je dors, je marche, je cours\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"le chien court\" then \"le chat dort\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"le chien court\" then \"le chat dort\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"il fait chaud, je cours\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"il fait chaud, je cours\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"il pleut, je ne cours pas\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"il pleut, je ne cours pas\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je dors, nous dormons\" then \"je cours, nous courons\" — one sheds",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je dors, nous dormons\" then \"je cours, nous courons\" — one sheds]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"chien\" then \"courir\" — ch before a, k before u",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"chien\" then \"courir\" — *ch* before *a*, *k* before *u*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"current, course, courier, curriculum\" — every one a running",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"current, course, courier, curriculum\" — every one a running]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ça marche\" — the agreement, two words",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ça marche\" — the agreement, two words]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say the chapter's four verbs with je. (J'entends, je dors, je marche, je cours.) What does curriculum literally mean? (A running — from currere.) Why did canis become chien while currere stayed hard? (The shift only hit c before a.) Which of the four began as a stretching? (Entendre — intendere, to stretch toward.) Now: \"the dog runs\" and \"it is hot.\" (Le chien court. Il fait chaud.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/french/narration/ch26.txt
+++ b/code/learning/human-languages/french/narration/ch26.txt
@@ -1,0 +1,204 @@
+French, chapter 26: Hearing, Sleeping, Walking, Running.
+4 lessons. All 4 can be done entirely by ear.
+
+
+Lesson 1 of 4.
+entendre — "to hear," and the stretching inside it.
+
+Warm-up.
+[pause 2 seconds]
+You can think and understand. Now the ear — and French's word for it is English's intend.
+
+You'll want to know: the word.
+entendre — to hear. Two nasal an sounds in a row, then the -dre of prendre: say it ahn-TAHN-druh. J'entends le chien. — I hear the dog.
+The -ds of j'entends is silent, as in je prends.
+
+Grammar Lens: the nasal that stays put.
+Prendre's nasal dies in the plural. Entendre looks like its twin and does the opposite — the stem never moves:
+j'entends — jahn-TAHN.
+tu entends — ahn-TAHN.
+il entend — ahn-TAHN (three identical to the ear).
+nous entendons — ahn-tahn-DOHN, nasal still there.
+vous entendez — ahn-tahn-DAY.
+ils entendent — ahn-TAHND.
+
+The word, taken apart: a stretching.
+entendre from Latin intendere — in- "toward" plus tendere, "to stretch." To intendere was to stretch a thing out and aim it: a bowstring, a journey, your attention. English kept the family — intend, plainest of them, plus intent, intense, tension, a tent (a stretched skin), extend and pretend.
+Set your three mind-verbs together: French pictures each as a different thing the body does.
+comprendre — to grasp together, built on prendre.
+penser — to weigh, from pēnsāre.
+entendre — to stretch toward.
+
+Why it's said this way: the sense that took over.
+From its oldest French records entendre already covers a span at once: to hear, to attend, to understand, to intend. Nothing arrived late. What happened since is that the other senses fell away and hearing took the word outright — because Latin's verb for hearing, audīre, wore down in French to ouïr and stopped being usable. English kept that family instead: audio, audience, audible, audition.
+The abandoned senses survive in phrases French never rebuilt:
+entendu — "understood," "agreed."
+s'entendre — to hear one another, and so to get along.
+l'entente — an understanding between parties, borrowed into English whole in Entente Cordiale.
+So the two languages split one Latin pair: French hears with the verb English uses for intending, and English hears with the verb French let go.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "entendre" — ahn-TAHN-druh, two nasals]
+[pause 8 seconds for the answer]
+[your turn — say: "j'entends le chien"]
+[pause 8 seconds for the answer]
+[your turn — say: "nous prenons" then "nous entendons" — one flattens, one holds]
+[pause 8 seconds for the answer]
+[your turn — say: "j'écris, je comprends, j'entends"]
+[pause 8 seconds for the answer]
+[your turn — say: the three pictures — stretching, grasping, weighing]
+[pause 8 seconds for the answer]
+[your turn — say: "intend, tension, tent" — all a stretching]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say "I hear the dog" and "we hear." (J'entends le chien. Nous entendons — and unlike nous prenons, nothing flattens.) What did intendere mean, and which English verb is its plainest survival? (To stretch toward; intend.) Why did French hand hearing to this verb? (Latin's audīre wore down to ouïr and fell out of use — English kept the audīre words instead.) What does s'entendre mean? (To get along.)
+
+
+Lesson 2 of 4.
+dormir — "to sleep," and the room named after it.
+
+Warm-up.
+[pause 2 seconds]
+After a verb that changed jobs, here is one that never changed. Dormir is Latin's word for sleeping, handed on almost untouched — and it hides one trap.
+
+You'll want to know: the word.
+dormir — to sleep. Said dor-MEER, with the throaty French r in the middle and at the end. Le chat dort. — The cat is sleeping.
+French has no separate "is sleeping" form. Il dort covers both "he sleeps" and "he is sleeping"; the plain present does all the work.
+
+Grammar Lens: the m that goes missing.
+The stem is dorm-, and in the singular French throws the m away. Listen for where it comes back:
+je dors — dor.
+tu dors — dor.
+il dort — dor (three identical, the m gone).
+nous dormons — dor-MOHN, and there it is.
+vous dormez — dor-MAY.
+ils dorment — DORM.
+One rule, and you have the whole verb: singular loses the last stem consonant, plural gets it back. A small family of -ir verbs shares the shape, so learning it once is worth more than one verb.
+
+The word, taken apart: dormīre.
+dormir from Latin dormīre, "to sleep." Spanish kept dormir, Italian dormire, Portuguese dormir — the verb crossed into its daughter languages untouched, which is rarer than it sounds. English has no inherited descendant; it borrowed the family later, through French:
+dormitory from dormītōrium, a sleeping place; French wore the identical word down to dortoir.
+dormant — Old French dormant, "sleeping"; a dormant volcano is asleep.
+dormer — a roof window, from Old French dormeor, because the room behind it was where you slept.
+And an honest stop. The dormouse looks like the best cousin of the lot and is not one. The story needs an Anglo-Norman word for "sleeper" that nobody has found in a text, and dormouse's real origin is unknown. A guess in circulation, not an etymology.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "dormir" — dor-MEER, throaty r]
+[pause 8 seconds for the answer]
+[your turn — say: "je dors" then "nous dormons" — the m vanishes, then returns]
+[pause 8 seconds for the answer]
+[your turn — say: "le chat dort" — the cat, the travelling word out of Egypt]
+[pause 8 seconds for the answer]
+[your turn — say: "j'entends le chat" then "le chat dort"]
+[pause 8 seconds for the answer]
+[your turn — say: "dormir, dormitory, dormant" — one Latin verb, borrowed back]
+[pause 8 seconds for the answer]
+[your turn — say: "je comprends" then "je dors"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say "the cat is sleeping" and "we sleep." (Le chat dort. Nous dormons — the m is silent in the singular and audible in the plural.) Where does dormitory come from? (Latin dormītōrium, "a sleeping place" — and French wore the same word down to dortoir.) Is the dormouse in this family? (No — that is folk etymology; the word's real origin is unknown.) And chat — an inherited Latin word, or a traveller? (A traveller, from cattus, moving with the cat itself out of Egypt.)
+
+
+Lesson 3 of 4.
+marcher — "to walk," and the step hiding inside French negation.
+
+Warm-up.
+[pause 2 seconds]
+You can hear and you can sleep. Now move. This verb does a second job too, used dozens of times a day.
+
+You'll want to know: the word.
+marcher — to walk. Said mar-SHAY: the -er is a clean ay, and the ch is sh, never k. Je marche. — I walk.
+After dormir's vanishing m, this one asks nothing: an ordinary -er verb. Je marche, tu marches, il marche, nous marchons, vous marchez, ils marchent — four of the six sound identical, just marsh.
+
+Why it's said this way: ça marche.
+Marcher is also the everyday verb for a thing working. A machine, a plan, an arrangement: if it functions, it walks.
+Ça marche. — "That works." Also "Fine," "Deal," "Sounds good." Ça ne marche pas. — "That doesn't work."
+There is your ne … pas from the answer-word non, round a real verb at last. And ça marche alone is an agreement, two words long.
+Entendre once held several jobs and shed all but hearing. Marcher holds two right now.
+
+The word, taken apart: a step, or a hammer.
+Here the honest answer is that nobody is certain. Old French marchier first meant "to trample, to tread on," and two accounts compete:
+Frankish markōn, "to mark, to press a step in" — preferred by most reference works.
+Late Latin marcāre, from marcus, "a hammer" — a blow and a tread being one motion.
+Three consequences, in falling order of certainty:
+English march, the verb, is borrowed straight from marcher. Secure whichever origin is right.
+English mark is Germanic, from Old English mearc. A relative only if the Frankish account holds — conditional, not a fact.
+French la marche, a borderland, with marquis and German margrave, comes from the Germanic noun marka, "boundary" — a separate arrival.
+And one cousin you own already. The pas in ne … pas began as Latin passus, "a step." Je ne marche pas is, underneath, "I do not walk a step."
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "marcher" — mar-SHAY, sh not k]
+[pause 8 seconds for the answer]
+[your turn — say: "je marche" then "nous marchons"]
+[pause 8 seconds for the answer]
+[your turn — say: "ça marche" — that works, that's fine]
+[pause 8 seconds for the answer]
+[your turn — say: "non", then "je ne marche pas" — and pas is a step]
+[pause 8 seconds for the answer]
+[your turn — say: "j'entends, je dors, je marche"]
+[pause 8 seconds for the answer]
+[your turn — say: "nous dormons, nous marchons" — one stem shifts, one never does]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say "I walk" and "that works." (Je marche. Ça marche.) What are the two competing origins? (Frankish markōn, "to press a step in," or Latin marcus, "a hammer." Genuinely unsettled.) Which English word is certainly related, and which only might be? (March, borrowed straight from marcher; mark only if the Frankish account is right.) What did pas mean before it meant "not"? (A step.)
+
+
+Lesson 4 of 4.
+courir — "to run," and why it is not chourir.
+
+Warm-up.
+[pause 2 seconds]
+Hearing, sleeping, walking — and now the fastest of the four. Its Latin root is one of the busiest in English, and its spelling settles a question the dog raised.
+
+You'll want to know: the word.
+courir — to run. Said koo-REER, throaty at both rs. Le chien court. — The dog runs.
+
+Grammar Lens: the same endings, a different stem.
+Courir takes dormir's singular endings — -s, -s, -t, all silent:
+je cours — koor.
+tu cours — koor.
+il court — koor.
+nous courons — koo-ROHN.
+vous courez — koo-RAY.
+ils courent — KOOR.
+But the resemblance stops there. Dormir sheds a consonant in the singular: dorm- becomes dor-. Courir sheds nothing — its stem cour- has nothing spare to lose.
+
+The word, taken apart: currere.
+Marcher left a choice between a Frankish verb and a Latin hammer. This one leaves none. courir from Latin currere, "to run," which English mined harder than almost any other verb:
+current and currency both run; a cursor runs across a screen; a course is a run, a corridor a running-place.
+courier, one who runs; curriculum, literally "a running."
+concur, run together; occur, run up against; excursion.
+Now the spelling question. Chien came from canis, and its c turned into ch — the shift that made champ and chanter. So why is this verb not chourir? Because that shift only struck c before a. Currere had c before u, untouched, so the k survived. One rule, two regular outcomes.
+One honest limit. Latin carrus, "wagon," gave English car and cargo, and descends from the same very old root. But Latin borrowed carrus from Gaulish: a cousin by another road, not a word built out of currere.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the chapter's four with je — "j'entends, je dors, je marche, je cours"]
+[pause 8 seconds for the answer]
+[your turn — say: "le chien court" then "le chat dort"]
+[pause 8 seconds for the answer]
+[your turn — say: "il fait chaud, je cours"]
+[pause 8 seconds for the answer]
+[your turn — say: "il pleut, je ne cours pas"]
+[pause 8 seconds for the answer]
+[your turn — say: "je dors, nous dormons" then "je cours, nous courons" — one sheds]
+[pause 8 seconds for the answer]
+[your turn — say: "chien" then "courir" — ch before a, k before u]
+[pause 8 seconds for the answer]
+[your turn — say: "current, course, courier, curriculum" — every one a running]
+[pause 8 seconds for the answer]
+[your turn — say: "ça marche" — the agreement, two words]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say the chapter's four verbs with je. (J'entends, je dors, je marche, je cours.) What does curriculum literally mean? (A running — from currere.) Why did canis become chien while currere stayed hard? (The shift only hit c before a.) Which of the four began as a stretching? (Entendre — intendere, to stretch toward.) Now: "the dog runs" and "it is hot." (Le chien court. Il fait chaud.)

--- a/code/learning/human-languages/french/narration/ch27.json
+++ b/code/learning/human-languages/french/narration/ch27.json
@@ -1,0 +1,856 @@
+{
+  "version": 1,
+  "language": "french",
+  "chapter": 27,
+  "title": "Sitting, Standing, Opening, Closing",
+  "drivablePrefix": 4,
+  "sourceHash": "fnv1a64:ac5b1968b18e6213",
+  "lessons": [
+    {
+      "id": "FR-C27-sasseoir",
+      "sequence": 830,
+      "title": "s'asseoir — \"to sit down,\" a verb you do to yourself",
+      "headword": "s'asseoir",
+      "romanization": "s'asseoir",
+      "gloss": "to sit down — a verb you do to yourself, from Latin sedēre, and the one French verb that ships with two accepted sets of forms",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:22351bcb8b4bd18e",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You have walked and you have run. Now stop. French does not say \"I sit\" — it says \"I seat myself,\" and that extra word is one you own."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: the word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "s'asseoir — to sit down. Said sah-SWAHR. Je m'assieds. — I sit down. Said juh mah-SYAY."
+            },
+            {
+              "kind": "speech",
+              "text": "The m' is the me inside je m'appelle: French treats sitting as something you do to yourself, so the pronoun is not optional."
+            },
+            {
+              "kind": "speech",
+              "text": "Keep two ideas apart. S'asseoir is the movement, lowering yourself into a chair. Je suis assis is the state after it, \"I am seated.\" English lets sit cover both; French makes you choose."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: one verb, two accepted sets",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The only verb in the course with two correct answers, both in dictionaries. Learn this series whole:"
+            },
+            {
+              "kind": "speech",
+              "text": "je m'assieds — mah-SYAY."
+            },
+            {
+              "kind": "speech",
+              "text": "tu t'assieds — tah-SYAY."
+            },
+            {
+              "kind": "speech",
+              "text": "il s'assied — sah-SYAY (three identical to the ear)."
+            },
+            {
+              "kind": "speech",
+              "text": "nous nous asseyons — noo-zah-say-YOHN."
+            },
+            {
+              "kind": "speech",
+              "text": "vous vous asseyez — voo-zah-say-YAY."
+            },
+            {
+              "kind": "speech",
+              "text": "ils s'asseyent — sah-SAY."
+            },
+            {
+              "kind": "speech",
+              "text": "Then recognise the rival singulars je m'assois, tu t'assois, il s'assoit — ordinary spoken French. Their plurals (assoyons, assoyez) are much rarer in France, so the series above is the safer one to own. Since 1990 the infinitive may also be spelled s'assoir. Nothing here is wrong; the language never chose."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: sedēre",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "s'asseoir from Vulgar Latin adsedēre, a remaking of Classical adsidēre — ad- \"at\" plus sedēre, \"to sit.\" Latin had built the compound; French only wore it down. And sedēre is everywhere in English:"
+            },
+            {
+              "kind": "speech",
+              "text": "sedentary, sitting work; a session, \"a sitting\"; sediment, what sits at the bottom."
+            },
+            {
+              "kind": "speech",
+              "text": "reside, sit back; preside and president, sitting in front; assiduous, sitting at a task."
+            },
+            {
+              "kind": "speech",
+              "text": "siege — an army sitting down before a city; possess, obsess, subsidy."
+            },
+            {
+              "kind": "speech",
+              "text": "A bishop's see is his sedēs, his seat."
+            },
+            {
+              "kind": "speech",
+              "text": "Dormir English only borrowed. This root it owns from birth too: sit, seat and settle come down the Germanic road from the same source."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"s'asseoir\" — sah-SWAHR",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"s'asseoir\" — *sah-SWAHR*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je m'assieds\" then \"nous nous asseyons\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je m'assieds\" then \"nous nous asseyons\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je m'appelle\" then \"je m'assieds\" — the same little m'",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je m'appelle\" then \"je m'assieds\" — the same little *m'*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je m'assieds\" then \"je suis assis\" — movement, then state",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je m'assieds\" then \"je suis assis\" — movement, then state]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je marche, je cours, je m'assieds, je dors\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je marche, je cours, je m'assieds, je dors\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"j'entends\" — the ear needs no chair",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"j'entends\" — the ear needs no chair]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sedentary, session, siege\" — every one a sitting",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sedentary, session, siege\" — every one a sitting]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say \"I sit down\" and \"we sit down.\" (Je m'assieds. Nous nous asseyons.) Why is the pronoun there? (French sits you yourself down — the same m' as in je m'appelle.) What is a siege, literally? (A sitting — an army sitting down before a city.) Which English words are cousins of sedēre by birth rather than borrowing? (Sit, seat, settle.) Now the pair: \"je cours\" and \"je dors.\""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "FR-C27-se-lever",
+      "sequence": 840,
+      "title": "se lever, debout — standing, which French says in two pieces",
+      "headword": "se lever, debout",
+      "romanization": "se lever, debout",
+      "gloss": "to stand — French has no single verb for it, so the movement is se lever (\"to lighten yourself\") and the state is être debout, literally \"on end\"",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:c7f80390b7695f21",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You sat down. Getting up is harder, because French has no single verb for \"to stand.\" It splits the idea in two."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: the movement",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "se lever — to get up, to rise. Said suh luh-VAY. Je me lève. — I get up. Said juh muh LEV."
+            },
+            {
+              "kind": "speech",
+              "text": "Reflexive, as s'asseoir is: you raise yourself. After that verb's two paradigms this is a relief — an ordinary -er verb with one habit. Silent ending, and the e takes a grave accent; spoken ending, and it flattens:"
+            },
+            {
+              "kind": "speech",
+              "text": "je me lève — LEV."
+            },
+            {
+              "kind": "speech",
+              "text": "tu te lèves — LEV."
+            },
+            {
+              "kind": "speech",
+              "text": "il se lève — LEV."
+            },
+            {
+              "kind": "speech",
+              "text": "nous nous levons — luh-VOHN, flat."
+            },
+            {
+              "kind": "speech",
+              "text": "vous vous levez — luh-VAY, flat."
+            },
+            {
+              "kind": "speech",
+              "text": "ils se lèvent — LEV."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "input",
+          "title": "You'll want to know: the state",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "debout — standing, upright. Said duh-BOO. Je suis debout. — I am standing."
+            },
+            {
+              "kind": "speech",
+              "text": "Se lever is the movement, debout the state — the split between sitting down and being seated. Debout is no verb: attach it to être."
+            },
+            {
+              "kind": "speech",
+              "text": "And it is transparent once opened: de + bout, \"on end.\" A bout is a tip or end, so standing is being set on your end. French did once have a plain verb for standing, ester; it survives only in a courtroom phrase, which is why the language builds this from pieces."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: lightness",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "lever from Latin levāre, \"to raise\" — built on levis, \"light in weight.\" To raise a thing is to lighten it. Hence elevate, elevator, levitate, levity; a lever, which lightens a load; alleviate, relieve, relief; leaven."
+            },
+            {
+              "kind": "speech",
+              "text": "So two of this course's verbs come from one corner of Roman thought. Penser is pēnsāre, \"to weigh\"; lever is levāre, \"to make light.\" Thinking weighs, rising un-weighs, and sedēre just sits there."
+            },
+            {
+              "kind": "speech",
+              "text": "One correction. Bout comes from bouter, \"to strike,\" taken from Frankish — and its English relative by descent is beat. Butt looks closer but is a later borrowing back out of French."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"se lever\" — suh luh-VAY",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"se lever\" — *suh luh-VAY*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je me lève\" then \"nous nous levons\" — sharp, then flat",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je me lève\" then \"nous nous levons\" — sharp, then flat]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je m'assieds\" then \"je me lève\" — down, then up",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je m'assieds\" then \"je me lève\" — down, then up]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je suis debout\" — the state, on être",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je suis debout\" — the state, on *être*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je me lève et je cours\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je me lève et je cours\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je pense\" then \"je me lève\" — weighing, then lightening",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je pense\" then \"je me lève\" — weighing, then lightening]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"elevate, lever, relief\" — all a raising",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"elevate, lever, relief\" — all a raising]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say \"I get up\" and \"we get up.\" (Je me lève. Nous nous levons — the accent appears only when the ending is silent.) How does French say \"I am standing\"? (Je suis debout — a state pinned to être, not a verb, and debout is de + bout, \"on end.\") Penser came from weighing; what does lever come from? (Levis, \"light in weight\".) And the opposite movement? (Je m'assieds.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "FR-C27-ouvrir",
+      "sequence": 850,
+      "title": "ouvrir — \"to open,\" an -ir verb wearing -er endings",
+      "headword": "ouvrir",
+      "romanization": "ouvrir",
+      "gloss": "to open — an -ir verb that takes -er endings, from a Latin verb reshaped to look like its own opposite, and the source of English overt and overture",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:9520fc80bfc81ee2",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You can sit and rise. Now the hand from Chapter 17. This verb is French conjugation's small trap: spelled like one family, behaving like another."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: the word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ouvrir — to open. Said oo-VREER. J'ouvre la main. — I open my hand."
+            },
+            {
+              "kind": "speech",
+              "text": "French says la main where English says \"my hand\"; with your own body the article does the work. And listen to that nasal — pain, main — the same -ain you have been making since the bread."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: the endings it should not have",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Ouvrir ends in -ir, so you would expect it to run like dormir. It does not. It takes the endings of marcher, an -er verb, exactly:"
+            },
+            {
+              "kind": "speech",
+              "text": "j'ouvre — JOOVR."
+            },
+            {
+              "kind": "speech",
+              "text": "tu ouvres — OOVR."
+            },
+            {
+              "kind": "speech",
+              "text": "il ouvre — OOVR."
+            },
+            {
+              "kind": "speech",
+              "text": "nous ouvrons — oo-VROHN."
+            },
+            {
+              "kind": "speech",
+              "text": "vous ouvrez — oo-VRAY."
+            },
+            {
+              "kind": "speech",
+              "text": "ils ouvrent — OOVR."
+            },
+            {
+              "kind": "speech",
+              "text": "Four identical to the ear, nous and vous audible: the shape of je marche, nous marchons. A small group of -ir verbs does this, and ouvrir is the one you meet most. The spelling promises one thing; listen to what the verb does."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: reshaped by its own opposite",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Latin's verb for opening was aperīre, which ouvrir does not look much like — because the word was remodelled on the way into popular Latin operīre. The likeliest cause is the pull of its own opposite, cooperīre, \"to cover,\" which became French couvrir. Opening and covering ended up rhyming and have stayed matched since. The meaning stayed aperīre's; only the shape moved."
+            },
+            {
+              "kind": "speech",
+              "text": "English collected both ends:"
+            },
+            {
+              "kind": "speech",
+              "text": "from aperīre — an aperture; an aperitif, the drink that opens a meal."
+            },
+            {
+              "kind": "speech",
+              "text": "from Old French ovrir — overt, its past participle \"opened,\" and overture, ouverture."
+            },
+            {
+              "kind": "speech",
+              "text": "from the covering half — curfew, Old French cuevrefeu, \"cover-fire,\" the bell that said to bank the hearth."
+            },
+            {
+              "kind": "speech",
+              "text": "Set that beside the hand. Maintenir is manū tenēre, \"to hold in the hand\" — and ouvrir la main releases that grip."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ouvrir\" — oo-VREER",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ouvrir\" — *oo-VREER*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"j'ouvre la main\" — and hear pain, main",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"j'ouvre la main\" — and hear *pain*, *main*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je marche, nous marchons\" then \"j'ouvre, nous ouvrons\" — one shape",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je marche, nous marchons\" then \"j'ouvre, nous ouvrons\" — one shape]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je m'assieds, je me lève, j'ouvre la main\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je m'assieds, je me lève, j'ouvre la main\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je suis debout et j'ouvre la main\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je suis debout et j'ouvre la main\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"maintenir\" then \"ouvrir\" — holding in the hand, then letting go",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"maintenir\" then \"ouvrir\" — holding in the hand, then letting go]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"aperture, aperitif, overt, overture\" — every one an opening",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"aperture, aperitif, overt, overture\" — every one an opening]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say \"I open my hand\" and \"we open.\" (J'ouvre la main. Nous ouvrons.) Which endings does ouvrir borrow, despite its spelling? (The -er set — marcher's.) What is an aperitif, literally? (The opener — the drink that opens a meal.) Why does ouvrir not look like Latin aperīre? (It was reshaped to match its own opposite, the verb for covering.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "FR-C27-fermer",
+      "sequence": 860,
+      "title": "fermer — \"to close,\" which in French means \"to make firm\"",
+      "headword": "fermer",
+      "romanization": "fermer",
+      "gloss": "to close — from Latin firmāre, \"to make firm,\" so a French door is not shut but made fast; the same verb gave Italian \"to stop\" and Spanish \"to sign\"",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:b24800fffba8e018",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The last of the four, and the opposite of the one before it. French chose an unexpected picture: to close a thing is to make it firm."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: the word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "fermer — to close. Said fer-MAY. Je ferme la main. — I close my hand. Il pleut. Je ferme. — It's raining. I'm closing up."
+            },
+            {
+              "kind": "speech",
+              "text": "A regular -er verb: je ferme, tu fermes, il ferme, nous fermons, vous fermez, ils ferment."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: two opposites, one set of endings",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Ouvrir borrowed the -er endings against its own spelling. Fermer owns them outright. So the two opposites conjugate in step, and drill as one pair:"
+            },
+            {
+              "kind": "speech",
+              "text": "j'ouvre / je ferme."
+            },
+            {
+              "kind": "speech",
+              "text": "nous ouvrons / nous fermons."
+            },
+            {
+              "kind": "speech",
+              "text": "ils ouvrent / ils ferment."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: making it firm",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "fermer from Latin firmāre, \"to make firm,\" from firmus, \"firm.\" A Roman door was not closed, it was secured. English took the adjective and left the verb: firm, affirm, confirm, infirm and the infirmary, the firmament — the sky as a solid vault."
+            },
+            {
+              "kind": "speech",
+              "text": "Probably also farm. Old French ferme meant a fixed rent, from Medieval Latin firma, \"a fixed payment,\" so a farm began as a lease and not a field. Etymologists call this history a confused one, because Old English feorm, \"food-rent,\" sat nearby and may have pulled on it. Likely, not clean."
+            },
+            {
+              "kind": "speech",
+              "text": "The best part is the split. One Latin verb, three languages, three jobs:"
+            },
+            {
+              "kind": "speech",
+              "text": "French fermer — to close."
+            },
+            {
+              "kind": "speech",
+              "text": "Italian fermare — to stop."
+            },
+            {
+              "kind": "speech",
+              "text": "Spanish firmar — to sign, because a signature makes a paper firm."
+            },
+            {
+              "kind": "speech",
+              "text": "And Spanish and Portuguese do not close with this verb at all. Their words come from Latin's bolt. So French shuts a door by making it solid while its neighbours slide a bar across."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"fermer\" — fer-MAY",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"fermer\" — *fer-MAY*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"j'ouvre la main\" then \"je ferme la main\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"j'ouvre la main\" then \"je ferme la main\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the chapter's four — \"je m'assieds, je me lève, j'ouvre, je ferme\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the chapter's four — \"je m'assieds, je me lève, j'ouvre, je ferme\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je suis debout et je ferme\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je suis debout et je ferme\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"il pleut, je ferme\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"il pleut, je ferme\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"vous fermez, s'il vous plaît\" then \"tu fermes, s'il te plaît\" — formal, then familiar",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"vous fermez, s'il vous plaît\" then \"tu fermes, s'il te plaît\" — formal, then familiar]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"je suis désolé, je ferme\" — the apology before the refusal",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"je suis désolé, je ferme\" — the apology before the refusal]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"fermer, firm, affirm, confirm\" — all a making-firm",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"fermer, firm, affirm, confirm\" — all a making-firm]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say the chapter's four with je. (Je m'assieds, je me lève, j'ouvre, je ferme.) What did firmāre mean, and what is a French door doing when it closes? (Making firm — being secured, not barred.) One Latin verb, three languages: Italian and Spanish? (Fermare, \"to stop\"; firmar, \"to sign\".) Now close politely in both registers, then apologise. (Vous fermez, s'il vous plaît. Tu fermes, s'il te plaît. Je suis désolé.) And the hand? (J'ouvre la main, je ferme la main.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/french/narration/ch27.txt
+++ b/code/learning/human-languages/french/narration/ch27.txt
@@ -1,0 +1,204 @@
+French, chapter 27: Sitting, Standing, Opening, Closing.
+4 lessons. All 4 can be done entirely by ear.
+
+
+Lesson 1 of 4.
+s'asseoir — "to sit down," a verb you do to yourself.
+
+Warm-up.
+[pause 2 seconds]
+You have walked and you have run. Now stop. French does not say "I sit" — it says "I seat myself," and that extra word is one you own.
+
+You'll want to know: the word.
+s'asseoir — to sit down. Said sah-SWAHR. Je m'assieds. — I sit down. Said juh mah-SYAY.
+The m' is the me inside je m'appelle: French treats sitting as something you do to yourself, so the pronoun is not optional.
+Keep two ideas apart. S'asseoir is the movement, lowering yourself into a chair. Je suis assis is the state after it, "I am seated." English lets sit cover both; French makes you choose.
+
+Grammar Lens: one verb, two accepted sets.
+The only verb in the course with two correct answers, both in dictionaries. Learn this series whole:
+je m'assieds — mah-SYAY.
+tu t'assieds — tah-SYAY.
+il s'assied — sah-SYAY (three identical to the ear).
+nous nous asseyons — noo-zah-say-YOHN.
+vous vous asseyez — voo-zah-say-YAY.
+ils s'asseyent — sah-SAY.
+Then recognise the rival singulars je m'assois, tu t'assois, il s'assoit — ordinary spoken French. Their plurals (assoyons, assoyez) are much rarer in France, so the series above is the safer one to own. Since 1990 the infinitive may also be spelled s'assoir. Nothing here is wrong; the language never chose.
+
+The word, taken apart: sedēre.
+s'asseoir from Vulgar Latin adsedēre, a remaking of Classical adsidēre — ad- "at" plus sedēre, "to sit." Latin had built the compound; French only wore it down. And sedēre is everywhere in English:
+sedentary, sitting work; a session, "a sitting"; sediment, what sits at the bottom.
+reside, sit back; preside and president, sitting in front; assiduous, sitting at a task.
+siege — an army sitting down before a city; possess, obsess, subsidy.
+A bishop's see is his sedēs, his seat.
+Dormir English only borrowed. This root it owns from birth too: sit, seat and settle come down the Germanic road from the same source.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "s'asseoir" — sah-SWAHR]
+[pause 8 seconds for the answer]
+[your turn — say: "je m'assieds" then "nous nous asseyons"]
+[pause 8 seconds for the answer]
+[your turn — say: "je m'appelle" then "je m'assieds" — the same little m']
+[pause 8 seconds for the answer]
+[your turn — say: "je m'assieds" then "je suis assis" — movement, then state]
+[pause 8 seconds for the answer]
+[your turn — say: "je marche, je cours, je m'assieds, je dors"]
+[pause 8 seconds for the answer]
+[your turn — say: "j'entends" — the ear needs no chair]
+[pause 8 seconds for the answer]
+[your turn — say: "sedentary, session, siege" — every one a sitting]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say "I sit down" and "we sit down." (Je m'assieds. Nous nous asseyons.) Why is the pronoun there? (French sits you yourself down — the same m' as in je m'appelle.) What is a siege, literally? (A sitting — an army sitting down before a city.) Which English words are cousins of sedēre by birth rather than borrowing? (Sit, seat, settle.) Now the pair: "je cours" and "je dors."
+
+
+Lesson 2 of 4.
+se lever, debout — standing, which French says in two pieces.
+
+Warm-up.
+[pause 2 seconds]
+You sat down. Getting up is harder, because French has no single verb for "to stand." It splits the idea in two.
+
+You'll want to know: the movement.
+se lever — to get up, to rise. Said suh luh-VAY. Je me lève. — I get up. Said juh muh LEV.
+Reflexive, as s'asseoir is: you raise yourself. After that verb's two paradigms this is a relief — an ordinary -er verb with one habit. Silent ending, and the e takes a grave accent; spoken ending, and it flattens:
+je me lève — LEV.
+tu te lèves — LEV.
+il se lève — LEV.
+nous nous levons — luh-VOHN, flat.
+vous vous levez — luh-VAY, flat.
+ils se lèvent — LEV.
+
+You'll want to know: the state.
+debout — standing, upright. Said duh-BOO. Je suis debout. — I am standing.
+Se lever is the movement, debout the state — the split between sitting down and being seated. Debout is no verb: attach it to être.
+And it is transparent once opened: de + bout, "on end." A bout is a tip or end, so standing is being set on your end. French did once have a plain verb for standing, ester; it survives only in a courtroom phrase, which is why the language builds this from pieces.
+
+The word, taken apart: lightness.
+lever from Latin levāre, "to raise" — built on levis, "light in weight." To raise a thing is to lighten it. Hence elevate, elevator, levitate, levity; a lever, which lightens a load; alleviate, relieve, relief; leaven.
+So two of this course's verbs come from one corner of Roman thought. Penser is pēnsāre, "to weigh"; lever is levāre, "to make light." Thinking weighs, rising un-weighs, and sedēre just sits there.
+One correction. Bout comes from bouter, "to strike," taken from Frankish — and its English relative by descent is beat. Butt looks closer but is a later borrowing back out of French.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "se lever" — suh luh-VAY]
+[pause 8 seconds for the answer]
+[your turn — say: "je me lève" then "nous nous levons" — sharp, then flat]
+[pause 8 seconds for the answer]
+[your turn — say: "je m'assieds" then "je me lève" — down, then up]
+[pause 8 seconds for the answer]
+[your turn — say: "je suis debout" — the state, on être]
+[pause 8 seconds for the answer]
+[your turn — say: "je me lève et je cours"]
+[pause 8 seconds for the answer]
+[your turn — say: "je pense" then "je me lève" — weighing, then lightening]
+[pause 8 seconds for the answer]
+[your turn — say: "elevate, lever, relief" — all a raising]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say "I get up" and "we get up." (Je me lève. Nous nous levons — the accent appears only when the ending is silent.) How does French say "I am standing"? (Je suis debout — a state pinned to être, not a verb, and debout is de + bout, "on end.") Penser came from weighing; what does lever come from? (Levis, "light in weight".) And the opposite movement? (Je m'assieds.)
+
+
+Lesson 3 of 4.
+ouvrir — "to open," an -ir verb wearing -er endings.
+
+Warm-up.
+[pause 2 seconds]
+You can sit and rise. Now the hand from Chapter 17. This verb is French conjugation's small trap: spelled like one family, behaving like another.
+
+You'll want to know: the word.
+ouvrir — to open. Said oo-VREER. J'ouvre la main. — I open my hand.
+French says la main where English says "my hand"; with your own body the article does the work. And listen to that nasal — pain, main — the same -ain you have been making since the bread.
+
+Grammar Lens: the endings it should not have.
+Ouvrir ends in -ir, so you would expect it to run like dormir. It does not. It takes the endings of marcher, an -er verb, exactly:
+j'ouvre — JOOVR.
+tu ouvres — OOVR.
+il ouvre — OOVR.
+nous ouvrons — oo-VROHN.
+vous ouvrez — oo-VRAY.
+ils ouvrent — OOVR.
+Four identical to the ear, nous and vous audible: the shape of je marche, nous marchons. A small group of -ir verbs does this, and ouvrir is the one you meet most. The spelling promises one thing; listen to what the verb does.
+
+The word, taken apart: reshaped by its own opposite.
+Latin's verb for opening was aperīre, which ouvrir does not look much like — because the word was remodelled on the way into popular Latin operīre. The likeliest cause is the pull of its own opposite, cooperīre, "to cover," which became French couvrir. Opening and covering ended up rhyming and have stayed matched since. The meaning stayed aperīre's; only the shape moved.
+English collected both ends:
+from aperīre — an aperture; an aperitif, the drink that opens a meal.
+from Old French ovrir — overt, its past participle "opened," and overture, ouverture.
+from the covering half — curfew, Old French cuevrefeu, "cover-fire," the bell that said to bank the hearth.
+Set that beside the hand. Maintenir is manū tenēre, "to hold in the hand" — and ouvrir la main releases that grip.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "ouvrir" — oo-VREER]
+[pause 8 seconds for the answer]
+[your turn — say: "j'ouvre la main" — and hear pain, main]
+[pause 8 seconds for the answer]
+[your turn — say: "je marche, nous marchons" then "j'ouvre, nous ouvrons" — one shape]
+[pause 8 seconds for the answer]
+[your turn — say: "je m'assieds, je me lève, j'ouvre la main"]
+[pause 8 seconds for the answer]
+[your turn — say: "je suis debout et j'ouvre la main"]
+[pause 8 seconds for the answer]
+[your turn — say: "maintenir" then "ouvrir" — holding in the hand, then letting go]
+[pause 8 seconds for the answer]
+[your turn — say: "aperture, aperitif, overt, overture" — every one an opening]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say "I open my hand" and "we open." (J'ouvre la main. Nous ouvrons.) Which endings does ouvrir borrow, despite its spelling? (The -er set — marcher's.) What is an aperitif, literally? (The opener — the drink that opens a meal.) Why does ouvrir not look like Latin aperīre? (It was reshaped to match its own opposite, the verb for covering.)
+
+
+Lesson 4 of 4.
+fermer — "to close," which in French means "to make firm".
+
+Warm-up.
+[pause 2 seconds]
+The last of the four, and the opposite of the one before it. French chose an unexpected picture: to close a thing is to make it firm.
+
+You'll want to know: the word.
+fermer — to close. Said fer-MAY. Je ferme la main. — I close my hand. Il pleut. Je ferme. — It's raining. I'm closing up.
+A regular -er verb: je ferme, tu fermes, il ferme, nous fermons, vous fermez, ils ferment.
+
+Grammar Lens: two opposites, one set of endings.
+Ouvrir borrowed the -er endings against its own spelling. Fermer owns them outright. So the two opposites conjugate in step, and drill as one pair:
+j'ouvre / je ferme.
+nous ouvrons / nous fermons.
+ils ouvrent / ils ferment.
+
+The word, taken apart: making it firm.
+fermer from Latin firmāre, "to make firm," from firmus, "firm." A Roman door was not closed, it was secured. English took the adjective and left the verb: firm, affirm, confirm, infirm and the infirmary, the firmament — the sky as a solid vault.
+Probably also farm. Old French ferme meant a fixed rent, from Medieval Latin firma, "a fixed payment," so a farm began as a lease and not a field. Etymologists call this history a confused one, because Old English feorm, "food-rent," sat nearby and may have pulled on it. Likely, not clean.
+The best part is the split. One Latin verb, three languages, three jobs:
+French fermer — to close.
+Italian fermare — to stop.
+Spanish firmar — to sign, because a signature makes a paper firm.
+And Spanish and Portuguese do not close with this verb at all. Their words come from Latin's bolt. So French shuts a door by making it solid while its neighbours slide a bar across.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "fermer" — fer-MAY]
+[pause 8 seconds for the answer]
+[your turn — say: "j'ouvre la main" then "je ferme la main"]
+[pause 8 seconds for the answer]
+[your turn — say: the chapter's four — "je m'assieds, je me lève, j'ouvre, je ferme"]
+[pause 8 seconds for the answer]
+[your turn — say: "je suis debout et je ferme"]
+[pause 8 seconds for the answer]
+[your turn — say: "il pleut, je ferme"]
+[pause 8 seconds for the answer]
+[your turn — say: "vous fermez, s'il vous plaît" then "tu fermes, s'il te plaît" — formal, then familiar]
+[pause 8 seconds for the answer]
+[your turn — say: "je suis désolé, je ferme" — the apology before the refusal]
+[pause 8 seconds for the answer]
+[your turn — say: "fermer, firm, affirm, confirm" — all a making-firm]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say the chapter's four with je. (Je m'assieds, je me lève, j'ouvre, je ferme.) What did firmāre mean, and what is a French door doing when it closes? (Making firm — being secured, not barred.) One Latin verb, three languages: Italian and Spanish? (Fermare, "to stop"; firmar, "to sign".) Now close politely in both registers, then apologise. (Vous fermez, s'il vous plaît. Tu fermes, s'il te plaît. Je suis désolé.) And the hand? (J'ouvre la main, je ferme la main.)

--- a/code/learning/human-languages/french/roadmap.md
+++ b/code/learning/human-languages/french/roadmap.md
@@ -182,6 +182,59 @@ compared, every Spanish form supplied in full (no prior Spanish assumed).
   in front of Latin's *sc-*, the same repair that made *école* and *étoile*, and
   **manuscript** (*manus* + *scrībere*) is where this verb and Ch.17's *la main*
   meet inside a single English word. **Authored.**
+- **Ch. 26 — Hearing, sleeping, walking, running**: ***entendre***
+  (`FR-C26-entendre`) ← *intendere*, **in-** "toward" + *tendere* "**to
+  stretch**" → *intend* (the plainest survival), *intent*, *intense*, *tension*,
+  *tent*, *extend*, *pretend*. From the oldest French texts it already means
+  hearing **and** attending **and** understanding **and** intending; the other
+  senses fell away as *ouïr* (← *audīre*) wore out, leaving *entendu*,
+  *s'entendre* "to get along" and *l'entente* — while English kept the *audīre*
+  family (*audio*, *audience*, *audible*). Three mind-verbs, three body
+  pictures: *comprendre* grasps, *penser* weighs, *entendre* stretches →
+  ***dormir*** (`FR-C26-dormir`) ← *dormīre*, inherited unchanged →
+  *dormitory* (and French's own *dortoir*), *dormant*, *dormer*; the
+  **dormouse** is named as **folk etymology**, resting on an Anglo-Norman word
+  nobody has found. Stem rule: the singular sheds the *m* (*je dors* / *nous
+  dormons*) → ***marcher*** (`FR-C26-marcher`), origin **genuinely unsettled**
+  between Frankish **markōn* "to press a step in" and Late Latin *marcāre* ←
+  *marcus* "a hammer"; English **march** is a secure borrowing *from* French,
+  English **mark** is a relative **only if** the Frankish account holds, and *la
+  marche* "borderland" (→ *marquis*, *margrave*) is a separate arrival from the
+  Germanic **noun**. Also "to work": ***ça marche***, and *ça ne marche pas*
+  brings Ch.18's *ne … pas* onto a real verb — *pas* being Latin *passus*, "a
+  step" → ***courir*** (`FR-C26-courir`), the payoff ← *currere* → *current*,
+  *currency*, *cursor*, *course*, *corridor*, *courier*, **curriculum** ("a
+  running"), *concur*, *occur*, *excursion*; its hard *c* settles why *canis*
+  became *chien* while *currere* did not — the *ca-* shift only ever struck **c
+  before a**. Latin *carrus* (→ *car*, *cargo*) is named as a **Gaulish loan
+  from the same root**, not a form built from *currere*. **Authored.**
+- **Ch. 27 — Sitting, standing, opening, closing**: ***s'asseoir***
+  (`FR-C27-sasseoir`) ← Vulgar Latin *adsedēre*, a remaking of Classical
+  *adsidēre* (*ad-* + *sedēre*) → *sedentary*, *session*, *sediment*,
+  *reside*, *preside*, *president*, *assiduous*, *siege*, *possess*, *obsess*,
+  *subsidy*, and a bishop's *see* (← *sedēs*); English *sit*, *seat* and
+  *settle* are **genuine Germanic cousins** by descent. Two accepted paradigms
+  are taught honestly — the *-ie-* series whole, the *-oi-* singulars as
+  ordinary speech whose plurals are much rarer — plus the 1990 spelling
+  *s'assoir*, and *je suis assis* as the **state** against the movement →
+  ***se lever* / *debout*** (`FR-C27-se-lever`): French has **no single verb**
+  for "to stand," so the movement is *se lever* ← *levāre* ← *levis*, "**light
+  in weight**" → *elevate*, *elevator*, *levitate*, *levity*, *lever*,
+  *alleviate*, *relieve*, *relief*, *leaven* — and the state is *être debout*,
+  *de* + *bout*, "**on end**." *Bout* ← *bouter* ← Frankish **bōtan*, whose
+  English cousin **by descent** is **beat**; *butt* is a later **loan back out
+  of French**. Old French *ester* survives only in a courtroom phrase →
+  ***ouvrir*** (`FR-C27-ouvrir`) ← popular Latin *operīre*, *aperīre*
+  **reshaped** to match its own antonym *cooperīre* (→ *couvrir*) →
+  *aperture*, *aperitif*, and through Old French *ovrir* the English **overt**
+  (its past participle) and **overture**; the trap is that this *-ir* verb takes
+  ***-er*** endings, *marcher*'s → ***fermer*** (`FR-C27-fermer`), the payoff
+  ← *firmāre*, "**to make firm**" ← *firmus* → *firm*, *affirm*, *confirm*,
+  *infirm*, *infirmary*, *firmament*, and **probably** *farm* (Old French
+  *ferme*, "a fixed rent") — hedged, because Old English *feorm* muddies it.
+  One Latin verb, three jobs: French *fermer* "close," Italian *fermare*
+  "stop," Spanish *firmar* "sign," while Spanish and Portuguese close with
+  **bolt** verbs from elsewhere. **Authored.**
 
 ## Planned (mirrors the Spanish theme sequence)
 

--- a/code/learning/human-languages/german/CHANGELOG.md
+++ b/code/learning/human-languages/german/CHANGELOG.md
@@ -1,5 +1,100 @@
 # Changelog
 
+## Eight more core verbs, in two more chapters (2026-08-07)
+
+Chapters 26 and 27 realize the eight core-verb concepts that **no track in the
+corpus had realized anywhere**. German goes **14/40 → 22/40** on the taxonomy's
+core verbs, and the count of core verbs unrealized in every track drops from
+**15 to 7**.
+
+| Lesson | Concept | Word |
+|---|---|---|
+| `GE-C26-sitzen` | `VERB-SIT` | sitzen |
+| `GE-C26-stehen` | `VERB-STAND` | stehen |
+| `GE-C26-schlafen` | `VERB-SLEEP` | schlafen |
+| `GE-C26-hoeren` | `VERB-HEAR` | hören |
+| `GE-C27-gehen` | `VERB-WALK` | gehen |
+| `GE-C27-laufen` | `VERB-RUN` | laufen, rennen |
+| `GE-C27-oeffnen` | `VERB-OPEN` | öffnen, aufmachen |
+| `GE-C27-schliessen` | `VERB-CLOSE` | schließen, zumachen |
+
+**Two chapters, not one**, on the Chapter 24/25 precedent: ten new atoms each,
+against `maxNewAtomsPerChapter: 12`, each with its own capability and its own
+payoff closing over all ten of its own atoms.
+
+**This is the set where the blood relationship is the lesson.** Every one of
+these eight is a cousin rather than a loan, and each shows a *different* and
+*teachable* correspondence, so the chapter can say **why** the words look alike:
+
+- *sitzen* **is** *sit* — Proto-Germanic \**sitjaną*, Old High German *sizzen*.
+  The second (High German) shift's **t**-branch, which the track had never
+  named: Germanic *t* → German *z*/*ss*. It retro-explains *Wasser* (ch. 11)
+  and *zehn* (ch. 6), taught long before there was a name for what had happened
+  to them. Chapter 25 had already given the **p**-branch on *helfen*.
+- *stehen* / *stand* — Germanic ran two stems, \**stāną* and \**standaną*.
+  English generalized the one with the nasal, German the one without; German's
+  **past** (*ich stand*, *gestanden*) hands the *n* back. PIE \**steh₂-* is the
+  root chapter 24 already named inside *verstehen*, and Latin *stō*/*stāre*
+  descends from it independently — as Latin *sedeō* does from *sitzen*'s
+  \**sed-*. Two roots, two families, no borrowing in either direction.
+- *schlafen* / *sleep* — two German changes stacked: the second shift's
+  **p** → **f**, plus *s* → *sch* before *l*, *m*, *n*, *w* (*schwimmen*,
+  *Schnee*, *Schmied*), which German also did before *p* and *t* and never
+  spelt — which is why *stehen* is said *SHTAY-en*. And the honest twist: the
+  inherited Indo-European verb for sleeping was \**swep-* (Latin *somnus*,
+  Greek *hýpnos*, Old Norse *sofa*). German and English replaced it
+  **together**, on \**sleb-* "be slack", before they were two languages.
+- *hören* / *hear* — the one change they **share**: Gothic *hausjan* keeps the
+  *s* that both Old English *hīeran* and Old High German *hōren* had already
+  turned to *r*. The initial *h* is Grimm's law on an old *k*, still audible in
+  Greek *akoúein* → English **acoustic**, and the same swap that gave *Hund*
+  against Latin *canis*. The "sharp-eared" analysis of the root is reported as
+  widely cited and unsettled, not as fact.
+- *laufen* / *leap* — a fourth **p**/**f** pair, after *helfen*, *offen* and
+  *schlafen*; *lope*, *elope* and *interloper* are the English scraps. Outside
+  Germanic there are no secure cousins, and the lesson says so.
+- *offen* / *open* — the pair chapter 25 *listed* when it named the second
+  shift, now taught. Neither word is a root: both are built on **up**, which is
+  why *offen* and *auf* are relatives, and why *aufmachen* is the same recipe
+  spoken out loud.
+- *schließen* has **no English cousin at all**. Germanic \**sleutaną* survives
+  in German and Dutch and left nothing in English, which closes things with
+  Latin's *close* and with *shut* — native, but really *shoot*, a bolt shot
+  across a door. That is the same story as chapter 25's *nehmen*, and the two
+  are named together.
+- *gehen* / *go* is the one verb that **cannot** be followed past Germanic; the
+  root is disputed and no agreed cousin list exists. Both languages had to
+  borrow a past: English took *went* from *wend*, German took *ging* and
+  *gegangen* from \**ganganą* — which English still owns in *gangway*.
+
+**The walk/run boundary, taught honestly.** English cuts between *walk* and
+*run*; German does not cut in the same place. *gehen* is unhurried, *rennen* is
+flat out, and *laufen* lies across the line, so **Wir laufen** is "we're
+walking" or "we're running" and only the situation decides. That is true across
+most of Germany and **not** in Austria, where *laufen* means *run* — recorded
+in the lesson as a regional split, per HL09 §8.1, rather than dropped.
+
+**Separable verbs, introduced with nothing new.** The track had never taught
+them. HL09 §5.2 allows a new structural move only on vocabulary the reader
+already holds, and both halves were held: *auf* from chapter 4's *auf
+Wiedersehen*, *machen* from chapter 5. So `GE-C27-oeffnen` introduces the split
+— **Ich mache die Hand auf** — and `GE-C27-schliessen` immediately re-uses it
+for *zumachen*. The object is *die Hand* throughout, because feminine and
+neuter accusative articles are identical to the nominative and this track has
+not taught cases.
+
+**Reach-back at two cadences (HL09 §7).** Every one of the eight names atoms
+from the one to three lessons immediately before it, across the chapter seam,
+and both payoffs reach several chapters back. Six atoms that no lesson had ever
+revisited are revisited here — `GE-SOUND-HAND-03`, `GE-ETYMON-HUND-03`,
+`GE-LEX-REGNET-05`, `GE-LEX-MOEGEN-LIEBEN-09`, `GE-ETYMON-MOEGEN-LIEBEN-10`,
+`GE-GRAMMAR-GERN-11`. The track's never-revisited share falls from **31 of 61
+atoms (51%) to 27 of 81 (33%)**. The two atoms of the final lesson are orphans
+because nothing follows them yet.
+
+All eight lessons are `voice` — drivable, no tables, no sight cues. Book: 140
+pages, zero missing characters, zero overfull boxes under XeLaTeX.
+
 ## Eight core verbs, in two chapters (2026-08-07)
 
 Chapters 24 and 25 add the eight verbs Spanish, Latin and Portuguese landed

--- a/code/learning/human-languages/german/README.md
+++ b/code/learning/human-languages/german/README.md
@@ -59,8 +59,14 @@ French *nuit* — one Indo-European word, split four ways.
   *schreiben* — and the strong-verb vowel break (*du liest*).
 - **Chapter 25 — Taking, Asking, Helping, Liking**: *nehmen*, *fragen*,
   *helfen*, *mögen/lieben* — and *gern*, German'''s third way of liking.
+- **Chapter 26 — Sitting, Standing, Sleeping, Hearing**: *sitzen*, *stehen*,
+  *schlafen*, *hören* — the second sound shift's *t*-branch, and a second way
+  for a strong verb to break (*du schläfst*).
+- **Chapter 27 — Going, Running, Opening, Closing**: *gehen*, *laufen*,
+  *rennen*, *öffnen*, *schließen* — where German's walk/run line actually
+  falls, and the first separable verbs (*Ich mache die Hand auf*).
 
-**All twenty-five chapters are authored and in the book (122 pages).**
+**All twenty-seven chapters are authored and in the book (140 pages).**
 
 ---
 
@@ -76,7 +82,7 @@ language.
 finish a chapter, and names the lesson that proves it. It is authored intent —
 no validator may rewrite it.
 
-**Nine of twenty-five chapters are authored: 17–25.** Those are exactly the
+**Eleven of twenty-seven chapters are authored: 17–27.** Those are exactly the
 chapters whose lessons have been migrated to schema version 2 and so declare
 real knowledge atoms. Chapters 1–16 are still schema v1 and carry no
 `practises.knowledge`, so a payoff written for them could only assess invented
@@ -97,6 +103,8 @@ actually assesses, floored at 0.5 by `core/chapter-policy.json`:
 | 23 Green and Yellow | `GE-C23-gruen-gelb` | 5 / 5 = 1.00 |
 | 24 Verbs of the Mind | `GE-C24-schreiben` | 10 / 10 = 1.00 |
 | 25 Taking, Asking, Helping, Liking | `GE-C25-moegen-lieben` | 10 / 10 = 1.00 |
+| 26 Sitting, Standing, Sleeping, Hearing | `GE-C26-hoeren` | 10 / 10 = 1.00 |
+| 27 Going, Running, Opening, Closing | `GE-C27-schliessen` | 10 / 10 = 1.00 |
 
 Chapter 17 is the one authored chapter that fails. It runs three word lessons
 deep — *Kopf*, *Kopf/Haupt*, *Hand* — with no terminal consolidation lesson, so
@@ -112,6 +120,17 @@ chapter 25's to all four of chapter 24's verbs plus `GE-LEX-HUND-02`,
 `GE-LEX-KATZE-04` (ch. 22) and `GE-LEX-WETTER-02` (ch. 21). That is HL09 §7:
 a payoff scoped only to its own chapter adds to the orphan pile rather than
 draining it.
+
+Chapters 26 and 27 do the same and were written to drain it deliberately.
+Chapter 26's payoff reaches to `GE-SOUND-GRIMMS-LAW-04` (ch. 17),
+`GE-LEX-HUND-02`/`GE-ETYMON-HUND-03`/`GE-LEX-KATZE-04` (ch. 22) and all three
+of chapter 25's closing atoms; chapter 27's reaches to `GE-LEX-NEHMEN-02`,
+`GE-ETYMON-NEHMEN-03` and `GE-ETYMON-HELFEN-08` (ch. 25), `GE-LEX-HAND-02` and
+`GE-SOUND-HAND-03` (ch. 17), and back into chapter 26. Six atoms that no lesson
+had ever revisited are revisited here: `GE-SOUND-HAND-03`, `GE-ETYMON-HUND-03`,
+`GE-LEX-REGNET-05`, `GE-LEX-MOEGEN-LIEBEN-09`, `GE-ETYMON-MOEGEN-LIEBEN-10` and
+`GE-GRAMMAR-GERN-11`. The track's never-revisited share falls from **31 of 61
+atoms (51%) to 27 of 81 (33%)**.
 
 ## Reinforcement chaining (HL09 §7)
 
@@ -129,6 +148,14 @@ runs at two cadences. Every lesson in chapters 24–25 also names atoms from the
 | `GE-C25-fragen` | `GE-C25-nehmen`, `GE-C24-lesen`, ch. 18 `ja`/`nein`/`doch` |
 | `GE-C25-helfen` | `GE-C25-fragen`, `GE-C25-nehmen`, ch. 17 and ch. 19 |
 | `GE-C25-moegen-lieben` | all of chapters 24 and 25, plus chapters 21 and 22 |
+| `GE-C26-sitzen` | `GE-C25-moegen-lieben`, `GE-C25-helfen`, `GE-C24-lesen` — *Ich sitze gern*, and the *p*-branch beside the new *t*-branch |
+| `GE-C26-stehen` | `GE-C26-sitzen`; ch. 24 `GE-C24-verstehen`, which had *stehen* inside it |
+| `GE-C26-schlafen` | `GE-C26-stehen`, `GE-C26-sitzen`, ch. 24's vowel break, ch. 21 `GE-LEX-REGNET-05` |
+| `GE-C26-hoeren` | all of chapter 26, plus chapters 17, 22 and 25 |
+| `GE-C27-gehen` | `GE-C26-hoeren`, `GE-C26-stehen`, `GE-C26-schlafen`, `GE-C26-sitzen` |
+| `GE-C27-laufen` | `GE-C27-gehen`; ch. 26's umlaut break, ch. 25 `GE-ETYMON-HELFEN-08`, ch. 22 `GE-LEX-HUND-02` |
+| `GE-C27-oeffnen` | `GE-C27-laufen`, `GE-C27-gehen`, ch. 25 `GE-ETYMON-HELFEN-08`, ch. 17 *Hand* |
+| `GE-C27-schliessen` | all of chapter 27, plus chapters 17, 25 and 26 |
 
 The field that carries this is `practises.knowledge`. `reviews_of` names lesson
 ids, not atoms, so it cannot close a reinforcement window and never has.

--- a/code/learning/human-languages/german/book/book.tex
+++ b/code/learning/human-languages/german/book/book.tex
@@ -105,6 +105,8 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch23-green-and-yellow}
 \input{chapters/ch24-mind-verbs}
 \input{chapters/ch25-doing-verbs}
+\input{chapters/ch26-still-verbs}
+\input{chapters/ch27-moving-verbs}
 
 
 \backmatter

--- a/code/learning/human-languages/german/book/chapters/ch26-still-verbs.tex
+++ b/code/learning/human-languages/german/book/chapters/ch26-still-verbs.tex
@@ -1,0 +1,286 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:3241b07fef4da498
+% canonical-lessons: GE-C26-sitzen, GE-C26-stehen, GE-C26-schlafen, GE-C26-hoeren
+
+\chapter{Sitting, Standing, Sleeping, Hearing}
+\label{ch:ge-still-verbs}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can say I sit, I stand, I sleep and I hear in German, tell the second shift's t-branch from its p-branch, break a verb's a to ä for du and er, and say which of the four changes German made alone and which it made alongside English.}
+
+The chapter closes on hören, the one verb of the four whose vowel cannot break because it was born umlauted: the reader produces all four ich forms and all four er forms, names schlafen as the only breaker, tells Grimm's law on the h of hören and Hund from the second shift on sitzen and schlafen, and hangs gern on the new verb. It reaches back past its own chapter to Chapter 17's Grimm's law, Chapter 22's Hund and Katze with the Hund etymology that had never been revisited, and Chapter 25's mögen, lieben and gern, all three of which were orphans until here.
+\end{chapteropening}
+
+\section[sitzen]{sitzen — the same word as \emph{sit}, respelt by one law}
+
+\label{lesson:GE-C26-sitzen}
+
+
+
+\begin{quote}
+\textbf{Helfen} \emph{is} \textbf{help}, split by the second sound shift: Germanic \textbf{p} became German \textbf{f}. That law has other branches. This verb rides one.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{tz-affricate} — \textbf{tz} is one squeezed sound, \emph{ts}, as in English \emph{cats}.
+  \item \texttt{i-short} — a short, tight \emph{i}: \textbf{sitzen} = \emph{ZIT-sen}, buzzed at the front because German \textbf{s} before a vowel is voiced.
+\end{itemize}
+\end{sounds}
+
+\subsection*{You'll want to know: sitzen}
+\textbf{sitzen} means \textquotedblleft{}\textbf{to sit}.\textquotedblright{}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{ich sitze} — I sit · \textbf{wir sitzen} — we sit
+  \item \textbf{du sitzt} — you sit · \textbf{ihr sitzt} — you all sit
+  \item \textbf{er sitzt} — he sits · \textbf{sie sitzen} — they sit
+\end{itemize}
+
+\begin{quote}
+\textbf{Ich sitze.} — a whole sentence, two words.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: strong does not mean it breaks}]
+\emph{Sitzen} is a \textbf{strong} verb — its past is \emph{saß}, not \emph{sitzte}. But its present never breaks its vowel: \emph{du sitzt, er sitzt}. Beside it, \emph{helfen} breaks to \emph{du hilfst}.
+
+So \textquotedblleft{}strong\textquotedblright{} is a fact about a verb's \textbf{past}; the \emph{du}/\emph{er} break is a separate habit only some strong verbs have.
+
+Chapter 25 gave two ways to say you like something: \textbf{ich mag} with a thing, \textbf{gern} hung on a verb. This verb takes the second.
+
+\begin{quote}
+\textbf{Ich sitze gern.} — \textquotedblleft{}I like sitting.\textquotedblright{}
+\end{quote}
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{sitzen} is Proto-Germanic \emph{\textbf{*sitjaną}}, and English \textbf{sit} is the same inherited word — Old English \emph{sittan}, Old High German \emph{sizzen}.
+
+The second, High German shift moved Germanic \textbf{p} to \textbf{f} in \emph{helfen}. It moved Germanic \textbf{t} just as hard, to \textbf{z} (said \emph{ts}) or \textbf{ss}: \emph{sittan} $\to$ \textbf{sitzen}, \emph{water} $\to$ \textbf{Wasser}, \emph{eat} $\to$ \textbf{essen}, \emph{ten} $\to$ \textbf{zehn}, \emph{bite} $\to$ \textbf{beißen}. Chapter 11 handed you \emph{Wasser} and Chapter 6 handed you \emph{zehn} long before there was a name for what had happened to them.
+
+Under both lies PIE \emph{\textbf{*sed-}}, \textquotedblleft{}to sit,\textquotedblright{} one of the family's great providers. Latin \emph{sedēre} gives \textbf{session}, \textbf{sedentary} and \textbf{preside}; Latin \emph{sedēs}, \textquotedblleft{}a seat,\textquotedblright{} gives the bishop's \textbf{see}. Greek \emph{hédra}, also \textquotedblleft{}a seat,\textquotedblright{} gives \textbf{cathedral} — the church with the bishop's chair — and \textbf{polyhedron}.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}ich sitze, du sitzt, er sitzt\textquotedblright{} — the \emph{i} never moves
+  \item the contrast — \textquotedblleft{}du sitzt\textquotedblright{} beside \textquotedblleft{}du hilfst\textquotedblright{}
+  \item \textquotedblleft{}Ich sitze gern.\textquotedblright{}
+  \item the \emph{t} branch four times — \textquotedblleft{}sitzen/sit, Wasser/water, essen/eat, zehn/ten\textquotedblright{}
+  \item the \emph{p} branch beside it — \textquotedblleft{}helfen/help\textquotedblright{}
+  \item the seat words — \textquotedblleft{}sitzen, sedēre, hédra, cathedral\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Give the \emph{du} and \emph{er} forms of \emph{sitzen}. (\emph{\textbf{Du sitzt, er sitzt}} — no break.) Which verb from Chapter 25 does break, and how? (\emph{\textbf{Helfen}} — \emph{du hilfst}.) Which sound did the second shift turn German's \textbf{z} and \textbf{ss} out of? (An old \textbf{t}.) Name two pairs from that branch. (\textbf{Wasser/water}, \textbf{essen/eat}, \textbf{zehn/ten}.) Say you like sitting. (\emph{\textbf{Ich sitze gern}}.)
+\end{tcolorbox}
+\section[stehen]{stehen — the verb that was hiding inside \emph{verstehen}}
+
+\label{lesson:GE-C26-stehen}
+
+
+
+\begin{quote}
+Chapter 24 broke \textbf{verstehen} into \emph{ver-} plus \emph{stehen}, and named \emph{stehen} as English \textbf{stand}. Here is that verb alone, and the letter the two languages disagree about.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{st-initial-scht} — \textbf{st} at the start of a German word is said \emph{sht}.
+  \item \texttt{h-silent-lengthening} — the \textbf{h} is silent and marks the long vowel: \textbf{stehen} = \emph{SHTAY-en}.
+\end{itemize}
+\end{sounds}
+
+\subsection*{You'll want to know: stehen}
+\textbf{stehen} means \textquotedblleft{}\textbf{to stand}.\textquotedblright{}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{ich stehe} — I stand · \textbf{wir stehen} — we stand
+  \item \textbf{du stehst} — you stand · \textbf{ihr steht} — you all stand
+  \item \textbf{er steht} — he stands · \textbf{sie stehen} — they stand
+\end{itemize}
+
+Like \emph{sitzen}, it keeps its vowel all the way through. Two postures, two sentences:
+
+\begin{quote}
+\textbf{Ich sitze. Ich stehe.}
+\end{quote}
+
+\begin{cousinweb}
+Germanic ran two stems off one root here: a short \emph{\textbf{*stāną}} and a longer \emph{\textbf{*standaną}} with an \textbf{n} wedged inside. English generalised the long one and got \textbf{stand}; German took the short one and got \textbf{stehen}, Old High German \emph{stān}.
+
+German did not lose the \emph{n}. It kept it in the past: \textbf{ich stand}, and the participle \textbf{gestanden}. German's past tense is spelt the way English's present is, out of the same drawer of stems.
+
+The root is PIE \emph{\textbf{*steh\textsubscript{2}-}}, the one Chapter 24 named, and it is everywhere. Latin \emph{stāre} gave \textbf{state}, \textbf{station}, \textbf{stable}, \textbf{constant}. Greek \emph{hístēmi}, \textquotedblleft{}I set up,\textquotedblright{} gave \textbf{static}, \textbf{system} and \textbf{ecstasy} — standing outside yourself. German built \textbf{die Stadt}, a city: a standing-place. English built \textbf{stead}, \textbf{steady} and \textbf{instead}.
+\end{cousinweb}
+
+\begin{culture}
+Notice the shape of what has happened. \emph{Sitzen} goes back to \emph{\textbf{*sed-}}, and so does Latin's \emph{sedēre}. \emph{Stehen} goes back to \emph{\textbf{*steh\textsubscript{2}-}}, and so does Latin's \emph{stāre}.
+
+Nothing was borrowed in either direction. Two families inherited the same two roots and held them to the same two meanings for thousands of years, because sitting and standing are things everybody does.
+\end{culture}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}ich stehe, du stehst, er steht\textquotedblright{} — \emph{SHTAY}, not \emph{STAY}
+  \item both postures — \textquotedblleft{}Ich sitze. Ich stehe.\textquotedblright{}
+  \item the verb inside the verb — \textquotedblleft{}stehen, verstehen\textquotedblright{}
+  \item where the \emph{n} went — \textquotedblleft{}ich stehe, ich stand, gestanden\textquotedblright{}
+  \item the Latin pair — \textquotedblleft{}sitzen/sedēre, stehen/stāre\textquotedblright{}
+  \item what stands in English — \textquotedblleft{}state, station, stable, stead\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Give the \emph{du} and \emph{er} forms. (\emph{\textbf{Du stehst, er steht}}.) Which letter does English's \emph{stand} carry that German's \emph{stehen} does not? (An \textbf{n}.) Where does German still keep it? (In the \textbf{past} — \emph{ich stand, gestanden}.) Which longer verb from Chapter 24 has \emph{stehen} inside it? (\emph{\textbf{Verstehen}}.) Say \textquotedblleft{}I sit. I stand.\textquotedblright{} (\emph{\textbf{Ich sitze. Ich stehe.}})
+\end{tcolorbox}
+\section[schlafen]{schlafen — \emph{sleep}, under two coats of paint}
+
+\label{lesson:GE-C26-schlafen}
+
+
+
+\begin{quote}
+\emph{Sitzen} and \emph{stehen} held their vowels still. This one does not — and it does not break the way the Chapter 24 verbs broke either.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{sch-sh} — \textbf{sch} is English \emph{sh}: \textbf{schlafen} = \emph{SHLAH-fen}.
+  \item \texttt{vowel-ae} — \textbf{ä} is a flat \emph{eh}: \textbf{schläft} = \emph{SHLEFT}.
+\end{itemize}
+\end{sounds}
+
+\subsection*{You'll want to know: schlafen}
+\textbf{schlafen} means \textquotedblleft{}\textbf{to sleep}.\textquotedblright{}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{ich schlafe} · \textbf{wir schlafen}
+  \item \textbf{du schläfst} · \textbf{ihr schlaft}
+  \item \textbf{er schläft} · \textbf{sie schlafen}
+\end{itemize}
+
+\begin{quote}
+\textbf{Die Katze schläft.} — \textquotedblleft{}The cat is sleeping.\textquotedblright{}
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: the second kind of break}]
+Chapter 24 gave you one break: long \emph{e} goes to \textbf{i} for \emph{du} and \emph{er} — \emph{du liest}, \emph{er hilft}. Here is the other: \textbf{a} takes two dots and becomes \textbf{ä} — \emph{du schläfst}, \emph{er schläft}.
+
+Those two dots are the umlaut, the mark that turns \emph{Buch} into \emph{Bücher}. The break lands in the same slot as before, \textbf{du} and \textbf{er} and nobody else, so only its raw material is new: \emph{e} verbs brighten to \emph{i}, \emph{a} verbs to \emph{ä}.
+
+\begin{quote}
+\textbf{Es regnet. Die Katze schläft.}
+\end{quote}
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{schlafen} is Proto-Germanic \emph{\textbf{*slēpaną}}, and English \textbf{sleep} is the same inherited word — Old English \emph{slæpan}, Old High German \emph{slāfan}.
+
+Two German changes sit between them. The first you know: the second shift, Germanic \textbf{p} to German \textbf{f}, as in \emph{helfen}. The second is new — German turned \textbf{s} into \emph{sh} before \emph{l}, \emph{m}, \emph{n} and \emph{w}, and wrote it down: \emph{sleep} $\to$ \textbf{schlafen}, \emph{swim} $\to$ \textbf{schwimmen}, \emph{snow} $\to$ \textbf{Schnee}, \emph{smith} $\to$ \textbf{Schmied}. It did the same before \emph{p} and \emph{t} and never spelt it, which is why \emph{stehen} is said \emph{SHTAY-en}.
+
+Now the honest part. The old Indo-European verb for sleeping was \emph{\textbf{*swep-}}, still in plain view: Latin \emph{somnus} gives \textbf{insomnia} and \textbf{somnolent}, Latin \emph{sopor} gives \textbf{soporific}, Greek \emph{hýpnos} gives \textbf{hypnosis}, and Old Norse \emph{sofa} is Swedish \emph{sova} today. German and English both threw that verb away and built a new one on \emph{\textbf{*sleb-}}, \textquotedblleft{}to be slack\textquotedblright{} — German still has \textbf{schlaff}, \textquotedblleft{}limp.\textquotedblright{} They made that swap \textbf{together}, before they were two languages.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}ich schlafe, du schläfst, er schläft\textquotedblright{} — the \emph{a} brightens to \emph{ä}
+  \item the three verbs — \textquotedblleft{}Ich sitze. Ich stehe. Ich schlafe.\textquotedblright{}
+  \item \textquotedblleft{}Es regnet. Die Katze schläft.\textquotedblright{}
+  \item both breaks in the same slot — \textquotedblleft{}du hilfst\textquotedblright{} beside \textquotedblleft{}du schläfst\textquotedblright{}
+  \item the \emph{sch} row — \textquotedblleft{}schlafen, schwimmen, Schnee, Schmied\textquotedblright{}
+  \item the verb they both threw away — \textquotedblleft{}somnus, hypnos, sova\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Give the \emph{du} and \emph{er} forms. (\emph{\textbf{Du schläfst, er schläft}} — two dots on the \emph{a}.) Which two people does a German verb break for? (\textbf{Du} and \textbf{er}, always.) Name the two changes between \emph{sleep} and \emph{schlafen}. (\textbf{p} to \textbf{f}, and \textbf{s} to \textbf{sch}.) Why is \emph{stehen} said \emph{SHTAY-en}? (\textbf{Same change}, never spelt.) Say \textquotedblleft{}the cat is sleeping.\textquotedblright{} (\emph{\textbf{Die Katze schläft}}.)
+\end{tcolorbox}
+\section[hören]{hören — \emph{hear}, and the end of a chapter that never moved}
+
+\label{lesson:GE-C26-hoeren}
+
+
+
+\begin{quote}
+\textbf{Ich sitze. Ich stehe. Ich schlafe.} Three verbs that stay put. Here is the fourth — the sense that works with your eyes shut.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{umlaut-oe} — \textbf{ö} is the \emph{e} of \emph{bed} said with rounded lips.
+  \item \texttt{r-uvular} — the \textbf{r} is a soft scrape at the back: \textbf{hören} = \emph{HUR-en}.
+\end{itemize}
+\end{sounds}
+
+\subsection*{You'll want to know: hören}
+\textbf{hören} means \textquotedblleft{}\textbf{to hear}.\textquotedblright{}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{ich höre} · \textbf{wir hören}
+  \item \textbf{du hörst} · \textbf{ihr hört}
+  \item \textbf{er hört} · \textbf{sie hören}
+\end{itemize}
+
+The \textbf{ö} never moves. \emph{Schlafen} grew its dots for \emph{du} and \emph{er}; \emph{hören} was born with them, so nothing is left to break.
+
+\begin{quote}
+\textbf{Der Hund hört. Die Katze hört.}
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: liking it, the Chapter 25 way}]
+\textbf{gern} hangs on this verb like any other:
+
+\begin{quote}
+\textbf{Ich höre gern.} — \textquotedblleft{}I like listening.\textquotedblright{}
+\end{quote}
+
+\emph{Gern} is English \textbf{yearn}: underneath, \textquotedblleft{}I hear yearningly.\textquotedblright{} Beside it is the other way of liking, \textbf{ich mag} — English \textbf{may}, with the power drained out.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{hören} is Proto-Germanic \emph{\textbf{*hauzijaną}}, and English \textbf{hear} is the same inherited word.
+
+This time the change is one they \textbf{share}. Gothic still says \emph{hausjan}, with an \textbf{s}; Old English \emph{hīeran} and Old High German \emph{hōren} had both turned it to \textbf{r}. \emph{Sitzen} shows where German left English; \emph{hören} shows a road they walked together.
+
+The \textbf{h} is Grimm's law, the first shift: an old \textbf{k} became Germanic \textbf{h}. Greek kept the \emph{k} — \emph{akoúein}, \textquotedblleft{}to hear,\textquotedblright{} which English borrowed back as \textbf{acoustic}. Same swap that made \emph{*kwon-} into \textbf{Hund} while Latin kept \emph{canis}.
+
+Some break the root up further, into \textquotedblleft{}sharp\textquotedblright{} plus \textquotedblleft{}ear\textquotedblright{} — which would make \emph{hören} \textquotedblleft{}sharp-eared\textquotedblright{} and put \textbf{das Ohr} inside it. Cited often, not settled.
+\end{cousinweb}
+
+\begin{culture}
+\textbf{gehören} means \textquotedblleft{}\textbf{to belong}.\textquotedblright{} It is \emph{ge-} welded onto \emph{hören}, and began as \textquotedblleft{}to hearken to\textquotedblright{}: what belongs to you answers when called.
+\end{culture}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item all four — \textquotedblleft{}Ich sitze. Ich stehe. Ich schlafe. Ich höre.\textquotedblright{}
+  \item the four \emph{er} forms — \textquotedblleft{}er sitzt, er steht, er schläft, er hört\textquotedblright{}
+  \item \textquotedblleft{}Der Hund hört. Die Katze schläft.\textquotedblright{}
+  \item \textquotedblleft{}Ich höre gern.\textquotedblright{}
+  \item the shared change — \textquotedblleft{}hausjan, hīeran, hōren\textquotedblright{}
+  \item the \emph{h} row — \textquotedblleft{}hören/akoúein, Hund/canis\textquotedblright{}
+  \item \textquotedblleft{}gehören is \emph{belong}\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Give all four \emph{ich} forms of this chapter. (\emph{\textbf{Ich sitze, ich stehe, ich schlafe, ich höre}}.) Which breaks its vowel? (\emph{\textbf{Schlafen}} — \emph{a} to \emph{ä}.) Which letter did Gothic keep where German and English have \emph{r}? (An \textbf{s}.) Which law put the \emph{h} on \emph{hören} and \emph{Hund}? (\textbf{Grimm's law}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/german/book/chapters/ch27-moving-verbs.tex
+++ b/code/learning/human-languages/german/book/chapters/ch27-moving-verbs.tex
@@ -1,0 +1,297 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:3da3cdbab9f0f237
+% canonical-lessons: GE-C27-gehen, GE-C27-laufen, GE-C27-oeffnen, GE-C27-schliessen
+
+\chapter{Going, Running, Opening, Closing}
+\label{ch:ge-moving-verbs}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can say I go, I run and I open and close my hand in German, split a separable verb so its prefix waits at the end of the sentence, and say why German's line between walking and running is not where English draws it.}
+
+The chapter closes on schließen, the second verb in these chapters that German kept and English lost: the reader produces all of Chapter 27's verbs, splits both aufmachen and zumachen around die Hand, names Schloss, Schlüssel and Schluss as the household built on the kept verb, and runs the eight-verb morning that closes Chapters 26 and 27 together. It reaches back to Chapter 25's nehmen and the second shift on helfen, to Chapter 17's Hand and its final-d devoicing, which had never been revisited, and to Chapter 26's sitzen, stehen and hören.
+\end{chapteropening}
+
+\section[gehen]{gehen — \emph{go}, and the word German never needed for \emph{walk}}
+
+\label{lesson:GE-C27-gehen}
+
+
+
+\begin{quote}
+Four verbs that stayed put — sitting, standing, sleeping, hearing. Now a chapter that moves, opening on the verb German uses where English has two.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{h-silent-lengthening} — the \textbf{h} is silent and lengthens: \textbf{gehen} = \emph{GAY-en}, built exactly like \emph{stehen}, \emph{SHTAY-en}.
+  \item \texttt{ge-prefix} — \textbf{ge-} at the front is said \emph{guh}, never \emph{jee}.
+\end{itemize}
+\end{sounds}
+
+\subsection*{You'll want to know: gehen}
+\textbf{gehen} means \textquotedblleft{}\textbf{to go}\textquotedblright{} — and also \textquotedblleft{}\textbf{to walk}.\textquotedblright{} German does not split those.
+
+\begin{itemize}
+\raggedright
+  \item \textbf{ich gehe} · \textbf{wir gehen}
+  \item \textbf{du gehst} · \textbf{ihr geht}
+  \item \textbf{er geht} · \textbf{sie gehen}
+\end{itemize}
+
+\begin{quote}
+\textbf{Ich stehe. Ich gehe.}
+\end{quote}
+
+Two verbs cut to the same short shape, each with a silent \emph{h} propping the vowel up. Say them together and you hear a matched pair: \emph{SHTAY-en, GAY-en}.
+
+\begin{cousinweb}
+\textbf{gehen} is Proto-Germanic \emph{\textbf{*gāną}} and English \textbf{go} is the same inherited word, Old English \emph{gān}.
+
+Both languages then hit the same problem: the verb had no usable past, and each went shopping. English took \textbf{went}, really the past of \emph{wend}, and left \emph{wend} stranded. German took \textbf{ging} and \textbf{gegangen} from another old verb, \emph{\textbf{*ganganą}}, \textquotedblleft{}to walk\textquotedblright{} — which English still owns in \textbf{gangway}, \textbf{gangplank}, and Scots \emph{gang}, \textquotedblleft{}to go.\textquotedblright{}
+
+\textbf{Gegangen} carries the same \emph{ge-} you met on \textbf{gehören}: an old prefix German fastens to a past participle.
+
+Beyond Germanic, be honest — the deeper root of \emph{go} is \textbf{disputed}, with no agreed list of cousins. It is the one verb here that cannot be followed back.
+\end{cousinweb}
+
+\begin{culture}
+Because \textbf{walk} is not an old word for travelling on foot. Old English \emph{wealcan} meant \textquotedblleft{}to roll, to toss,\textquotedblright{} and its German cousin \textbf{walken} still means what it always meant: \textbf{to full cloth}, to work wool by trampling it.
+
+English promoted that trampling verb around 1200. German never did, so \emph{gehen} covers both jobs.
+\end{culture}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}ich gehe, du gehst, er geht\textquotedblright{}
+  \item the matched pair — \textquotedblleft{}Ich stehe. Ich gehe.\textquotedblright{}
+  \item the borrowed pasts — \textquotedblleft{}go/went\textquotedblright{} beside \textquotedblleft{}gehen/ging/gegangen\textquotedblright{}
+  \item where English kept the other verb — \textquotedblleft{}gangway, gangplank\textquotedblright{}
+  \item the \emph{ge-} on both — \textquotedblleft{}gehören, gegangen\textquotedblright{}
+  \item what \emph{walken} does — it fulls cloth, it does not travel
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Give the \emph{du} and \emph{er} forms. (\emph{\textbf{Du gehst, er geht}}.) Which English verb is \emph{gehen}? (\textbf{Go}, and \textbf{walk} as well.) Where did \emph{went} come from? (From \emph{\textbf{wend}}.) What does German's cousin of \emph{walk} mean? (\textbf{To full cloth}.) How far back can \emph{gehen} be traced? (\textbf{Not past Germanic}.)
+\end{tcolorbox}
+\section[laufen]{laufen — the verb that lies across English's line}
+
+\label{lesson:GE-C27-laufen}
+
+
+
+\begin{quote}
+\textbf{Ich gehe} covers going and walking. German has two words for \emph{run}, and one of them is not only about running.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{diphthong-au} — \textbf{au} is the \emph{ow} of \emph{house}: \textbf{laufen} = \emph{LOW-fen}.
+  \item \texttt{diphthong-eu} — \textbf{äu} is the \emph{oy} of \emph{boy}: \textbf{läuft} = \emph{LOYFT}.
+\end{itemize}
+\end{sounds}
+
+\subsection*{You'll want to know: laufen}
+\textbf{laufen} means \textquotedblleft{}\textbf{to run}\textquotedblright{} — and often \textquotedblleft{}to walk.\textquotedblright{}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{ich laufe} · \textbf{wir laufen}
+  \item \textbf{du läufst} · \textbf{ihr lauft}
+  \item \textbf{er läuft} · \textbf{sie laufen}
+\end{itemize}
+
+The \emph{schlafen} break is here too, in the same \emph{du} and \emph{er} slot: \textbf{au} brightens to \textbf{äu}.
+
+\begin{quote}
+\textbf{Der Hund läuft.}
+\end{quote}
+
+\begin{culture}
+English draws a hard line between \emph{walk} and \emph{run}. German draws it elsewhere, and leaves one verb lying across it.
+
+\begin{itemize}
+\raggedright
+  \item \textbf{gehen} — on foot, unhurried.
+  \item \textbf{laufen} — on foot at any speed at all.
+  \item \textbf{rennen} — flat out. \emph{ich renne, du rennst, er rennt.}
+\end{itemize}
+
+So \textbf{Wir laufen} is \textquotedblleft{}we're walking\textquotedblright{} or \textquotedblleft{}we're running,\textquotedblright{} and only the situation tells you which. That holds across most of Germany. In \textbf{Austria} it does not: there \emph{laufen} means \emph{run}. This course teaches the German usage.
+
+\begin{quote}
+\textbf{Der Hund rennt.} — no ambiguity left.
+\end{quote}
+\end{culture}
+
+\begin{cousinweb}
+\textbf{laufen} is Proto-Germanic \emph{\textbf{*hlaupaną}}, and English kept it as \textbf{leap} — Old English \emph{hlēapan}. One more \textbf{p} against \textbf{f}, the second shift, on the pattern of \emph{helfen/help}, \emph{offen/open} and \emph{schlafen/sleep}.
+
+English holds three more scraps: \textbf{lope}, and — through Dutch relatives of the same verb — \textbf{elope} and \textbf{interloper}, both people running off. Outside Germanic there are \textbf{no secure cousins}.
+
+\textbf{Rennen} is a sharper story. Germanic had \emph{*rinnaną}, \textquotedblleft{}to run, to flow,\textquotedblright{} and beside it a causative \emph{*rannijaną}, \textquotedblleft{}to make something run.\textquotedblright{} German fused the two into \textbf{rennen} and kept \emph{rinnen}, \textquotedblleft{}to trickle,\textquotedblright{} alongside. English fused the same two into \textbf{run} — one merger, carried out separately in each language.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}ich laufe, du läufst, er läuft\textquotedblright{} — \emph{LOW-fuh, LOYFST, LOYFT}
+  \item the three speeds — \textquotedblleft{}Ich gehe. Ich laufe. Ich renne.\textquotedblright{}
+  \item \textquotedblleft{}Der Hund läuft. Der Hund rennt.\textquotedblright{}
+  \item the \emph{p}/\emph{f} row now four long — \textquotedblleft{}helfen/help, offen/open, schlafen/sleep, laufen/leap\textquotedblright{}
+  \item the runaways — \textquotedblleft{}lope, elope, interloper\textquotedblright{}
+  \item the doubled merger — \textquotedblleft{}rinnen, rennen\textquotedblright{} beside English's one \emph{run}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Give the \emph{du} and \emph{er} forms of \emph{laufen}. (\emph{\textbf{Du läufst, er läuft}} — \emph{au} to \emph{äu}.) Which English verb is \emph{laufen}? (\textbf{Leap} — and it means \emph{run}.) Which German verb means only \textquotedblleft{}run fast\textquotedblright{}? (\emph{\textbf{Rennen}}.) Does \textbf{Wir laufen} mean walking or running? (\textbf{Either} — except in Austria, where it is running.) Say \textquotedblleft{}the dog runs.\textquotedblright{} (\emph{\textbf{Der Hund rennt}}.)
+\end{tcolorbox}
+\section[öffnen]{öffnen — \emph{open}, which was always the word \emph{up}}
+
+\label{lesson:GE-C27-oeffnen}
+
+
+
+\begin{quote}
+\textbf{Ich gehe. Ich laufe. Ich renne.} Now something done with the hands, and the German habit that breaks a verb in two.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{umlaut-oe} — \textbf{ö} is the \emph{e} of \emph{bed} with rounded lips.
+  \item \texttt{fn-cluster} — \textbf{-fn-} runs straight together: \textbf{öffnen} = \emph{UFF-nen}.
+\end{itemize}
+\end{sounds}
+
+\subsection*{You'll want to know: öffnen}
+\textbf{öffnen} means \textquotedblleft{}\textbf{to open}.\textquotedblright{}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{ich öffne} · \textbf{wir öffnen}
+  \item \textbf{du öffnest} · \textbf{ihr öffnet}
+  \item \textbf{er öffnet} · \textbf{sie öffnen}
+\end{itemize}
+
+An extra \textbf{e} slips in for \emph{du}, \emph{er} and \emph{ihr}, because \emph{öffnst} cannot be said. Now a noun you already have, whose \textbf{d} is spoken as a \textbf{t}:
+
+\begin{quote}
+\textbf{Ich öffne die Hand.} — \textquotedblleft{}I open my hand.\textquotedblright{} (\emph{dee Hant})
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: a verb that comes apart}]
+\emph{Öffnen} is the neutral, slightly formal word. What people say out loud is \textbf{aufmachen}, and both halves are yours already: \textbf{auf} from Chapter 4's \emph{auf Wiedersehen}, \textbf{machen} from Chapter 5.
+
+Here is the German part. In an ordinary sentence, \textbf{the prefix leaves the verb and waits at the end}:
+
+\begin{quote}
+\textbf{Ich mache die Hand auf.} — literally \textquotedblleft{}I make the hand up.\textquotedblright{}
+\end{quote}
+
+\emph{Machen} takes the slot after \emph{ich}; \emph{auf} goes to the back and sits there. German does this to hundreds of verbs, and calls them \textbf{separable}.
+\end{grammarlens}
+
+\begin{cousinweb}
+Behind the verb is the adjective \textbf{offen}, \textquotedblleft{}open\textquotedblright{} — which Chapter 25 already put beside \textbf{open} as a \textbf{p}-to-\textbf{f} pair from the second shift.
+
+The better secret is that \textbf{neither word is a root}. Old English \emph{open} goes back to Proto-Germanic \emph{\textbf{*upana-}}, \textquotedblleft{}put up,\textquotedblright{} formed on the word that is now English \textbf{up} — it has the shape of a past participle, though no such verb \textquotedblleft{}to up\textquotedblright{} is attested. German ran the same sum and got \emph{offen}, which is why \emph{offen} and \textbf{auf} are relatives and not merely neighbours.
+
+So \emph{aufmachen} is not a quaint compound. It is the ancient recipe for \textquotedblleft{}open,\textquotedblright{} rebuilt out loud — and German pulls it apart every time you use it.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}ich öffne, du öffnest, er öffnet\textquotedblright{} — the extra \emph{e}
+  \item \textquotedblleft{}Ich öffne die Hand.\textquotedblright{} — \emph{dee Hant}
+  \item the split — \textquotedblleft{}Ich mache die Hand auf.\textquotedblright{}
+  \item the \emph{p}/\emph{f} pair — \textquotedblleft{}offen/open\textquotedblright{}
+  \item what it is made of — \textquotedblleft{}auf, up, offen, open\textquotedblright{}
+  \item the feet verbs before the hand one — \textquotedblleft{}Ich gehe. Ich laufe. Ich renne.\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Give the \emph{du} and \emph{er} forms. (\emph{\textbf{Du öffnest, er öffnet}}.) Which older word is \emph{offen} built from? (\textbf{Auf} — English \textbf{up}.) Where does \emph{auf} go in \textbf{Ich mache die Hand auf}? (\textbf{To the end}.) What is such a verb called? (\textbf{Separable}.) How is the \emph{d} of \emph{Hand} spoken? (As a \textbf{t}.)
+\end{tcolorbox}
+\section[schließen]{schließen — the second verb English lost}
+
+\label{lesson:GE-C27-schliessen}
+
+
+
+\begin{quote}
+You can open a hand two ways, \textbf{ich öffne} and \textbf{ich mache … auf}. Closing works the same, and the closing verb has the stranger history.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{ie-long-ee} — \textbf{ie} is a long \emph{ee}: \textbf{schließen} = \emph{SHLEE-sen}.
+  \item \texttt{eszett} — \textbf{ß} is a sharp \emph{s}, and it appears here because the \emph{ee} before it is long.
+\end{itemize}
+\end{sounds}
+
+\subsection*{You'll want to know: schließen}
+\textbf{schließen} means \textquotedblleft{}\textbf{to close},\textquotedblright{} and also \textquotedblleft{}to lock.\textquotedblright{}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{ich schließe} · \textbf{wir schließen}
+  \item \textbf{du schließt} · \textbf{ihr schließt}
+  \item \textbf{er schließt} · \textbf{sie schließen}
+\end{itemize}
+
+Its everyday partner is \textbf{zumachen} — \emph{zu} plus \emph{machen} — splitting exactly as \emph{aufmachen} did:
+
+\begin{quote}
+\textbf{Ich schließe die Hand.} \textbf{Ich mache die Hand zu.}
+\end{quote}
+
+The vowel shortens in the past, and the moment it does the \textbf{ß} becomes \textbf{ss}: \emph{schließen}, but \emph{schloss}.
+
+\begin{cousinweb}
+\textbf{schließen} is Proto-Germanic \emph{\textbf{*sleutaną}}, \textquotedblleft{}to shut, to bolt.\textquotedblright{} Dutch kept it as \emph{sluiten}. \textbf{English has nothing} — no inherited cousin at all.
+
+So English closes things with borrowed and unrelated words. \textbf{Close} is Latin \emph{claudere}, by way of French. \textbf{Shut} is native but a different verb entirely: Old English \emph{scyttan}, to \textbf{shoot} a bolt across a door.
+
+That makes two verbs here with the same shape of story. Chapter 25 gave you \emph{nehmen}, which English lost to Norse \emph{take}. This is the second.
+
+On the verb it kept, German built a household: \textbf{das Schloss}, a lock — and, because a castle is the locked place, a castle; \textbf{der Schlüssel}, a key; \textbf{der Schluss}, the end. English says \textbf{conclusion} for that last one, from \emph{claudere} — the same idea out of the other family's parts.
+
+A link between the Germanic verb and Latin \emph{claudere} has been \textbf{proposed}. It is not established.
+\end{cousinweb}
+
+\begin{grammarlens}[title={What you've built across these two chapters}]
+Eight verbs, and a whole small morning:
+
+\begin{quote}
+\textbf{Ich schlafe. Ich höre. Ich stehe. Ich gehe. Ich laufe. Ich renne. Ich sitze. Ich mache die Hand auf. Ich mache die Hand zu.}
+\end{quote}
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}ich schließe, du schließt, er schließt\textquotedblright{}
+  \item the pair — \textquotedblleft{}Ich mache die Hand auf. Ich mache die Hand zu.\textquotedblright{}
+  \item the spelling swap — \textquotedblleft{}schließen, schloss\textquotedblright{}
+  \item the household — \textquotedblleft{}Schloss, Schlüssel, Schluss\textquotedblright{}
+  \item the two lost verbs — \textquotedblleft{}nehmen, schließen; English took \emph{take} and \emph{close}\textquotedblright{}
+  \item the four \emph{p}/\emph{f} pairs — \textquotedblleft{}helfen/help, offen/open, schlafen/sleep, laufen/leap\textquotedblright{}
+  \item the whole morning — \textquotedblleft{}Ich schlafe. Ich höre. Ich stehe. Ich gehe. Ich laufe. Ich renne. Ich sitze.\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Give the \emph{du} and \emph{er} forms. (\emph{\textbf{Du schließt, er schließt}}.) Which English verb is the cousin of \emph{schließen}? (\textbf{None} — English lost it.) Where did \emph{close} and \emph{shut} come from? (\textbf{Latin}, and from \textbf{shoot}.) Name three words German hung on the verb. (\textbf{Schloss}, \textbf{Schlüssel}, \textbf{Schluss}.) Close your hand, both ways, then run the eight verbs.
+\end{tcolorbox}

--- a/code/learning/human-languages/german/chapters.json
+++ b/code/learning/human-languages/german/chapters.json
@@ -214,6 +214,73 @@
           "GE-LEX-WETTER-02"
         ]
       }
+    },
+    {
+      "chapter": 26,
+      "title": "Sitting, Standing, Sleeping, Hearing",
+      "label": "ch:ge-still-verbs",
+      "canDo": "I can say I sit, I stand, I sleep and I hear in German, tell the second shift's t-branch from its p-branch, break a verb's a to ä for du and er, and say which of the four changes German made alone and which it made alongside English.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "GE-C26-hoeren",
+        "kind": "production",
+        "summary": "The chapter closes on hören, the one verb of the four whose vowel cannot break because it was born umlauted: the reader produces all four ich forms and all four er forms, names schlafen as the only breaker, tells Grimm's law on the h of hören and Hund from the second shift on sitzen and schlafen, and hangs gern on the new verb. It reaches back past its own chapter to Chapter 17's Grimm's law, Chapter 22's Hund and Katze with the Hund etymology that had never been revisited, and Chapter 25's mögen, lieben and gern, all three of which were orphans until here.",
+        "assesses": [
+          "GE-LEX-SITZEN-02",
+          "GE-ETYMON-SITZEN-03",
+          "GE-LEX-STEHEN-04",
+          "GE-ETYMON-STEHEN-05",
+          "GE-LEX-SCHLAFEN-06",
+          "GE-ETYMON-SCHLAFEN-07",
+          "GE-GRAMMAR-UMLAUT-BREAK-08",
+          "GE-LEX-HOEREN-09",
+          "GE-ETYMON-HOEREN-10",
+          "GE-FALSEFRIEND-GEHOEREN-11",
+          "GE-SOUND-GRIMMS-LAW-04",
+          "GE-LEX-HUND-02",
+          "GE-ETYMON-HUND-03",
+          "GE-LEX-KATZE-04",
+          "GE-LEX-MOEGEN-LIEBEN-09",
+          "GE-ETYMON-MOEGEN-LIEBEN-10",
+          "GE-GRAMMAR-GERN-11"
+        ]
+      }
+    },
+    {
+      "chapter": 27,
+      "title": "Going, Running, Opening, Closing",
+      "label": "ch:ge-moving-verbs",
+      "canDo": "I can say I go, I run and I open and close my hand in German, split a separable verb so its prefix waits at the end of the sentence, and say why German's line between walking and running is not where English draws it.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "GE-C27-schliessen",
+        "kind": "production",
+        "summary": "The chapter closes on schließen, the second verb in these chapters that German kept and English lost: the reader produces all of Chapter 27's verbs, splits both aufmachen and zumachen around die Hand, names Schloss, Schlüssel and Schluss as the household built on the kept verb, and runs the eight-verb morning that closes Chapters 26 and 27 together. It reaches back to Chapter 25's nehmen and the second shift on helfen, to Chapter 17's Hand and its final-d devoicing, which had never been revisited, and to Chapter 26's sitzen, stehen and hören.",
+        "assesses": [
+          "GE-LEX-GEHEN-02",
+          "GE-ETYMON-GEHEN-03",
+          "GE-LEX-LAUFEN-04",
+          "GE-ETYMON-LAUFEN-05",
+          "GE-LEX-RENNEN-06",
+          "GE-LEX-OEFFNEN-07",
+          "GE-ETYMON-OFFEN-08",
+          "GE-GRAMMAR-SEPARABLE-09",
+          "GE-LEX-SCHLIESSEN-10",
+          "GE-ETYMON-SCHLIESSEN-11",
+          "GE-LEX-NEHMEN-02",
+          "GE-ETYMON-NEHMEN-03",
+          "GE-ETYMON-HELFEN-08",
+          "GE-LEX-HAND-02",
+          "GE-SOUND-HAND-03",
+          "GE-LEX-SITZEN-02",
+          "GE-LEX-STEHEN-04",
+          "GE-LEX-HOEREN-09"
+        ]
+      }
     }
   ]
 }

--- a/code/learning/human-languages/german/curriculum.json
+++ b/code/learning/human-languages/german/curriculum.json
@@ -339,6 +339,32 @@
       "before": [],
       "inline": [],
       "after": []
+    },
+    {
+      "id": "GE-PATH-029",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "GE-C26-sitzen",
+        "GE-C26-stehen",
+        "GE-C26-schlafen",
+        "GE-C26-hoeren"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "GE-PATH-030",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "GE-C27-gehen",
+        "GE-C27-laufen",
+        "GE-C27-oeffnen",
+        "GE-C27-schliessen"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
     }
   ],
   "spine": {
@@ -458,7 +484,9 @@
         "GE-PATH-018",
         "GE-PATH-021",
         "GE-PATH-027",
-        "GE-PATH-028"
+        "GE-PATH-028",
+        "GE-PATH-029",
+        "GE-PATH-030"
       ],
       "omits": [
         "VERB-INFINITIVE",
@@ -467,7 +495,6 @@
         "VERB-SAY",
         "VERB-SPEAK",
         "VERB-SEE",
-        "VERB-HEAR",
         "VERB-KNOW",
         "VERB-CAN",
         "VERB-GIVE",
@@ -476,19 +503,12 @@
         "VERB-PUT",
         "VERB-EAT",
         "VERB-DRINK",
-        "VERB-SLEEP",
         "VERB-WORK",
         "VERB-PLAY",
-        "VERB-WALK",
-        "VERB-RUN",
-        "VERB-SIT",
-        "VERB-STAND",
         "VERB-WAIT",
         "VERB-ANSWER",
         "VERB-MEET",
-        "VERB-BUY",
-        "VERB-OPEN",
-        "VERB-CLOSE"
+        "VERB-BUY"
       ],
       "relocates": {}
     },

--- a/code/learning/human-languages/german/lessons/GE-C26-hoeren.md
+++ b/code/learning/human-languages/german/lessons/GE-C26-hoeren.md
@@ -1,0 +1,112 @@
+---
+schema_version: 2
+id: GE-C26-hoeren
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 820
+chapter: 26
+type: word
+headword: hören
+gloss: to hear — the same verb as English hear, and the closing of a chapter of four things you do without going anywhere
+concept_tag: VERB-HEAR
+prerequisites: [GE-C26-schlafen, GE-C26-stehen, GE-C22-hund-katze]
+sounds: [umlaut-oe, r-uvular]
+roots: [germanic-hauzijana, pie-kous, grimms-law]
+etymology_hook: "hören is hear, and Gothic hausjan shows the s both languages turned to r; the h is Grimm's law working on the k still audible in Greek akoúein, which gives English acoustic"
+duration:
+  max_seconds: 290
+requires:
+  knowledge: [GE-LEX-SCHLAFEN-06, GE-GRAMMAR-UMLAUT-BREAK-08, GE-LEX-STEHEN-04, GE-LEX-SITZEN-02, GE-SOUND-GRIMMS-LAW-04, GE-LEX-HUND-02, GE-ETYMON-HUND-03, GE-GRAMMAR-GERN-11]
+introduces:
+  knowledge: [GE-LEX-HOEREN-09, GE-ETYMON-HOEREN-10, GE-FALSEFRIEND-GEHOEREN-11]
+practises:
+  knowledge: [GE-LEX-HOEREN-09, GE-ETYMON-HOEREN-10, GE-FALSEFRIEND-GEHOEREN-11, GE-LEX-SITZEN-02, GE-ETYMON-SITZEN-03, GE-LEX-STEHEN-04, GE-ETYMON-STEHEN-05, GE-LEX-SCHLAFEN-06, GE-ETYMON-SCHLAFEN-07, GE-GRAMMAR-UMLAUT-BREAK-08, GE-SOUND-GRIMMS-LAW-04, GE-LEX-HUND-02, GE-ETYMON-HUND-03, GE-LEX-KATZE-04, GE-LEX-MOEGEN-LIEBEN-09, GE-ETYMON-MOEGEN-LIEBEN-10, GE-GRAMMAR-GERN-11]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [GE-C26-schlafen, GE-C26-stehen, GE-C26-sitzen, GE-C22-hund-katze, GE-C25-moegen-lieben]
+---
+
+# hören — *hear*, and the end of a chapter that never moved
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-SITZEN-02, GE-LEX-STEHEN-04, GE-LEX-SCHLAFEN-06] -->
+
+[PAUSE 2s] **Ich sitze. Ich stehe. Ich schlafe.** Three verbs that stay put.
+Here is the fourth — the sense that works with your eyes shut.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `umlaut-oe` — **ö** is the *e* of *bed* said with rounded lips.
+- `r-uvular` — the **r** is a soft scrape at the back: **hören** = *HUR-en*.
+
+## You'll want to know: hören
+<!-- hl-knowledge: introduces=[GE-LEX-HOEREN-09]; assesses=[GE-LEX-HUND-02, GE-LEX-KATZE-04, GE-GRAMMAR-UMLAUT-BREAK-08] -->
+
+**hören** means "**to hear**."
+
+- **ich höre** · **wir hören**
+- **du hörst** · **ihr hört**
+- **er hört** · **sie hören**
+
+The **ö** never moves. *Schlafen* grew its dots for *du* and *er*; *hören* was
+born with them, so nothing is left to break.
+
+> **Der Hund hört. Die Katze hört.**
+
+## Grammar Lens: liking it, the Chapter 25 way
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-HOEREN-09, GE-GRAMMAR-GERN-11, GE-LEX-MOEGEN-LIEBEN-09, GE-ETYMON-MOEGEN-LIEBEN-10] -->
+
+**gern** hangs on this verb like any other:
+
+> **Ich höre gern.** — "I like listening."
+
+*Gern* is English **yearn**: underneath, "I hear yearningly." Beside it is the
+other way of liking, **ich mag** — English **may**, with the power drained out.
+
+## The word, taken apart: the s that became an r
+<!-- hl-knowledge: introduces=[GE-ETYMON-HOEREN-10]; assesses=[GE-LEX-HOEREN-09, GE-SOUND-GRIMMS-LAW-04, GE-ETYMON-HUND-03, GE-ETYMON-SITZEN-03] -->
+
+**hören** is Proto-Germanic ***\*hauzijaną***, and English **hear** is the same
+inherited word.
+
+This time the change is one they **share**. Gothic still says *hausjan*, with an
+**s**; Old English *hīeran* and Old High German *hōren* had both turned it to
+**r**. *Sitzen* shows where German left English; *hören* shows a road they
+walked together.
+
+The **h** is Grimm's law, the first shift: an old **k** became Germanic **h**.
+Greek kept the *k* — *akoúein*, "to hear," which English borrowed back as
+**acoustic**. Same swap that made *\*kwon-* into **Hund** while Latin kept
+*canis*.
+
+Some break the root up further, into "sharp" plus "ear" — which would make
+*hören* "sharp-eared" and put **das Ohr** inside it. Cited often, not settled.
+
+## Why it's said this way: gehören is not "hear"
+<!-- hl-knowledge: introduces=[GE-FALSEFRIEND-GEHOEREN-11]; assesses=[GE-LEX-HOEREN-09] -->
+
+**gehören** means "**to belong**." It is *ge-* welded onto *hören*, and began as
+"to hearken to": what belongs to you answers when called.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-HOEREN-09, GE-ETYMON-HOEREN-10, GE-FALSEFRIEND-GEHOEREN-11, GE-LEX-SITZEN-02, GE-ETYMON-SITZEN-03, GE-LEX-STEHEN-04, GE-ETYMON-STEHEN-05, GE-LEX-SCHLAFEN-06, GE-ETYMON-SCHLAFEN-07, GE-GRAMMAR-UMLAUT-BREAK-08, GE-SOUND-GRIMMS-LAW-04, GE-LEX-HUND-02, GE-ETYMON-HUND-03, GE-LEX-KATZE-04, GE-GRAMMAR-GERN-11, GE-LEX-MOEGEN-LIEBEN-09] -->
+
+[PAUSE 1s]
+- [YOU SAY: all four — "Ich sitze. Ich stehe. Ich schlafe. Ich höre."]
+- [YOU SAY: the four *er* forms — "er sitzt, er steht, er schläft, er hört"]
+- [YOU SAY: "Der Hund hört. Die Katze schläft."]
+- [YOU SAY: "Ich höre gern."]
+- [YOU SAY: the shared change — "hausjan, hīeran, hōren"]
+- [YOU SAY: the *h* row — "hören/akoúein, Hund/canis"]
+- [YOU SAY: "gehören is *belong*"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-HOEREN-09, GE-ETYMON-HOEREN-10, GE-FALSEFRIEND-GEHOEREN-11, GE-LEX-SITZEN-02, GE-LEX-STEHEN-04, GE-LEX-SCHLAFEN-06, GE-GRAMMAR-UMLAUT-BREAK-08, GE-SOUND-GRIMMS-LAW-04, GE-GRAMMAR-GERN-11, GE-LEX-HUND-02] -->
+
+[PAUSE 3s] Give all four *ich* forms of this chapter. (***Ich sitze, ich stehe,
+ich schlafe, ich höre***.) Which breaks its vowel? (***Schlafen*** — *a* to *ä*.)
+Which letter did Gothic keep where German and English have *r*? (An **s**.)
+Which law put the *h* on *hören* and *Hund*? (**Grimm's law**.)

--- a/code/learning/human-languages/german/lessons/GE-C26-schlafen.md
+++ b/code/learning/human-languages/german/lessons/GE-C26-schlafen.md
@@ -1,0 +1,107 @@
+---
+schema_version: 2
+id: GE-C26-schlafen
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 810
+chapter: 26
+type: word
+headword: schlafen
+gloss: to sleep — the same word as English sleep under two coats of German paint, and a second way for a strong verb to break
+concept_tag: VERB-SLEEP
+prerequisites: [GE-C26-stehen, GE-C26-sitzen, GE-C21-das-wetter]
+sounds: [sch-sh, vowel-ae]
+roots: [germanic-slepana, pie-sleb, high-german-shift]
+etymology_hook: "schlafen is sleep with two German changes stacked on it — p to f, and s to sch before l; and the older word for sleep, *swep-, walked off into Latin somnus and Greek hypnos while German and English replaced it together"
+duration:
+  max_seconds: 292
+requires:
+  knowledge: [GE-LEX-STEHEN-04, GE-ETYMON-STEHEN-05, GE-LEX-SITZEN-02, GE-GRAMMAR-STRONG-VOWEL-09, GE-ETYMON-HELFEN-08, GE-LEX-KATZE-04, GE-LEX-REGNET-05]
+introduces:
+  knowledge: [GE-LEX-SCHLAFEN-06, GE-ETYMON-SCHLAFEN-07, GE-GRAMMAR-UMLAUT-BREAK-08]
+practises:
+  knowledge: [GE-LEX-SCHLAFEN-06, GE-ETYMON-SCHLAFEN-07, GE-GRAMMAR-UMLAUT-BREAK-08, GE-LEX-STEHEN-04, GE-ETYMON-STEHEN-05, GE-LEX-SITZEN-02, GE-GRAMMAR-STRONG-VOWEL-09, GE-ETYMON-HELFEN-08, GE-LEX-KATZE-04, GE-LEX-REGNET-05]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [GE-C26-stehen, GE-C26-sitzen, GE-C21-das-wetter]
+---
+
+# schlafen — *sleep*, under two coats of paint
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-SITZEN-02, GE-LEX-STEHEN-04] -->
+
+[PAUSE 2s] *Sitzen* and *stehen* held their vowels still. This one does not —
+and it does not break the way the Chapter 24 verbs broke either.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `sch-sh` — **sch** is English *sh*: **schlafen** = *SHLAH-fen*.
+- `vowel-ae` — **ä** is a flat *eh*: **schläft** = *SHLEFT*.
+
+## You'll want to know: schlafen
+<!-- hl-knowledge: introduces=[GE-LEX-SCHLAFEN-06]; assesses=[GE-LEX-KATZE-04] -->
+
+**schlafen** means "**to sleep**."
+
+- **ich schlafe** · **wir schlafen**
+- **du schläfst** · **ihr schlaft**
+- **er schläft** · **sie schlafen**
+
+> **Die Katze schläft.** — "The cat is sleeping."
+
+## Grammar Lens: the second kind of break
+<!-- hl-knowledge: introduces=[GE-GRAMMAR-UMLAUT-BREAK-08]; assesses=[GE-LEX-SCHLAFEN-06, GE-GRAMMAR-STRONG-VOWEL-09, GE-LEX-REGNET-05] -->
+
+Chapter 24 gave you one break: long *e* goes to **i** for *du* and *er* — *du
+liest*, *er hilft*. Here is the other: **a** takes two dots and becomes **ä** —
+*du schläfst*, *er schläft*.
+
+Those two dots are the umlaut, the mark that turns *Buch* into *Bücher*. The
+break lands in the same slot as before, **du** and **er** and nobody else, so
+only its raw material is new: *e* verbs brighten to *i*, *a* verbs to *ä*.
+
+> **Es regnet. Die Katze schläft.**
+
+## The word, taken apart: two coats of paint
+<!-- hl-knowledge: introduces=[GE-ETYMON-SCHLAFEN-07]; assesses=[GE-LEX-SCHLAFEN-06, GE-ETYMON-HELFEN-08, GE-ETYMON-STEHEN-05] -->
+
+**schlafen** is Proto-Germanic ***\*slēpaną***, and English **sleep** is the
+same inherited word — Old English *slæpan*, Old High German *slāfan*.
+
+Two German changes sit between them. The first you know: the second shift,
+Germanic **p** to German **f**, as in *helfen*. The second is new — German
+turned **s** into *sh* before *l*, *m*, *n* and *w*, and wrote it down: *sleep*
+→ **schlafen**, *swim* → **schwimmen**, *snow* → **Schnee**, *smith* →
+**Schmied**. It did the same before *p* and *t* and never spelt it, which is why
+*stehen* is said *SHTAY-en*.
+
+Now the honest part. The old Indo-European verb for sleeping was ***\*swep-***,
+still in plain view: Latin *somnus* gives **insomnia** and **somnolent**, Latin
+*sopor* gives **soporific**, Greek *hýpnos* gives **hypnosis**, and Old Norse
+*sofa* is Swedish *sova* today. German and English both threw that verb away and
+built a new one on ***\*sleb-***, "to be slack" — German still has **schlaff**,
+"limp." They made that swap **together**, before they were two languages.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-SCHLAFEN-06, GE-ETYMON-SCHLAFEN-07, GE-GRAMMAR-UMLAUT-BREAK-08, GE-GRAMMAR-STRONG-VOWEL-09, GE-LEX-SITZEN-02, GE-LEX-STEHEN-04, GE-LEX-KATZE-04, GE-LEX-REGNET-05, GE-ETYMON-HELFEN-08] -->
+
+[PAUSE 1s]
+- [YOU SAY: "ich schlafe, du schläfst, er schläft" — the *a* brightens to *ä*]
+- [YOU SAY: the three verbs — "Ich sitze. Ich stehe. Ich schlafe."]
+- [YOU SAY: "Es regnet. Die Katze schläft."]
+- [YOU SAY: both breaks in the same slot — "du hilfst" beside "du schläfst"]
+- [YOU SAY: the *sch* row — "schlafen, schwimmen, Schnee, Schmied"]
+- [YOU SAY: the verb they both threw away — "somnus, hypnos, sova"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-SCHLAFEN-06, GE-ETYMON-SCHLAFEN-07, GE-GRAMMAR-UMLAUT-BREAK-08, GE-GRAMMAR-STRONG-VOWEL-09, GE-LEX-KATZE-04, GE-ETYMON-STEHEN-05] -->
+
+[PAUSE 3s] Give the *du* and *er* forms. (***Du schläfst, er schläft*** — two
+dots on the *a*.) Which two people does a German verb break for? (**Du** and
+**er**, always.) Name the two changes between *sleep* and *schlafen*. (**p** to
+**f**, and **s** to **sch**.) Why is *stehen* said *SHTAY-en*? (**Same change**,
+never spelt.) Say "the cat is sleeping." (***Die Katze schläft***.)

--- a/code/learning/human-languages/german/lessons/GE-C26-sitzen.md
+++ b/code/learning/human-languages/german/lessons/GE-C26-sitzen.md
@@ -1,0 +1,108 @@
+---
+schema_version: 2
+id: GE-C26-sitzen
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 790
+chapter: 26
+type: word
+headword: sitzen
+gloss: to sit — the same inherited word as English sit, respelt by the other branch of the shift that separated helfen from help
+concept_tag: VERB-SIT
+prerequisites: [GE-C25-moegen-lieben, GE-C25-helfen, GE-C24-lesen]
+sounds: [tz-affricate, i-short]
+roots: [germanic-sitjana, pie-sed, high-german-shift]
+etymology_hook: "sitzen is sit, moved by the second shift's other branch — Germanic t became German z and ss, the step behind Wasser/water and zehn/ten; and the root *sed- seats Latin sedēre in session and Greek hédra in cathedral"
+duration:
+  max_seconds: 289
+requires:
+  knowledge: [GE-LEX-MOEGEN-LIEBEN-09, GE-GRAMMAR-GERN-11, GE-LEX-HELFEN-07, GE-ETYMON-HELFEN-08, GE-GRAMMAR-STRONG-VOWEL-09]
+introduces:
+  knowledge: [GE-LEX-SITZEN-02, GE-ETYMON-SITZEN-03]
+practises:
+  knowledge: [GE-LEX-SITZEN-02, GE-ETYMON-SITZEN-03, GE-LEX-MOEGEN-LIEBEN-09, GE-GRAMMAR-GERN-11, GE-LEX-HELFEN-07, GE-ETYMON-HELFEN-08, GE-GRAMMAR-STRONG-VOWEL-09]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [GE-C25-moegen-lieben, GE-C25-helfen, GE-C24-lesen]
+---
+
+# sitzen — the same word as *sit*, respelt by one law
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[GE-ETYMON-HELFEN-08] -->
+
+[PAUSE 2s] **Helfen** *is* **help**, split by the second sound shift: Germanic
+**p** became German **f**. That law has other branches. This verb rides one.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `tz-affricate` — **tz** is one squeezed sound, *ts*, as in English *cats*.
+- `i-short` — a short, tight *i*: **sitzen** = *ZIT-sen*, buzzed at the front
+  because German **s** before a vowel is voiced.
+
+## You'll want to know: sitzen
+<!-- hl-knowledge: introduces=[GE-LEX-SITZEN-02]; assesses=[] -->
+
+**sitzen** means "**to sit**."
+
+- **ich sitze** — I sit · **wir sitzen** — we sit
+- **du sitzt** — you sit · **ihr sitzt** — you all sit
+- **er sitzt** — he sits · **sie sitzen** — they sit
+
+> **Ich sitze.** — a whole sentence, two words.
+
+## Grammar Lens: strong does not mean it breaks
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-SITZEN-02, GE-GRAMMAR-STRONG-VOWEL-09, GE-LEX-HELFEN-07, GE-LEX-MOEGEN-LIEBEN-09, GE-GRAMMAR-GERN-11] -->
+
+*Sitzen* is a **strong** verb — its past is *saß*, not *sitzte*. But its present
+never breaks its vowel: *du sitzt, er sitzt*. Beside it, *helfen* breaks to *du
+hilfst*.
+
+So "strong" is a fact about a verb's **past**; the *du*/*er* break is a separate
+habit only some strong verbs have.
+
+Chapter 25 gave two ways to say you like something: **ich mag** with a thing,
+**gern** hung on a verb. This verb takes the second.
+
+> **Ich sitze gern.** — "I like sitting."
+
+## The word, taken apart: the shift's other branch
+<!-- hl-knowledge: introduces=[GE-ETYMON-SITZEN-03]; assesses=[GE-LEX-SITZEN-02, GE-ETYMON-HELFEN-08] -->
+
+**sitzen** is Proto-Germanic ***\*sitjaną***, and English **sit** is the same
+inherited word — Old English *sittan*, Old High German *sizzen*.
+
+The second, High German shift moved Germanic **p** to **f** in *helfen*. It
+moved Germanic **t** just as hard, to **z** (said *ts*) or **ss**: *sittan* →
+**sitzen**, *water* → **Wasser**, *eat* → **essen**, *ten* → **zehn**, *bite* →
+**beißen**. Chapter 11 handed you *Wasser* and Chapter 6 handed you *zehn* long
+before there was a name for what had happened to them.
+
+Under both lies PIE ***\*sed-***, "to sit," one of the family's great providers.
+Latin *sedēre* gives **session**, **sedentary** and **preside**; Latin *sedēs*,
+"a seat," gives the bishop's **see**. Greek *hédra*, also "a seat," gives
+**cathedral** — the church with the bishop's chair — and **polyhedron**.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-SITZEN-02, GE-ETYMON-SITZEN-03, GE-GRAMMAR-STRONG-VOWEL-09, GE-LEX-HELFEN-07, GE-ETYMON-HELFEN-08, GE-LEX-MOEGEN-LIEBEN-09, GE-GRAMMAR-GERN-11] -->
+
+[PAUSE 1s]
+- [YOU SAY: "ich sitze, du sitzt, er sitzt" — the *i* never moves]
+- [YOU SAY: the contrast — "du sitzt" beside "du hilfst"]
+- [YOU SAY: "Ich sitze gern."]
+- [YOU SAY: the *t* branch four times — "sitzen/sit, Wasser/water, essen/eat,
+  zehn/ten"]
+- [YOU SAY: the *p* branch beside it — "helfen/help"]
+- [YOU SAY: the seat words — "sitzen, sedēre, hédra, cathedral"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-SITZEN-02, GE-ETYMON-SITZEN-03, GE-GRAMMAR-STRONG-VOWEL-09, GE-LEX-HELFEN-07, GE-GRAMMAR-GERN-11] -->
+
+[PAUSE 3s] Give the *du* and *er* forms of *sitzen*. (***Du sitzt, er sitzt*** —
+no break.) Which verb from Chapter 25 does break, and how? (***Helfen*** — *du
+hilfst*.) Which sound did the second shift turn German's **z** and **ss** out
+of? (An old **t**.) Name two pairs from that branch. (**Wasser/water**,
+**essen/eat**, **zehn/ten**.) Say you like sitting. (***Ich sitze gern***.)

--- a/code/learning/human-languages/german/lessons/GE-C26-stehen.md
+++ b/code/learning/human-languages/german/lessons/GE-C26-stehen.md
@@ -1,0 +1,108 @@
+---
+schema_version: 2
+id: GE-C26-stehen
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 800
+chapter: 26
+type: word
+headword: stehen
+gloss: to stand — the verb Chapter 24 found inside verstehen, and the one place German keeps a letter English put in the wrong tense
+concept_tag: VERB-STAND
+prerequisites: [GE-C26-sitzen, GE-C24-verstehen]
+sounds: [st-initial-scht, h-silent-lengthening]
+roots: [germanic-stana, pie-steh2, high-german-shift]
+etymology_hook: "stehen and stand are one root down two stems — German took the one without the n and English the one with it, and German's own past, ich stand, hands the n back"
+duration:
+  max_seconds: 290
+requires:
+  knowledge: [GE-LEX-SITZEN-02, GE-ETYMON-SITZEN-03, GE-LEX-VERSTEHEN-05, GE-ETYMON-VERSTEHEN-06]
+introduces:
+  knowledge: [GE-LEX-STEHEN-04, GE-ETYMON-STEHEN-05]
+practises:
+  knowledge: [GE-LEX-STEHEN-04, GE-ETYMON-STEHEN-05, GE-LEX-SITZEN-02, GE-ETYMON-SITZEN-03, GE-LEX-VERSTEHEN-05, GE-ETYMON-VERSTEHEN-06]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [GE-C26-sitzen, GE-C24-verstehen]
+---
+
+# stehen — the verb that was hiding inside *verstehen*
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-VERSTEHEN-05, GE-ETYMON-VERSTEHEN-06] -->
+
+[PAUSE 2s] Chapter 24 broke **verstehen** into *ver-* plus *stehen*, and named
+*stehen* as English **stand**. Here is that verb alone, and the letter the two
+languages disagree about.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `st-initial-scht` — **st** at the start of a German word is said *sht*.
+- `h-silent-lengthening` — the **h** is silent and marks the long vowel:
+  **stehen** = *SHTAY-en*.
+
+## You'll want to know: stehen
+<!-- hl-knowledge: introduces=[GE-LEX-STEHEN-04]; assesses=[GE-LEX-SITZEN-02] -->
+
+**stehen** means "**to stand**."
+
+- **ich stehe** — I stand · **wir stehen** — we stand
+- **du stehst** — you stand · **ihr steht** — you all stand
+- **er steht** — he stands · **sie stehen** — they stand
+
+Like *sitzen*, it keeps its vowel all the way through. Two postures, two
+sentences:
+
+> **Ich sitze. Ich stehe.**
+
+## The word, taken apart: the missing n
+<!-- hl-knowledge: introduces=[GE-ETYMON-STEHEN-05]; assesses=[GE-LEX-STEHEN-04, GE-ETYMON-VERSTEHEN-06] -->
+
+Germanic ran two stems off one root here: a short ***\*stāną*** and a longer
+***\*standaną*** with an **n** wedged inside. English generalised the long one
+and got **stand**; German took the short one and got **stehen**, Old High German
+*stān*.
+
+German did not lose the *n*. It kept it in the past: **ich stand**, and the
+participle **gestanden**. German's past tense is spelt the way English's present
+is, out of the same drawer of stems.
+
+The root is PIE ***\*steh₂-***, the one Chapter 24 named, and it is everywhere.
+Latin *stāre* gave **state**, **station**, **stable**, **constant**. Greek
+*hístēmi*, "I set up," gave **static**, **system** and **ecstasy** — standing
+outside yourself. German built **die Stadt**, a city: a standing-place. English
+built **stead**, **steady** and **instead**.
+
+## Why it's said this way: two postures, two Latin cousins
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-SITZEN-02, GE-ETYMON-SITZEN-03, GE-LEX-STEHEN-04, GE-ETYMON-STEHEN-05] -->
+
+Notice the shape of what has happened. *Sitzen* goes back to ***\*sed-***, and so
+does Latin's *sedēre*. *Stehen* goes back to ***\*steh₂-***, and so does Latin's
+*stāre*.
+
+Nothing was borrowed in either direction. Two families inherited the same two
+roots and held them to the same two meanings for thousands of years, because
+sitting and standing are things everybody does.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-STEHEN-04, GE-ETYMON-STEHEN-05, GE-LEX-SITZEN-02, GE-ETYMON-SITZEN-03, GE-LEX-VERSTEHEN-05, GE-ETYMON-VERSTEHEN-06] -->
+
+[PAUSE 1s]
+- [YOU SAY: "ich stehe, du stehst, er steht" — *SHTAY*, not *STAY*]
+- [YOU SAY: both postures — "Ich sitze. Ich stehe."]
+- [YOU SAY: the verb inside the verb — "stehen, verstehen"]
+- [YOU SAY: where the *n* went — "ich stehe, ich stand, gestanden"]
+- [YOU SAY: the Latin pair — "sitzen/sedēre, stehen/stāre"]
+- [YOU SAY: what stands in English — "state, station, stable, stead"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-STEHEN-04, GE-ETYMON-STEHEN-05, GE-LEX-SITZEN-02, GE-LEX-VERSTEHEN-05] -->
+
+[PAUSE 3s] Give the *du* and *er* forms. (***Du stehst, er steht***.) Which
+letter does English's *stand* carry that German's *stehen* does not? (An **n**.)
+Where does German still keep it? (In the **past** — *ich stand, gestanden*.)
+Which longer verb from Chapter 24 has *stehen* inside it? (***Verstehen***.)
+Say "I sit. I stand." (***Ich sitze. Ich stehe.***)

--- a/code/learning/human-languages/german/lessons/GE-C27-gehen.md
+++ b/code/learning/human-languages/german/lessons/GE-C27-gehen.md
@@ -1,0 +1,106 @@
+---
+schema_version: 2
+id: GE-C27-gehen
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 830
+chapter: 27
+type: word
+headword: gehen
+gloss: to go, and to walk — because German has no separate word for walking, and English's walk turns out to be a word about cloth
+concept_tag: VERB-WALK
+prerequisites: [GE-C26-hoeren, GE-C26-stehen, GE-C05-machen]
+sounds: [h-silent-lengthening, ge-prefix]
+roots: [germanic-gana, germanic-gangana]
+etymology_hook: "gehen is go, and both languages borrowed a past for it — English took went from wend, German took ging and gegangen from gangan, which English still has in gangway; meanwhile English walk has a German cousin, walken, and it means to full cloth"
+duration:
+  max_seconds: 282
+requires:
+  knowledge: [GE-LEX-HOEREN-09, GE-ETYMON-HOEREN-10, GE-FALSEFRIEND-GEHOEREN-11, GE-LEX-STEHEN-04, GE-ETYMON-STEHEN-05, GE-LEX-SCHLAFEN-06, GE-LEX-SITZEN-02]
+introduces:
+  knowledge: [GE-LEX-GEHEN-02, GE-ETYMON-GEHEN-03]
+practises:
+  knowledge: [GE-LEX-GEHEN-02, GE-ETYMON-GEHEN-03, GE-LEX-HOEREN-09, GE-ETYMON-HOEREN-10, GE-FALSEFRIEND-GEHOEREN-11, GE-LEX-STEHEN-04, GE-ETYMON-STEHEN-05, GE-LEX-SCHLAFEN-06, GE-LEX-SITZEN-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [GE-C26-hoeren, GE-C26-stehen, GE-C26-schlafen]
+---
+
+# gehen — *go*, and the word German never needed for *walk*
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-SITZEN-02, GE-LEX-STEHEN-04, GE-LEX-SCHLAFEN-06, GE-LEX-HOEREN-09] -->
+
+[PAUSE 2s] Four verbs that stayed put — sitting, standing, sleeping, hearing.
+Now a chapter that moves, opening on the verb German uses where English has two.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `h-silent-lengthening` — the **h** is silent and lengthens: **gehen** =
+  *GAY-en*, built exactly like *stehen*, *SHTAY-en*.
+- `ge-prefix` — **ge-** at the front is said *guh*, never *jee*.
+
+## You'll want to know: gehen
+<!-- hl-knowledge: introduces=[GE-LEX-GEHEN-02]; assesses=[GE-LEX-STEHEN-04] -->
+
+**gehen** means "**to go**" — and also "**to walk**." German does not split
+those.
+
+- **ich gehe** · **wir gehen**
+- **du gehst** · **ihr geht**
+- **er geht** · **sie gehen**
+
+> **Ich stehe. Ich gehe.**
+
+Two verbs cut to the same short shape, each with a silent *h* propping the vowel
+up. Say them together and you hear a matched pair: *SHTAY-en, GAY-en*.
+
+## The word, taken apart: two languages, two borrowed pasts
+<!-- hl-knowledge: introduces=[GE-ETYMON-GEHEN-03]; assesses=[GE-LEX-GEHEN-02, GE-ETYMON-STEHEN-05, GE-FALSEFRIEND-GEHOEREN-11] -->
+
+**gehen** is Proto-Germanic ***\*gāną*** and English **go** is the same
+inherited word, Old English *gān*.
+
+Both languages then hit the same problem: the verb had no usable past, and each
+went shopping. English took **went**, really the past of *wend*, and left *wend*
+stranded. German took **ging** and **gegangen** from another old verb,
+***\*ganganą***, "to walk" — which English still owns in **gangway**,
+**gangplank**, and Scots *gang*, "to go."
+
+**Gegangen** carries the same *ge-* you met on **gehören**: an old prefix German
+fastens to a past participle.
+
+Beyond Germanic, be honest — the deeper root of *go* is **disputed**, with no
+agreed list of cousins. It is the one verb here that cannot be followed back.
+
+## Why it's said this way: English's *walk* is about cloth
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-GEHEN-02, GE-ETYMON-GEHEN-03] -->
+
+Because **walk** is not an old word for travelling on foot. Old English
+*wealcan* meant "to roll, to toss," and its German cousin **walken** still means
+what it always meant: **to full cloth**, to work wool by trampling it.
+
+English promoted that trampling verb around 1200. German never did, so *gehen*
+covers both jobs.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-GEHEN-02, GE-ETYMON-GEHEN-03, GE-LEX-STEHEN-04, GE-ETYMON-STEHEN-05, GE-LEX-HOEREN-09, GE-ETYMON-HOEREN-10, GE-FALSEFRIEND-GEHOEREN-11, GE-LEX-SCHLAFEN-06] -->
+
+[PAUSE 1s]
+- [YOU SAY: "ich gehe, du gehst, er geht"]
+- [YOU SAY: the matched pair — "Ich stehe. Ich gehe."]
+- [YOU SAY: the borrowed pasts — "go/went" beside "gehen/ging/gegangen"]
+- [YOU SAY: where English kept the other verb — "gangway, gangplank"]
+- [YOU SAY: the *ge-* on both — "gehören, gegangen"]
+- [YOU SAY: what *walken* does — it fulls cloth, it does not travel]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-GEHEN-02, GE-ETYMON-GEHEN-03, GE-LEX-STEHEN-04, GE-FALSEFRIEND-GEHOEREN-11] -->
+
+[PAUSE 3s] Give the *du* and *er* forms. (***Du gehst, er geht***.) Which
+English verb is *gehen*? (**Go**, and **walk** as well.) Where did *went* come
+from? (From ***wend***.) What does German's cousin of *walk* mean? (**To full
+cloth**.) How far back can *gehen* be traced? (**Not past Germanic**.)

--- a/code/learning/human-languages/german/lessons/GE-C27-laufen.md
+++ b/code/learning/human-languages/german/lessons/GE-C27-laufen.md
@@ -1,0 +1,110 @@
+---
+schema_version: 2
+id: GE-C27-laufen
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 840
+chapter: 27
+type: word
+headword: laufen
+gloss: to run — and to walk, because German draws the line in a different place from English, with rennen at the fast end
+concept_tag: VERB-RUN
+prerequisites: [GE-C27-gehen, GE-C26-schlafen, GE-C22-hund-katze]
+sounds: [diphthong-au, diphthong-eu]
+roots: [germanic-hlaupana, germanic-rinnana, high-german-shift]
+etymology_hook: "laufen is English leap, one more p-to-f pair; and where English cuts between walk and run, German has gehen, laufen lying across the line, and rennen at the far end — with rennen and run each merging the same two old verbs separately"
+duration:
+  max_seconds: 288
+requires:
+  knowledge: [GE-LEX-GEHEN-02, GE-ETYMON-GEHEN-03, GE-GRAMMAR-UMLAUT-BREAK-08, GE-ETYMON-HELFEN-08, GE-ETYMON-SCHLAFEN-07, GE-LEX-HUND-02]
+introduces:
+  knowledge: [GE-LEX-LAUFEN-04, GE-ETYMON-LAUFEN-05, GE-LEX-RENNEN-06]
+practises:
+  knowledge: [GE-LEX-LAUFEN-04, GE-ETYMON-LAUFEN-05, GE-LEX-RENNEN-06, GE-LEX-GEHEN-02, GE-ETYMON-GEHEN-03, GE-GRAMMAR-UMLAUT-BREAK-08, GE-ETYMON-HELFEN-08, GE-ETYMON-SCHLAFEN-07, GE-LEX-HUND-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [GE-C27-gehen, GE-C26-schlafen, GE-C22-hund-katze]
+---
+
+# laufen — the verb that lies across English's line
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-GEHEN-02] -->
+
+[PAUSE 2s] **Ich gehe** covers going and walking. German has two words for
+*run*, and one of them is not only about running.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `diphthong-au` — **au** is the *ow* of *house*: **laufen** = *LOW-fen*.
+- `diphthong-eu` — **äu** is the *oy* of *boy*: **läuft** = *LOYFT*.
+
+## You'll want to know: laufen
+<!-- hl-knowledge: introduces=[GE-LEX-LAUFEN-04]; assesses=[GE-GRAMMAR-UMLAUT-BREAK-08, GE-LEX-HUND-02] -->
+
+**laufen** means "**to run**" — and often "to walk."
+
+- **ich laufe** · **wir laufen**
+- **du läufst** · **ihr lauft**
+- **er läuft** · **sie laufen**
+
+The *schlafen* break is here too, in the same *du* and *er* slot: **au**
+brightens to **äu**.
+
+> **Der Hund läuft.**
+
+## Why it's said this way: the line is not where you expect
+<!-- hl-knowledge: introduces=[GE-LEX-RENNEN-06]; assesses=[GE-LEX-LAUFEN-04, GE-LEX-GEHEN-02] -->
+
+English draws a hard line between *walk* and *run*. German draws it elsewhere,
+and leaves one verb lying across it.
+
+- **gehen** — on foot, unhurried.
+- **laufen** — on foot at any speed at all.
+- **rennen** — flat out. *ich renne, du rennst, er rennt.*
+
+So **Wir laufen** is "we're walking" or "we're running," and only the situation
+tells you which. That holds across most of Germany. In **Austria** it does not:
+there *laufen* means *run*. This course teaches the German usage.
+
+> **Der Hund rennt.** — no ambiguity left.
+
+## The word, taken apart: laufen is *leap*
+<!-- hl-knowledge: introduces=[GE-ETYMON-LAUFEN-05]; assesses=[GE-LEX-LAUFEN-04, GE-LEX-RENNEN-06, GE-ETYMON-HELFEN-08, GE-ETYMON-SCHLAFEN-07] -->
+
+**laufen** is Proto-Germanic ***\*hlaupaną***, and English kept it as **leap** —
+Old English *hlēapan*. One more **p** against **f**, the second shift, on
+the pattern of *helfen/help*, *offen/open* and *schlafen/sleep*.
+
+English holds three more scraps: **lope**, and — through Dutch relatives of the
+same verb — **elope** and **interloper**, both people running off. Outside
+Germanic there are **no secure cousins**.
+
+**Rennen** is a sharper story. Germanic had *\*rinnaną*, "to run, to flow," and
+beside it a causative *\*rannijaną*, "to make something run." German fused the
+two into **rennen** and kept *rinnen*, "to trickle," alongside. English fused
+the same two into **run** — one merger, carried out separately in each language.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-LAUFEN-04, GE-ETYMON-LAUFEN-05, GE-LEX-RENNEN-06, GE-LEX-GEHEN-02, GE-ETYMON-GEHEN-03, GE-GRAMMAR-UMLAUT-BREAK-08, GE-ETYMON-HELFEN-08, GE-LEX-HUND-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: "ich laufe, du läufst, er läuft" — *LOW-fuh, LOYFST, LOYFT*]
+- [YOU SAY: the three speeds — "Ich gehe. Ich laufe. Ich renne."]
+- [YOU SAY: "Der Hund läuft. Der Hund rennt."]
+- [YOU SAY: the *p*/*f* row now four long — "helfen/help, offen/open,
+  schlafen/sleep, laufen/leap"]
+- [YOU SAY: the runaways — "lope, elope, interloper"]
+- [YOU SAY: the doubled merger — "rinnen, rennen" beside English's one *run*]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-LAUFEN-04, GE-ETYMON-LAUFEN-05, GE-LEX-RENNEN-06, GE-LEX-GEHEN-02, GE-GRAMMAR-UMLAUT-BREAK-08] -->
+
+[PAUSE 3s] Give the *du* and *er* forms of *laufen*. (***Du läufst, er läuft***
+— *au* to *äu*.) Which English verb is *laufen*? (**Leap** — and it means
+*run*.) Which German verb means only "run fast"? (***Rennen***.) Does
+**Wir laufen** mean walking or running? (**Either** — except in Austria, where
+it is running.) Say "the dog runs." (***Der Hund rennt***.)

--- a/code/learning/human-languages/german/lessons/GE-C27-oeffnen.md
+++ b/code/learning/human-languages/german/lessons/GE-C27-oeffnen.md
@@ -1,0 +1,106 @@
+---
+schema_version: 2
+id: GE-C27-oeffnen
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 850
+chapter: 27
+type: word
+headword: öffnen
+gloss: to open — built on offen, which is English open, which is really the word up; and the doorway into German's separable verbs
+concept_tag: VERB-OPEN
+prerequisites: [GE-C27-laufen, GE-C25-helfen, GE-C17-hand]
+sounds: [umlaut-oe, fn-cluster]
+roots: [germanic-upana, high-german-shift]
+etymology_hook: "offen is English open, one more p-to-f pair, and neither word is a root — both were built out of up, German auf; so aufmachen says the same thing twice and splits in half doing it"
+duration:
+  max_seconds: 290
+requires:
+  knowledge: [GE-LEX-LAUFEN-04, GE-LEX-RENNEN-06, GE-LEX-GEHEN-02, GE-ETYMON-HELFEN-08, GE-LEX-HAND-02, GE-SOUND-HAND-03]
+introduces:
+  knowledge: [GE-LEX-OEFFNEN-07, GE-ETYMON-OFFEN-08, GE-GRAMMAR-SEPARABLE-09]
+practises:
+  knowledge: [GE-LEX-OEFFNEN-07, GE-ETYMON-OFFEN-08, GE-GRAMMAR-SEPARABLE-09, GE-LEX-LAUFEN-04, GE-LEX-RENNEN-06, GE-LEX-GEHEN-02, GE-ETYMON-HELFEN-08, GE-LEX-HAND-02, GE-SOUND-HAND-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [GE-C27-laufen, GE-C25-helfen, GE-C17-hand]
+---
+
+# öffnen — *open*, which was always the word *up*
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-GEHEN-02, GE-LEX-LAUFEN-04, GE-LEX-RENNEN-06] -->
+
+[PAUSE 2s] **Ich gehe. Ich laufe. Ich renne.** Now something done with the
+hands, and the German habit that breaks a verb in two.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `umlaut-oe` — **ö** is the *e* of *bed* with rounded lips.
+- `fn-cluster` — **-fn-** runs straight together: **öffnen** = *UFF-nen*.
+
+## You'll want to know: öffnen
+<!-- hl-knowledge: introduces=[GE-LEX-OEFFNEN-07]; assesses=[GE-LEX-HAND-02, GE-SOUND-HAND-03] -->
+
+**öffnen** means "**to open**."
+
+- **ich öffne** · **wir öffnen**
+- **du öffnest** · **ihr öffnet**
+- **er öffnet** · **sie öffnen**
+
+An extra **e** slips in for *du*, *er* and *ihr*, because *öffnst* cannot be
+said. Now a noun you already have, whose **d** is spoken as a **t**:
+
+> **Ich öffne die Hand.** — "I open my hand." (*dee Hant*)
+
+## Grammar Lens: a verb that comes apart
+<!-- hl-knowledge: introduces=[GE-GRAMMAR-SEPARABLE-09]; assesses=[GE-LEX-OEFFNEN-07, GE-LEX-HAND-02] -->
+
+*Öffnen* is the neutral, slightly formal word. What people say out loud is
+**aufmachen**, and both halves are yours already: **auf** from Chapter 4's *auf
+Wiedersehen*, **machen** from Chapter 5.
+
+Here is the German part. In an ordinary sentence, **the prefix leaves the verb
+and waits at the end**:
+
+> **Ich mache die Hand auf.** — literally "I make the hand up."
+
+*Machen* takes the slot after *ich*; *auf* goes to the back and sits there.
+German does this to hundreds of verbs, and calls them **separable**.
+
+## The word, taken apart: open was never a root
+<!-- hl-knowledge: introduces=[GE-ETYMON-OFFEN-08]; assesses=[GE-LEX-OEFFNEN-07, GE-ETYMON-HELFEN-08, GE-GRAMMAR-SEPARABLE-09] -->
+
+Behind the verb is the adjective **offen**, "open" — which Chapter 25 already
+put beside **open** as a **p**-to-**f** pair from the second shift.
+
+The better secret is that **neither word is a root**. Old English *open* goes
+back to Proto-Germanic ***\*upana-***, "put up," formed on the word that is now
+English **up** — it has the shape of a past participle, though no such verb "to
+up" is attested. German ran the same sum and got *offen*, which is why *offen*
+and **auf** are relatives and not merely neighbours.
+
+So *aufmachen* is not a quaint compound. It is the ancient recipe for "open,"
+rebuilt out loud — and German pulls it apart every time you use it.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-OEFFNEN-07, GE-ETYMON-OFFEN-08, GE-GRAMMAR-SEPARABLE-09, GE-LEX-HAND-02, GE-SOUND-HAND-03, GE-ETYMON-HELFEN-08, GE-LEX-GEHEN-02, GE-LEX-LAUFEN-04, GE-LEX-RENNEN-06] -->
+
+[PAUSE 1s]
+- [YOU SAY: "ich öffne, du öffnest, er öffnet" — the extra *e*]
+- [YOU SAY: "Ich öffne die Hand." — *dee Hant*]
+- [YOU SAY: the split — "Ich mache die Hand auf."]
+- [YOU SAY: the *p*/*f* pair — "offen/open"]
+- [YOU SAY: what it is made of — "auf, up, offen, open"]
+- [YOU SAY: the feet verbs before the hand one — "Ich gehe. Ich laufe. Ich renne."]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-OEFFNEN-07, GE-ETYMON-OFFEN-08, GE-GRAMMAR-SEPARABLE-09, GE-LEX-HAND-02, GE-SOUND-HAND-03] -->
+
+[PAUSE 3s] Give the *du* and *er* forms. (***Du öffnest, er öffnet***.) Which
+older word is *offen* built from? (**Auf** — English **up**.) Where does *auf*
+go in **Ich mache die Hand auf**? (**To the end**.) What is such a verb called?
+(**Separable**.) How is the *d* of *Hand* spoken? (As a **t**.)

--- a/code/learning/human-languages/german/lessons/GE-C27-schliessen.md
+++ b/code/learning/human-languages/german/lessons/GE-C27-schliessen.md
@@ -1,0 +1,115 @@
+---
+schema_version: 2
+id: GE-C27-schliessen
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 860
+chapter: 27
+type: word
+headword: schließen
+gloss: to close — the second verb in these chapters that German kept and English lost, and the one that locked up Schloss, Schlüssel and Schluss
+concept_tag: VERB-CLOSE
+prerequisites: [GE-C27-oeffnen, GE-C25-nehmen, GE-C26-sitzen]
+sounds: [eszett, ie-long-ee]
+roots: [germanic-sleutana]
+etymology_hook: "schließen has no English cousin at all — English closes with Latin's close and with shut, which is really shoot; German kept the old verb and hung Schloss, Schlüssel and Schluss on it, the way English hangs conclusion on claudere"
+duration:
+  max_seconds: 292
+requires:
+  knowledge: [GE-LEX-OEFFNEN-07, GE-ETYMON-OFFEN-08, GE-GRAMMAR-SEPARABLE-09, GE-LEX-GEHEN-02, GE-ETYMON-GEHEN-03, GE-LEX-LAUFEN-04, GE-ETYMON-LAUFEN-05, GE-LEX-RENNEN-06, GE-LEX-NEHMEN-02, GE-ETYMON-NEHMEN-03, GE-LEX-HAND-02, GE-SOUND-HAND-03, GE-LEX-SITZEN-02, GE-LEX-STEHEN-04, GE-LEX-HOEREN-09, GE-ETYMON-HELFEN-08]
+introduces:
+  knowledge: [GE-LEX-SCHLIESSEN-10, GE-ETYMON-SCHLIESSEN-11]
+practises:
+  knowledge: [GE-LEX-SCHLIESSEN-10, GE-ETYMON-SCHLIESSEN-11, GE-LEX-OEFFNEN-07, GE-ETYMON-OFFEN-08, GE-GRAMMAR-SEPARABLE-09, GE-LEX-GEHEN-02, GE-ETYMON-GEHEN-03, GE-LEX-LAUFEN-04, GE-ETYMON-LAUFEN-05, GE-LEX-RENNEN-06, GE-LEX-NEHMEN-02, GE-ETYMON-NEHMEN-03, GE-LEX-HAND-02, GE-SOUND-HAND-03, GE-LEX-SITZEN-02, GE-LEX-STEHEN-04, GE-LEX-HOEREN-09, GE-ETYMON-HELFEN-08]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-contemporary
+reviews_of: [GE-C27-oeffnen, GE-C27-laufen, GE-C27-gehen, GE-C25-nehmen, GE-C17-hand]
+---
+
+# schließen — the second verb English lost
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-OEFFNEN-07, GE-GRAMMAR-SEPARABLE-09] -->
+
+[PAUSE 2s] You can open a hand two ways, **ich öffne** and **ich mache … auf**.
+Closing works the same, and the closing verb has the stranger history.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `ie-long-ee` — **ie** is a long *ee*: **schließen** = *SHLEE-sen*.
+- `eszett` — **ß** is a sharp *s*, and it appears here because the *ee* before it
+  is long.
+
+## You'll want to know: schließen
+<!-- hl-knowledge: introduces=[GE-LEX-SCHLIESSEN-10]; assesses=[GE-LEX-HAND-02, GE-SOUND-HAND-03, GE-GRAMMAR-SEPARABLE-09] -->
+
+**schließen** means "**to close**," and also "to lock."
+
+- **ich schließe** · **wir schließen**
+- **du schließt** · **ihr schließt**
+- **er schließt** · **sie schließen**
+
+Its everyday partner is **zumachen** — *zu* plus *machen* — splitting exactly as
+*aufmachen* did:
+
+> **Ich schließe die Hand.**
+> **Ich mache die Hand zu.**
+
+The vowel shortens in the past, and the moment it does the **ß** becomes **ss**:
+*schließen*, but *schloss*.
+
+## The word, taken apart: a verb with no English cousin
+<!-- hl-knowledge: introduces=[GE-ETYMON-SCHLIESSEN-11]; assesses=[GE-LEX-SCHLIESSEN-10, GE-LEX-NEHMEN-02, GE-ETYMON-NEHMEN-03] -->
+
+**schließen** is Proto-Germanic ***\*sleutaną***, "to shut, to bolt." Dutch kept
+it as *sluiten*. **English has nothing** — no inherited cousin at all.
+
+So English closes things with borrowed and unrelated words. **Close** is Latin
+*claudere*, by way of French. **Shut** is native but a different verb entirely:
+Old English *scyttan*, to **shoot** a bolt across a door.
+
+That makes two verbs here with the same shape of story. Chapter 25 gave you
+*nehmen*, which English lost to Norse *take*. This is the second.
+
+On the verb it kept, German built a household: **das Schloss**, a lock — and,
+because a castle is the locked place, a castle; **der Schlüssel**, a key; **der
+Schluss**, the end. English says **conclusion** for that last one, from
+*claudere* — the same idea out of the other family's parts.
+
+A link between the Germanic verb and Latin *claudere* has been **proposed**. It
+is not established.
+
+## What you've built across these two chapters
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-SITZEN-02, GE-LEX-STEHEN-04, GE-LEX-HOEREN-09, GE-LEX-GEHEN-02, GE-LEX-LAUFEN-04, GE-LEX-RENNEN-06, GE-LEX-OEFFNEN-07, GE-LEX-SCHLIESSEN-10, GE-GRAMMAR-SEPARABLE-09] -->
+
+Eight verbs, and a whole small morning:
+
+> **Ich schlafe. Ich höre. Ich stehe. Ich gehe. Ich laufe. Ich renne. Ich sitze.
+> Ich mache die Hand auf. Ich mache die Hand zu.**
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-SCHLIESSEN-10, GE-ETYMON-SCHLIESSEN-11, GE-LEX-OEFFNEN-07, GE-ETYMON-OFFEN-08, GE-GRAMMAR-SEPARABLE-09, GE-LEX-GEHEN-02, GE-ETYMON-GEHEN-03, GE-LEX-LAUFEN-04, GE-ETYMON-LAUFEN-05, GE-LEX-RENNEN-06, GE-LEX-NEHMEN-02, GE-ETYMON-NEHMEN-03, GE-LEX-HAND-02, GE-SOUND-HAND-03, GE-LEX-SITZEN-02, GE-LEX-STEHEN-04, GE-LEX-HOEREN-09, GE-ETYMON-HELFEN-08] -->
+
+[PAUSE 1s]
+- [YOU SAY: "ich schließe, du schließt, er schließt"]
+- [YOU SAY: the pair — "Ich mache die Hand auf. Ich mache die Hand zu."]
+- [YOU SAY: the spelling swap — "schließen, schloss"]
+- [YOU SAY: the household — "Schloss, Schlüssel, Schluss"]
+- [YOU SAY: the two lost verbs — "nehmen, schließen; English took *take* and
+  *close*"]
+- [YOU SAY: the four *p*/*f* pairs — "helfen/help, offen/open, schlafen/sleep,
+  laufen/leap"]
+- [YOU SAY: the whole morning — "Ich schlafe. Ich höre. Ich stehe. Ich gehe.
+  Ich laufe. Ich renne. Ich sitze."]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[GE-LEX-SCHLIESSEN-10, GE-ETYMON-SCHLIESSEN-11, GE-LEX-OEFFNEN-07, GE-GRAMMAR-SEPARABLE-09, GE-LEX-NEHMEN-02, GE-LEX-HAND-02, GE-LEX-GEHEN-02, GE-LEX-RENNEN-06] -->
+
+[PAUSE 3s] Give the *du* and *er* forms. (***Du schließt, er schließt***.) Which
+English verb is the cousin of *schließen*? (**None** — English lost it.) Where
+did *close* and *shut* come from? (**Latin**, and from **shoot**.) Name three
+words German hung on the verb. (**Schloss**, **Schlüssel**, **Schluss**.) Close
+your hand, both ways, then run the eight verbs.

--- a/code/learning/human-languages/german/narration/ch26.json
+++ b/code/learning/human-languages/german/narration/ch26.json
@@ -1,0 +1,839 @@
+{
+  "version": 1,
+  "language": "german",
+  "chapter": 26,
+  "title": "Sitting, Standing, Sleeping, Hearing",
+  "drivablePrefix": 4,
+  "sourceHash": "fnv1a64:9f1e817b7beec48a",
+  "lessons": [
+    {
+      "id": "GE-C26-sitzen",
+      "sequence": 790,
+      "title": "sitzen — the same word as sit, respelt by one law",
+      "headword": "sitzen",
+      "romanization": "sitzen",
+      "gloss": "to sit — the same inherited word as English sit, respelt by the other branch of the shift that separated helfen from help",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:afb92dd9ac5c4a8b",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Helfen is help, split by the second sound shift: Germanic p became German f. That law has other branches. This verb rides one."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "tz-affricate — tz is one squeezed sound, ts, as in English cats."
+            },
+            {
+              "kind": "speech",
+              "text": "i-short — a short, tight i: sitzen = ZIT-sen, buzzed at the front because German s before a vowel is voiced."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "input",
+          "title": "You'll want to know: sitzen",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "sitzen means \"to sit.\""
+            },
+            {
+              "kind": "speech",
+              "text": "ich sitze — I sit, wir sitzen — we sit."
+            },
+            {
+              "kind": "speech",
+              "text": "du sitzt — you sit, ihr sitzt — you all sit."
+            },
+            {
+              "kind": "speech",
+              "text": "er sitzt — he sits, sie sitzen — they sit."
+            },
+            {
+              "kind": "speech",
+              "text": "Ich sitze. — a whole sentence, two words."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: strong does not mean it breaks",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Sitzen is a strong verb — its past is saß, not sitzte. But its present never breaks its vowel: du sitzt, er sitzt. Beside it, helfen breaks to du hilfst."
+            },
+            {
+              "kind": "speech",
+              "text": "So \"strong\" is a fact about a verb's past; the du/er break is a separate habit only some strong verbs have."
+            },
+            {
+              "kind": "speech",
+              "text": "Chapter 25 gave two ways to say you like something: ich mag with a thing, gern hung on a verb. This verb takes the second."
+            },
+            {
+              "kind": "speech",
+              "text": "Ich sitze gern. — \"I like sitting.\""
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "etymology",
+          "title": "The word, taken apart: the shift's other branch",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "sitzen is Proto-Germanic sitjaną, and English sit is the same inherited word — Old English sittan, Old High German sizzen."
+            },
+            {
+              "kind": "speech",
+              "text": "The second, High German shift moved Germanic p to f in helfen. It moved Germanic t just as hard, to z (said ts) or ss: sittan becomes sitzen, water becomes Wasser, eat becomes essen, ten becomes zehn, bite becomes beißen. Chapter 11 handed you Wasser and Chapter 6 handed you zehn long before there was a name for what had happened to them."
+            },
+            {
+              "kind": "speech",
+              "text": "Under both lies PIE sed-, \"to sit,\" one of the family's great providers. Latin sedēre gives session, sedentary and preside; Latin sedēs, \"a seat,\" gives the bishop's see. Greek hédra, also \"a seat,\" gives cathedral — the church with the bishop's chair — and polyhedron."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ich sitze, du sitzt, er sitzt\" — the i never moves",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ich sitze, du sitzt, er sitzt\" — the *i* never moves]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the contrast — \"du sitzt\" beside \"du hilfst\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the contrast — \"du sitzt\" beside \"du hilfst\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Ich sitze gern.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Ich sitze gern.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the t branch four times — \"sitzen/sit, Wasser/water, essen/eat, zehn/ten\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the *t* branch four times — \"sitzen/sit, Wasser/water, essen/eat, zehn/ten\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the p branch beside it — \"helfen/help\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the *p* branch beside it — \"helfen/help\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the seat words — \"sitzen, sedēre, hédra, cathedral\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the seat words — \"sitzen, sedēre, hédra, cathedral\"]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give the du and er forms of sitzen. (Du sitzt, er sitzt — no break.) Which verb from Chapter 25 does break, and how? (Helfen — du hilfst.) Which sound did the second shift turn German's z and ss out of? (An old t.) Name two pairs from that branch. (Wasser/water, essen/eat, zehn/ten.) Say you like sitting. (Ich sitze gern.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GE-C26-stehen",
+      "sequence": 800,
+      "title": "stehen — the verb that was hiding inside verstehen",
+      "headword": "stehen",
+      "romanization": "stehen",
+      "gloss": "to stand — the verb Chapter 24 found inside verstehen, and the one place German keeps a letter English put in the wrong tense",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:c5502f60549c0f38",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Chapter 24 broke verstehen into ver- plus stehen, and named stehen as English stand. Here is that verb alone, and the letter the two languages disagree about."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "st-initial-scht — st at the start of a German word is said sht."
+            },
+            {
+              "kind": "speech",
+              "text": "h-silent-lengthening — the h is silent and marks the long vowel: stehen = SHTAY-en."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "input",
+          "title": "You'll want to know: stehen",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "stehen means \"to stand.\""
+            },
+            {
+              "kind": "speech",
+              "text": "ich stehe — I stand, wir stehen — we stand."
+            },
+            {
+              "kind": "speech",
+              "text": "du stehst — you stand, ihr steht — you all stand."
+            },
+            {
+              "kind": "speech",
+              "text": "er steht — he stands, sie stehen — they stand."
+            },
+            {
+              "kind": "speech",
+              "text": "Like sitzen, it keeps its vowel all the way through. Two postures, two sentences:"
+            },
+            {
+              "kind": "speech",
+              "text": "Ich sitze. Ich stehe."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: the missing n",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Germanic ran two stems off one root here: a short stāną and a longer standaną with an n wedged inside. English generalised the long one and got stand; German took the short one and got stehen, Old High German stān."
+            },
+            {
+              "kind": "speech",
+              "text": "German did not lose the n. It kept it in the past: ich stand, and the participle gestanden. German's past tense is spelt the way English's present is, out of the same drawer of stems."
+            },
+            {
+              "kind": "speech",
+              "text": "The root is PIE steh₂-, the one Chapter 24 named, and it is everywhere. Latin stāre gave state, station, stable, constant. Greek hístēmi, \"I set up,\" gave static, system and ecstasy — standing outside yourself. German built die Stadt, a city: a standing-place. English built stead, steady and instead."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way: two postures, two Latin cousins",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Notice the shape of what has happened. Sitzen goes back to sed-, and so does Latin's sedēre. Stehen goes back to steh₂-, and so does Latin's stāre."
+            },
+            {
+              "kind": "speech",
+              "text": "Nothing was borrowed in either direction. Two families inherited the same two roots and held them to the same two meanings for thousands of years, because sitting and standing are things everybody does."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ich stehe, du stehst, er steht\" — SHTAY, not STAY",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ich stehe, du stehst, er steht\" — *SHTAY*, not *STAY*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "both postures — \"Ich sitze. Ich stehe.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: both postures — \"Ich sitze. Ich stehe.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the verb inside the verb — \"stehen, verstehen\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the verb inside the verb — \"stehen, verstehen\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "where the n went — \"ich stehe, ich stand, gestanden\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: where the *n* went — \"ich stehe, ich stand, gestanden\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the Latin pair — \"sitzen/sedēre, stehen/stāre\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the Latin pair — \"sitzen/sedēre, stehen/stāre\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what stands in English — \"state, station, stable, stead\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what stands in English — \"state, station, stable, stead\"]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give the du and er forms. (Du stehst, er steht.) Which letter does English's stand carry that German's stehen does not? (An n.) Where does German still keep it? (In the past — ich stand, gestanden.) Which longer verb from Chapter 24 has stehen inside it? (Verstehen.) Say \"I sit. I stand.\" (Ich sitze. Ich stehe.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GE-C26-schlafen",
+      "sequence": 810,
+      "title": "schlafen — sleep, under two coats of paint",
+      "headword": "schlafen",
+      "romanization": "schlafen",
+      "gloss": "to sleep — the same word as English sleep under two coats of German paint, and a second way for a strong verb to break",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:ecd66be4bbd05f73",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Sitzen and stehen held their vowels still. This one does not — and it does not break the way the Chapter 24 verbs broke either."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "sch-sh — sch is English sh: schlafen = SHLAH-fen."
+            },
+            {
+              "kind": "speech",
+              "text": "vowel-ae — ä is a flat eh: schläft = SHLEFT."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "input",
+          "title": "You'll want to know: schlafen",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "schlafen means \"to sleep.\""
+            },
+            {
+              "kind": "speech",
+              "text": "ich schlafe, wir schlafen."
+            },
+            {
+              "kind": "speech",
+              "text": "du schläfst, ihr schlaft."
+            },
+            {
+              "kind": "speech",
+              "text": "er schläft, sie schlafen."
+            },
+            {
+              "kind": "speech",
+              "text": "Die Katze schläft. — \"The cat is sleeping.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the second kind of break",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Chapter 24 gave you one break: long e goes to i for du and er — du liest, er hilft. Here is the other: a takes two dots and becomes ä — du schläfst, er schläft."
+            },
+            {
+              "kind": "speech",
+              "text": "Those two dots are the umlaut, the mark that turns Buch into Bücher. The break lands in the same slot as before, du and er and nobody else, so only its raw material is new: e verbs brighten to i, a verbs to ä."
+            },
+            {
+              "kind": "speech",
+              "text": "Es regnet. Die Katze schläft."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "etymology",
+          "title": "The word, taken apart: two coats of paint",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "schlafen is Proto-Germanic slēpaną, and English sleep is the same inherited word — Old English slæpan, Old High German slāfan."
+            },
+            {
+              "kind": "speech",
+              "text": "Two German changes sit between them. The first you know: the second shift, Germanic p to German f, as in helfen. The second is new — German turned s into sh before l, m, n and w, and wrote it down: sleep becomes schlafen, swim becomes schwimmen, snow becomes Schnee, smith becomes Schmied. It did the same before p and t and never spelt it, which is why stehen is said SHTAY-en."
+            },
+            {
+              "kind": "speech",
+              "text": "Now the honest part. The old Indo-European verb for sleeping was swep-, still in plain view: Latin somnus gives insomnia and somnolent, Latin sopor gives soporific, Greek hýpnos gives hypnosis, and Old Norse sofa is Swedish sova today. German and English both threw that verb away and built a new one on sleb-, \"to be slack\" — German still has schlaff, \"limp.\" They made that swap together, before they were two languages."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ich schlafe, du schläfst, er schläft\" — the a brightens to ä",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ich schlafe, du schläfst, er schläft\" — the *a* brightens to *ä*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three verbs — \"Ich sitze. Ich stehe. Ich schlafe.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three verbs — \"Ich sitze. Ich stehe. Ich schlafe.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Es regnet. Die Katze schläft.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Es regnet. Die Katze schläft.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "both breaks in the same slot — \"du hilfst\" beside \"du schläfst\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: both breaks in the same slot — \"du hilfst\" beside \"du schläfst\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the sch row — \"schlafen, schwimmen, Schnee, Schmied\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the *sch* row — \"schlafen, schwimmen, Schnee, Schmied\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the verb they both threw away — \"somnus, hypnos, sova\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the verb they both threw away — \"somnus, hypnos, sova\"]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give the du and er forms. (Du schläfst, er schläft — two dots on the a.) Which two people does a German verb break for? (Du and er, always.) Name the two changes between sleep and schlafen. (p to f, and s to sch.) Why is stehen said SHTAY-en? (Same change, never spelt.) Say \"the cat is sleeping.\" (Die Katze schläft.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GE-C26-hoeren",
+      "sequence": 820,
+      "title": "hören — hear, and the end of a chapter that never moved",
+      "headword": "hören",
+      "romanization": "hören",
+      "gloss": "to hear — the same verb as English hear, and the closing of a chapter of four things you do without going anywhere",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:5f32d7202016c02e",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Ich sitze. Ich stehe. Ich schlafe. Three verbs that stay put. Here is the fourth — the sense that works with your eyes shut."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "umlaut-oe — ö is the e of bed said with rounded lips."
+            },
+            {
+              "kind": "speech",
+              "text": "r-uvular — the r is a soft scrape at the back: hören = HUR-en."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "input",
+          "title": "You'll want to know: hören",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "hören means \"to hear.\""
+            },
+            {
+              "kind": "speech",
+              "text": "ich höre, wir hören."
+            },
+            {
+              "kind": "speech",
+              "text": "du hörst, ihr hört."
+            },
+            {
+              "kind": "speech",
+              "text": "er hört, sie hören."
+            },
+            {
+              "kind": "speech",
+              "text": "The ö never moves. Schlafen grew its dots for du and er; hören was born with them, so nothing is left to break."
+            },
+            {
+              "kind": "speech",
+              "text": "Der Hund hört. Die Katze hört."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: liking it, the Chapter 25 way",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "gern hangs on this verb like any other:"
+            },
+            {
+              "kind": "speech",
+              "text": "Ich höre gern. — \"I like listening.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Gern is English yearn: underneath, \"I hear yearningly.\" Beside it is the other way of liking, ich mag — English may, with the power drained out."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "etymology",
+          "title": "The word, taken apart: the s that became an r",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "hören is Proto-Germanic hauzijaną, and English hear is the same inherited word."
+            },
+            {
+              "kind": "speech",
+              "text": "This time the change is one they share. Gothic still says hausjan, with an s; Old English hīeran and Old High German hōren had both turned it to r. Sitzen shows where German left English; hören shows a road they walked together."
+            },
+            {
+              "kind": "speech",
+              "text": "The h is Grimm's law, the first shift: an old k became Germanic h. Greek kept the k — akoúein, \"to hear,\" which English borrowed back as acoustic. Same swap that made kwon- into Hund while Latin kept canis."
+            },
+            {
+              "kind": "speech",
+              "text": "Some break the root up further, into \"sharp\" plus \"ear\" — which would make hören \"sharp-eared\" and put das Ohr inside it. Cited often, not settled."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way: gehören is not \"hear\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "gehören means \"to belong.\" It is ge- welded onto hören, and began as \"to hearken to\": what belongs to you answers when called."
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "all four — \"Ich sitze. Ich stehe. Ich schlafe. Ich höre.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: all four — \"Ich sitze. Ich stehe. Ich schlafe. Ich höre.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the four er forms — \"er sitzt, er steht, er schläft, er hört\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the four *er* forms — \"er sitzt, er steht, er schläft, er hört\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Der Hund hört. Die Katze schläft.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Der Hund hört. Die Katze schläft.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Ich höre gern.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Ich höre gern.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the shared change — \"hausjan, hīeran, hōren\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the shared change — \"hausjan, hīeran, hōren\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the h row — \"hören/akoúein, Hund/canis\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the *h* row — \"hören/akoúein, Hund/canis\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"gehören is belong\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"gehören is *belong*\"]"
+            }
+          ]
+        },
+        {
+          "index": 7,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give all four ich forms of this chapter. (Ich sitze, ich stehe, ich schlafe, ich höre.) Which breaks its vowel? (Schlafen — a to ä.) Which letter did Gothic keep where German and English have r? (An s.) Which law put the h on hören and Hund? (Grimm's law.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/german/narration/ch26.txt
+++ b/code/learning/human-languages/german/narration/ch26.txt
@@ -1,0 +1,202 @@
+German, chapter 26: Sitting, Standing, Sleeping, Hearing.
+4 lessons. All 4 can be done entirely by ear.
+
+
+Lesson 1 of 4.
+sitzen — the same word as sit, respelt by one law.
+
+Warm-up.
+[pause 2 seconds]
+Helfen is help, split by the second sound shift: Germanic p became German f. That law has other branches. This verb rides one.
+
+Sounds you'll need.
+tz-affricate — tz is one squeezed sound, ts, as in English cats.
+i-short — a short, tight i: sitzen = ZIT-sen, buzzed at the front because German s before a vowel is voiced.
+
+You'll want to know: sitzen.
+sitzen means "to sit."
+ich sitze — I sit, wir sitzen — we sit.
+du sitzt — you sit, ihr sitzt — you all sit.
+er sitzt — he sits, sie sitzen — they sit.
+Ich sitze. — a whole sentence, two words.
+
+Grammar Lens: strong does not mean it breaks.
+Sitzen is a strong verb — its past is saß, not sitzte. But its present never breaks its vowel: du sitzt, er sitzt. Beside it, helfen breaks to du hilfst.
+So "strong" is a fact about a verb's past; the du/er break is a separate habit only some strong verbs have.
+Chapter 25 gave two ways to say you like something: ich mag with a thing, gern hung on a verb. This verb takes the second.
+Ich sitze gern. — "I like sitting."
+
+The word, taken apart: the shift's other branch.
+sitzen is Proto-Germanic sitjaną, and English sit is the same inherited word — Old English sittan, Old High German sizzen.
+The second, High German shift moved Germanic p to f in helfen. It moved Germanic t just as hard, to z (said ts) or ss: sittan becomes sitzen, water becomes Wasser, eat becomes essen, ten becomes zehn, bite becomes beißen. Chapter 11 handed you Wasser and Chapter 6 handed you zehn long before there was a name for what had happened to them.
+Under both lies PIE sed-, "to sit," one of the family's great providers. Latin sedēre gives session, sedentary and preside; Latin sedēs, "a seat," gives the bishop's see. Greek hédra, also "a seat," gives cathedral — the church with the bishop's chair — and polyhedron.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "ich sitze, du sitzt, er sitzt" — the i never moves]
+[pause 8 seconds for the answer]
+[your turn — say: the contrast — "du sitzt" beside "du hilfst"]
+[pause 8 seconds for the answer]
+[your turn — say: "Ich sitze gern."]
+[pause 8 seconds for the answer]
+[your turn — say: the t branch four times — "sitzen/sit, Wasser/water, essen/eat, zehn/ten"]
+[pause 8 seconds for the answer]
+[your turn — say: the p branch beside it — "helfen/help"]
+[pause 8 seconds for the answer]
+[your turn — say: the seat words — "sitzen, sedēre, hédra, cathedral"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give the du and er forms of sitzen. (Du sitzt, er sitzt — no break.) Which verb from Chapter 25 does break, and how? (Helfen — du hilfst.) Which sound did the second shift turn German's z and ss out of? (An old t.) Name two pairs from that branch. (Wasser/water, essen/eat, zehn/ten.) Say you like sitting. (Ich sitze gern.)
+
+
+Lesson 2 of 4.
+stehen — the verb that was hiding inside verstehen.
+
+Warm-up.
+[pause 2 seconds]
+Chapter 24 broke verstehen into ver- plus stehen, and named stehen as English stand. Here is that verb alone, and the letter the two languages disagree about.
+
+Sounds you'll need.
+st-initial-scht — st at the start of a German word is said sht.
+h-silent-lengthening — the h is silent and marks the long vowel: stehen = SHTAY-en.
+
+You'll want to know: stehen.
+stehen means "to stand."
+ich stehe — I stand, wir stehen — we stand.
+du stehst — you stand, ihr steht — you all stand.
+er steht — he stands, sie stehen — they stand.
+Like sitzen, it keeps its vowel all the way through. Two postures, two sentences:
+Ich sitze. Ich stehe.
+
+The word, taken apart: the missing n.
+Germanic ran two stems off one root here: a short stāną and a longer standaną with an n wedged inside. English generalised the long one and got stand; German took the short one and got stehen, Old High German stān.
+German did not lose the n. It kept it in the past: ich stand, and the participle gestanden. German's past tense is spelt the way English's present is, out of the same drawer of stems.
+The root is PIE steh₂-, the one Chapter 24 named, and it is everywhere. Latin stāre gave state, station, stable, constant. Greek hístēmi, "I set up," gave static, system and ecstasy — standing outside yourself. German built die Stadt, a city: a standing-place. English built stead, steady and instead.
+
+Why it's said this way: two postures, two Latin cousins.
+Notice the shape of what has happened. Sitzen goes back to sed-, and so does Latin's sedēre. Stehen goes back to steh₂-, and so does Latin's stāre.
+Nothing was borrowed in either direction. Two families inherited the same two roots and held them to the same two meanings for thousands of years, because sitting and standing are things everybody does.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "ich stehe, du stehst, er steht" — SHTAY, not STAY]
+[pause 8 seconds for the answer]
+[your turn — say: both postures — "Ich sitze. Ich stehe."]
+[pause 8 seconds for the answer]
+[your turn — say: the verb inside the verb — "stehen, verstehen"]
+[pause 8 seconds for the answer]
+[your turn — say: where the n went — "ich stehe, ich stand, gestanden"]
+[pause 8 seconds for the answer]
+[your turn — say: the Latin pair — "sitzen/sedēre, stehen/stāre"]
+[pause 8 seconds for the answer]
+[your turn — say: what stands in English — "state, station, stable, stead"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give the du and er forms. (Du stehst, er steht.) Which letter does English's stand carry that German's stehen does not? (An n.) Where does German still keep it? (In the past — ich stand, gestanden.) Which longer verb from Chapter 24 has stehen inside it? (Verstehen.) Say "I sit. I stand." (Ich sitze. Ich stehe.)
+
+
+Lesson 3 of 4.
+schlafen — sleep, under two coats of paint.
+
+Warm-up.
+[pause 2 seconds]
+Sitzen and stehen held their vowels still. This one does not — and it does not break the way the Chapter 24 verbs broke either.
+
+Sounds you'll need.
+sch-sh — sch is English sh: schlafen = SHLAH-fen.
+vowel-ae — ä is a flat eh: schläft = SHLEFT.
+
+You'll want to know: schlafen.
+schlafen means "to sleep."
+ich schlafe, wir schlafen.
+du schläfst, ihr schlaft.
+er schläft, sie schlafen.
+Die Katze schläft. — "The cat is sleeping."
+
+Grammar Lens: the second kind of break.
+Chapter 24 gave you one break: long e goes to i for du and er — du liest, er hilft. Here is the other: a takes two dots and becomes ä — du schläfst, er schläft.
+Those two dots are the umlaut, the mark that turns Buch into Bücher. The break lands in the same slot as before, du and er and nobody else, so only its raw material is new: e verbs brighten to i, a verbs to ä.
+Es regnet. Die Katze schläft.
+
+The word, taken apart: two coats of paint.
+schlafen is Proto-Germanic slēpaną, and English sleep is the same inherited word — Old English slæpan, Old High German slāfan.
+Two German changes sit between them. The first you know: the second shift, Germanic p to German f, as in helfen. The second is new — German turned s into sh before l, m, n and w, and wrote it down: sleep becomes schlafen, swim becomes schwimmen, snow becomes Schnee, smith becomes Schmied. It did the same before p and t and never spelt it, which is why stehen is said SHTAY-en.
+Now the honest part. The old Indo-European verb for sleeping was swep-, still in plain view: Latin somnus gives insomnia and somnolent, Latin sopor gives soporific, Greek hýpnos gives hypnosis, and Old Norse sofa is Swedish sova today. German and English both threw that verb away and built a new one on sleb-, "to be slack" — German still has schlaff, "limp." They made that swap together, before they were two languages.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "ich schlafe, du schläfst, er schläft" — the a brightens to ä]
+[pause 8 seconds for the answer]
+[your turn — say: the three verbs — "Ich sitze. Ich stehe. Ich schlafe."]
+[pause 8 seconds for the answer]
+[your turn — say: "Es regnet. Die Katze schläft."]
+[pause 8 seconds for the answer]
+[your turn — say: both breaks in the same slot — "du hilfst" beside "du schläfst"]
+[pause 8 seconds for the answer]
+[your turn — say: the sch row — "schlafen, schwimmen, Schnee, Schmied"]
+[pause 8 seconds for the answer]
+[your turn — say: the verb they both threw away — "somnus, hypnos, sova"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give the du and er forms. (Du schläfst, er schläft — two dots on the a.) Which two people does a German verb break for? (Du and er, always.) Name the two changes between sleep and schlafen. (p to f, and s to sch.) Why is stehen said SHTAY-en? (Same change, never spelt.) Say "the cat is sleeping." (Die Katze schläft.)
+
+
+Lesson 4 of 4.
+hören — hear, and the end of a chapter that never moved.
+
+Warm-up.
+[pause 2 seconds]
+Ich sitze. Ich stehe. Ich schlafe. Three verbs that stay put. Here is the fourth — the sense that works with your eyes shut.
+
+Sounds you'll need.
+umlaut-oe — ö is the e of bed said with rounded lips.
+r-uvular — the r is a soft scrape at the back: hören = HUR-en.
+
+You'll want to know: hören.
+hören means "to hear."
+ich höre, wir hören.
+du hörst, ihr hört.
+er hört, sie hören.
+The ö never moves. Schlafen grew its dots for du and er; hören was born with them, so nothing is left to break.
+Der Hund hört. Die Katze hört.
+
+Grammar Lens: liking it, the Chapter 25 way.
+gern hangs on this verb like any other:
+Ich höre gern. — "I like listening."
+Gern is English yearn: underneath, "I hear yearningly." Beside it is the other way of liking, ich mag — English may, with the power drained out.
+
+The word, taken apart: the s that became an r.
+hören is Proto-Germanic hauzijaną, and English hear is the same inherited word.
+This time the change is one they share. Gothic still says hausjan, with an s; Old English hīeran and Old High German hōren had both turned it to r. Sitzen shows where German left English; hören shows a road they walked together.
+The h is Grimm's law, the first shift: an old k became Germanic h. Greek kept the k — akoúein, "to hear," which English borrowed back as acoustic. Same swap that made kwon- into Hund while Latin kept canis.
+Some break the root up further, into "sharp" plus "ear" — which would make hören "sharp-eared" and put das Ohr inside it. Cited often, not settled.
+
+Why it's said this way: gehören is not "hear".
+gehören means "to belong." It is ge- welded onto hören, and began as "to hearken to": what belongs to you answers when called.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: all four — "Ich sitze. Ich stehe. Ich schlafe. Ich höre."]
+[pause 8 seconds for the answer]
+[your turn — say: the four er forms — "er sitzt, er steht, er schläft, er hört"]
+[pause 8 seconds for the answer]
+[your turn — say: "Der Hund hört. Die Katze schläft."]
+[pause 8 seconds for the answer]
+[your turn — say: "Ich höre gern."]
+[pause 8 seconds for the answer]
+[your turn — say: the shared change — "hausjan, hīeran, hōren"]
+[pause 8 seconds for the answer]
+[your turn — say: the h row — "hören/akoúein, Hund/canis"]
+[pause 8 seconds for the answer]
+[your turn — say: "gehören is belong"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give all four ich forms of this chapter. (Ich sitze, ich stehe, ich schlafe, ich höre.) Which breaks its vowel? (Schlafen — a to ä.) Which letter did Gothic keep where German and English have r? (An s.) Which law put the h on hören and Hund? (Grimm's law.)

--- a/code/learning/human-languages/german/narration/ch27.json
+++ b/code/learning/human-languages/german/narration/ch27.json
@@ -1,0 +1,856 @@
+{
+  "version": 1,
+  "language": "german",
+  "chapter": 27,
+  "title": "Going, Running, Opening, Closing",
+  "drivablePrefix": 4,
+  "sourceHash": "fnv1a64:983170162f81dec0",
+  "lessons": [
+    {
+      "id": "GE-C27-gehen",
+      "sequence": 830,
+      "title": "gehen — go, and the word German never needed for walk",
+      "headword": "gehen",
+      "romanization": "gehen",
+      "gloss": "to go, and to walk — because German has no separate word for walking, and English's walk turns out to be a word about cloth",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:9cfcead00ceeff1c",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Four verbs that stayed put — sitting, standing, sleeping, hearing. Now a chapter that moves, opening on the verb German uses where English has two."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "h-silent-lengthening — the h is silent and lengthens: gehen = GAY-en, built exactly like stehen, SHTAY-en."
+            },
+            {
+              "kind": "speech",
+              "text": "ge-prefix — ge- at the front is said guh, never jee."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "input",
+          "title": "You'll want to know: gehen",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "gehen means \"to go\" — and also \"to walk.\" German does not split those."
+            },
+            {
+              "kind": "speech",
+              "text": "ich gehe, wir gehen."
+            },
+            {
+              "kind": "speech",
+              "text": "du gehst, ihr geht."
+            },
+            {
+              "kind": "speech",
+              "text": "er geht, sie gehen."
+            },
+            {
+              "kind": "speech",
+              "text": "Ich stehe. Ich gehe."
+            },
+            {
+              "kind": "speech",
+              "text": "Two verbs cut to the same short shape, each with a silent h propping the vowel up. Say them together and you hear a matched pair: SHTAY-en, GAY-en."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: two languages, two borrowed pasts",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "gehen is Proto-Germanic gāną and English go is the same inherited word, Old English gān."
+            },
+            {
+              "kind": "speech",
+              "text": "Both languages then hit the same problem: the verb had no usable past, and each went shopping. English took went, really the past of wend, and left wend stranded. German took ging and gegangen from another old verb, ganganą, \"to walk\" — which English still owns in gangway, gangplank, and Scots gang, \"to go.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Gegangen carries the same ge- you met on gehören: an old prefix German fastens to a past participle."
+            },
+            {
+              "kind": "speech",
+              "text": "Beyond Germanic, be honest — the deeper root of go is disputed, with no agreed list of cousins. It is the one verb here that cannot be followed back."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way: English's walk is about cloth",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Because walk is not an old word for travelling on foot. Old English wealcan meant \"to roll, to toss,\" and its German cousin walken still means what it always meant: to full cloth, to work wool by trampling it."
+            },
+            {
+              "kind": "speech",
+              "text": "English promoted that trampling verb around 1200. German never did, so gehen covers both jobs."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ich gehe, du gehst, er geht\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ich gehe, du gehst, er geht\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the matched pair — \"Ich stehe. Ich gehe.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the matched pair — \"Ich stehe. Ich gehe.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the borrowed pasts — \"go/went\" beside \"gehen/ging/gegangen\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the borrowed pasts — \"go/went\" beside \"gehen/ging/gegangen\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "where English kept the other verb — \"gangway, gangplank\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: where English kept the other verb — \"gangway, gangplank\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the ge- on both — \"gehören, gegangen\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the *ge-* on both — \"gehören, gegangen\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what walken does — it fulls cloth, it does not travel",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what *walken* does — it fulls cloth, it does not travel]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give the du and er forms. (Du gehst, er geht.) Which English verb is gehen? (Go, and walk as well.) Where did went come from? (From wend.) What does German's cousin of walk mean? (To full cloth.) How far back can gehen be traced? (Not past Germanic.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GE-C27-laufen",
+      "sequence": 840,
+      "title": "laufen — the verb that lies across English's line",
+      "headword": "laufen",
+      "romanization": "laufen",
+      "gloss": "to run — and to walk, because German draws the line in a different place from English, with rennen at the fast end",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:b7282b0745a98b5d",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Ich gehe covers going and walking. German has two words for run, and one of them is not only about running."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "diphthong-au — au is the ow of house: laufen = LOW-fen."
+            },
+            {
+              "kind": "speech",
+              "text": "diphthong-eu — äu is the oy of boy: läuft = LOYFT."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "input",
+          "title": "You'll want to know: laufen",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "laufen means \"to run\" — and often \"to walk.\""
+            },
+            {
+              "kind": "speech",
+              "text": "ich laufe, wir laufen."
+            },
+            {
+              "kind": "speech",
+              "text": "du läufst, ihr lauft."
+            },
+            {
+              "kind": "speech",
+              "text": "er läuft, sie laufen."
+            },
+            {
+              "kind": "speech",
+              "text": "The schlafen break is here too, in the same du and er slot: au brightens to äu."
+            },
+            {
+              "kind": "speech",
+              "text": "Der Hund läuft."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way: the line is not where you expect",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "English draws a hard line between walk and run. German draws it elsewhere, and leaves one verb lying across it."
+            },
+            {
+              "kind": "speech",
+              "text": "gehen — on foot, unhurried."
+            },
+            {
+              "kind": "speech",
+              "text": "laufen — on foot at any speed at all."
+            },
+            {
+              "kind": "speech",
+              "text": "rennen — flat out. ich renne, du rennst, er rennt."
+            },
+            {
+              "kind": "speech",
+              "text": "So Wir laufen is \"we're walking\" or \"we're running,\" and only the situation tells you which. That holds across most of Germany. In Austria it does not: there laufen means run. This course teaches the German usage."
+            },
+            {
+              "kind": "speech",
+              "text": "Der Hund rennt. — no ambiguity left."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "etymology",
+          "title": "The word, taken apart: laufen is leap",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "laufen is Proto-Germanic hlaupaną, and English kept it as leap — Old English hlēapan. One more p against f, the second shift, on the pattern of helfen/help, offen/open and schlafen/sleep."
+            },
+            {
+              "kind": "speech",
+              "text": "English holds three more scraps: lope, and — through Dutch relatives of the same verb — elope and interloper, both people running off. Outside Germanic there are no secure cousins."
+            },
+            {
+              "kind": "speech",
+              "text": "Rennen is a sharper story. Germanic had rinnaną, \"to run, to flow,\" and beside it a causative rannijaną, \"to make something run.\" German fused the two into rennen and kept rinnen, \"to trickle,\" alongside. English fused the same two into run — one merger, carried out separately in each language."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ich laufe, du läufst, er läuft\" — LOW-fuh, LOYFST, LOYFT",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ich laufe, du läufst, er läuft\" — *LOW-fuh, LOYFST, LOYFT*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three speeds — \"Ich gehe. Ich laufe. Ich renne.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three speeds — \"Ich gehe. Ich laufe. Ich renne.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Der Hund läuft. Der Hund rennt.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Der Hund läuft. Der Hund rennt.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the p/f row now four long — \"helfen/help, offen/open, schlafen/sleep, laufen/leap\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the *p*/*f* row now four long — \"helfen/help, offen/open, schlafen/sleep, laufen/leap\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the runaways — \"lope, elope, interloper\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the runaways — \"lope, elope, interloper\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the doubled merger — \"rinnen, rennen\" beside English's one run",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the doubled merger — \"rinnen, rennen\" beside English's one *run*]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give the du and er forms of laufen. (Du läufst, er läuft — au to äu.) Which English verb is laufen? (Leap — and it means run.) Which German verb means only \"run fast\"? (Rennen.) Does Wir laufen mean walking or running? (Either — except in Austria, where it is running.) Say \"the dog runs.\" (Der Hund rennt.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GE-C27-oeffnen",
+      "sequence": 850,
+      "title": "öffnen — open, which was always the word up",
+      "headword": "öffnen",
+      "romanization": "öffnen",
+      "gloss": "to open — built on offen, which is English open, which is really the word up; and the doorway into German's separable verbs",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:6077fbe3623e96ba",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Ich gehe. Ich laufe. Ich renne. Now something done with the hands, and the German habit that breaks a verb in two."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "umlaut-oe — ö is the e of bed with rounded lips."
+            },
+            {
+              "kind": "speech",
+              "text": "fn-cluster — -fn- runs straight together: öffnen = UFF-nen."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "input",
+          "title": "You'll want to know: öffnen",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "öffnen means \"to open.\""
+            },
+            {
+              "kind": "speech",
+              "text": "ich öffne, wir öffnen."
+            },
+            {
+              "kind": "speech",
+              "text": "du öffnest, ihr öffnet."
+            },
+            {
+              "kind": "speech",
+              "text": "er öffnet, sie öffnen."
+            },
+            {
+              "kind": "speech",
+              "text": "An extra e slips in for du, er and ihr, because öffnst cannot be said. Now a noun you already have, whose d is spoken as a t:"
+            },
+            {
+              "kind": "speech",
+              "text": "Ich öffne die Hand. — \"I open my hand.\" (dee Hant)."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: a verb that comes apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Öffnen is the neutral, slightly formal word. What people say out loud is aufmachen, and both halves are yours already: auf from Chapter 4's auf Wiedersehen, machen from Chapter 5."
+            },
+            {
+              "kind": "speech",
+              "text": "Here is the German part. In an ordinary sentence, the prefix leaves the verb and waits at the end:"
+            },
+            {
+              "kind": "speech",
+              "text": "Ich mache die Hand auf. — literally \"I make the hand up.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Machen takes the slot after ich; auf goes to the back and sits there. German does this to hundreds of verbs, and calls them separable."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "etymology",
+          "title": "The word, taken apart: open was never a root",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Behind the verb is the adjective offen, \"open\" — which Chapter 25 already put beside open as a p-to-f pair from the second shift."
+            },
+            {
+              "kind": "speech",
+              "text": "The better secret is that neither word is a root. Old English open goes back to Proto-Germanic upana-, \"put up,\" formed on the word that is now English up — it has the shape of a past participle, though no such verb \"to up\" is attested. German ran the same sum and got offen, which is why offen and auf are relatives and not merely neighbours."
+            },
+            {
+              "kind": "speech",
+              "text": "So aufmachen is not a quaint compound. It is the ancient recipe for \"open,\" rebuilt out loud — and German pulls it apart every time you use it."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ich öffne, du öffnest, er öffnet\" — the extra e",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ich öffne, du öffnest, er öffnet\" — the extra *e*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Ich öffne die Hand.\" — dee Hant",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Ich öffne die Hand.\" — *dee Hant*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the split — \"Ich mache die Hand auf.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the split — \"Ich mache die Hand auf.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the p/f pair — \"offen/open\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the *p*/*f* pair — \"offen/open\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what it is made of — \"auf, up, offen, open\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what it is made of — \"auf, up, offen, open\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the feet verbs before the hand one — \"Ich gehe. Ich laufe. Ich renne.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the feet verbs before the hand one — \"Ich gehe. Ich laufe. Ich renne.\"]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give the du and er forms. (Du öffnest, er öffnet.) Which older word is offen built from? (Auf — English up.) Where does auf go in Ich mache die Hand auf? (To the end.) What is such a verb called? (Separable.) How is the d of Hand spoken? (As a t.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GE-C27-schliessen",
+      "sequence": 860,
+      "title": "schließen — the second verb English lost",
+      "headword": "schließen",
+      "romanization": "schließen",
+      "gloss": "to close — the second verb in these chapters that German kept and English lost, and the one that locked up Schloss, Schlüssel and Schluss",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:7fbdf7b45126355b",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You can open a hand two ways, ich öffne and ich mache … auf. Closing works the same, and the closing verb has the stranger history."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ie-long-ee — ie is a long ee: schließen = SHLEE-sen."
+            },
+            {
+              "kind": "speech",
+              "text": "eszett — ß is a sharp s, and it appears here because the ee before it is long."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "input",
+          "title": "You'll want to know: schließen",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "schließen means \"to close,\" and also \"to lock.\""
+            },
+            {
+              "kind": "speech",
+              "text": "ich schließe, wir schließen."
+            },
+            {
+              "kind": "speech",
+              "text": "du schließt, ihr schließt."
+            },
+            {
+              "kind": "speech",
+              "text": "er schließt, sie schließen."
+            },
+            {
+              "kind": "speech",
+              "text": "Its everyday partner is zumachen — zu plus machen — splitting exactly as aufmachen did:"
+            },
+            {
+              "kind": "speech",
+              "text": "Ich schließe die Hand. Ich mache die Hand zu."
+            },
+            {
+              "kind": "speech",
+              "text": "The vowel shortens in the past, and the moment it does the ß becomes ss: schließen, but schloss."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: a verb with no English cousin",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "schließen is Proto-Germanic sleutaną, \"to shut, to bolt.\" Dutch kept it as sluiten. English has nothing — no inherited cousin at all."
+            },
+            {
+              "kind": "speech",
+              "text": "So English closes things with borrowed and unrelated words. Close is Latin claudere, by way of French. Shut is native but a different verb entirely: Old English scyttan, to shoot a bolt across a door."
+            },
+            {
+              "kind": "speech",
+              "text": "That makes two verbs here with the same shape of story. Chapter 25 gave you nehmen, which English lost to Norse take. This is the second."
+            },
+            {
+              "kind": "speech",
+              "text": "On the verb it kept, German built a household: das Schloss, a lock — and, because a castle is the locked place, a castle; der Schlüssel, a key; der Schluss, the end. English says conclusion for that last one, from claudere — the same idea out of the other family's parts."
+            },
+            {
+              "kind": "speech",
+              "text": "A link between the Germanic verb and Latin claudere has been proposed. It is not established."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "notice",
+          "title": "What you've built across these two chapters",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Eight verbs, and a whole small morning:"
+            },
+            {
+              "kind": "speech",
+              "text": "Ich schlafe. Ich höre. Ich stehe. Ich gehe. Ich laufe. Ich renne. Ich sitze. Ich mache die Hand auf. Ich mache die Hand zu."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ich schließe, du schließt, er schließt\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ich schließe, du schließt, er schließt\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the pair — \"Ich mache die Hand auf. Ich mache die Hand zu.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the pair — \"Ich mache die Hand auf. Ich mache die Hand zu.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the spelling swap — \"schließen, schloss\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the spelling swap — \"schließen, schloss\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the household — \"Schloss, Schlüssel, Schluss\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the household — \"Schloss, Schlüssel, Schluss\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two lost verbs — \"nehmen, schließen; English took take and close\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two lost verbs — \"nehmen, schließen; English took *take* and *close*\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the four p/f pairs — \"helfen/help, offen/open, schlafen/sleep, laufen/leap\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the four *p*/*f* pairs — \"helfen/help, offen/open, schlafen/sleep, laufen/leap\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the whole morning — \"Ich schlafe. Ich höre. Ich stehe. Ich gehe. Ich laufe. Ich renne. Ich sitze.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the whole morning — \"Ich schlafe. Ich höre. Ich stehe. Ich gehe. Ich laufe. Ich renne. Ich sitze.\"]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give the du and er forms. (Du schließt, er schließt.) Which English verb is the cousin of schließen? (None — English lost it.) Where did close and shut come from? (Latin, and from shoot.) Name three words German hung on the verb. (Schloss, Schlüssel, Schluss.) Close your hand, both ways, then run the eight verbs."
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/german/narration/ch27.txt
+++ b/code/learning/human-languages/german/narration/ch27.txt
@@ -1,0 +1,206 @@
+German, chapter 27: Going, Running, Opening, Closing.
+4 lessons. All 4 can be done entirely by ear.
+
+
+Lesson 1 of 4.
+gehen — go, and the word German never needed for walk.
+
+Warm-up.
+[pause 2 seconds]
+Four verbs that stayed put — sitting, standing, sleeping, hearing. Now a chapter that moves, opening on the verb German uses where English has two.
+
+Sounds you'll need.
+h-silent-lengthening — the h is silent and lengthens: gehen = GAY-en, built exactly like stehen, SHTAY-en.
+ge-prefix — ge- at the front is said guh, never jee.
+
+You'll want to know: gehen.
+gehen means "to go" — and also "to walk." German does not split those.
+ich gehe, wir gehen.
+du gehst, ihr geht.
+er geht, sie gehen.
+Ich stehe. Ich gehe.
+Two verbs cut to the same short shape, each with a silent h propping the vowel up. Say them together and you hear a matched pair: SHTAY-en, GAY-en.
+
+The word, taken apart: two languages, two borrowed pasts.
+gehen is Proto-Germanic gāną and English go is the same inherited word, Old English gān.
+Both languages then hit the same problem: the verb had no usable past, and each went shopping. English took went, really the past of wend, and left wend stranded. German took ging and gegangen from another old verb, ganganą, "to walk" — which English still owns in gangway, gangplank, and Scots gang, "to go."
+Gegangen carries the same ge- you met on gehören: an old prefix German fastens to a past participle.
+Beyond Germanic, be honest — the deeper root of go is disputed, with no agreed list of cousins. It is the one verb here that cannot be followed back.
+
+Why it's said this way: English's walk is about cloth.
+Because walk is not an old word for travelling on foot. Old English wealcan meant "to roll, to toss," and its German cousin walken still means what it always meant: to full cloth, to work wool by trampling it.
+English promoted that trampling verb around 1200. German never did, so gehen covers both jobs.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "ich gehe, du gehst, er geht"]
+[pause 8 seconds for the answer]
+[your turn — say: the matched pair — "Ich stehe. Ich gehe."]
+[pause 8 seconds for the answer]
+[your turn — say: the borrowed pasts — "go/went" beside "gehen/ging/gegangen"]
+[pause 8 seconds for the answer]
+[your turn — say: where English kept the other verb — "gangway, gangplank"]
+[pause 8 seconds for the answer]
+[your turn — say: the ge- on both — "gehören, gegangen"]
+[pause 8 seconds for the answer]
+[your turn — say: what walken does — it fulls cloth, it does not travel]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give the du and er forms. (Du gehst, er geht.) Which English verb is gehen? (Go, and walk as well.) Where did went come from? (From wend.) What does German's cousin of walk mean? (To full cloth.) How far back can gehen be traced? (Not past Germanic.)
+
+
+Lesson 2 of 4.
+laufen — the verb that lies across English's line.
+
+Warm-up.
+[pause 2 seconds]
+Ich gehe covers going and walking. German has two words for run, and one of them is not only about running.
+
+Sounds you'll need.
+diphthong-au — au is the ow of house: laufen = LOW-fen.
+diphthong-eu — äu is the oy of boy: läuft = LOYFT.
+
+You'll want to know: laufen.
+laufen means "to run" — and often "to walk."
+ich laufe, wir laufen.
+du läufst, ihr lauft.
+er läuft, sie laufen.
+The schlafen break is here too, in the same du and er slot: au brightens to äu.
+Der Hund läuft.
+
+Why it's said this way: the line is not where you expect.
+English draws a hard line between walk and run. German draws it elsewhere, and leaves one verb lying across it.
+gehen — on foot, unhurried.
+laufen — on foot at any speed at all.
+rennen — flat out. ich renne, du rennst, er rennt.
+So Wir laufen is "we're walking" or "we're running," and only the situation tells you which. That holds across most of Germany. In Austria it does not: there laufen means run. This course teaches the German usage.
+Der Hund rennt. — no ambiguity left.
+
+The word, taken apart: laufen is leap.
+laufen is Proto-Germanic hlaupaną, and English kept it as leap — Old English hlēapan. One more p against f, the second shift, on the pattern of helfen/help, offen/open and schlafen/sleep.
+English holds three more scraps: lope, and — through Dutch relatives of the same verb — elope and interloper, both people running off. Outside Germanic there are no secure cousins.
+Rennen is a sharper story. Germanic had rinnaną, "to run, to flow," and beside it a causative rannijaną, "to make something run." German fused the two into rennen and kept rinnen, "to trickle," alongside. English fused the same two into run — one merger, carried out separately in each language.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "ich laufe, du läufst, er läuft" — LOW-fuh, LOYFST, LOYFT]
+[pause 8 seconds for the answer]
+[your turn — say: the three speeds — "Ich gehe. Ich laufe. Ich renne."]
+[pause 8 seconds for the answer]
+[your turn — say: "Der Hund läuft. Der Hund rennt."]
+[pause 8 seconds for the answer]
+[your turn — say: the p/f row now four long — "helfen/help, offen/open, schlafen/sleep, laufen/leap"]
+[pause 8 seconds for the answer]
+[your turn — say: the runaways — "lope, elope, interloper"]
+[pause 8 seconds for the answer]
+[your turn — say: the doubled merger — "rinnen, rennen" beside English's one run]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give the du and er forms of laufen. (Du läufst, er läuft — au to äu.) Which English verb is laufen? (Leap — and it means run.) Which German verb means only "run fast"? (Rennen.) Does Wir laufen mean walking or running? (Either — except in Austria, where it is running.) Say "the dog runs." (Der Hund rennt.)
+
+
+Lesson 3 of 4.
+öffnen — open, which was always the word up.
+
+Warm-up.
+[pause 2 seconds]
+Ich gehe. Ich laufe. Ich renne. Now something done with the hands, and the German habit that breaks a verb in two.
+
+Sounds you'll need.
+umlaut-oe — ö is the e of bed with rounded lips.
+fn-cluster — -fn- runs straight together: öffnen = UFF-nen.
+
+You'll want to know: öffnen.
+öffnen means "to open."
+ich öffne, wir öffnen.
+du öffnest, ihr öffnet.
+er öffnet, sie öffnen.
+An extra e slips in for du, er and ihr, because öffnst cannot be said. Now a noun you already have, whose d is spoken as a t:
+Ich öffne die Hand. — "I open my hand." (dee Hant).
+
+Grammar Lens: a verb that comes apart.
+Öffnen is the neutral, slightly formal word. What people say out loud is aufmachen, and both halves are yours already: auf from Chapter 4's auf Wiedersehen, machen from Chapter 5.
+Here is the German part. In an ordinary sentence, the prefix leaves the verb and waits at the end:
+Ich mache die Hand auf. — literally "I make the hand up."
+Machen takes the slot after ich; auf goes to the back and sits there. German does this to hundreds of verbs, and calls them separable.
+
+The word, taken apart: open was never a root.
+Behind the verb is the adjective offen, "open" — which Chapter 25 already put beside open as a p-to-f pair from the second shift.
+The better secret is that neither word is a root. Old English open goes back to Proto-Germanic upana-, "put up," formed on the word that is now English up — it has the shape of a past participle, though no such verb "to up" is attested. German ran the same sum and got offen, which is why offen and auf are relatives and not merely neighbours.
+So aufmachen is not a quaint compound. It is the ancient recipe for "open," rebuilt out loud — and German pulls it apart every time you use it.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "ich öffne, du öffnest, er öffnet" — the extra e]
+[pause 8 seconds for the answer]
+[your turn — say: "Ich öffne die Hand." — dee Hant]
+[pause 8 seconds for the answer]
+[your turn — say: the split — "Ich mache die Hand auf."]
+[pause 8 seconds for the answer]
+[your turn — say: the p/f pair — "offen/open"]
+[pause 8 seconds for the answer]
+[your turn — say: what it is made of — "auf, up, offen, open"]
+[pause 8 seconds for the answer]
+[your turn — say: the feet verbs before the hand one — "Ich gehe. Ich laufe. Ich renne."]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give the du and er forms. (Du öffnest, er öffnet.) Which older word is offen built from? (Auf — English up.) Where does auf go in Ich mache die Hand auf? (To the end.) What is such a verb called? (Separable.) How is the d of Hand spoken? (As a t.)
+
+
+Lesson 4 of 4.
+schließen — the second verb English lost.
+
+Warm-up.
+[pause 2 seconds]
+You can open a hand two ways, ich öffne and ich mache … auf. Closing works the same, and the closing verb has the stranger history.
+
+Sounds you'll need.
+ie-long-ee — ie is a long ee: schließen = SHLEE-sen.
+eszett — ß is a sharp s, and it appears here because the ee before it is long.
+
+You'll want to know: schließen.
+schließen means "to close," and also "to lock."
+ich schließe, wir schließen.
+du schließt, ihr schließt.
+er schließt, sie schließen.
+Its everyday partner is zumachen — zu plus machen — splitting exactly as aufmachen did:
+Ich schließe die Hand. Ich mache die Hand zu.
+The vowel shortens in the past, and the moment it does the ß becomes ss: schließen, but schloss.
+
+The word, taken apart: a verb with no English cousin.
+schließen is Proto-Germanic sleutaną, "to shut, to bolt." Dutch kept it as sluiten. English has nothing — no inherited cousin at all.
+So English closes things with borrowed and unrelated words. Close is Latin claudere, by way of French. Shut is native but a different verb entirely: Old English scyttan, to shoot a bolt across a door.
+That makes two verbs here with the same shape of story. Chapter 25 gave you nehmen, which English lost to Norse take. This is the second.
+On the verb it kept, German built a household: das Schloss, a lock — and, because a castle is the locked place, a castle; der Schlüssel, a key; der Schluss, the end. English says conclusion for that last one, from claudere — the same idea out of the other family's parts.
+A link between the Germanic verb and Latin claudere has been proposed. It is not established.
+
+What you've built across these two chapters.
+Eight verbs, and a whole small morning:
+Ich schlafe. Ich höre. Ich stehe. Ich gehe. Ich laufe. Ich renne. Ich sitze. Ich mache die Hand auf. Ich mache die Hand zu.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "ich schließe, du schließt, er schließt"]
+[pause 8 seconds for the answer]
+[your turn — say: the pair — "Ich mache die Hand auf. Ich mache die Hand zu."]
+[pause 8 seconds for the answer]
+[your turn — say: the spelling swap — "schließen, schloss"]
+[pause 8 seconds for the answer]
+[your turn — say: the household — "Schloss, Schlüssel, Schluss"]
+[pause 8 seconds for the answer]
+[your turn — say: the two lost verbs — "nehmen, schließen; English took take and close"]
+[pause 8 seconds for the answer]
+[your turn — say: the four p/f pairs — "helfen/help, offen/open, schlafen/sleep, laufen/leap"]
+[pause 8 seconds for the answer]
+[your turn — say: the whole morning — "Ich schlafe. Ich höre. Ich stehe. Ich gehe. Ich laufe. Ich renne. Ich sitze."]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give the du and er forms. (Du schließt, er schließt.) Which English verb is the cousin of schließen? (None — English lost it.) Where did close and shut come from? (Latin, and from shoot.) Name three words German hung on the verb. (Schloss, Schlüssel, Schluss.) Close your hand, both ways, then run the eight verbs.

--- a/code/learning/human-languages/german/roadmap.md
+++ b/code/learning/human-languages/german/roadmap.md
@@ -186,12 +186,51 @@ Spanish and French where a contrast helps. The recurring decoder is the
   lesson says so → ***mögen, lieben*** (`GE-C25-moegen-lieben`, the payoff) —
   *may*, *love*, and **gern** (*yearn*), German's three ways of liking, where
   *Ich lese gern* has no English shape. **Authored.**
+- **Ch. 26 — Sitting, standing, sleeping, hearing**: ***sitzen***
+  (`GE-C26-sitzen`) — **is** *sit*, and the first naming of the second shift's
+  **t**-branch (Germanic *t* → German *z*/*ss*), which retro-explains *Wasser*
+  (Ch. 11) and *zehn* (Ch. 6); PIE \**sed-* carries Latin *sedēre* into
+  *session* and Greek *hédra* into *cathedral*. "Strong" is separated from "the
+  vowel breaks" → ***stehen*** (`GE-C26-stehen`) — the verb Ch. 24 found inside
+  *verstehen*, now on its own: Germanic ran \**stāną* and \**standaną*,
+  English generalized the nasal stem, German the other, and German's **past**
+  (*ich stand*, *gestanden*) hands the *n* back. Latin *stāre* descends from
+  the same \**steh₂-*, as *sedēre* does from \**sed-* → ***schlafen***
+  (`GE-C26-schlafen`) — the **second** kind of vowel break, *a* → *ä*, in the
+  same *du*/*er* slot; two German changes on *sleep* (**p**→**f**, and *s*→*sch*
+  before *l*/*m*/*n*/*w*, unspelt before *p*/*t*, which is why *stehen* is
+  *SHTAY-en*); and the honest twist that the inherited word for sleep was
+  \**swep-* (*somnus*, *hýpnos*, *sofa*), replaced by German and English
+  **together** → ***hören*** (`GE-C26-hoeren`, the payoff) — the one change
+  they **share**, Gothic *hausjan*'s *s* turned to *r* on both sides; Grimm's
+  law on the *h*, with Greek *akoúein* → *acoustic* keeping the *k*, the same
+  swap as *Hund*/*canis*. The "sharp-eared" root analysis is marked cited but
+  unsettled; ***gehören*** ("to belong") is the false friend. **Authored.**
+- **Ch. 27 — Going, running, opening, closing**: ***gehen*** (`GE-C27-gehen`)
+  — the one verb here that **cannot** be traced past Germanic; both languages
+  borrowed a past (*went* ← *wend*; *ging*/*gegangen* ← \**ganganą*, still
+  English *gangway*), and English's *walk* turns out to be German *walken*,
+  "to full cloth", which is why German needs no separate word → ***laufen***
+  (`GE-C27-laufen`) — **is** *leap*, a fourth **p**/**f** pair; the umlaut break
+  returns on *au* → *äu*; and the **walk/run boundary** is taught honestly:
+  *gehen* unhurried, *rennen* flat out, *laufen* across the line — with the
+  Germany/Austria split recorded, not dropped. *Rennen* and *run* each merge
+  \**rinnaną* with its causative \**rannijaną*, separately → ***öffnen***
+  (`GE-C27-oeffnen`) — *offen* is the *open* Ch. 25 only listed; neither word is
+  a root, both are built on **up** (German *auf*), so *aufmachen* is the recipe
+  spoken aloud. **Separable verbs** are introduced here, on nothing new: *auf*
+  (Ch. 4) + *machen* (Ch. 5), split around *die Hand* → ***schließen***
+  (`GE-C27-schliessen`, the payoff) — **no English cousin at all**; English
+  closes with Latin's *close* and with *shut* (really *shoot*), so this is
+  Ch. 25's *nehmen* story a second time. *Schloss*, *Schlüssel*, *Schluss* are
+  the household German built on the verb it kept; the proposed link to Latin
+  *claudere* is reported as unestablished. **Authored.**
 
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 26+ | Cases (der→den→dem) — now owed explicitly, since Ch. 25 had to route around the accusative article after *mögen* and the dative object of *helfen*; then food, sprechen & the rest of the irregular verbs — following the shared theme order |
+| 28+ | Cases (der→den→dem) — owed since Ch. 25 had to route around the accusative article after *mögen* and the dative object of *helfen*, and Ch. 27 had to pick *die Hand* as its object for the same reason; then the rest of the separable verbs now that Ch. 27 has opened them, food, sprechen & the remaining irregular verbs — following the shared theme order |
 
 The **du / Sie** lesson (Ch. 2) completes the formal/informal set across the
 languages: Spanish *tú/usted* (from "your grace"), French *tu/vous* (the

--- a/code/learning/human-languages/latin/CHANGELOG.md
+++ b/code/learning/human-languages/latin/CHANGELOG.md
@@ -1,5 +1,76 @@
 # Changelog
 
+## Eight more verbs — Chapters 40 and 41
+
+- Adds a **third verb tranche**, one canonical concept per lesson, split across
+  two chapters of four. Chapter 40, *Hearing, Sleeping, Sitting, Standing*:
+  `LA-C40-audio` (VERB-HEAR), `LA-C40-dormio` (VERB-SLEEP), `LA-C40-sedeo`
+  (VERB-SIT), `LA-C40-sto` (VERB-STAND). Chapter 41, *Walking, Running,
+  Opening, Closing*: `LA-C41-ambulo` (VERB-WALK), `LA-C41-curro` (VERB-RUN),
+  `LA-C41-aperio` (VERB-OPEN), `LA-C41-claudo` (VERB-CLOSE). All eight concepts
+  were realised by **no track in the corpus** before this change.
+- **Nine atoms per chapter against a budget of twelve.** Eight lexical and eight
+  etymological, plus one extra concept atom in each chapter:
+  `LA-ETYMON-INHERITED-VS-BORROWED-03` in `LA-C40-sedeo` and
+  `LA-ETYMON-APERIO-OPERIO-03` in `LA-C41-aperio`. Two sittings of four rather
+  than one of eight, for the reason chapters 38 and 39 give: page count costs a
+  reader nothing and a gentler ramp does not come free.
+- **Conjugation class is named, never taught.** These eight span four classes —
+  *audiō*, *dormiō* and *aperiō* fourth; *sedeō* second; *ambulō* and *stō*
+  first; *currō* and *claudō* third — so each lesson says which group its verb
+  belongs to and what that predicts about the endings, and stops there. The
+  paradigm system itself is not in scope at A1.
+- **Chapter 40 names inherited against borrowed.** `LA-C40-sedeo` introduces the
+  distinction the track had been relying on without stating it: English *sit*,
+  *seat*, *set*, *settle*, *saddle*, *nest* and *soot* come down from PIE
+  \*sed- through Germanic with no Latin involved, while *session*, *sedentary*,
+  *preside*, *dissident*, *assiduous* and *siege* were taken out of Latin
+  centuries later. `LA-C40-sto` repeats the figure on \*sta- (*stand* inherited,
+  *station* borrowed), and `LA-C41-claudo` closes it from the other side:
+  English *close* is not a cousin of *claudere* but the verb itself, borrowed.
+- **Chapter 41 shows one root under two prefixes.** *Aperīre* is *ap-* ("off,
+  away") on a root \*wer- "to cover" — literally *un-cover* — and *operīre* is
+  *op-* ("over") on the same root. English took both halves and never noticed:
+  *aperture*, *aperitif*, *overt* from the opening verb; *cover*, *covert*,
+  *discover*, *curfew* and *kerchief* from the shutting one. `LA-C41-claudo`
+  then generalises it, setting *include*/*exclude* beside *accept*/*except* and
+  *intellegō*.
+- **Doubtful etymologies are flagged, not used.** *Dormouse* is attested in
+  English before the French sleeper-word it is supposed to come from, so
+  `LA-C40-dormio` names it as a trap rather than a hook. *April* from *aperīre*
+  is called folk etymology outright. *Sedan* from *sedēre*, French *aller* (and
+  *alley*) from *ambulāre*, and English *horse* from \*kers- are each marked as
+  proposals rather than settled facts, and English *still* is removed from the
+  \*sta- family because it belongs to a different root.
+- **Reinforcement runs at two cadences, and it is measured.** Every lesson
+  practises atoms from the one to three lessons before it, across the 39/40
+  chapter seam. Both payoffs reach further: `LA-C40-sto` retrieves *sum* and
+  *eō* from chapter 37, and `LA-C41-claudo` retrieves *capiō* from chapter 39
+  and *intellegō* from chapter 38. Measured against the same corpus without
+  these two chapters, Latin's never-revisited atom count falls from **35 to
+  30** — the five rescued are `LA-ETYMON-SUM-02`, `LA-ETYMON-EO-02`,
+  `LA-ETYMON-VENIO-02`, `LA-ETYMON-CAPIO-02` and `LA-ETYMON-INTELLEGO-02`,
+  none of which had been revisited at any distance since it was introduced.
+  These chapters add **no new orphans**: all eighteen atoms they introduce are
+  themselves revisited at least once.
+- Both payoffs clear the 0.5 representativeness floor honestly: chapter 40 at
+  **7 of 9** (0.78) and chapter 41 at **7 of 9** (0.78), counting only the
+  chapter's own atoms. The corpus-wide count of payoffs below the floor is
+  unchanged at 25.
+- One forward-reference finding appears and is **not** in these lessons:
+  `LA-C11-menses` already glossed *Aprīlis* as "perhaps *aperīre*", and that
+  word now has a teaching lesson 58 lessons later. Chapter 41 states the
+  stronger and more accurate position — the *April* link is folk etymology —
+  so the two do not contradict, but chapter 11's gloss is the weaker of the two
+  and is worth revisiting on its own.
+- Every lesson's computed duration is under the five-minute ceiling (291–299
+  seconds), no lesson uses a table, and all eight derive as `voice` — the track
+  stays at 96% drivable across 41 chapters.
+- PIE roots are cited in plain ASCII Watkins form (\*au-, \*drem-, \*sed-,
+  \*sta-, \*kers-, \*wer-, \*klau-) because Latin Modern Roman has no glyph for
+  the subscript digits and laryngeal diacritics the fuller notation needs. The
+  book compiles under XeLaTeX with **zero** `Missing character` warnings.
+
 ## Eight more verbs — Chapters 38 and 39
 
 - Adds a **second verb tranche**, one canonical concept per lesson, split

--- a/code/learning/human-languages/latin/README.md
+++ b/code/learning/human-languages/latin/README.md
@@ -22,9 +22,9 @@ before the whole; and a book you can read straight through.
 
 ## Progress
 
-- **Chapters 1–39 are authored** as 73 prerequisite-ordered lessons, from
+- **Chapters 1–41 are authored** as 81 prerequisite-ordered lessons, from
   greetings and numbers through names, time, everyday courtesy, the honest
-  limits of reconstructed conversational phrases, and the sixteen verbs the
+  limits of reconstructed conversational phrases, and the twenty-four verbs the
   language leans on hardest.
 - **Chapter 37 gives the track its verbs** — *sum*, *habeō*, *eō*, *veniō*,
   *dīcō*, *videō*, *sciō*, *dō*, one per lesson. Each teaches its six
@@ -42,17 +42,32 @@ before the whole; and a book you can read straight through.
   Each lesson also names the lookalikes that are not relatives — English
   *read*, *write*, *think*, *ask* and *help* are all Germanic, *juvenile* is
   not from *iuvō*, and *capital* is not from *capiō*.
+- **Chapters 40 and 41 add the last eight of the core forty** — *audiō*,
+  *dormiō*, *sedeō*, *stō* in chapter 40, then *ambulō*, *currō*, *aperiō*,
+  *claudō* in chapter 41. Each lesson names the conjugation its verb belongs to
+  (fourth, second, first, third) without teaching the whole system, and the two
+  chapters carry the richest English dividend in the track: *audiō* behind
+  *audio*, *audit* and — through *ob-audīre*, "to listen toward" — *obey*;
+  *currō* behind *current*, *curriculum* and *corridor*, and behind *car* a
+  second time by way of a Gaulish wagon-word; *claudō* behind *close* itself.
+- **Chapter 40 names a distinction the track had been using silently** —
+  *inherited* against *borrowed*. English *sit* and *stand* descend from the
+  same ancestors as *sedeō* and *stō* without passing through Latin, while
+  *session* and *station* were taken out of Latin centuries later. Chapter 41
+  then shows the opposite figure: *aperiō* ("cover away") and *operīre*
+  ("cover over") are one root under two prefixes, and English holds both halves
+  — *aperture* from the first, *cover* and *curfew* from the second.
 - **Five chapters end on a dedicated payoff lesson** — 1, 19, 21, 33, and 36.
   Chapters 19, 21, and 36 close on a real Latin exchange assembled only from
   words the reader has already been taught; chapter 33 closes on a sorting task,
   because its material is etymological and would not honestly support a
   conversation.
-- **Chapters 2–39 are generated from the same schema-v2 lessons used by Language
+- **Chapters 2–41 are generated from the same schema-v2 lessons used by Language
   Ladder.** Chapter 1 remains the hand-authored opening; deterministic source
   hashes keep every later app/book chapter pair aligned.
 - Every lesson has a shared-spine placement, explicit knowledge boundaries, and
   an effective duration below five minutes.
-- **All 39 chapters carry a capability entry** in
+- **All 41 chapters carry a capability entry** in
   [`chapters.json`](./chapters.json) — no chapter is skipped, and no entry is a
   stub.
 

--- a/code/learning/human-languages/latin/book/book.tex
+++ b/code/learning/human-languages/latin/book/book.tex
@@ -118,6 +118,8 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch37-core-verbs}
 \input{chapters/ch38-mind-verbs}
 \input{chapters/ch39-doing-verbs}
+\input{chapters/ch40-sense-and-posture-verbs}
+\input{chapters/ch41-motion-verbs}
 
 \backmatter
 

--- a/code/learning/human-languages/latin/book/chapters/ch40-sense-and-posture-verbs.tex
+++ b/code/learning/human-languages/latin/book/chapters/ch40-sense-and-posture-verbs.tex
@@ -1,0 +1,219 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:1cddd2598214fb8f
+% canonical-lessons: LA-C40-audio, LA-C40-dormio, LA-C40-sedeo, LA-C40-sto
+
+\chapter{Hearing, Sleeping, Sitting, Standing}
+\label{ch:la-sense-and-posture-verbs}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can say I hear, I sleep, I sit and I stand in Latin, produce the he-or-she form of each, name the conjugation each belongs to, and tell an English word inherited from the shared ancestor apart from one borrowed out of Latin.}
+
+The chapter closes on stō: after learning it the reader produces all four first-person forms and all four third-person forms in sequence — audiō, dormiō, sedeō, stō and audit, dormit, sedet, stat — sorts stand from station as inherited against borrowed, and reaches back three chapters to retrieve sum and eō, neither of which had been revisited since chapter 37.
+\end{chapteropening}
+
+\section[audiō, audīre]{audiō — hearing, and the word for obeying}
+
+\label{lesson:LA-C40-audio}
+
+
+
+\begin{quote}
+The last chapter ended on \textbf{amō}, whose trail stopped early — no secure ancient root to walk back to. This verb is the opposite case: its trail runs all the way back, and forward into a surprising English word. It is also the natural partner of \textbf{rogō}: you ask, and then you hear.
+\end{quote}
+
+\subsection*{You'll want to know: audiō — \textquotedblleft{}I hear\textquotedblright{}}
+\textbf{Audiō} means \textquotedblleft{}\textbf{I hear},\textquotedblright{} and also \textquotedblleft{}I listen to.\textquotedblright{} The dictionary form is \textbf{audīre}. The \emph{au} is one sound, close to English \emph{ow} in \textquotedblleft{}now.\textquotedblright{}
+
+\begin{itemize}
+\raggedright
+  \item \textbf{audiō} — I hear
+  \item \textbf{audīs} — you hear, to one person
+  \item \textbf{audit} — he hears, she hears
+  \item \textbf{audīmus} — we hear
+  \item \textbf{audītis} — you hear, to several people
+  \item \textbf{audiunt} — they hear
+\end{itemize}
+
+This is a \textbf{fourth-conjugation} verb — the group whose dictionary form ends in \textbf{-īre}. Note the \textquotedblleft{}they\textquotedblright{} form: \textbf{audiunt}, with a \emph{u} slipped in.
+
+\begin{cousinweb}
+The root is Proto-Indo-European \emph{\textbf{*au-}}, \textquotedblleft{}to perceive.\textquotedblright{} Latin built \emph{audīre} on it, and English borrowed the results wholesale: \textbf{audio}, \textbf{audible}, \textbf{audience}, \textbf{audition}, \textbf{auditor}, \textbf{auditorium}.
+
+\textbf{Audit} is the best of them. An audit was literally a \emph{hearing}: accounts were read out loud and checked by ear, long before anyone checked them by eye. The word kept the procedure and lost the sound.
+
+Now the one nobody guesses. Put \emph{ob-} (\textquotedblleft{}toward\textquotedblright{}) in front of \emph{audīre} and Latin gives \emph{oboedīre}, \textquotedblleft{}to listen toward\textquotedblright{} — which through French becomes English \textbf{obey}, \textbf{obedient} and \textbf{disobey}. To obey is to listen hard at someone. The town crier's \textbf{oyez} is the same verb, an Old French imperative: \textquotedblleft{}hear ye.\textquotedblright{}
+
+The Greek branch of \emph{\textbf{*au-}} produced words for perceiving in general: \textbf{aesthetic}, and \textbf{anaesthesia}, \textquotedblleft{}no perception at all.\textquotedblright{}
+
+One flag. English \textbf{hear} is \emph{not} a relative. It is Germanic, from another root — the one that also gives Greek \emph{akoúein} and so English \textbf{acoustic}. \emph{Audio} and \emph{acoustic} mean nearly the same thing and are not cousins.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}audiō\textquotedblright{} — I hear
+  \item \textquotedblleft{}audīs, audit\textquotedblright{} — you hear, he or she hears
+  \item \textquotedblleft{}audīmus, audītis, audiunt\textquotedblright{} — we, you all, they
+  \item the pair from the last chapter beside it — rogō, amō
+  \item the English relatives — audience, audit, obey
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+How does Latin say \textquotedblleft{}I hear\textquotedblright{}? (\textbf{Audiō}.) \textquotedblleft{}They hear\textquotedblright{}? (\textbf{Audiunt}.) Which conjugation is it? (\textbf{The fourth} — the \emph{-īre} group.) What was an \textbf{audit} originally, and which everyday word is \emph{ob-} plus \emph{audīre}? (\textbf{A hearing}, accounts read aloud — and \textbf{obey}.) Which verb from the last chapter had no securely reconstructed root, and which one means \textquotedblleft{}I ask\textquotedblright{}? (\textbf{Amō}, and \textbf{rogō}.)
+\end{tcolorbox}
+\section[dormiō, dormīre]{dormiō — the verb you do with your senses off}
+
+\label{lesson:LA-C40-dormio}
+
+
+
+\begin{quote}
+\textbf{Audiō} is hearing; \textbf{videō}, from an earlier chapter, is seeing. This verb is the state in which you do neither.
+\end{quote}
+
+\subsection*{You'll want to know: dormiō — \textquotedblleft{}I sleep\textquotedblright{}}
+\textbf{Dormiō} means \textquotedblleft{}\textbf{I sleep}.\textquotedblright{} The dictionary form is \textbf{dormīre}. The first \emph{o} is short, the \emph{ī} of \emph{dormīre} is long: \emph{dor-MEE-reh}.
+
+\begin{itemize}
+\raggedright
+  \item \textbf{dormiō} — I sleep
+  \item \textbf{dormīs} — you sleep, to one person
+  \item \textbf{dormit} — he sleeps, she sleeps
+  \item \textbf{dormīmus} — we sleep
+  \item \textbf{dormītis} — you sleep, to several people
+  \item \textbf{dormiunt} — they sleep
+\end{itemize}
+
+This is the same \textbf{fourth conjugation} as the verb before it, and it takes the same endings — including that \emph{u} in \textbf{dormiunt}. Two verbs in the group is enough to hear the pattern.
+
+\begin{cousinweb}
+The root is Proto-Indo-European \emph{\textbf{*drem-}}, \textquotedblleft{}to sleep.\textquotedblright{} It is a quiet root: Sanskrit \emph{drāti}, Greek \emph{darthánein}, Old Church Slavonic \emph{drěmati}. Latin \emph{dormīre} is the western member, and English inherited none of it — every English word here is a loan.
+
+Borrowed whole: \textbf{dormitory} (\emph{dormītōrium}, \textquotedblleft{}a sleeping place\textquotedblright{}), and its clipped form \emph{dorm}. \textbf{Dormant}, from French, is a thing that is sleeping rather than dead. A \textbf{dormer} window began as the window of a sleeping room.
+
+Now a warning, because this one is a trap dressed as a gift. \textbf{Dormouse} looks like the perfect example and is not securely one. The animal's name is attested in English before the French word for a sleeper it is supposed to come from, and the \emph{-mouse} half may simply be English speakers making sense of a syllable they did not recognise. A hook you have to defend is not a hook.
+
+Latin's other word for sleep is the noun \textbf{somnus}, from a different root entirely, and English took plenty from that too: \textbf{insomnia} (\textquotedblleft{}no sleep\textquotedblright{}), \textbf{somnolent}, and \textbf{soporific}. So the two Latin sleep-words divided the English vocabulary between them: the verb gave the rooms you sleep in, the noun gave the sleep itself.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}dormiō\textquotedblright{} — I sleep
+  \item \textquotedblleft{}dormīs, dormit\textquotedblright{} — you sleep, he or she sleeps
+  \item \textquotedblleft{}dormīmus, dormītis, dormiunt\textquotedblright{} — we, you all, they
+  \item the two senses this verb switches off — audiō, videō
+  \item the English relatives — dormitory, dormant
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+How does Latin say \textquotedblleft{}I sleep\textquotedblright{}? (\textbf{Dormiō}.) \textquotedblleft{}They sleep\textquotedblright{}? (\textbf{Dormiunt}.) Which conjugation, and which other verb shares it here? (\textbf{The fourth} — with \textbf{audiō}.) Why is \textbf{dormouse} not a safe example? (\textbf{Because the connection is not secure} — the English word is older than the French one it supposedly comes from.) Which Latin noun gives \textbf{insomnia}, and which verb means \textquotedblleft{}I see\textquotedblright{}? (\textbf{Somnus}, and \textbf{videō}.)
+\end{tcolorbox}
+\section[sedeō, sedēre]{sedeō — the same word English already had}
+
+\label{lesson:LA-C40-sedeo}
+
+
+
+\begin{quote}
+\textbf{Dormīre} left English nothing but loans. This verb is the reverse, and it lets us name a distinction the course has been using without stating it.
+\end{quote}
+
+\subsection*{You'll want to know: sedeō — \textquotedblleft{}I sit\textquotedblright{}}
+\textbf{Sedeō} means \textquotedblleft{}\textbf{I sit},\textquotedblright{} and also \textquotedblleft{}I stay put.\textquotedblright{} The dictionary form is \textbf{sedēre}, with a long \emph{ē}.
+
+\begin{itemize}
+\raggedright
+  \item \textbf{sedeō} — I sit
+  \item \textbf{sedēs} — you sit, to one person
+  \item \textbf{sedet} — he sits, she sits
+  \item \textbf{sedēmus} — we sit
+  \item \textbf{sedētis} — you sit, to several people
+  \item \textbf{sedent} — they sit
+\end{itemize}
+
+This one is \textbf{second conjugation} — the \emph{-ēre} group. That long \emph{ē} is the whole signal, so give it room.
+
+\begin{cousinweb}
+The root is Proto-Indo-European \emph{\textbf{*sed-}}, \textquotedblleft{}to sit,\textquotedblright{} and English has it by two different routes — which is the point.
+
+\textbf{Inherited}, down the Germanic line, with no Latin involved: \textbf{sit}, \textbf{seat}, \textbf{set} (\textquotedblleft{}cause to sit\textquotedblright{}), \textbf{settle}, \textbf{saddle}. Two are hidden: \textbf{nest} is \textquotedblleft{}the place where one sits down,\textquotedblright{} and \textbf{soot} is what settles.
+
+\textbf{Borrowed}, later, out of Latin \emph{sedēre}: \textbf{session}, \textbf{sedentary}, \textbf{sediment}, \textbf{sedate}, \textbf{preside}, \textbf{reside}, \textbf{dissident} (\textquotedblleft{}sitting apart\textquotedblright{}), \textbf{assiduous} (\textquotedblleft{}sitting at it\textquotedblright{}), \textbf{possess}. \textbf{Siege} is a seat too — an army sitting down in front of a town.
+
+Hold the two apart. An \textbf{inherited} word came down to English from the shared ancestor without passing through Latin; a \textbf{borrowed} word was taken out of Latin, usually centuries later. \emph{Sit} and \emph{session} are one ancient word by two roads, and they look nothing alike because one wore down for three thousand years while the other was copied out of a book. You met this shape when \textbf{capiō} turned out to be the true relative of English \emph{have}, with the borrowed \emph{capture} beside it.
+
+One flag. \textbf{Sedan} is often attached to \emph{sedēre}, and the connection is not established. Leave it out.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}sedeō\textquotedblright{} — I sit, long ē in sedēre
+  \item \textquotedblleft{}sedēs, sedet\textquotedblright{} — you sit, he or she sits
+  \item \textquotedblleft{}sedēmus, sedētis, sedent\textquotedblright{} — we, you all, they
+  \item the three verbs of this chapter so far — audiō, dormiō, sedeō
+  \item the inherited word, then the borrowed one — sit, session
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+How does Latin say \textquotedblleft{}I sit\textquotedblright{}? (\textbf{Sedeō}.) \textquotedblleft{}They sit\textquotedblright{}? (\textbf{Sedent}.) Which conjugation? (\textbf{The second} — the long \emph{-ēre} group.) Is English \textbf{sit} borrowed from Latin, and what about \textbf{session}? (\textbf{Sit is inherited}, by a different road; \textbf{session is borrowed}.) Which earlier verb showed that same shape, and why is \textbf{dormouse} not usable that way? (\textbf{Capiō} — cousin of \emph{have}, source of \emph{capture}; and \emph{dormouse}'s link to sleeping is not secure.)
+\end{tcolorbox}
+\section[stō, stāre]{stō — standing, and the four together}
+
+\label{lesson:LA-C40-sto}
+
+
+
+\begin{quote}
+Three verbs so far: hearing, sleeping, sitting. One remains. It is the opposite of the last, and it shows the inherited-and-borrowed pattern \textbf{sedeō} just taught all over.
+\end{quote}
+
+\subsection*{You'll want to know: stō — \textquotedblleft{}I stand\textquotedblright{}}
+\textbf{Stō} means \textquotedblleft{}\textbf{I stand},\textquotedblright{} and by extension \textquotedblleft{}I stay.\textquotedblright{} The dictionary form is \textbf{stāre}. Two letters in the \textquotedblleft{}I\textquotedblright{} form makes it the shortest verb you have met.
+
+\begin{itemize}
+\raggedright
+  \item \textbf{stō} — I stand
+  \item \textbf{stās} — you stand, to one person
+  \item \textbf{stat} — he stands, she stands
+  \item \textbf{stāmus} — we stand
+  \item \textbf{stātis} — you stand, to several people
+  \item \textbf{stant} — they stand
+\end{itemize}
+
+This is \textbf{first conjugation}, the \emph{-āre} group, and in the present tense perfectly regular: the long \emph{ā} runs through every form after the first.
+
+\begin{cousinweb}
+The root is Proto-Indo-European \emph{\textbf{*sta-}}, \textquotedblleft{}to stand.\textquotedblright{} Sort the English by the two roads that gave \emph{sit} and \emph{session}.
+
+\textbf{Inherited}: \textbf{stand} — with an extra \emph{n} wedged into the middle, which is why it looks unlike \emph{stō} — plus \textbf{stead} (as in \emph{instead}), \textbf{steed}, \textbf{stall} and \textbf{stool}.
+
+\textbf{Borrowed} from \emph{stāre}: \textbf{station}, \textbf{statue}, \textbf{status}, \textbf{state}, \textbf{stable}, \textbf{estate}, \textbf{stage}, \textbf{substance}, \textbf{circumstance} (\textquotedblleft{}standing around\textquotedblright{}), \textbf{obstacle} (\textquotedblleft{}standing in the way\textquotedblright{}), \textbf{constant}, \textbf{instant}, \textbf{distance}. Two are so worn down they hide: \emph{constāre}, \textquotedblleft{}to stand at a price,\textquotedblright{} is English \textbf{cost}, and \emph{restāre}, \textquotedblleft{}to stand back,\textquotedblright{} is the \textbf{rest} that means the remainder. The doubled-up \emph{sistere} gives \textbf{consist}, \textbf{resist}, \textbf{insist} and \textbf{assist}.
+
+Set this beside the verb for being. \textbf{Sum} and \textbf{est} are inherited cousins of English \emph{am} and \emph{is} — the same two-road picture, only there the English side kept the meaning exactly. And set it against \textbf{eō}, \textquotedblleft{}I go\textquotedblright{}: \emph{stāre} is what you do when you are not going, and English holds both halves, \emph{station} from this verb and \emph{exit} from that one.
+
+One flag. English \textbf{still} is often thrown in here and does not belong.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}stō, stās, stat\textquotedblright{} — I stand, you stand, he or she stands
+  \item this chapter's four \textquotedblleft{}I\textquotedblright{} forms — audiō, dormiō, sedeō, stō
+  \item the four \textquotedblleft{}he or she\textquotedblright{} forms — audit, dormit, sedet, stat
+  \item the two from an earlier chapter beside them — sum, eō
+  \item inherited, then borrowed — stand, station
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Give this chapter's four \textquotedblleft{}I\textquotedblright{} forms. (\textbf{Audiō, dormiō, sedeō, stō}.) Now the four \textquotedblleft{}he or she\textquotedblright{} forms. (\textbf{Audit, dormit, sedet, stat}.) Which of the four is second conjugation? (\textbf{Sedeō} — the long \emph{-ēre} group.) Which English word for standing is inherited, which is borrowed, and what is \textbf{cost} taken apart? (\textbf{Stand} inherited, \textbf{station} borrowed; \emph{constāre}, what a thing stands at.) Which earlier verb has \emph{am} and \emph{is} as its inherited English cousins, and which one means \textquotedblleft{}I go\textquotedblright{}? (\textbf{Sum}, and \textbf{eō} — the verb behind \emph{exit}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/latin/book/chapters/ch41-motion-verbs.tex
+++ b/code/learning/human-languages/latin/book/chapters/ch41-motion-verbs.tex
@@ -1,0 +1,222 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:2b002dc26979c3db
+% canonical-lessons: LA-C41-ambulo, LA-C41-curro, LA-C41-aperio, LA-C41-claudo
+
+\chapter{Walking, Running, Opening, Closing}
+\label{ch:la-motion-verbs}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can say I walk, I run, I open and I close in Latin, produce the he-or-she form of each, name the conjugation each belongs to, and say what a Latin prefix does to the verb it sits on.}
+
+The chapter closes on claudō: after learning it the reader produces all four first-person forms and all four third-person forms in sequence — ambulō, currō, aperiō, claudō and ambulat, currit, aperit, claudit — reads include/exclude beside accept/except and intellegō as one prefix rule, and so retrieves capiō and intellegō from two and three chapters back, neither of them revisited before now.
+\end{chapteropening}
+
+\section[ambulō, ambulāre]{ambulō — walking about}
+
+\label{lesson:LA-C41-ambulo}
+
+
+
+\begin{quote}
+The last chapter left you sitting and standing — \textbf{sedeō} and \textbf{stō}, both of them staying put. This chapter moves.
+\end{quote}
+
+\subsection*{You'll want to know: ambulō — \textquotedblleft{}I walk\textquotedblright{}}
+\textbf{Ambulō} means \textquotedblleft{}\textbf{I walk},\textquotedblright{} with a flavour of walking \emph{about} rather than walking \emph{to} somewhere. The dictionary form is \textbf{ambulāre}.
+
+\begin{itemize}
+\raggedright
+  \item \textbf{ambulō} — I walk
+  \item \textbf{ambulās} — you walk, to one person
+  \item \textbf{ambulat} — he walks, she walks
+  \item \textbf{ambulāmus} — we walk
+  \item \textbf{ambulātis} — you walk, to several people
+  \item \textbf{ambulant} — they walk
+\end{itemize}
+
+Like \textbf{stō}, this is \textbf{first conjugation} — the \emph{-āre} group — with the same endings hung on a longer stem.
+
+\begin{cousinweb}
+Start with the honest limit, because this word has one. The front half is secure: \emph{amb-}, \textquotedblleft{}around,\textquotedblright{} the same element as in \emph{ambi-}. The back half is not settled — usually connected with an old root meaning \textquotedblleft{}to wander\textquotedblright{} or \textquotedblleft{}to go,\textquotedblright{} but the join has never been nailed down, so the standard gloss is a reasonable guess rather than a proof.
+
+The harvest is not in doubt at all. \textbf{Amble} came through French and kept the leisurely sense exactly. \textbf{Ambulatory} is both an adjective and the walking-gallery of a church. \textbf{Perambulate} gave the Victorian \textbf{perambulator} and, clipped, the \textbf{pram}. A \textbf{preamble} walks in front (\emph{prae-}, \textquotedblleft{}before\textquotedblright{}).
+
+Two compounds are worth saying out loud. A \textbf{funambulist} walks a rope (\emph{fūnis}). A \textbf{somnambulist} walks in sleep — and \emph{somnus} is the Latin sleep-noun named in the last chapter, so that word is two pieces you already have.
+
+The best is \textbf{ambulance}. A French military hospital that followed the army instead of waiting for it was an \emph{hôpital ambulant} — a walking hospital. English took the second word and forgot the first, so the vehicle is named for moving.
+
+Two flags. English \textbf{walk} is Germanic and no relation. And French \emph{aller}, \textquotedblleft{}to go\textquotedblright{} — with \textbf{alley} behind it — is often derived from \emph{ambulāre} by heavy wear, but that derivation is disputed. Do not lean on it.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}ambulō\textquotedblright{} — I walk
+  \item \textquotedblleft{}ambulās, ambulat\textquotedblright{} — you walk, he or she walks
+  \item \textquotedblleft{}ambulāmus, ambulātis, ambulant\textquotedblright{} — we, you all, they
+  \item the two still verbs it moves away from — sedeō, stō
+  \item the English relatives — amble, preamble, ambulance
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+How does Latin say \textquotedblleft{}I walk\textquotedblright{}? (\textbf{Ambulō}.) \textquotedblleft{}They walk\textquotedblright{}? (\textbf{Ambulant}.) Which conjugation, and which earlier verb shares it? (\textbf{The first}, the \emph{-āre} group — with \textbf{stō}.) Which half of the word is uncertain, and why is a vehicle called an \textbf{ambulance}? (\textbf{The back half}; and because the hospital walked — it followed the army.) Which verb means \textquotedblleft{}I sit\textquotedblright{}? (\textbf{Sedeō}.)
+\end{tcolorbox}
+\section[currō, currere]{currō — running, and the root that came by two roads}
+
+\label{lesson:LA-C41-curro}
+
+
+
+\begin{quote}
+\textbf{Ambulō} is walking about, and its own back half is a guess. This verb is the fast one, and its ancestry is not a guess at all.
+\end{quote}
+
+\subsection*{You'll want to know: currō — \textquotedblleft{}I run\textquotedblright{}}
+\textbf{Currō} means \textquotedblleft{}\textbf{I run},\textquotedblright{} and also \textquotedblleft{}I race.\textquotedblright{} The dictionary form is \textbf{currere}. Every vowel is short, the \emph{r}s are rolled, the \emph{c} is hard: \emph{KOOR-reh-reh}.
+
+\begin{itemize}
+\raggedright
+  \item \textbf{currō} — I run
+  \item \textbf{curris} — you run, to one person
+  \item \textbf{currit} — he runs, she runs
+  \item \textbf{currimus} — we run
+  \item \textbf{curritis} — you run, to several people
+  \item \textbf{currunt} — they run
+\end{itemize}
+
+This is \textbf{third conjugation}, whose dictionary form ends in \emph{-ere} with a \emph{short} second-to-last vowel. Say \textbf{currere} with the stress at the front to hear the difference from the long \emph{-ēre} of the second.
+
+\begin{cousinweb}
+The root is Proto-Indo-European \emph{\textbf{*kers-}}, \textquotedblleft{}to run,\textquotedblright{} and it reached English by two very different roads.
+
+\textbf{Through the Latin verb}: \textbf{current} (a running of water, then of electricity), \textbf{currency} (money that runs), \textbf{cursor}, \textbf{cursive}, \textbf{course}, \textbf{discourse}, \textbf{occur} (\textquotedblleft{}to run to meet\textquotedblright{}), \textbf{recur}, \textbf{excursion}, \textbf{precursor}, and \textbf{succour} — \emph{sub-} plus \emph{currere}, to run underneath someone and hold them up. \textbf{Corridor} is Italian for \textquotedblleft{}a running-place,\textquotedblright{} and \textbf{curriculum} is simply a racecourse.
+
+\textbf{Through a wagon}: the Gauls had a word \emph{karros} for a war chariot, from the very same root, and Latin borrowed it as \emph{carrus}. From that noun English has \textbf{car}, \textbf{carry}, \textbf{carriage}, \textbf{cargo}, \textbf{charge} (which began as loading a wagon), and \textbf{career} — first a road for carts, then the speed you take one at. \textbf{Carpenter} is there too: a \emph{carpentārius} made wagons.
+
+Set this beside \textbf{veniō}, \textquotedblleft{}I come.\textquotedblright{} \emph{Veniō} is arriving; \emph{currō} is the speed. English keeps them apart the same way — an \emph{event} comes out, a \emph{course} is the running of it.
+
+Two flags. English \textbf{hurry} is not related. And the claim that English \textbf{horse} belongs to this root is a proposal, not a settled fact.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}currō\textquotedblright{} — I run, hard c, rolled r
+  \item \textquotedblleft{}curris, currit\textquotedblright{} — you run, he or she runs
+  \item \textquotedblleft{}currimus, curritis, currunt\textquotedblright{} — we, you all, they
+  \item the three speeds so far — stō, ambulō, currō
+  \item the relatives — current, curriculum, car
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+How does Latin say \textquotedblleft{}I run\textquotedblright{}? (\textbf{Currō}.) \textquotedblleft{}They run\textquotedblright{}? (\textbf{Currunt}.) Which conjugation? (\textbf{The third} — short \emph{-ere}.) What is a \textbf{curriculum} literally, and how did \textbf{car} get into the family? (\textbf{A racecourse}; and through a Gaulish wagon-word Latin borrowed, from the same root.) Which earlier verb means \textquotedblleft{}I come\textquotedblright{}, the arriving to this verb's speed, and which means \textquotedblleft{}I walk about\textquotedblright{}? (\textbf{Veniō}, and \textbf{ambulō}.)
+\end{tcolorbox}
+\section[aperiō, aperīre]{aperiō — to un-cover}
+
+\label{lesson:LA-C41-aperio}
+
+
+
+\begin{quote}
+\textbf{Currō} showed one root reaching English by two roads. This verb shows something rarer: one root standing inside two Latin words that mean the opposite of each other.
+\end{quote}
+
+\subsection*{You'll want to know: aperiō — \textquotedblleft{}I open\textquotedblright{}}
+\textbf{Aperiō} means \textquotedblleft{}\textbf{I open},\textquotedblright{} and also \textquotedblleft{}I uncover, I reveal.\textquotedblright{} The dictionary form is \textbf{aperīre}, with a long \emph{ī}.
+
+\begin{itemize}
+\raggedright
+  \item \textbf{aperiō} — I open
+  \item \textbf{aperīs} — you open, to one person
+  \item \textbf{aperit} — he opens, she opens
+  \item \textbf{aperīmus} — we open
+  \item \textbf{aperītis} — you open, to several people
+  \item \textbf{aperiunt} — they open
+\end{itemize}
+
+This is \textbf{fourth conjugation}, the \emph{-īre} group, and it takes exactly the endings \textbf{audiō} and \textbf{dormiō} took — including that \emph{u} before the ending in \textbf{aperiunt}.
+
+\begin{cousinweb}
+\emph{Aperīre} is taken apart as \emph{ap-}, \textquotedblleft{}off, away,\textquotedblright{} welded onto an old root \emph{\textbf{*wer-}} meaning \textquotedblleft{}to cover.\textquotedblright{} To open, in Latin, is to cover \emph{away}.
+
+Now the elegant part. Latin has a second verb on the very same root: \textbf{operīre}, \textquotedblleft{}to cover, to shut\textquotedblright{} — \emph{op-}, \textquotedblleft{}over,\textquotedblright{} on \emph{*wer-}. The two verbs differ in one syllable at the front, and that syllable turns covering into uncovering:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{aperīre} — cover \emph{away} $\to$ open
+  \item \textbf{operīre} — cover \emph{over} $\to$ shut
+\end{itemize}
+
+English took both halves and never noticed they were a pair. From the opening verb: \textbf{aperture}, an opening; \textbf{aperitif}, the drink that opens a meal; and, worn down through French \emph{ouvrir}, \textbf{overt} and \textbf{overture}. From the shutting verb, mostly with \emph{co-} in front (\emph{cooperīre}, \textquotedblleft{}to cover completely\textquotedblright{}): \textbf{cover}, \textbf{covert}, and \textbf{discover}, which is \emph{dis-} undoing the covering. Two French phrases came in whole: a \textbf{curfew} is \emph{couvre-feu}, \textquotedblleft{}cover the fire,\textquotedblright{} and a \textbf{kerchief} is \emph{couvre-chef}.
+
+Two honest notes. The Vulgar Latin descendants of these verbs blurred into each other, which is why French \emph{ouvrir} and \emph{couvrir} rhyme today. And \textbf{April} — you will see it explained as \textquotedblleft{}the opening month,\textquotedblright{} from \emph{aperīre}. That is folk etymology; the real origin is unsettled.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}aperiō\textquotedblright{} — I open
+  \item \textquotedblleft{}aperīs, aperit\textquotedblright{} — you open, he or she opens
+  \item \textquotedblleft{}aperīmus, aperītis, aperiunt\textquotedblright{} — we, you all, they
+  \item the pair, and what each prefix does — aperīre, cover away; operīre, cover over
+  \item the chapter so far — ambulō, currō, aperiō
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+How does Latin say \textquotedblleft{}I open\textquotedblright{}, and how \textquotedblleft{}they open\textquotedblright{}? (\textbf{Aperiō}, \textbf{aperiunt}.) Which conjugation, and what does \emph{aperīre} literally say? (\textbf{The fourth}, the \emph{-īre} group; and \textbf{cover away} — un-cover.) What is its opposite, and what does that prefix change? (\emph{\textbf{Operīre}} — \emph{op-}, \textquotedblleft{}over,\textquotedblright{} so cover \emph{over}.) Which English word is \emph{couvre-feu}, is \textbf{April} from this verb, and which verb means \textquotedblleft{}I run\textquotedblright{}? (\textbf{Curfew}; \textbf{no}, that is folk etymology; and \textbf{currō}.)
+\end{tcolorbox}
+\section[claudō, claudere]{claudō — closing, and the four together}
+
+\label{lesson:LA-C41-claudo}
+
+
+
+\begin{quote}
+\textbf{Aperiō} opened by covering \emph{away}, and named its own Latin opposite. But that opposite is not the verb a Roman reached for to shut a door. This one is, and it is the word English says every day.
+\end{quote}
+
+\subsection*{You'll want to know: claudō — \textquotedblleft{}I close\textquotedblright{}}
+\textbf{Claudō} means \textquotedblleft{}\textbf{I close},\textquotedblright{} \textquotedblleft{}I shut in.\textquotedblright{} The dictionary form is \textbf{claudere}. The \emph{au} is one sound, as in \textbf{audiō}; the \emph{c} is hard: \emph{KLOW-deh-reh}.
+
+\begin{itemize}
+\raggedright
+  \item \textbf{claudō} — I close
+  \item \textbf{claudis} — you close, to one person
+  \item \textbf{claudit} — he closes, she closes
+  \item \textbf{claudimus} — we close
+  \item \textbf{clauditis} — you close, to several people
+  \item \textbf{claudunt} — they close
+\end{itemize}
+
+Like \textbf{currō}, this is \textbf{third conjugation} — short \emph{-ere}. That is three classes across this chapter's four verbs, worth noticing and not worth memorising: the class only tells you the endings.
+
+\begin{cousinweb}
+The root is Proto-Indo-European \emph{\textbf{*klau-}}, and it did not mean \textquotedblleft{}shut.\textquotedblright{} It meant \textbf{hook} or \textbf{peg} — the crooked wood you jam a door with. The action is named after the object, and Latin kept it: \emph{clāvis}, \textquotedblleft{}key.\textquotedblright{}
+
+English \textbf{close} is this verb. Not a cousin — the verb itself, borrowed through French from \emph{clausum}. That matters, because you learned to sort the two ways apart: \textbf{sit} was inherited, \textbf{session} was a loan. \emph{Close} is a loan that stopped looking like one. Beside it stand \textbf{closet}, \textbf{closure}, \textbf{disclose}, and the noun \textbf{clause}. A \textbf{cloister} is a \emph{claustrum}, a bolted place, and \textbf{sluice} is \emph{exclūsa}, \textquotedblleft{}water shut out.\textquotedblright{}
+
+Then the prefixes, where the chapter's two halves meet. \emph{Claudere} takes them by the handful: \textbf{include}, \textbf{exclude}, \textbf{conclude}, \textbf{preclude}, \textbf{recluse}. Set \emph{include} and \emph{exclude} beside \textbf{accept} and \textbf{except} — the same two prefixes on \emph{capere}. Set them beside \textbf{intellegō}, where \emph{inter-} turns picking into understanding. A prefix carries the meaning.
+
+From \emph{clāvis}, the key: \textbf{clavicle} (a little key — the collarbone), \textbf{clef}, and \textbf{conclave}, a room locked \emph{with a key}. Greek \emph{kleís} is the same inherited word and means both those things too.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}claudō, claudis, claudit\textquotedblright{} — I close, you close, he or she closes
+  \item this chapter's four \textquotedblleft{}I\textquotedblright{} forms — ambulō, currō, aperiō, claudō
+  \item the four \textquotedblleft{}he or she\textquotedblright{} forms — ambulat, currit, aperit, claudit
+  \item two prefixes, two verbs — include, exclude; accept, except
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Give this chapter's four \textquotedblleft{}I\textquotedblright{} forms, then the four \textquotedblleft{}he or she\textquotedblright{} forms. (\textbf{Ambulō, currō, aperiō, claudō}; \textbf{ambulat, currit, aperit, claudit}.) Which two share the third conjugation? (\textbf{Currō and claudō}.) Is English \textbf{close} inherited or borrowed, and what did the root name? (\textbf{Borrowed} — this Latin verb itself; and a \textbf{hook or peg}.) Which verb gives \textbf{accept} and \textbf{except}, the same prefixes as \emph{include} and \emph{exclude}, and which is \emph{inter-} plus \textquotedblleft{}to pick out\textquotedblright{}? (\textbf{Capiō}, and \textbf{intellegō}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/latin/chapters.json
+++ b/code/learning/human-languages/latin/chapters.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "language": "latin",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. All 39 Latin chapters are authored here. Chapters 1, 19, 21, 33 and 36 own a terminal consolidation lesson that recombines the chapter's material; every other chapter's payoff is still its last lesson by sequence, which is where that chapter's recombination and wrap-up recall currently live. Chapter 1's title and label come from its hand-written book/chapters/ch01-greetings.tex, the only Latin chapter with no core/book-generation.json target.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. All 41 Latin chapters are authored here. Chapters 1, 19, 21, 33 and 36 own a terminal consolidation lesson that recombines the chapter's material; every other chapter's payoff is still its last lesson by sequence, which is where that chapter's recombination and wrap-up recall currently live. Chapter 1's title and label come from its hand-written book/chapters/ch01-greetings.tex, the only Latin chapter with no core/book-generation.json target.",
   "chapters": [
     {
       "chapter": 1,
@@ -847,6 +847,62 @@
           "LA-LEX-ADIUVO-01",
           "LA-LEX-AMO-01",
           "LA-ETYMON-AMO-02"
+        ]
+      }
+    },
+    {
+      "chapter": 40,
+      "title": "Hearing, Sleeping, Sitting, Standing",
+      "label": "ch:la-sense-and-posture-verbs",
+      "canDo": "I can say I hear, I sleep, I sit and I stand in Latin, produce the he-or-she form of each, name the conjugation each belongs to, and tell an English word inherited from the shared ancestor apart from one borrowed out of Latin.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "LA-C40-sto",
+        "kind": "production",
+        "summary": "The chapter closes on stō: after learning it the reader produces all four first-person forms and all four third-person forms in sequence — audiō, dormiō, sedeō, stō and audit, dormit, sedet, stat — sorts stand from station as inherited against borrowed, and reaches back three chapters to retrieve sum and eō, neither of which had been revisited since chapter 37.",
+        "assesses": [
+          "LA-LEX-AUDIO-01",
+          "LA-LEX-DORMIO-01",
+          "LA-LEX-SEDEO-01",
+          "LA-ETYMON-SEDEO-02",
+          "LA-ETYMON-INHERITED-VS-BORROWED-03",
+          "LA-LEX-STO-01",
+          "LA-ETYMON-STO-02",
+          "LA-LEX-SUM-01",
+          "LA-ETYMON-SUM-02",
+          "LA-LEX-EO-01",
+          "LA-ETYMON-EO-02"
+        ]
+      }
+    },
+    {
+      "chapter": 41,
+      "title": "Walking, Running, Opening, Closing",
+      "label": "ch:la-motion-verbs",
+      "canDo": "I can say I walk, I run, I open and I close in Latin, produce the he-or-she form of each, name the conjugation each belongs to, and say what a Latin prefix does to the verb it sits on.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "LA-C41-claudo",
+        "kind": "production",
+        "summary": "The chapter closes on claudō: after learning it the reader produces all four first-person forms and all four third-person forms in sequence — ambulō, currō, aperiō, claudō and ambulat, currit, aperit, claudit — reads include/exclude beside accept/except and intellegō as one prefix rule, and so retrieves capiō and intellegō from two and three chapters back, neither of them revisited before now.",
+        "assesses": [
+          "LA-LEX-AMBULO-01",
+          "LA-LEX-CURRO-01",
+          "LA-LEX-APERIO-01",
+          "LA-ETYMON-APERIO-02",
+          "LA-ETYMON-APERIO-OPERIO-03",
+          "LA-LEX-CLAUDO-01",
+          "LA-ETYMON-CLAUDO-02",
+          "LA-LEX-CAPIO-01",
+          "LA-ETYMON-CAPIO-02",
+          "LA-LEX-INTELLEGO-01",
+          "LA-ETYMON-INTELLEGO-02",
+          "LA-ETYMON-SEDEO-02",
+          "LA-ETYMON-INHERITED-VS-BORROWED-03"
         ]
       }
     }

--- a/code/learning/human-languages/latin/curriculum.json
+++ b/code/learning/human-languages/latin/curriculum.json
@@ -364,6 +364,36 @@
         "LA-EXT-027-LANGUAGE-SPECIFIC"
       ],
       "after": []
+    },
+    {
+      "id": "LA-PATH-028",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "LA-C40-audio",
+        "LA-C40-dormio",
+        "LA-C40-sedeo",
+        "LA-C40-sto"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-028-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "LA-PATH-029",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "LA-C41-ambulo",
+        "LA-C41-curro",
+        "LA-C41-aperio",
+        "LA-C41-claudo"
+      ],
+      "before": [],
+      "inline": [
+        "LA-EXT-029-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
     }
   ],
   "spine": {
@@ -493,14 +523,15 @@
       "segments": [
         "LA-PATH-025",
         "LA-PATH-026",
-        "LA-PATH-027"
+        "LA-PATH-027",
+        "LA-PATH-028",
+        "LA-PATH-029"
       ],
       "omits": [
         "VERB-INFINITIVE",
         "VERB-PRESENT-HABITUAL",
         "VERB-DO-MAKE",
         "VERB-SPEAK",
-        "VERB-HEAR",
         "VERB-LEARN",
         "VERB-CAN",
         "VERB-BRING",
@@ -508,20 +539,13 @@
         "VERB-PUT",
         "VERB-EAT",
         "VERB-DRINK",
-        "VERB-SLEEP",
         "VERB-LIVE",
         "VERB-WORK",
         "VERB-PLAY",
-        "VERB-WALK",
-        "VERB-RUN",
-        "VERB-SIT",
-        "VERB-STAND",
         "VERB-WAIT",
         "VERB-ANSWER",
         "VERB-MEET",
-        "VERB-BUY",
-        "VERB-OPEN",
-        "VERB-CLOSE"
+        "VERB-BUY"
       ],
       "relocates": {}
     },
@@ -863,6 +887,34 @@
         "LA-C39-rogo",
         "LA-C39-adiuvo",
         "LA-C39-amo"
+      ]
+    },
+    {
+      "id": "LA-EXT-028-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can produce the present-tense forms of the four Latin verbs of hearing, sleeping, sitting and standing, and tell an English word inherited from the shared ancestor apart from one borrowed out of Latin.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C40-audio",
+        "LA-C40-dormio",
+        "LA-C40-sedeo",
+        "LA-C40-sto"
+      ]
+    },
+    {
+      "id": "LA-EXT-029-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can produce the present-tense forms of the four Latin verbs of walking, running, opening and closing, and say what a Latin prefix does to the verb it sits on.",
+      "prerequisites": [],
+      "lessons": [
+        "LA-C41-ambulo",
+        "LA-C41-curro",
+        "LA-C41-aperio",
+        "LA-C41-claudo"
       ]
     }
   ]

--- a/code/learning/human-languages/latin/lessons/LA-C40-audio.md
+++ b/code/learning/human-languages/latin/lessons/LA-C40-audio.md
@@ -1,0 +1,99 @@
+---
+schema_version: 2
+id: LA-C40-audio
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 800
+chapter: 40
+type: word
+headword: audiō, audīre
+gloss: "I hear" — the verb inside audio, audience and audit, and, less obviously, inside obey
+concept_tag: VERB-HEAR
+prerequisites: [LA-C39-amo, LA-C39-rogo]
+sounds: [macron-long-vowel, macron-none-short-vowel]
+roots: [audire-latin]
+etymology_hook: "audīre ('to hear'), from PIE *au- ('to perceive'), gives audio, audible, audience, audition, auditor, auditorium and audit — a hearing of accounts read aloud — and, through ob-audīre ('to listen toward'), obey, obedient and oyez; the Greek branch of the same root gives aesthetic and anaesthesia, while English hear belongs to a different root entirely"
+duration:
+  max_seconds: 285
+requires:
+  knowledge: [LA-LEX-AMO-01, LA-ETYMON-AMO-02, LA-LEX-ROGO-01]
+introduces:
+  knowledge: [LA-LEX-AUDIO-01, LA-ETYMON-AUDIO-02]
+practises:
+  knowledge: [LA-LEX-AMO-01, LA-ETYMON-AMO-02, LA-LEX-ROGO-01, LA-LEX-AUDIO-01, LA-ETYMON-AUDIO-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: classical
+reviews_of: [LA-C39-amo, LA-C39-rogo]
+---
+
+# audiō — hearing, and the word for obeying
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-AMO-01, LA-ETYMON-AMO-02, LA-LEX-ROGO-01] -->
+
+[PAUSE 2s] The last chapter ended on **amō**, whose trail stopped early — no
+secure ancient root to walk back to. This verb is the opposite case: its
+trail runs all the way back, and forward into a surprising English word. It
+is also the natural partner of **rogō**: you ask, and then you hear.
+
+## You'll want to know: audiō — "I hear"
+<!-- hl-knowledge: introduces=[LA-LEX-AUDIO-01]; assesses=[] -->
+
+**Audiō** means "**I hear**," and also "I listen to." The dictionary form is
+**audīre**. The *au* is one sound, close to English *ow* in "now."
+
+- **audiō** — I hear
+- **audīs** — you hear, to one person
+- **audit** — he hears, she hears
+- **audīmus** — we hear
+- **audītis** — you hear, to several people
+- **audiunt** — they hear
+
+This is a **fourth-conjugation** verb — the group whose dictionary form ends
+in **-īre**. Note the "they" form: **audiunt**, with a *u* slipped in.
+
+## The word, taken apart: hearing, obeying, and a false relative
+<!-- hl-knowledge: introduces=[LA-ETYMON-AUDIO-02]; assesses=[] -->
+
+The root is Proto-Indo-European ***\*au-***, "to perceive." Latin built
+*audīre* on it, and English borrowed the results wholesale: **audio**,
+**audible**, **audience**, **audition**, **auditor**, **auditorium**.
+
+**Audit** is the best of them. An audit was literally a *hearing*: accounts
+were read out loud and checked by ear, long before anyone checked them by
+eye. The word kept the procedure and lost the sound.
+
+Now the one nobody guesses. Put *ob-* ("toward") in front of *audīre* and
+Latin gives *oboedīre*, "to listen toward" — which through French becomes
+English **obey**, **obedient** and **disobey**. To obey is to listen hard at
+someone. The town crier's **oyez** is the same verb, an Old French
+imperative: "hear ye."
+
+The Greek branch of ***\*au-*** produced words for perceiving in general:
+**aesthetic**, and **anaesthesia**, "no perception at all."
+
+One flag. English **hear** is *not* a relative. It is Germanic, from another
+root — the one that also gives Greek *akoúein* and so English **acoustic**.
+*Audio* and *acoustic* mean nearly the same thing and are not cousins.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-AMO-01, LA-LEX-ROGO-01, LA-LEX-AUDIO-01, LA-ETYMON-AUDIO-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: "audiō" — I hear]
+- [YOU SAY: "audīs, audit" — you hear, he or she hears]
+- [YOU SAY: "audīmus, audītis, audiunt" — we, you all, they]
+- [YOU SAY: the pair from the last chapter beside it — rogō, amō]
+- [YOU SAY: the English relatives — audience, audit, obey]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-AMO-01, LA-ETYMON-AMO-02, LA-LEX-ROGO-01, LA-LEX-AUDIO-01, LA-ETYMON-AUDIO-02] -->
+
+[PAUSE 3s] How does Latin say "I hear"? (**Audiō**.) "They hear"?
+(**Audiunt**.) Which conjugation is it? (**The fourth** — the *-īre* group.)
+What was an **audit** originally, and which everyday word is *ob-* plus
+*audīre*? (**A hearing**, accounts read aloud — and **obey**.) Which verb
+from the last chapter had no securely reconstructed root, and which one
+means "I ask"? (**Amō**, and **rogō**.)

--- a/code/learning/human-languages/latin/lessons/LA-C40-dormio.md
+++ b/code/learning/human-languages/latin/lessons/LA-C40-dormio.md
@@ -1,0 +1,100 @@
+---
+schema_version: 2
+id: LA-C40-dormio
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 810
+chapter: 40
+type: word
+headword: dormiō, dormīre
+gloss: "I sleep" — the verb behind dormitory and dormant, and the one word English may only look as though it borrowed
+concept_tag: VERB-SLEEP
+prerequisites: [LA-C40-audio]
+sounds: [macron-long-vowel, macron-none-short-vowel]
+roots: [dormire-latin]
+etymology_hook: "dormīre ('to sleep') is from PIE *drem-, the root behind Sanskrit and Greek sleep-words, and gives dormitory, dorm, dormant and dormer; the unrelated noun somnus supplies insomnia, somnolent and soporific, while dormouse only looks like a member of the family and is not securely one"
+duration:
+  max_seconds: 285
+requires:
+  knowledge: [LA-LEX-AUDIO-01, LA-ETYMON-AUDIO-02, LA-LEX-VIDEO-01]
+introduces:
+  knowledge: [LA-LEX-DORMIO-01, LA-ETYMON-DORMIO-02]
+practises:
+  knowledge: [LA-LEX-AUDIO-01, LA-ETYMON-AUDIO-02, LA-LEX-VIDEO-01, LA-LEX-DORMIO-01, LA-ETYMON-DORMIO-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: classical
+reviews_of: [LA-C40-audio, LA-C37-video]
+---
+
+# dormiō — the verb you do with your senses off
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-AUDIO-01, LA-ETYMON-AUDIO-02, LA-LEX-VIDEO-01] -->
+
+[PAUSE 2s] **Audiō** is hearing; **videō**, from an earlier chapter, is
+seeing. This verb is the state in which you do neither.
+
+## You'll want to know: dormiō — "I sleep"
+<!-- hl-knowledge: introduces=[LA-LEX-DORMIO-01]; assesses=[] -->
+
+**Dormiō** means "**I sleep**." The dictionary form is **dormīre**. The
+first *o* is short, the *ī* of *dormīre* is long: *dor-MEE-reh*.
+
+- **dormiō** — I sleep
+- **dormīs** — you sleep, to one person
+- **dormit** — he sleeps, she sleeps
+- **dormīmus** — we sleep
+- **dormītis** — you sleep, to several people
+- **dormiunt** — they sleep
+
+This is the same **fourth conjugation** as the verb before it, and it takes
+the same endings — including that *u* in **dormiunt**. Two verbs in the
+group is enough to hear the pattern.
+
+## The word, taken apart: two words for sleep, only one of them yours
+<!-- hl-knowledge: introduces=[LA-ETYMON-DORMIO-02]; assesses=[] -->
+
+The root is Proto-Indo-European ***\*drem-***, "to sleep." It is a quiet
+root: Sanskrit *drāti*, Greek *darthánein*, Old Church Slavonic *drěmati*.
+Latin *dormīre* is the western member, and English inherited none of it —
+every English word here is a loan.
+
+Borrowed whole: **dormitory** (*dormītōrium*, "a sleeping place"), and its
+clipped form *dorm*. **Dormant**, from French, is a thing that is sleeping
+rather than dead. A **dormer** window began as the window of a sleeping
+room.
+
+Now a warning, because this one is a trap dressed as a gift. **Dormouse**
+looks like the perfect example and is not securely one. The animal's name
+is attested in English before the French word for a sleeper it is supposed
+to come from, and the *-mouse* half may simply be English speakers making
+sense of a syllable they did not recognise. A hook you have to defend is
+not a hook.
+
+Latin's other word for sleep is the noun **somnus**, from a different root
+entirely, and English took plenty from that too: **insomnia** ("no sleep"),
+**somnolent**, and **soporific**. So the two Latin sleep-words divided the
+English vocabulary between them: the verb gave the rooms you sleep in, the
+noun gave the sleep itself.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-AUDIO-01, LA-LEX-VIDEO-01, LA-LEX-DORMIO-01, LA-ETYMON-DORMIO-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: "dormiō" — I sleep]
+- [YOU SAY: "dormīs, dormit" — you sleep, he or she sleeps]
+- [YOU SAY: "dormīmus, dormītis, dormiunt" — we, you all, they]
+- [YOU SAY: the two senses this verb switches off — audiō, videō]
+- [YOU SAY: the English relatives — dormitory, dormant]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-AUDIO-01, LA-ETYMON-AUDIO-02, LA-LEX-VIDEO-01, LA-LEX-DORMIO-01, LA-ETYMON-DORMIO-02] -->
+
+[PAUSE 3s] How does Latin say "I sleep"? (**Dormiō**.) "They sleep"?
+(**Dormiunt**.) Which conjugation, and which other verb shares it here?
+(**The fourth** — with **audiō**.) Why is **dormouse** not a safe example?
+(**Because the connection is not secure** — the English word is older than
+the French one it supposedly comes from.) Which Latin noun gives **insomnia**,
+and which verb means "I see"? (**Somnus**, and **videō**.)

--- a/code/learning/human-languages/latin/lessons/LA-C40-sedeo.md
+++ b/code/learning/human-languages/latin/lessons/LA-C40-sedeo.md
@@ -1,0 +1,101 @@
+---
+schema_version: 2
+id: LA-C40-sedeo
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 820
+chapter: 40
+type: word
+headword: sedeō, sedēre
+gloss: "I sit" — the verb that is English *sit* by descent and English *session* by loan, and the clearest case of the difference
+concept_tag: VERB-SIT
+prerequisites: [LA-C40-dormio, LA-C39-capio]
+sounds: [macron-long-vowel, macron-none-short-vowel]
+roots: [sedere-latin]
+etymology_hook: "sedēre ('to sit') is from PIE *sed-, which English inherited independently as sit, seat, set, settle, saddle, nest and soot, and which English also borrowed back through Latin as session, sedentary, sediment, preside, reside, subside, dissident, assiduous, possess and siege — so sit and session are the same ancient word arriving by two roads"
+duration:
+  max_seconds: 285
+requires:
+  knowledge: [LA-LEX-DORMIO-01, LA-ETYMON-DORMIO-02, LA-LEX-AUDIO-01, LA-ETYMON-CAPIO-02]
+introduces:
+  knowledge: [LA-LEX-SEDEO-01, LA-ETYMON-SEDEO-02, LA-ETYMON-INHERITED-VS-BORROWED-03]
+practises:
+  knowledge: [LA-LEX-DORMIO-01, LA-ETYMON-DORMIO-02, LA-LEX-AUDIO-01, LA-ETYMON-CAPIO-02, LA-LEX-SEDEO-01, LA-ETYMON-SEDEO-02, LA-ETYMON-INHERITED-VS-BORROWED-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: classical
+reviews_of: [LA-C40-dormio, LA-C40-audio, LA-C39-capio]
+---
+
+# sedeō — the same word English already had
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-DORMIO-01, LA-ETYMON-DORMIO-02, LA-LEX-AUDIO-01] -->
+
+[PAUSE 2s] **Dormīre** left English nothing but loans. This verb is the
+reverse, and it lets us name a distinction the course has been using without
+stating it.
+
+## You'll want to know: sedeō — "I sit"
+<!-- hl-knowledge: introduces=[LA-LEX-SEDEO-01]; assesses=[] -->
+
+**Sedeō** means "**I sit**," and also "I stay put." The dictionary form is
+**sedēre**, with a long *ē*.
+
+- **sedeō** — I sit
+- **sedēs** — you sit, to one person
+- **sedet** — he sits, she sits
+- **sedēmus** — we sit
+- **sedētis** — you sit, to several people
+- **sedent** — they sit
+
+This one is **second conjugation** — the *-ēre* group. That long *ē* is the
+whole signal, so give it room.
+
+## The word, taken apart: inherited and borrowed are not the same thing
+<!-- hl-knowledge: introduces=[LA-ETYMON-SEDEO-02, LA-ETYMON-INHERITED-VS-BORROWED-03]; assesses=[LA-ETYMON-CAPIO-02] -->
+
+The root is Proto-Indo-European ***\*sed-***, "to sit," and English has it
+by two different routes — which is the point.
+
+**Inherited**, down the Germanic line, with no Latin involved: **sit**,
+**seat**, **set** ("cause to sit"), **settle**, **saddle**. Two are hidden:
+**nest** is "the place where one sits down," and **soot** is what settles.
+
+**Borrowed**, later, out of Latin *sedēre*: **session**, **sedentary**,
+**sediment**, **sedate**, **preside**, **reside**, **dissident** ("sitting
+apart"), **assiduous** ("sitting at it"), **possess**. **Siege** is a seat
+too — an army sitting down in front of a town.
+
+Hold the two apart. An **inherited** word came down to English from the
+shared ancestor without passing through Latin; a **borrowed** word was taken
+out of Latin, usually centuries later. *Sit* and *session* are one ancient
+word by two roads, and they look nothing alike because one wore down for
+three thousand years while the other was copied out of a book. You met this
+shape when **capiō** turned out to be the true relative of English *have*,
+with the borrowed *capture* beside it.
+
+One flag. **Sedan** is often attached to *sedēre*, and the connection is
+not established. Leave it out.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-DORMIO-01, LA-LEX-AUDIO-01, LA-LEX-SEDEO-01, LA-ETYMON-SEDEO-02, LA-ETYMON-INHERITED-VS-BORROWED-03] -->
+
+[PAUSE 1s]
+- [YOU SAY: "sedeō" — I sit, long ē in sedēre]
+- [YOU SAY: "sedēs, sedet" — you sit, he or she sits]
+- [YOU SAY: "sedēmus, sedētis, sedent" — we, you all, they]
+- [YOU SAY: the three verbs of this chapter so far — audiō, dormiō, sedeō]
+- [YOU SAY: the inherited word, then the borrowed one — sit, session]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-DORMIO-01, LA-ETYMON-DORMIO-02, LA-LEX-AUDIO-01, LA-ETYMON-CAPIO-02, LA-LEX-SEDEO-01, LA-ETYMON-SEDEO-02, LA-ETYMON-INHERITED-VS-BORROWED-03] -->
+
+[PAUSE 3s] How does Latin say "I sit"? (**Sedeō**.) "They sit"?
+(**Sedent**.) Which conjugation? (**The second** — the long *-ēre* group.)
+Is English **sit** borrowed from Latin, and what about **session**?
+(**Sit is inherited**, by a different road; **session is borrowed**.) Which
+earlier verb showed that same shape, and why is **dormouse** not usable that
+way? (**Capiō** — cousin of *have*, source of *capture*; and *dormouse*'s
+link to sleeping is not secure.)

--- a/code/learning/human-languages/latin/lessons/LA-C40-sto.md
+++ b/code/learning/human-languages/latin/lessons/LA-C40-sto.md
@@ -1,0 +1,103 @@
+---
+schema_version: 2
+id: LA-C40-sto
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 830
+chapter: 40
+type: word
+headword: stō, stāre
+gloss: "I stand" — the shortest verb in the chapter and the most productive in English, and the fourth of four
+concept_tag: VERB-STAND
+prerequisites: [LA-C40-sedeo, LA-C37-sum, LA-C37-eo]
+sounds: [macron-long-vowel, macron-none-short-vowel]
+roots: [stare-latin]
+etymology_hook: "stāre ('to stand') is from PIE *sta-, which English inherited as stand, stead, steed, stall and stool and borrowed back as station, statue, status, state, stable, estate, stage, substance, circumstance, obstacle, constant, instant and distance — and, through constāre and restāre, cost and rest; the reduplicated Latin sistere adds consist, resist, insist and assist"
+duration:
+  max_seconds: 285
+requires:
+  knowledge: [LA-LEX-SEDEO-01, LA-ETYMON-SEDEO-02, LA-ETYMON-INHERITED-VS-BORROWED-03, LA-LEX-AUDIO-01, LA-LEX-DORMIO-01, LA-LEX-SUM-01, LA-ETYMON-SUM-02, LA-LEX-EO-01, LA-ETYMON-EO-02]
+introduces:
+  knowledge: [LA-LEX-STO-01, LA-ETYMON-STO-02]
+practises:
+  knowledge: [LA-LEX-AUDIO-01, LA-LEX-DORMIO-01, LA-LEX-SEDEO-01, LA-ETYMON-SEDEO-02, LA-ETYMON-INHERITED-VS-BORROWED-03, LA-LEX-STO-01, LA-ETYMON-STO-02, LA-LEX-SUM-01, LA-ETYMON-SUM-02, LA-LEX-EO-01, LA-ETYMON-EO-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: classical
+reviews_of: [LA-C40-sedeo, LA-C40-audio, LA-C40-dormio, LA-C37-sum, LA-C37-eo]
+---
+
+# stō — standing, and the four together
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-SEDEO-01, LA-ETYMON-INHERITED-VS-BORROWED-03, LA-LEX-AUDIO-01, LA-LEX-DORMIO-01] -->
+
+[PAUSE 2s] Three verbs so far: hearing, sleeping, sitting. One remains. It
+is the opposite of the last, and it shows the inherited-and-borrowed pattern
+**sedeō** just taught all over.
+
+## You'll want to know: stō — "I stand"
+<!-- hl-knowledge: introduces=[LA-LEX-STO-01]; assesses=[] -->
+
+**Stō** means "**I stand**," and by extension "I stay." The dictionary form
+is **stāre**. Two letters in the "I" form makes it the shortest verb you
+have met.
+
+- **stō** — I stand
+- **stās** — you stand, to one person
+- **stat** — he stands, she stands
+- **stāmus** — we stand
+- **stātis** — you stand, to several people
+- **stant** — they stand
+
+This is **first conjugation**, the *-āre* group, and in the present tense
+perfectly regular: the long *ā* runs through every form after the first.
+
+## The word, taken apart: the most productive root in the book
+<!-- hl-knowledge: introduces=[LA-ETYMON-STO-02]; assesses=[LA-ETYMON-SEDEO-02, LA-ETYMON-INHERITED-VS-BORROWED-03, LA-LEX-SUM-01, LA-ETYMON-SUM-02, LA-LEX-EO-01, LA-ETYMON-EO-02] -->
+
+The root is Proto-Indo-European ***\*sta-***, "to stand." Sort the English
+by the two roads that gave *sit* and *session*.
+
+**Inherited**: **stand** — with an extra *n* wedged into the middle, which
+is why it looks unlike *stō* — plus **stead** (as in *instead*), **steed**,
+**stall** and **stool**.
+
+**Borrowed** from *stāre*: **station**, **statue**, **status**, **state**,
+**stable**, **estate**, **stage**, **substance**, **circumstance**
+("standing around"), **obstacle** ("standing in the way"), **constant**,
+**instant**, **distance**. Two are so worn down they hide: *constāre*, "to
+stand at a price," is English **cost**, and *restāre*, "to stand back," is
+the **rest** that means the remainder. The doubled-up *sistere* gives
+**consist**, **resist**, **insist** and **assist**.
+
+Set this beside the verb for being. **Sum** and **est** are inherited
+cousins of English *am* and *is* — the same two-road picture, only there the
+English side kept the meaning exactly. And set it against **eō**, "I go":
+*stāre* is what you do when you are not going, and English holds both
+halves, *station* from this verb and *exit* from that one.
+
+One flag. English **still** is often thrown in here and does not belong.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-AUDIO-01, LA-LEX-DORMIO-01, LA-LEX-SEDEO-01, LA-LEX-STO-01, LA-ETYMON-STO-02, LA-LEX-SUM-01, LA-LEX-EO-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: "stō, stās, stat" — I stand, you stand, he or she stands]
+- [YOU SAY: this chapter's four "I" forms — audiō, dormiō, sedeō, stō]
+- [YOU SAY: the four "he or she" forms — audit, dormit, sedet, stat]
+- [YOU SAY: the two from an earlier chapter beside them — sum, eō]
+- [YOU SAY: inherited, then borrowed — stand, station]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-AUDIO-01, LA-LEX-DORMIO-01, LA-LEX-SEDEO-01, LA-ETYMON-SEDEO-02, LA-ETYMON-INHERITED-VS-BORROWED-03, LA-LEX-STO-01, LA-ETYMON-STO-02, LA-LEX-SUM-01, LA-ETYMON-SUM-02, LA-LEX-EO-01, LA-ETYMON-EO-02] -->
+
+[PAUSE 3s] Give this chapter's four "I" forms. (**Audiō, dormiō, sedeō,
+stō**.) Now the four "he or she" forms. (**Audit, dormit, sedet, stat**.)
+Which of the four is second conjugation? (**Sedeō** — the long *-ēre*
+group.) Which English word for standing is inherited, which is borrowed, and
+what is **cost** taken apart? (**Stand** inherited, **station** borrowed;
+*constāre*, what a thing stands at.) Which earlier verb has *am* and *is* as
+its inherited English cousins, and which one means "I go"? (**Sum**, and
+**eō** — the verb behind *exit*.)

--- a/code/learning/human-languages/latin/lessons/LA-C41-ambulo.md
+++ b/code/learning/human-languages/latin/lessons/LA-C41-ambulo.md
@@ -1,0 +1,102 @@
+---
+schema_version: 2
+id: LA-C41-ambulo
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 840
+chapter: 41
+type: word
+headword: ambulō, ambulāre
+gloss: "I walk" — the verb behind ambulance, preamble and the pram, and a rare case where the front half is clear and the back half is not
+concept_tag: VERB-WALK
+prerequisites: [LA-C40-sto]
+sounds: [macron-long-vowel, macron-none-short-vowel]
+roots: [ambulare-latin]
+etymology_hook: "ambulāre ('to walk about') is amb- ('around') plus a second element usually connected with a root meaning 'to wander', though that half is not settled; it gives amble, ambulatory, ambulance (from a walking field hospital), preamble, perambulator and pram, circumambulate, funambulist and somnambulist, while English walk is Germanic and unrelated"
+duration:
+  max_seconds: 285
+requires:
+  knowledge: [LA-LEX-STO-01, LA-ETYMON-STO-02, LA-LEX-SEDEO-01]
+introduces:
+  knowledge: [LA-LEX-AMBULO-01, LA-ETYMON-AMBULO-02]
+practises:
+  knowledge: [LA-LEX-STO-01, LA-ETYMON-STO-02, LA-LEX-SEDEO-01, LA-LEX-AMBULO-01, LA-ETYMON-AMBULO-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: classical
+reviews_of: [LA-C40-sto, LA-C40-sedeo]
+---
+
+# ambulō — walking about
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-STO-01, LA-ETYMON-STO-02, LA-LEX-SEDEO-01] -->
+
+[PAUSE 2s] The last chapter left you sitting and standing — **sedeō** and
+**stō**, both of them staying put. This chapter moves.
+
+## You'll want to know: ambulō — "I walk"
+<!-- hl-knowledge: introduces=[LA-LEX-AMBULO-01]; assesses=[] -->
+
+**Ambulō** means "**I walk**," with a flavour of walking *about* rather than
+walking *to* somewhere. The dictionary form is **ambulāre**.
+
+- **ambulō** — I walk
+- **ambulās** — you walk, to one person
+- **ambulat** — he walks, she walks
+- **ambulāmus** — we walk
+- **ambulātis** — you walk, to several people
+- **ambulant** — they walk
+
+Like **stō**, this is **first conjugation** — the *-āre* group — with the
+same endings hung on a longer stem.
+
+## The word, taken apart: a clear front, a doubtful back, a huge harvest
+<!-- hl-knowledge: introduces=[LA-ETYMON-AMBULO-02]; assesses=[] -->
+
+Start with the honest limit, because this word has one. The front half is
+secure: *amb-*, "around," the same element as in *ambi-*.
+The back half is not settled — usually connected with an old root meaning
+"to wander" or "to go," but the join has never been nailed down, so the
+standard gloss is a reasonable guess rather than a proof.
+
+The harvest is not in doubt at all. **Amble** came through French and kept
+the leisurely sense exactly. **Ambulatory** is both an adjective and the
+walking-gallery of a church. **Perambulate** gave the Victorian
+**perambulator** and, clipped, the **pram**. A **preamble** walks in front
+(*prae-*, "before").
+
+Two compounds are worth saying out loud. A **funambulist** walks a rope
+(*fūnis*). A **somnambulist** walks in sleep — and *somnus* is the Latin
+sleep-noun named in the last chapter, so that word is two pieces you already
+have.
+
+The best is **ambulance**. A French military hospital that followed the army
+instead of waiting for it was an *hôpital ambulant* — a walking hospital.
+English took the second word and forgot the first, so the vehicle is named
+for moving.
+
+Two flags. English **walk** is Germanic and no relation. And French *aller*,
+"to go" — with **alley** behind it — is often derived from *ambulāre* by
+heavy wear, but that derivation is disputed. Do not lean on it.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-STO-01, LA-LEX-SEDEO-01, LA-LEX-AMBULO-01, LA-ETYMON-AMBULO-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: "ambulō" — I walk]
+- [YOU SAY: "ambulās, ambulat" — you walk, he or she walks]
+- [YOU SAY: "ambulāmus, ambulātis, ambulant" — we, you all, they]
+- [YOU SAY: the two still verbs it moves away from — sedeō, stō]
+- [YOU SAY: the English relatives — amble, preamble, ambulance]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-STO-01, LA-ETYMON-STO-02, LA-LEX-SEDEO-01, LA-LEX-AMBULO-01, LA-ETYMON-AMBULO-02] -->
+
+[PAUSE 3s] How does Latin say "I walk"? (**Ambulō**.) "They walk"?
+(**Ambulant**.) Which conjugation, and which earlier verb shares it? (**The
+first**, the *-āre* group — with **stō**.) Which half of the word is
+uncertain, and why is a vehicle called an **ambulance**? (**The back half**;
+and because the hospital walked — it followed the army.) Which verb means
+"I sit"? (**Sedeō**.)

--- a/code/learning/human-languages/latin/lessons/LA-C41-aperio.md
+++ b/code/learning/human-languages/latin/lessons/LA-C41-aperio.md
@@ -1,0 +1,104 @@
+---
+schema_version: 2
+id: LA-C41-aperio
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 860
+chapter: 41
+type: word
+headword: aperiō, aperīre
+gloss: "I open" — half of a matched pair, built from one root with two opposite prefixes
+concept_tag: VERB-OPEN
+prerequisites: [LA-C41-curro]
+sounds: [macron-long-vowel, macron-none-short-vowel]
+roots: [aperire-latin]
+etymology_hook: "aperīre ('to open') is analysed as ap- ('off, away') on a root *wer- meaning 'to cover', so it literally un-covers; its exact opposite operīre ('to shut') is op- ('over') on the same root, and English holds both halves — aperture, aperitif, overt and overture from the first, and cover, covert, discover, curfew and kerchief from the second; the old link between aperīre and April is folk etymology"
+duration:
+  max_seconds: 285
+requires:
+  knowledge: [LA-LEX-CURRO-01, LA-ETYMON-CURRO-02, LA-LEX-AMBULO-01]
+introduces:
+  knowledge: [LA-LEX-APERIO-01, LA-ETYMON-APERIO-02, LA-ETYMON-APERIO-OPERIO-03]
+practises:
+  knowledge: [LA-LEX-CURRO-01, LA-ETYMON-CURRO-02, LA-LEX-AMBULO-01, LA-LEX-APERIO-01, LA-ETYMON-APERIO-02, LA-ETYMON-APERIO-OPERIO-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: classical
+reviews_of: [LA-C41-curro, LA-C41-ambulo]
+---
+
+# aperiō — to un-cover
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-CURRO-01, LA-ETYMON-CURRO-02, LA-LEX-AMBULO-01] -->
+
+[PAUSE 2s] **Currō** showed one root reaching English by two roads. This
+verb shows something rarer: one root standing inside two Latin words that
+mean the opposite of each other.
+
+## You'll want to know: aperiō — "I open"
+<!-- hl-knowledge: introduces=[LA-LEX-APERIO-01]; assesses=[] -->
+
+**Aperiō** means "**I open**," and also "I uncover, I reveal." The
+dictionary form is **aperīre**, with a long *ī*.
+
+- **aperiō** — I open
+- **aperīs** — you open, to one person
+- **aperit** — he opens, she opens
+- **aperīmus** — we open
+- **aperītis** — you open, to several people
+- **aperiunt** — they open
+
+This is **fourth conjugation**, the *-īre* group, and it takes exactly the
+endings **audiō** and **dormiō** took — including that *u* before the ending
+in **aperiunt**.
+
+## The word, taken apart: one root, two prefixes, two opposite verbs
+<!-- hl-knowledge: introduces=[LA-ETYMON-APERIO-02, LA-ETYMON-APERIO-OPERIO-03]; assesses=[] -->
+
+*Aperīre* is taken apart as *ap-*, "off, away," welded onto an old root
+***\*wer-*** meaning "to cover." To open, in Latin, is to cover *away*.
+
+Now the elegant part. Latin has a second verb on the very same root:
+**operīre**, "to cover, to shut" — *op-*, "over," on *\*wer-*. The two verbs
+differ in one syllable at the front, and that syllable turns covering into
+uncovering:
+
+- **aperīre** — cover *away* → open
+- **operīre** — cover *over* → shut
+
+English took both halves and never noticed they were a pair. From the
+opening verb: **aperture**, an opening; **aperitif**, the drink that opens
+a meal; and, worn down through French *ouvrir*, **overt** and **overture**.
+From the shutting verb, mostly with *co-* in front (*cooperīre*, "to cover
+completely"): **cover**, **covert**, and **discover**, which is *dis-*
+undoing the covering. Two French phrases came in whole: a **curfew** is
+*couvre-feu*, "cover the fire," and a **kerchief** is *couvre-chef*.
+
+Two honest notes. The Vulgar Latin descendants of these verbs blurred into
+each other, which is why French *ouvrir* and *couvrir* rhyme today. And
+**April** — you will see it explained as "the opening month," from
+*aperīre*. That is folk etymology; the real origin is unsettled.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-CURRO-01, LA-LEX-AMBULO-01, LA-LEX-APERIO-01, LA-ETYMON-APERIO-02, LA-ETYMON-APERIO-OPERIO-03] -->
+
+[PAUSE 1s]
+- [YOU SAY: "aperiō" — I open]
+- [YOU SAY: "aperīs, aperit" — you open, he or she opens]
+- [YOU SAY: "aperīmus, aperītis, aperiunt" — we, you all, they]
+- [YOU SAY: the pair, and what each prefix does — aperīre, cover away;
+  operīre, cover over]
+- [YOU SAY: the chapter so far — ambulō, currō, aperiō]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-CURRO-01, LA-ETYMON-CURRO-02, LA-LEX-AMBULO-01, LA-LEX-APERIO-01, LA-ETYMON-APERIO-02, LA-ETYMON-APERIO-OPERIO-03] -->
+
+[PAUSE 3s] How does Latin say "I open", and how "they open"? (**Aperiō**,
+**aperiunt**.) Which conjugation, and what does *aperīre* literally say?
+(**The fourth**, the *-īre* group; and **cover away** — un-cover.)
+What is its opposite, and what does that prefix change? (***Operīre*** —
+*op-*, "over," so cover *over*.) Which English word is *couvre-feu*, is
+**April** from this verb, and which verb means "I run"? (**Curfew**;
+**no**, that is folk etymology; and **currō**.)

--- a/code/learning/human-languages/latin/lessons/LA-C41-claudo.md
+++ b/code/learning/human-languages/latin/lessons/LA-C41-claudo.md
@@ -1,0 +1,101 @@
+---
+schema_version: 2
+id: LA-C41-claudo
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 870
+chapter: 41
+type: word
+headword: claudō, claudere
+gloss: "I close" — the word English calls *close*, and the fourth of four
+concept_tag: VERB-CLOSE
+prerequisites: [LA-C41-aperio, LA-C39-capio, LA-C38-intellego]
+sounds: [macron-none-short-vowel, c-as-k]
+roots: [claudere-latin]
+etymology_hook: "claudere ('to shut') is from PIE *klau-, 'hook, peg' — the thing you bolt a door with — and gives close itself, plus closet, closure, disclose, clause, cloister, include, exclude, conclude, preclude, recluse and sluice; the sister noun clāvis ('key') adds clavicle, clef and conclave, and Greek kleís is the same inherited word, meaning both key and collarbone"
+duration:
+  max_seconds: 285
+requires:
+  knowledge: [LA-LEX-APERIO-01, LA-ETYMON-APERIO-02, LA-ETYMON-APERIO-OPERIO-03, LA-LEX-AMBULO-01, LA-LEX-CURRO-01, LA-LEX-CAPIO-01, LA-ETYMON-CAPIO-02, LA-LEX-INTELLEGO-01, LA-ETYMON-INTELLEGO-02, LA-ETYMON-SEDEO-02, LA-ETYMON-INHERITED-VS-BORROWED-03]
+introduces:
+  knowledge: [LA-LEX-CLAUDO-01, LA-ETYMON-CLAUDO-02]
+practises:
+  knowledge: [LA-LEX-AMBULO-01, LA-LEX-CURRO-01, LA-LEX-APERIO-01, LA-ETYMON-APERIO-02, LA-ETYMON-APERIO-OPERIO-03, LA-LEX-CLAUDO-01, LA-ETYMON-CLAUDO-02, LA-LEX-CAPIO-01, LA-ETYMON-CAPIO-02, LA-LEX-INTELLEGO-01, LA-ETYMON-INTELLEGO-02, LA-ETYMON-SEDEO-02, LA-ETYMON-INHERITED-VS-BORROWED-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: classical
+reviews_of: [LA-C41-aperio, LA-C41-ambulo, LA-C41-curro, LA-C39-capio, LA-C38-intellego]
+---
+
+# claudō — closing, and the four together
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-APERIO-01, LA-ETYMON-APERIO-02, LA-ETYMON-APERIO-OPERIO-03, LA-LEX-AMBULO-01, LA-LEX-CURRO-01] -->
+
+[PAUSE 2s] **Aperiō** opened by covering *away*, and named its own Latin
+opposite. But that opposite is not the verb a Roman reached for to shut a
+door. This one is, and it is the word English says every day.
+
+## You'll want to know: claudō — "I close"
+<!-- hl-knowledge: introduces=[LA-LEX-CLAUDO-01]; assesses=[] -->
+
+**Claudō** means "**I close**," "I shut in." The dictionary form is
+**claudere**. The *au* is one sound, as in **audiō**; the *c* is hard:
+*KLOW-deh-reh*.
+
+- **claudō** — I close
+- **claudis** — you close, to one person
+- **claudit** — he closes, she closes
+- **claudimus** — we close
+- **clauditis** — you close, to several people
+- **claudunt** — they close
+
+Like **currō**, this is **third conjugation** — short *-ere*. That is three
+classes across this chapter's four verbs, worth noticing and not worth
+memorising: the class only tells you the endings.
+
+## The word, taken apart: the word you already say
+<!-- hl-knowledge: introduces=[LA-ETYMON-CLAUDO-02]; assesses=[LA-LEX-CAPIO-01, LA-ETYMON-CAPIO-02, LA-LEX-INTELLEGO-01, LA-ETYMON-INTELLEGO-02, LA-ETYMON-SEDEO-02, LA-ETYMON-INHERITED-VS-BORROWED-03] -->
+
+The root is Proto-Indo-European ***\*klau-***, and it did not mean "shut."
+It meant **hook** or **peg** — the crooked wood you jam a door with. The
+action is named after the object, and Latin kept it: *clāvis*, "key."
+
+English **close** is this verb. Not a cousin — the verb itself, borrowed
+through French from *clausum*. That matters, because you learned to sort the
+two ways apart: **sit** was inherited, **session** was a loan. *Close* is a
+loan that stopped looking like one. Beside it stand **closet**, **closure**,
+**disclose**, and the noun **clause**. A **cloister** is a *claustrum*, a
+bolted place, and **sluice** is *exclūsa*, "water shut out."
+
+Then the prefixes, where the chapter's two halves meet. *Claudere* takes
+them by the handful: **include**, **exclude**, **conclude**, **preclude**,
+**recluse**. Set *include* and *exclude* beside **accept** and **except** —
+the same two prefixes on *capere*. Set them beside **intellegō**, where
+*inter-* turns picking into understanding. A prefix carries the meaning.
+
+From *clāvis*, the key: **clavicle** (a little key — the collarbone),
+**clef**, and **conclave**, a room locked *with a key*. Greek *kleís* is the
+same inherited word and means both those things too.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-AMBULO-01, LA-LEX-CURRO-01, LA-LEX-APERIO-01, LA-LEX-CLAUDO-01, LA-ETYMON-CLAUDO-02, LA-LEX-CAPIO-01, LA-LEX-INTELLEGO-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: "claudō, claudis, claudit" — I close, you close, he or she closes]
+- [YOU SAY: this chapter's four "I" forms — ambulō, currō, aperiō, claudō]
+- [YOU SAY: the four "he or she" forms — ambulat, currit, aperit, claudit]
+- [YOU SAY: two prefixes, two verbs — include, exclude; accept, except]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-AMBULO-01, LA-LEX-CURRO-01, LA-LEX-APERIO-01, LA-ETYMON-APERIO-02, LA-ETYMON-APERIO-OPERIO-03, LA-LEX-CLAUDO-01, LA-ETYMON-CLAUDO-02, LA-LEX-CAPIO-01, LA-ETYMON-CAPIO-02, LA-LEX-INTELLEGO-01, LA-ETYMON-INTELLEGO-02, LA-ETYMON-SEDEO-02, LA-ETYMON-INHERITED-VS-BORROWED-03] -->
+
+[PAUSE 3s] Give this chapter's four "I" forms, then the four "he or she"
+forms. (**Ambulō, currō, aperiō, claudō**; **ambulat, currit, aperit,
+claudit**.) Which two share the third conjugation? (**Currō and claudō**.)
+Is English **close** inherited or borrowed, and what did the root name?
+(**Borrowed** — this Latin verb itself; and a **hook or peg**.) Which verb
+gives **accept** and **except**, the same prefixes as *include* and
+*exclude*, and which is *inter-* plus "to pick out"? (**Capiō**, and
+**intellegō**.)

--- a/code/learning/human-languages/latin/lessons/LA-C41-curro.md
+++ b/code/learning/human-languages/latin/lessons/LA-C41-curro.md
@@ -1,0 +1,102 @@
+---
+schema_version: 2
+id: LA-C41-curro
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 850
+chapter: 41
+type: word
+headword: currō, currere
+gloss: "I run" — the verb inside current, curriculum, courier and corridor, and, by way of a Celtic wagon, inside car
+concept_tag: VERB-RUN
+prerequisites: [LA-C41-ambulo, LA-C37-venio]
+sounds: [macron-none-short-vowel, c-as-k]
+roots: [currere-latin]
+etymology_hook: "currere ('to run') is from PIE *kers-, and gives current, currency, curriculum ('a racecourse'), cursor, cursive, course, discourse, occur, recur, excursion, precursor, succour and corridor; the same root reached Latin a second time as the Gaulish loan carrus ('wagon'), which supplies car, carry, cargo, charge, carriage, career and carpenter"
+duration:
+  max_seconds: 285
+requires:
+  knowledge: [LA-LEX-AMBULO-01, LA-ETYMON-AMBULO-02, LA-LEX-STO-01, LA-LEX-VENIO-01, LA-ETYMON-VENIO-02]
+introduces:
+  knowledge: [LA-LEX-CURRO-01, LA-ETYMON-CURRO-02]
+practises:
+  knowledge: [LA-LEX-AMBULO-01, LA-ETYMON-AMBULO-02, LA-LEX-STO-01, LA-LEX-VENIO-01, LA-ETYMON-VENIO-02, LA-LEX-CURRO-01, LA-ETYMON-CURRO-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: classical
+reviews_of: [LA-C41-ambulo, LA-C40-sto, LA-C37-venio]
+---
+
+# currō — running, and the root that came by two roads
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-AMBULO-01, LA-ETYMON-AMBULO-02, LA-LEX-STO-01] -->
+
+[PAUSE 2s] **Ambulō** is walking about, and its own back half is a guess.
+This verb is the fast one, and its ancestry is not a guess at all.
+
+## You'll want to know: currō — "I run"
+<!-- hl-knowledge: introduces=[LA-LEX-CURRO-01]; assesses=[] -->
+
+**Currō** means "**I run**," and also "I race." The dictionary form is
+**currere**. Every vowel is short, the *r*s are rolled, the *c* is hard:
+*KOOR-reh-reh*.
+
+- **currō** — I run
+- **curris** — you run, to one person
+- **currit** — he runs, she runs
+- **currimus** — we run
+- **curritis** — you run, to several people
+- **currunt** — they run
+
+This is **third conjugation**, whose dictionary form ends in *-ere* with a
+*short* second-to-last vowel. Say **currere** with the stress at the front
+to hear the difference from the long *-ēre* of the second.
+
+## The word, taken apart: one root, two arrivals
+<!-- hl-knowledge: introduces=[LA-ETYMON-CURRO-02]; assesses=[LA-LEX-VENIO-01, LA-ETYMON-VENIO-02] -->
+
+The root is Proto-Indo-European ***\*kers-***, "to run," and it reached
+English by two very different roads.
+
+**Through the Latin verb**: **current** (a running of water, then of
+electricity), **currency** (money that runs), **cursor**, **cursive**,
+**course**, **discourse**, **occur** ("to run to meet"), **recur**,
+**excursion**, **precursor**, and **succour** — *sub-* plus *currere*, to
+run underneath someone and hold them up. **Corridor** is Italian for "a
+running-place," and **curriculum** is simply a racecourse.
+
+**Through a wagon**: the Gauls had a word *karros* for a war chariot, from
+the very same root, and Latin borrowed it as *carrus*. From that noun
+English has **car**, **carry**, **carriage**, **cargo**, **charge** (which
+began as loading a wagon), and **career** — first a road for carts, then the
+speed you take one at. **Carpenter** is there too: a *carpentārius* made
+wagons.
+
+Set this beside **veniō**, "I come." *Veniō* is arriving; *currō* is the
+speed. English keeps them apart the same way — an *event* comes out, a
+*course* is the running of it.
+
+Two flags. English **hurry** is not related. And the claim that English
+**horse** belongs to this root is a proposal, not a settled fact.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-AMBULO-01, LA-LEX-STO-01, LA-LEX-VENIO-01, LA-LEX-CURRO-01, LA-ETYMON-CURRO-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: "currō" — I run, hard c, rolled r]
+- [YOU SAY: "curris, currit" — you run, he or she runs]
+- [YOU SAY: "currimus, curritis, currunt" — we, you all, they]
+- [YOU SAY: the three speeds so far — stō, ambulō, currō]
+- [YOU SAY: the relatives — current, curriculum, car]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[LA-LEX-AMBULO-01, LA-ETYMON-AMBULO-02, LA-LEX-STO-01, LA-LEX-VENIO-01, LA-ETYMON-VENIO-02, LA-LEX-CURRO-01, LA-ETYMON-CURRO-02] -->
+
+[PAUSE 3s] How does Latin say "I run"? (**Currō**.) "They run"?
+(**Currunt**.) Which conjugation? (**The third** — short *-ere*.) What is a
+**curriculum** literally, and how did **car** get into the family? (**A
+racecourse**; and through a Gaulish wagon-word Latin borrowed, from the same
+root.) Which earlier verb means "I come", the arriving to this verb's speed,
+and which means "I walk about"? (**Veniō**, and **ambulō**.)

--- a/code/learning/human-languages/latin/narration/ch40.json
+++ b/code/learning/human-languages/latin/narration/ch40.json
@@ -1,0 +1,711 @@
+{
+  "version": 1,
+  "language": "latin",
+  "chapter": 40,
+  "title": "Hearing, Sleeping, Sitting, Standing",
+  "drivablePrefix": 4,
+  "sourceHash": "fnv1a64:ae6b9b154fb369b2",
+  "lessons": [
+    {
+      "id": "LA-C40-audio",
+      "sequence": 800,
+      "title": "audiō — hearing, and the word for obeying",
+      "headword": "audiō, audīre",
+      "romanization": "audiō, audīre",
+      "gloss": "\"I hear\" — the verb inside audio, audience and audit, and, less obviously, inside obey",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:7857a70e4ef5dbec",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The last chapter ended on amō, whose trail stopped early — no secure ancient root to walk back to. This verb is the opposite case: its trail runs all the way back, and forward into a surprising English word. It is also the natural partner of rogō: you ask, and then you hear."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: audiō — \"I hear\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Audiō means \"I hear,\" and also \"I listen to.\" The dictionary form is audīre. The au is one sound, close to English ow in \"now.\""
+            },
+            {
+              "kind": "speech",
+              "text": "audiō — I hear."
+            },
+            {
+              "kind": "speech",
+              "text": "audīs — you hear, to one person."
+            },
+            {
+              "kind": "speech",
+              "text": "audit — he hears, she hears."
+            },
+            {
+              "kind": "speech",
+              "text": "audīmus — we hear."
+            },
+            {
+              "kind": "speech",
+              "text": "audītis — you hear, to several people."
+            },
+            {
+              "kind": "speech",
+              "text": "audiunt — they hear."
+            },
+            {
+              "kind": "speech",
+              "text": "This is a fourth-conjugation verb — the group whose dictionary form ends in -īre. Note the \"they\" form: audiunt, with a u slipped in."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: hearing, obeying, and a false relative",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The root is Proto-Indo-European au-, \"to perceive.\" Latin built audīre on it, and English borrowed the results wholesale: audio, audible, audience, audition, auditor, auditorium."
+            },
+            {
+              "kind": "speech",
+              "text": "Audit is the best of them. An audit was literally a hearing: accounts were read out loud and checked by ear, long before anyone checked them by eye. The word kept the procedure and lost the sound."
+            },
+            {
+              "kind": "speech",
+              "text": "Now the one nobody guesses. Put ob- (\"toward\") in front of audīre and Latin gives oboedīre, \"to listen toward\" — which through French becomes English obey, obedient and disobey. To obey is to listen hard at someone. The town crier's oyez is the same verb, an Old French imperative: \"hear ye.\""
+            },
+            {
+              "kind": "speech",
+              "text": "The Greek branch of au- produced words for perceiving in general: aesthetic, and anaesthesia, \"no perception at all.\""
+            },
+            {
+              "kind": "speech",
+              "text": "One flag. English hear is not a relative. It is Germanic, from another root — the one that also gives Greek akoúein and so English acoustic. Audio and acoustic mean nearly the same thing and are not cousins."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"audiō\" — I hear",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"audiō\" — I hear]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"audīs, audit\" — you hear, he or she hears",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"audīs, audit\" — you hear, he or she hears]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"audīmus, audītis, audiunt\" — we, you all, they",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"audīmus, audītis, audiunt\" — we, you all, they]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the pair from the last chapter beside it — rogō, amō",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the pair from the last chapter beside it — rogō, amō]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the English relatives — audience, audit, obey",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the English relatives — audience, audit, obey]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "How does Latin say \"I hear\"? (Audiō.) \"They hear\"? (Audiunt.) Which conjugation is it? (The fourth — the -īre group.) What was an audit originally, and which everyday word is ob- plus audīre? (A hearing, accounts read aloud — and obey.) Which verb from the last chapter had no securely reconstructed root, and which one means \"I ask\"? (Amō, and rogō.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "LA-C40-dormio",
+      "sequence": 810,
+      "title": "dormiō — the verb you do with your senses off",
+      "headword": "dormiō, dormīre",
+      "romanization": "dormiō, dormīre",
+      "gloss": "\"I sleep\" — the verb behind dormitory and dormant, and the one word English may only look as though it borrowed",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:3478cf58bd29876f",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Audiō is hearing; videō, from an earlier chapter, is seeing. This verb is the state in which you do neither."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: dormiō — \"I sleep\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Dormiō means \"I sleep.\" The dictionary form is dormīre. The first o is short, the ī of dormīre is long: dor-MEE-reh."
+            },
+            {
+              "kind": "speech",
+              "text": "dormiō — I sleep."
+            },
+            {
+              "kind": "speech",
+              "text": "dormīs — you sleep, to one person."
+            },
+            {
+              "kind": "speech",
+              "text": "dormit — he sleeps, she sleeps."
+            },
+            {
+              "kind": "speech",
+              "text": "dormīmus — we sleep."
+            },
+            {
+              "kind": "speech",
+              "text": "dormītis — you sleep, to several people."
+            },
+            {
+              "kind": "speech",
+              "text": "dormiunt — they sleep."
+            },
+            {
+              "kind": "speech",
+              "text": "This is the same fourth conjugation as the verb before it, and it takes the same endings — including that u in dormiunt. Two verbs in the group is enough to hear the pattern."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: two words for sleep, only one of them yours",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The root is Proto-Indo-European drem-, \"to sleep.\" It is a quiet root: Sanskrit drāti, Greek darthánein, Old Church Slavonic drěmati. Latin dormīre is the western member, and English inherited none of it — every English word here is a loan."
+            },
+            {
+              "kind": "speech",
+              "text": "Borrowed whole: dormitory (dormītōrium, \"a sleeping place\"), and its clipped form dorm. Dormant, from French, is a thing that is sleeping rather than dead. A dormer window began as the window of a sleeping room."
+            },
+            {
+              "kind": "speech",
+              "text": "Now a warning, because this one is a trap dressed as a gift. Dormouse looks like the perfect example and is not securely one. The animal's name is attested in English before the French word for a sleeper it is supposed to come from, and the -mouse half may simply be English speakers making sense of a syllable they did not recognise. A hook you have to defend is not a hook."
+            },
+            {
+              "kind": "speech",
+              "text": "Latin's other word for sleep is the noun somnus, from a different root entirely, and English took plenty from that too: insomnia (\"no sleep\"), somnolent, and soporific. So the two Latin sleep-words divided the English vocabulary between them: the verb gave the rooms you sleep in, the noun gave the sleep itself."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"dormiō\" — I sleep",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"dormiō\" — I sleep]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"dormīs, dormit\" — you sleep, he or she sleeps",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"dormīs, dormit\" — you sleep, he or she sleeps]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"dormīmus, dormītis, dormiunt\" — we, you all, they",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"dormīmus, dormītis, dormiunt\" — we, you all, they]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two senses this verb switches off — audiō, videō",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two senses this verb switches off — audiō, videō]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the English relatives — dormitory, dormant",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the English relatives — dormitory, dormant]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "How does Latin say \"I sleep\"? (Dormiō.) \"They sleep\"? (Dormiunt.) Which conjugation, and which other verb shares it here? (The fourth — with audiō.) Why is dormouse not a safe example? (Because the connection is not secure — the English word is older than the French one it supposedly comes from.) Which Latin noun gives insomnia, and which verb means \"I see\"? (Somnus, and videō.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "LA-C40-sedeo",
+      "sequence": 820,
+      "title": "sedeō — the same word English already had",
+      "headword": "sedeō, sedēre",
+      "romanization": "sedeō, sedēre",
+      "gloss": "\"I sit\" — the verb that is English sit by descent and English session by loan, and the clearest case of the difference",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:1f6f7d06cae484ef",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Dormīre left English nothing but loans. This verb is the reverse, and it lets us name a distinction the course has been using without stating it."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: sedeō — \"I sit\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Sedeō means \"I sit,\" and also \"I stay put.\" The dictionary form is sedēre, with a long ē."
+            },
+            {
+              "kind": "speech",
+              "text": "sedeō — I sit."
+            },
+            {
+              "kind": "speech",
+              "text": "sedēs — you sit, to one person."
+            },
+            {
+              "kind": "speech",
+              "text": "sedet — he sits, she sits."
+            },
+            {
+              "kind": "speech",
+              "text": "sedēmus — we sit."
+            },
+            {
+              "kind": "speech",
+              "text": "sedētis — you sit, to several people."
+            },
+            {
+              "kind": "speech",
+              "text": "sedent — they sit."
+            },
+            {
+              "kind": "speech",
+              "text": "This one is second conjugation — the -ēre group. That long ē is the whole signal, so give it room."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: inherited and borrowed are not the same thing",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The root is Proto-Indo-European sed-, \"to sit,\" and English has it by two different routes — which is the point."
+            },
+            {
+              "kind": "speech",
+              "text": "Inherited, down the Germanic line, with no Latin involved: sit, seat, set (\"cause to sit\"), settle, saddle. Two are hidden: nest is \"the place where one sits down,\" and soot is what settles."
+            },
+            {
+              "kind": "speech",
+              "text": "Borrowed, later, out of Latin sedēre: session, sedentary, sediment, sedate, preside, reside, dissident (\"sitting apart\"), assiduous (\"sitting at it\"), possess. Siege is a seat too — an army sitting down in front of a town."
+            },
+            {
+              "kind": "speech",
+              "text": "Hold the two apart. An inherited word came down to English from the shared ancestor without passing through Latin; a borrowed word was taken out of Latin, usually centuries later. Sit and session are one ancient word by two roads, and they look nothing alike because one wore down for three thousand years while the other was copied out of a book. You met this shape when capiō turned out to be the true relative of English have, with the borrowed capture beside it."
+            },
+            {
+              "kind": "speech",
+              "text": "One flag. Sedan is often attached to sedēre, and the connection is not established. Leave it out."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sedeō\" — I sit, long ē in sedēre",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sedeō\" — I sit, long ē in sedēre]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sedēs, sedet\" — you sit, he or she sits",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sedēs, sedet\" — you sit, he or she sits]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sedēmus, sedētis, sedent\" — we, you all, they",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sedēmus, sedētis, sedent\" — we, you all, they]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three verbs of this chapter so far — audiō, dormiō, sedeō",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three verbs of this chapter so far — audiō, dormiō, sedeō]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the inherited word, then the borrowed one — sit, session",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the inherited word, then the borrowed one — sit, session]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "How does Latin say \"I sit\"? (Sedeō.) \"They sit\"? (Sedent.) Which conjugation? (The second — the long -ēre group.) Is English sit borrowed from Latin, and what about session? (Sit is inherited, by a different road; session is borrowed.) Which earlier verb showed that same shape, and why is dormouse not usable that way? (Capiō — cousin of have, source of capture; and dormouse's link to sleeping is not secure.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "LA-C40-sto",
+      "sequence": 830,
+      "title": "stō — standing, and the four together",
+      "headword": "stō, stāre",
+      "romanization": "stō, stāre",
+      "gloss": "\"I stand\" — the shortest verb in the chapter and the most productive in English, and the fourth of four",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:a9e7c0df7dfd7fca",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Three verbs so far: hearing, sleeping, sitting. One remains. It is the opposite of the last, and it shows the inherited-and-borrowed pattern sedeō just taught all over."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: stō — \"I stand\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Stō means \"I stand,\" and by extension \"I stay.\" The dictionary form is stāre. Two letters in the \"I\" form makes it the shortest verb you have met."
+            },
+            {
+              "kind": "speech",
+              "text": "stō — I stand."
+            },
+            {
+              "kind": "speech",
+              "text": "stās — you stand, to one person."
+            },
+            {
+              "kind": "speech",
+              "text": "stat — he stands, she stands."
+            },
+            {
+              "kind": "speech",
+              "text": "stāmus — we stand."
+            },
+            {
+              "kind": "speech",
+              "text": "stātis — you stand, to several people."
+            },
+            {
+              "kind": "speech",
+              "text": "stant — they stand."
+            },
+            {
+              "kind": "speech",
+              "text": "This is first conjugation, the -āre group, and in the present tense perfectly regular: the long ā runs through every form after the first."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: the most productive root in the book",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The root is Proto-Indo-European sta-, \"to stand.\" Sort the English by the two roads that gave sit and session."
+            },
+            {
+              "kind": "speech",
+              "text": "Inherited: stand — with an extra n wedged into the middle, which is why it looks unlike stō — plus stead (as in instead), steed, stall and stool."
+            },
+            {
+              "kind": "speech",
+              "text": "Borrowed from stāre: station, statue, status, state, stable, estate, stage, substance, circumstance (\"standing around\"), obstacle (\"standing in the way\"), constant, instant, distance. Two are so worn down they hide: constāre, \"to stand at a price,\" is English cost, and restāre, \"to stand back,\" is the rest that means the remainder. The doubled-up sistere gives consist, resist, insist and assist."
+            },
+            {
+              "kind": "speech",
+              "text": "Set this beside the verb for being. Sum and est are inherited cousins of English am and is — the same two-road picture, only there the English side kept the meaning exactly. And set it against eō, \"I go\": stāre is what you do when you are not going, and English holds both halves, station from this verb and exit from that one."
+            },
+            {
+              "kind": "speech",
+              "text": "One flag. English still is often thrown in here and does not belong."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"stō, stās, stat\" — I stand, you stand, he or she stands",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"stō, stās, stat\" — I stand, you stand, he or she stands]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "this chapter's four \"I\" forms — audiō, dormiō, sedeō, stō",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: this chapter's four \"I\" forms — audiō, dormiō, sedeō, stō]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the four \"he or she\" forms — audit, dormit, sedet, stat",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the four \"he or she\" forms — audit, dormit, sedet, stat]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two from an earlier chapter beside them — sum, eō",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two from an earlier chapter beside them — sum, eō]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "inherited, then borrowed — stand, station",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: inherited, then borrowed — stand, station]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give this chapter's four \"I\" forms. (Audiō, dormiō, sedeō, stō.) Now the four \"he or she\" forms. (Audit, dormit, sedet, stat.) Which of the four is second conjugation? (Sedeō — the long -ēre group.) Which English word for standing is inherited, which is borrowed, and what is cost taken apart? (Stand inherited, station borrowed; constāre, what a thing stands at.) Which earlier verb has am and is as its inherited English cousins, and which one means \"I go\"? (Sum, and eō — the verb behind exit.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/latin/narration/ch40.txt
+++ b/code/learning/human-languages/latin/narration/ch40.txt
@@ -1,0 +1,169 @@
+Latin, chapter 40: Hearing, Sleeping, Sitting, Standing.
+4 lessons. All 4 can be done entirely by ear.
+
+
+Lesson 1 of 4.
+audiō — hearing, and the word for obeying.
+
+Warm-up.
+[pause 2 seconds]
+The last chapter ended on amō, whose trail stopped early — no secure ancient root to walk back to. This verb is the opposite case: its trail runs all the way back, and forward into a surprising English word. It is also the natural partner of rogō: you ask, and then you hear.
+
+You'll want to know: audiō — "I hear".
+Audiō means "I hear," and also "I listen to." The dictionary form is audīre. The au is one sound, close to English ow in "now."
+audiō — I hear.
+audīs — you hear, to one person.
+audit — he hears, she hears.
+audīmus — we hear.
+audītis — you hear, to several people.
+audiunt — they hear.
+This is a fourth-conjugation verb — the group whose dictionary form ends in -īre. Note the "they" form: audiunt, with a u slipped in.
+
+The word, taken apart: hearing, obeying, and a false relative.
+The root is Proto-Indo-European au-, "to perceive." Latin built audīre on it, and English borrowed the results wholesale: audio, audible, audience, audition, auditor, auditorium.
+Audit is the best of them. An audit was literally a hearing: accounts were read out loud and checked by ear, long before anyone checked them by eye. The word kept the procedure and lost the sound.
+Now the one nobody guesses. Put ob- ("toward") in front of audīre and Latin gives oboedīre, "to listen toward" — which through French becomes English obey, obedient and disobey. To obey is to listen hard at someone. The town crier's oyez is the same verb, an Old French imperative: "hear ye."
+The Greek branch of au- produced words for perceiving in general: aesthetic, and anaesthesia, "no perception at all."
+One flag. English hear is not a relative. It is Germanic, from another root — the one that also gives Greek akoúein and so English acoustic. Audio and acoustic mean nearly the same thing and are not cousins.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "audiō" — I hear]
+[pause 8 seconds for the answer]
+[your turn — say: "audīs, audit" — you hear, he or she hears]
+[pause 8 seconds for the answer]
+[your turn — say: "audīmus, audītis, audiunt" — we, you all, they]
+[pause 8 seconds for the answer]
+[your turn — say: the pair from the last chapter beside it — rogō, amō]
+[pause 8 seconds for the answer]
+[your turn — say: the English relatives — audience, audit, obey]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+How does Latin say "I hear"? (Audiō.) "They hear"? (Audiunt.) Which conjugation is it? (The fourth — the -īre group.) What was an audit originally, and which everyday word is ob- plus audīre? (A hearing, accounts read aloud — and obey.) Which verb from the last chapter had no securely reconstructed root, and which one means "I ask"? (Amō, and rogō.)
+
+
+Lesson 2 of 4.
+dormiō — the verb you do with your senses off.
+
+Warm-up.
+[pause 2 seconds]
+Audiō is hearing; videō, from an earlier chapter, is seeing. This verb is the state in which you do neither.
+
+You'll want to know: dormiō — "I sleep".
+Dormiō means "I sleep." The dictionary form is dormīre. The first o is short, the ī of dormīre is long: dor-MEE-reh.
+dormiō — I sleep.
+dormīs — you sleep, to one person.
+dormit — he sleeps, she sleeps.
+dormīmus — we sleep.
+dormītis — you sleep, to several people.
+dormiunt — they sleep.
+This is the same fourth conjugation as the verb before it, and it takes the same endings — including that u in dormiunt. Two verbs in the group is enough to hear the pattern.
+
+The word, taken apart: two words for sleep, only one of them yours.
+The root is Proto-Indo-European drem-, "to sleep." It is a quiet root: Sanskrit drāti, Greek darthánein, Old Church Slavonic drěmati. Latin dormīre is the western member, and English inherited none of it — every English word here is a loan.
+Borrowed whole: dormitory (dormītōrium, "a sleeping place"), and its clipped form dorm. Dormant, from French, is a thing that is sleeping rather than dead. A dormer window began as the window of a sleeping room.
+Now a warning, because this one is a trap dressed as a gift. Dormouse looks like the perfect example and is not securely one. The animal's name is attested in English before the French word for a sleeper it is supposed to come from, and the -mouse half may simply be English speakers making sense of a syllable they did not recognise. A hook you have to defend is not a hook.
+Latin's other word for sleep is the noun somnus, from a different root entirely, and English took plenty from that too: insomnia ("no sleep"), somnolent, and soporific. So the two Latin sleep-words divided the English vocabulary between them: the verb gave the rooms you sleep in, the noun gave the sleep itself.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "dormiō" — I sleep]
+[pause 8 seconds for the answer]
+[your turn — say: "dormīs, dormit" — you sleep, he or she sleeps]
+[pause 8 seconds for the answer]
+[your turn — say: "dormīmus, dormītis, dormiunt" — we, you all, they]
+[pause 8 seconds for the answer]
+[your turn — say: the two senses this verb switches off — audiō, videō]
+[pause 8 seconds for the answer]
+[your turn — say: the English relatives — dormitory, dormant]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+How does Latin say "I sleep"? (Dormiō.) "They sleep"? (Dormiunt.) Which conjugation, and which other verb shares it here? (The fourth — with audiō.) Why is dormouse not a safe example? (Because the connection is not secure — the English word is older than the French one it supposedly comes from.) Which Latin noun gives insomnia, and which verb means "I see"? (Somnus, and videō.)
+
+
+Lesson 3 of 4.
+sedeō — the same word English already had.
+
+Warm-up.
+[pause 2 seconds]
+Dormīre left English nothing but loans. This verb is the reverse, and it lets us name a distinction the course has been using without stating it.
+
+You'll want to know: sedeō — "I sit".
+Sedeō means "I sit," and also "I stay put." The dictionary form is sedēre, with a long ē.
+sedeō — I sit.
+sedēs — you sit, to one person.
+sedet — he sits, she sits.
+sedēmus — we sit.
+sedētis — you sit, to several people.
+sedent — they sit.
+This one is second conjugation — the -ēre group. That long ē is the whole signal, so give it room.
+
+The word, taken apart: inherited and borrowed are not the same thing.
+The root is Proto-Indo-European sed-, "to sit," and English has it by two different routes — which is the point.
+Inherited, down the Germanic line, with no Latin involved: sit, seat, set ("cause to sit"), settle, saddle. Two are hidden: nest is "the place where one sits down," and soot is what settles.
+Borrowed, later, out of Latin sedēre: session, sedentary, sediment, sedate, preside, reside, dissident ("sitting apart"), assiduous ("sitting at it"), possess. Siege is a seat too — an army sitting down in front of a town.
+Hold the two apart. An inherited word came down to English from the shared ancestor without passing through Latin; a borrowed word was taken out of Latin, usually centuries later. Sit and session are one ancient word by two roads, and they look nothing alike because one wore down for three thousand years while the other was copied out of a book. You met this shape when capiō turned out to be the true relative of English have, with the borrowed capture beside it.
+One flag. Sedan is often attached to sedēre, and the connection is not established. Leave it out.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "sedeō" — I sit, long ē in sedēre]
+[pause 8 seconds for the answer]
+[your turn — say: "sedēs, sedet" — you sit, he or she sits]
+[pause 8 seconds for the answer]
+[your turn — say: "sedēmus, sedētis, sedent" — we, you all, they]
+[pause 8 seconds for the answer]
+[your turn — say: the three verbs of this chapter so far — audiō, dormiō, sedeō]
+[pause 8 seconds for the answer]
+[your turn — say: the inherited word, then the borrowed one — sit, session]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+How does Latin say "I sit"? (Sedeō.) "They sit"? (Sedent.) Which conjugation? (The second — the long -ēre group.) Is English sit borrowed from Latin, and what about session? (Sit is inherited, by a different road; session is borrowed.) Which earlier verb showed that same shape, and why is dormouse not usable that way? (Capiō — cousin of have, source of capture; and dormouse's link to sleeping is not secure.)
+
+
+Lesson 4 of 4.
+stō — standing, and the four together.
+
+Warm-up.
+[pause 2 seconds]
+Three verbs so far: hearing, sleeping, sitting. One remains. It is the opposite of the last, and it shows the inherited-and-borrowed pattern sedeō just taught all over.
+
+You'll want to know: stō — "I stand".
+Stō means "I stand," and by extension "I stay." The dictionary form is stāre. Two letters in the "I" form makes it the shortest verb you have met.
+stō — I stand.
+stās — you stand, to one person.
+stat — he stands, she stands.
+stāmus — we stand.
+stātis — you stand, to several people.
+stant — they stand.
+This is first conjugation, the -āre group, and in the present tense perfectly regular: the long ā runs through every form after the first.
+
+The word, taken apart: the most productive root in the book.
+The root is Proto-Indo-European sta-, "to stand." Sort the English by the two roads that gave sit and session.
+Inherited: stand — with an extra n wedged into the middle, which is why it looks unlike stō — plus stead (as in instead), steed, stall and stool.
+Borrowed from stāre: station, statue, status, state, stable, estate, stage, substance, circumstance ("standing around"), obstacle ("standing in the way"), constant, instant, distance. Two are so worn down they hide: constāre, "to stand at a price," is English cost, and restāre, "to stand back," is the rest that means the remainder. The doubled-up sistere gives consist, resist, insist and assist.
+Set this beside the verb for being. Sum and est are inherited cousins of English am and is — the same two-road picture, only there the English side kept the meaning exactly. And set it against eō, "I go": stāre is what you do when you are not going, and English holds both halves, station from this verb and exit from that one.
+One flag. English still is often thrown in here and does not belong.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "stō, stās, stat" — I stand, you stand, he or she stands]
+[pause 8 seconds for the answer]
+[your turn — say: this chapter's four "I" forms — audiō, dormiō, sedeō, stō]
+[pause 8 seconds for the answer]
+[your turn — say: the four "he or she" forms — audit, dormit, sedet, stat]
+[pause 8 seconds for the answer]
+[your turn — say: the two from an earlier chapter beside them — sum, eō]
+[pause 8 seconds for the answer]
+[your turn — say: inherited, then borrowed — stand, station]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give this chapter's four "I" forms. (Audiō, dormiō, sedeō, stō.) Now the four "he or she" forms. (Audit, dormit, sedet, stat.) Which of the four is second conjugation? (Sedeō — the long -ēre group.) Which English word for standing is inherited, which is borrowed, and what is cost taken apart? (Stand inherited, station borrowed; constāre, what a thing stands at.) Which earlier verb has am and is as its inherited English cousins, and which one means "I go"? (Sum, and eō — the verb behind exit.)

--- a/code/learning/human-languages/latin/narration/ch41.json
+++ b/code/learning/human-languages/latin/narration/ch41.json
@@ -1,0 +1,706 @@
+{
+  "version": 1,
+  "language": "latin",
+  "chapter": 41,
+  "title": "Walking, Running, Opening, Closing",
+  "drivablePrefix": 4,
+  "sourceHash": "fnv1a64:fe69dc2b788501fe",
+  "lessons": [
+    {
+      "id": "LA-C41-ambulo",
+      "sequence": 840,
+      "title": "ambulō — walking about",
+      "headword": "ambulō, ambulāre",
+      "romanization": "ambulō, ambulāre",
+      "gloss": "\"I walk\" — the verb behind ambulance, preamble and the pram, and a rare case where the front half is clear and the back half is not",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:d622fafe7bc4956d",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The last chapter left you sitting and standing — sedeō and stō, both of them staying put. This chapter moves."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: ambulō — \"I walk\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Ambulō means \"I walk,\" with a flavour of walking about rather than walking to somewhere. The dictionary form is ambulāre."
+            },
+            {
+              "kind": "speech",
+              "text": "ambulō — I walk."
+            },
+            {
+              "kind": "speech",
+              "text": "ambulās — you walk, to one person."
+            },
+            {
+              "kind": "speech",
+              "text": "ambulat — he walks, she walks."
+            },
+            {
+              "kind": "speech",
+              "text": "ambulāmus — we walk."
+            },
+            {
+              "kind": "speech",
+              "text": "ambulātis — you walk, to several people."
+            },
+            {
+              "kind": "speech",
+              "text": "ambulant — they walk."
+            },
+            {
+              "kind": "speech",
+              "text": "Like stō, this is first conjugation — the -āre group — with the same endings hung on a longer stem."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: a clear front, a doubtful back, a huge harvest",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Start with the honest limit, because this word has one. The front half is secure: amb-, \"around,\" the same element as in ambi-. The back half is not settled — usually connected with an old root meaning \"to wander\" or \"to go,\" but the join has never been nailed down, so the standard gloss is a reasonable guess rather than a proof."
+            },
+            {
+              "kind": "speech",
+              "text": "The harvest is not in doubt at all. Amble came through French and kept the leisurely sense exactly. Ambulatory is both an adjective and the walking-gallery of a church. Perambulate gave the Victorian perambulator and, clipped, the pram. A preamble walks in front (prae-, \"before\")."
+            },
+            {
+              "kind": "speech",
+              "text": "Two compounds are worth saying out loud. A funambulist walks a rope (fūnis). A somnambulist walks in sleep — and somnus is the Latin sleep-noun named in the last chapter, so that word is two pieces you already have."
+            },
+            {
+              "kind": "speech",
+              "text": "The best is ambulance. A French military hospital that followed the army instead of waiting for it was an hôpital ambulant — a walking hospital. English took the second word and forgot the first, so the vehicle is named for moving."
+            },
+            {
+              "kind": "speech",
+              "text": "Two flags. English walk is Germanic and no relation. And French aller, \"to go\" — with alley behind it — is often derived from ambulāre by heavy wear, but that derivation is disputed. Do not lean on it."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ambulō\" — I walk",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ambulō\" — I walk]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ambulās, ambulat\" — you walk, he or she walks",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ambulās, ambulat\" — you walk, he or she walks]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ambulāmus, ambulātis, ambulant\" — we, you all, they",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ambulāmus, ambulātis, ambulant\" — we, you all, they]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two still verbs it moves away from — sedeō, stō",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two still verbs it moves away from — sedeō, stō]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the English relatives — amble, preamble, ambulance",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the English relatives — amble, preamble, ambulance]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "How does Latin say \"I walk\"? (Ambulō.) \"They walk\"? (Ambulant.) Which conjugation, and which earlier verb shares it? (The first, the -āre group — with stō.) Which half of the word is uncertain, and why is a vehicle called an ambulance? (The back half; and because the hospital walked — it followed the army.) Which verb means \"I sit\"? (Sedeō.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "LA-C41-curro",
+      "sequence": 850,
+      "title": "currō — running, and the root that came by two roads",
+      "headword": "currō, currere",
+      "romanization": "currō, currere",
+      "gloss": "\"I run\" — the verb inside current, curriculum, courier and corridor, and, by way of a Celtic wagon, inside car",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:bc6edcf40433f26f",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Ambulō is walking about, and its own back half is a guess. This verb is the fast one, and its ancestry is not a guess at all."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: currō — \"I run\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Currō means \"I run,\" and also \"I race.\" The dictionary form is currere. Every vowel is short, the rs are rolled, the c is hard: KOOR-reh-reh."
+            },
+            {
+              "kind": "speech",
+              "text": "currō — I run."
+            },
+            {
+              "kind": "speech",
+              "text": "curris — you run, to one person."
+            },
+            {
+              "kind": "speech",
+              "text": "currit — he runs, she runs."
+            },
+            {
+              "kind": "speech",
+              "text": "currimus — we run."
+            },
+            {
+              "kind": "speech",
+              "text": "curritis — you run, to several people."
+            },
+            {
+              "kind": "speech",
+              "text": "currunt — they run."
+            },
+            {
+              "kind": "speech",
+              "text": "This is third conjugation, whose dictionary form ends in -ere with a short second-to-last vowel. Say currere with the stress at the front to hear the difference from the long -ēre of the second."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: one root, two arrivals",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The root is Proto-Indo-European kers-, \"to run,\" and it reached English by two very different roads."
+            },
+            {
+              "kind": "speech",
+              "text": "Through the Latin verb: current (a running of water, then of electricity), currency (money that runs), cursor, cursive, course, discourse, occur (\"to run to meet\"), recur, excursion, precursor, and succour — sub- plus currere, to run underneath someone and hold them up. Corridor is Italian for \"a running-place,\" and curriculum is simply a racecourse."
+            },
+            {
+              "kind": "speech",
+              "text": "Through a wagon: the Gauls had a word karros for a war chariot, from the very same root, and Latin borrowed it as carrus. From that noun English has car, carry, carriage, cargo, charge (which began as loading a wagon), and career — first a road for carts, then the speed you take one at. Carpenter is there too: a carpentārius made wagons."
+            },
+            {
+              "kind": "speech",
+              "text": "Set this beside veniō, \"I come.\" Veniō is arriving; currō is the speed. English keeps them apart the same way — an event comes out, a course is the running of it."
+            },
+            {
+              "kind": "speech",
+              "text": "Two flags. English hurry is not related. And the claim that English horse belongs to this root is a proposal, not a settled fact."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"currō\" — I run, hard c, rolled r",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"currō\" — I run, hard c, rolled r]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"curris, currit\" — you run, he or she runs",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"curris, currit\" — you run, he or she runs]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"currimus, curritis, currunt\" — we, you all, they",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"currimus, curritis, currunt\" — we, you all, they]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three speeds so far — stō, ambulō, currō",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three speeds so far — stō, ambulō, currō]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the relatives — current, curriculum, car",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the relatives — current, curriculum, car]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "How does Latin say \"I run\"? (Currō.) \"They run\"? (Currunt.) Which conjugation? (The third — short -ere.) What is a curriculum literally, and how did car get into the family? (A racecourse; and through a Gaulish wagon-word Latin borrowed, from the same root.) Which earlier verb means \"I come\", the arriving to this verb's speed, and which means \"I walk about\"? (Veniō, and ambulō.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "LA-C41-aperio",
+      "sequence": 860,
+      "title": "aperiō — to un-cover",
+      "headword": "aperiō, aperīre",
+      "romanization": "aperiō, aperīre",
+      "gloss": "\"I open\" — half of a matched pair, built from one root with two opposite prefixes",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:06626b6294c4415e",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Currō showed one root reaching English by two roads. This verb shows something rarer: one root standing inside two Latin words that mean the opposite of each other."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: aperiō — \"I open\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Aperiō means \"I open,\" and also \"I uncover, I reveal.\" The dictionary form is aperīre, with a long ī."
+            },
+            {
+              "kind": "speech",
+              "text": "aperiō — I open."
+            },
+            {
+              "kind": "speech",
+              "text": "aperīs — you open, to one person."
+            },
+            {
+              "kind": "speech",
+              "text": "aperit — he opens, she opens."
+            },
+            {
+              "kind": "speech",
+              "text": "aperīmus — we open."
+            },
+            {
+              "kind": "speech",
+              "text": "aperītis — you open, to several people."
+            },
+            {
+              "kind": "speech",
+              "text": "aperiunt — they open."
+            },
+            {
+              "kind": "speech",
+              "text": "This is fourth conjugation, the -īre group, and it takes exactly the endings audiō and dormiō took — including that u before the ending in aperiunt."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: one root, two prefixes, two opposite verbs",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Aperīre is taken apart as ap-, \"off, away,\" welded onto an old root wer- meaning \"to cover.\" To open, in Latin, is to cover away."
+            },
+            {
+              "kind": "speech",
+              "text": "Now the elegant part. Latin has a second verb on the very same root: operīre, \"to cover, to shut\" — op-, \"over,\" on wer-. The two verbs differ in one syllable at the front, and that syllable turns covering into uncovering:"
+            },
+            {
+              "kind": "speech",
+              "text": "aperīre — cover away becomes open."
+            },
+            {
+              "kind": "speech",
+              "text": "operīre — cover over becomes shut."
+            },
+            {
+              "kind": "speech",
+              "text": "English took both halves and never noticed they were a pair. From the opening verb: aperture, an opening; aperitif, the drink that opens a meal; and, worn down through French ouvrir, overt and overture. From the shutting verb, mostly with co- in front (cooperīre, \"to cover completely\"): cover, covert, and discover, which is dis- undoing the covering. Two French phrases came in whole: a curfew is couvre-feu, \"cover the fire,\" and a kerchief is couvre-chef."
+            },
+            {
+              "kind": "speech",
+              "text": "Two honest notes. The Vulgar Latin descendants of these verbs blurred into each other, which is why French ouvrir and couvrir rhyme today. And April — you will see it explained as \"the opening month,\" from aperīre. That is folk etymology; the real origin is unsettled."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"aperiō\" — I open",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"aperiō\" — I open]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"aperīs, aperit\" — you open, he or she opens",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"aperīs, aperit\" — you open, he or she opens]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"aperīmus, aperītis, aperiunt\" — we, you all, they",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"aperīmus, aperītis, aperiunt\" — we, you all, they]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the pair, and what each prefix does — aperīre, cover away; operīre, cover over",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the pair, and what each prefix does — aperīre, cover away; operīre, cover over]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the chapter so far — ambulō, currō, aperiō",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the chapter so far — ambulō, currō, aperiō]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "How does Latin say \"I open\", and how \"they open\"? (Aperiō, aperiunt.) Which conjugation, and what does aperīre literally say? (The fourth, the -īre group; and cover away — un-cover.) What is its opposite, and what does that prefix change? (Operīre — op-, \"over,\" so cover over.) Which English word is couvre-feu, is April from this verb, and which verb means \"I run\"? (Curfew; no, that is folk etymology; and currō.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "LA-C41-claudo",
+      "sequence": 870,
+      "title": "claudō — closing, and the four together",
+      "headword": "claudō, claudere",
+      "romanization": "claudō, claudere",
+      "gloss": "\"I close\" — the word English calls close, and the fourth of four",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:e7fda89b85277a5e",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Aperiō opened by covering away, and named its own Latin opposite. But that opposite is not the verb a Roman reached for to shut a door. This one is, and it is the word English says every day."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: claudō — \"I close\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Claudō means \"I close,\" \"I shut in.\" The dictionary form is claudere. The au is one sound, as in audiō; the c is hard: KLOW-deh-reh."
+            },
+            {
+              "kind": "speech",
+              "text": "claudō — I close."
+            },
+            {
+              "kind": "speech",
+              "text": "claudis — you close, to one person."
+            },
+            {
+              "kind": "speech",
+              "text": "claudit — he closes, she closes."
+            },
+            {
+              "kind": "speech",
+              "text": "claudimus — we close."
+            },
+            {
+              "kind": "speech",
+              "text": "clauditis — you close, to several people."
+            },
+            {
+              "kind": "speech",
+              "text": "claudunt — they close."
+            },
+            {
+              "kind": "speech",
+              "text": "Like currō, this is third conjugation — short -ere. That is three classes across this chapter's four verbs, worth noticing and not worth memorising: the class only tells you the endings."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: the word you already say",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The root is Proto-Indo-European klau-, and it did not mean \"shut.\" It meant hook or peg — the crooked wood you jam a door with. The action is named after the object, and Latin kept it: clāvis, \"key.\""
+            },
+            {
+              "kind": "speech",
+              "text": "English close is this verb. Not a cousin — the verb itself, borrowed through French from clausum. That matters, because you learned to sort the two ways apart: sit was inherited, session was a loan. Close is a loan that stopped looking like one. Beside it stand closet, closure, disclose, and the noun clause. A cloister is a claustrum, a bolted place, and sluice is exclūsa, \"water shut out.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Then the prefixes, where the chapter's two halves meet. Claudere takes them by the handful: include, exclude, conclude, preclude, recluse. Set include and exclude beside accept and except — the same two prefixes on capere. Set them beside intellegō, where inter- turns picking into understanding. A prefix carries the meaning."
+            },
+            {
+              "kind": "speech",
+              "text": "From clāvis, the key: clavicle (a little key — the collarbone), clef, and conclave, a room locked with a key. Greek kleís is the same inherited word and means both those things too."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"claudō, claudis, claudit\" — I close, you close, he or she closes",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"claudō, claudis, claudit\" — I close, you close, he or she closes]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "this chapter's four \"I\" forms — ambulō, currō, aperiō, claudō",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: this chapter's four \"I\" forms — ambulō, currō, aperiō, claudō]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the four \"he or she\" forms — ambulat, currit, aperit, claudit",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the four \"he or she\" forms — ambulat, currit, aperit, claudit]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "two prefixes, two verbs — include, exclude; accept, except",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: two prefixes, two verbs — include, exclude; accept, except]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give this chapter's four \"I\" forms, then the four \"he or she\" forms. (Ambulō, currō, aperiō, claudō; ambulat, currit, aperit, claudit.) Which two share the third conjugation? (Currō and claudō.) Is English close inherited or borrowed, and what did the root name? (Borrowed — this Latin verb itself; and a hook or peg.) Which verb gives accept and except, the same prefixes as include and exclude, and which is inter- plus \"to pick out\"? (Capiō, and intellegō.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/latin/narration/ch41.txt
+++ b/code/learning/human-languages/latin/narration/ch41.txt
@@ -1,0 +1,168 @@
+Latin, chapter 41: Walking, Running, Opening, Closing.
+4 lessons. All 4 can be done entirely by ear.
+
+
+Lesson 1 of 4.
+ambulō — walking about.
+
+Warm-up.
+[pause 2 seconds]
+The last chapter left you sitting and standing — sedeō and stō, both of them staying put. This chapter moves.
+
+You'll want to know: ambulō — "I walk".
+Ambulō means "I walk," with a flavour of walking about rather than walking to somewhere. The dictionary form is ambulāre.
+ambulō — I walk.
+ambulās — you walk, to one person.
+ambulat — he walks, she walks.
+ambulāmus — we walk.
+ambulātis — you walk, to several people.
+ambulant — they walk.
+Like stō, this is first conjugation — the -āre group — with the same endings hung on a longer stem.
+
+The word, taken apart: a clear front, a doubtful back, a huge harvest.
+Start with the honest limit, because this word has one. The front half is secure: amb-, "around," the same element as in ambi-. The back half is not settled — usually connected with an old root meaning "to wander" or "to go," but the join has never been nailed down, so the standard gloss is a reasonable guess rather than a proof.
+The harvest is not in doubt at all. Amble came through French and kept the leisurely sense exactly. Ambulatory is both an adjective and the walking-gallery of a church. Perambulate gave the Victorian perambulator and, clipped, the pram. A preamble walks in front (prae-, "before").
+Two compounds are worth saying out loud. A funambulist walks a rope (fūnis). A somnambulist walks in sleep — and somnus is the Latin sleep-noun named in the last chapter, so that word is two pieces you already have.
+The best is ambulance. A French military hospital that followed the army instead of waiting for it was an hôpital ambulant — a walking hospital. English took the second word and forgot the first, so the vehicle is named for moving.
+Two flags. English walk is Germanic and no relation. And French aller, "to go" — with alley behind it — is often derived from ambulāre by heavy wear, but that derivation is disputed. Do not lean on it.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "ambulō" — I walk]
+[pause 8 seconds for the answer]
+[your turn — say: "ambulās, ambulat" — you walk, he or she walks]
+[pause 8 seconds for the answer]
+[your turn — say: "ambulāmus, ambulātis, ambulant" — we, you all, they]
+[pause 8 seconds for the answer]
+[your turn — say: the two still verbs it moves away from — sedeō, stō]
+[pause 8 seconds for the answer]
+[your turn — say: the English relatives — amble, preamble, ambulance]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+How does Latin say "I walk"? (Ambulō.) "They walk"? (Ambulant.) Which conjugation, and which earlier verb shares it? (The first, the -āre group — with stō.) Which half of the word is uncertain, and why is a vehicle called an ambulance? (The back half; and because the hospital walked — it followed the army.) Which verb means "I sit"? (Sedeō.)
+
+
+Lesson 2 of 4.
+currō — running, and the root that came by two roads.
+
+Warm-up.
+[pause 2 seconds]
+Ambulō is walking about, and its own back half is a guess. This verb is the fast one, and its ancestry is not a guess at all.
+
+You'll want to know: currō — "I run".
+Currō means "I run," and also "I race." The dictionary form is currere. Every vowel is short, the rs are rolled, the c is hard: KOOR-reh-reh.
+currō — I run.
+curris — you run, to one person.
+currit — he runs, she runs.
+currimus — we run.
+curritis — you run, to several people.
+currunt — they run.
+This is third conjugation, whose dictionary form ends in -ere with a short second-to-last vowel. Say currere with the stress at the front to hear the difference from the long -ēre of the second.
+
+The word, taken apart: one root, two arrivals.
+The root is Proto-Indo-European kers-, "to run," and it reached English by two very different roads.
+Through the Latin verb: current (a running of water, then of electricity), currency (money that runs), cursor, cursive, course, discourse, occur ("to run to meet"), recur, excursion, precursor, and succour — sub- plus currere, to run underneath someone and hold them up. Corridor is Italian for "a running-place," and curriculum is simply a racecourse.
+Through a wagon: the Gauls had a word karros for a war chariot, from the very same root, and Latin borrowed it as carrus. From that noun English has car, carry, carriage, cargo, charge (which began as loading a wagon), and career — first a road for carts, then the speed you take one at. Carpenter is there too: a carpentārius made wagons.
+Set this beside veniō, "I come." Veniō is arriving; currō is the speed. English keeps them apart the same way — an event comes out, a course is the running of it.
+Two flags. English hurry is not related. And the claim that English horse belongs to this root is a proposal, not a settled fact.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "currō" — I run, hard c, rolled r]
+[pause 8 seconds for the answer]
+[your turn — say: "curris, currit" — you run, he or she runs]
+[pause 8 seconds for the answer]
+[your turn — say: "currimus, curritis, currunt" — we, you all, they]
+[pause 8 seconds for the answer]
+[your turn — say: the three speeds so far — stō, ambulō, currō]
+[pause 8 seconds for the answer]
+[your turn — say: the relatives — current, curriculum, car]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+How does Latin say "I run"? (Currō.) "They run"? (Currunt.) Which conjugation? (The third — short -ere.) What is a curriculum literally, and how did car get into the family? (A racecourse; and through a Gaulish wagon-word Latin borrowed, from the same root.) Which earlier verb means "I come", the arriving to this verb's speed, and which means "I walk about"? (Veniō, and ambulō.)
+
+
+Lesson 3 of 4.
+aperiō — to un-cover.
+
+Warm-up.
+[pause 2 seconds]
+Currō showed one root reaching English by two roads. This verb shows something rarer: one root standing inside two Latin words that mean the opposite of each other.
+
+You'll want to know: aperiō — "I open".
+Aperiō means "I open," and also "I uncover, I reveal." The dictionary form is aperīre, with a long ī.
+aperiō — I open.
+aperīs — you open, to one person.
+aperit — he opens, she opens.
+aperīmus — we open.
+aperītis — you open, to several people.
+aperiunt — they open.
+This is fourth conjugation, the -īre group, and it takes exactly the endings audiō and dormiō took — including that u before the ending in aperiunt.
+
+The word, taken apart: one root, two prefixes, two opposite verbs.
+Aperīre is taken apart as ap-, "off, away," welded onto an old root wer- meaning "to cover." To open, in Latin, is to cover away.
+Now the elegant part. Latin has a second verb on the very same root: operīre, "to cover, to shut" — op-, "over," on wer-. The two verbs differ in one syllable at the front, and that syllable turns covering into uncovering:
+aperīre — cover away becomes open.
+operīre — cover over becomes shut.
+English took both halves and never noticed they were a pair. From the opening verb: aperture, an opening; aperitif, the drink that opens a meal; and, worn down through French ouvrir, overt and overture. From the shutting verb, mostly with co- in front (cooperīre, "to cover completely"): cover, covert, and discover, which is dis- undoing the covering. Two French phrases came in whole: a curfew is couvre-feu, "cover the fire," and a kerchief is couvre-chef.
+Two honest notes. The Vulgar Latin descendants of these verbs blurred into each other, which is why French ouvrir and couvrir rhyme today. And April — you will see it explained as "the opening month," from aperīre. That is folk etymology; the real origin is unsettled.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "aperiō" — I open]
+[pause 8 seconds for the answer]
+[your turn — say: "aperīs, aperit" — you open, he or she opens]
+[pause 8 seconds for the answer]
+[your turn — say: "aperīmus, aperītis, aperiunt" — we, you all, they]
+[pause 8 seconds for the answer]
+[your turn — say: the pair, and what each prefix does — aperīre, cover away; operīre, cover over]
+[pause 8 seconds for the answer]
+[your turn — say: the chapter so far — ambulō, currō, aperiō]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+How does Latin say "I open", and how "they open"? (Aperiō, aperiunt.) Which conjugation, and what does aperīre literally say? (The fourth, the -īre group; and cover away — un-cover.) What is its opposite, and what does that prefix change? (Operīre — op-, "over," so cover over.) Which English word is couvre-feu, is April from this verb, and which verb means "I run"? (Curfew; no, that is folk etymology; and currō.)
+
+
+Lesson 4 of 4.
+claudō — closing, and the four together.
+
+Warm-up.
+[pause 2 seconds]
+Aperiō opened by covering away, and named its own Latin opposite. But that opposite is not the verb a Roman reached for to shut a door. This one is, and it is the word English says every day.
+
+You'll want to know: claudō — "I close".
+Claudō means "I close," "I shut in." The dictionary form is claudere. The au is one sound, as in audiō; the c is hard: KLOW-deh-reh.
+claudō — I close.
+claudis — you close, to one person.
+claudit — he closes, she closes.
+claudimus — we close.
+clauditis — you close, to several people.
+claudunt — they close.
+Like currō, this is third conjugation — short -ere. That is three classes across this chapter's four verbs, worth noticing and not worth memorising: the class only tells you the endings.
+
+The word, taken apart: the word you already say.
+The root is Proto-Indo-European klau-, and it did not mean "shut." It meant hook or peg — the crooked wood you jam a door with. The action is named after the object, and Latin kept it: clāvis, "key."
+English close is this verb. Not a cousin — the verb itself, borrowed through French from clausum. That matters, because you learned to sort the two ways apart: sit was inherited, session was a loan. Close is a loan that stopped looking like one. Beside it stand closet, closure, disclose, and the noun clause. A cloister is a claustrum, a bolted place, and sluice is exclūsa, "water shut out."
+Then the prefixes, where the chapter's two halves meet. Claudere takes them by the handful: include, exclude, conclude, preclude, recluse. Set include and exclude beside accept and except — the same two prefixes on capere. Set them beside intellegō, where inter- turns picking into understanding. A prefix carries the meaning.
+From clāvis, the key: clavicle (a little key — the collarbone), clef, and conclave, a room locked with a key. Greek kleís is the same inherited word and means both those things too.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "claudō, claudis, claudit" — I close, you close, he or she closes]
+[pause 8 seconds for the answer]
+[your turn — say: this chapter's four "I" forms — ambulō, currō, aperiō, claudō]
+[pause 8 seconds for the answer]
+[your turn — say: the four "he or she" forms — ambulat, currit, aperit, claudit]
+[pause 8 seconds for the answer]
+[your turn — say: two prefixes, two verbs — include, exclude; accept, except]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give this chapter's four "I" forms, then the four "he or she" forms. (Ambulō, currō, aperiō, claudō; ambulat, currit, aperit, claudit.) Which two share the third conjugation? (Currō and claudō.) Is English close inherited or borrowed, and what did the root name? (Borrowed — this Latin verb itself; and a hook or peg.) Which verb gives accept and except, the same prefixes as include and exclude, and which is inter- plus "to pick out"? (Capiō, and intellegō.)

--- a/code/learning/human-languages/spanish/CHANGELOG.md
+++ b/code/learning/human-languages/spanish/CHANGELOG.md
@@ -1,5 +1,84 @@
 # Changelog
 
+## Chapters 36-37 — the third verb tranche, and a corrected etymology
+
+Fifteen of the shared spine's forty core verbs were still realized by **no track
+anywhere**. This lands eight of them in Spanish, atom-first, one verb per lesson:
+
+| Chapter | Lessons | Concept |
+|---|---|---|
+| 36 — Hearing, Sleeping, Walking, Running | `ES-C36-oir` · `ES-C36-dormir` · `ES-C36-caminar` · `ES-C36-correr` | `VERB-HEAR` · `VERB-SLEEP` · `VERB-WALK` · `VERB-RUN` |
+| 37 — Opening, Closing, Sitting Down, Standing Up | `ES-C37-abrir` · `ES-C37-cerrar` · `ES-C37-sentarse` · `ES-C37-levantarse` | `VERB-OPEN` · `VERB-CLOSE` · `VERB-SIT` · `VERB-STAND` |
+
+Spanish covers **29 of the 40 core verbs (73%)**, and these eight leave the
+"taught by nobody" set, which drops from 15 to 7.
+
+**The brief for this tranche derived *cerrar* from Latin *claudere*. It does
+not.** *Cerrar* comes from Late Latin **serāre**, "to bolt", from **sera**, the
+bar dropped across a door (Vulgar Latin *serrāre*; Italian *serrare*, French
+*serrer*). *Claudere* is where English got *close, clause, include, exclude,
+conclude, recluse* — and Spanish kept it only in scholarly re-borrowings
+(*incluir*, *excluir*, *concluir*, *clausura*). That inversion became the
+lesson: the bigger English family belongs to the verb Spanish gave up. Two other
+tempting links are named and refused rather than stretched — **April** is not
+from *aperīre* (old folk etymology; the better proposals are Etruscan *Apru* or
+an Italic "the next one"), and *sera*'s link to *serere* "to join in a row" is
+usual but not certain.
+
+What the chapters teach beyond the verbs:
+
+- **The body-position verbs are reflexive**, and both were built the same way:
+  *sentar* ← Vulgar Latin \**sedentāre* from *sedēns*, and *levantar* ←
+  \**levantāre* from *levāns* — two Latin **present participles** turned into new
+  verbs. The pair also separates the two features cleanly: *sentarse* is
+  reflexive **and** an e→ie stem-changer, *levantarse* is reflexive only. Spanish
+  has no verb for standing as a *state*, so **estar de pie** is taught alongside.
+- **oír vs escuchar** — the involuntary/voluntary split English marks less
+  sharply. *Oír* is wildly irregular: the *-go* yo-form *oigo* joins the Chapter
+  12 club, and *oyes/oye/oyen* are a **spelling** rule, not a sound change.
+- **dormir (o→ue) and cerrar (e→ie)** are the payoff for the boot Chapter 11
+  taught and Chapter 34 spent on *pensar*/*entender* — the same rule, both vowels.
+- ***abrir* has an irregular past participle**, *abierto*, inherited whole from
+  Latin *apertum*, against *cerrado* made by rule.
+
+Etymology is the widest honest cousin web: *audīre* (audio, audience, audition,
+auditorium, audit, and **obey** ← *oboedīre* = *ob-* + *audīre*), with
+*escuchar* ← *auscultāre* giving *auscultate* and **scout**; *dormīre*
+(dormitory, dormant, dormer — *dormouse* flagged as likely but unproved);
+*currere* (current, currency, curriculum, courier, cursor, corridor, occur,
+excursion), with English **car** ← Gaulish *carrus* shown to be a cousin at PIE
+\**kers-*; *sedēre* (sedentary, session, siege, preside, reside, assess,
+possess, cathedral, chair) beside its Germanic branch *sit/seat/settle/saddle/
+nest*; *aperīre* (aperture, overt, overture, aperitif); *levāre* (lever,
+elevate, levity, alleviate, relieve, leaven, levy, **the Levant**).
+
+Two honest gaps are stated as gaps rather than filled: *caminar* rests on
+**Gaulish** *camminus* by way of *el camino*, a Celtic loan that stocked every
+Romance language and reached English only inside borrowed French phrases (while
+the near-identical Latin *camīnus* "hearth" is a different word and gave English
+*chimney*); and ***andar*'s origin is genuinely disputed** — Medieval Latin
+*andāre*, with *ambulāre* and *ambitāre* both proposed and neither proved, so
+*amble* and *ambulance* are offered as a conditional maybe.
+
+Reinforcement runs at two cadences, per HL09 §7.2. Each lesson practises the
+atoms of the one or two before it, across the chapter seam (`ES-C36-oir`
+practises Chapter 35's *gustar*; `ES-C37-abrir` practises Chapter 36's
+*correr*), which closes R1 at zero new lessons. Each payoff reaches several
+chapters back to atoms nothing had revisited: Chapter 36's `correr` rescues
+`ES-LEX-PERRO-03`/`ES-EVIDENCE-PERRO-04` (Ch 32) and `ES-LEX-WEEKEND-01` (Ch
+21); Chapter 37's `levantarse` rescues `ES-GRAMMAR-REFLEXIVE-FIRST-PERSON` (Ch
+3, the atom *sentarse* is built on) and `ES-LEX-MANO-01`/
+`ES-GRAMMAR-MANO-GENDER-02`/`ES-LEX-CABEZA-01` (Ch 24). Spanish's
+never-revisited atoms fall from **90 of 199 (45%)** to **80 of 221 (36%)**.
+
+Wiring: `curriculum.json` gains `ES-PATH-032` and `ES-PATH-033` on
+`SPINE-SAY-WHAT-I-DO` and drops the eight concepts from that node's `omits`;
+`chapters.json`, `core/book-generation.json`, `book.tex` and the generated
+`ch36`/`ch37` TeX and narration follow. All eight lessons are schema v2, `voice`
+modality, ≤3 new atoms each (11 per chapter, against `maxNewAtomsPerChapter: 12`)
+and computed at 268-298 s — the drivable prefix is 4 of 4 for both chapters. The
+book compiles to 262 pages with zero `Missing character` warnings.
+
 ## Chapters 34-35 — the second verb tranche, eight verbs no track had
 
 Twenty-three of the shared spine's forty core verbs were realized by **no track

--- a/code/learning/human-languages/spanish/README.md
+++ b/code/learning/human-languages/spanish/README.md
@@ -68,14 +68,14 @@ Requires a LaTeX distribution with `xelatex`/`latexmk` on PATH (MiKTeX or
 TeX Live). The compiled PDF isn't committed — it's regenerated from source,
 same as build artifacts elsewhere in this repo.
 
-Chapters 1–6, 19–33 and 34–35 are generated from the same canonical lesson ASTs
+Chapters 1–6, 19–33 and 34–37 are generated from the same canonical lesson ASTs
 consumed by Language Ladder. Run `npm run build && npm run generate:books` from
 `code/packages/typescript/human-language-data` after editing those lessons; CI
 rejects stale generated TeX or source-hash metadata. Chapters 7–18 are still
 handwritten LaTeX during the staged one-source migration. `units/` is legacy
 source material, not a second canonical copy. The complete PDF builds without
 missing glyphs, layout-box warnings, bookmark warnings, duplicate destinations,
-LaTeX warnings, or font fallbacks — 246 pages as of Chapters 34–35. (Length is
+LaTeX warnings, or font fallbacks — 262 pages as of Chapters 36–37. (Length is
 never a cost here, so the page count is expected to rise with every tranche.)
 
 ## Progress
@@ -146,10 +146,22 @@ exactly where a word needs it:
   *preguntar* and *pedir* → ayudar (← *adiūtāre*: literally English *aid*) →
   **gustar**, which runs backwards — *me gusta el libro* is "the book pleases
   me", so the verb agrees with the thing, not with you.
+- **Chapter 36 — Hearing, Sleeping, Walking, Running**: oír (← *audīre*, and
+  *obey* ← *ob-* + *audīre*), with *escuchar* as the deliberate half of
+  listening → dormir (← *dormīre*), whose *o→ue* is the boot's other vowel →
+  caminar (← *el camino* ← Gaulish *camminus*), beside *andar*, whose origin is
+  genuinely disputed → correr (← *currere*), whose family reaches *car* through
+  Celtic.
+- **Chapter 37 — Opening, Closing, Sitting Down, Standing Up**: abrir (←
+  *aperīre*), with the irregular participle *abierto* → cerrar (← *serāre*, the
+  **bar across a door** — *not* *claudere*, which English kept and Spanish gave
+  up) → sentarse (← \**sedentāre*) → levantarse (← \**levantāre*). Both
+  body-position verbs are reflexive and both were built from a Latin present
+  participle; standing as a *state* is **estar de pie**, not a verb at all.
 
 Every noun carries its gender (*el*/*la*) and plural; every pronoun is traced
-to its root. **All 35 chapters are authored and in the book (246 pages);
-Chapters 1–6, 19–33 and 34–35 are generated from canonical lessons.** Lessons are
+to its root. **All 37 chapters are authored and in the book (262 pages);
+Chapters 1–6, 19–33 and 34–37 are generated from canonical lessons.** Lessons are
 named by **slug** (e.g. `ES-C01-dia`), not numbered — order lives in the book
 (which LaTeX auto-numbers) and in `session-map.md`, so inserting a lesson never
 renumbers anything. - **Pronunciation**:
@@ -195,7 +207,7 @@ cd book && latexmk -xelatex book.tex   # or: ./build.sh / .\build.ps1
 Needs a LaTeX distribution with `xelatex`/`latexmk` on PATH. The PDF is not
 committed; it is regenerated from source like any other build artefact.
 
-Chapters 1–6, 19–33 and 34–35 are generated from the same canonical lesson ASTs
+Chapters 1–6, 19–33 and 34–37 are generated from the same canonical lesson ASTs
 consumed by Language Ladder. Run `npm run build && npm run generate:books` from
 `code/packages/typescript/human-language-data` after editing those lessons; CI
 rejects stale generated TeX or source-hash metadata. Chapters 7–18 are still
@@ -214,8 +226,8 @@ entry says, in the reader's own voice, what finishing that chapter lets them
 knowledge atoms that payoff exercises. It is authored intent, not a derived
 cache — no validator may rewrite it.
 
-All 23 Spanish chapters that own a `core/book-generation.json` target are
-authored: **1–6**, **19–33** and **34–35**. Chapters **7–18** are deliberately
+All 25 Spanish chapters that own a `core/book-generation.json` target are
+authored: **1–6**, **19–33** and **34–37**. Chapters **7–18** are deliberately
 absent.
 Their lessons are still schema v1 with no declared `practises.knowledge`, so
 there is no honest payoff to point at; a stub would destroy the very signal the
@@ -223,7 +235,7 @@ HL05 gap report exists to measure. That absence is tracked debt, and it clears
 when those chapters migrate to schema v2.
 
 Chapters 1–6 end in a terminal `practice-mix` lesson, which is the payoff.
-Chapters 19–35 have no practice lesson, so the payoff is the chapter's last
+Chapters 19–37 have no practice lesson, so the payoff is the chapter's last
 lesson by sequence — the one carrying its recombination and wrap-up recall.
 
 ## Files

--- a/code/learning/human-languages/spanish/book/book.tex
+++ b/code/learning/human-languages/spanish/book/book.tex
@@ -119,6 +119,8 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch33-green-and-yellow}
 \input{chapters/ch34-verbs-of-the-mind}
 \input{chapters/ch35-take-ask-help}
+\input{chapters/ch36-hear-sleep-walk-run}
+\input{chapters/ch37-open-close-sit-stand}
 
 \backmatter
 

--- a/code/learning/human-languages/spanish/book/chapters/ch36-hear-sleep-walk-run.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch36-hear-sleep-walk-run.tex
@@ -1,0 +1,278 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:3e6206d3d514062c
+% canonical-lessons: ES-C36-oir, ES-C36-dormir, ES-C36-caminar, ES-C36-correr
+
+\chapter{Hearing, Sleeping, Walking, Running}
+\label{ch:spanish-hear-sleep-walk-run}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can say I hear, sleep, walk and run in Spanish, write oír's y where the spelling demands it, and break dormir's o to ue the way a boot verb does.}
+
+Run the chapter's four verbs together and sort them by what they do to their stems: correr, caminar and andar leave theirs alone, dormir breaks o to ue, oír grows a g in oigo and writes y in oyes. Then name each verb's source in turn — audīre, dormīre, Gaulish camminus, currere — and set the two words with no settled origin, andar and perro, against them.
+\end{chapteropening}
+
+\section[oír]{oír — \textquotedblleft{}to hear\textquotedblright{}, and the y that appears from nowhere}
+
+\label{lesson:ES-C36-oir}
+
+
+
+\begin{quote}
+Say \emph{Me gusta el café} once — the coffee is pleasing to me, and the coffee is the subject. Now a verb about the ears, and one of the most bent-out-of-shape words in the language.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{accent-i} — the accent on \textbf{í} keeps the vowels apart: \emph{o-EER}, two beats.
+  \item \texttt{y-glide} — the \textbf{y} in \emph{oyes} is the consonant of English \emph{yes}: \emph{O-yes}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{oír} (\textquotedblleft{}\textbf{to hear}\textquotedblright{}) $\leftarrow$ Latin \textbf{audīre}, \textquotedblleft{}to hear\textquotedblright{}. Spanish wore it right down: the \emph{d} between vowels dropped away and \emph{au-} collapsed to \emph{o-}.
+
+English never inherited it but borrowed it repeatedly, and the family keeps the \emph{aud-} Spanish threw away: \textbf{audio}, \textbf{audible}, \textbf{audition}, \textbf{auditorium}, \textbf{audit}, \textbf{audience} — the people doing the hearing.
+
+Then the surprise. \textbf{Obey} is Latin \textbf{oboedīre}, \emph{ob-} (\textquotedblleft{}toward\textquotedblright{}) + \emph{audīre}: obeying is literally \textbf{listening toward} someone. \textbf{Obedient} comes with it.
+\end{cousinweb}
+
+\begin{culture}
+Spanish splits what English leaves joined. \textbf{Oír} is what your ears do whether you meant it or not. \textbf{Escuchar} is on purpose.
+
+\emph{Escuchar} has its own root: Latin \textbf{auscultāre}, \textquotedblleft{}to listen to\textquotedblright{}, built on \emph{auris}, \textquotedblleft{}ear\textquotedblright{}. A doctor \textbf{auscultates} a chest; and when Old French wore \emph{auscultāre} down to \emph{escouter}, English borrowed it as \textbf{scout} — one sent out to listen. English can draw the line when it wants. Spanish makes you.
+\end{culture}
+
+\begin{grammarlens}[title={Grammar Lens: the -go yo-form, and a spelling rule}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{person} & \textbf{form} \\
+\midrule
+yo & \textbf{oigo} \\
+tú & \textbf{oyes} \\
+él/ella/usted & \textbf{oye} \\
+nosotros & \textbf{oímos} \\
+ellos/ustedes & \textbf{oyen} \\
+\bottomrule
+\end{tabularx}
+
+Two separate things. The \emph{yo}-form grows the hard \textbf{-g-} you know from \emph{tengo}, \emph{hago} and \emph{digo}; \emph{oír} joins that club.
+
+The rest is \textbf{spelling}, not sound. Spanish will not write an unstressed \textbf{i} stranded between two vowels, so \emph{oi-es} is impossible and the letter becomes \textbf{y}: \emph{oyes}, \emph{oye}, \emph{oyen}. \emph{Oímos} keeps its accent because there the \emph{i} is stressed.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}oigo, oyes, oye, oímos, oyen\textquotedblright{}
+  \item \textquotedblleft{}¿Me oyes?\textquotedblright{} — can you hear me?
+  \item \textquotedblleft{}Me gusta oír\textquotedblright{} — hearing is pleasing to me
+  \item \textquotedblleft{}oír\textquotedblright{} then English \textquotedblleft{}audio, audience, obey\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which Latin verb is behind \emph{oír}, and what has \emph{obey} to do with it? (\textbf{Audīre}; \emph{oboedīre} is \textquotedblleft{}to listen toward\textquotedblright{}.) Why \emph{oyes} and not \emph{oies}? (Spanish will not leave an unstressed \emph{i} between two vowels.) Which of \emph{oír} and \emph{escuchar} do you choose to do? (\textbf{Escuchar}.) And in \emph{me gusta el café}, what is the subject? (\textbf{El café}.)
+\end{tcolorbox}
+\section[dormir]{dormir — \textquotedblleft{}to sleep\textquotedblright{}, and the boot's other vowel}
+
+\label{lesson:ES-C36-dormir}
+
+
+
+\begin{quote}
+Run \emph{oír} once more: \emph{oigo, oyes, oye, oímos, oyen} — and remember that the \textbf{y} in \emph{oyes} is a spelling rule, not a new sound. Now a verb whose stem cracks the way \emph{pensar}'s did, but on a different vowel.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{diphthong-ue} — under stress the \emph{o} breaks open: \textbf{duermo} = \emph{DWER-mo}.
+  \item \texttt{r-tap} — one soft flick of the tongue in \emph{dormir}, nothing like an English \emph{r}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{dormir} (\textquotedblleft{}\textbf{to sleep}\textquotedblright{}) $\leftarrow$ Latin \textbf{dormīre}, \textquotedblleft{}to sleep\textquotedblright{} — one of the rare verbs Spanish inherited almost untouched. English took the root only through French and Latin, and every borrowing still points at a bed:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{dormitory}, and its clipped \textbf{dorm} — the room where sleeping is done.
+  \item \textbf{dormant} — from the French participle \emph{dormant}, \textquotedblleft{}sleeping\textquotedblright{}. A dormant volcano is a sleeping one.
+  \item \textbf{dormer} — the window let into a roof, named for the sleeping-loft behind it.
+\end{itemize}
+
+Spanish keeps its own branch: \textbf{el dormitorio} for the bedroom, and \emph{la bella durmiente} for Sleeping Beauty.
+
+\begin{quote}
+The \textbf{dormouse} looks like the obvious member of this family, and careful dictionaries will not commit. An Anglo-Norman \emph{dormeus}, \textquotedblleft{}sleepy\textquotedblright{}, is the best guess, but the trail goes cold. Treat it as likely rather than proved.
+\end{quote}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the boot again, with o$\to$ue}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{person} & \textbf{form} & \textbf{stem} \\
+\midrule
+yo & \textbf{duermo} & broken \\
+tú & \textbf{duermes} & broken \\
+él/ella/usted & \textbf{duerme} & broken \\
+nosotros & \textbf{dormimos} & plain \\
+ellos/ustedes & \textbf{duermen} & broken \\
+\bottomrule
+\end{tabularx}
+
+\emph{Pensar} broke \textbf{e$\to$ie} under stress. \emph{Dormir} breaks \textbf{o$\to$ue} under exactly the same condition, and for exactly the same reason: the stress falls on the stem in four of these forms and on the ending in \emph{dormimos}, so only \emph{dormimos} keeps its plain \emph{o}.
+
+That is the whole of the rule. Spanish has two stressed vowels that will not sit still — \emph{e} becomes \emph{ie}, \emph{o} becomes \emph{ue} — and once you can hear where the stress lands, you can predict which forms crack without memorising a list.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}duermo, duermes, duerme, dormimos, duermen\textquotedblright{}
+  \item \textquotedblleft{}pienso\textquotedblright{} then \textquotedblleft{}duermo\textquotedblright{} — e to ie, o to ue, one rule
+  \item \textquotedblleft{}No duermo bien\textquotedblright{} — I don't sleep well
+  \item \textquotedblleft{}dormir\textquotedblright{} then English \textquotedblleft{}dormitory, dormant, dormer\textquotedblright{} — the sleeping family
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which form of \emph{dormir} keeps its plain \emph{o}, and why? (\emph{Dormimos} — the stress lands on the ending.) Name two English cousins of \emph{dormīre}. (\emph{Dormitory, dormant, dormer}.) What did \emph{pēnsāre}, behind \emph{pensar}, mean literally? (\textbf{To weigh}.) And what is the \emph{yo}-form of \emph{oír}? (\textbf{Oigo}.)
+\end{tcolorbox}
+\section[caminar]{caminar — \textquotedblleft{}to walk\textquotedblright{}, from a word Rome borrowed from the Celts}
+
+\label{lesson:ES-C36-caminar}
+
+
+
+\begin{quote}
+\emph{Duermo, duermes, duerme} — the \emph{o} cracking to \emph{ue}. Relax: the two verbs here do nothing of the kind. The interest is in where they came from.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{k-hard} — the \emph{c} before \emph{a} is a hard \emph{k}: \emph{ka-mi-NAR}.
+  \item \texttt{vowel-a} — a short clean \emph{a}, the same in every syllable.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{caminar} (\textquotedblleft{}\textbf{to walk}\textquotedblright{}) was built on the noun \textbf{el camino}, \textquotedblleft{}the road\textquotedblright{} — and \emph{camino} is not a Latin word at all. Latin \textbf{camminus} was a loan from \textbf{Gaulish}, the Celtic language of pre-Roman France, from a word for a step or a way. It stocked the roads of every Romance language: \emph{camino}, Portuguese \emph{caminho}, Italian \emph{cammino}, French \emph{chemin}.
+
+Here the cousin web runs out, and that is worth saying plainly: this root reached English only inside borrowed French phrases. The Celtic layer did reach English by other doors — Latin also took Gaulish \emph{carrus}, a wagon, behind \textbf{car} and \textbf{cargo}. \emph{Camminus} never crossed.
+
+\begin{quote}
+\textbf{A false friend that looks certain.} Latin also had \textbf{camīnus}, \textquotedblleft{}hearth\textquotedblright{}, from Greek \emph{kaminos} — and \emph{that} gave English \textbf{chimney}. Two nearly identical Latin words, no relation.
+\end{quote}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: two plain verbs, and which to reach for}]
+Spanish has a second everyday verb here, \textbf{andar}. Both take ordinary \emph{-ar} endings and neither breaks its stem.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{person} & \textbf{caminar} & \textbf{andar} \\
+\midrule
+yo & \textbf{camino} & \textbf{ando} \\
+tú & \textbf{caminas} & \textbf{andas} \\
+él/ella/usted & \textbf{camina} & \textbf{anda} \\
+nosotros & \textbf{caminamos} & \textbf{andamos} \\
+ellos/ustedes & \textbf{caminan} & \textbf{andan} \\
+\bottomrule
+\end{tabularx}
+
+\textbf{Caminar} is walking as the thing you are doing. \textbf{Andar} is wider: to go about, and by extension to work at all — \emph{no anda}, of a machine, means \textquotedblleft{}it isn't running\textquotedblright{}. Either serves for a walk.
+\end{grammarlens}
+
+\begin{culture}
+\emph{Camino} has a clean history. \emph{Andar} does not. It comes down from Medieval Latin \textbf{andāre}, and where \emph{andāre} came from is \textbf{genuinely disputed}: \emph{ambulāre} (\textquotedblleft{}to walk about\textquotedblright{}) and \emph{ambitāre} (\textquotedblleft{}to go around\textquotedblright{}) are both proposed and neither is proved. If \emph{ambulāre} is right, \textbf{amble} and \textbf{ambulance} are cousins — but that \textquotedblleft{}if\textquotedblright{} carries real weight.
+\end{culture}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}camino, caminas, camina, caminamos, caminan\textquotedblright{}
+  \item \textquotedblleft{}ando, andas, anda, andamos, andan\textquotedblright{}
+  \item \textquotedblleft{}Camino una hora\textquotedblright{} — I walk for an hour
+  \item \textquotedblleft{}el camino\textquotedblright{} then \textquotedblleft{}camino\textquotedblright{} — the road, and I walk it
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which language did Latin borrow \emph{camminus} from? (\textbf{Gaulish}.) Which English word comes from the \emph{other} Latin \emph{camīnus}, the hearth? (\textbf{Chimney} — unrelated.) Is \emph{andar}'s origin settled? (\textbf{No}.) Say \textquotedblleft{}I walk for an hour\textquotedblright{}. (\emph{Camino una hora}.) And the \emph{nosotros} form of \emph{dormir}? (\emph{Dormimos}.)
+\end{tcolorbox}
+\section[correr]{correr — \textquotedblleft{}to run\textquotedblright{}, and the root that runs through half of English}
+
+\label{lesson:ES-C36-correr}
+
+
+
+\begin{quote}
+You can walk two ways now — \emph{camino} and \emph{ando}. Speed it up. This last verb of the chapter is the plainest to conjugate and the richest to trace.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{rolled-rr} — the double \emph{r} is a full trill: \emph{ko-RRER}. It is a different letter from a single \emph{r}, and swapping them swaps words.
+  \item \texttt{vowel-o} — a short pure \emph{o}, no glide toward English \emph{ow}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{correr} (\textquotedblleft{}\textbf{to run}\textquotedblright{}) $\leftarrow$ Latin \textbf{currere}, \textquotedblleft{}to run\textquotedblright{}. English borrowed this root harder than almost any other, and the descendants have spread so far from running that they no longer look related:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{current} — water that runs; \textbf{currency}, money running hand to hand.
+  \item \textbf{curriculum} — a \emph{running}, a racecourse. A course of study is a track you run.
+  \item \textbf{courier}, a runner; \textbf{course}, \textbf{cursor}, \textbf{cursive} — writing that runs.
+  \item \textbf{corridor} — a place for running along, by way of Italian.
+  \item with prefixes: \textbf{occur} (\emph{ob-}, to run up against), \textbf{recur}, \textbf{incur}, \textbf{precursor}, \textbf{excursion}.
+\end{itemize}
+
+And a cousin from the lesson before: Gaulish \emph{carrus}, behind English \textbf{car} and \textbf{cargo}, comes from the very same Proto-Indo-European root \emph{\textbf{kers-}}, \textquotedblleft{}to run\textquotedblright{}. Latin took one road and Celtic another; English holds both ends.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: a plain -er verb, and four verbs together}]
+\emph{Correr} breaks nothing and grows nothing: \textbf{corro, corres, corre, corremos, corren}. That makes it the clean case the chapter's others stand out against:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{verb} & \textbf{what it does to its stem} \\
+\midrule
+\textbf{correr} & nothing — \emph{corro, corres, corre} \\
+\textbf{caminar}, \textbf{andar} & nothing — \emph{camino, ando} \\
+\textbf{dormir} & breaks \emph{o} to \emph{ue} under stress — \emph{duermo}, but \emph{dormimos} \\
+\textbf{oír} & grows \emph{-g-} in \emph{oigo}, and writes \emph{y} in \emph{oyes}, \emph{oye}, \emph{oyen} \\
+\bottomrule
+\end{tabularx}
+
+Only two of the four misbehave, and each misbehaves by a rule you can state.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}corro, corres, corre, corremos, corren\textquotedblright{}
+  \item \textquotedblleft{}El perro corre\textquotedblright{} — the dog runs
+  \item \textquotedblleft{}Camino, no corro\textquotedblright{} — I walk, I don't run
+  \item \textquotedblleft{}Corro el sábado\textquotedblright{} — I run on Saturday; Spanish uses the bare article where English says \emph{on}
+  \item \textquotedblleft{}Oigo, duermo, camino, corro\textquotedblright{} — the whole chapter in four words
+  \item \textquotedblleft{}correr\textquotedblright{} then English \textquotedblleft{}current, curriculum, corridor\textquotedblright{} — the running family
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Name each verb's source in turn: \emph{oír}, \emph{dormir}, \emph{caminar}, \emph{correr}. (\textbf{Audīre}; \textbf{dormīre}; Gaulish \emph{camminus}, by way of \emph{el camino}; \textbf{currere}.) Which of the four leave their stems alone? (\emph{Caminar}, \emph{andar} and \emph{correr}.) Say \textquotedblleft{}the dog runs\textquotedblright{}. (\emph{El perro corre}.) Two words here have no settled origin — which? (\emph{Andar}, and \emph{perro}, whose three proposals all lack the evidence to decide between them.) And which English everyday word is a cousin of \emph{correr} through Celtic? (\textbf{Car}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch37-open-close-sit-stand.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch37-open-close-sit-stand.tex
@@ -1,0 +1,256 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:60ab3e2d720ff3b6
+% canonical-lessons: ES-C37-abrir, ES-C37-cerrar, ES-C37-sentarse, ES-C37-levantarse
+
+\chapter{Opening, Closing, Sitting Down, Standing Up}
+\label{ch:spanish-open-close-sit-stand}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can say I open, close, sit down and stand up in Spanish, and use the reflexive pronoun that makes sentarse and levantarse land the action back on me.}
+
+Say the chapter in one breath — abro el libro, me siento, cierro el libro, me levanto — then separate the two features it taught: sentarse is reflexive and a stem-changer, levantarse is reflexive only. Name the shared recipe behind both body-position verbs (a Latin present participle, sedēns and levāns), pick abierto out as the one irregular participle, and reach back to la mano for why the article stays feminine.
+\end{chapteropening}
+
+\section[abrir]{abrir — \textquotedblleft{}to open\textquotedblright{}, and the one part of it that misbehaves}
+
+\label{lesson:ES-C37-abrir}
+
+
+
+\begin{quote}
+Say \emph{corro} and \emph{camino} once — two verbs that gave you no trouble. This one is nearly as easy, and its one misbehaving piece is a word you will read on a shop door before you ever say it.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{b-soft} — between vowels the \emph{b} barely closes the lips: \emph{a-BREER}.
+  \item \texttt{r-tap} — a single flick for the final \emph{r}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{abrir} (\textquotedblleft{}\textbf{to open}\textquotedblright{}) $\leftarrow$ Latin \textbf{aperīre}, \textquotedblleft{}to open, to uncover\textquotedblright{}. The \emph{p} softened to \emph{b} between vowels on the way into Spanish — the slide that turned \emph{sapere} into \emph{saber} and \emph{lupus} into \emph{lobo}.
+
+English took the root through two doors and does not notice they are one word:
+
+\begin{itemize}
+\raggedright
+  \item straight from Latin \emph{apertūra}: \textbf{aperture}, the opening a lens makes.
+  \item through French \emph{ovrir} and its participle \emph{overt}: \textbf{overt} (\textquotedblleft{}out in the open\textquotedblright{}) and \textbf{overture}, an opera's opening.
+  \item \textbf{aperitif}, a drink that \emph{opens} the appetite; Spanish, \textbf{el aperitivo}.
+\end{itemize}
+
+\begin{quote}
+\textbf{The cousin that is not one.} \emph{April} looks like it belongs here — the opening month. That is old folk etymology and is not accepted: the better proposals point at an Etruscan \emph{Apru}, borrowed from Aphrodite, or at an Italic word meaning \textquotedblleft{}the next one\textquotedblright{}. A hook this pretty is the kind to check.
+\end{quote}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: regular everywhere but the participle}]
+In the present, \emph{abrir} is a plain \emph{-ir} verb, the family \emph{escribir} belongs to: \textbf{abro, abres, abre, abrimos, abren}. Nothing breaks, nothing grows.
+
+The \textbf{past participle} is where the irregularity lives. A regular \emph{-ir} verb would give \emph{abrido}. Spanish says \textbf{abierto}, straight down from Latin \emph{apertum}, keeping the \emph{e} that broke to \emph{ie} under stress long ago.
+
+You will meet that participle long before the tense it belongs to, because it is a word on doors: \textbf{ABIERTO} on the sign, \textbf{está abierto} for \textquotedblleft{}it is open now\textquotedblright{}. \emph{Escribir} does the same with \textbf{escrito}. Both refuse the regular ending because both inherited a Latin participle whole.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}abro, abres, abre, abrimos, abren\textquotedblright{}
+  \item \textquotedblleft{}Abro el libro\textquotedblright{} then \textquotedblleft{}Está abierto\textquotedblright{}
+  \item \textquotedblleft{}abrir\textquotedblright{} then English \textquotedblleft{}aperture, overt, overture\textquotedblright{}
+  \item \textquotedblleft{}correr\textquotedblright{} then English \textquotedblleft{}current, curriculum\textquotedblright{} — still there from before
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What is the past participle of \emph{abrir}, and what would a regular verb have given? (\textbf{Abierto}; \emph{abrido}.) Name two English words from \emph{aperīre}. (\emph{Aperture, overt, overture, aperitif}.) Is \emph{April} one? (\textbf{No} — folk etymology.) Which other verb keeps an inherited Latin participle? (\emph{Escribir} $\to$ \emph{escrito}.) And which Latin verb is behind \emph{correr}? (\textbf{Currere}.)
+\end{tcolorbox}
+\section[cerrar]{cerrar — \textquotedblleft{}to close\textquotedblright{}, from the bar across the door}
+
+\label{lesson:ES-C37-cerrar}
+
+
+
+\begin{quote}
+\emph{Abro, abres, abre} — and the sign saying \textbf{ABIERTO}. Here is the sign on the other side of the day, and a verb that cracks its stem.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{soft-c} — \emph{c} before \emph{e} is soft: a \emph{th} across most of Spain, an \emph{s} across Latin America.
+  \item \texttt{rolled-rr} — the double \emph{r} is fully trilled: \emph{se-RRAR}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{cerrar} (\textquotedblleft{}\textbf{to close}\textquotedblright{}) $\leftarrow$ Late Latin \textbf{serāre}, \textquotedblleft{}to bolt, to fasten\textquotedblright{}, from the noun \textbf{sera}: the \textbf{bar you drop across a door}. Closing here is a physical object being put in place, not an abstraction.
+
+Its Romance siblings kept the pressure: Italian \emph{serrare}, French \emph{serrer}, \textquotedblleft{}to squeeze, to tighten\textquotedblright{}. English holds one of that branch, \textbf{serried}, as in ranks pressed shut against each other. Reference works generally connect \emph{sera} to Latin \textbf{serere}, \textquotedblleft{}to join in a row\textquotedblright{}, which would make \textbf{series} and \textbf{insert} distant relatives — usual, but not certain.
+\end{cousinweb}
+
+\begin{culture}
+Latin had a perfectly good verb for closing: \textbf{claudere}. English is full of it — \textbf{close}, \textbf{closet}, \textbf{closure}, \textbf{clause}, \textbf{cloister}, \textbf{include}, \textbf{exclude}, \textbf{conclude}, \textbf{recluse}.
+
+Spanish let it go. For shutting a door it took \emph{serāre} instead, and kept \emph{claudere} only in words scholars borrowed back much later: \textbf{incluir}, \textbf{excluir}, \textbf{concluir}, \textbf{clausura}. That inversion is worth sitting with: the bigger English family belongs to the verb Spanish gave up. A cousin web maps what each language kept, and these two kept opposite halves.
+\end{culture}
+
+\begin{grammarlens}[title={Grammar Lens: e$\to$ie, and the sign on the door}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{person} & \textbf{form} \\
+\midrule
+yo & \textbf{cierro} \\
+tú & \textbf{cierras} \\
+él/ella/usted & \textbf{cierra} \\
+nosotros & \textbf{cerramos} \\
+ellos/ustedes & \textbf{cierran} \\
+\bottomrule
+\end{tabularx}
+
+\emph{Dormir} broke \textbf{o$\to$ue}. \emph{Cerrar} breaks \textbf{e$\to$ie} — the same boot, the other vowel, the same trigger: stress on the stem. \emph{Cerramos} is plain because there the stress moves to the ending.
+
+Its participle, unlike \emph{abierto}, is regular: \textbf{cerrado}. The two signs on one door are built differently — \emph{abierto} inherited whole from Latin, \emph{cerrado} made by rule.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}cierro, cierras, cierra, cerramos, cierran\textquotedblright{}
+  \item \textquotedblleft{}Abro el libro\textquotedblright{} then \textquotedblleft{}Cierro el libro\textquotedblright{}
+  \item \textquotedblleft{}ABIERTO\textquotedblright{} then \textquotedblleft{}CERRADO\textquotedblright{} — the two signs
+  \item \textquotedblleft{}aperīre, aperture\textquotedblright{} then \textquotedblleft{}serāre, serried\textquotedblright{} — the two doors' roots
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What was a \emph{sera}, and does \emph{cerrar} come from \emph{claudere}? (\textbf{The bar dropped across a door}; and \textbf{no} — Spanish kept \emph{claudere} only in \emph{incluir}, \emph{excluir}, \emph{concluir}.) Which form of \emph{cerrar} keeps its plain \emph{e}, and why? (\emph{Cerramos} — the stress moves to the ending, as in \emph{dormimos}.) Which participle is irregular, \emph{abierto} or \emph{cerrado}? (\emph{Abierto}.) And what did \emph{intendere}, behind \emph{entender}, mean literally? (\textbf{To stretch toward}.)
+\end{tcolorbox}
+\section[sentarse]{sentarse — \textquotedblleft{}to seat oneself\textquotedblright{}, which is how Spanish thinks about sitting down}
+
+\label{lesson:ES-C37-sentarse}
+
+
+
+\begin{quote}
+Two things in hand. \emph{Cierro} — the \emph{e} cracking to \emph{ie}. And \emph{me llamo}, \textquotedblleft{}I call \textbf{myself}\textquotedblright{}, where the little \emph{me} bounced the action back onto you. This verb needs both at once.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{diphthong-ie} — the stressed \emph{e} breaks: \textbf{me siento} = \emph{me SYEN-to}.
+  \item \texttt{s-clear} — a clean hissing \emph{s}, never a \emph{z} buzz.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{sentar} $\leftarrow$ Vulgar Latin \emph{\textbf{sedentāre}, built not on the Latin verb but on its \textbf{present participle}: }sedēns\emph{, \textquotedblleft{}sitting\textquotedblright{}, from \textbf{sedēre}, \textquotedblleft{}to sit\textquotedblright{}. Spanish made a new verb out of being in a sitting state.}
+
+\emph{Sedēre} is one of the great English suppliers, and hardly any descendant still looks like sitting: \textbf{sedentary}, \textbf{sediment}, \textbf{sedate}; \textbf{session} and \textbf{siege} (an army sitting down outside a city); \textbf{preside}, \textbf{reside}; \textbf{assess}, \textbf{obsess}, \textbf{possess}. By way of Greek \emph{hedra}, \textquotedblleft{}seat\textquotedblright{}, it also gives \textbf{cathedral} and \textbf{chair}.
+
+Then the other branch. English \textbf{sit}, \textbf{seat}, \textbf{settle}, \textbf{saddle} and \textbf{nest} come down from the very same root, \emph{\textbf{sed-}}, through Germanic rather than Latin. Neither borrowed from the other: they are siblings, exactly as \emph{padre} and \emph{father} are, each branch reshaping the sounds its own way.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: seating someone, and seating yourself}]
+Plain \textbf{sentar} means to seat somebody \emph{else}. To sit down yourself, you send the action back with the pronoun that made \emph{me llamo} \textquotedblleft{}I call myself\textquotedblright{}:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{person} & \textbf{form} \\
+\midrule
+yo & \textbf{me siento} \\
+tú & \textbf{te sientas} \\
+él/ella/usted & \textbf{se sienta} \\
+nosotros & \textbf{nos sentamos} \\
+ellos/ustedes & \textbf{se sientan} \\
+\bottomrule
+\end{tabularx}
+
+Two patterns run at once, and you have both. The pronoun changes with the person — \emph{me, te, se, nos, se} — and the stem breaks \emph{e$\to$ie} wherever the stress lands on it, leaving \emph{nos sentamos} plain. The pronoun stands before a conjugated verb and clips onto an infinitive, hence the name \textbf{sentarse}.
+
+\begin{quote}
+\textbf{Two verbs, one shape.} \emph{Me siento} is also the \emph{yo}-form of \emph{sentirse}, \textquotedblleft{}to feel\textquotedblright{}: \emph{me siento bien} is \textquotedblleft{}I feel fine\textquotedblright{}. Only what follows tells them apart.
+\end{quote}
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}me siento, te sientas, se sienta, nos sentamos, se sientan\textquotedblright{}
+  \item \textquotedblleft{}me llamo\textquotedblright{} then \textquotedblleft{}me siento\textquotedblright{} — the same little me, twice
+  \item \textquotedblleft{}Cierro el libro y me siento\textquotedblright{} — I close the book and sit down
+  \item \textquotedblleft{}sentarse\textquotedblright{} then English \textquotedblleft{}session, sedentary, preside\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What does \emph{sentarse} say literally, and which Latin form was it built on? (\textbf{To seat oneself}; the participle \emph{sedēns}.) Are English \emph{sit} and Latin \emph{sedēre} parent and child, or siblings? (\textbf{Siblings} — separate branches of one root, like \emph{father} and \emph{padre}.) Which form keeps its plain \emph{e}, and what was a \emph{sera}? (\emph{Nos sentamos}; \textbf{the bar across a door}.)
+\end{tcolorbox}
+\section[levantarse]{levantarse — \textquotedblleft{}to raise oneself\textquotedblright{}, and how Spanish says \textquotedblleft{}stand\textquotedblright{}}
+
+\label{lesson:ES-C37-levantarse}
+
+
+
+\begin{quote}
+\emph{Me siento} put you in the chair, the little \emph{me} bouncing the action back onto you. Now get out of it. The pronoun works the same way; this time the stem does not crack at all.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{v-b} — Spanish \emph{v} and \emph{b} are one sound: \emph{le-ban-TAR}.
+  \item \texttt{nasal-n} — a clean \emph{n} before the \emph{t}, not swallowed.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{levantar} $\leftarrow$ Vulgar Latin \emph{\textbf{levantāre}, from \textbf{levāns}, the present participle of \textbf{levāre}, \textquotedblleft{}to raise, to lighten\textquotedblright{} — itself from \textbf{levis}, \textquotedblleft{}light, not heavy\textquotedblright{}.}
+
+Notice the shape: a Latin \textbf{present participle}, made into a new verb — the identical recipe that gave \emph{sentar} from \emph{sedēns}. Spanish built both of its body-position verbs out of a word for the state rather than the act.
+
+\emph{Levāre} is everywhere in English: \textbf{lever}, \textbf{elevate}, \textbf{elevator} for raising; \textbf{levity}, \textbf{levitate}, \textbf{alleviate}, \textbf{relieve} for lightening; \textbf{leaven}, what raises the bread, and \textbf{levy}, a tax \emph{raised}. And \textbf{the Levant}, from French \emph{levant}, \textquotedblleft{}rising\textquotedblright{}: from western Europe it lay where the sun came up. English \textbf{light}, the opposite of heavy, is the Germanic cousin of \emph{levis}, as \emph{sit} is of \emph{sedēre}.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: raising a thing, raising yourself, standing still}]
+\textbf{Levantar} on its own raises something else. \textbf{Levantarse} raises \emph{you}:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{Spanish} & \textbf{what it means} \\
+\midrule
+\textbf{Levanto la mano} & I raise my hand \\
+\textbf{Levanto la cabeza} & I lift my head \\
+\textbf{Me levanto} & I get up, I stand up \\
+\bottomrule
+\end{tabularx}
+
+The endings are ordinary \emph{-ar} throughout — \textbf{me levanto, te levantas, se levanta, nos levantamos, se levantan} — and nothing breaks. So the chapter has now shown its two features apart: \emph{sentarse} is reflexive \textbf{and} a stem-changer; \emph{levantarse} is reflexive \textbf{only}.
+
+For standing as a \emph{state}, Spanish uses no verb. It says \textbf{estar de pie} — \textquotedblleft{}to be on foot\textquotedblright{}, \emph{el pie} being the foot. English's single \textquotedblleft{}stand\textquotedblright{} splits in two: \emph{me levanto} for getting up, \emph{estoy de pie} for being up.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}me levanto, te levantas, se levanta, nos levantamos, se levantan\textquotedblright{}
+  \item \textquotedblleft{}Levanto la mano\textquotedblright{} then \textquotedblleft{}Levanto la cabeza\textquotedblright{} then \textquotedblleft{}Me levanto\textquotedblright{}
+  \item \textquotedblleft{}Estoy de pie\textquotedblright{} — I am standing
+  \item \textquotedblleft{}Abro el libro, me siento, cierro el libro, me levanto\textquotedblright{}
+  \item \textquotedblleft{}levantar\textquotedblright{} then English \textquotedblleft{}lever, elevate, Levant\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say the chapter's four verbs, then say how you are standing. (\emph{Abro, cierro, me siento, me levanto}; \emph{estoy de pie}.) What do \emph{sentar} and \emph{levantar} share in their making, and which also breaks its stem? (Both from a Latin \textbf{present participle}, \emph{sedēns} and \emph{levāns}; \emph{sentarse} breaks \emph{e$\to$ie}.) Name the two roots on that door, and which participle is irregular. (\textbf{Aperīre} and \textbf{serāre} — \emph{not} \emph{claudere}; \emph{abierto}.) Why \emph{la} mano? (\emph{Manus} was feminine in Latin.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/chapters.json
+++ b/code/learning/human-languages/spanish/chapters.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "language": "spanish",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 1-6, 19-33 and 34-35 are authored here — every Spanish chapter that owns a core/book-generation.json target. Chapters 7-18 are deliberately absent: their lessons are still schema_version 1 with no practises.knowledge, so no payoff can be claimed for them honestly. That absence is real, measurable debt and must not be papered over with placeholders. Chapters 1-6 end in a terminal practice-mix; chapters 19-35 have none, so their payoff is the chapter's last lesson by sequence, which is where the recombination and wrap-up recall actually live.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 1-6 and 19-37 are authored here — every Spanish chapter that owns a core/book-generation.json target. Chapters 7-18 are deliberately absent: their lessons are still schema_version 1 with no practises.knowledge, so no payoff can be claimed for them honestly. That absence is real, measurable debt and must not be papered over with placeholders. Chapters 1-6 end in a terminal practice-mix; chapters 19-37 have none, so their payoff is the chapter's last lesson by sequence, which is where the recombination and wrap-up recall actually live.",
   "chapters": [
     {
       "chapter": 1,
@@ -450,6 +450,63 @@
           "ES-LEX-GUSTAR-07",
           "ES-ETYMON-GUSTAR-08",
           "ES-GRAMMAR-GUSTAR-INVERSION-09"
+        ]
+      }
+    },
+    {
+      "chapter": 36,
+      "title": "Hearing, Sleeping, Walking, Running",
+      "label": "ch:spanish-hear-sleep-walk-run",
+      "canDo": "I can say I hear, sleep, walk and run in Spanish, write oír's y where the spelling demands it, and break dormir's o to ue the way a boot verb does.",
+      "spineNodes": ["SPINE-SAY-WHAT-I-DO"],
+      "payoff": {
+        "lesson": "ES-C36-correr",
+        "kind": "task",
+        "summary": "Run the chapter's four verbs together and sort them by what they do to their stems: correr, caminar and andar leave theirs alone, dormir breaks o to ue, oír grows a g in oigo and writes y in oyes. Then name each verb's source in turn — audīre, dormīre, Gaulish camminus, currere — and set the two words with no settled origin, andar and perro, against them.",
+        "assesses": [
+          "ES-LEX-OIR-01",
+          "ES-ETYMON-OIR-02",
+          "ES-GRAMMAR-OIR-Y-03",
+          "ES-LEX-DORMIR-04",
+          "ES-ETYMON-DORMIR-05",
+          "ES-GRAMMAR-STEM-O-UE-06",
+          "ES-LEX-CAMINAR-07",
+          "ES-LEX-ANDAR-08",
+          "ES-ETYMON-CAMINAR-09",
+          "ES-LEX-CORRER-10",
+          "ES-ETYMON-CORRER-11",
+          "ES-LEX-PERRO-03",
+          "ES-EVIDENCE-PERRO-04",
+          "ES-LEX-WEEKEND-01"
+        ]
+      }
+    },
+    {
+      "chapter": 37,
+      "title": "Opening, Closing, Sitting Down, Standing Up",
+      "label": "ch:spanish-open-close-sit-stand",
+      "canDo": "I can say I open, close, sit down and stand up in Spanish, and use the reflexive pronoun that makes sentarse and levantarse land the action back on me.",
+      "spineNodes": ["SPINE-SAY-WHAT-I-DO"],
+      "payoff": {
+        "lesson": "ES-C37-levantarse",
+        "kind": "task",
+        "summary": "Say the chapter in one breath — abro el libro, me siento, cierro el libro, me levanto — then separate the two features it taught: sentarse is reflexive and a stem-changer, levantarse is reflexive only. Name the shared recipe behind both body-position verbs (a Latin present participle, sedēns and levāns), pick abierto out as the one irregular participle, and reach back to la mano for why the article stays feminine.",
+        "assesses": [
+          "ES-LEX-ABRIR-01",
+          "ES-ETYMON-ABRIR-02",
+          "ES-GRAMMAR-ABIERTO-03",
+          "ES-LEX-CERRAR-04",
+          "ES-ETYMON-CERRAR-05",
+          "ES-ETYMON-CLAUDERE-06",
+          "ES-LEX-SENTARSE-07",
+          "ES-ETYMON-SENTARSE-08",
+          "ES-LEX-LEVANTARSE-09",
+          "ES-ETYMON-LEVANTARSE-10",
+          "ES-LEX-DE-PIE-11",
+          "ES-GRAMMAR-REFLEXIVE-FIRST-PERSON",
+          "ES-LEX-MANO-01",
+          "ES-GRAMMAR-MANO-GENDER-02",
+          "ES-LEX-CABEZA-01"
         ]
       }
     }

--- a/code/learning/human-languages/spanish/curriculum.json
+++ b/code/learning/human-languages/spanish/curriculum.json
@@ -456,6 +456,32 @@
       "before": [],
       "inline": [],
       "after": []
+    },
+    {
+      "id": "ES-PATH-032",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "ES-C36-oir",
+        "ES-C36-dormir",
+        "ES-C36-caminar",
+        "ES-C36-correr"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-033",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "ES-C37-abrir",
+        "ES-C37-cerrar",
+        "ES-C37-sentarse",
+        "ES-C37-levantarse"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
     }
   ],
   "spine": {
@@ -584,30 +610,24 @@
         "ES-PATH-028",
         "ES-PATH-029",
         "ES-PATH-030",
-        "ES-PATH-031"
+        "ES-PATH-031",
+        "ES-PATH-032",
+        "ES-PATH-033"
       ],
       "omits": [
         "VERB-INFINITIVE",
         "VERB-PRESENT-HABITUAL",
         "VERB-SEE",
-        "VERB-HEAR",
         "VERB-KNOW",
         "VERB-LEARN",
         "VERB-GIVE",
         "VERB-BRING",
         "VERB-GET",
-        "VERB-SLEEP",
         "VERB-PLAY",
-        "VERB-WALK",
-        "VERB-RUN",
-        "VERB-SIT",
-        "VERB-STAND",
         "VERB-WAIT",
         "VERB-ANSWER",
         "VERB-MEET",
-        "VERB-BUY",
-        "VERB-OPEN",
-        "VERB-CLOSE"
+        "VERB-BUY"
       ],
       "relocates": {
         "VERB-SPEAK": "SPINE-POLITE-REQUEST-REPAIR",

--- a/code/learning/human-languages/spanish/lessons/ES-C36-caminar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C36-caminar.md
@@ -1,0 +1,106 @@
+---
+schema_version: 2
+id: ES-C36-caminar
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 1710
+chapter: 36
+type: word
+headword: caminar
+gloss: to walk — built on a Celtic word for a path, beside andar, whose own past is unsettled
+concept_tag: VERB-WALK
+prerequisites: [ES-C36-dormir, ES-C29-la-hora]
+sounds: [k-hard, vowel-a]
+roots: [camminus-gaulish]
+etymology_hook: "caminar ← el camino ← Late Latin camminus, borrowed from Gaulish — a Celtic word Latin adopted; it stocked every Romance language (camino, caminho, cammino, chemin) and left English nothing, while the near-identical camīnus 'hearth' is a different word and gave English chimney"
+duration:
+  max_seconds: 260
+requires:
+  knowledge: [ES-LEX-DORMIR-04, ES-GRAMMAR-STEM-O-UE-06, ES-LEX-HORA-01]
+introduces:
+  knowledge: [ES-LEX-CAMINAR-07, ES-LEX-ANDAR-08, ES-ETYMON-CAMINAR-09]
+practises:
+  knowledge: [ES-LEX-DORMIR-04, ES-GRAMMAR-STEM-O-UE-06, ES-LEX-HORA-01, ES-LEX-CAMINAR-07, ES-LEX-ANDAR-08, ES-ETYMON-CAMINAR-09]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C36-dormir, ES-C29-la-hora]
+---
+
+# caminar — "to walk", from a word Rome borrowed from the Celts
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-DORMIR-04, ES-GRAMMAR-STEM-O-UE-06] -->
+
+[PAUSE 2s] *Duermo, duermes, duerme* — the *o* cracking to *ue*. Relax: the two
+verbs here do nothing of the kind. The interest is in where they came from.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `k-hard` — the *c* before *a* is a hard *k*: *ka-mi-NAR*.
+- `vowel-a` — a short clean *a*, the same in every syllable.
+
+## The word, taken apart: caminar
+<!-- hl-knowledge: introduces=[ES-LEX-CAMINAR-07, ES-ETYMON-CAMINAR-09]; assesses=[] -->
+
+**caminar** ("**to walk**") was built on the noun **el camino**, "the road" —
+and *camino* is not a Latin word at all. Latin **camminus** was a loan from
+**Gaulish**, the Celtic language of pre-Roman France, from a word for a step or
+a way. It stocked the roads of every Romance language: *camino*, Portuguese
+*caminho*, Italian *cammino*, French *chemin*.
+
+Here the cousin web runs out, and that is worth saying plainly: this root
+reached English only inside borrowed French phrases. The Celtic layer did reach
+English by other doors — Latin also took Gaulish *carrus*, a wagon, behind
+**car** and **cargo**. *Camminus* never crossed.
+
+> **A false friend that looks certain.** Latin also had **camīnus**, "hearth",
+> from Greek *kaminos* — and *that* gave English **chimney**. Two nearly
+> identical Latin words, no relation.
+
+## Grammar Lens: two plain verbs, and which to reach for
+<!-- hl-knowledge: introduces=[ES-LEX-ANDAR-08]; assesses=[ES-LEX-CAMINAR-07] -->
+
+Spanish has a second everyday verb here, **andar**. Both take ordinary *-ar*
+endings and neither breaks its stem.
+
+| person | caminar | andar |
+|---|---|---|
+| yo | **camino** | **ando** |
+| tú | **caminas** | **andas** |
+| él/ella/usted | **camina** | **anda** |
+| nosotros | **caminamos** | **andamos** |
+| ellos/ustedes | **caminan** | **andan** |
+
+**Caminar** is walking as the thing you are doing. **Andar** is wider: to go
+about, and by extension to work at all — *no anda*, of a machine, means "it
+isn't running". Either serves for a walk.
+
+## Why it's said this way: a verb with no settled past
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ANDAR-08, ES-ETYMON-CAMINAR-09] -->
+
+*Camino* has a clean history. *Andar* does not. It comes down from Medieval
+Latin **andāre**, and where *andāre* came from is **genuinely disputed**:
+*ambulāre* ("to walk about") and *ambitāre* ("to go around") are both proposed
+and neither is proved. If *ambulāre* is right, **amble** and **ambulance** are
+cousins — but that "if" carries real weight.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CAMINAR-07, ES-LEX-ANDAR-08, ES-ETYMON-CAMINAR-09, ES-LEX-HORA-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: "camino, caminas, camina, caminamos, caminan"]
+- [YOU SAY: "ando, andas, anda, andamos, andan"]
+- [YOU SAY: "Camino una hora" — I walk for an hour]
+- [YOU SAY: "el camino" then "camino" — the road, and I walk it]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CAMINAR-07, ES-LEX-ANDAR-08, ES-ETYMON-CAMINAR-09, ES-LEX-HORA-01, ES-LEX-DORMIR-04] -->
+
+[PAUSE 3s] Which language did Latin borrow *camminus* from? (**Gaulish**.)
+Which English word comes from the *other* Latin *camīnus*, the hearth?
+(**Chimney** — unrelated.) Is *andar*'s origin settled? (**No**.) Say "I walk
+for an hour". (*Camino una hora*.) And the *nosotros* form of *dormir*?
+(*Dormimos*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C36-correr.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C36-correr.md
@@ -1,0 +1,98 @@
+---
+schema_version: 2
+id: ES-C36-correr
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 1720
+chapter: 36
+type: word
+headword: correr
+gloss: to run — a plain -er verb sitting on one of the largest roots English ever borrowed
+concept_tag: VERB-RUN
+prerequisites: [ES-C36-caminar, ES-C32-perro, ES-C21-sabado-domingo]
+sounds: [rolled-rr, vowel-o]
+roots: [currere-latin]
+etymology_hook: "correr ← Latin currere 'to run' → current, currency, curriculum, courier, course, cursor, corridor, occur, recur, excursion; and English car is a cousin at one further remove, through Gaulish rather than Latin"
+duration:
+  max_seconds: 285
+requires:
+  knowledge: [ES-LEX-CAMINAR-07, ES-LEX-ANDAR-08, ES-ETYMON-CAMINAR-09, ES-LEX-PERRO-03, ES-EVIDENCE-PERRO-04, ES-LEX-WEEKEND-01]
+introduces:
+  knowledge: [ES-LEX-CORRER-10, ES-ETYMON-CORRER-11]
+practises:
+  knowledge: [ES-LEX-OIR-01, ES-ETYMON-OIR-02, ES-GRAMMAR-OIR-Y-03, ES-LEX-DORMIR-04, ES-ETYMON-DORMIR-05, ES-GRAMMAR-STEM-O-UE-06, ES-LEX-CAMINAR-07, ES-LEX-ANDAR-08, ES-ETYMON-CAMINAR-09, ES-LEX-CORRER-10, ES-ETYMON-CORRER-11, ES-LEX-PERRO-03, ES-EVIDENCE-PERRO-04, ES-LEX-WEEKEND-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C36-caminar, ES-C36-dormir, ES-C36-oir, ES-C32-perro]
+---
+
+# correr — "to run", and the root that runs through half of English
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CAMINAR-07, ES-LEX-ANDAR-08] -->
+
+[PAUSE 2s] You can walk two ways now — *camino* and *ando*. Speed it up. This
+last verb of the chapter is the plainest to conjugate and the richest to trace.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `rolled-rr` — the double *r* is a full trill: *ko-RRER*. It is a different letter from a single *r*, and swapping them swaps words.
+- `vowel-o` — a short pure *o*, no glide toward English *ow*.
+
+## The word, taken apart: correr
+<!-- hl-knowledge: introduces=[ES-LEX-CORRER-10, ES-ETYMON-CORRER-11]; assesses=[] -->
+
+**correr** ("**to run**") ← Latin **currere**, "to run". English borrowed this
+root harder than almost any other, and the descendants have spread so far from
+running that they no longer look related:
+
+- **current** — water that runs; **currency**, money running hand to hand.
+- **curriculum** — a *running*, a racecourse. A course of study is a track you run.
+- **courier**, a runner; **course**, **cursor**, **cursive** — writing that runs.
+- **corridor** — a place for running along, by way of Italian.
+- with prefixes: **occur** (*ob-*, to run up against), **recur**, **incur**,
+  **precursor**, **excursion**.
+
+And a cousin from the lesson before: Gaulish *carrus*, behind English **car**
+and **cargo**, comes from the very same Proto-Indo-European root ***kers-***,
+"to run". Latin took one road and Celtic another; English holds both ends.
+
+## Grammar Lens: a plain -er verb, and four verbs together
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CORRER-10, ES-LEX-OIR-01, ES-GRAMMAR-OIR-Y-03, ES-LEX-DORMIR-04, ES-GRAMMAR-STEM-O-UE-06] -->
+
+*Correr* breaks nothing and grows nothing: **corro, corres, corre, corremos,
+corren**. That makes it the clean case the chapter's others stand out against:
+
+| verb | what it does to its stem |
+|---|---|
+| **correr** | nothing — *corro, corres, corre* |
+| **caminar**, **andar** | nothing — *camino, ando* |
+| **dormir** | breaks *o* to *ue* under stress — *duermo*, but *dormimos* |
+| **oír** | grows *-g-* in *oigo*, and writes *y* in *oyes*, *oye*, *oyen* |
+
+Only two of the four misbehave, and each misbehaves by a rule you can state.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CORRER-10, ES-ETYMON-CORRER-11, ES-LEX-CAMINAR-07, ES-LEX-DORMIR-04, ES-LEX-OIR-01, ES-LEX-PERRO-03, ES-LEX-WEEKEND-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: "corro, corres, corre, corremos, corren"]
+- [YOU SAY: "El perro corre" — the dog runs]
+- [YOU SAY: "Camino, no corro" — I walk, I don't run]
+- [YOU SAY: "Corro el sábado" — I run on Saturday; Spanish uses the bare article where English says *on*]
+- [YOU SAY: "Oigo, duermo, camino, corro" — the whole chapter in four words]
+- [YOU SAY: "correr" then English "current, curriculum, corridor" — the running family]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-OIR-01, ES-ETYMON-OIR-02, ES-GRAMMAR-OIR-Y-03, ES-LEX-DORMIR-04, ES-ETYMON-DORMIR-05, ES-GRAMMAR-STEM-O-UE-06, ES-LEX-CAMINAR-07, ES-LEX-ANDAR-08, ES-ETYMON-CAMINAR-09, ES-LEX-CORRER-10, ES-ETYMON-CORRER-11, ES-LEX-PERRO-03, ES-EVIDENCE-PERRO-04] -->
+
+[PAUSE 3s] Name each verb's source in turn: *oír*, *dormir*, *caminar*,
+*correr*. (**Audīre**; **dormīre**; Gaulish *camminus*, by way of *el camino*;
+**currere**.) Which of the four leave their stems alone? (*Caminar*, *andar*
+and *correr*.) Say "the dog runs". (*El perro corre*.) Two words here have no
+settled origin — which? (*Andar*, and *perro*, whose three proposals all lack
+the evidence to decide between them.) And which English everyday word is a
+cousin of *correr* through Celtic? (**Car**.)

--- a/code/learning/human-languages/spanish/lessons/ES-C36-dormir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C36-dormir.md
@@ -1,0 +1,100 @@
+---
+schema_version: 2
+id: ES-C36-dormir
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 1700
+chapter: 36
+type: word
+headword: dormir
+gloss: to sleep — and the other half of the boot, where a stressed o breaks to ue
+concept_tag: VERB-SLEEP
+prerequisites: [ES-C36-oir, ES-C34-pensar]
+sounds: [diphthong-ue, r-tap]
+roots: [dormire-latin]
+etymology_hook: "dormir ← Latin dormīre 'to sleep' → dormitory, dormant, dormer; the stressed o breaks to ue (duermo), the same crack pensar makes with e→ie"
+duration:
+  max_seconds: 265
+requires:
+  knowledge: [ES-LEX-OIR-01, ES-GRAMMAR-OIR-Y-03, ES-LEX-PENSAR-01, ES-ETYMON-PENSAR-02]
+introduces:
+  knowledge: [ES-LEX-DORMIR-04, ES-ETYMON-DORMIR-05, ES-GRAMMAR-STEM-O-UE-06]
+practises:
+  knowledge: [ES-LEX-OIR-01, ES-GRAMMAR-OIR-Y-03, ES-LEX-PENSAR-01, ES-ETYMON-PENSAR-02, ES-LEX-DORMIR-04, ES-ETYMON-DORMIR-05, ES-GRAMMAR-STEM-O-UE-06]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C36-oir, ES-C34-pensar]
+---
+
+# dormir — "to sleep", and the boot's other vowel
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-OIR-01, ES-GRAMMAR-OIR-Y-03] -->
+
+[PAUSE 2s] Run *oír* once more: *oigo, oyes, oye, oímos, oyen* — and remember
+that the **y** in *oyes* is a spelling rule, not a new sound. Now a verb whose
+stem cracks the way *pensar*'s did, but on a different vowel.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `diphthong-ue` — under stress the *o* breaks open: **duermo** = *DWER-mo*.
+- `r-tap` — one soft flick of the tongue in *dormir*, nothing like an English *r*.
+
+## The word, taken apart: dormir
+<!-- hl-knowledge: introduces=[ES-LEX-DORMIR-04, ES-ETYMON-DORMIR-05]; assesses=[] -->
+
+**dormir** ("**to sleep**") ← Latin **dormīre**, "to sleep" — one of the rare
+verbs Spanish inherited almost untouched. English took the root only through
+French and Latin, and every borrowing still points at a bed:
+
+- **dormitory**, and its clipped **dorm** — the room where sleeping is done.
+- **dormant** — from the French participle *dormant*, "sleeping". A dormant
+  volcano is a sleeping one.
+- **dormer** — the window let into a roof, named for the sleeping-loft behind it.
+
+Spanish keeps its own branch: **el dormitorio** for the bedroom, and *la bella
+durmiente* for Sleeping Beauty.
+
+> The **dormouse** looks like the obvious member of this family, and careful
+> dictionaries will not commit. An Anglo-Norman *dormeus*, "sleepy", is the best
+> guess, but the trail goes cold. Treat it as likely rather than proved.
+
+## Grammar Lens: the boot again, with o→ue
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-STEM-O-UE-06]; assesses=[ES-LEX-DORMIR-04, ES-LEX-PENSAR-01] -->
+
+| person | form | stem |
+|---|---|---|
+| yo | **duermo** | broken |
+| tú | **duermes** | broken |
+| él/ella/usted | **duerme** | broken |
+| nosotros | **dormimos** | plain |
+| ellos/ustedes | **duermen** | broken |
+
+*Pensar* broke **e→ie** under stress. *Dormir* breaks **o→ue** under exactly the
+same condition, and for exactly the same reason: the stress falls on the stem in
+four of these forms and on the ending in *dormimos*, so only *dormimos* keeps
+its plain *o*.
+
+That is the whole of the rule. Spanish has two stressed vowels that will not sit
+still — *e* becomes *ie*, *o* becomes *ue* — and once you can hear where the
+stress lands, you can predict which forms crack without memorising a list.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-DORMIR-04, ES-ETYMON-DORMIR-05, ES-GRAMMAR-STEM-O-UE-06, ES-LEX-PENSAR-01, ES-LEX-OIR-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: "duermo, duermes, duerme, dormimos, duermen"]
+- [YOU SAY: "pienso" then "duermo" — e to ie, o to ue, one rule]
+- [YOU SAY: "No duermo bien" — I don't sleep well]
+- [YOU SAY: "dormir" then English "dormitory, dormant, dormer" — the sleeping family]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-DORMIR-04, ES-ETYMON-DORMIR-05, ES-GRAMMAR-STEM-O-UE-06, ES-LEX-PENSAR-01, ES-ETYMON-PENSAR-02, ES-LEX-OIR-01] -->
+
+[PAUSE 3s] Which form of *dormir* keeps its plain *o*, and why? (*Dormimos* —
+the stress lands on the ending.) Name two English cousins of *dormīre*.
+(*Dormitory, dormant, dormer*.) What did *pēnsāre*, behind *pensar*, mean
+literally? (**To weigh**.) And what is the *yo*-form of *oír*? (**Oigo**.)

--- a/code/learning/human-languages/spanish/lessons/ES-C36-oir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C36-oir.md
@@ -1,0 +1,105 @@
+---
+schema_version: 2
+id: ES-C36-oir
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 1690
+chapter: 36
+type: word
+headword: oír
+gloss: to hear — the half of listening you do not choose, and a verb that sprouts a y
+concept_tag: VERB-HEAR
+prerequisites: [ES-C35-gustar, ES-C12-yo-go]
+sounds: [accent-i, y-glide]
+roots: [audire-latin]
+etymology_hook: "oír ← Latin audīre 'to hear' → audio, audible, audience, audition, auditorium, audit — and obey, because oboedīre is ob- 'toward' + audīre: to obey is to listen toward someone"
+duration:
+  max_seconds: 275
+requires:
+  knowledge: [ES-LEX-GUSTAR-07, ES-GRAMMAR-GUSTAR-INVERSION-09]
+introduces:
+  knowledge: [ES-LEX-OIR-01, ES-ETYMON-OIR-02, ES-GRAMMAR-OIR-Y-03]
+practises:
+  knowledge: [ES-LEX-GUSTAR-07, ES-GRAMMAR-GUSTAR-INVERSION-09, ES-LEX-OIR-01, ES-ETYMON-OIR-02, ES-GRAMMAR-OIR-Y-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C35-gustar, ES-C12-yo-go]
+---
+
+# oír — "to hear", and the y that appears from nowhere
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-GUSTAR-07, ES-GRAMMAR-GUSTAR-INVERSION-09] -->
+
+[PAUSE 2s] Say *Me gusta el café* once — the coffee is pleasing to me, and the
+coffee is the subject. Now a verb about the ears, and one of the most
+bent-out-of-shape words in the language.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `accent-i` — the accent on **í** keeps the vowels apart: *o-EER*, two beats.
+- `y-glide` — the **y** in *oyes* is the consonant of English *yes*: *O-yes*.
+
+## The word, taken apart: oír
+<!-- hl-knowledge: introduces=[ES-LEX-OIR-01, ES-ETYMON-OIR-02]; assesses=[] -->
+
+**oír** ("**to hear**") ← Latin **audīre**, "to hear". Spanish wore it right
+down: the *d* between vowels dropped away and *au-* collapsed to *o-*.
+
+English never inherited it but borrowed it repeatedly, and the family keeps the
+*aud-* Spanish threw away: **audio**, **audible**, **audition**, **auditorium**,
+**audit**, **audience** — the people doing the hearing.
+
+Then the surprise. **Obey** is Latin **oboedīre**, *ob-* ("toward") + *audīre*:
+obeying is literally **listening toward** someone. **Obedient** comes with it.
+
+## Why it's said this way: hearing is not listening
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-OIR-01, ES-ETYMON-OIR-02] -->
+
+Spanish splits what English leaves joined. **Oír** is what your ears do whether
+you meant it or not. **Escuchar** is on purpose.
+
+*Escuchar* has its own root: Latin **auscultāre**, "to listen to", built on
+*auris*, "ear". A doctor **auscultates** a chest; and when Old French wore
+*auscultāre* down to *escouter*, English borrowed it as **scout** — one sent out
+to listen. English can draw the line when it wants. Spanish makes you.
+
+## Grammar Lens: the -go yo-form, and a spelling rule
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-OIR-Y-03]; assesses=[ES-LEX-OIR-01] -->
+
+| person | form |
+|---|---|
+| yo | **oigo** |
+| tú | **oyes** |
+| él/ella/usted | **oye** |
+| nosotros | **oímos** |
+| ellos/ustedes | **oyen** |
+
+Two separate things. The *yo*-form grows the hard **-g-** you know from *tengo*,
+*hago* and *digo*; *oír* joins that club.
+
+The rest is **spelling**, not sound. Spanish will not write an unstressed **i**
+stranded between two vowels, so *oi-es* is impossible and the letter becomes
+**y**: *oyes*, *oye*, *oyen*. *Oímos* keeps its accent because there the *i* is
+stressed.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-OIR-01, ES-ETYMON-OIR-02, ES-GRAMMAR-OIR-Y-03, ES-LEX-GUSTAR-07, ES-GRAMMAR-GUSTAR-INVERSION-09] -->
+
+[PAUSE 1s]
+- [YOU SAY: "oigo, oyes, oye, oímos, oyen"]
+- [YOU SAY: "¿Me oyes?" — can you hear me?]
+- [YOU SAY: "Me gusta oír" — hearing is pleasing to me]
+- [YOU SAY: "oír" then English "audio, audience, obey"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-OIR-01, ES-ETYMON-OIR-02, ES-GRAMMAR-OIR-Y-03, ES-LEX-GUSTAR-07] -->
+
+[PAUSE 3s] Which Latin verb is behind *oír*, and what has *obey* to do with it?
+(**Audīre**; *oboedīre* is "to listen toward".) Why *oyes* and not *oies*?
+(Spanish will not leave an unstressed *i* between two vowels.) Which of *oír*
+and *escuchar* do you choose to do? (**Escuchar**.) And in *me gusta el café*,
+what is the subject? (**El café**.)

--- a/code/learning/human-languages/spanish/lessons/ES-C37-abrir.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C37-abrir.md
@@ -1,0 +1,96 @@
+---
+schema_version: 2
+id: ES-C37-abrir
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 1730
+chapter: 37
+type: word
+headword: abrir
+gloss: to open — a regular -ir verb with one irregular part, the participle abierto
+concept_tag: VERB-OPEN
+prerequisites: [ES-C36-correr, ES-C34-escribir]
+sounds: [b-soft, r-tap]
+roots: [aperire-latin]
+etymology_hook: "abrir ← Latin aperīre 'to open, uncover' → aperture, overt, overture, aperitif; the tempting link to April is folk etymology and is not accepted"
+duration:
+  max_seconds: 275
+requires:
+  knowledge: [ES-LEX-CORRER-10, ES-ETYMON-CORRER-11, ES-LEX-CAMINAR-07, ES-LEX-ESCRIBIR-07]
+introduces:
+  knowledge: [ES-LEX-ABRIR-01, ES-ETYMON-ABRIR-02, ES-GRAMMAR-ABIERTO-03]
+practises:
+  knowledge: [ES-LEX-CORRER-10, ES-ETYMON-CORRER-11, ES-LEX-CAMINAR-07, ES-LEX-ESCRIBIR-07, ES-LEX-ABRIR-01, ES-ETYMON-ABRIR-02, ES-GRAMMAR-ABIERTO-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C36-correr, ES-C34-escribir]
+---
+
+# abrir — "to open", and the one part of it that misbehaves
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CORRER-10, ES-LEX-CAMINAR-07] -->
+
+[PAUSE 2s] Say *corro* and *camino* once — two verbs that gave you no trouble.
+This one is nearly as easy, and its one misbehaving piece is a word you will
+read on a shop door before you ever say it.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `b-soft` — between vowels the *b* barely closes the lips: *a-BREER*.
+- `r-tap` — a single flick for the final *r*.
+
+## The word, taken apart: abrir
+<!-- hl-knowledge: introduces=[ES-LEX-ABRIR-01, ES-ETYMON-ABRIR-02]; assesses=[ES-LEX-ESCRIBIR-07] -->
+
+**abrir** ("**to open**") ← Latin **aperīre**, "to open, to uncover". The *p*
+softened to *b* between vowels on the way into Spanish — the slide that turned
+*sapere* into *saber* and *lupus* into *lobo*.
+
+English took the root through two doors and does not notice they are one word:
+
+- straight from Latin *apertūra*: **aperture**, the opening a lens makes.
+- through French *ovrir* and its participle *overt*: **overt** ("out in the
+  open") and **overture**, an opera's opening.
+- **aperitif**, a drink that *opens* the appetite; Spanish, **el aperitivo**.
+
+> **The cousin that is not one.** *April* looks like it belongs here — the
+> opening month. That is old folk etymology and is not accepted: the better
+> proposals point at an Etruscan *Apru*, borrowed from Aphrodite, or at an
+> Italic word meaning "the next one". A hook this pretty is the kind to check.
+
+## Grammar Lens: regular everywhere but the participle
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-ABIERTO-03]; assesses=[ES-LEX-ABRIR-01, ES-LEX-ESCRIBIR-07] -->
+
+In the present, *abrir* is a plain *-ir* verb, the family *escribir* belongs to:
+**abro, abres, abre, abrimos, abren**. Nothing breaks, nothing grows.
+
+The **past participle** is where the irregularity lives. A regular *-ir* verb
+would give *abrido*. Spanish says **abierto**, straight down from Latin
+*apertum*, keeping the *e* that broke to *ie* under stress long ago.
+
+You will meet that participle long before the tense it belongs to, because it is
+a word on doors: **ABIERTO** on the sign, **está abierto** for "it is open now".
+*Escribir* does the same with **escrito**. Both refuse the regular ending
+because both inherited a Latin participle whole.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ABRIR-01, ES-ETYMON-ABRIR-02, ES-GRAMMAR-ABIERTO-03, ES-LEX-CORRER-10, ES-ETYMON-CORRER-11] -->
+
+[PAUSE 1s]
+- [YOU SAY: "abro, abres, abre, abrimos, abren"]
+- [YOU SAY: "Abro el libro" then "Está abierto"]
+- [YOU SAY: "abrir" then English "aperture, overt, overture"]
+- [YOU SAY: "correr" then English "current, curriculum" — still there from before]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ABRIR-01, ES-ETYMON-ABRIR-02, ES-GRAMMAR-ABIERTO-03, ES-LEX-ESCRIBIR-07, ES-LEX-CORRER-10] -->
+
+[PAUSE 3s] What is the past participle of *abrir*, and what would a regular verb
+have given? (**Abierto**; *abrido*.) Name two English words from *aperīre*.
+(*Aperture, overt, overture, aperitif*.) Is *April* one? (**No** — folk
+etymology.) Which other verb keeps an inherited Latin participle? (*Escribir* →
+*escrito*.) And which Latin verb is behind *correr*? (**Currere**.)

--- a/code/learning/human-languages/spanish/lessons/ES-C37-cerrar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C37-cerrar.md
@@ -1,0 +1,107 @@
+---
+schema_version: 2
+id: ES-C37-cerrar
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 1740
+chapter: 37
+type: word
+headword: cerrar
+gloss: to close — from the bar dropped across a door, not from the Latin verb English inherited
+concept_tag: VERB-CLOSE
+prerequisites: [ES-C37-abrir, ES-C34-entender]
+sounds: [soft-c, rolled-rr]
+roots: [serare-latin]
+etymology_hook: "cerrar ← Late Latin serāre 'to bolt' ← sera, the bar across a door — NOT from claudere, which is where English got close, clause, include, exclude and recluse; Spanish kept claudere only in learned words"
+duration:
+  max_seconds: 285
+requires:
+  knowledge: [ES-LEX-ABRIR-01, ES-ETYMON-ABRIR-02, ES-GRAMMAR-ABIERTO-03, ES-GRAMMAR-STEM-O-UE-06, ES-ETYMON-ENTENDER-04]
+introduces:
+  knowledge: [ES-LEX-CERRAR-04, ES-ETYMON-CERRAR-05, ES-ETYMON-CLAUDERE-06]
+practises:
+  knowledge: [ES-LEX-ABRIR-01, ES-ETYMON-ABRIR-02, ES-GRAMMAR-ABIERTO-03, ES-GRAMMAR-STEM-O-UE-06, ES-ETYMON-ENTENDER-04, ES-LEX-CERRAR-04, ES-ETYMON-CERRAR-05, ES-ETYMON-CLAUDERE-06]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C37-abrir, ES-C34-entender, ES-C36-dormir]
+---
+
+# cerrar — "to close", from the bar across the door
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ABRIR-01, ES-GRAMMAR-ABIERTO-03] -->
+
+[PAUSE 2s] *Abro, abres, abre* — and the sign saying **ABIERTO**. Here is the
+sign on the other side of the day, and a verb that cracks its stem.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `soft-c` — *c* before *e* is soft: a *th* across most of Spain, an *s* across Latin America.
+- `rolled-rr` — the double *r* is fully trilled: *se-RRAR*.
+
+## The word, taken apart: cerrar
+<!-- hl-knowledge: introduces=[ES-LEX-CERRAR-04, ES-ETYMON-CERRAR-05]; assesses=[] -->
+
+**cerrar** ("**to close**") ← Late Latin **serāre**, "to bolt, to fasten", from
+the noun **sera**: the **bar you drop across a door**. Closing here is a
+physical object being put in place, not an abstraction.
+
+Its Romance siblings kept the pressure: Italian *serrare*, French *serrer*, "to
+squeeze, to tighten". English holds one of that branch, **serried**, as in ranks
+pressed shut against each other. Reference works generally connect *sera* to
+Latin **serere**, "to join in a row", which would make **series** and **insert**
+distant relatives — usual, but not certain.
+
+## Why it's said this way: the road Spanish did not take
+<!-- hl-knowledge: introduces=[ES-ETYMON-CLAUDERE-06]; assesses=[ES-LEX-CERRAR-04] -->
+
+Latin had a perfectly good verb for closing: **claudere**. English is full of
+it — **close**, **closet**, **closure**, **clause**, **cloister**, **include**,
+**exclude**, **conclude**, **recluse**.
+
+Spanish let it go. For shutting a door it took *serāre* instead, and kept
+*claudere* only in words scholars borrowed back much later: **incluir**,
+**excluir**, **concluir**, **clausura**. That inversion is worth sitting with:
+the bigger English family belongs to the verb Spanish gave up. A cousin web maps
+what each language kept, and these two kept opposite halves.
+
+## Grammar Lens: e→ie, and the sign on the door
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CERRAR-04, ES-GRAMMAR-STEM-O-UE-06, ES-GRAMMAR-ABIERTO-03] -->
+
+| person | form |
+|---|---|
+| yo | **cierro** |
+| tú | **cierras** |
+| él/ella/usted | **cierra** |
+| nosotros | **cerramos** |
+| ellos/ustedes | **cierran** |
+
+*Dormir* broke **o→ue**. *Cerrar* breaks **e→ie** — the same boot, the other
+vowel, the same trigger: stress on the stem. *Cerramos* is plain because there
+the stress moves to the ending.
+
+Its participle, unlike *abierto*, is regular: **cerrado**. The two signs on one
+door are built differently — *abierto* inherited whole from Latin, *cerrado*
+made by rule.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CERRAR-04, ES-ETYMON-CERRAR-05, ES-ETYMON-CLAUDERE-06, ES-LEX-ABRIR-01, ES-ETYMON-ABRIR-02, ES-GRAMMAR-ABIERTO-03] -->
+
+[PAUSE 1s]
+- [YOU SAY: "cierro, cierras, cierra, cerramos, cierran"]
+- [YOU SAY: "Abro el libro" then "Cierro el libro"]
+- [YOU SAY: "ABIERTO" then "CERRADO" — the two signs]
+- [YOU SAY: "aperīre, aperture" then "serāre, serried" — the two doors' roots]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CERRAR-04, ES-ETYMON-CERRAR-05, ES-ETYMON-CLAUDERE-06, ES-GRAMMAR-STEM-O-UE-06, ES-ETYMON-ENTENDER-04, ES-GRAMMAR-ABIERTO-03] -->
+
+[PAUSE 3s] What was a *sera*, and does *cerrar* come from *claudere*? (**The bar
+dropped across a door**; and **no** — Spanish kept *claudere* only in *incluir*,
+*excluir*, *concluir*.) Which form of *cerrar* keeps its plain *e*, and why?
+(*Cerramos* — the stress moves to the ending, as in *dormimos*.) Which
+participle is irregular, *abierto* or *cerrado*? (*Abierto*.) And what did
+*intendere*, behind *entender*, mean literally? (**To stretch toward**.)

--- a/code/learning/human-languages/spanish/lessons/ES-C37-levantarse.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C37-levantarse.md
@@ -1,0 +1,103 @@
+---
+schema_version: 2
+id: ES-C37-levantarse
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 1760
+chapter: 37
+type: word
+headword: levantarse
+gloss: to get up, to stand up — "to raise oneself", built from a participle exactly as sentarse was
+concept_tag: VERB-STAND
+prerequisites: [ES-C37-sentarse, ES-C24-mano]
+sounds: [v-b, nasal-n]
+roots: [levare-latin]
+etymology_hook: "levantarse ← levantar ← Vulgar Latin *levantāre, from levāns, the present participle of levāre 'to raise' → lever, levy, levity, elevate, alleviate, relieve, leaven, levitate, and the Levant, named as the direction of the rising sun"
+duration:
+  max_seconds: 255
+requires:
+  knowledge: [ES-LEX-SENTARSE-07, ES-ETYMON-SENTARSE-08, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON, ES-LEX-MANO-01, ES-GRAMMAR-MANO-GENDER-02, ES-LEX-CABEZA-01, ES-LEX-ABRIR-01, ES-LEX-CERRAR-04]
+introduces:
+  knowledge: [ES-LEX-LEVANTARSE-09, ES-ETYMON-LEVANTARSE-10, ES-LEX-DE-PIE-11]
+practises:
+  knowledge: [ES-LEX-ABRIR-01, ES-ETYMON-ABRIR-02, ES-GRAMMAR-ABIERTO-03, ES-LEX-CERRAR-04, ES-ETYMON-CERRAR-05, ES-ETYMON-CLAUDERE-06, ES-LEX-SENTARSE-07, ES-ETYMON-SENTARSE-08, ES-LEX-LEVANTARSE-09, ES-ETYMON-LEVANTARSE-10, ES-LEX-DE-PIE-11, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON, ES-LEX-MANO-01, ES-GRAMMAR-MANO-GENDER-02, ES-LEX-CABEZA-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C37-sentarse, ES-C37-cerrar, ES-C37-abrir, ES-C24-mano]
+---
+
+# levantarse — "to raise oneself", and how Spanish says "stand"
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-SENTARSE-07, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON] -->
+
+[PAUSE 2s] *Me siento* put you in the chair, the little *me* bouncing the action
+back onto you. Now get out of it. The pronoun works the same way; this time the
+stem does not crack at all.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `v-b` — Spanish *v* and *b* are one sound: *le-ban-TAR*.
+- `nasal-n` — a clean *n* before the *t*, not swallowed.
+
+## The word, taken apart: levantarse
+<!-- hl-knowledge: introduces=[ES-LEX-LEVANTARSE-09, ES-ETYMON-LEVANTARSE-10]; assesses=[ES-ETYMON-SENTARSE-08] -->
+
+**levantar** ← Vulgar Latin ***levantāre**, from **levāns**, the present
+participle of **levāre**, "to raise, to lighten" — itself from **levis**,
+"light, not heavy".
+
+Notice the shape: a Latin **present participle**, made into a new verb — the
+identical recipe that gave *sentar* from *sedēns*. Spanish built both of its
+body-position verbs out of a word for the state rather than the act.
+
+*Levāre* is everywhere in English: **lever**, **elevate**, **elevator** for
+raising; **levity**, **levitate**, **alleviate**, **relieve** for lightening;
+**leaven**, what raises the bread, and **levy**, a tax *raised*. And **the
+Levant**, from French *levant*, "rising": from western Europe it lay where the
+sun came up. English **light**, the opposite of heavy, is the Germanic cousin of
+*levis*, as *sit* is of *sedēre*.
+
+## Grammar Lens: raising a thing, raising yourself, standing still
+<!-- hl-knowledge: introduces=[ES-LEX-DE-PIE-11]; assesses=[ES-LEX-LEVANTARSE-09, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON, ES-LEX-MANO-01, ES-GRAMMAR-MANO-GENDER-02] -->
+
+**Levantar** on its own raises something else. **Levantarse** raises *you*:
+
+| Spanish | what it means |
+|---|---|
+| **Levanto la mano** | I raise my hand |
+| **Levanto la cabeza** | I lift my head |
+| **Me levanto** | I get up, I stand up |
+
+The endings are ordinary *-ar* throughout — **me levanto, te levantas, se
+levanta, nos levantamos, se levantan** — and nothing breaks. So the chapter has
+now shown its two features apart: *sentarse* is reflexive **and** a stem-changer;
+*levantarse* is reflexive **only**.
+
+For standing as a *state*, Spanish uses no verb. It says **estar de pie** — "to
+be on foot", *el pie* being the foot. English's single "stand" splits in two:
+*me levanto* for getting up, *estoy de pie* for being up.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-LEVANTARSE-09, ES-ETYMON-LEVANTARSE-10, ES-LEX-DE-PIE-11, ES-LEX-SENTARSE-07, ES-LEX-ABRIR-01, ES-LEX-CERRAR-04, ES-LEX-MANO-01, ES-LEX-CABEZA-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: "me levanto, te levantas, se levanta, nos levantamos, se levantan"]
+- [YOU SAY: "Levanto la mano" then "Levanto la cabeza" then "Me levanto"]
+- [YOU SAY: "Estoy de pie" — I am standing]
+- [YOU SAY: "Abro el libro, me siento, cierro el libro, me levanto"]
+- [YOU SAY: "levantar" then English "lever, elevate, Levant"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ABRIR-01, ES-ETYMON-ABRIR-02, ES-GRAMMAR-ABIERTO-03, ES-LEX-CERRAR-04, ES-ETYMON-CERRAR-05, ES-ETYMON-CLAUDERE-06, ES-LEX-SENTARSE-07, ES-ETYMON-SENTARSE-08, ES-LEX-LEVANTARSE-09, ES-ETYMON-LEVANTARSE-10, ES-LEX-DE-PIE-11, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON, ES-LEX-MANO-01, ES-GRAMMAR-MANO-GENDER-02] -->
+
+[PAUSE 3s] Say the chapter's four verbs, then say how you are standing. (*Abro,
+cierro, me siento, me levanto*; *estoy de pie*.) What do *sentar* and *levantar*
+share in their making, and which also breaks its stem? (Both from a Latin
+**present participle**, *sedēns* and *levāns*; *sentarse* breaks *e→ie*.) Name
+the two roots on that door, and which participle is irregular. (**Aperīre** and
+**serāre** — *not* *claudere*; *abierto*.) Why *la* mano? (*Manus* was feminine
+in Latin.)

--- a/code/learning/human-languages/spanish/lessons/ES-C37-sentarse.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C37-sentarse.md
@@ -1,0 +1,102 @@
+---
+schema_version: 2
+id: ES-C37-sentarse
+spine_node: SPINE-SAY-WHAT-I-DO
+sequence: 1750
+chapter: 37
+type: word
+headword: sentarse
+gloss: to sit down — literally "to seat oneself", the reflexive that lands the action back on you
+concept_tag: VERB-SIT
+prerequisites: [ES-C37-cerrar, ES-C03-me-llamo, ES-C23-padre-madre]
+sounds: [diphthong-ie, s-clear]
+roots: [sedere-latin]
+etymology_hook: "sentarse ← sentar ← Vulgar Latin *sedentāre, from sedēns, the present participle of sedēre 'to sit' → sedentary, session, sediment, siege, preside, reside, assess, possess; and English sit, seat, settle, saddle and nest are the Germanic branch of the same root *sed-"
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [ES-LEX-CERRAR-04, ES-ETYMON-CERRAR-05, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON, ES-LEX-ME-LLAMO, ES-ETYMON-PARENTS-SOUND-LAW-03]
+introduces:
+  knowledge: [ES-LEX-SENTARSE-07, ES-ETYMON-SENTARSE-08]
+practises:
+  knowledge: [ES-LEX-CERRAR-04, ES-ETYMON-CERRAR-05, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON, ES-LEX-ME-LLAMO, ES-ETYMON-PARENTS-SOUND-LAW-03, ES-LEX-SENTARSE-07, ES-ETYMON-SENTARSE-08]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C37-cerrar, ES-C03-me-llamo, ES-C03-se-llama]
+---
+
+# sentarse — "to seat oneself", which is how Spanish thinks about sitting down
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CERRAR-04, ES-LEX-ME-LLAMO, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON] -->
+
+[PAUSE 2s] Two things in hand. *Cierro* — the *e* cracking to *ie*. And *me
+llamo*, "I call **myself**", where the little *me* bounced the action back onto
+you. This verb needs both at once.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `diphthong-ie` — the stressed *e* breaks: **me siento** = *me SYEN-to*.
+- `s-clear` — a clean hissing *s*, never a *z* buzz.
+
+## The word, taken apart: sentarse
+<!-- hl-knowledge: introduces=[ES-LEX-SENTARSE-07, ES-ETYMON-SENTARSE-08]; assesses=[ES-ETYMON-PARENTS-SOUND-LAW-03] -->
+
+**sentar** ← Vulgar Latin ***sedentāre**, built not on the Latin verb but on its
+**present participle**: *sedēns*, "sitting", from **sedēre**, "to sit". Spanish
+made a new verb out of being in a sitting state.
+
+*Sedēre* is one of the great English suppliers, and hardly any descendant still
+looks like sitting: **sedentary**, **sediment**, **sedate**; **session** and
+**siege** (an army sitting down outside a city); **preside**, **reside**;
+**assess**, **obsess**, **possess**. By way of Greek *hedra*, "seat", it also
+gives **cathedral** and **chair**.
+
+Then the other branch. English **sit**, **seat**, **settle**, **saddle** and
+**nest** come down from the very same root, ***sed-***, through Germanic rather
+than Latin. Neither borrowed from the other: they are siblings, exactly as
+*padre* and *father* are, each branch reshaping the sounds its own way.
+
+## Grammar Lens: seating someone, and seating yourself
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-SENTARSE-07, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON] -->
+
+Plain **sentar** means to seat somebody *else*. To sit down yourself, you send
+the action back with the pronoun that made *me llamo* "I call myself":
+
+| person | form |
+|---|---|
+| yo | **me siento** |
+| tú | **te sientas** |
+| él/ella/usted | **se sienta** |
+| nosotros | **nos sentamos** |
+| ellos/ustedes | **se sientan** |
+
+Two patterns run at once, and you have both. The pronoun changes with the
+person — *me, te, se, nos, se* — and the stem breaks *e→ie* wherever the stress
+lands on it, leaving *nos sentamos* plain. The pronoun stands before a
+conjugated verb and clips onto an infinitive, hence the name **sentarse**.
+
+> **Two verbs, one shape.** *Me siento* is also the *yo*-form of *sentirse*, "to
+> feel": *me siento bien* is "I feel fine". Only what follows tells them apart.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-SENTARSE-07, ES-ETYMON-SENTARSE-08, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON, ES-LEX-CERRAR-04] -->
+
+[PAUSE 1s]
+- [YOU SAY: "me siento, te sientas, se sienta, nos sentamos, se sientan"]
+- [YOU SAY: "me llamo" then "me siento" — the same little me, twice]
+- [YOU SAY: "Cierro el libro y me siento" — I close the book and sit down]
+- [YOU SAY: "sentarse" then English "session, sedentary, preside"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-SENTARSE-07, ES-ETYMON-SENTARSE-08, ES-GRAMMAR-REFLEXIVE-FIRST-PERSON, ES-ETYMON-PARENTS-SOUND-LAW-03, ES-LEX-CERRAR-04, ES-ETYMON-CERRAR-05] -->
+
+[PAUSE 3s] What does *sentarse* say literally, and which Latin form was it built
+on? (**To seat oneself**; the participle *sedēns*.) Are English *sit* and Latin
+*sedēre* parent and child, or siblings? (**Siblings** — separate branches of one
+root, like *father* and *padre*.) Which form keeps its plain *e*, and what was a
+*sera*? (*Nos sentamos*; **the bar across a door**.)

--- a/code/learning/human-languages/spanish/narration/ch36.json
+++ b/code/learning/human-languages/spanish/narration/ch36.json
@@ -1,0 +1,748 @@
+{
+  "version": 1,
+  "language": "spanish",
+  "chapter": 36,
+  "title": "Hearing, Sleeping, Walking, Running",
+  "drivablePrefix": 4,
+  "sourceHash": "fnv1a64:0e305c37e6fc9666",
+  "lessons": [
+    {
+      "id": "ES-C36-oir",
+      "sequence": 1690,
+      "title": "oír — \"to hear\", and the y that appears from nowhere",
+      "headword": "oír",
+      "romanization": "oír",
+      "gloss": "to hear — the half of listening you do not choose, and a verb that sprouts a y",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:95c8c58081d9ca9c",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say Me gusta el café once — the coffee is pleasing to me, and the coffee is the subject. Now a verb about the ears, and one of the most bent-out-of-shape words in the language."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "accent-i — the accent on í keeps the vowels apart: o-EER, two beats."
+            },
+            {
+              "kind": "speech",
+              "text": "y-glide — the y in oyes is the consonant of English yes: O-yes."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: oír",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "oír (\"to hear\") from Latin audīre, \"to hear\". Spanish wore it right down: the d between vowels dropped away and au- collapsed to o-."
+            },
+            {
+              "kind": "speech",
+              "text": "English never inherited it but borrowed it repeatedly, and the family keeps the aud- Spanish threw away: audio, audible, audition, auditorium, audit, audience — the people doing the hearing."
+            },
+            {
+              "kind": "speech",
+              "text": "Then the surprise. Obey is Latin oboedīre, ob- (\"toward\") + audīre: obeying is literally listening toward someone. Obedient comes with it."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way: hearing is not listening",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Spanish splits what English leaves joined. Oír is what your ears do whether you meant it or not. Escuchar is on purpose."
+            },
+            {
+              "kind": "speech",
+              "text": "Escuchar has its own root: Latin auscultāre, \"to listen to\", built on auris, \"ear\". A doctor auscultates a chest; and when Old French wore auscultāre down to escouter, English borrowed it as scout — one sent out to listen. English can draw the line when it wants. Spanish makes you."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "grammar",
+          "title": "Grammar Lens: the -go yo-form, and a spelling rule",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "person",
+                "form"
+              ],
+              "columns": 2,
+              "rowCount": 5,
+              "utterances": [
+                "person: yo. form: oigo.",
+                "person: tú. form: oyes.",
+                "person: él/ella/usted. form: oye.",
+                "person: nosotros. form: oímos.",
+                "person: ellos/ustedes. form: oyen."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Two separate things. The yo-form grows the hard -g- you know from tengo, hago and digo; oír joins that club."
+            },
+            {
+              "kind": "speech",
+              "text": "The rest is spelling, not sound. Spanish will not write an unstressed i stranded between two vowels, so oi-es is impossible and the letter becomes y: oyes, oye, oyen. Oímos keeps its accent because there the i is stressed."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"oigo, oyes, oye, oímos, oyen\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"oigo, oyes, oye, oímos, oyen\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"¿Me oyes?\" — can you hear me?",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"¿Me oyes?\" — can you hear me?]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Me gusta oír\" — hearing is pleasing to me",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Me gusta oír\" — hearing is pleasing to me]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"oír\" then English \"audio, audience, obey\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"oír\" then English \"audio, audience, obey\"]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Which Latin verb is behind oír, and what has obey to do with it? (Audīre; oboedīre is \"to listen toward\".) Why oyes and not oies? (Spanish will not leave an unstressed i between two vowels.) Which of oír and escuchar do you choose to do? (Escuchar.) And in me gusta el café, what is the subject? (El café.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C36-dormir",
+      "sequence": 1700,
+      "title": "dormir — \"to sleep\", and the boot's other vowel",
+      "headword": "dormir",
+      "romanization": "dormir",
+      "gloss": "to sleep — and the other half of the boot, where a stressed o breaks to ue",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:23270a43f8e6de20",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Run oír once more: oigo, oyes, oye, oímos, oyen — and remember that the y in oyes is a spelling rule, not a new sound. Now a verb whose stem cracks the way pensar's did, but on a different vowel."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "diphthong-ue — under stress the o breaks open: duermo = DWER-mo."
+            },
+            {
+              "kind": "speech",
+              "text": "r-tap — one soft flick of the tongue in dormir, nothing like an English r."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: dormir",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "dormir (\"to sleep\") from Latin dormīre, \"to sleep\" — one of the rare verbs Spanish inherited almost untouched. English took the root only through French and Latin, and every borrowing still points at a bed:"
+            },
+            {
+              "kind": "speech",
+              "text": "dormitory, and its clipped dorm — the room where sleeping is done."
+            },
+            {
+              "kind": "speech",
+              "text": "dormant — from the French participle dormant, \"sleeping\". A dormant volcano is a sleeping one."
+            },
+            {
+              "kind": "speech",
+              "text": "dormer — the window let into a roof, named for the sleeping-loft behind it."
+            },
+            {
+              "kind": "speech",
+              "text": "Spanish keeps its own branch: el dormitorio for the bedroom, and la bella durmiente for Sleeping Beauty."
+            },
+            {
+              "kind": "speech",
+              "text": "The dormouse looks like the obvious member of this family, and careful dictionaries will not commit. An Anglo-Norman dormeus, \"sleepy\", is the best guess, but the trail goes cold. Treat it as likely rather than proved."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the boot again, with o becomes ue",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "person",
+                "form",
+                "stem"
+              ],
+              "columns": 3,
+              "rowCount": 5,
+              "utterances": [
+                "person: yo. form: duermo. stem: broken.",
+                "person: tú. form: duermes. stem: broken.",
+                "person: él/ella/usted. form: duerme. stem: broken.",
+                "person: nosotros. form: dormimos. stem: plain.",
+                "person: ellos/ustedes. form: duermen. stem: broken."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Pensar broke e becomes ie under stress. Dormir breaks o becomes ue under exactly the same condition, and for exactly the same reason: the stress falls on the stem in four of these forms and on the ending in dormimos, so only dormimos keeps its plain o."
+            },
+            {
+              "kind": "speech",
+              "text": "That is the whole of the rule. Spanish has two stressed vowels that will not sit still — e becomes ie, o becomes ue — and once you can hear where the stress lands, you can predict which forms crack without memorising a list."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"duermo, duermes, duerme, dormimos, duermen\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"duermo, duermes, duerme, dormimos, duermen\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"pienso\" then \"duermo\" — e to ie, o to ue, one rule",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"pienso\" then \"duermo\" — e to ie, o to ue, one rule]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"No duermo bien\" — I don't sleep well",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"No duermo bien\" — I don't sleep well]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"dormir\" then English \"dormitory, dormant, dormer\" — the sleeping family",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"dormir\" then English \"dormitory, dormant, dormer\" — the sleeping family]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Which form of dormir keeps its plain o, and why? (Dormimos — the stress lands on the ending.) Name two English cousins of dormīre. (Dormitory, dormant, dormer.) What did pēnsāre, behind pensar, mean literally? (To weigh.) And what is the yo-form of oír? (Oigo.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C36-caminar",
+      "sequence": 1710,
+      "title": "caminar — \"to walk\", from a word Rome borrowed from the Celts",
+      "headword": "caminar",
+      "romanization": "caminar",
+      "gloss": "to walk — built on a Celtic word for a path, beside andar, whose own past is unsettled",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:e8a248a22b872d8c",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Duermo, duermes, duerme — the o cracking to ue. Relax: the two verbs here do nothing of the kind. The interest is in where they came from."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "k-hard — the c before a is a hard k: ka-mi-NAR."
+            },
+            {
+              "kind": "speech",
+              "text": "vowel-a — a short clean a, the same in every syllable."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: caminar",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "caminar (\"to walk\") was built on the noun el camino, \"the road\" — and camino is not a Latin word at all. Latin camminus was a loan from Gaulish, the Celtic language of pre-Roman France, from a word for a step or a way. It stocked the roads of every Romance language: camino, Portuguese caminho, Italian cammino, French chemin."
+            },
+            {
+              "kind": "speech",
+              "text": "Here the cousin web runs out, and that is worth saying plainly: this root reached English only inside borrowed French phrases. The Celtic layer did reach English by other doors — Latin also took Gaulish carrus, a wagon, behind car and cargo. Camminus never crossed."
+            },
+            {
+              "kind": "speech",
+              "text": "A false friend that looks certain. Latin also had camīnus, \"hearth\", from Greek kaminos — and that gave English chimney. Two nearly identical Latin words, no relation."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: two plain verbs, and which to reach for",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Spanish has a second everyday verb here, andar. Both take ordinary -ar endings and neither breaks its stem."
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "person",
+                "caminar",
+                "andar"
+              ],
+              "columns": 3,
+              "rowCount": 5,
+              "utterances": [
+                "person: yo. caminar: camino. andar: ando.",
+                "person: tú. caminar: caminas. andar: andas.",
+                "person: él/ella/usted. caminar: camina. andar: anda.",
+                "person: nosotros. caminar: caminamos. andar: andamos.",
+                "person: ellos/ustedes. caminar: caminan. andar: andan."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Caminar is walking as the thing you are doing. Andar is wider: to go about, and by extension to work at all — no anda, of a machine, means \"it isn't running\". Either serves for a walk."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way: a verb with no settled past",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Camino has a clean history. Andar does not. It comes down from Medieval Latin andāre, and where andāre came from is genuinely disputed: ambulāre (\"to walk about\") and ambitāre (\"to go around\") are both proposed and neither is proved. If ambulāre is right, amble and ambulance are cousins — but that \"if\" carries real weight."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"camino, caminas, camina, caminamos, caminan\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"camino, caminas, camina, caminamos, caminan\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ando, andas, anda, andamos, andan\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ando, andas, anda, andamos, andan\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Camino una hora\" — I walk for an hour",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Camino una hora\" — I walk for an hour]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"el camino\" then \"camino\" — the road, and I walk it",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"el camino\" then \"camino\" — the road, and I walk it]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Which language did Latin borrow camminus from? (Gaulish.) Which English word comes from the other Latin camīnus, the hearth? (Chimney — unrelated.) Is andar's origin settled? (No.) Say \"I walk for an hour\". (Camino una hora.) And the nosotros form of dormir? (Dormimos.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C36-correr",
+      "sequence": 1720,
+      "title": "correr — \"to run\", and the root that runs through half of English",
+      "headword": "correr",
+      "romanization": "correr",
+      "gloss": "to run — a plain -er verb sitting on one of the largest roots English ever borrowed",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:7f6e36b48265ebc3",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You can walk two ways now — camino and ando. Speed it up. This last verb of the chapter is the plainest to conjugate and the richest to trace."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "rolled-rr — the double r is a full trill: ko-RRER. It is a different letter from a single r, and swapping them swaps words."
+            },
+            {
+              "kind": "speech",
+              "text": "vowel-o — a short pure o, no glide toward English ow."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: correr",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "correr (\"to run\") from Latin currere, \"to run\". English borrowed this root harder than almost any other, and the descendants have spread so far from running that they no longer look related:"
+            },
+            {
+              "kind": "speech",
+              "text": "current — water that runs; currency, money running hand to hand."
+            },
+            {
+              "kind": "speech",
+              "text": "curriculum — a running, a racecourse. A course of study is a track you run."
+            },
+            {
+              "kind": "speech",
+              "text": "courier, a runner; course, cursor, cursive — writing that runs."
+            },
+            {
+              "kind": "speech",
+              "text": "corridor — a place for running along, by way of Italian."
+            },
+            {
+              "kind": "speech",
+              "text": "with prefixes: occur (ob-, to run up against), recur, incur, precursor, excursion."
+            },
+            {
+              "kind": "speech",
+              "text": "And a cousin from the lesson before: Gaulish carrus, behind English car and cargo, comes from the very same Proto-Indo-European root kers-, \"to run\". Latin took one road and Celtic another; English holds both ends."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: a plain -er verb, and four verbs together",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Correr breaks nothing and grows nothing: corro, corres, corre, corremos, corren. That makes it the clean case the chapter's others stand out against:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "verb",
+                "what it does to its stem"
+              ],
+              "columns": 2,
+              "rowCount": 4,
+              "utterances": [
+                "verb: correr. what it does to its stem: nothing — corro, corres, corre.",
+                "verb: caminar, andar. what it does to its stem: nothing — camino, ando.",
+                "verb: dormir. what it does to its stem: breaks o to ue under stress — duermo, but dormimos.",
+                "verb: oír. what it does to its stem: grows -g- in oigo, and writes y in oyes, oye, oyen."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Only two of the four misbehave, and each misbehaves by a rule you can state."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"corro, corres, corre, corremos, corren\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"corro, corres, corre, corremos, corren\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"El perro corre\" — the dog runs",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"El perro corre\" — the dog runs]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Camino, no corro\" — I walk, I don't run",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Camino, no corro\" — I walk, I don't run]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Corro el sábado\" — I run on Saturday; Spanish uses the bare article where English says on",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Corro el sábado\" — I run on Saturday; Spanish uses the bare article where English says *on*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Oigo, duermo, camino, corro\" — the whole chapter in four words",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Oigo, duermo, camino, corro\" — the whole chapter in four words]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"correr\" then English \"current, curriculum, corridor\" — the running family",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"correr\" then English \"current, curriculum, corridor\" — the running family]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Name each verb's source in turn: oír, dormir, caminar, correr. (Audīre; dormīre; Gaulish camminus, by way of el camino; currere.) Which of the four leave their stems alone? (Caminar, andar and correr.) Say \"the dog runs\". (El perro corre.) Two words here have no settled origin — which? (Andar, and perro, whose three proposals all lack the evidence to decide between them.) And which English everyday word is a cousin of correr through Celtic? (Car.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/spanish/narration/ch36.txt
+++ b/code/learning/human-languages/spanish/narration/ch36.txt
@@ -1,0 +1,187 @@
+Spanish, chapter 36: Hearing, Sleeping, Walking, Running.
+4 lessons. All 4 can be done entirely by ear.
+
+
+Lesson 1 of 4.
+oír — "to hear", and the y that appears from nowhere.
+
+Warm-up.
+[pause 2 seconds]
+Say Me gusta el café once — the coffee is pleasing to me, and the coffee is the subject. Now a verb about the ears, and one of the most bent-out-of-shape words in the language.
+
+Sounds you'll need.
+accent-i — the accent on í keeps the vowels apart: o-EER, two beats.
+y-glide — the y in oyes is the consonant of English yes: O-yes.
+
+The word, taken apart: oír.
+oír ("to hear") from Latin audīre, "to hear". Spanish wore it right down: the d between vowels dropped away and au- collapsed to o-.
+English never inherited it but borrowed it repeatedly, and the family keeps the aud- Spanish threw away: audio, audible, audition, auditorium, audit, audience — the people doing the hearing.
+Then the surprise. Obey is Latin oboedīre, ob- ("toward") + audīre: obeying is literally listening toward someone. Obedient comes with it.
+
+Why it's said this way: hearing is not listening.
+Spanish splits what English leaves joined. Oír is what your ears do whether you meant it or not. Escuchar is on purpose.
+Escuchar has its own root: Latin auscultāre, "to listen to", built on auris, "ear". A doctor auscultates a chest; and when Old French wore auscultāre down to escouter, English borrowed it as scout — one sent out to listen. English can draw the line when it wants. Spanish makes you.
+
+Grammar Lens: the -go yo-form, and a spelling rule.
+[a table of 5 rows, read aloud]
+person: yo. form: oigo.
+person: tú. form: oyes.
+person: él/ella/usted. form: oye.
+person: nosotros. form: oímos.
+person: ellos/ustedes. form: oyen.
+Two separate things. The yo-form grows the hard -g- you know from tengo, hago and digo; oír joins that club.
+The rest is spelling, not sound. Spanish will not write an unstressed i stranded between two vowels, so oi-es is impossible and the letter becomes y: oyes, oye, oyen. Oímos keeps its accent because there the i is stressed.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "oigo, oyes, oye, oímos, oyen"]
+[pause 8 seconds for the answer]
+[your turn — say: "¿Me oyes?" — can you hear me?]
+[pause 8 seconds for the answer]
+[your turn — say: "Me gusta oír" — hearing is pleasing to me]
+[pause 8 seconds for the answer]
+[your turn — say: "oír" then English "audio, audience, obey"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Which Latin verb is behind oír, and what has obey to do with it? (Audīre; oboedīre is "to listen toward".) Why oyes and not oies? (Spanish will not leave an unstressed i between two vowels.) Which of oír and escuchar do you choose to do? (Escuchar.) And in me gusta el café, what is the subject? (El café.)
+
+
+Lesson 2 of 4.
+dormir — "to sleep", and the boot's other vowel.
+
+Warm-up.
+[pause 2 seconds]
+Run oír once more: oigo, oyes, oye, oímos, oyen — and remember that the y in oyes is a spelling rule, not a new sound. Now a verb whose stem cracks the way pensar's did, but on a different vowel.
+
+Sounds you'll need.
+diphthong-ue — under stress the o breaks open: duermo = DWER-mo.
+r-tap — one soft flick of the tongue in dormir, nothing like an English r.
+
+The word, taken apart: dormir.
+dormir ("to sleep") from Latin dormīre, "to sleep" — one of the rare verbs Spanish inherited almost untouched. English took the root only through French and Latin, and every borrowing still points at a bed:
+dormitory, and its clipped dorm — the room where sleeping is done.
+dormant — from the French participle dormant, "sleeping". A dormant volcano is a sleeping one.
+dormer — the window let into a roof, named for the sleeping-loft behind it.
+Spanish keeps its own branch: el dormitorio for the bedroom, and la bella durmiente for Sleeping Beauty.
+The dormouse looks like the obvious member of this family, and careful dictionaries will not commit. An Anglo-Norman dormeus, "sleepy", is the best guess, but the trail goes cold. Treat it as likely rather than proved.
+
+Grammar Lens: the boot again, with o becomes ue.
+[a table of 5 rows, read aloud]
+person: yo. form: duermo. stem: broken.
+person: tú. form: duermes. stem: broken.
+person: él/ella/usted. form: duerme. stem: broken.
+person: nosotros. form: dormimos. stem: plain.
+person: ellos/ustedes. form: duermen. stem: broken.
+Pensar broke e becomes ie under stress. Dormir breaks o becomes ue under exactly the same condition, and for exactly the same reason: the stress falls on the stem in four of these forms and on the ending in dormimos, so only dormimos keeps its plain o.
+That is the whole of the rule. Spanish has two stressed vowels that will not sit still — e becomes ie, o becomes ue — and once you can hear where the stress lands, you can predict which forms crack without memorising a list.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "duermo, duermes, duerme, dormimos, duermen"]
+[pause 8 seconds for the answer]
+[your turn — say: "pienso" then "duermo" — e to ie, o to ue, one rule]
+[pause 8 seconds for the answer]
+[your turn — say: "No duermo bien" — I don't sleep well]
+[pause 8 seconds for the answer]
+[your turn — say: "dormir" then English "dormitory, dormant, dormer" — the sleeping family]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Which form of dormir keeps its plain o, and why? (Dormimos — the stress lands on the ending.) Name two English cousins of dormīre. (Dormitory, dormant, dormer.) What did pēnsāre, behind pensar, mean literally? (To weigh.) And what is the yo-form of oír? (Oigo.)
+
+
+Lesson 3 of 4.
+caminar — "to walk", from a word Rome borrowed from the Celts.
+
+Warm-up.
+[pause 2 seconds]
+Duermo, duermes, duerme — the o cracking to ue. Relax: the two verbs here do nothing of the kind. The interest is in where they came from.
+
+Sounds you'll need.
+k-hard — the c before a is a hard k: ka-mi-NAR.
+vowel-a — a short clean a, the same in every syllable.
+
+The word, taken apart: caminar.
+caminar ("to walk") was built on the noun el camino, "the road" — and camino is not a Latin word at all. Latin camminus was a loan from Gaulish, the Celtic language of pre-Roman France, from a word for a step or a way. It stocked the roads of every Romance language: camino, Portuguese caminho, Italian cammino, French chemin.
+Here the cousin web runs out, and that is worth saying plainly: this root reached English only inside borrowed French phrases. The Celtic layer did reach English by other doors — Latin also took Gaulish carrus, a wagon, behind car and cargo. Camminus never crossed.
+A false friend that looks certain. Latin also had camīnus, "hearth", from Greek kaminos — and that gave English chimney. Two nearly identical Latin words, no relation.
+
+Grammar Lens: two plain verbs, and which to reach for.
+Spanish has a second everyday verb here, andar. Both take ordinary -ar endings and neither breaks its stem.
+[a table of 5 rows, read aloud]
+person: yo. caminar: camino. andar: ando.
+person: tú. caminar: caminas. andar: andas.
+person: él/ella/usted. caminar: camina. andar: anda.
+person: nosotros. caminar: caminamos. andar: andamos.
+person: ellos/ustedes. caminar: caminan. andar: andan.
+Caminar is walking as the thing you are doing. Andar is wider: to go about, and by extension to work at all — no anda, of a machine, means "it isn't running". Either serves for a walk.
+
+Why it's said this way: a verb with no settled past.
+Camino has a clean history. Andar does not. It comes down from Medieval Latin andāre, and where andāre came from is genuinely disputed: ambulāre ("to walk about") and ambitāre ("to go around") are both proposed and neither is proved. If ambulāre is right, amble and ambulance are cousins — but that "if" carries real weight.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "camino, caminas, camina, caminamos, caminan"]
+[pause 8 seconds for the answer]
+[your turn — say: "ando, andas, anda, andamos, andan"]
+[pause 8 seconds for the answer]
+[your turn — say: "Camino una hora" — I walk for an hour]
+[pause 8 seconds for the answer]
+[your turn — say: "el camino" then "camino" — the road, and I walk it]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Which language did Latin borrow camminus from? (Gaulish.) Which English word comes from the other Latin camīnus, the hearth? (Chimney — unrelated.) Is andar's origin settled? (No.) Say "I walk for an hour". (Camino una hora.) And the nosotros form of dormir? (Dormimos.)
+
+
+Lesson 4 of 4.
+correr — "to run", and the root that runs through half of English.
+
+Warm-up.
+[pause 2 seconds]
+You can walk two ways now — camino and ando. Speed it up. This last verb of the chapter is the plainest to conjugate and the richest to trace.
+
+Sounds you'll need.
+rolled-rr — the double r is a full trill: ko-RRER. It is a different letter from a single r, and swapping them swaps words.
+vowel-o — a short pure o, no glide toward English ow.
+
+The word, taken apart: correr.
+correr ("to run") from Latin currere, "to run". English borrowed this root harder than almost any other, and the descendants have spread so far from running that they no longer look related:
+current — water that runs; currency, money running hand to hand.
+curriculum — a running, a racecourse. A course of study is a track you run.
+courier, a runner; course, cursor, cursive — writing that runs.
+corridor — a place for running along, by way of Italian.
+with prefixes: occur (ob-, to run up against), recur, incur, precursor, excursion.
+And a cousin from the lesson before: Gaulish carrus, behind English car and cargo, comes from the very same Proto-Indo-European root kers-, "to run". Latin took one road and Celtic another; English holds both ends.
+
+Grammar Lens: a plain -er verb, and four verbs together.
+Correr breaks nothing and grows nothing: corro, corres, corre, corremos, corren. That makes it the clean case the chapter's others stand out against:
+[a table of 4 rows, read aloud]
+verb: correr. what it does to its stem: nothing — corro, corres, corre.
+verb: caminar, andar. what it does to its stem: nothing — camino, ando.
+verb: dormir. what it does to its stem: breaks o to ue under stress — duermo, but dormimos.
+verb: oír. what it does to its stem: grows -g- in oigo, and writes y in oyes, oye, oyen.
+Only two of the four misbehave, and each misbehaves by a rule you can state.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "corro, corres, corre, corremos, corren"]
+[pause 8 seconds for the answer]
+[your turn — say: "El perro corre" — the dog runs]
+[pause 8 seconds for the answer]
+[your turn — say: "Camino, no corro" — I walk, I don't run]
+[pause 8 seconds for the answer]
+[your turn — say: "Corro el sábado" — I run on Saturday; Spanish uses the bare article where English says on]
+[pause 8 seconds for the answer]
+[your turn — say: "Oigo, duermo, camino, corro" — the whole chapter in four words]
+[pause 8 seconds for the answer]
+[your turn — say: "correr" then English "current, curriculum, corridor" — the running family]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Name each verb's source in turn: oír, dormir, caminar, correr. (Audīre; dormīre; Gaulish camminus, by way of el camino; currere.) Which of the four leave their stems alone? (Caminar, andar and correr.) Say "the dog runs". (El perro corre.) Two words here have no settled origin — which? (Andar, and perro, whose three proposals all lack the evidence to decide between them.) And which English everyday word is a cousin of correr through Celtic? (Car.)

--- a/code/learning/human-languages/spanish/narration/ch37.json
+++ b/code/learning/human-languages/spanish/narration/ch37.json
@@ -1,0 +1,701 @@
+{
+  "version": 1,
+  "language": "spanish",
+  "chapter": 37,
+  "title": "Opening, Closing, Sitting Down, Standing Up",
+  "drivablePrefix": 4,
+  "sourceHash": "fnv1a64:3899f6300550ff70",
+  "lessons": [
+    {
+      "id": "ES-C37-abrir",
+      "sequence": 1730,
+      "title": "abrir — \"to open\", and the one part of it that misbehaves",
+      "headword": "abrir",
+      "romanization": "abrir",
+      "gloss": "to open — a regular -ir verb with one irregular part, the participle abierto",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:f0a0b0104cc7285b",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say corro and camino once — two verbs that gave you no trouble. This one is nearly as easy, and its one misbehaving piece is a word you will read on a shop door before you ever say it."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "b-soft — between vowels the b barely closes the lips: a-BREER."
+            },
+            {
+              "kind": "speech",
+              "text": "r-tap — a single flick for the final r."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: abrir",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "abrir (\"to open\") from Latin aperīre, \"to open, to uncover\". The p softened to b between vowels on the way into Spanish — the slide that turned sapere into saber and lupus into lobo."
+            },
+            {
+              "kind": "speech",
+              "text": "English took the root through two doors and does not notice they are one word:"
+            },
+            {
+              "kind": "speech",
+              "text": "straight from Latin apertūra: aperture, the opening a lens makes."
+            },
+            {
+              "kind": "speech",
+              "text": "through French ovrir and its participle overt: overt (\"out in the open\") and overture, an opera's opening."
+            },
+            {
+              "kind": "speech",
+              "text": "aperitif, a drink that opens the appetite; Spanish, el aperitivo."
+            },
+            {
+              "kind": "speech",
+              "text": "The cousin that is not one. April looks like it belongs here — the opening month. That is old folk etymology and is not accepted: the better proposals point at an Etruscan Apru, borrowed from Aphrodite, or at an Italic word meaning \"the next one\". A hook this pretty is the kind to check."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: regular everywhere but the participle",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "In the present, abrir is a plain -ir verb, the family escribir belongs to: abro, abres, abre, abrimos, abren. Nothing breaks, nothing grows."
+            },
+            {
+              "kind": "speech",
+              "text": "The past participle is where the irregularity lives. A regular -ir verb would give abrido. Spanish says abierto, straight down from Latin apertum, keeping the e that broke to ie under stress long ago."
+            },
+            {
+              "kind": "speech",
+              "text": "You will meet that participle long before the tense it belongs to, because it is a word on doors: ABIERTO on the sign, está abierto for \"it is open now\". Escribir does the same with escrito. Both refuse the regular ending because both inherited a Latin participle whole."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"abro, abres, abre, abrimos, abren\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"abro, abres, abre, abrimos, abren\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Abro el libro\" then \"Está abierto\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Abro el libro\" then \"Está abierto\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"abrir\" then English \"aperture, overt, overture\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"abrir\" then English \"aperture, overt, overture\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"correr\" then English \"current, curriculum\" — still there from before",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"correr\" then English \"current, curriculum\" — still there from before]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What is the past participle of abrir, and what would a regular verb have given? (Abierto; abrido.) Name two English words from aperīre. (Aperture, overt, overture, aperitif.) Is April one? (No — folk etymology.) Which other verb keeps an inherited Latin participle? (Escribir becomes escrito.) And which Latin verb is behind correr? (Currere.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C37-cerrar",
+      "sequence": 1740,
+      "title": "cerrar — \"to close\", from the bar across the door",
+      "headword": "cerrar",
+      "romanization": "cerrar",
+      "gloss": "to close — from the bar dropped across a door, not from the Latin verb English inherited",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:8d8eec3b9af68c5b",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Abro, abres, abre — and the sign saying ABIERTO. Here is the sign on the other side of the day, and a verb that cracks its stem."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "soft-c — c before e is soft: a th across most of Spain, an s across Latin America."
+            },
+            {
+              "kind": "speech",
+              "text": "rolled-rr — the double r is fully trilled: se-RRAR."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: cerrar",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "cerrar (\"to close\") from Late Latin serāre, \"to bolt, to fasten\", from the noun sera: the bar you drop across a door. Closing here is a physical object being put in place, not an abstraction."
+            },
+            {
+              "kind": "speech",
+              "text": "Its Romance siblings kept the pressure: Italian serrare, French serrer, \"to squeeze, to tighten\". English holds one of that branch, serried, as in ranks pressed shut against each other. Reference works generally connect sera to Latin serere, \"to join in a row\", which would make series and insert distant relatives — usual, but not certain."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way: the road Spanish did not take",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Latin had a perfectly good verb for closing: claudere. English is full of it — close, closet, closure, clause, cloister, include, exclude, conclude, recluse."
+            },
+            {
+              "kind": "speech",
+              "text": "Spanish let it go. For shutting a door it took serāre instead, and kept claudere only in words scholars borrowed back much later: incluir, excluir, concluir, clausura. That inversion is worth sitting with: the bigger English family belongs to the verb Spanish gave up. A cousin web maps what each language kept, and these two kept opposite halves."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "grammar",
+          "title": "Grammar Lens: e becomes ie, and the sign on the door",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "person",
+                "form"
+              ],
+              "columns": 2,
+              "rowCount": 5,
+              "utterances": [
+                "person: yo. form: cierro.",
+                "person: tú. form: cierras.",
+                "person: él/ella/usted. form: cierra.",
+                "person: nosotros. form: cerramos.",
+                "person: ellos/ustedes. form: cierran."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Dormir broke o becomes ue. Cerrar breaks e becomes ie — the same boot, the other vowel, the same trigger: stress on the stem. Cerramos is plain because there the stress moves to the ending."
+            },
+            {
+              "kind": "speech",
+              "text": "Its participle, unlike abierto, is regular: cerrado. The two signs on one door are built differently — abierto inherited whole from Latin, cerrado made by rule."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"cierro, cierras, cierra, cerramos, cierran\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"cierro, cierras, cierra, cerramos, cierran\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Abro el libro\" then \"Cierro el libro\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Abro el libro\" then \"Cierro el libro\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ABIERTO\" then \"CERRADO\" — the two signs",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ABIERTO\" then \"CERRADO\" — the two signs]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"aperīre, aperture\" then \"serāre, serried\" — the two doors' roots",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"aperīre, aperture\" then \"serāre, serried\" — the two doors' roots]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What was a sera, and does cerrar come from claudere? (The bar dropped across a door; and no — Spanish kept claudere only in incluir, excluir, concluir.) Which form of cerrar keeps its plain e, and why? (Cerramos — the stress moves to the ending, as in dormimos.) Which participle is irregular, abierto or cerrado? (Abierto.) And what did intendere, behind entender, mean literally? (To stretch toward.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C37-sentarse",
+      "sequence": 1750,
+      "title": "sentarse — \"to seat oneself\", which is how Spanish thinks about sitting down",
+      "headword": "sentarse",
+      "romanization": "sentarse",
+      "gloss": "to sit down — literally \"to seat oneself\", the reflexive that lands the action back on you",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:07fa41c64388469a",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Two things in hand. Cierro — the e cracking to ie. And me llamo, \"I call myself\", where the little me bounced the action back onto you. This verb needs both at once."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "diphthong-ie — the stressed e breaks: me siento = me SYEN-to."
+            },
+            {
+              "kind": "speech",
+              "text": "s-clear — a clean hissing s, never a z buzz."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: sentarse",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "sentar from Vulgar Latin sedentāre, built not on the Latin verb but on its present participle: sedēns, \"sitting\", from sedēre, \"to sit\". Spanish made a new verb out of being in a sitting state."
+            },
+            {
+              "kind": "speech",
+              "text": "Sedēre is one of the great English suppliers, and hardly any descendant still looks like sitting: sedentary, sediment, sedate; session and siege (an army sitting down outside a city); preside, reside; assess, obsess, possess. By way of Greek hedra, \"seat\", it also gives cathedral and chair."
+            },
+            {
+              "kind": "speech",
+              "text": "Then the other branch. English sit, seat, settle, saddle and nest come down from the very same root, sed-, through Germanic rather than Latin. Neither borrowed from the other: they are siblings, exactly as padre and father are, each branch reshaping the sounds its own way."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: seating someone, and seating yourself",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Plain sentar means to seat somebody else. To sit down yourself, you send the action back with the pronoun that made me llamo \"I call myself\":"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "person",
+                "form"
+              ],
+              "columns": 2,
+              "rowCount": 5,
+              "utterances": [
+                "person: yo. form: me siento.",
+                "person: tú. form: te sientas.",
+                "person: él/ella/usted. form: se sienta.",
+                "person: nosotros. form: nos sentamos.",
+                "person: ellos/ustedes. form: se sientan."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Two patterns run at once, and you have both. The pronoun changes with the person — me, te, se, nos, se — and the stem breaks e becomes ie wherever the stress lands on it, leaving nos sentamos plain. The pronoun stands before a conjugated verb and clips onto an infinitive, hence the name sentarse."
+            },
+            {
+              "kind": "speech",
+              "text": "Two verbs, one shape. Me siento is also the yo-form of sentirse, \"to feel\": me siento bien is \"I feel fine\". Only what follows tells them apart."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"me siento, te sientas, se sienta, nos sentamos, se sientan\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"me siento, te sientas, se sienta, nos sentamos, se sientan\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"me llamo\" then \"me siento\" — the same little me, twice",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"me llamo\" then \"me siento\" — the same little me, twice]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Cierro el libro y me siento\" — I close the book and sit down",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Cierro el libro y me siento\" — I close the book and sit down]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sentarse\" then English \"session, sedentary, preside\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sentarse\" then English \"session, sedentary, preside\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does sentarse say literally, and which Latin form was it built on? (To seat oneself; the participle sedēns.) Are English sit and Latin sedēre parent and child, or siblings? (Siblings — separate branches of one root, like father and padre.) Which form keeps its plain e, and what was a sera? (Nos sentamos; the bar across a door.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C37-levantarse",
+      "sequence": 1760,
+      "title": "levantarse — \"to raise oneself\", and how Spanish says \"stand\"",
+      "headword": "levantarse",
+      "romanization": "levantarse",
+      "gloss": "to get up, to stand up — \"to raise oneself\", built from a participle exactly as sentarse was",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:12daf97af771d3c5",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Me siento put you in the chair, the little me bouncing the action back onto you. Now get out of it. The pronoun works the same way; this time the stem does not crack at all."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "v-b — Spanish v and b are one sound: le-ban-TAR."
+            },
+            {
+              "kind": "speech",
+              "text": "nasal-n — a clean n before the t, not swallowed."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: levantarse",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "levantar from Vulgar Latin levantāre, from levāns, the present participle of levāre, \"to raise, to lighten\" — itself from levis, \"light, not heavy\"."
+            },
+            {
+              "kind": "speech",
+              "text": "Notice the shape: a Latin present participle, made into a new verb — the identical recipe that gave sentar from sedēns. Spanish built both of its body-position verbs out of a word for the state rather than the act."
+            },
+            {
+              "kind": "speech",
+              "text": "Levāre is everywhere in English: lever, elevate, elevator for raising; levity, levitate, alleviate, relieve for lightening; leaven, what raises the bread, and levy, a tax raised. And the Levant, from French levant, \"rising\": from western Europe it lay where the sun came up. English light, the opposite of heavy, is the Germanic cousin of levis, as sit is of sedēre."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: raising a thing, raising yourself, standing still",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Levantar on its own raises something else. Levantarse raises you:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "Spanish",
+                "what it means"
+              ],
+              "columns": 2,
+              "rowCount": 3,
+              "utterances": [
+                "Levanto la mano means I raise my hand.",
+                "Levanto la cabeza means I lift my head.",
+                "Me levanto means I get up, I stand up."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "The endings are ordinary -ar throughout — me levanto, te levantas, se levanta, nos levantamos, se levantan — and nothing breaks. So the chapter has now shown its two features apart: sentarse is reflexive and a stem-changer; levantarse is reflexive only."
+            },
+            {
+              "kind": "speech",
+              "text": "For standing as a state, Spanish uses no verb. It says estar de pie — \"to be on foot\", el pie being the foot. English's single \"stand\" splits in two: me levanto for getting up, estoy de pie for being up."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"me levanto, te levantas, se levanta, nos levantamos, se levantan\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"me levanto, te levantas, se levanta, nos levantamos, se levantan\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Levanto la mano\" then \"Levanto la cabeza\" then \"Me levanto\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Levanto la mano\" then \"Levanto la cabeza\" then \"Me levanto\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Estoy de pie\" — I am standing",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Estoy de pie\" — I am standing]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Abro el libro, me siento, cierro el libro, me levanto\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Abro el libro, me siento, cierro el libro, me levanto\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"levantar\" then English \"lever, elevate, Levant\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"levantar\" then English \"lever, elevate, Levant\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say the chapter's four verbs, then say how you are standing. (Abro, cierro, me siento, me levanto; estoy de pie.) What do sentar and levantar share in their making, and which also breaks its stem? (Both from a Latin present participle, sedēns and levāns; sentarse breaks e becomes ie.) Name the two roots on that door, and which participle is irregular. (Aperīre and serāre — not claudere; abierto.) Why la mano? (Manus was feminine in Latin.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/spanish/narration/ch37.txt
+++ b/code/learning/human-languages/spanish/narration/ch37.txt
@@ -1,0 +1,173 @@
+Spanish, chapter 37: Opening, Closing, Sitting Down, Standing Up.
+4 lessons. All 4 can be done entirely by ear.
+
+
+Lesson 1 of 4.
+abrir — "to open", and the one part of it that misbehaves.
+
+Warm-up.
+[pause 2 seconds]
+Say corro and camino once — two verbs that gave you no trouble. This one is nearly as easy, and its one misbehaving piece is a word you will read on a shop door before you ever say it.
+
+Sounds you'll need.
+b-soft — between vowels the b barely closes the lips: a-BREER.
+r-tap — a single flick for the final r.
+
+The word, taken apart: abrir.
+abrir ("to open") from Latin aperīre, "to open, to uncover". The p softened to b between vowels on the way into Spanish — the slide that turned sapere into saber and lupus into lobo.
+English took the root through two doors and does not notice they are one word:
+straight from Latin apertūra: aperture, the opening a lens makes.
+through French ovrir and its participle overt: overt ("out in the open") and overture, an opera's opening.
+aperitif, a drink that opens the appetite; Spanish, el aperitivo.
+The cousin that is not one. April looks like it belongs here — the opening month. That is old folk etymology and is not accepted: the better proposals point at an Etruscan Apru, borrowed from Aphrodite, or at an Italic word meaning "the next one". A hook this pretty is the kind to check.
+
+Grammar Lens: regular everywhere but the participle.
+In the present, abrir is a plain -ir verb, the family escribir belongs to: abro, abres, abre, abrimos, abren. Nothing breaks, nothing grows.
+The past participle is where the irregularity lives. A regular -ir verb would give abrido. Spanish says abierto, straight down from Latin apertum, keeping the e that broke to ie under stress long ago.
+You will meet that participle long before the tense it belongs to, because it is a word on doors: ABIERTO on the sign, está abierto for "it is open now". Escribir does the same with escrito. Both refuse the regular ending because both inherited a Latin participle whole.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "abro, abres, abre, abrimos, abren"]
+[pause 8 seconds for the answer]
+[your turn — say: "Abro el libro" then "Está abierto"]
+[pause 8 seconds for the answer]
+[your turn — say: "abrir" then English "aperture, overt, overture"]
+[pause 8 seconds for the answer]
+[your turn — say: "correr" then English "current, curriculum" — still there from before]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What is the past participle of abrir, and what would a regular verb have given? (Abierto; abrido.) Name two English words from aperīre. (Aperture, overt, overture, aperitif.) Is April one? (No — folk etymology.) Which other verb keeps an inherited Latin participle? (Escribir becomes escrito.) And which Latin verb is behind correr? (Currere.)
+
+
+Lesson 2 of 4.
+cerrar — "to close", from the bar across the door.
+
+Warm-up.
+[pause 2 seconds]
+Abro, abres, abre — and the sign saying ABIERTO. Here is the sign on the other side of the day, and a verb that cracks its stem.
+
+Sounds you'll need.
+soft-c — c before e is soft: a th across most of Spain, an s across Latin America.
+rolled-rr — the double r is fully trilled: se-RRAR.
+
+The word, taken apart: cerrar.
+cerrar ("to close") from Late Latin serāre, "to bolt, to fasten", from the noun sera: the bar you drop across a door. Closing here is a physical object being put in place, not an abstraction.
+Its Romance siblings kept the pressure: Italian serrare, French serrer, "to squeeze, to tighten". English holds one of that branch, serried, as in ranks pressed shut against each other. Reference works generally connect sera to Latin serere, "to join in a row", which would make series and insert distant relatives — usual, but not certain.
+
+Why it's said this way: the road Spanish did not take.
+Latin had a perfectly good verb for closing: claudere. English is full of it — close, closet, closure, clause, cloister, include, exclude, conclude, recluse.
+Spanish let it go. For shutting a door it took serāre instead, and kept claudere only in words scholars borrowed back much later: incluir, excluir, concluir, clausura. That inversion is worth sitting with: the bigger English family belongs to the verb Spanish gave up. A cousin web maps what each language kept, and these two kept opposite halves.
+
+Grammar Lens: e becomes ie, and the sign on the door.
+[a table of 5 rows, read aloud]
+person: yo. form: cierro.
+person: tú. form: cierras.
+person: él/ella/usted. form: cierra.
+person: nosotros. form: cerramos.
+person: ellos/ustedes. form: cierran.
+Dormir broke o becomes ue. Cerrar breaks e becomes ie — the same boot, the other vowel, the same trigger: stress on the stem. Cerramos is plain because there the stress moves to the ending.
+Its participle, unlike abierto, is regular: cerrado. The two signs on one door are built differently — abierto inherited whole from Latin, cerrado made by rule.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "cierro, cierras, cierra, cerramos, cierran"]
+[pause 8 seconds for the answer]
+[your turn — say: "Abro el libro" then "Cierro el libro"]
+[pause 8 seconds for the answer]
+[your turn — say: "ABIERTO" then "CERRADO" — the two signs]
+[pause 8 seconds for the answer]
+[your turn — say: "aperīre, aperture" then "serāre, serried" — the two doors' roots]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What was a sera, and does cerrar come from claudere? (The bar dropped across a door; and no — Spanish kept claudere only in incluir, excluir, concluir.) Which form of cerrar keeps its plain e, and why? (Cerramos — the stress moves to the ending, as in dormimos.) Which participle is irregular, abierto or cerrado? (Abierto.) And what did intendere, behind entender, mean literally? (To stretch toward.)
+
+
+Lesson 3 of 4.
+sentarse — "to seat oneself", which is how Spanish thinks about sitting down.
+
+Warm-up.
+[pause 2 seconds]
+Two things in hand. Cierro — the e cracking to ie. And me llamo, "I call myself", where the little me bounced the action back onto you. This verb needs both at once.
+
+Sounds you'll need.
+diphthong-ie — the stressed e breaks: me siento = me SYEN-to.
+s-clear — a clean hissing s, never a z buzz.
+
+The word, taken apart: sentarse.
+sentar from Vulgar Latin sedentāre, built not on the Latin verb but on its present participle: sedēns, "sitting", from sedēre, "to sit". Spanish made a new verb out of being in a sitting state.
+Sedēre is one of the great English suppliers, and hardly any descendant still looks like sitting: sedentary, sediment, sedate; session and siege (an army sitting down outside a city); preside, reside; assess, obsess, possess. By way of Greek hedra, "seat", it also gives cathedral and chair.
+Then the other branch. English sit, seat, settle, saddle and nest come down from the very same root, sed-, through Germanic rather than Latin. Neither borrowed from the other: they are siblings, exactly as padre and father are, each branch reshaping the sounds its own way.
+
+Grammar Lens: seating someone, and seating yourself.
+Plain sentar means to seat somebody else. To sit down yourself, you send the action back with the pronoun that made me llamo "I call myself":
+[a table of 5 rows, read aloud]
+person: yo. form: me siento.
+person: tú. form: te sientas.
+person: él/ella/usted. form: se sienta.
+person: nosotros. form: nos sentamos.
+person: ellos/ustedes. form: se sientan.
+Two patterns run at once, and you have both. The pronoun changes with the person — me, te, se, nos, se — and the stem breaks e becomes ie wherever the stress lands on it, leaving nos sentamos plain. The pronoun stands before a conjugated verb and clips onto an infinitive, hence the name sentarse.
+Two verbs, one shape. Me siento is also the yo-form of sentirse, "to feel": me siento bien is "I feel fine". Only what follows tells them apart.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "me siento, te sientas, se sienta, nos sentamos, se sientan"]
+[pause 8 seconds for the answer]
+[your turn — say: "me llamo" then "me siento" — the same little me, twice]
+[pause 8 seconds for the answer]
+[your turn — say: "Cierro el libro y me siento" — I close the book and sit down]
+[pause 8 seconds for the answer]
+[your turn — say: "sentarse" then English "session, sedentary, preside"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does sentarse say literally, and which Latin form was it built on? (To seat oneself; the participle sedēns.) Are English sit and Latin sedēre parent and child, or siblings? (Siblings — separate branches of one root, like father and padre.) Which form keeps its plain e, and what was a sera? (Nos sentamos; the bar across a door.)
+
+
+Lesson 4 of 4.
+levantarse — "to raise oneself", and how Spanish says "stand".
+
+Warm-up.
+[pause 2 seconds]
+Me siento put you in the chair, the little me bouncing the action back onto you. Now get out of it. The pronoun works the same way; this time the stem does not crack at all.
+
+Sounds you'll need.
+v-b — Spanish v and b are one sound: le-ban-TAR.
+nasal-n — a clean n before the t, not swallowed.
+
+The word, taken apart: levantarse.
+levantar from Vulgar Latin levantāre, from levāns, the present participle of levāre, "to raise, to lighten" — itself from levis, "light, not heavy".
+Notice the shape: a Latin present participle, made into a new verb — the identical recipe that gave sentar from sedēns. Spanish built both of its body-position verbs out of a word for the state rather than the act.
+Levāre is everywhere in English: lever, elevate, elevator for raising; levity, levitate, alleviate, relieve for lightening; leaven, what raises the bread, and levy, a tax raised. And the Levant, from French levant, "rising": from western Europe it lay where the sun came up. English light, the opposite of heavy, is the Germanic cousin of levis, as sit is of sedēre.
+
+Grammar Lens: raising a thing, raising yourself, standing still.
+Levantar on its own raises something else. Levantarse raises you:
+[a table of 3 rows, read aloud]
+Levanto la mano means I raise my hand.
+Levanto la cabeza means I lift my head.
+Me levanto means I get up, I stand up.
+The endings are ordinary -ar throughout — me levanto, te levantas, se levanta, nos levantamos, se levantan — and nothing breaks. So the chapter has now shown its two features apart: sentarse is reflexive and a stem-changer; levantarse is reflexive only.
+For standing as a state, Spanish uses no verb. It says estar de pie — "to be on foot", el pie being the foot. English's single "stand" splits in two: me levanto for getting up, estoy de pie for being up.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "me levanto, te levantas, se levanta, nos levantamos, se levantan"]
+[pause 8 seconds for the answer]
+[your turn — say: "Levanto la mano" then "Levanto la cabeza" then "Me levanto"]
+[pause 8 seconds for the answer]
+[your turn — say: "Estoy de pie" — I am standing]
+[pause 8 seconds for the answer]
+[your turn — say: "Abro el libro, me siento, cierro el libro, me levanto"]
+[pause 8 seconds for the answer]
+[your turn — say: "levantar" then English "lever, elevate, Levant"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say the chapter's four verbs, then say how you are standing. (Abro, cierro, me siento, me levanto; estoy de pie.) What do sentar and levantar share in their making, and which also breaks its stem? (Both from a Latin present participle, sedēns and levāns; sentarse breaks e becomes ie.) Name the two roots on that door, and which participle is irregular. (Aperīre and serāre — not claudere; abierto.) Why la mano? (Manus was feminine in Latin.)

--- a/code/learning/human-languages/spanish/roadmap.md
+++ b/code/learning/human-languages/spanish/roadmap.md
@@ -229,10 +229,40 @@ order lives in the book, which LaTeX auto-numbers, and in `session-map.md`.)
   "the book pleases me", so the **thing liked is the subject** and the verb
   agrees with it, never with you. **Authored.**
 
-Next: the remaining core verbs — twenty-three of the shared spine's forty are
-still unrealized by any track. From here the course hands over rules, not
-phrases. Grammar accumulates piece by piece. The theme skeleton below plans the
-wider road.
+- **Ch. 36 — Hearing, sleeping, walking, running**: **oír** ("to hear" ←
+  *audīre* → audio, audible, audience, audition, auditorium, audit, and **obey**
+  ← *oboedīre* = *ob-* "toward" + *audīre*), set against *escuchar* ←
+  *auscultāre* (→ auscultate, **scout**) for the listening you choose; its *yo*
+  joins Ch. 12's *-go* club and its *y* is a **spelling** rule → **dormir** ("to
+  sleep" ← *dormīre* → dormitory, dormant, dormer; *dormouse* left as likely
+  but unproved), whose **o→ue** is the boot's other vowel → **caminar** ("to
+  walk" ← *el camino* ← Late Latin *camminus*, a **Gaulish** loan that stocked
+  every Romance road and reached English only inside borrowed French phrases;
+  the near-identical *camīnus* "hearth" is a different word and gave **chimney**),
+  beside **andar**, whose origin is **genuinely disputed** → **correr** ("to
+  run" ← *currere* → current, currency, curriculum, courier, cursor, corridor,
+  occur, excursion), the payoff, which also shows English **car** to be a cousin
+  through Gaulish *carrus* at PIE \**kers-*. **Authored.**
+
+- **Ch. 37 — Opening, closing, sitting down, standing up**: **abrir** ("to open"
+  ← *aperīre* → aperture, overt, overture, aperitif; *April* named as folk
+  etymology and refused), with the irregular participle **abierto** → **cerrar**
+  ("to close" ← Late Latin *serāre*, from *sera*, **the bar dropped across a
+  door** — **not** *claudere*, which gave English close, clause, include,
+  exclude, recluse and which Spanish kept only in *incluir*, *excluir*,
+  *concluir*, *clausura*) → **sentarse** ("to seat oneself" ← Vulgar Latin
+  \**sedentāre* from *sedēns* → sedentary, session, siege, preside, reside,
+  assess, cathedral, chair; and the Germanic branch *sit, seat, settle, saddle,
+  nest*) → **levantarse** ("to raise oneself" ← \**levantāre* from *levāns* →
+  lever, elevate, levity, alleviate, relieve, leaven, levy, **the Levant**), the
+  payoff. Both body-position verbs are **reflexive** and both were made from a
+  Latin **present participle**; standing as a *state* is **estar de pie**, no
+  verb at all. **Authored.**
+
+Next: the remaining core verbs — seven of the shared spine's forty are still
+unrealized by any track. From here the course hands over rules, not phrases.
+Grammar accumulates piece by piece. The theme skeleton below plans the wider
+road.
 
 ## Theme Skeleton (planning only)
 

--- a/code/learning/human-languages/spanish/session-map.md
+++ b/code/learning/human-languages/spanish/session-map.md
@@ -86,6 +86,29 @@ each is a prerequisite of the next.
 rebuilt rather than translated, and because it reaches back to *mucho gusto*
 from Chapter 3 — the same *gustus*, met as a noun long before the verb.
 
+## Chapters 36-37 — the third verb tranche
+
+Eight more core verbs no track had realized, one verb per session-slot, chained
+so each is a prerequisite of the next.
+
+| New lesson(s) | Introduces |
+|---|---|
+| oír | *audīre* "to hear", and *obey* ← *ob-* + *audīre*; *oigo* joins the *-go* club, *oyes* is a spelling rule |
+| dormir | *dormīre* "to sleep"; the boot's other vowel, o→ue |
+| caminar | Gaulish *camminus* by way of *el camino*; *andar*'s origin genuinely disputed |
+| correr | *currere* "to run"; **car** shown to be a cousin through Celtic |
+| abrir | *aperīre* "to uncover"; the irregular participle *abierto*; *April* refused |
+| cerrar | *serāre* ← *sera*, the bar across a door — **not** *claudere*; e→ie again |
+| sentarse | \**sedentāre* ← *sedēns*; the reflexive from *me llamo*, now on a verb |
+| levantarse | \**levantāre* ← *levāns*; reflexive without a stem change; *estar de pie* |
+
+Each session practises the atoms of the one or two before it, across the chapter
+seam, which is what closes the R1 window (HL09 §7.2). *Correr* and *levantarse*
+close their chapters and reach further back: *correr* to *perro* (Ch. 32) and
+the weekend (Ch. 21), *levantarse* to the reflexive of *me llamo* (Ch. 3) and to
+*la mano* and *la cabeza* (Ch. 24) — *levanto la mano* being the same verb
+without the pronoun.
+
 ## What comes next (recursive)
 
 Chapter 4 answers what Chapter 3 ends on: their reply to **"¿cómo está

--- a/code/packages/typescript/human-language-data/tests/chapters.test.ts
+++ b/code/packages/typescript/human-language-data/tests/chapters.test.ts
@@ -225,11 +225,11 @@ describe("corpus snapshot", () => {
     // bookChapters 377 -> 378, declaredChapters 279 -> 280, chaptersWithoutCapability
     // holds at 98. A new chapter that shipped without a `canDo`/`payoff` would have
     // pushed the debt to 99, which is exactly what this trio is here to catch.
-    expect(report.summary.bookChapters).toBe(434);
+    expect(report.summary.bookChapters).toBe(442);
     // 317 -> 318 when russian chapter 3 gained a capability. It was the only
     // generated chapter with no HL05 entry, so it was also the only generated chapter
     // the book could not give an opening to.
-    expect(report.summary.declaredChapters).toBe(336);
+    expect(report.summary.declaredChapters).toBe(344);
     expect(report.summary.chaptersWithoutCapability).toBe(98);
     expect(report.summary.payoffsNotClosed).toBe(0);
     expect(report.summary.unknownPayoffLessons).toBe(0);

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -264,9 +264,9 @@ describe("the real corpus", () => {
     // lesson's own, structurally unreachable), Bengali 12 of 18 -> 4 of 35, Tamil 53% ->
     // 38%, Arabic four ch28-30 atoms off zero. Adding vocabulary and reducing orphans at
     // the same time is the whole point; a corpus that only grows is not a course.
-    expect(report.summary.atomsTaught).toBe(1847);
-    expect(report.summary.atomsNeverRevisited).toBe(596);
-    expect(report.summary.neverRevisitedPercent).toBe(32);
+    expect(report.summary.atomsTaught).toBe(1929);
+    expect(report.summary.atomsNeverRevisited).toBe(569);
+    expect(report.summary.neverRevisitedPercent).toBe(29);
 
     // 509 -> 517, and the eight split into TWO DIFFERENT PHENOMENA this number conflates.
     //
@@ -285,15 +285,15 @@ describe("the real corpus", () => {
     // NOT being rewritten to move this number, because contorting good prose to satisfy a
     // naive matcher is the exact failure the sight-cue detector already demonstrated.
     // If this metric is to gate anything, it wants a severity split by distance first.
-    expect(report.summary.forwardReferences).toBe(510);
+    expect(report.summary.forwardReferences).toBe(515);
 
     // HL09 step 3 closed 17 R1 windows in chapters 3-6, measured on the corpus of the
     // day as 766 -> 749. The absolute figures drift as main lands lessons; what the
     // change is accountable for is the 17. R2 moves only with new lessons, never from
     // that work — closing a near window does not close a far one, and nothing yet
     // addresses R2/R3/R4.
-    expect(report.summary.missedByWindow.R1).toBe(775);
-    expect(report.summary.missedByWindow.R2).toBe(1216);
+    expect(report.summary.missedByWindow.R1).toBe(779);
+    expect(report.summary.missedByWindow.R2).toBe(1265);
   });
 
   it("shows what a declared reading order was worth", () => {
@@ -316,11 +316,11 @@ describe("the real corpus", () => {
     // 93 -> 102. The independent Python audit these four numbers reproduce was run
     // against the 146-lesson corpus; the walk is unchanged, only its input grew.
     expect(spanish).toMatchObject({
-      lessonCount: 154,
+      lessonCount: 162,
       lessonsWithoutSequence: 6,
       forwardPrerequisites: 5,
-      atomsTaught: 199,
-      atomsNeverRevisited: 90,
+      atomsTaught: 221,
+      atomsNeverRevisited: 80,
     });
   });
 

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -96,7 +96,10 @@ describe("real curriculum", () => {
     // 33 -> 35: the second Spanish verb tranche added Chapters 34 and 35, the track's
     // first chapters filed under an A2 spine node (SPINE-SAY-WHAT-I-DO) rather than an
     // A1 social function. Both are generated from schema-v2 lessons like 1-6 and 19-33.
-    expect(books.books.find((book) => book.language === "spanish")?.chapters.length).toBe(35);
+    // 35 -> 37: the third verb tranche added Chapters 36 (oír, dormir, caminar, correr)
+    // and 37 (abrir, cerrar, sentarse, levantarse), again split 4+4 to stay inside
+    // maxNewAtomsPerChapter, and again on SPINE-SAY-WHAT-I-DO.
+    expect(books.books.find((book) => book.language === "spanish")?.chapters.length).toBe(37);
     expect(
       books.books
         .find((book) => book.language === "persian")

--- a/code/packages/typescript/human-language-data/tests/level-gate.test.ts
+++ b/code/packages/typescript/human-language-data/tests/level-gate.test.ts
@@ -70,7 +70,7 @@ describe("the gate that would have caught the A2 claim", () => {
     // catch — a number meaning "everything taught" published against one meaning
     // "by the end of pre-A1".
     expect(vocab.shortfall).toBe(256);
-    expect(spanish.vocabulary).toBe(113);
+    expect(spanish.vocabulary).toBe(121);
     expect(vocab.shortfall).toBeGreaterThan(LEVEL_VOCABULARY["pre-A1"] - spanish.vocabulary);
   });
 

--- a/code/packages/typescript/human-language-data/tests/levels.test.ts
+++ b/code/packages/typescript/human-language-data/tests/levels.test.ts
@@ -219,7 +219,7 @@ describe("corpus snapshot", () => {
 
     expect(summary.byLevel["pre-A1"]).toBe(650);
     expect(summary.byLevel.A1).toBe(297);
-    expect(summary.byLevel.A2).toBe(290);
+    expect(summary.byLevel.A2).toBe(322);
     expect(summary.byLevel.B1).toBe(0);
     expect(summary.byLevel.B2).toBe(0);
     expect(summary.byLevel.C1).toBe(0);
@@ -228,7 +228,7 @@ describe("corpus snapshot", () => {
     // 170 lessons sit in no realization-path segment, all of them schema-v1. They are the
     // reason `mappedPercent` is not 100, and mapping them is migration work, not a gate.
     expect(summary.unmapped).toBe(148);
-    expect(summary.mappedPercent).toBe(89);
+    expect(summary.mappedPercent).toBe(90);
   });
 
   it("shows twenty tracks have reached A2, and only two have not reached A1", () => {

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -792,14 +792,14 @@ describe("corpus regression", () => {
     // headline per-track number is the standing recommendation; until then, expect this
     // figure to rise whenever a non-Latin track authors honestly.
     expect(manifest.summary).toEqual({
-      totalLessons: 1385,
-      voice: 909,
+      totalLessons: 1417,
+      voice: 941,
       sight: 423,
       pen: 53,
-      drivableLessons: 909,
+      drivableLessons: 941,
       drivablePercent: 66,
       trackCount: 22,
-      chapterCount: 434,
+      chapterCount: 442,
       // Prerequisite order still costs a commuter 132 of the 965 ear-only lessons:
       // they sit behind a blocker in their own chapter and stay unreachable in the car
       // until HL-C17 reshapes the remaining wide tables.
@@ -808,8 +808,8 @@ describe("corpus regression", () => {
       // and the alphabetical fallback it replaced had been flattering this number by
       // putting eyes-needed lessons later than they really come. The real order is
       // worse, which is the measurement becoming honest, not the corpus regressing.
-      drivablePrefixTotal: 726,
-      fullyDrivableChapters: 289,
+      drivablePrefixTotal: 758,
+      fullyDrivableChapters: 297,
       unstartableChapters: 108,
       overriddenLessons: 0,
       lessonsWithoutChapter: 0,

--- a/code/packages/typescript/human-language-data/tests/narration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/narration.test.ts
@@ -608,7 +608,7 @@ describe("the whole corpus", () => {
     // 378, not the 375 this was authored against: HL-C39 and HL-C40 each added a
     // Chapter 1 (Mandarin Chinese and Japanese) while this branch waited to merge, and
     // the Latin core-verb chapter (chapter 37, eight verb lessons) added one more.
-    expect(chapters).toHaveLength(434);
+    expect(chapters).toHaveLength(442);
   });
 
   it("leaves no Markdown typography in the spoken script", () => {

--- a/code/packages/typescript/human-language-data/tests/ramp.test.ts
+++ b/code/packages/typescript/human-language-data/tests/ramp.test.ts
@@ -106,7 +106,7 @@ describe("corpus snapshot", () => {
     // schema-v2 migration lands; the violation count will rise as it does, and that is
     // the measurement improving rather than the corpus worsening.
     expect(report.summary.unmeasurableLessons).toBe(572);
-    expect(report.summary.measurablePercent).toBe(59);
+    expect(report.summary.measurablePercent).toBe(60);
   });
 
   it("names the steepest lesson, which is where a burn-down starts", () => {

--- a/code/packages/typescript/human-language-data/tests/verbs.test.ts
+++ b/code/packages/typescript/human-language-data/tests/verbs.test.ts
@@ -96,8 +96,8 @@ describe("corpus snapshot", () => {
     expect(report.summary.coreVerbCount).toBe(40);
 
     expect(report.summary.tracksWithNoCoreVerb).toBe(2);
-    expect(report.summary.universallyMissing).toHaveLength(15);
-    expect(report.summary.meanCoveredPercent).toBe(33);
+    expect(report.summary.universallyMissing).toHaveLength(7);
+    expect(report.summary.meanCoveredPercent).toBe(36);
 
     // The tracks that have joined the cross-language corpus, named explicitly so a
     // regression that silently unhooks these lessons cannot hide inside a total.
@@ -109,20 +109,32 @@ describe("corpus snapshot", () => {
       "VERB-COME",
       "VERB-SAY",
       "VERB-SEE",
-      "VERB-KNOW",
       // The second tranche (chapters 38-39) — the same eight Spanish and Portuguese
       // authored in parallel, so all three joined on them at once.
+      "VERB-HEAR",
+      "VERB-KNOW",
       "VERB-THINK",
       "VERB-UNDERSTAND",
       "VERB-READ",
       "VERB-WRITE",
       "VERB-GIVE",
       "VERB-TAKE",
+      // Chapters 40-41 — the everyday verbs nobody taught. This set is where Latin's
+      // taproot claim pays: *sto* and *sedeo* are COGNATE with English stand and sit
+      // through *steh2- and *sed-, not borrowed, while *curro* and *claudo* gave English
+      // current/courier and close/clause/include by the ordinary Latin route.
+      "VERB-SLEEP",
+      "VERB-WALK",
+      "VERB-RUN",
+      "VERB-SIT",
+      "VERB-STAND",
       "VERB-ASK",
       "VERB-HELP",
+      "VERB-OPEN",
+      "VERB-CLOSE",
       "VERB-LIKE-LOVE",
     ]);
-    expect(latin.coveredPercent).toBe(40);
+    expect(latin.coveredPercent).toBe(60);
     expect(report.tracks.find((track) => track.language === "arabic")!.covered).toEqual([
       "VERB-GO",
       "VERB-COME",
@@ -210,7 +222,7 @@ describe("corpus snapshot", () => {
     // querer. `ser` takes VERB-BE (one lesson per concept), and the rest have no core
     // concept that fits without stretching it.
     const spanish = report.tracks.find((track) => track.language === "spanish")!;
-    expect(spanish.covered).toHaveLength(21);
+    expect(spanish.covered).toHaveLength(29);
     expect(spanish.extras.length).toBe(6);
 
     // THE EIGHT THAT NOBODY TAUGHT. Twenty-three of the forty core verbs were realized by


### PR DESCRIPTION
Spanish, Latin, French and German take eight verbs **no track taught**: HEAR SLEEP WALK RUN SIT STAND OPEN CLOSE. Each is now a four-way join.

```
universallyMissing 15 → 7        meanCoveredPercent 33 → 36
spanish 21→29/40 · latin 16→24/40 · french 14→22/40 · german 14→22/40

atomsTaught 1847 → 1929    atomsNeverRevisited 596 → 569
            neverRevisitedPercent  32 → 29
```

**Under 30% for the first time.** It was 51% when first measured.

## Four errors in my brief, all caught by agents checking sources

**`cerrar` does not come from *claudere*.** It is Late Latin *serāre* ← *sera*, the bar dropped across a door (Italian *serrare*, French *serrer*, English *serried*). *Claudere* gave English close/clause/include/exclude — and **Spanish kept it only in scholarly re-borrowings** (*incluir*, *excluir*, *clausura*). The agent made that inversion the lesson: *the bigger English family belongs to the verb Spanish gave up.* Better content than I specified.

**`entendre` did not shift from "intend" to "hear".** CNRTL dates *« percevoir par l'ouïe »* to **c. 1050 — the earliest sense**, ahead of "understand" (c. 1100) and "intend" (c. 1121). The other senses fell away as *ouïr* eroded. My framing was backwards, not merely loose.

**`April` is not from *aperīre*** — folk etymology, flagged **independently by both the Spanish and Latin agents** from different sources.

**`dormouse` is folk etymology too** — English attests it early 15c, *before* French *dormeuse* (17c) — flagged **independently by Latin and French**.

Also corrected: *ambulō*'s back half is unsettled; English *still* is not in the \*steh₂- family; *scout* ← *auscultāre* is one of two competing accounts; *horse* ← \*kers- is a proposal; *carrus* is a Gaulish **loan** sharing *currere*'s root, not derived from it; *ouvrir* is *aperīre* reshaped on its antonym; English *butt* is a loan back out of French; *schließen* has no English cognate at all.

**And my font warning was over-broad.** `src/book.ts` maps `ḱ ṓ ḗ ḯ ₁₂₃ ʰ ʷ ⁿ` before LaTeX sees them, so standard PIE citations render fine. Genuinely unmapped: `ǵ ǣ ḵ ẖ ḳ ṉ ṟ ẕ ṁ` and the ring-below.

## Reinforcement

Latin's is the cleanest yet — **zero new orphans**. Its first pass left two atoms unrevisited and it went back and closed both rather than reporting them as structurally unavoidable. French rescued 11 orphaned atoms, Spanish 9, German 6.

## Also fixed: four badly stale README rows

Spanish read *"Chapters 1-3 authored; ~30 lessons"* while having **37 chapters and 162 lessons**. German read *"Chapters 1-2"* and was 25 chapters out. Prose that nothing recomputes — the pattern this project keeps rediscovering.

## Verification

- **919 tests pass** at default timeouts, no CLI flags (396 + 523).
- Three drift gates clean; artifacts regenerated, never hand-merged.
- Books: spanish 262pp, latin 164pp, french 134pp, german 140pp — **zero `Missing character`**.
- Every lesson computed under the 300s ceiling; Spanish and Latin trimmed real drafts down from 310–397s rather than adjusting a declared duration.

`lessons 1385 → 1417 · chapters 434 → 442 · A2 lessons 290 → 322`

🤖 Generated with [Claude Code](https://claude.com/claude-code)