### PR TITLE
feat(human-language-data): Spanish chapter 38 — the first content above A2

### DIFF
--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -3,50 +3,146 @@
   "sourceBaseUrl": "https://github.com/adhithyan15/coding-adventures/blob/main/code/learning/human-languages/",
   "scriptSets": {
     "telugu-comparisons": [
-      { "unicodeScript": "Telugu", "scriptCommand": "te" },
-      { "unicodeScript": "Tamil", "scriptCommand": "ta" },
-      { "unicodeScript": "Kannada", "scriptCommand": "ka" },
-      { "unicodeScript": "Malayalam", "scriptCommand": "ml" },
-      { "unicodeScript": "Devanagari", "scriptCommand": "dv" },
-      { "unicodeScript": "Arabic", "scriptCommand": "ar" }
+      {
+        "unicodeScript": "Telugu",
+        "scriptCommand": "te"
+      },
+      {
+        "unicodeScript": "Tamil",
+        "scriptCommand": "ta"
+      },
+      {
+        "unicodeScript": "Kannada",
+        "scriptCommand": "ka"
+      },
+      {
+        "unicodeScript": "Malayalam",
+        "scriptCommand": "ml"
+      },
+      {
+        "unicodeScript": "Devanagari",
+        "scriptCommand": "dv"
+      },
+      {
+        "unicodeScript": "Arabic",
+        "scriptCommand": "ar"
+      }
     ],
     "kannada-comparisons": [
-      { "unicodeScript": "Kannada", "scriptCommand": "kn" },
-      { "unicodeScript": "Tamil", "scriptCommand": "ta" },
-      { "unicodeScript": "Telugu", "scriptCommand": "te" },
-      { "unicodeScript": "Malayalam", "scriptCommand": "ml" },
-      { "unicodeScript": "Devanagari", "scriptCommand": "dv" },
-      { "unicodeScript": "Arabic", "scriptCommand": "ar" }
+      {
+        "unicodeScript": "Kannada",
+        "scriptCommand": "kn"
+      },
+      {
+        "unicodeScript": "Tamil",
+        "scriptCommand": "ta"
+      },
+      {
+        "unicodeScript": "Telugu",
+        "scriptCommand": "te"
+      },
+      {
+        "unicodeScript": "Malayalam",
+        "scriptCommand": "ml"
+      },
+      {
+        "unicodeScript": "Devanagari",
+        "scriptCommand": "dv"
+      },
+      {
+        "unicodeScript": "Arabic",
+        "scriptCommand": "ar"
+      }
     ],
     "malayalam-comparisons": [
-      { "unicodeScript": "Malayalam", "scriptCommand": "ml" },
-      { "unicodeScript": "Tamil", "scriptCommand": "ta" },
-      { "unicodeScript": "Telugu", "scriptCommand": "te" },
-      { "unicodeScript": "Kannada", "scriptCommand": "ka" },
-      { "unicodeScript": "Devanagari", "scriptCommand": "dv" },
-      { "unicodeScript": "Arabic", "scriptCommand": "ar" }
+      {
+        "unicodeScript": "Malayalam",
+        "scriptCommand": "ml"
+      },
+      {
+        "unicodeScript": "Tamil",
+        "scriptCommand": "ta"
+      },
+      {
+        "unicodeScript": "Telugu",
+        "scriptCommand": "te"
+      },
+      {
+        "unicodeScript": "Kannada",
+        "scriptCommand": "ka"
+      },
+      {
+        "unicodeScript": "Devanagari",
+        "scriptCommand": "dv"
+      },
+      {
+        "unicodeScript": "Arabic",
+        "scriptCommand": "ar"
+      }
     ],
     "tamil-comparisons": [
-      { "unicodeScript": "Tamil", "scriptCommand": "ta" },
-      { "unicodeScript": "Telugu", "scriptCommand": "te" },
-      { "unicodeScript": "Kannada", "scriptCommand": "ka" },
-      { "unicodeScript": "Malayalam", "scriptCommand": "ml" },
-      { "unicodeScript": "Devanagari", "scriptCommand": "dv" },
-      { "unicodeScript": "Arabic", "scriptCommand": "ar" }
+      {
+        "unicodeScript": "Tamil",
+        "scriptCommand": "ta"
+      },
+      {
+        "unicodeScript": "Telugu",
+        "scriptCommand": "te"
+      },
+      {
+        "unicodeScript": "Kannada",
+        "scriptCommand": "ka"
+      },
+      {
+        "unicodeScript": "Malayalam",
+        "scriptCommand": "ml"
+      },
+      {
+        "unicodeScript": "Devanagari",
+        "scriptCommand": "dv"
+      },
+      {
+        "unicodeScript": "Arabic",
+        "scriptCommand": "ar"
+      }
     ],
     "arabic-main": [
-      { "unicodeScript": "Arabic", "scriptCommand": "ar" },
-      { "unicodeScript": "Hebrew", "scriptCommand": "he" }
+      {
+        "unicodeScript": "Arabic",
+        "scriptCommand": "ar"
+      },
+      {
+        "unicodeScript": "Hebrew",
+        "scriptCommand": "he"
+      }
     ],
     "hindi-main": [
-      { "unicodeScript": "Devanagari", "scriptCommand": "hi" },
-      { "unicodeScript": "Arabic", "scriptCommand": "ar" },
-      { "unicodeScript": "Cyrillic", "scriptCommand": "ru" }
+      {
+        "unicodeScript": "Devanagari",
+        "scriptCommand": "hi"
+      },
+      {
+        "unicodeScript": "Arabic",
+        "scriptCommand": "ar"
+      },
+      {
+        "unicodeScript": "Cyrillic",
+        "scriptCommand": "ru"
+      }
     ],
     "japanese-main": [
-      { "unicodeScript": "Katakana", "scriptCommand": "ja" },
-      { "unicodeScript": "Hiragana", "scriptCommand": "ja" },
-      { "unicodeScript": "Han", "scriptCommand": "ja" }
+      {
+        "unicodeScript": "Katakana",
+        "scriptCommand": "ja"
+      },
+      {
+        "unicodeScript": "Hiragana",
+        "scriptCommand": "ja"
+      },
+      {
+        "unicodeScript": "Han",
+        "scriptCommand": "ja"
+      }
     ]
   },
   "targets": [
@@ -226,6 +322,13 @@
       "title": "Opening, Closing, Sitting Down, Standing Up",
       "label": "ch:spanish-open-close-sit-stand",
       "output": "spanish/book/chapters/ch37-open-close-sit-stand.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 38,
+      "title": "Telling What Happened",
+      "label": "ch:spanish-narrating",
+      "output": "spanish/book/chapters/ch38-narrating.tex"
     },
     {
       "language": "italian",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -2876,6 +2876,18 @@
       "tex": "spanish/book/chapters/ch37-open-close-sit-stand.tex"
     },
     {
+      "language": "spanish",
+      "chapter": 38,
+      "sourceHash": "fnv1a64:df3c16c1c32fc89c",
+      "lessonIds": [
+        "ES-C38-luego",
+        "ES-C38-porque",
+        "ES-C38-imperfecto",
+        "ES-C38-contar"
+      ],
+      "tex": "spanish/book/chapters/ch38-narrating.tex"
+    },
+    {
       "language": "tamil",
       "chapter": 6,
       "sourceHash": "fnv1a64:8cb1982f517a21f4",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -5975,6 +5975,23 @@
       "jsonHash": "fnv1a64:ca00d1b6d278148f"
     },
     {
+      "language": "spanish",
+      "chapter": 38,
+      "sourceHash": "fnv1a64:5a76e34b3a495c6c",
+      "lessonIds": [
+        "ES-C38-luego",
+        "ES-C38-porque",
+        "ES-C38-imperfecto",
+        "ES-C38-contar"
+      ],
+      "voiceLessons": 4,
+      "drivablePrefix": 4,
+      "text": "spanish/narration/ch38.txt",
+      "json": "spanish/narration/ch38.json",
+      "textHash": "fnv1a64:c6899120915c3776",
+      "jsonHash": "fnv1a64:aca860193470ca05"
+    },
+    {
       "language": "tamil",
       "chapter": 1,
       "sourceHash": "fnv1a64:fe3d3298ecc5bc3a",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,18 +7,18 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:b038dfc28a1e5988",
+  "sourceHash": "fnv1a64:1606aba1098f884c",
   "summary": {
-    "totalLessons": 1417,
-    "voice": 941,
+    "totalLessons": 1421,
+    "voice": 945,
     "sight": 423,
     "pen": 53,
-    "drivableLessons": 941,
-    "drivablePercent": 66,
+    "drivableLessons": 945,
+    "drivablePercent": 67,
     "trackCount": 22,
-    "chapterCount": 442,
-    "drivablePrefixTotal": 758,
-    "fullyDrivableChapters": 297,
+    "chapterCount": 443,
+    "drivablePrefixTotal": 762,
+    "fullyDrivableChapters": 298,
     "unstartableChapters": 108,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
@@ -5796,12 +5796,12 @@
     },
     {
       "language": "spanish",
-      "lessonCount": 162,
-      "voice": 137,
+      "lessonCount": 166,
+      "voice": 141,
       "sight": 18,
       "pen": 7,
       "drivablePercent": 85,
-      "drivablePrefixTotal": 107,
+      "drivablePrefixTotal": 111,
       "modalities": [
         "voice",
         "sight",
@@ -6479,6 +6479,25 @@
             "ES-C37-cerrar",
             "ES-C37-sentarse",
             "ES-C37-levantarse"
+          ]
+        },
+        {
+          "chapter": 38,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "ES-C38-luego",
+            "ES-C38-porque",
+            "ES-C38-imperfecto",
+            "ES-C38-contar"
           ]
         }
       ]
@@ -30470,6 +30489,78 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:12daf97af771d3c5"
+    },
+    {
+      "id": "ES-C38-luego",
+      "language": "spanish",
+      "chapter": 38,
+      "sequence": 1770,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9ae2c7b60116965d"
+    },
+    {
+      "id": "ES-C38-porque",
+      "language": "spanish",
+      "chapter": 38,
+      "sequence": 1780,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0df5a4eb3d1eeec6"
+    },
+    {
+      "id": "ES-C38-imperfecto",
+      "language": "spanish",
+      "chapter": 38,
+      "sequence": 1790,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4f40474a50c0b81c"
+    },
+    {
+      "id": "ES-C38-contar",
+      "language": "spanish",
+      "chapter": 38,
+      "sequence": 1800,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:24a3806589d6e25c"
     },
     {
       "id": "TA-W01-curves-va-ka",

--- a/code/learning/human-languages/spanish/book/book.tex
+++ b/code/learning/human-languages/spanish/book/book.tex
@@ -121,6 +121,7 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch35-take-ask-help}
 \input{chapters/ch36-hear-sleep-walk-run}
 \input{chapters/ch37-open-close-sit-stand}
+\input{chapters/ch38-narrating}
 
 \backmatter
 

--- a/code/learning/human-languages/spanish/book/chapters/ch38-narrating.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch38-narrating.tex
@@ -1,0 +1,275 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:df3c16c1c32fc89c
+% canonical-lessons: ES-C38-luego, ES-C38-porque, ES-C38-imperfecto, ES-C38-contar
+
+\chapter{Telling What Happened}
+\label{ch:spanish-narrating}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can tell a short connected story about something that happened — ordering the events with luego, giving a reason with porque, and choosing the imperfect for the scene and the preterite for the events.}
+
+Tell a four-sentence story out loud: Llovía. Me levanté, luego bebí café. No corrí, porque llovía mucho. Me senté y leí. Every word in it has been taught in this book, and the two pasts divide the work between scene and event.
+\end{chapteropening}
+
+\section[luego]{luego — a word you already have, doing a job you have not seen it do}
+
+\label{lesson:ES-C38-luego}
+
+
+
+\begin{quote}
+Nothing new to learn here — you have said \textbf{luego} every time you said \emph{hasta luego}. What is new is that it can stand alone, between two events, and put them in order.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{diphthong-ue} — \emph{ue} is one glide, not two syllables.
+  \item \texttt{g-soft-gw} — between vowels the \emph{g} softens; \textbf{luego} is \emph{LWEH-ɣo}, not the hard stop English puts in \emph{go}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+You already know where it comes from: Latin \textbf{locō}, the ablative of \emph{\textbf{locus}}, \textquotedblleft{}place\textquotedblright{} — \textquotedblleft{}in that place\textquotedblright{}, a word about \emph{where} that slid into a word about \emph{when}. That is why \emph{hasta luego} is \textquotedblleft{}until later\textquotedblright{}.
+
+What you have not been shown is how much else \emph{locus} is holding up. It gives \textbf{local}, \textbf{locate}, \textbf{location}, \textbf{locus}, \textbf{allocate}, \textbf{dislocate}. And through French \emph{lieu}, \textquotedblleft{}place\textquotedblright{}, it gives \textbf{lieutenant} — literally the officer \emph{holding the place} of another.
+
+\begin{quote}
+\textbf{A leftover worth knowing.} \emph{\textbf{Desde luego}} means \textquotedblleft{}of course\textquotedblright{}. It was built on an older sense of \emph{luego}, \textquotedblleft{}\textbf{immediately}\textquotedblright{}, so its literal force was nearer \textquotedblleft{}from this moment on\textquotedblright{}. The bare word has since drifted to \textquotedblleft{}later\textquotedblright{}; the phrase kept the old sense.
+\end{quote}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: luego between two events}]
+Out of the farewell, \emph{luego} is not glued to a verb. It marks the join between two events and sits at the front of the second:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+Me siento. \textbf{Luego} leo. & I sit down. \textbf{Then} I read. \\
+Bebo café y \textbf{luego} escribo. & I drink coffee and \textbf{then} I write. \\
+Me levanto \textbf{y luego} corro. & I get up \textbf{and then} I run. \\
+\bottomrule
+\end{tabularx}
+
+Two events, in order, with one word doing the ordering — and it is a word you have been saying since chapter five.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}hasta luego\textquotedblright{} then just \textquotedblleft{}luego\textquotedblright{} — same word, standing alone
+  \item \textquotedblleft{}Me siento. Luego leo.\textquotedblright{}
+  \item \textquotedblleft{}Me levanto y luego corro.\textquotedblright{}
+  \item \textquotedblleft{}luego\textquotedblright{} then English \textquotedblleft{}local, locate, lieutenant\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What job does \emph{luego} do here that it does not do in \emph{hasta luego}? (It \textbf{joins two events in order}, instead of sitting inside a fixed farewell.) Which English officer's title hides the same \emph{locus}? (\textbf{Lieutenant} — the one holding another's place.) Which older sense of \emph{luego} is frozen inside \emph{desde luego}? (\textbf{Immediately} — not \textquotedblleft{}later\textquotedblright{}.)
+\end{tcolorbox}
+\section[porque]{porque — \textquotedblleft{}because\textquotedblright{}, and the reason a sequence turns into a story}
+
+\label{lesson:ES-C38-porque}
+
+
+
+\begin{quote}
+With \emph{luego} you can put two events in order. But order is not yet a story. \emph{I sat down, then I read} tells nobody \textbf{why}. One more word closes that gap, and it is two words wearing a single coat.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{k-hard} — \emph{qu} before \emph{e} is a plain \emph{k}; the \emph{u} is silent. \textbf{porque} = \emph{POR-keh}.
+  \item \texttt{r-tap} — a single flick of the tongue, not the rolled \emph{rr}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{porque} = \textbf{por} + \textbf{que}, fused.
+
+\textbf{por} descends from Latin \emph{\textbf{prō}}, \textquotedblleft{}for, in front of, on behalf of\textquotedblright{} — the same \emph{prō} standing at the front of \textbf{pro}vide, \textbf{pro}ceed, \textbf{pro}tect, \textbf{pro}pose, and surviving whole in the English phrase \emph{quid \textbf{pro} quo}.
+
+\textbf{que} descends from Latin \emph{\textbf{quid}}, \textquotedblleft{}what\textquotedblright{} — and then quietly took over every job Latin had given \emph{\textbf{quod}}, without taking its form.
+
+And this is the good part. That Latin \emph{qu-} is one branch of the Proto-Indo-European interrogative root \emph{\textbf{*k\textsuperscript{w}o-}}. The other branch went into Germanic, where \emph{*k\textsuperscript{w}-} softened to \emph{hw-} — Grimm's Law turning a stop into a breath — and came out as English \textbf{who}, \textbf{what}, \textbf{when}, \textbf{where}, \textbf{why}.
+
+So Spanish \emph{que} and English \emph{what} are not borrowed from one another. They are \textbf{siblings} — the same ancient question-word, walked down two different roads. \emph{Quid pro quo} puts both Latin halves of \emph{porque} side by side in an English sentence.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: porque, por qué, el porqué}]
+Three spellings, three jobs, and they are genuinely distinct in writing:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{written} & \textbf{stress} & \textbf{job} \\
+\midrule
+\textbf{porque} & one word, no accent & \textbf{because} — gives the reason \\
+\textbf{por qué} & two words, accent on \emph{qué} & \textbf{why} — asks for the reason \\
+\textbf{el porqué} & one word, accent, with \emph{el} & \textbf{the reason} — a noun \\
+\bottomrule
+\end{tabularx}
+
+\emph{¿\textbf{Por qué} te levantas?} — \textbf{Why} do you get up? \emph{Me levanto \textbf{porque} corro.} — I get up \textbf{because} I run. \emph{No entiendo \textbf{el porqué}.} — I don't understand \textbf{the reason}.
+
+The accent is not decoration. It marks \emph{qué} as the questioning one, exactly as it does on other question words.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}porque\textquotedblright{} — \emph{POR-keh}, silent \emph{u}
+  \item \textquotedblleft{}Me siento porque leo.\textquotedblright{} — I sit down because I read.
+  \item \textquotedblleft{}Me levanto y luego corro, porque hace sol.\textquotedblright{}
+  \item the three shapes — \textquotedblleft{}porque, por qué, el porqué\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What two Latin words are fused inside \emph{porque}? (\emph{\textbf{prō}} and \emph{\textbf{quid}}.) Are Spanish \emph{que} and English \emph{what} parent and child, or siblings? (\textbf{Siblings} — Latin \emph{qu-} and Germanic \emph{wh-} from one root, \emph{\textbf{*k\textsuperscript{w}o-}}.) Which of the three spellings asks a question? (\emph{\textbf{Por qué}} — two words, accent on \emph{qué}.)
+\end{tcolorbox}
+\section[llovía / llovió]{llovía / llovió — the same rain, told two ways}
+
+\label{lesson:ES-C38-imperfecto}
+
+
+
+\begin{quote}
+You already have both past tenses. The imperfect — \emph{hablaba}, \emph{comía} — came in chapter sixteen, with its three irregulars. Nothing here is a new form. What is new is \textbf{which one to reach for}, and that turns out to be the whole trick of telling a story.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{double-l-y} — \emph{ll} is a \emph{y} glide: \textbf{llovía} = \emph{yo-VEE-a}.
+  \item \texttt{accent-i} — the accent splits the vowels: \emph{llo-VÍ-a}, three beats.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+The name is the lesson, and it is worth having.
+
+\textbf{Imperfecto} is Latin \emph{\textbf{imperfectus}}: \emph{\textbf{in-}} (\textquotedblleft{}not\textquotedblright{}) plus \emph{\textbf{perfectus}}, \textquotedblleft{}carried all the way through\textquotedblright{} — itself \emph{\textbf{per-}} (\textquotedblleft{}through\textquotedblright{}) plus \emph{\textbf{facere}} (\textquotedblleft{}to do, to make\textquotedblright{}). That \emph{facere} is everywhere in English: \textbf{fact}, \textbf{factory}, \textbf{effect}, \textbf{manufacture}, and \textbf{perfect} itself, which still means \emph{finished through}.
+
+So the imperfect is the \textbf{not-carried-through} tense. Not unfinished in quality — unfinished in \emph{time}. It shows an action still running, with no edge on it. That is not a label bolted on afterwards; it is a description of the job.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the scene and the events}]
+Take one fact — it rained — and watch the tense decide what \emph{kind} of fact it is:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+\textbf{Llovía.} & It was raining. \emph{(no edge — the weather that day)} \\
+\textbf{Llovió.} & It rained. \emph{(edged — a thing that happened)} \\
+\bottomrule
+\end{tabularx}
+
+Neither is more correct. They answer different questions. A told story needs both, in a division of labour that never varies:
+
+\begin{quote}
+The \textbf{imperfect paints the scene} — what was going on, what things were like. The \textbf{preterite drops the events into it} — what then happened.
+\end{quote}
+
+\emph{Llovía. Luego me levanté.} — It was raining \emph{(scene)}. Then I got up \emph{(event)}.
+
+English has no separate form for this, which is the only reason it feels hard. English leans on \emph{was ‑ing} and \emph{used to} and lets context carry the rest. Spanish decided it once, in the ending.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item the pair — \textquotedblleft{}llovía\textquotedblright{} then \textquotedblleft{}llovió\textquotedblright{}
+  \item scene, then event — \textquotedblleft{}Llovía. Luego me levanté.\textquotedblright{}
+  \item \textquotedblleft{}No corrí, porque llovía.\textquotedblright{} — the reason is a scene, the running an event
+  \item \textquotedblleft{}Comía pan porque llovía.\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What does \emph{imperfectus} literally say, and which English word shares its second half? (\textbf{Not carried through}; \textbf{perfect} — and \emph{fact}, \emph{factory}.) In a story, which tense paints the background and which drops in the events? (\textbf{Imperfect} paints; \textbf{preterite} drops in.) Which of \emph{llovía} and \emph{llovió} has an edge on it? (\emph{\textbf{Llovió}} — a thing that happened.)
+\end{tcolorbox}
+\section[contar]{contar — to tell a story, which is also to count it up}
+
+\label{lesson:ES-C38-contar}
+
+
+
+\begin{quote}
+Three pieces are in your hands: \emph{luego} to order events, \emph{porque} to explain them, the imperfect to hold the background still. This lesson adds no fourth piece — it puts the three together, under the verb that names the act.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{diphthong-ue} — the stem breaks under stress: \textbf{cuento} = \emph{KWEN-to}, but \textbf{contamos} stays plain.
+  \item \texttt{k-hard} — \emph{c} before \emph{o} is a hard \emph{k}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{contar} means \textbf{to count} — and \textbf{to tell a story}. One verb, both jobs, and not a pun.
+
+It descends from Latin \emph{\textbf{computāre}}, \textquotedblleft{}to reckon up\textquotedblright{}: \emph{\textbf{com-}} (\textquotedblleft{}together\textquotedblright{}) plus \emph{\textbf{putāre}}, which meant \textquotedblleft{}to prune\textquotedblright{}, then \textquotedblleft{}to settle an account\textquotedblright{}, then simply \textquotedblleft{}to reckon\textquotedblright{}. \emph{Putāre} gives \textbf{amputate}, \textbf{dispute}, \textbf{deputy}; \emph{computāre} gives \textbf{count}, \textbf{compute}, \textbf{account}.
+
+English carries the same double sense — to \textbf{recount} an event, to give an \textbf{account} of yourself — but those are the very same word, borrowed through Old French from \emph{computāre}. Spanish's relatives, not an independent echo.
+
+The independent echo is \textbf{tell}: Germanic, unrelated, and it \emph{also} once meant \textquotedblleft{}to count\textquotedblright{} — hence a bank \textbf{teller}, and \emph{all told}. Two unrelated languages, one thought: \textbf{a story is a reckoning-up of events in order.}
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the backbone of a told story}]
+\emph{Contar} breaks \emph{o} to \emph{ue} under stress:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{person} & \textbf{form} \\
+\midrule
+yo & \textbf{cuento} \\
+tú & \textbf{cuentas} \\
+él/ella/usted & \textbf{cuenta} \\
+nosotros & \textbf{contamos} \\
+ellos/ustedes & \textbf{cuentan} \\
+\bottomrule
+\end{tabularx}
+
+Here is the shape of a told story:
+
+\begin{quote}
+\textbf{Llovía}. Me \textbf{levanté}, \textbf{luego} \textbf{bebí} café. No \textbf{corrí}, \textbf{porque} \textbf{llovía} mucho. Me \textbf{senté} y \textbf{leí}.
+\end{quote}
+
+>
+
+\begin{quote}
+\emph{It was raining. I got up, then I drank coffee. I didn't run, because it was raining hard. I sat down and read.}
+\end{quote}
+
+Watch the two pasts divide the work. \emph{\textbf{Llovía}} — imperfect, holding the scene still. \emph{\textbf{Me levanté\emph{, }bebí\emph{, }me senté\emph{, }leí}} — preterite, dropping events in. \emph{Luego} orders them; \emph{porque} explains one.
+
+That is a narration, and every word in it is one this book has taught you.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}cuento, cuentas, cuenta, contamos, cuentan\textquotedblright{}
+  \item \textquotedblleft{}Cuento hasta cinco.\textquotedblright{} — I count to five. Same verb.
+  \item the scene, then the event — \textquotedblleft{}Llovía. Luego me levanté.\textquotedblright{}
+  \item the whole thing — \textquotedblleft{}Llovía. Me levanté, luego bebí café. No corrí, porque llovía mucho.\textquotedblright{}
+  \item \textquotedblleft{}contar\textquotedblright{} then English \textquotedblleft{}count, account, recount, teller\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+\emph{Contar} does two jobs — which two, and what Latin verb explains both? (\textbf{Count} and \textbf{tell}; \emph{\textbf{computāre}}, \textquotedblleft{}to reckon up\textquotedblright{}.) Which English word carries the same double sense? (\textbf{Recount} — or \emph{an account}; and \emph{tell} itself, as in a bank \emph{teller}.) In your story, which tense held the rain and which one poured the coffee? (\textbf{Imperfect} \emph{llovía}; \textbf{preterite} \emph{bebí}.) Name the two joining words you used. (\emph{\textbf{Luego}} for order, \emph{\textbf{porque}} for reason.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/chapters.json
+++ b/code/learning/human-languages/spanish/chapters.json
@@ -8,7 +8,9 @@
       "title": "Hola and Buenos Días",
       "label": "ch:first-words",
       "canDo": "I can greet someone in Spanish, say how I am, and wish them a good day.",
-      "spineNodes": ["SPINE-MEET-GREET"],
+      "spineNodes": [
+        "SPINE-MEET-GREET"
+      ],
       "payoff": {
         "lesson": "ES-C01-practice",
         "kind": "dialogue",
@@ -30,7 +32,9 @@
       "title": "The Rest of the Greetings",
       "label": "ch:greetings",
       "canDo": "I can greet someone correctly at any hour — morning, afternoon, or night.",
-      "spineNodes": ["SPINE-TIME-OF-DAY"],
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
       "payoff": {
         "lesson": "ES-C02-practice",
         "kind": "dialogue",
@@ -51,7 +55,9 @@
       "title": "Introducing Yourself",
       "label": "ch:introductions",
       "canDo": "I can give my name, ask someone else's, and say it was a pleasure to meet them.",
-      "spineNodes": ["SPINE-EXCHANGE-NAMES"],
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
       "payoff": {
         "lesson": "ES-C03-practice",
         "kind": "dialogue",
@@ -102,7 +108,9 @@
       "title": "Farewells",
       "label": "ch:farewells",
       "canDo": "I can close a Spanish conversation and pick the goodbye that fits how soon I will see the person again.",
-      "spineNodes": ["SPINE-TAKE-LEAVE"],
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
       "payoff": {
         "lesson": "ES-C05-practice",
         "kind": "dialogue",
@@ -123,7 +131,9 @@
       "title": "The First Verbs",
       "label": "ch:first-verbs",
       "canDo": "I can build my own Spanish sentences with -ar verbs and ask politely for a coffee.",
-      "spineNodes": ["SPINE-POLITE-REQUEST-REPAIR"],
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
       "payoff": {
         "lesson": "ES-C06-practice",
         "kind": "production",
@@ -148,7 +158,9 @@
       "title": "Yes and No",
       "label": "ch:spanish-basic-responses",
       "canDo": "I can answer yes or no in Spanish and negate a sentence by putting no in front of the verb.",
-      "spineNodes": ["SPINE-RESPOND-BASIC"],
+      "spineNodes": [
+        "SPINE-RESPOND-BASIC"
+      ],
       "payoff": {
         "lesson": "ES-C19-no",
         "kind": "task",
@@ -164,7 +176,9 @@
       "title": "Lo Siento",
       "label": "ch:spanish-sorry",
       "canDo": "I can apologise in Spanish and choose between lo siento and perdón.",
-      "spineNodes": ["SPINE-POLITE-REQUEST-REPAIR"],
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
       "payoff": {
         "lesson": "ES-C20-perdon",
         "kind": "task",
@@ -183,7 +197,9 @@
       "title": "Days of the Week",
       "label": "ch:spanish-days-of-the-week",
       "canDo": "I can name all seven days of the week in Spanish and say why the last two broke away from the planet names.",
-      "spineNodes": ["SPINE-TIME-OF-DAY"],
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
       "payoff": {
         "lesson": "ES-C21-sabado-domingo",
         "kind": "task",
@@ -201,7 +217,9 @@
       "title": "Black, White, Red, and Blue",
       "label": "ch:spanish-black-white-red-blue",
       "canDo": "I can name black, white, red and blue in Spanish and say which of them Spanish borrowed rather than inherited.",
-      "spineNodes": ["SPINE-DEFINITE-REFERENCE"],
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
       "payoff": {
         "lesson": "ES-C22-azul",
         "kind": "task",
@@ -221,7 +239,9 @@
       "title": "Parents and Siblings",
       "label": "ch:spanish-family",
       "canDo": "I can name my parents and my siblings in Spanish and explain why hermano is not built on Latin's word for brother.",
-      "spineNodes": ["SPINE-EXCHANGE-NAMES"],
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
       "payoff": {
         "lesson": "ES-C23-hermano-hache",
         "kind": "task",
@@ -239,7 +259,9 @@
       "title": "Head and Hand",
       "label": "ch:spanish-head-and-hand",
       "canDo": "I can name the head and the hand in Spanish and get la mano's gender right despite its -o ending.",
-      "spineNodes": ["SPINE-CHECK-WELLBEING"],
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING"
+      ],
       "payoff": {
         "lesson": "ES-C24-mano",
         "kind": "task",
@@ -257,7 +279,9 @@
       "title": "The Seasons",
       "label": "ch:spanish-seasons",
       "canDo": "I can name the four seasons in Spanish and explain how verano moved from spring to summer.",
-      "spineNodes": ["SPINE-TIME-OF-DAY"],
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
       "payoff": {
         "lesson": "ES-C25-las-estaciones",
         "kind": "task",
@@ -274,7 +298,9 @@
       "title": "Water, Wine, and Bread",
       "label": "ch:spanish-water-wine-bread",
       "canDo": "I can name water, wine and bread in Spanish and say why a compañero is someone who shares bread with me.",
-      "spineNodes": ["SPINE-POLITE-REQUEST-REPAIR"],
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
       "payoff": {
         "lesson": "ES-C26-pan",
         "kind": "task",
@@ -291,7 +317,9 @@
       "title": "The Months",
       "label": "ch:spanish-months",
       "canDo": "I can name the twelve months in Spanish and explain why diciembre carries the Latin word for ten.",
-      "spineNodes": ["SPINE-TIME-OF-DAY"],
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
       "payoff": {
         "lesson": "ES-C27-los-meses",
         "kind": "task",
@@ -309,7 +337,9 @@
       "title": "Noon and Midnight",
       "label": "ch:spanish-noon-midnight",
       "canDo": "I can say that it is noon or midnight in Spanish and break both words into their two living halves.",
-      "spineNodes": ["SPINE-TIME-OF-DAY"],
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
       "payoff": {
         "lesson": "ES-C28-mediodia-medianoche",
         "kind": "task",
@@ -325,7 +355,9 @@
       "title": "Telling Time",
       "label": "ch:spanish-telling-time",
       "canDo": "I can tell the time in Spanish and choose correctly between es la una and son las dos.",
-      "spineNodes": ["SPINE-TIME-OF-DAY"],
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
       "payoff": {
         "lesson": "ES-C29-la-hora",
         "kind": "task",
@@ -342,7 +374,9 @@
       "title": "The Weather",
       "label": "ch:spanish-weather",
       "canDo": "I can talk about the weather in Spanish and know why llueve refuses to join hace.",
-      "spineNodes": ["SPINE-TIME-OF-DAY"],
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
       "payoff": {
         "lesson": "ES-C30-llueve",
         "kind": "task",
@@ -363,7 +397,9 @@
       "title": "Numbers Eleven to Twenty",
       "label": "ch:spanish-numbers-eleven-to-twenty",
       "canDo": "I can count from eleven to twenty in Spanish and say where the fused Latin teens stop and the ten-and-X ones begin.",
-      "spineNodes": ["SPINE-COUNT-ONE-TO-FIVE"],
+      "spineNodes": [
+        "SPINE-COUNT-ONE-TO-FIVE"
+      ],
       "payoff": {
         "lesson": "ES-C31-veinte",
         "kind": "task",
@@ -384,7 +420,9 @@
       "title": "Dog and Cat",
       "label": "ch:spanish-dog-and-cat",
       "canDo": "I can name a dog and a cat in Spanish and say which of the two words still has no agreed origin.",
-      "spineNodes": ["SPINE-DEFINITE-REFERENCE"],
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
       "payoff": {
         "lesson": "ES-C32-perro",
         "kind": "task",
@@ -402,7 +440,9 @@
       "title": "Green and Yellow",
       "label": "ch:spanish-green-and-yellow",
       "canDo": "I can name green and yellow in Spanish and explain why amarillo is built on the word for bitter.",
-      "spineNodes": ["SPINE-DEFINITE-REFERENCE"],
+      "spineNodes": [
+        "SPINE-DEFINITE-REFERENCE"
+      ],
       "payoff": {
         "lesson": "ES-C33-amarillo",
         "kind": "task",
@@ -420,7 +460,9 @@
       "title": "Four Verbs of the Mind",
       "label": "ch:spanish-verbs-of-the-mind",
       "canDo": "I can say what I think, understand, read and write in Spanish, and break the stems of pensar and entender the way a stem-changer requires.",
-      "spineNodes": ["SPINE-SAY-WHAT-I-DO"],
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
       "payoff": {
         "lesson": "ES-C34-escribir",
         "kind": "task",
@@ -439,7 +481,9 @@
       "title": "Taking, Asking, Helping — and the Backwards Verb",
       "label": "ch:spanish-backwards-verb",
       "canDo": "I can say I take, ask and help in Spanish, and build a sentence with gustar the way Spanish actually builds it — with the thing liked as the subject.",
-      "spineNodes": ["SPINE-SAY-WHAT-I-DO"],
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
       "payoff": {
         "lesson": "ES-C35-gustar",
         "kind": "task",
@@ -458,7 +502,9 @@
       "title": "Hearing, Sleeping, Walking, Running",
       "label": "ch:spanish-hear-sleep-walk-run",
       "canDo": "I can say I hear, sleep, walk and run in Spanish, write oír's y where the spelling demands it, and break dormir's o to ue the way a boot verb does.",
-      "spineNodes": ["SPINE-SAY-WHAT-I-DO"],
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
       "payoff": {
         "lesson": "ES-C36-correr",
         "kind": "task",
@@ -486,7 +532,9 @@
       "title": "Opening, Closing, Sitting Down, Standing Up",
       "label": "ch:spanish-open-close-sit-stand",
       "canDo": "I can say I open, close, sit down and stand up in Spanish, and use the reflexive pronoun that makes sentarse and levantarse land the action back on me.",
-      "spineNodes": ["SPINE-SAY-WHAT-I-DO"],
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
       "payoff": {
         "lesson": "ES-C37-levantarse",
         "kind": "task",
@@ -507,6 +555,30 @@
           "ES-LEX-MANO-01",
           "ES-GRAMMAR-MANO-GENDER-02",
           "ES-LEX-CABEZA-01"
+        ]
+      }
+    },
+    {
+      "chapter": 38,
+      "title": "Telling What Happened",
+      "label": "ch:spanish-narrating",
+      "canDo": "I can tell a short connected story about something that happened — ordering the events with luego, giving a reason with porque, and choosing the imperfect for the scene and the preterite for the events.",
+      "spineNodes": [
+        "SPINE-NARRATE-EVENTS"
+      ],
+      "payoff": {
+        "lesson": "ES-C38-contar",
+        "kind": "task",
+        "summary": "Tell a four-sentence story out loud: Llovía. Me levanté, luego bebí café. No corrí, porque llovía mucho. Me senté y leí. Every word in it has been taught in this book, and the two pasts divide the work between scene and event.",
+        "assesses": [
+          "ES-GRAMMAR-LUEGO-CONNECTIVE-01",
+          "ES-LEX-PORQUE-03",
+          "ES-ETYMON-PORQUE-04",
+          "ES-GRAMMAR-SCENE-VS-EVENT-06",
+          "ES-ETYMON-IMPERFECTUS-07",
+          "ES-LEX-CONTAR-08",
+          "ES-ETYMON-CONTAR-09",
+          "ES-GRAMMAR-NARRATIVE-10"
         ]
       }
     }

--- a/code/learning/human-languages/spanish/curriculum.json
+++ b/code/learning/human-languages/spanish/curriculum.json
@@ -482,6 +482,19 @@
       "before": [],
       "inline": [],
       "after": []
+    },
+    {
+      "id": "ES-PATH-034",
+      "spine_node": "SPINE-NARRATE-EVENTS",
+      "lessons": [
+        "ES-C38-luego",
+        "ES-C38-porque",
+        "ES-C38-imperfecto",
+        "ES-C38-contar"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
     }
   ],
   "spine": {
@@ -664,13 +677,10 @@
       "relocates": {}
     },
     "SPINE-NARRATE-EVENTS": {
-      "segments": [],
-      "omits": [
-        "NARRATIVE-SEQUENCE",
-        "CONNECTIVE-THEN",
-        "CONNECTIVE-BECAUSE",
-        "ASPECT-ONGOING-PAST"
+      "segments": [
+        "ES-PATH-034"
       ],
+      "omits": [],
       "relocates": {}
     },
     "SPINE-GIVE-REASONS": {

--- a/code/learning/human-languages/spanish/lessons/ES-C38-contar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C38-contar.md
@@ -1,0 +1,112 @@
+---
+schema_version: 2
+id: ES-C38-contar
+spine_node: SPINE-NARRATE-EVENTS
+sequence: 1800
+chapter: 38
+type: word
+headword: contar
+gloss: to tell a story — and also to count, because in Spanish, as once in English, a story is something you reckon up
+concept_tag: NARRATIVE-SEQUENCE
+prerequisites: [ES-C38-imperfecto, ES-C38-porque, ES-C38-luego]
+sounds: [k-hard, diphthong-ue]
+roots: [computare-latin, putare-latin]
+etymology_hook: "contar ← Latin computāre, 'to reckon up' = com- ('together') + putāre ('to prune, to settle an account'); putāre also gives amputate, dispute, repute, deputy and impute, while computāre itself gives count, compute, account and discount — and the double sense of contar, to count AND to tell, is matched exactly by English recount and by give an account of, and by tell itself, whose older meaning was to count (a bank teller, and all told)"
+duration:
+  max_seconds: 295
+requires:
+  knowledge: [ES-GRAMMAR-SCENE-VS-EVENT-06, ES-LEX-PORQUE-03, ES-GRAMMAR-LUEGO-CONNECTIVE-01, ES-ETYMON-IMPERFECTUS-07]
+introduces:
+  knowledge: [ES-LEX-CONTAR-08, ES-ETYMON-CONTAR-09, ES-GRAMMAR-NARRATIVE-10]
+practises:
+  knowledge: [ES-GRAMMAR-SCENE-VS-EVENT-06, ES-ETYMON-IMPERFECTUS-07, ES-LEX-PORQUE-03, ES-ETYMON-PORQUE-04, ES-GRAMMAR-LUEGO-CONNECTIVE-01, ES-ETYMON-LOCUS, ES-LEX-CONTAR-08, ES-ETYMON-CONTAR-09, ES-GRAMMAR-NARRATIVE-10]
+skills: [listening, speaking, reading, writing]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C38-imperfecto, ES-C38-porque, ES-C38-luego, ES-C37-sentarse]
+---
+
+# contar — to tell a story, which is also to count it up
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-LUEGO-CONNECTIVE-01, ES-LEX-PORQUE-03, ES-GRAMMAR-SCENE-VS-EVENT-06] -->
+
+[PAUSE 2s] Three pieces are in your hands: *luego* to order events, *porque* to
+explain them, the imperfect to hold the background still. This lesson adds no
+fourth piece — it puts the three together, under the verb that names the act.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `diphthong-ue` — the stem breaks under stress: **cuento** = *KWEN-to*, but
+  **contamos** stays plain.
+- `k-hard` — *c* before *o* is a hard *k*.
+
+## The word, taken apart: contar
+<!-- hl-knowledge: introduces=[ES-LEX-CONTAR-08, ES-ETYMON-CONTAR-09]; assesses=[] -->
+
+**contar** means **to count** — and **to tell a story**. One verb, both jobs,
+and not a pun.
+
+It descends from Latin ***computāre***, "to reckon up": ***com-*** ("together")
+plus ***putāre***, which meant "to prune", then "to settle an account", then
+simply "to reckon". *Putāre* gives **amputate**, **dispute**, **deputy**;
+*computāre* gives **count**, **compute**, **account**.
+
+English carries the same double sense — to **recount** an event, to give an
+**account** of yourself — but those are the very same word, borrowed through Old
+French from *computāre*. Spanish's relatives, not an independent echo.
+
+The independent echo is **tell**: Germanic, unrelated, and it *also* once meant
+"to count" — hence a bank **teller**, and *all told*. Two unrelated languages,
+one thought: **a story is a reckoning-up of events in order.**
+
+## Grammar Lens: the backbone of a told story
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-NARRATIVE-10]; assesses=[ES-GRAMMAR-SCENE-VS-EVENT-06, ES-GRAMMAR-LUEGO-CONNECTIVE-01, ES-LEX-PORQUE-03] -->
+
+*Contar* breaks *o* to *ue* under stress:
+
+| person | form |
+|---|---|
+| yo | **cuento** |
+| tú | **cuentas** |
+| él/ella/usted | **cuenta** |
+| nosotros | **contamos** |
+| ellos/ustedes | **cuentan** |
+
+Here is the shape of a told story:
+
+> **Llovía**. Me **levanté**, **luego** **bebí** café. No **corrí**, **porque**
+> **llovía** mucho. Me **senté** y **leí**.
+>
+> *It was raining. I got up, then I drank coffee. I didn't run, because it was
+> raining hard. I sat down and read.*
+
+Watch the two pasts divide the work. ***Llovía*** — imperfect, holding the scene
+still. ***Me levanté*, *bebí*, *me senté*, *leí*** — preterite, dropping events
+in. *Luego* orders them; *porque* explains one.
+
+That is a narration, and every word in it is one this book has taught you.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CONTAR-08, ES-ETYMON-CONTAR-09, ES-GRAMMAR-NARRATIVE-10, ES-GRAMMAR-SCENE-VS-EVENT-06, ES-GRAMMAR-LUEGO-CONNECTIVE-01, ES-LEX-PORQUE-03] -->
+
+[PAUSE 1s]
+- [YOU SAY: "cuento, cuentas, cuenta, contamos, cuentan"]
+- [YOU SAY: "Cuento hasta cinco." — I count to five. Same verb.]
+- [YOU SAY: the scene, then the event — "Llovía. Luego me levanté."]
+- [YOU SAY: the whole thing — "Llovía. Me levanté, luego bebí café. No corrí,
+  porque llovía mucho."]
+- [YOU SAY: "contar" then English "count, account, recount, teller"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CONTAR-08, ES-ETYMON-CONTAR-09, ES-GRAMMAR-NARRATIVE-10, ES-GRAMMAR-SCENE-VS-EVENT-06, ES-ETYMON-IMPERFECTUS-07, ES-LEX-PORQUE-03, ES-ETYMON-PORQUE-04, ES-GRAMMAR-LUEGO-CONNECTIVE-01, ES-ETYMON-LOCUS] -->
+
+[PAUSE 3s] *Contar* does two jobs — which two, and what Latin verb explains both?
+(**Count** and **tell**; ***computāre***, "to reckon up".) Which English word
+carries the same double sense? (**Recount** — or *an account*; and *tell* itself,
+as in a bank *teller*.) In your story, which tense held the rain and which one
+poured the coffee? (**Imperfect** *llovía*; **preterite** *bebí*.) Name the two
+joining words you used. (***Luego*** for order, ***porque*** for reason.)

--- a/code/learning/human-languages/spanish/lessons/ES-C38-imperfecto.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C38-imperfecto.md
@@ -1,0 +1,100 @@
+---
+schema_version: 2
+id: ES-C38-imperfecto
+spine_node: SPINE-NARRATE-EVENTS
+sequence: 1790
+chapter: 38
+type: word
+headword: llovía / llovió
+gloss: the same rain in two tenses — how a story uses the imperfect for the scene and the preterite for the events
+concept_tag: ASPECT-ONGOING-PAST
+prerequisites: [ES-C38-porque]
+sounds: [double-l-y, accent-i]
+roots: [imperfectus-latin]
+etymology_hook: "you already have the endings; what is new is the NAME and what it tells you — imperfecto is Latin imperfectus, in- ('not') + perfectus ('carried all the way through'), from per- ('through') + facere ('do, make'), the same facere behind fact, factory, effect and perfect; the tense is called unfinished because that is precisely the job it does in a story"
+duration:
+  max_seconds: 260
+requires:
+  knowledge: [ES-LEX-PORQUE-03, ES-GRAMMAR-LUEGO-CONNECTIVE-01]
+introduces:
+  knowledge: [ES-GRAMMAR-SCENE-VS-EVENT-06, ES-ETYMON-IMPERFECTUS-07]
+practises:
+  knowledge: [ES-LEX-PORQUE-03, ES-GRAMMAR-LUEGO-CONNECTIVE-01, ES-GRAMMAR-SCENE-VS-EVENT-06, ES-ETYMON-IMPERFECTUS-07]
+skills: [listening, speaking, reading]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C16-imperfecto, ES-C16-tres-irregulares, ES-C38-porque, ES-C38-luego]
+---
+
+# llovía / llovió — the same rain, told two ways
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-LUEGO-CONNECTIVE-01, ES-LEX-PORQUE-03] -->
+
+[PAUSE 2s] You already have both past tenses. The imperfect — *hablaba*, *comía*
+— came in chapter sixteen, with its three irregulars. Nothing here is a new form.
+What is new is **which one to reach for**, and that turns out to be the whole
+trick of telling a story.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `double-l-y` — *ll* is a *y* glide: **llovía** = *yo-VEE-a*.
+- `accent-i` — the accent splits the vowels: *llo-VÍ-a*, three beats.
+
+## The word, taken apart: why "imperfect"
+<!-- hl-knowledge: introduces=[ES-ETYMON-IMPERFECTUS-07]; assesses=[] -->
+
+The name is the lesson, and it is worth having.
+
+**Imperfecto** is Latin ***imperfectus***: ***in-*** ("not") plus ***perfectus***,
+"carried all the way through" — itself ***per-*** ("through") plus ***facere***
+("to do, to make"). That *facere* is everywhere in English: **fact**, **factory**,
+**effect**, **manufacture**, and **perfect** itself, which still means *finished
+through*.
+
+So the imperfect is the **not-carried-through** tense. Not unfinished in quality —
+unfinished in *time*. It shows an action still running, with no edge on it. That
+is not a label bolted on afterwards; it is a description of the job.
+
+## Grammar Lens: the scene and the events
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-SCENE-VS-EVENT-06]; assesses=[ES-LEX-PORQUE-03, ES-GRAMMAR-LUEGO-CONNECTIVE-01] -->
+
+Take one fact — it rained — and watch the tense decide what *kind* of fact it is:
+
+| | |
+|---|---|
+| **Llovía.** | It was raining. *(no edge — the weather that day)* |
+| **Llovió.** | It rained. *(edged — a thing that happened)* |
+
+Neither is more correct. They answer different questions. A told story needs
+both, in a division of labour that never varies:
+
+> The **imperfect paints the scene** — what was going on, what things were like.
+> The **preterite drops the events into it** — what then happened.
+
+*Llovía. Luego me levanté.* — It was raining *(scene)*. Then I got up *(event)*.
+
+English has no separate form for this, which is the only reason it feels hard.
+English leans on *was ‑ing* and *used to* and lets context carry the rest.
+Spanish decided it once, in the ending.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-SCENE-VS-EVENT-06, ES-ETYMON-IMPERFECTUS-07, ES-LEX-PORQUE-03] -->
+
+[PAUSE 1s]
+- [YOU SAY: the pair — "llovía" then "llovió"]
+- [YOU SAY: scene, then event — "Llovía. Luego me levanté."]
+- [YOU SAY: "No corrí, porque llovía." — the reason is a scene, the running an event]
+- [YOU SAY: "Comía pan porque llovía."]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-SCENE-VS-EVENT-06, ES-ETYMON-IMPERFECTUS-07, ES-LEX-PORQUE-03, ES-GRAMMAR-LUEGO-CONNECTIVE-01] -->
+
+[PAUSE 3s] What does *imperfectus* literally say, and which English word shares
+its second half? (**Not carried through**; **perfect** — and *fact*, *factory*.)
+In a story, which tense paints the background and which drops in the events?
+(**Imperfect** paints; **preterite** drops in.) Which of *llovía* and *llovió*
+has an edge on it? (***Llovió*** — a thing that happened.)

--- a/code/learning/human-languages/spanish/lessons/ES-C38-luego.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C38-luego.md
@@ -1,0 +1,95 @@
+---
+schema_version: 2
+id: ES-C38-luego
+spine_node: SPINE-NARRATE-EVENTS
+sequence: 1770
+chapter: 38
+type: word
+headword: luego
+gloss: then, next — a word you already own from hasta luego, now doing a second job: joining two events in order
+concept_tag: CONNECTIVE-THEN
+prerequisites: [ES-C05-hasta-luego, ES-C37-sentarse, ES-C37-levantarse]
+sounds: [g-soft-gw, diphthong-ue]
+roots: [locus-latin]
+etymology_hook: "the locus etymology is already yours from hasta luego; what this lesson adds is where else that Latin locus surfaces — local, locate, location, allocate, dislocate, and, through French lieu 'place', lieutenant, the officer who holds another's place"
+duration:
+  max_seconds: 220
+requires:
+  knowledge: [ES-LEX-LUEGO, ES-ETYMON-LOCUS, ES-LEX-SENTARSE-07, ES-LEX-LEVANTARSE-09]
+introduces:
+  knowledge: [ES-GRAMMAR-LUEGO-CONNECTIVE-01]
+practises:
+  knowledge: [ES-LEX-LUEGO, ES-ETYMON-LOCUS, ES-LEX-SENTARSE-07, ES-LEX-LEVANTARSE-09, ES-GRAMMAR-LUEGO-CONNECTIVE-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C05-hasta-luego, ES-C37-sentarse, ES-C37-levantarse]
+---
+
+# luego — a word you already have, doing a job you have not seen it do
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-LUEGO] -->
+
+[PAUSE 2s] Nothing new to learn here — you have said **luego** every time you
+said *hasta luego*. What is new is that it can stand alone, between two events,
+and put them in order.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `diphthong-ue` — *ue* is one glide, not two syllables.
+- `g-soft-gw` — between vowels the *g* softens; **luego** is *LWEH-ɣo*, not the
+  hard stop English puts in *go*.
+
+## The word, taken apart: luego
+<!-- hl-knowledge: introduces=[]; assesses=[ES-ETYMON-LOCUS, ES-LEX-LUEGO] -->
+
+You already know where it comes from: Latin **locō**, the ablative of ***locus***,
+"place" — "in that place", a word about *where* that slid into a word about
+*when*. That is why *hasta luego* is "until later".
+
+What you have not been shown is how much else *locus* is holding up. It gives
+**local**, **locate**, **location**, **locus**, **allocate**, **dislocate**. And
+through French *lieu*, "place", it gives **lieutenant** — literally the officer
+*holding the place* of another.
+
+> **A leftover worth knowing.** ***Desde luego*** means "of course". It was built
+> on an older sense of *luego*, "**immediately**", so its literal force was nearer
+> "from this moment on". The bare word has since drifted to "later"; the phrase
+> kept the old sense.
+
+## Grammar Lens: luego between two events
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-LUEGO-CONNECTIVE-01]; assesses=[ES-LEX-SENTARSE-07, ES-LEX-LEVANTARSE-09] -->
+
+Out of the farewell, *luego* is not glued to a verb. It marks the join between
+two events and sits at the front of the second:
+
+| | |
+|---|---|
+| Me siento. **Luego** leo. | I sit down. **Then** I read. |
+| Bebo café y **luego** escribo. | I drink coffee and **then** I write. |
+| Me levanto **y luego** corro. | I get up **and then** I run. |
+
+Two events, in order, with one word doing the ordering — and it is a word you
+have been saying since chapter five.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-LUEGO-CONNECTIVE-01, ES-ETYMON-LOCUS, ES-LEX-SENTARSE-07, ES-LEX-LEVANTARSE-09] -->
+
+[PAUSE 1s]
+- [YOU SAY: "hasta luego" then just "luego" — same word, standing alone]
+- [YOU SAY: "Me siento. Luego leo."]
+- [YOU SAY: "Me levanto y luego corro."]
+- [YOU SAY: "luego" then English "local, locate, lieutenant"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-LUEGO-CONNECTIVE-01, ES-ETYMON-LOCUS, ES-LEX-LUEGO, ES-LEX-SENTARSE-07] -->
+
+[PAUSE 3s] What job does *luego* do here that it does not do in *hasta luego*?
+(It **joins two events in order**, instead of sitting inside a fixed farewell.)
+Which English officer's title hides the same *locus*? (**Lieutenant** — the one
+holding another's place.) Which older sense of *luego* is frozen inside *desde
+luego*? (**Immediately** — not "later".)

--- a/code/learning/human-languages/spanish/lessons/ES-C38-porque.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C38-porque.md
@@ -1,0 +1,103 @@
+---
+schema_version: 2
+id: ES-C38-porque
+spine_node: SPINE-NARRATE-EVENTS
+sequence: 1780
+chapter: 38
+type: word
+headword: porque
+gloss: because — two tiny words fused into one, and the reason a sequence becomes a story
+concept_tag: CONNECTIVE-BECAUSE
+prerequisites: [ES-C38-luego]
+sounds: [k-hard, r-tap]
+roots: [pro-latin, kwo-pie]
+etymology_hook: "porque = por (← Latin prō, 'for, in front of') + que (← Latin quid, which then usurped the roles of quod without taking its form), fused into one word; the qu- of quid is the Latin form of PIE *kʷo-, the same interrogative root that surfaces in Germanic as the wh- of who, what, when, where and why — so Spanish que and English what are cousins, not borrowings"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-GRAMMAR-LUEGO-CONNECTIVE-01, ES-ETYMON-LOCUS]
+introduces:
+  knowledge: [ES-LEX-PORQUE-03, ES-ETYMON-PORQUE-04, ES-GRAMMAR-PORQUE-THREE-05]
+practises:
+  knowledge: [ES-GRAMMAR-LUEGO-CONNECTIVE-01, ES-ETYMON-LOCUS, ES-LEX-PORQUE-03, ES-ETYMON-PORQUE-04, ES-GRAMMAR-PORQUE-THREE-05]
+skills: [listening, speaking, reading, writing]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C38-luego, ES-C37-sentarse]
+---
+
+# porque — "because", and the reason a sequence turns into a story
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-GRAMMAR-LUEGO-CONNECTIVE-01] -->
+
+[PAUSE 2s] With *luego* you can put two events in order. But order is not yet a
+story. *I sat down, then I read* tells nobody **why**. One more word closes that
+gap, and it is two words wearing a single coat.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `k-hard` — *qu* before *e* is a plain *k*; the *u* is silent. **porque** =
+  *POR-keh*.
+- `r-tap` — a single flick of the tongue, not the rolled *rr*.
+
+## The word, taken apart: porque
+<!-- hl-knowledge: introduces=[ES-LEX-PORQUE-03, ES-ETYMON-PORQUE-04]; assesses=[] -->
+
+**porque** = **por** + **que**, fused.
+
+**por** descends from Latin ***prō***, "for, in front of, on behalf of" — the
+same *prō* standing at the front of **pro**vide, **pro**ceed, **pro**tect,
+**pro**pose, and surviving whole in the English phrase *quid **pro** quo*.
+
+**que** descends from Latin ***quid***, "what" — and then quietly took over every
+job Latin had given ***quod***, without taking its form.
+
+And this is the good part. That Latin *qu-* is one branch of the
+Proto-Indo-European interrogative root ***\*kʷo-***. The other branch went into Germanic, where
+*\*kʷ-* softened to *hw-* — Grimm's Law turning a stop into a breath — and came
+out as English **who**, **what**, **when**, **where**, **why**.
+
+So Spanish *que* and English *what* are not borrowed from one another. They are
+**siblings** — the same ancient question-word, walked down two different roads.
+*Quid pro quo* puts both Latin halves of *porque* side by side in an English
+sentence.
+
+## Grammar Lens: porque, por qué, el porqué
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-PORQUE-THREE-05]; assesses=[ES-LEX-PORQUE-03] -->
+
+Three spellings, three jobs, and they are genuinely distinct in writing:
+
+| written | stress | job |
+|---|---|---|
+| **porque** | one word, no accent | **because** — gives the reason |
+| **por qué** | two words, accent on *qué* | **why** — asks for the reason |
+| **el porqué** | one word, accent, with *el* | **the reason** — a noun |
+
+*¿**Por qué** te levantas?* — **Why** do you get up?
+*Me levanto **porque** corro.* — I get up **because** I run.
+*No entiendo **el porqué**.* — I don't understand **the reason**.
+
+The accent is not decoration. It marks *qué* as the questioning one, exactly as
+it does on other question words.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-PORQUE-03, ES-ETYMON-PORQUE-04, ES-GRAMMAR-PORQUE-THREE-05, ES-GRAMMAR-LUEGO-CONNECTIVE-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: "porque" — *POR-keh*, silent *u*]
+- [YOU SAY: "Me siento porque leo." — I sit down because I read.]
+- [YOU SAY: "Me levanto y luego corro, porque hace sol."]
+- [YOU SAY: the three shapes — "porque, por qué, el porqué"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-PORQUE-03, ES-ETYMON-PORQUE-04, ES-GRAMMAR-PORQUE-THREE-05, ES-GRAMMAR-LUEGO-CONNECTIVE-01, ES-ETYMON-LOCUS] -->
+
+[PAUSE 3s] What two Latin words are fused inside *porque*? (***prō*** and
+***quid***.) Are Spanish *que* and English *what* parent and child, or siblings?
+(**Siblings** — Latin *qu-* and Germanic *wh-* from one root, ***\*kʷo-***.)
+Which of the three spellings asks a question? (***Por qué*** — two words, accent
+on *qué*.)

--- a/code/learning/human-languages/spanish/narration/ch38.json
+++ b/code/learning/human-languages/spanish/narration/ch38.json
@@ -1,0 +1,718 @@
+{
+  "version": 1,
+  "language": "spanish",
+  "chapter": 38,
+  "title": "Telling What Happened",
+  "drivablePrefix": 4,
+  "sourceHash": "fnv1a64:5a76e34b3a495c6c",
+  "lessons": [
+    {
+      "id": "ES-C38-luego",
+      "sequence": 1770,
+      "title": "luego — a word you already have, doing a job you have not seen it do",
+      "headword": "luego",
+      "romanization": "luego",
+      "gloss": "then, next — a word you already own from hasta luego, now doing a second job: joining two events in order",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:9ae2c7b60116965d",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Nothing new to learn here — you have said luego every time you said hasta luego. What is new is that it can stand alone, between two events, and put them in order."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "diphthong-ue — ue is one glide, not two syllables."
+            },
+            {
+              "kind": "speech",
+              "text": "g-soft-gw — between vowels the g softens; luego is LWEH-ɣo, not the hard stop English puts in go."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: luego",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "You already know where it comes from: Latin locō, the ablative of locus, \"place\" — \"in that place\", a word about where that slid into a word about when. That is why hasta luego is \"until later\"."
+            },
+            {
+              "kind": "speech",
+              "text": "What you have not been shown is how much else locus is holding up. It gives local, locate, location, locus, allocate, dislocate. And through French lieu, \"place\", it gives lieutenant — literally the officer holding the place of another."
+            },
+            {
+              "kind": "speech",
+              "text": "A leftover worth knowing. Desde luego means \"of course\". It was built on an older sense of luego, \"immediately\", so its literal force was nearer \"from this moment on\". The bare word has since drifted to \"later\"; the phrase kept the old sense."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: luego between two events",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Out of the farewell, luego is not glued to a verb. It marks the join between two events and sits at the front of the second:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 3,
+              "utterances": [
+                "Me siento. Luego leo., I sit down. Then I read.",
+                "Bebo café y luego escribo., I drink coffee and then I write.",
+                "Me levanto y luego corro., I get up and then I run."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Two events, in order, with one word doing the ordering — and it is a word you have been saying since chapter five."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"hasta luego\" then just \"luego\" — same word, standing alone",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"hasta luego\" then just \"luego\" — same word, standing alone]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Me siento. Luego leo.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Me siento. Luego leo.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Me levanto y luego corro.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Me levanto y luego corro.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"luego\" then English \"local, locate, lieutenant\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"luego\" then English \"local, locate, lieutenant\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What job does luego do here that it does not do in hasta luego? (It joins two events in order, instead of sitting inside a fixed farewell.) Which English officer's title hides the same locus? (Lieutenant — the one holding another's place.) Which older sense of luego is frozen inside desde luego? (Immediately — not \"later\".)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C38-porque",
+      "sequence": 1780,
+      "title": "porque — \"because\", and the reason a sequence turns into a story",
+      "headword": "porque",
+      "romanization": "porque",
+      "gloss": "because — two tiny words fused into one, and the reason a sequence becomes a story",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:0df5a4eb3d1eeec6",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "With luego you can put two events in order. But order is not yet a story. I sat down, then I read tells nobody why. One more word closes that gap, and it is two words wearing a single coat."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "k-hard — qu before e is a plain k; the u is silent. porque = POR-keh."
+            },
+            {
+              "kind": "speech",
+              "text": "r-tap — a single flick of the tongue, not the rolled rr."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: porque",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "porque = por + que, fused."
+            },
+            {
+              "kind": "speech",
+              "text": "por descends from Latin prō, \"for, in front of, on behalf of\" — the same prō standing at the front of provide, proceed, protect, propose, and surviving whole in the English phrase quid pro quo."
+            },
+            {
+              "kind": "speech",
+              "text": "que descends from Latin quid, \"what\" — and then quietly took over every job Latin had given quod, without taking its form."
+            },
+            {
+              "kind": "speech",
+              "text": "And this is the good part. That Latin qu- is one branch of the Proto-Indo-European interrogative root kʷo-. The other branch went into Germanic, where kʷ- softened to hw- — Grimm's Law turning a stop into a breath — and came out as English who, what, when, where, why."
+            },
+            {
+              "kind": "speech",
+              "text": "So Spanish que and English what are not borrowed from one another. They are siblings — the same ancient question-word, walked down two different roads. Quid pro quo puts both Latin halves of porque side by side in an English sentence."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: porque, por qué, el porqué",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Three spellings, three jobs, and they are genuinely distinct in writing:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "written",
+                "stress",
+                "job"
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "written: porque. stress: one word, no accent. job: because — gives the reason.",
+                "written: por qué. stress: two words, accent on qué. job: why — asks for the reason.",
+                "written: el porqué. stress: one word, accent, with el. job: the reason — a noun."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "¿Por qué te levantas? — Why do you get up? Me levanto porque corro. — I get up because I run. No entiendo el porqué. — I don't understand the reason."
+            },
+            {
+              "kind": "speech",
+              "text": "The accent is not decoration. It marks qué as the questioning one, exactly as it does on other question words."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"porque\" — POR-keh, silent u",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"porque\" — *POR-keh*, silent *u*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Me siento porque leo.\" — I sit down because I read.",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Me siento porque leo.\" — I sit down because I read.]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Me levanto y luego corro, porque hace sol.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Me levanto y luego corro, porque hace sol.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three shapes — \"porque, por qué, el porqué\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three shapes — \"porque, por qué, el porqué\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What two Latin words are fused inside porque? (prō and quid.) Are Spanish que and English what parent and child, or siblings? (Siblings — Latin qu- and Germanic wh- from one root, kʷo-.) Which of the three spellings asks a question? (Por qué — two words, accent on qué.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C38-imperfecto",
+      "sequence": 1790,
+      "title": "llovía / llovió — the same rain, told two ways",
+      "headword": "llovía / llovió",
+      "romanization": "llovía / llovió",
+      "gloss": "the same rain in two tenses — how a story uses the imperfect for the scene and the preterite for the events",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:4f40474a50c0b81c",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You already have both past tenses. The imperfect — hablaba, comía — came in chapter sixteen, with its three irregulars. Nothing here is a new form. What is new is which one to reach for, and that turns out to be the whole trick of telling a story."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "double-l-y — ll is a y glide: llovía = yo-VEE-a."
+            },
+            {
+              "kind": "speech",
+              "text": "accent-i — the accent splits the vowels: llo-VÍ-a, three beats."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: why \"imperfect\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The name is the lesson, and it is worth having."
+            },
+            {
+              "kind": "speech",
+              "text": "Imperfecto is Latin imperfectus: in- (\"not\") plus perfectus, \"carried all the way through\" — itself per- (\"through\") plus facere (\"to do, to make\"). That facere is everywhere in English: fact, factory, effect, manufacture, and perfect itself, which still means finished through."
+            },
+            {
+              "kind": "speech",
+              "text": "So the imperfect is the not-carried-through tense. Not unfinished in quality — unfinished in time. It shows an action still running, with no edge on it. That is not a label bolted on afterwards; it is a description of the job."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the scene and the events",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Take one fact — it rained — and watch the tense decide what kind of fact it is:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "Llovía., It was raining. (no edge — the weather that day).",
+                "Llovió., It rained. (edged — a thing that happened)."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Neither is more correct. They answer different questions. A told story needs both, in a division of labour that never varies:"
+            },
+            {
+              "kind": "speech",
+              "text": "The imperfect paints the scene — what was going on, what things were like. The preterite drops the events into it — what then happened."
+            },
+            {
+              "kind": "speech",
+              "text": "Llovía. Luego me levanté. — It was raining (scene). Then I got up (event)."
+            },
+            {
+              "kind": "speech",
+              "text": "English has no separate form for this, which is the only reason it feels hard. English leans on was ‑ing and used to and lets context carry the rest. Spanish decided it once, in the ending."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the pair — \"llovía\" then \"llovió\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the pair — \"llovía\" then \"llovió\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "scene, then event — \"Llovía. Luego me levanté.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: scene, then event — \"Llovía. Luego me levanté.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"No corrí, porque llovía.\" — the reason is a scene, the running an event",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"No corrí, porque llovía.\" — the reason is a scene, the running an event]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Comía pan porque llovía.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Comía pan porque llovía.\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does imperfectus literally say, and which English word shares its second half? (Not carried through; perfect — and fact, factory.) In a story, which tense paints the background and which drops in the events? (Imperfect paints; preterite drops in.) Which of llovía and llovió has an edge on it? (Llovió — a thing that happened.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C38-contar",
+      "sequence": 1800,
+      "title": "contar — to tell a story, which is also to count it up",
+      "headword": "contar",
+      "romanization": "contar",
+      "gloss": "to tell a story — and also to count, because in Spanish, as once in English, a story is something you reckon up",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:24a3806589d6e25c",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Three pieces are in your hands: luego to order events, porque to explain them, the imperfect to hold the background still. This lesson adds no fourth piece — it puts the three together, under the verb that names the act."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "diphthong-ue — the stem breaks under stress: cuento = KWEN-to, but contamos stays plain."
+            },
+            {
+              "kind": "speech",
+              "text": "k-hard — c before o is a hard k."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: contar",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "contar means to count — and to tell a story. One verb, both jobs, and not a pun."
+            },
+            {
+              "kind": "speech",
+              "text": "It descends from Latin computāre, \"to reckon up\": com- (\"together\") plus putāre, which meant \"to prune\", then \"to settle an account\", then simply \"to reckon\". Putāre gives amputate, dispute, deputy; computāre gives count, compute, account."
+            },
+            {
+              "kind": "speech",
+              "text": "English carries the same double sense — to recount an event, to give an account of yourself — but those are the very same word, borrowed through Old French from computāre. Spanish's relatives, not an independent echo."
+            },
+            {
+              "kind": "speech",
+              "text": "The independent echo is tell: Germanic, unrelated, and it also once meant \"to count\" — hence a bank teller, and all told. Two unrelated languages, one thought: a story is a reckoning-up of events in order."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the backbone of a told story",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Contar breaks o to ue under stress:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "person",
+                "form"
+              ],
+              "columns": 2,
+              "rowCount": 5,
+              "utterances": [
+                "person: yo. form: cuento.",
+                "person: tú. form: cuentas.",
+                "person: él/ella/usted. form: cuenta.",
+                "person: nosotros. form: contamos.",
+                "person: ellos/ustedes. form: cuentan."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Here is the shape of a told story:"
+            },
+            {
+              "kind": "speech",
+              "text": "Llovía. Me levanté, luego bebí café. No corrí, porque llovía mucho. Me senté y leí. It was raining. I got up, then I drank coffee. I didn't run, because it was raining hard. I sat down and read."
+            },
+            {
+              "kind": "speech",
+              "text": "Watch the two pasts divide the work. Llovía — imperfect, holding the scene still. Me levanté, bebí, me senté, leí — preterite, dropping events in. Luego orders them; porque explains one."
+            },
+            {
+              "kind": "speech",
+              "text": "That is a narration, and every word in it is one this book has taught you."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"cuento, cuentas, cuenta, contamos, cuentan\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"cuento, cuentas, cuenta, contamos, cuentan\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Cuento hasta cinco.\" — I count to five. Same verb.",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Cuento hasta cinco.\" — I count to five. Same verb.]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the scene, then the event — \"Llovía. Luego me levanté.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the scene, then the event — \"Llovía. Luego me levanté.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the whole thing — \"Llovía. Me levanté, luego bebí café. No corrí, porque llovía mucho.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the whole thing — \"Llovía. Me levanté, luego bebí café. No corrí, porque llovía mucho.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"contar\" then English \"count, account, recount, teller\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"contar\" then English \"count, account, recount, teller\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Contar does two jobs — which two, and what Latin verb explains both? (Count and tell; computāre, \"to reckon up\".) Which English word carries the same double sense? (Recount — or an account; and tell itself, as in a bank teller.) In your story, which tense held the rain and which one poured the coffee? (Imperfect llovía; preterite bebí.) Name the two joining words you used. (Luego for order, porque for reason.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/spanish/narration/ch38.txt
+++ b/code/learning/human-languages/spanish/narration/ch38.txt
@@ -1,0 +1,175 @@
+Spanish, chapter 38: Telling What Happened.
+4 lessons. All 4 can be done entirely by ear.
+
+
+Lesson 1 of 4.
+luego — a word you already have, doing a job you have not seen it do.
+
+Warm-up.
+[pause 2 seconds]
+Nothing new to learn here — you have said luego every time you said hasta luego. What is new is that it can stand alone, between two events, and put them in order.
+
+Sounds you'll need.
+diphthong-ue — ue is one glide, not two syllables.
+g-soft-gw — between vowels the g softens; luego is LWEH-ɣo, not the hard stop English puts in go.
+
+The word, taken apart: luego.
+You already know where it comes from: Latin locō, the ablative of locus, "place" — "in that place", a word about where that slid into a word about when. That is why hasta luego is "until later".
+What you have not been shown is how much else locus is holding up. It gives local, locate, location, locus, allocate, dislocate. And through French lieu, "place", it gives lieutenant — literally the officer holding the place of another.
+A leftover worth knowing. Desde luego means "of course". It was built on an older sense of luego, "immediately", so its literal force was nearer "from this moment on". The bare word has since drifted to "later"; the phrase kept the old sense.
+
+Grammar Lens: luego between two events.
+Out of the farewell, luego is not glued to a verb. It marks the join between two events and sits at the front of the second:
+[a table of 3 rows, read aloud]
+Me siento. Luego leo., I sit down. Then I read.
+Bebo café y luego escribo., I drink coffee and then I write.
+Me levanto y luego corro., I get up and then I run.
+Two events, in order, with one word doing the ordering — and it is a word you have been saying since chapter five.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "hasta luego" then just "luego" — same word, standing alone]
+[pause 8 seconds for the answer]
+[your turn — say: "Me siento. Luego leo."]
+[pause 8 seconds for the answer]
+[your turn — say: "Me levanto y luego corro."]
+[pause 8 seconds for the answer]
+[your turn — say: "luego" then English "local, locate, lieutenant"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What job does luego do here that it does not do in hasta luego? (It joins two events in order, instead of sitting inside a fixed farewell.) Which English officer's title hides the same locus? (Lieutenant — the one holding another's place.) Which older sense of luego is frozen inside desde luego? (Immediately — not "later".)
+
+
+Lesson 2 of 4.
+porque — "because", and the reason a sequence turns into a story.
+
+Warm-up.
+[pause 2 seconds]
+With luego you can put two events in order. But order is not yet a story. I sat down, then I read tells nobody why. One more word closes that gap, and it is two words wearing a single coat.
+
+Sounds you'll need.
+k-hard — qu before e is a plain k; the u is silent. porque = POR-keh.
+r-tap — a single flick of the tongue, not the rolled rr.
+
+The word, taken apart: porque.
+porque = por + que, fused.
+por descends from Latin prō, "for, in front of, on behalf of" — the same prō standing at the front of provide, proceed, protect, propose, and surviving whole in the English phrase quid pro quo.
+que descends from Latin quid, "what" — and then quietly took over every job Latin had given quod, without taking its form.
+And this is the good part. That Latin qu- is one branch of the Proto-Indo-European interrogative root kʷo-. The other branch went into Germanic, where kʷ- softened to hw- — Grimm's Law turning a stop into a breath — and came out as English who, what, when, where, why.
+So Spanish que and English what are not borrowed from one another. They are siblings — the same ancient question-word, walked down two different roads. Quid pro quo puts both Latin halves of porque side by side in an English sentence.
+
+Grammar Lens: porque, por qué, el porqué.
+Three spellings, three jobs, and they are genuinely distinct in writing:
+[a table of 3 rows, read aloud]
+written: porque. stress: one word, no accent. job: because — gives the reason.
+written: por qué. stress: two words, accent on qué. job: why — asks for the reason.
+written: el porqué. stress: one word, accent, with el. job: the reason — a noun.
+¿Por qué te levantas? — Why do you get up? Me levanto porque corro. — I get up because I run. No entiendo el porqué. — I don't understand the reason.
+The accent is not decoration. It marks qué as the questioning one, exactly as it does on other question words.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "porque" — POR-keh, silent u]
+[pause 8 seconds for the answer]
+[your turn — say: "Me siento porque leo." — I sit down because I read.]
+[pause 8 seconds for the answer]
+[your turn — say: "Me levanto y luego corro, porque hace sol."]
+[pause 8 seconds for the answer]
+[your turn — say: the three shapes — "porque, por qué, el porqué"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What two Latin words are fused inside porque? (prō and quid.) Are Spanish que and English what parent and child, or siblings? (Siblings — Latin qu- and Germanic wh- from one root, kʷo-.) Which of the three spellings asks a question? (Por qué — two words, accent on qué.)
+
+
+Lesson 3 of 4.
+llovía / llovió — the same rain, told two ways.
+
+Warm-up.
+[pause 2 seconds]
+You already have both past tenses. The imperfect — hablaba, comía — came in chapter sixteen, with its three irregulars. Nothing here is a new form. What is new is which one to reach for, and that turns out to be the whole trick of telling a story.
+
+Sounds you'll need.
+double-l-y — ll is a y glide: llovía = yo-VEE-a.
+accent-i — the accent splits the vowels: llo-VÍ-a, three beats.
+
+The word, taken apart: why "imperfect".
+The name is the lesson, and it is worth having.
+Imperfecto is Latin imperfectus: in- ("not") plus perfectus, "carried all the way through" — itself per- ("through") plus facere ("to do, to make"). That facere is everywhere in English: fact, factory, effect, manufacture, and perfect itself, which still means finished through.
+So the imperfect is the not-carried-through tense. Not unfinished in quality — unfinished in time. It shows an action still running, with no edge on it. That is not a label bolted on afterwards; it is a description of the job.
+
+Grammar Lens: the scene and the events.
+Take one fact — it rained — and watch the tense decide what kind of fact it is:
+[a table of 2 rows, read aloud]
+Llovía., It was raining. (no edge — the weather that day).
+Llovió., It rained. (edged — a thing that happened).
+Neither is more correct. They answer different questions. A told story needs both, in a division of labour that never varies:
+The imperfect paints the scene — what was going on, what things were like. The preterite drops the events into it — what then happened.
+Llovía. Luego me levanté. — It was raining (scene). Then I got up (event).
+English has no separate form for this, which is the only reason it feels hard. English leans on was ‑ing and used to and lets context carry the rest. Spanish decided it once, in the ending.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the pair — "llovía" then "llovió"]
+[pause 8 seconds for the answer]
+[your turn — say: scene, then event — "Llovía. Luego me levanté."]
+[pause 8 seconds for the answer]
+[your turn — say: "No corrí, porque llovía." — the reason is a scene, the running an event]
+[pause 8 seconds for the answer]
+[your turn — say: "Comía pan porque llovía."]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does imperfectus literally say, and which English word shares its second half? (Not carried through; perfect — and fact, factory.) In a story, which tense paints the background and which drops in the events? (Imperfect paints; preterite drops in.) Which of llovía and llovió has an edge on it? (Llovió — a thing that happened.)
+
+
+Lesson 4 of 4.
+contar — to tell a story, which is also to count it up.
+
+Warm-up.
+[pause 2 seconds]
+Three pieces are in your hands: luego to order events, porque to explain them, the imperfect to hold the background still. This lesson adds no fourth piece — it puts the three together, under the verb that names the act.
+
+Sounds you'll need.
+diphthong-ue — the stem breaks under stress: cuento = KWEN-to, but contamos stays plain.
+k-hard — c before o is a hard k.
+
+The word, taken apart: contar.
+contar means to count — and to tell a story. One verb, both jobs, and not a pun.
+It descends from Latin computāre, "to reckon up": com- ("together") plus putāre, which meant "to prune", then "to settle an account", then simply "to reckon". Putāre gives amputate, dispute, deputy; computāre gives count, compute, account.
+English carries the same double sense — to recount an event, to give an account of yourself — but those are the very same word, borrowed through Old French from computāre. Spanish's relatives, not an independent echo.
+The independent echo is tell: Germanic, unrelated, and it also once meant "to count" — hence a bank teller, and all told. Two unrelated languages, one thought: a story is a reckoning-up of events in order.
+
+Grammar Lens: the backbone of a told story.
+Contar breaks o to ue under stress:
+[a table of 5 rows, read aloud]
+person: yo. form: cuento.
+person: tú. form: cuentas.
+person: él/ella/usted. form: cuenta.
+person: nosotros. form: contamos.
+person: ellos/ustedes. form: cuentan.
+Here is the shape of a told story:
+Llovía. Me levanté, luego bebí café. No corrí, porque llovía mucho. Me senté y leí. It was raining. I got up, then I drank coffee. I didn't run, because it was raining hard. I sat down and read.
+Watch the two pasts divide the work. Llovía — imperfect, holding the scene still. Me levanté, bebí, me senté, leí — preterite, dropping events in. Luego orders them; porque explains one.
+That is a narration, and every word in it is one this book has taught you.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "cuento, cuentas, cuenta, contamos, cuentan"]
+[pause 8 seconds for the answer]
+[your turn — say: "Cuento hasta cinco." — I count to five. Same verb.]
+[pause 8 seconds for the answer]
+[your turn — say: the scene, then the event — "Llovía. Luego me levanté."]
+[pause 8 seconds for the answer]
+[your turn — say: the whole thing — "Llovía. Me levanté, luego bebí café. No corrí, porque llovía mucho."]
+[pause 8 seconds for the answer]
+[your turn — say: "contar" then English "count, account, recount, teller"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Contar does two jobs — which two, and what Latin verb explains both? (Count and tell; computāre, "to reckon up".) Which English word carries the same double sense? (Recount — or an account; and tell itself, as in a bank teller.) In your story, which tense held the rain and which one poured the coffee? (Imperfect llovía; preterite bebí.) Name the two joining words you used. (Luego for order, porque for reason.)

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,72 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — the first content above A2: Spanish chapter 38 (HL09, SPINE-NARRATE-EVENTS)
+
+The B1–C2 spine landed with all 17 nodes declared as gaps in all 22 tracks. This
+realizes the first of them, in one track, as a worked example: **"Telling What
+Happened"**, four lessons, one concept each.
+
+| lesson | concept | what is new |
+|---|---|---|
+| `ES-C38-luego` | CONNECTIVE-THEN | the connective use of a word chapter 5 already gave you |
+| `ES-C38-porque` | CONNECTIVE-BECAUSE | joining a reason to a claim |
+| `ES-C38-imperfecto` | ASPECT-ONGOING-PAST | **not** the forms — scene versus event |
+| `ES-C38-contar` | NARRATIVE-SEQUENCE | the synthesis: a four-sentence told story |
+
+Every lesson carries an etymological connection, per HL09. Spanish `touches` B1 now;
+`attained` is still null, which is the distinction the level gate exists to keep.
+
+### Note — two lessons were re-teaching material the book already owned
+
+Review caught both, and both were the same mistake: writing a B1 lesson without
+checking what the track had already taught.
+
+- **The imperfect is taught in full at chapter 16**, with its three irregulars and
+  the same `-ābam` etymology. The draft presented it as new — 22 chapters late.
+  Rewritten to teach the only thing that *is* new at B1: **which past tense to reach
+  for**, scene versus event. Chapter 16 is now cited, reviewed, and credited.
+- **`luego` is taught at chapter 5**, inside *hasta luego*, along with its `locus`
+  etymology. The draft re-introduced `ES-LEX-LUEGO` and the etymology as fresh atoms.
+  It now *requires* chapter 5's atoms and introduces only
+  `ES-GRAMMAR-LUEGO-CONNECTIVE-01` — the connective function, which is genuinely new.
+
+Also caught: the payoff story used five words the course never teaches (*ventana*,
+*temprano*, *cada*, *hambre*, *historia*) directly beneath the claim **"every word is
+one you already own"**. The story is rebuilt from taught vocabulary and the claim is
+now true. `forwardReferences` cannot see this class — its blind spot is words the
+course teaches *nowhere*.
+
+### Fixed — four wrong etymologies and one missing book target
+
+- *"`*kʷ-` **hardened** to `hw-`"* — Grimm's Law turns a stop into a fricative. That
+  is softening, and it was the one sentence the lesson was built on.
+- *"`que` ← Latin `quid` / **`quod`**"* — `que` inherits `quid` and *usurps* `quod`'s
+  roles without taking its form. The lesson's own recall answer already said `quid`.
+- *"Knock the final consonant off each"* — false for `-ābās` → `-abas`, in the table
+  three lines below. Both this and the contested intervocalic-`b`-loss claim were cut
+  with the rest of the forms material.
+- *"Two languages, **independently**"* — English *recount* and *account* are the same
+  word Spanish inherited, via Old French. Only *tell* is a genuine parallel, and the
+  paragraph now says so.
+
+**The chapter reached the app but not the book.** `core/book-generation.json` is a
+hand-maintained target list; narration and modality are corpus-driven and picked
+chapter 38 up automatically, so `check:books` passed while the book had no chapter.
+Target added and `book.tex` wired — `bookChapters` 442 → 443.
+
+### Changed — two pin comments that described the wrong cause
+
+- **R1 +3 / R2 +10** was attributed to the final lesson's atoms having nothing after
+  them. Wrong: of the +3 R1 exactly one is a chapter-38 atom, and of the +10 R2 none
+  is. `continuity.ts` only judges a window that fits, so *lengthening* the track
+  un-suppressed windows on chapters 36–37. The debt was already there; appending a
+  chapter made it measurable.
+- **forwardReferences +6** was called six instances of the fixed phrase from chapter
+  4. Five are chapter 5; the sixth (`ES-C10-practice`) is bare adverbial *luego* —
+  a real 28-lesson-early leak, reported identically to the five spirals. That is the
+  severity split the metric's own comment has been asking for.
+
 ### Added — the B1–C2 spine, so the ladder has rungs above A2 (HL09 §3.1)
 
 `spine.json` stopped at A2. The level gate handled that correctly — it refused B1–C2

--- a/code/packages/typescript/human-language-data/tests/chapters.test.ts
+++ b/code/packages/typescript/human-language-data/tests/chapters.test.ts
@@ -225,11 +225,11 @@ describe("corpus snapshot", () => {
     // bookChapters 377 -> 378, declaredChapters 279 -> 280, chaptersWithoutCapability
     // holds at 98. A new chapter that shipped without a `canDo`/`payoff` would have
     // pushed the debt to 99, which is exactly what this trio is here to catch.
-    expect(report.summary.bookChapters).toBe(442);
+    expect(report.summary.bookChapters).toBe(443); // +1: Spanish ch38 reaches the BOOK
     // 317 -> 318 when russian chapter 3 gained a capability. It was the only
     // generated chapter with no HL05 entry, so it was also the only generated chapter
     // the book could not give an opening to.
-    expect(report.summary.declaredChapters).toBe(344);
+    expect(report.summary.declaredChapters).toBe(345); // +1: Spanish ch38, the B1 pilot
     expect(report.summary.chaptersWithoutCapability).toBe(98);
     expect(report.summary.payoffsNotClosed).toBe(0);
     expect(report.summary.unknownPayoffLessons).toBe(0);

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -264,8 +264,8 @@ describe("the real corpus", () => {
     // lesson's own, structurally unreachable), Bengali 12 of 18 -> 4 of 35, Tamil 53% ->
     // 38%, Arabic four ch28-30 atoms off zero. Adding vocabulary and reducing orphans at
     // the same time is the whole point; a corpus that only grows is not a course.
-    expect(report.summary.atomsTaught).toBe(1929);
-    expect(report.summary.atomsNeverRevisited).toBe(569);
+    expect(report.summary.atomsTaught).toBe(1938); // +9: the four Spanish B1 lessons
+    expect(report.summary.atomsNeverRevisited).toBe(571);
     expect(report.summary.neverRevisitedPercent).toBe(29);
 
     // 509 -> 517, and the eight split into TWO DIFFERENT PHENOMENA this number conflates.
@@ -285,15 +285,37 @@ describe("the real corpus", () => {
     // NOT being rewritten to move this number, because contorting good prose to satisfy a
     // naive matcher is the exact failure the sight-cue detector already demonstrated.
     // If this metric is to gate anything, it wants a severity split by distance first.
-    expect(report.summary.forwardReferences).toBe(515);
+    //
+    // 515 -> 521, and all six are the word *luego*, which chapter 38 takes as a
+    // headword. FIVE are chapter 5, inside the fixed farewell *hasta luego* (plus one
+    // in the chapter-4 practice) — a spiral, not a leak, and chapter 38 now opens by
+    // saying the word is already the reader's rather than pretending it is new.
+    // The SIXTH is different: `ES-C10-practice` uses bare adverbial *luego* ("y luego
+    // voy a trabajar"), which is the connective sense, 28 lessons early. That one is a
+    // real leak. The metric reports all six identically, which is exactly the severity
+    // split the comment above asks for: it cannot tell a spiral from a leak.
+    // Note it keys on the HEADWORD, not the atom — chapter 38 introduces only
+    // ES-GRAMMAR-LUEGO-CONNECTIVE-01 and requires chapter 5's ES-LEX-LUEGO, yet the
+    // count is unchanged by that wiring.
+    expect(report.summary.forwardReferences).toBe(521);
 
     // HL09 step 3 closed 17 R1 windows in chapters 3-6, measured on the corpus of the
     // day as 766 -> 749. The absolute figures drift as main lands lessons; what the
     // change is accountable for is the 17. R2 moves only with new lessons, never from
     // that work — closing a near window does not close a far one, and nothing yet
     // addresses R2/R3/R4.
-    expect(report.summary.missedByWindow.R1).toBe(779);
-    expect(report.summary.missedByWindow.R2).toBe(1265);
+    //
+    // Chapter 38 costs +3 R1 and +10 R2, and almost none of that is its own atoms.
+    // `continuity.ts` only judges a window that FITS: `if (at + window.from > last)
+    // continue`. Lengthening Spanish by four lessons pushed `last` out and un-suppressed
+    // windows that were previously never judged — on chapter 36 and 37 atoms. Of the
+    // +3 R1 exactly one is a chapter-38 atom; of the +10 R2, none is.
+    //
+    // So this is not a cost the new chapter incurred; it is a debt the old chapters
+    // already had, which only became measurable once something followed them. Any
+    // chapter appended to any track will do this, and the number is honest either way.
+    expect(report.summary.missedByWindow.R1).toBe(782);
+    expect(report.summary.missedByWindow.R2).toBe(1275);
   });
 
   it("shows what a declared reading order was worth", () => {
@@ -316,11 +338,14 @@ describe("the real corpus", () => {
     // 93 -> 102. The independent Python audit these four numbers reproduce was run
     // against the 146-lesson corpus; the walk is unchanged, only its input grew.
     expect(spanish).toMatchObject({
-      lessonCount: 162,
+      // Chapter 38 added four lessons and ten atoms. The two ORDER numbers did not
+      // move -- no new unsequenced lesson, no new forward prerequisite -- which is the
+      // point of the pin: new content is supposed to leave the walk alone.
+      lessonCount: 166,
       lessonsWithoutSequence: 6,
       forwardPrerequisites: 5,
-      atomsTaught: 221,
-      atomsNeverRevisited: 80,
+      atomsTaught: 230,
+      atomsNeverRevisited: 82,
     });
   });
 

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -99,7 +99,7 @@ describe("real curriculum", () => {
     // 35 -> 37: the third verb tranche added Chapters 36 (oír, dormir, caminar, correr)
     // and 37 (abrir, cerrar, sentarse, levantarse), again split 4+4 to stay inside
     // maxNewAtomsPerChapter, and again on SPINE-SAY-WHAT-I-DO.
-    expect(books.books.find((book) => book.language === "spanish")?.chapters.length).toBe(37);
+    expect(books.books.find((book) => book.language === "spanish")?.chapters.length).toBe(38);
     expect(
       books.books
         .find((book) => book.language === "persian")

--- a/code/packages/typescript/human-language-data/tests/level-gate.test.ts
+++ b/code/packages/typescript/human-language-data/tests/level-gate.test.ts
@@ -36,8 +36,10 @@ describe("the gate that would have caught the A2 claim", () => {
     const gate = realReport().levelGate!;
     const spanish = gate.tracks.find((t) => t.language === "spanish")!;
 
-    // The number that misled: one lesson pointing at one A2 node moves `touches`.
-    expect(spanish.touches).toBe("A2");
+    // The number that misled: one lesson pointing at one node moves `touches`, and
+    // chapter 38 has now moved it to B1 on the strength of four lessons. `attained`
+    // is unmoved at null, which is exactly the distinction this module exists for.
+    expect(spanish.touches).toBe("B1");
     // The number that does not: Spanish has not met even pre-A1's criteria.
     expect(spanish.attained).toBeNull();
     expect(spanish.inProgressAt).toBe("pre-A1");
@@ -70,7 +72,7 @@ describe("the gate that would have caught the A2 claim", () => {
     // catch — a number meaning "everything taught" published against one meaning
     // "by the end of pre-A1".
     expect(vocab.shortfall).toBe(256);
-    expect(spanish.vocabulary).toBe(121);
+    expect(spanish.vocabulary).toBe(125);
     expect(vocab.shortfall).toBeGreaterThan(LEVEL_VOCABULARY["pre-A1"] - spanish.vocabulary);
   });
 

--- a/code/packages/typescript/human-language-data/tests/levels.test.ts
+++ b/code/packages/typescript/human-language-data/tests/levels.test.ts
@@ -220,7 +220,9 @@ describe("corpus snapshot", () => {
     expect(summary.byLevel["pre-A1"]).toBe(650);
     expect(summary.byLevel.A1).toBe(297);
     expect(summary.byLevel.A2).toBe(322);
-    expect(summary.byLevel.B1).toBe(0);
+    // 4, not 0: Spanish chapter 38 realizes SPINE-NARRATE-EVENTS, the first B1 node
+    // any track has touched. B2-C2 remain authored-but-unrealized.
+    expect(summary.byLevel.B1).toBe(4);
     expect(summary.byLevel.B2).toBe(0);
     expect(summary.byLevel.C1).toBe(0);
     expect(summary.byLevel.C2).toBe(0);
@@ -236,8 +238,8 @@ describe("corpus snapshot", () => {
     const summary = summarizeLevels(lessons, paths, spine);
     // `reach` is the highest level a track has ANY lesson at, so this names the tracks
     // rather than counting them — "no track is at A2" has become a list, and listing it
-    // keeps the assertion as tight as the original. Nothing has reached B1 or beyond,
-    // which is still the honest ceiling for the whole corpus.
+    // keeps the assertion as tight as the original. Spanish has now left this list --
+    // it reaches B1 -- so the list is 19, and the ceiling for everyone else is A2.
     expect(
       summary.tracks.filter((track) => track.reach === "A2").map((track) => track.language),
     ).toEqual([
@@ -257,14 +259,16 @@ describe("corpus snapshot", () => {
       "punjabi",
       "russian",
       "sanskrit",
-      "spanish",
       "tamil",
       "telugu",
       "urdu",
     ]);
+    // Exactly one track now exceeds A2, and naming it is stronger than a blanket
+    // "nothing does" -- it says which rung was climbed and by whom.
     expect(
-      summary.tracks.every((track) => track.reach === null || levelRank(track.reach) <= levelRank("A2")),
-    ).toBe(true);
+      summary.tracks.filter((track) => track.reach !== null && levelRank(track.reach) > levelRank("A2"))
+        .map((track) => track.language),
+    ).toEqual(["spanish"]);
     expect(
       summary.tracks.filter((track) => track.reach === "pre-A1").map((track) => track.language),
     ).toEqual(["chinese", "japanese"]);

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -792,14 +792,16 @@ describe("corpus regression", () => {
     // headline per-track number is the standing recommendation; until then, expect this
     // figure to rise whenever a non-Latin track authors honestly.
     expect(manifest.summary).toEqual({
-      totalLessons: 1417,
-      voice: 941,
+      // All four Spanish B1 lessons are ear-only, so the B1 pilot is fully drivable
+      // and nudges the whole-corpus figure from 66% to 67%.
+      totalLessons: 1421,
+      voice: 945,
       sight: 423,
       pen: 53,
-      drivableLessons: 941,
-      drivablePercent: 66,
+      drivableLessons: 945,
+      drivablePercent: 67,
       trackCount: 22,
-      chapterCount: 442,
+      chapterCount: 443,
       // Prerequisite order still costs a commuter 132 of the 965 ear-only lessons:
       // they sit behind a blocker in their own chapter and stay unreachable in the car
       // until HL-C17 reshapes the remaining wide tables.
@@ -808,8 +810,8 @@ describe("corpus regression", () => {
       // and the alphabetical fallback it replaced had been flattering this number by
       // putting eyes-needed lessons later than they really come. The real order is
       // worse, which is the measurement becoming honest, not the corpus regressing.
-      drivablePrefixTotal: 758,
-      fullyDrivableChapters: 297,
+      drivablePrefixTotal: 762,
+      fullyDrivableChapters: 298,
       unstartableChapters: 108,
       overriddenLessons: 0,
       lessonsWithoutChapter: 0,

--- a/code/packages/typescript/human-language-data/tests/narration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/narration.test.ts
@@ -608,7 +608,7 @@ describe("the whole corpus", () => {
     // 378, not the 375 this was authored against: HL-C39 and HL-C40 each added a
     // Chapter 1 (Mandarin Chinese and Japanese) while this branch waited to merge, and
     // the Latin core-verb chapter (chapter 37, eight verb lessons) added one more.
-    expect(chapters).toHaveLength(442);
+    expect(chapters).toHaveLength(443);
   });
 
   it("leaves no Markdown typography in the spoken script", () => {

--- a/lessons.md
+++ b/lessons.md
@@ -2895,3 +2895,31 @@ wrote six new patterns with the same flaw, and seven sites were hiding behind
 "this **whole** curriculum" / "this **single** course". When a guard grows, re-read
 the comments on the patterns already there — they are notes from the last person who
 got it wrong, and that was me.
+
+
+## Before authoring a lesson, read what the track already taught
+
+I wrote a four-lesson B1 chapter for Spanish. Two of the four re-taught material the
+book already owned, and I did not notice because I designed the chapter from the
+spine node downward instead of from the corpus upward.
+
+- The **imperfect** is taught in full at chapter 16, three irregulars and all, with
+  the same Latin-endings etymology I "introduced" at chapter 38.
+- **`luego`** is taught at chapter 5 inside *hasta luego*, with the same `locus`
+  etymology, as the atoms `ES-LEX-LUEGO` and `ES-ETYMON-LOCUS` — which my new lesson
+  re-introduced under new names, so `atomsTaught` counted the word twice.
+
+Neither is visible from the spine. Both are one grep away.
+
+**Rule:** before writing a lesson, grep the track for the headword AND for the
+concept, and read any lesson that already covers either. Then write the lesson for
+what is genuinely left — which is usually narrower, and better, than what you planned.
+Chapter 38's imperfect lesson went from "here is a tense" (wrong, and 22 chapters
+late) to "here is which of the two you already have to reach for" — the actual B1
+skill, and a smaller, truer step.
+
+**Corollary — a "you already own every word" claim is checkable, so check it.** The
+payoff story used five words the course teaches nowhere, printed directly under the
+sentence "every word is one you already own". The `forwardReferences` metric cannot
+catch this: its blind spot is vocabulary the corpus never teaches at all. Diff the
+story's words against the track's headword list by hand.


### PR DESCRIPTION
The B1–C2 spine landed with all 17 nodes declared as gaps in all 22 tracks. This realizes the first of them in one track, as a worked example: **"Telling What Happened"** — four lessons, one concept each, an etymological connection in every one.

| lesson | concept | what is actually new |
|---|---|---|
| `ES-C38-luego` | CONNECTIVE-THEN | the connective use of a word chapter 5 already gave you |
| `ES-C38-porque` | CONNECTIVE-BECAUSE | joining a reason to a claim |
| `ES-C38-imperfecto` | ASPECT-ONGOING-PAST | **not** the forms — scene versus event |
| `ES-C38-contar` | NARRATIVE-SEQUENCE | the synthesis: a four-sentence told story |

Spanish **`touches` B1** now; **`attained` is still null**, which is exactly the distinction the level gate exists to keep. Authoring a rung, then climbing one step of it, is still not attaining it.

## Two of the four lessons were re-teaching material the book already owned

Review caught both, and both are the same mistake: I designed the chapter from the spine node downward instead of from the corpus upward.

- **The imperfect is taught in full at chapter 16** — three irregulars, same Latin-endings etymology. My draft presented it as new, 22 chapters late. It now teaches the only thing that *is* new at B1: **which of the two pasts to reach for**. Chapter 16 is cited, reviewed and credited.
- **`luego` is taught at chapter 5**, inside *hasta luego*, with the same `locus` etymology, as atoms my draft re-introduced under new names. It now *requires* chapter 5's atoms and introduces only `ES-GRAMMAR-LUEGO-CONNECTIVE-01`.

Neither duplication is visible from the spine. Both were one grep away. That rule is now in `lessons.md`.

## The payoff claimed something checkable, and it was false

The story used five words the course teaches **nowhere** — *ventana*, *temprano*, *cada*, *hambre*, *historia* — printed directly beneath *"every word is one you already own"*. Rebuilt from taught vocabulary; the claim is now true. `forwardReferences` is structurally blind to this class: its blind spot is vocabulary the corpus never teaches at all.

## Four wrong etymologies

- *"`*kʷ-` **hardened** to `hw-`"* — Grimm's Law turns a stop into a fricative. That's softening, and it was the one sentence the lesson was built on.
- *"`que` ← `quid` / **`quod`**"* — `que` inherits `quid` and *usurps* `quod`'s roles without taking its form. The lesson's own recall answer already said `quid`.
- *"Knock the final consonant off each"* — false for `-ābās` → `-abas`, in the table three lines below.
- *"Two languages, **independently**"* — English *recount* and *account* are the same word Spanish inherited, via Old French. Only *tell* is a genuine parallel.

## The chapter reached the app but not the book

`core/book-generation.json` is a hand-maintained target list; narration and modality are corpus-driven and picked chapter 38 up automatically. So `check:books` passed over a book with no chapter 38. Target added, `book.tex` wired, `bookChapters` 442 → 443. The payoff also needed an explicit `assesses` list — without one the gate scored it **0/9** representative; it is now 8/9, the ninth being a writing-only distinction a spoken story cannot exercise.

## Two pin comments described the wrong cause

- **R1 +3 / R2 +10** was blamed on the final lesson's atoms. Wrong: of the +3 R1 exactly one is a chapter-38 atom, and of the +10 R2 none is. `continuity.ts` only judges a window that *fits*, so lengthening the track un-suppressed windows on chapters 36–37. Old debt becoming measurable, not new cost.
- **forwardReferences +6** — five are spirals from chapter 5 (*hasta luego*); the sixth, `ES-C10-practice`, is bare adverbial *luego*, a real 28-lesson-early leak reported identically. That is the severity split the metric's own comment has been asking for.

## Verification

396 tests pass. `check:books`, `check:narration`, `check:modality` clean. All four lessons are under the 5-minute ceiling and voice-drivable, so the B1 chapter is teachable entirely by ear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
