### PR TITLE
feat(human-language-data): the B1–C2 spine, so the ladder has rungs above A2

### DIFF
--- a/code/learning/human-languages/arabic/curriculum.json
+++ b/code/learning/human-languages/arabic/curriculum.json
@@ -581,6 +581,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/bengali/curriculum.json
+++ b/code/learning/human-languages/bengali/curriculum.json
@@ -345,6 +345,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/chinese/curriculum.json
+++ b/code/learning/human-languages/chinese/curriculum.json
@@ -217,6 +217,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -584,6 +584,346 @@
       "family": "VERB",
       "gloss": "to like / to love",
       "core": true
+    },
+    "NARRATIVE-SEQUENCE": {
+      "family": "DISCOURSE",
+      "gloss": "putting events in the order they happened",
+      "core": false
+    },
+    "CONNECTIVE-THEN": {
+      "family": "DISCOURSE",
+      "gloss": "then, next — joining events in sequence",
+      "core": false
+    },
+    "CONNECTIVE-BECAUSE": {
+      "family": "DISCOURSE",
+      "gloss": "because — joining a claim to its reason",
+      "core": false
+    },
+    "ASPECT-ONGOING-PAST": {
+      "family": "GRAMMAR",
+      "gloss": "was doing — an action in progress in the past",
+      "core": false
+    },
+    "OPINION-I-THINK": {
+      "family": "STANCE",
+      "gloss": "I think, in my view — marking an opinion as one's own",
+      "core": false
+    },
+    "CONNECTIVE-SO": {
+      "family": "DISCOURSE",
+      "gloss": "so, therefore — joining a reason to its consequence",
+      "core": false
+    },
+    "MODAL-SHOULD": {
+      "family": "GRAMMAR",
+      "gloss": "should, ought to — advice and mild obligation",
+      "core": false
+    },
+    "DIRECTION-ASK": {
+      "family": "TRAVEL",
+      "gloss": "asking the way, and following the answer",
+      "core": false
+    },
+    "TRANSPORT-TICKET": {
+      "family": "TRAVEL",
+      "gloss": "buying a ticket and naming a destination",
+      "core": false
+    },
+    "LODGING-ROOM": {
+      "family": "TRAVEL",
+      "gloss": "asking for a room and what it includes",
+      "core": false
+    },
+    "PROBLEM-REPORT": {
+      "family": "TRAVEL",
+      "gloss": "saying something has gone wrong, and what is needed",
+      "core": false
+    },
+    "ADJECTIVE-FEELING": {
+      "family": "LEXIS",
+      "gloss": "adjectives for how one feels",
+      "core": false
+    },
+    "COMPARISON-BASIC": {
+      "family": "GRAMMAR",
+      "gloss": "bigger than, the biggest — comparing two or more things",
+      "core": false
+    },
+    "TIME-DURATION": {
+      "family": "GRAMMAR",
+      "gloss": "for how long, since when",
+      "core": false
+    },
+    "CONDITIONAL-REAL": {
+      "family": "GRAMMAR",
+      "gloss": "if X, then Y — for outcomes that really can follow",
+      "core": false
+    },
+    "CONNECTIVE-IF": {
+      "family": "DISCOURSE",
+      "gloss": "if — introducing a condition",
+      "core": false
+    },
+    "MODAL-WOULD": {
+      "family": "GRAMMAR",
+      "gloss": "would — a consequence that depends on a condition",
+      "core": false
+    },
+    "ARGUMENT-CLAIM": {
+      "family": "DISCOURSE",
+      "gloss": "stating the position an argument will defend",
+      "core": false
+    },
+    "ARGUMENT-EVIDENCE": {
+      "family": "DISCOURSE",
+      "gloss": "supporting a claim with a reason or an example",
+      "core": false
+    },
+    "CONNECTIVE-HOWEVER": {
+      "family": "DISCOURSE",
+      "gloss": "however, on the other hand — marking a contrast",
+      "core": false
+    },
+    "CONNECTIVE-ALTHOUGH": {
+      "family": "DISCOURSE",
+      "gloss": "although, even though — conceding a point",
+      "core": false
+    },
+    "REPORTED-SPEECH": {
+      "family": "GRAMMAR",
+      "gloss": "he said that… — reporting rather than quoting",
+      "core": false
+    },
+    "TENSE-BACKSHIFT": {
+      "family": "GRAMMAR",
+      "gloss": "the tense shift a report imposes, where the language has one",
+      "core": false
+    },
+    "QUOTATION-DIRECT": {
+      "family": "DISCOURSE",
+      "gloss": "quoting words as they were spoken",
+      "core": false
+    },
+    "DISCOURSE-TOPIC-SENTENCE": {
+      "family": "DISCOURSE",
+      "gloss": "the sentence that tells you what a paragraph is about",
+      "core": false
+    },
+    "RELATIVE-CLAUSE": {
+      "family": "GRAMMAR",
+      "gloss": "the man who…, the book that… — modifying a noun with a clause",
+      "core": false
+    },
+    "VOICE-PASSIVE": {
+      "family": "GRAMMAR",
+      "gloss": "it was written — where the language has a passive",
+      "core": false
+    },
+    "VOCAB-FIELD-SPECIFIC": {
+      "family": "LEXIS",
+      "gloss": "the vocabulary of one subject area",
+      "core": false
+    },
+    "ABSTRACT-NOUN": {
+      "family": "LEXIS",
+      "gloss": "nouns for things you cannot point at",
+      "core": false
+    },
+    "HEDGE-PROBABLY": {
+      "family": "STANCE",
+      "gloss": "probably, it seems — marking a claim as less than certain",
+      "core": false
+    },
+    "NOMINALIZATION": {
+      "family": "GRAMMAR",
+      "gloss": "turning a verb or adjective into a noun",
+      "core": false
+    },
+    "IMPLICATURE": {
+      "family": "PRAGMATICS",
+      "gloss": "what a speaker means without saying it",
+      "core": false
+    },
+    "IRONY-MARKER": {
+      "family": "PRAGMATICS",
+      "gloss": "the signals that a sentence means its opposite",
+      "core": false
+    },
+    "IDIOM-COMMON": {
+      "family": "LEXIS",
+      "gloss": "fixed phrases whose meaning is not the sum of their words",
+      "core": false
+    },
+    "TONE-SHIFT": {
+      "family": "PRAGMATICS",
+      "gloss": "hearing when the tone of a passage changes",
+      "core": false
+    },
+    "DISCOURSE-COHESION": {
+      "family": "DISCOURSE",
+      "gloss": "the devices that hold a long text together",
+      "core": false
+    },
+    "PARAGRAPH-PLAN": {
+      "family": "DISCOURSE",
+      "gloss": "arranging paragraphs so an argument builds",
+      "core": false
+    },
+    "CONNECTIVE-FURTHERMORE": {
+      "family": "DISCOURSE",
+      "gloss": "furthermore, moreover — adding weight to a point",
+      "core": false
+    },
+    "REFERENCE-ANAPHORA": {
+      "family": "DISCOURSE",
+      "gloss": "pronouns and repeats that point back to something already named",
+      "core": false
+    },
+    "REGISTER-FORMAL": {
+      "family": "PRAGMATICS",
+      "gloss": "the formal register and when it is required",
+      "core": false
+    },
+    "REGISTER-COLLOQUIAL": {
+      "family": "PRAGMATICS",
+      "gloss": "the everyday register and where it would be wrong",
+      "core": false
+    },
+    "HONORIFIC-SYSTEM": {
+      "family": "PRAGMATICS",
+      "gloss": "grammaticalised respect, where the language has it",
+      "core": false
+    },
+    "POLITENESS-STRATEGY": {
+      "family": "PRAGMATICS",
+      "gloss": "softening, distancing, and other ways of being polite",
+      "core": false
+    },
+    "DIALECT-FEATURE": {
+      "family": "VARIATION",
+      "gloss": "a feature that marks one regional variety",
+      "core": false
+    },
+    "ACCENT-VARIATION": {
+      "family": "VARIATION",
+      "gloss": "the same word pronounced differently by region",
+      "core": false
+    },
+    "LEXICAL-VARIANT-REGIONAL": {
+      "family": "VARIATION",
+      "gloss": "different everyday words for the same thing by region",
+      "core": false
+    },
+    "DIGLOSSIA": {
+      "family": "VARIATION",
+      "gloss": "a high and a low variety used in different settings",
+      "core": false
+    },
+    "SYNTHESIS-MULTI-SOURCE": {
+      "family": "DISCOURSE",
+      "gloss": "building one account from several sources",
+      "core": false
+    },
+    "PARAPHRASE": {
+      "family": "DISCOURSE",
+      "gloss": "restating someone's point accurately in your own words",
+      "core": false
+    },
+    "ATTRIBUTION-CITE": {
+      "family": "DISCOURSE",
+      "gloss": "saying whose claim it is",
+      "core": false
+    },
+    "SUMMARY-COMPRESSION": {
+      "family": "DISCOURSE",
+      "gloss": "keeping the argument while cutting the length",
+      "core": false
+    },
+    "NUANCE-MODALITY": {
+      "family": "STANCE",
+      "gloss": "fine gradations of certainty, obligation and permission",
+      "core": false
+    },
+    "COLLOCATION-PRECISE": {
+      "family": "LEXIS",
+      "gloss": "the word that habitually goes with this one",
+      "core": false
+    },
+    "EMPHASIS-DEVICE": {
+      "family": "GRAMMAR",
+      "gloss": "word order, particles or stress used to emphasise",
+      "core": false
+    },
+    "CONNOTATION-CHOICE": {
+      "family": "LEXIS",
+      "gloss": "choosing between near-synonyms for their overtones",
+      "core": false
+    },
+    "LITERARY-REGISTER": {
+      "family": "CULTURE",
+      "gloss": "the register of poetry and literary prose",
+      "core": false
+    },
+    "ARCHAIC-FORM": {
+      "family": "CULTURE",
+      "gloss": "forms that survive only in older or ceremonial text",
+      "core": false
+    },
+    "METER-AND-VERSE": {
+      "family": "CULTURE",
+      "gloss": "how the language's verse is measured",
+      "core": false
+    },
+    "ORTHOGRAPHY-HISTORICAL": {
+      "family": "CULTURE",
+      "gloss": "older spellings and scripts a reader will meet",
+      "core": false
+    },
+    "CULTURAL-ALLUSION": {
+      "family": "CULTURE",
+      "gloss": "references a native reader is expected to catch",
+      "core": false
+    },
+    "PROVERB": {
+      "family": "CULTURE",
+      "gloss": "proverbs and the situations that call for them",
+      "core": false
+    },
+    "EUPHEMISM-AND-TABOO": {
+      "family": "CULTURE",
+      "gloss": "what is said indirectly, and what is not said",
+      "core": false
+    },
+    "HUMOR-CONVENTION": {
+      "family": "CULTURE",
+      "gloss": "what counts as funny, and how it is signalled",
+      "core": false
+    },
+    "EXPLANATION-GIVE": {
+      "family": "DISCOURSE",
+      "gloss": "giving the reason behind a claim",
+      "core": false
+    },
+    "AMBITION-EXPRESS": {
+      "family": "STANCE",
+      "gloss": "stating a hope or an ambition",
+      "core": false
+    },
+    "CONDITION-DEPENDS": {
+      "family": "DISCOURSE",
+      "gloss": "saying an outcome depends on something",
+      "core": false
+    },
+    "SPEECH-ACT-REPORT": {
+      "family": "DISCOURSE",
+      "gloss": "the verbs a report is built on",
+      "core": false
+    },
+    "HEDGE-SUPPOSE": {
+      "family": "STANCE",
+      "gloss": "supposing, assuming — advancing a claim tentatively",
+      "core": false
     }
   },
   "namespaced": {

--- a/code/learning/human-languages/core/spine.json
+++ b/code/learning/human-languages/core/spine.json
@@ -279,6 +279,270 @@
       "concepts": [
         "VERB-FUTURE"
       ]
+    },
+    {
+      "id": "SPINE-NARRATE-EVENTS",
+      "stage": "B1",
+      "canDo": "I can tell a simple connected story about something that happened, in order.",
+      "prerequisites": [
+        "SPINE-TALK-ABOUT-PAST"
+      ],
+      "core": true,
+      "concepts": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ]
+    },
+    {
+      "id": "SPINE-GIVE-REASONS",
+      "stage": "B1",
+      "canDo": "I can give reasons and explanations for my opinions and plans.",
+      "prerequisites": [
+        "SPINE-NEGATE-AND-ASK",
+        "SPINE-SAY-WHAT-I-WANT"
+      ],
+      "core": true,
+      "concepts": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ]
+    },
+    {
+      "id": "SPINE-HANDLE-TRAVEL",
+      "stage": "B1",
+      "canDo": "I can deal with most situations that come up while travelling.",
+      "prerequisites": [
+        "SPINE-ASK-LOCATION",
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "core": true,
+      "concepts": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ]
+    },
+    {
+      "id": "SPINE-DESCRIBE-EXPERIENCE",
+      "stage": "B1",
+      "canDo": "I can describe experiences, feelings and ambitions.",
+      "prerequisites": [
+        "SPINE-NARRATE-EVENTS"
+      ],
+      "core": true,
+      "concepts": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ]
+    },
+    {
+      "id": "SPINE-EXPRESS-CONDITION",
+      "stage": "B1",
+      "canDo": "I can say what would happen if something else did.",
+      "prerequisites": [
+        "SPINE-GIVE-REASONS"
+      ],
+      "core": true,
+      "concepts": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ]
+    },
+    {
+      "id": "SPINE-ARGUE-A-VIEW",
+      "stage": "B2",
+      "canDo": "I can develop an argument, giving relevant reasons and examples.",
+      "prerequisites": [
+        "SPINE-GIVE-REASONS",
+        "SPINE-EXPRESS-CONDITION"
+      ],
+      "core": true,
+      "concepts": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ]
+    },
+    {
+      "id": "SPINE-REPORT-WHAT-OTHERS-SAID",
+      "stage": "B2",
+      "canDo": "I can report what someone else said or asked.",
+      "prerequisites": [
+        "SPINE-NARRATE-EVENTS"
+      ],
+      "core": true,
+      "concepts": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ]
+    },
+    {
+      "id": "SPINE-READ-EXTENDED-PROSE",
+      "stage": "B2",
+      "canDo": "I can read articles and reports on contemporary matters.",
+      "prerequisites": [
+        "SPINE-DESCRIBE-EXPERIENCE"
+      ],
+      "core": true,
+      "concepts": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ]
+    },
+    {
+      "id": "SPINE-DISCUSS-ABSTRACT",
+      "stage": "B2",
+      "canDo": "I can take part in a discussion of abstract or unfamiliar topics.",
+      "prerequisites": [
+        "SPINE-ARGUE-A-VIEW",
+        "SPINE-READ-EXTENDED-PROSE"
+      ],
+      "core": true,
+      "concepts": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ]
+    },
+    {
+      "id": "SPINE-INFER-IMPLICIT-MEANING",
+      "stage": "C1",
+      "canDo": "I can grasp what a speaker implies without saying it.",
+      "prerequisites": [
+        "SPINE-DISCUSS-ABSTRACT"
+      ],
+      "core": true,
+      "concepts": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ]
+    },
+    {
+      "id": "SPINE-STRUCTURE-EXTENDED-TEXT",
+      "stage": "C1",
+      "canDo": "I can produce clear, well-structured text on a complex subject.",
+      "prerequisites": [
+        "SPINE-READ-EXTENDED-PROSE",
+        "SPINE-ARGUE-A-VIEW"
+      ],
+      "core": true,
+      "concepts": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ]
+    },
+    {
+      "id": "SPINE-SHIFT-REGISTER",
+      "stage": "C1",
+      "canDo": "I can shift register to suit the person I am speaking to and the setting.",
+      "prerequisites": [
+        "SPINE-DISCUSS-ABSTRACT"
+      ],
+      "core": true,
+      "concepts": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ]
+    },
+    {
+      "id": "SPINE-FOLLOW-REGIONAL-VARIATION",
+      "stage": "C1",
+      "canDo": "I can follow a speaker whose regional variety differs from the one I learned.",
+      "prerequisites": [
+        "SPINE-SHIFT-REGISTER"
+      ],
+      "core": true,
+      "concepts": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ]
+    },
+    {
+      "id": "SPINE-SUMMARIZE-FROM-SOURCES",
+      "stage": "C2",
+      "canDo": "I can summarise several sources and reconstruct the argument in my own words.",
+      "prerequisites": [
+        "SPINE-STRUCTURE-EXTENDED-TEXT",
+        "SPINE-INFER-IMPLICIT-MEANING"
+      ],
+      "core": true,
+      "concepts": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ]
+    },
+    {
+      "id": "SPINE-EXPRESS-FINE-SHADES",
+      "stage": "C2",
+      "canDo": "I can convey finer shades of meaning precisely.",
+      "prerequisites": [
+        "SPINE-SHIFT-REGISTER",
+        "SPINE-SUMMARIZE-FROM-SOURCES"
+      ],
+      "core": true,
+      "concepts": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ]
+    },
+    {
+      "id": "SPINE-READ-LITERARY-AND-CLASSICAL",
+      "stage": "C2",
+      "canDo": "I can read literary and older texts and feel the period they come from.",
+      "prerequisites": [
+        "SPINE-INFER-IMPLICIT-MEANING",
+        "SPINE-FOLLOW-REGIONAL-VARIATION"
+      ],
+      "core": true,
+      "concepts": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ]
+    },
+    {
+      "id": "SPINE-READ-CULTURAL-WEIGHT",
+      "stage": "C2",
+      "canDo": "I can read the cultural weight of a phrase, not only its meaning.",
+      "prerequisites": [
+        "SPINE-SHIFT-REGISTER",
+        "SPINE-READ-LITERARY-AND-CLASSICAL"
+      ],
+      "core": true,
+      "concepts": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ]
     }
   ]
 }

--- a/code/learning/human-languages/french/curriculum.json
+++ b/code/learning/human-languages/french/curriculum.json
@@ -475,6 +475,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/german/curriculum.json
+++ b/code/learning/human-languages/german/curriculum.json
@@ -542,6 +542,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/gujarati/curriculum.json
+++ b/code/learning/human-languages/gujarati/curriculum.json
@@ -331,6 +331,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/hindi/curriculum.json
+++ b/code/learning/human-languages/hindi/curriculum.json
@@ -572,6 +572,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/italian/curriculum.json
+++ b/code/learning/human-languages/italian/curriculum.json
@@ -497,6 +497,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/japanese/curriculum.json
+++ b/code/learning/human-languages/japanese/curriculum.json
@@ -239,6 +239,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/kannada/curriculum.json
+++ b/code/learning/human-languages/kannada/curriculum.json
@@ -528,6 +528,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/latin/curriculum.json
+++ b/code/learning/human-languages/latin/curriculum.json
@@ -577,6 +577,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/malayalam/curriculum.json
+++ b/code/learning/human-languages/malayalam/curriculum.json
@@ -550,6 +550,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/marathi/curriculum.json
+++ b/code/learning/human-languages/marathi/curriculum.json
@@ -357,6 +357,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/persian/curriculum.json
+++ b/code/learning/human-languages/persian/curriculum.json
@@ -316,6 +316,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/portuguese/curriculum.json
+++ b/code/learning/human-languages/portuguese/curriculum.json
@@ -519,6 +519,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/punjabi/curriculum.json
+++ b/code/learning/human-languages/punjabi/curriculum.json
@@ -346,6 +346,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/russian/curriculum.json
+++ b/code/learning/human-languages/russian/curriculum.json
@@ -304,6 +304,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/sanskrit/curriculum.json
+++ b/code/learning/human-languages/sanskrit/curriculum.json
@@ -331,6 +331,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/spanish/curriculum.json
+++ b/code/learning/human-languages/spanish/curriculum.json
@@ -662,6 +662,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/tamil/curriculum.json
+++ b/code/learning/human-languages/tamil/curriculum.json
@@ -601,6 +601,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/telugu/curriculum.json
+++ b/code/learning/human-languages/telugu/curriculum.json
@@ -539,6 +539,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/learning/human-languages/urdu/curriculum.json
+++ b/code/learning/human-languages/urdu/curriculum.json
@@ -322,6 +322,176 @@
         "VERB-FUTURE"
       ],
       "relocates": {}
+    },
+    "SPINE-NARRATE-EVENTS": {
+      "segments": [],
+      "omits": [
+        "NARRATIVE-SEQUENCE",
+        "CONNECTIVE-THEN",
+        "CONNECTIVE-BECAUSE",
+        "ASPECT-ONGOING-PAST"
+      ],
+      "relocates": {}
+    },
+    "SPINE-GIVE-REASONS": {
+      "segments": [],
+      "omits": [
+        "OPINION-I-THINK",
+        "CONNECTIVE-SO",
+        "MODAL-SHOULD",
+        "EXPLANATION-GIVE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-HANDLE-TRAVEL": {
+      "segments": [],
+      "omits": [
+        "DIRECTION-ASK",
+        "TRANSPORT-TICKET",
+        "LODGING-ROOM",
+        "PROBLEM-REPORT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DESCRIBE-EXPERIENCE": {
+      "segments": [],
+      "omits": [
+        "ADJECTIVE-FEELING",
+        "AMBITION-EXPRESS",
+        "COMPARISON-BASIC",
+        "TIME-DURATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-CONDITION": {
+      "segments": [],
+      "omits": [
+        "CONDITIONAL-REAL",
+        "CONNECTIVE-IF",
+        "MODAL-WOULD",
+        "CONDITION-DEPENDS"
+      ],
+      "relocates": {}
+    },
+    "SPINE-ARGUE-A-VIEW": {
+      "segments": [],
+      "omits": [
+        "ARGUMENT-CLAIM",
+        "ARGUMENT-EVIDENCE",
+        "CONNECTIVE-HOWEVER",
+        "CONNECTIVE-ALTHOUGH"
+      ],
+      "relocates": {}
+    },
+    "SPINE-REPORT-WHAT-OTHERS-SAID": {
+      "segments": [],
+      "omits": [
+        "REPORTED-SPEECH",
+        "TENSE-BACKSHIFT",
+        "SPEECH-ACT-REPORT",
+        "QUOTATION-DIRECT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-EXTENDED-PROSE": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-TOPIC-SENTENCE",
+        "RELATIVE-CLAUSE",
+        "VOICE-PASSIVE",
+        "VOCAB-FIELD-SPECIFIC"
+      ],
+      "relocates": {}
+    },
+    "SPINE-DISCUSS-ABSTRACT": {
+      "segments": [],
+      "omits": [
+        "ABSTRACT-NOUN",
+        "HEDGE-PROBABLY",
+        "HEDGE-SUPPOSE",
+        "NOMINALIZATION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-INFER-IMPLICIT-MEANING": {
+      "segments": [],
+      "omits": [
+        "IMPLICATURE",
+        "IRONY-MARKER",
+        "IDIOM-COMMON",
+        "TONE-SHIFT"
+      ],
+      "relocates": {}
+    },
+    "SPINE-STRUCTURE-EXTENDED-TEXT": {
+      "segments": [],
+      "omits": [
+        "DISCOURSE-COHESION",
+        "PARAGRAPH-PLAN",
+        "CONNECTIVE-FURTHERMORE",
+        "REFERENCE-ANAPHORA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SHIFT-REGISTER": {
+      "segments": [],
+      "omits": [
+        "REGISTER-FORMAL",
+        "REGISTER-COLLOQUIAL",
+        "HONORIFIC-SYSTEM",
+        "POLITENESS-STRATEGY"
+      ],
+      "relocates": {}
+    },
+    "SPINE-FOLLOW-REGIONAL-VARIATION": {
+      "segments": [],
+      "omits": [
+        "DIALECT-FEATURE",
+        "ACCENT-VARIATION",
+        "LEXICAL-VARIANT-REGIONAL",
+        "DIGLOSSIA"
+      ],
+      "relocates": {}
+    },
+    "SPINE-SUMMARIZE-FROM-SOURCES": {
+      "segments": [],
+      "omits": [
+        "SYNTHESIS-MULTI-SOURCE",
+        "PARAPHRASE",
+        "ATTRIBUTION-CITE",
+        "SUMMARY-COMPRESSION"
+      ],
+      "relocates": {}
+    },
+    "SPINE-EXPRESS-FINE-SHADES": {
+      "segments": [],
+      "omits": [
+        "NUANCE-MODALITY",
+        "COLLOCATION-PRECISE",
+        "EMPHASIS-DEVICE",
+        "CONNOTATION-CHOICE"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-LITERARY-AND-CLASSICAL": {
+      "segments": [],
+      "omits": [
+        "LITERARY-REGISTER",
+        "ARCHAIC-FORM",
+        "METER-AND-VERSE",
+        "ORTHOGRAPHY-HISTORICAL"
+      ],
+      "relocates": {}
+    },
+    "SPINE-READ-CULTURAL-WEIGHT": {
+      "segments": [],
+      "omits": [
+        "CULTURAL-ALLUSION",
+        "PROVERB",
+        "EUPHEMISM-AND-TABOO",
+        "HUMOR-CONVENTION"
+      ],
+      "relocates": {}
     }
   },
   "extensions": [

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — the B1–C2 spine, so the ladder has rungs above A2 (HL09 §3.1)
+
+`spine.json` stopped at A2. The level gate handled that correctly — it refused B1–C2
+on the grounds that "no node is unrealized" is not "every node is realized" — but the
+effect was that **no amount of content could ever certify above A2**, because there
+was nothing to certify against.
+
+**17 nodes**: B1 ×5, B2 ×4, C1 ×4, C2 ×4, each a CEFR can-do statement with
+prerequisites that resolve and never point up a level (both asserted).
+
+- **B1** narrate in order, give reasons, cope while travelling, describe experience,
+  express a real condition.
+- **B2** argue a view, report what others said, read extended prose, discuss the
+  abstract.
+- **C1** infer what is implied, structure a long text, shift register — and
+  **follow regional variation**, which had no home in the spine at all.
+- **C2** synthesise several sources, express fine shades, read literary and older
+  text, and **read the cultural weight of a phrase**, not only its meaning.
+
+**68 concepts registered canonically**, each owned by exactly one node. Five were
+first written as `VERB-EXPLAIN`, `VERB-HOPE` and so on, which silently pushed
+`coreVerbCount` from 40 to 45 — joining a baseline that HL-C46/47/49 owns. They are
+named by discourse function instead (`EXPLANATION-GIVE`, `AMBITION-EXPRESS`).
+
+**All 22 tracks declare all 17 as gaps** — `segments: []` with every concept in
+`omits`. A ledger that stays silent about a node reads the same as one that has
+nothing to say; this one says exactly what is missing.
+
+Nothing is realized, and the gate still reports every track at pre-A1 with its real
+blockers. Authoring a rung does not climb it — the test that used to assert "B1 is not
+authored" now asserts the stronger thing: B1 exists, and no track attains it.
+
 ### Fixed — the course named as a set (HL-C50)
 
 The last of the standalone-book classes: the series referred to as a **set**, without

--- a/code/packages/typescript/human-language-data/tests/level-gate.test.ts
+++ b/code/packages/typescript/human-language-data/tests/level-gate.test.ts
@@ -84,9 +84,11 @@ describe("the gate that would have caught the A2 claim", () => {
     expect(hindi.blockers.map((b) => b.criterion)).not.toContain("atom-budget");
   });
 
-  it("refuses a level with no authored spine nodes instead of passing it vacuously", () => {
-    // spine.json has zero B1-C2 nodes. "No node is unrealized" is not "every node is
-    // realized" — without this, those levels passed criterion 1 on no evidence.
+  it("fails an authored-but-unrealized level on a COUNT, not on absence", () => {
+    // spine.json used to have zero B1-C2 nodes, and the gate refused those levels on
+    // the grounds that "no node is unrealized" is not "every node is realized".
+    // The tranche is authored now, so the refusal has a better reason: 17 nodes exist
+    // and none is realized by any track. The failure names a number instead of a void.
     const e = loadEverything();
     const gate = runLevelGate({
       lessons: e.lessons,
@@ -96,10 +98,13 @@ describe("the gate that would have caught the A2 claim", () => {
       ramp: measureRamp(e.lessons, loadChapterPolicy()),
       continuity: measureContinuity(e.lessons),
     });
-    // No track reaches B1, so assert the rule directly on the spine instead.
-    const authored = new Set(e.spine.nodes.map((n) => n.stage));
-    expect(authored.has("B1")).toBe(false);
-    expect(gate.tracks.every((t) => t.attained === null || t.attained !== "B1")).toBe(true);
+    const authored = e.spine.nodes.filter((n) => n.stage === "B1");
+    expect(authored.length).toBeGreaterThan(0);
+    // Authoring a rung does not climb it. No track may attain B1 on an empty ledger.
+    expect(gate.tracks.every((t) => t.attained === null)).toBe(true);
+    // And the whole ladder is now reachable in principle: every CEFR level has nodes.
+    const stages = new Set(e.spine.nodes.map((n) => n.stage));
+    for (const level of ["B1", "B2", "C1", "C2"]) expect(stages.has(level)).toBe(true);
   });
 
   it("stops at the FIRST failing level, because the criteria are cumulative", () => {


### PR DESCRIPTION
`spine.json` stopped at A2. The level gate handled that correctly — it refused B1–C2 because *"no node is unrealized"* is not *"every node is realized"* — but the consequence was that **no amount of content could ever certify above A2**, since there was nothing to certify against. That, not content volume, was what blocked the climb.

## 17 nodes

Each a CEFR can-do statement. Prerequisites all resolve, and none points up a level — both asserted at author time rather than hoped for.

- **B1** — narrate in order · give reasons · cope while travelling · describe experience · express a real condition
- **B2** — argue a view · report what others said · read extended prose · discuss the abstract
- **C1** — infer what is implied · structure a long text · shift register · **follow regional variation**, which had no home in the spine at all
- **C2** — synthesise several sources · express fine shades · read literary and older text · **read the cultural weight of a phrase**, not only its meaning

The last two are the ones you asked for and the spine had no way to express: regional variation and cultural immersion are now rungs, not asides.

## 68 concepts, registered canonically

Each owned by exactly one node. Five were first written as `VERB-EXPLAIN`, `VERB-HOPE` and the like — which silently pushed `coreVerbCount` from 40 to 45, annexing a baseline [HL-C46/47/49](https://github.com/adhithyan15/coding-adventures/pull/10065) owns. Caught by that workstream's own pin; they're named by discourse function now (`EXPLANATION-GIVE`, `AMBITION-EXPRESS`).

## All 22 tracks declare all 17 as gaps

`segments: []` with every concept in `omits`. A ledger that stays silent about a node reads the same as one that has nothing to say; this one says exactly what is missing.

## Authoring a rung does not climb it

Nothing is realized, and the gate still reports **every track at pre-A1** with its real blockers (Spanish: 44 headwords against 300, 91 under-reinforced atoms). The test that asserted *"B1 is not authored"* now asserts the stronger fact — B1 exists, no track attains it, and every CEFR level is reachable in principle.

## Verification

396 tests pass. `check:books`, `check:narration`, `check:modality` clean.

Note: this change is data and schema rather than prose, so its correctness rests on the validators — canonical concepts, unique ownership, resolving prerequisites, no upward dependencies, and every track's ledger complete. All are enforced by `validateCurriculum` and the suite, not by review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
