### PR TITLE
feat(human-language-data): Spanish chapter 41 — the second B1 rung (+ a book-manifest bug)

### DIFF
--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -2291,17 +2291,24 @@
     },
     {
       "language": "spanish",
-      "chapter": 38,
+      "chapter": 39,
       "title": "Bringing, Getting, Playing, Meeting",
       "label": "ch:spanish-bring-get-play-meet",
       "output": "spanish/book/chapters/ch39-bring-get-play-meet.tex"
     },
     {
       "language": "spanish",
-      "chapter": 39,
+      "chapter": 40,
       "title": "Waiting, Answering, Buying",
       "label": "ch:spanish-wait-answer-buy",
       "output": "spanish/book/chapters/ch40-wait-answer-buy.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 41,
+      "title": "Saying Why",
+      "label": "ch:spanish-giving-reasons",
+      "output": "spanish/book/chapters/ch41-giving-reasons.tex"
     },
     {
       "language": "tamil",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -2958,18 +2958,6 @@
     },
     {
       "language": "spanish",
-      "chapter": 38,
-      "sourceHash": "fnv1a64:c8ea6dde6af5f2dd",
-      "lessonIds": [
-        "ES-C38-luego",
-        "ES-C38-porque",
-        "ES-C38-imperfecto",
-        "ES-C38-contar"
-      ],
-      "tex": "spanish/book/chapters/ch39-bring-get-play-meet.tex"
-    },
-    {
-      "language": "spanish",
       "chapter": 39,
       "sourceHash": "fnv1a64:1734ff08f45ebaae",
       "lessonIds": [
@@ -2978,7 +2966,30 @@
         "ES-C39-jugar",
         "ES-C39-conocer"
       ],
+      "tex": "spanish/book/chapters/ch39-bring-get-play-meet.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 40,
+      "sourceHash": "fnv1a64:650e2d332d10835d",
+      "lessonIds": [
+        "ES-C40-esperar",
+        "ES-C40-contestar",
+        "ES-C40-comprar"
+      ],
       "tex": "spanish/book/chapters/ch40-wait-answer-buy.tex"
+    },
+    {
+      "language": "spanish",
+      "chapter": 41,
+      "sourceHash": "fnv1a64:2ba56f5f98a0e31a",
+      "lessonIds": [
+        "ES-C41-creer",
+        "ES-C41-asi-que",
+        "ES-C41-deber",
+        "ES-C41-explicar"
+      ],
+      "tex": "spanish/book/chapters/ch41-giving-reasons.tex"
     },
     {
       "language": "tamil",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -6124,6 +6124,23 @@
       "jsonHash": "fnv1a64:b0bae32827f8a1cb"
     },
     {
+      "language": "spanish",
+      "chapter": 41,
+      "sourceHash": "fnv1a64:aaf392ed71c29d4f",
+      "lessonIds": [
+        "ES-C41-creer",
+        "ES-C41-asi-que",
+        "ES-C41-deber",
+        "ES-C41-explicar"
+      ],
+      "voiceLessons": 4,
+      "drivablePrefix": 4,
+      "text": "spanish/narration/ch41.txt",
+      "json": "spanish/narration/ch41.json",
+      "textHash": "fnv1a64:cf2b639c3ae23d4e",
+      "jsonHash": "fnv1a64:c513701f04d28793"
+    },
+    {
       "language": "tamil",
       "chapter": 1,
       "sourceHash": "fnv1a64:fe3d3298ecc5bc3a",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,18 +7,18 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:91118e65c81835b4",
+  "sourceHash": "fnv1a64:9d4f556624b18a5c",
   "summary": {
-    "totalLessons": 1449,
-    "voice": 973,
+    "totalLessons": 1453,
+    "voice": 977,
     "sight": 423,
     "pen": 53,
-    "drivableLessons": 973,
+    "drivableLessons": 977,
     "drivablePercent": 67,
     "trackCount": 22,
-    "chapterCount": 451,
-    "drivablePrefixTotal": 790,
-    "fullyDrivableChapters": 306,
+    "chapterCount": 452,
+    "drivablePrefixTotal": 794,
+    "fullyDrivableChapters": 307,
     "unstartableChapters": 108,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
@@ -5907,12 +5907,12 @@
     },
     {
       "language": "spanish",
-      "lessonCount": 173,
-      "voice": 148,
+      "lessonCount": 177,
+      "voice": 152,
       "sight": 18,
       "pen": 7,
       "drivablePercent": 86,
-      "drivablePrefixTotal": 118,
+      "drivablePrefixTotal": 122,
       "modalities": [
         "voice",
         "sight",
@@ -6646,6 +6646,25 @@
             "ES-C40-esperar",
             "ES-C40-contestar",
             "ES-C40-comprar"
+          ]
+        },
+        {
+          "chapter": 41,
+          "lessonCount": 4,
+          "voice": 4,
+          "sight": 0,
+          "pen": 0,
+          "modalities": [
+            "voice"
+          ],
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "ES-C41-creer",
+            "ES-C41-asi-que",
+            "ES-C41-deber",
+            "ES-C41-explicar"
           ]
         }
       ]
@@ -31213,6 +31232,78 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:32c3212f61c32a32"
+    },
+    {
+      "id": "ES-C41-creer",
+      "language": "spanish",
+      "chapter": 41,
+      "sequence": 1880,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3ee4a04c90402814"
+    },
+    {
+      "id": "ES-C41-asi-que",
+      "language": "spanish",
+      "chapter": 41,
+      "sequence": 1890,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ed35ac545ee26f56"
+    },
+    {
+      "id": "ES-C41-deber",
+      "language": "spanish",
+      "chapter": 41,
+      "sequence": 1900,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:09df6b06ec0fe3c8"
+    },
+    {
+      "id": "ES-C41-explicar",
+      "language": "spanish",
+      "chapter": 41,
+      "sequence": 1910,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:46ebaea1981bf7f9"
     },
     {
       "id": "TA-W01-curves-va-ka",

--- a/code/learning/human-languages/spanish/book/book.tex
+++ b/code/learning/human-languages/spanish/book/book.tex
@@ -124,6 +124,7 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch38-narrating}
 \input{chapters/ch39-bring-get-play-meet}
 \input{chapters/ch40-wait-answer-buy}
+\input{chapters/ch41-giving-reasons}
 
 \backmatter
 

--- a/code/learning/human-languages/spanish/book/chapters/ch39-bring-get-play-meet.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch39-bring-get-play-meet.tex
@@ -1,261 +1,124 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:c8ea6dde6af5f2dd
-% canonical-lessons: ES-C38-luego, ES-C38-porque, ES-C38-imperfecto, ES-C38-contar
+% canonical-source-hash: fnv1a64:1734ff08f45ebaae
+% canonical-lessons: ES-C39-traer, ES-C39-conseguir, ES-C39-jugar, ES-C39-conocer
 
 \chapter{Bringing, Getting, Playing, Meeting}
 \label{ch:spanish-bring-get-play-meet}
 
 \begin{chapteropening}
-\textbf{By the end of this chapter:} \emph{I can tell a short connected story about something that happened — ordering the events with luego, giving a reason with porque, and choosing the imperfect for the scene and the preterite for the events.}
+\textbf{By the end of this chapter:} \emph{I can say I bring, get, play and meet in Spanish, and name what each verb does to its yo-form or its stem: traigo grows a hard g, consigo breaks e to i and drops a silent u, juego breaks u to ue alone in the language, and conozco keeps a cluster the other forms lost.}
 
-Tell a four-sentence story out loud: Llovía. Me levanté, luego bebí café. No corrí, porque llovía mucho. Me senté y leí. Every word in it has been taught in this book, and the two pasts divide the work between scene and event.
+Run the chapter's four verbs in the yo-form — traigo, consigo, juego, conozco — and say what each one does to itself, then name its Latin root and what that root meant: trahere to drag, cōnsequī to follow, iocārī to joke, cognōscere to begin to know. Choose conocer for a person and saber for a fact, and say which of the four carries a thing toward you rather than away. The chapter also reaches back for oigo, the yo-form that first grew a hard g, and for padre beside English father, the model for saying that Spanish and English words can be siblings rather than borrowings.
 \end{chapteropening}
 
-\section[luego]{luego — a word you already have, doing a job you have not seen it do}
+\section[traer]{traer — \textquotedblleft{}to bring\textquotedblright{}, and the direction baked into it}
 
-\label{lesson:ES-C38-luego}
+\label{lesson:ES-C39-traer}
 
 
 
 \begin{quote}
-Nothing new to learn here — you have said \textbf{luego} every time you said \emph{hasta luego}. What is new is that it can stand alone, between two events, and put them in order.
+\emph{Me levanto}, and now \emph{estoy de pie}. Up, and carrying something. The verb for that has a direction inside it that English leaves open.
 \end{quote}
 
 \begin{sounds}
 \begin{itemize}
 \raggedright
-  \item \texttt{diphthong-ue} — \emph{ue} is one glide, not two syllables.
-  \item \texttt{g-soft-gw} — between vowels the \emph{g} softens; \textbf{luego} is \emph{LWEH-gho}, not the hard stop English puts in \emph{go}.
+  \item \texttt{r-tap} — one flick of the tongue: \emph{tra-ER}, two beats.
+  \item \texttt{g-hard} — the \emph{g} of \emph{traigo} is hard, as in English \emph{go}.
 \end{itemize}
 \end{sounds}
 
 \begin{cousinweb}
-You already know where it comes from: Latin \textbf{locō}, the ablative of \emph{\textbf{locus}}, \textquotedblleft{}place\textquotedblright{} — \textquotedblleft{}in that place\textquotedblright{}, a word about \emph{where} that slid into a word about \emph{when}. That is why \emph{hasta luego} is \textquotedblleft{}until later\textquotedblright{}.
+\textbf{traer} (\textquotedblleft{}\textbf{to bring}\textquotedblright{}) $\leftarrow$ Latin \textbf{trahere}, \textquotedblleft{}\textbf{to drag, to pull}\textquotedblright{}. Bringing started out as hauling.
 
-What you have not been shown is how much else \emph{locus} is holding up. It gives \textbf{local}, \textbf{locate}, \textbf{location}, \textbf{locus}, \textbf{allocate}, \textbf{dislocate}. And through French \emph{lieu}, \textquotedblleft{}place\textquotedblright{}, it gives \textbf{lieutenant} — literally the officer \emph{holding the place} of another.
+Latin built a second stem, \emph{tract-}, and English helped itself to both: \textbf{tractor}, \textbf{traction}, \textbf{attract}, \textbf{contract}, \textbf{subtract}, \textbf{extract}, \textbf{distract}, \textbf{retract} — and \textbf{abstract}, \emph{abs-} + \emph{trahere}, something \textquotedblleft{}dragged away\textquotedblright{} from anything particular.
 
-\begin{quote}
-\textbf{A leftover worth knowing.} \emph{\textbf{Desde luego}} means \textquotedblleft{}of course\textquotedblright{}. It was built on an older sense of \emph{luego}, \textquotedblleft{}\textbf{immediately}\textquotedblright{}, so its literal force was nearer \textquotedblleft{}from this moment on\textquotedblright{}. The bare word has since drifted to \textquotedblleft{}later\textquotedblright{}; the phrase kept the old sense.
-\end{quote}
+Then the worn-down half, through French: \textbf{trace}, \textbf{train} (what is dragged along behind), \textbf{trail}, \textbf{portray} $\leftarrow$ \emph{prōtrahere}, \textquotedblleft{}to draw forth\textquotedblright{}, and \textbf{retreat} $\leftarrow$ \emph{retrahere}, \textquotedblleft{}to draw back\textquotedblright{}.
 \end{cousinweb}
 
-\begin{grammarlens}[title={Grammar Lens: luego between two events}]
-Out of the farewell, \emph{luego} is not glued to a verb. It marks the join between two events and sits at the front of the second:
-
-\noindent
-\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
-\toprule
-\textbf{} & \textbf{} \\
-\midrule
-Me siento. \textbf{Luego} leo. & I sit down. \textbf{Then} I read. \\
-Bebo café y \textbf{luego} escribo. & I drink coffee and \textbf{then} I write. \\
-Me levanto \textbf{y luego} corro. & I get up \textbf{and then} I run. \\
-\bottomrule
-\end{tabularx}
-
-Two events, in order, with one word doing the ordering — and it is a word you have been saying since chapter five.
-\end{grammarlens}
-
-\subsection*{Your turn}
-Say these aloud:
-
-\begin{itemize}
-\raggedright
-  \item \textquotedblleft{}hasta luego\textquotedblright{} then just \textquotedblleft{}luego\textquotedblright{} — same word, standing alone
-  \item \textquotedblleft{}Me siento. Luego leo.\textquotedblright{}
-  \item \textquotedblleft{}Me levanto y luego corro.\textquotedblright{}
-  \item \textquotedblleft{}luego\textquotedblright{} then English \textquotedblleft{}local, locate, lieutenant\textquotedblright{}
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-What job does \emph{luego} do here that it does not do in \emph{hasta luego}? (It \textbf{joins two events in order}, instead of sitting inside a fixed farewell.) Which English officer's title hides the same \emph{locus}? (\textbf{Lieutenant} — the one holding another's place.) Which older sense of \emph{luego} is frozen inside \emph{desde luego}? (\textbf{Immediately} — not \textquotedblleft{}later\textquotedblright{}.)
-\end{tcolorbox}
-\section[porque]{porque — \textquotedblleft{}because\textquotedblright{}, and the reason a sequence turns into a story}
-
-\label{lesson:ES-C38-porque}
-
-
-
-\begin{quote}
-With \emph{luego} you can put two events in order. But order is not yet a story. \emph{I sat down, then I read} tells nobody \textbf{why}. One more word closes that gap, and it is two words wearing a single coat.
-\end{quote}
-
-\begin{sounds}
-\begin{itemize}
-\raggedright
-  \item \texttt{k-hard} — \emph{qu} before \emph{e} is a plain \emph{k}; the \emph{u} is silent. \textbf{porque} = \emph{POR-keh}.
-  \item \texttt{r-tap} — a single flick of the tongue, not the rolled \emph{rr}.
-\end{itemize}
-\end{sounds}
-
-\begin{cousinweb}
-\textbf{porque} = \textbf{por} + \textbf{que}, fused.
-
-\textbf{por} descends from Latin \emph{\textbf{prō}}, \textquotedblleft{}for, in front of, on behalf of\textquotedblright{} — the same \emph{prō} standing at the front of \textbf{pro}vide, \textbf{pro}ceed, \textbf{pro}tect, \textbf{pro}pose, and surviving whole in the English phrase \emph{quid \textbf{pro} quo}.
-
-\textbf{que} descends from Latin \emph{\textbf{quid}}, \textquotedblleft{}what\textquotedblright{} — and then quietly took over every job Latin had given \emph{\textbf{quod}}, without taking its form.
-
-And this is the good part. That Latin \emph{qu-} is one branch of the Proto-Indo-European interrogative root \emph{\textbf{*k\textsuperscript{w}o-}}. The other branch went into Germanic, where \emph{*k\textsuperscript{w}-} softened to \emph{hw-} — Grimm's Law turning a stop into a breath — and came out as English \textbf{who}, \textbf{what}, \textbf{when}, \textbf{where}, \textbf{why}.
-
-So Spanish \emph{que} and English \emph{what} are not borrowed from one another. They are \textbf{siblings} — the same ancient question-word, walked down two different roads. \emph{Quid pro quo} puts both Latin halves of \emph{porque} side by side in an English sentence.
-\end{cousinweb}
-
-\begin{grammarlens}[title={Grammar Lens: porque, por qué, el porqué}]
-Three spellings, three jobs, and they are genuinely distinct in writing:
-
-\noindent
-\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
-\toprule
-\textbf{written} & \textbf{stress} & \textbf{job} \\
-\midrule
-\textbf{porque} & one word, no accent & \textbf{because} — gives the reason \\
-\textbf{por qué} & two words, accent on \emph{qué} & \textbf{why} — asks for the reason \\
-\textbf{el porqué} & one word, accent, with \emph{el} & \textbf{the reason} — a noun \\
-\bottomrule
-\end{tabularx}
-
-\emph{¿\textbf{Por qué} te levantas?} — \textbf{Why} do you get up? \emph{Me levanto \textbf{porque} corro.} — I get up \textbf{because} I run. \emph{No entiendo \textbf{el porqué}.} — I don't understand \textbf{the reason}.
-
-The accent is not decoration. It marks \emph{qué} as the questioning one, exactly as it does on other question words.
-\end{grammarlens}
-
-\subsection*{Your turn}
-Say these aloud:
-
-\begin{itemize}
-\raggedright
-  \item \textquotedblleft{}porque\textquotedblright{} — \emph{POR-keh}, silent \emph{u}
-  \item \textquotedblleft{}Me siento porque leo.\textquotedblright{} — I sit down because I read.
-  \item \textquotedblleft{}Me levanto y luego corro, porque hace sol.\textquotedblright{}
-  \item the three shapes — \textquotedblleft{}porque, por qué, el porqué\textquotedblright{}
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-What two Latin words are fused inside \emph{porque}? (\emph{\textbf{prō}} and \emph{\textbf{quid}}.) Are Spanish \emph{que} and English \emph{what} parent and child, or siblings? (\textbf{Siblings} — Latin \emph{qu-} and Germanic \emph{wh-} from one root, \emph{\textbf{*k\textsuperscript{w}o-}}.) Which of the three spellings asks a question? (\emph{\textbf{Por qué}} — two words, accent on \emph{qué}.)
-\end{tcolorbox}
-\section[llovía / llovió]{llovía / llovió — the same rain, told two ways}
-
-\label{lesson:ES-C38-imperfecto}
-
-
-
-\begin{quote}
-You already have both past tenses. The imperfect — \emph{hablaba}, \emph{comía} — came in chapter sixteen, with its three irregulars. Nothing here is a new form. What is new is \textbf{which one to reach for}, and that turns out to be the whole trick of telling a story.
-\end{quote}
-
-\begin{sounds}
-\begin{itemize}
-\raggedright
-  \item \texttt{double-l-y} — \emph{ll} is a \emph{y} glide: \textbf{llovía} = \emph{yo-VEE-a}.
-  \item \texttt{accent-i} — the accent splits the vowels: \emph{llo-VÍ-a}, three beats.
-\end{itemize}
-\end{sounds}
-
-\begin{cousinweb}
-The name is the lesson, and it is worth having.
-
-\textbf{Imperfecto} is Latin \emph{\textbf{imperfectus}}: \emph{\textbf{in-}} (\textquotedblleft{}not\textquotedblright{}) plus \emph{\textbf{perfectus}}, \textquotedblleft{}carried all the way through\textquotedblright{} — itself \emph{\textbf{per-}} (\textquotedblleft{}through\textquotedblright{}) plus \emph{\textbf{facere}} (\textquotedblleft{}to do, to make\textquotedblright{}). That \emph{facere} is everywhere in English: \textbf{fact}, \textbf{factory}, \textbf{effect}, \textbf{manufacture}, and \textbf{perfect} itself, which still means \emph{finished through}.
-
-So the imperfect is the \textbf{not-carried-through} tense. Not unfinished in quality — unfinished in \emph{time}. It shows an action still running, with no edge on it. That is not a label bolted on afterwards; it is a description of the job.
-\end{cousinweb}
-
-\begin{grammarlens}[title={Grammar Lens: the scene and the events}]
-Take one fact — it rained — and watch the tense decide what \emph{kind} of fact it is:
-
-\noindent
-\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
-\toprule
-\textbf{} & \textbf{} \\
-\midrule
-\textbf{Llovía.} & It was raining. \emph{(no edge — the weather that day)} \\
-\textbf{Llovió.} & It rained. \emph{(edged — a thing that happened)} \\
-\bottomrule
-\end{tabularx}
-
-Neither is more correct. They answer different questions. A told story needs both, in a division of labour that never varies:
-
-\begin{quote}
-The \textbf{imperfect paints the scene} — what was going on, what things were like. The \textbf{preterite drops the events into it} — what then happened.
-\end{quote}
-
-\emph{Llovía. Luego me levanté.} — It was raining \emph{(scene)}. Then I got up \emph{(event)}.
-
-English has no separate form for this, which is the only reason it feels hard. English leans on \emph{was ‑ing} and \emph{used to} and lets context carry the rest. Spanish decided it once, in the ending.
-\end{grammarlens}
-
-\subsection*{Your turn}
-Say these aloud:
-
-\begin{itemize}
-\raggedright
-  \item the pair — \textquotedblleft{}llovía\textquotedblright{} then \textquotedblleft{}llovió\textquotedblright{}
-  \item scene, then event — \textquotedblleft{}Llovía. Luego me levanté.\textquotedblright{}
-  \item \textquotedblleft{}No corrí, porque llovía.\textquotedblright{} — the reason is a scene, the running an event
-  \item \textquotedblleft{}Comía pan porque llovía.\textquotedblright{}
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-What does \emph{imperfectus} literally say, and which English word shares its second half? (\textbf{Not carried through}; \textbf{perfect} — and \emph{fact}, \emph{factory}.) In a story, which tense paints the background and which drops in the events? (\textbf{Imperfect} paints; \textbf{preterite} drops in.) Which of \emph{llovía} and \emph{llovió} has an edge on it? (\emph{\textbf{Llovió}} — a thing that happened.)
-\end{tcolorbox}
-\section[contar]{contar — to tell a story, which is also to count it up}
-
-\label{lesson:ES-C38-contar}
-
-
-
-\begin{quote}
-Three pieces are in your hands: \emph{luego} to order events, \emph{porque} to explain them, the imperfect to hold the background still. This lesson adds no fourth piece — it puts the three together, under the verb that names the act.
-\end{quote}
-
-\begin{sounds}
-\begin{itemize}
-\raggedright
-  \item \texttt{diphthong-ue} — the stem breaks under stress: \textbf{cuento} = \emph{KWEN-to}, but \textbf{contamos} stays plain.
-  \item \texttt{k-hard} — \emph{c} before \emph{o} is a hard \emph{k}.
-\end{itemize}
-\end{sounds}
-
-\begin{cousinweb}
-\textbf{contar} means \textbf{to count} — and \textbf{to tell a story}. One verb, both jobs, and not a pun.
-
-It descends from Latin \emph{\textbf{computāre}}, \textquotedblleft{}to reckon up\textquotedblright{}: \emph{\textbf{com-}} (\textquotedblleft{}together\textquotedblright{}) plus \emph{\textbf{putāre}}, which meant \textquotedblleft{}to prune\textquotedblright{}, then \textquotedblleft{}to settle an account\textquotedblright{}, then simply \textquotedblleft{}to reckon\textquotedblright{}. \emph{Putāre} gives \textbf{amputate}, \textbf{dispute}, \textbf{deputy}; \emph{computāre} gives \textbf{count}, \textbf{compute}, \textbf{account}.
-
-English carries the same double sense — to \textbf{recount} an event, to give an \textbf{account} of yourself — but those are the very same word, borrowed through Old French from \emph{computāre}. Spanish's relatives, not an independent echo.
-
-The independent echo is \textbf{tell}: Germanic, unrelated, and it \emph{also} once meant \textquotedblleft{}to count\textquotedblright{} — hence a bank \textbf{teller}, and \emph{all told}. Two unrelated languages, one thought: \textbf{a story is a reckoning-up of events in order.}
-\end{cousinweb}
-
-\begin{grammarlens}[title={Grammar Lens: the backbone of a told story}]
-\emph{Contar} breaks \emph{o} to \emph{ue} under stress:
-
+\begin{grammarlens}[title={Grammar Lens: the hard g, for the second time}]
 \noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
 \textbf{person} & \textbf{form} \\
 \midrule
-yo & \textbf{cuento} \\
-tú & \textbf{cuentas} \\
-él/ella/usted & \textbf{cuenta} \\
-nosotros & \textbf{contamos} \\
-ellos/ustedes & \textbf{cuentan} \\
+yo & \textbf{traigo} \\
+tú & \textbf{traes} \\
+él/ella/usted & \textbf{trae} \\
+nosotros & \textbf{traemos} \\
+ellos/ustedes & \textbf{traen} \\
 \bottomrule
 \end{tabularx}
 
-Here is the shape of a told story:
+\emph{Oír} grew a hard \textbf{-g-} in \emph{oigo} and nowhere else in its present. \emph{Traer} does the identical thing: \textbf{traigo}, and then four ordinary \emph{-er} endings. One club, two members so far, and neither one announces itself.
+\end{grammarlens}
+
+\begin{culture}
+English lets one verb wander: \emph{bring me the bread}, \emph{bring it to the café} — same word, opposite journeys. Spanish will not.
+
+\textbf{Traer} moves a thing \textbf{toward you}. \textbf{Llevar} moves it \textbf{away}. \emph{Traigo el pan} is the bread arriving here; \emph{llevo el pan} is the bread leaving with me. You choose by where you are standing, never by what you are carrying.
+
+And \textbf{llevar} $\leftarrow$ Latin \textbf{levāre}, \textquotedblleft{}to raise\textquotedblright{} — the verb already behind \emph{levantarse}. To carry a load was first to lift it.
+\end{culture}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}traigo, traes, trae, traemos, traen\textquotedblright{}
+  \item \textquotedblleft{}Traigo el pan\textquotedblright{} then \textquotedblleft{}Llevo el pan\textquotedblright{} — here, then away
+  \item \textquotedblleft{}oigo\textquotedblright{} then \textquotedblleft{}traigo\textquotedblright{} — the same hard g
+  \item \textquotedblleft{}traer\textquotedblright{} then English \textquotedblleft{}tractor, attract, abstract\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which way does \emph{traer} carry a thing, and which verb goes the other way? (\textbf{Toward you}; \emph{llevar}.) What did \emph{trahere} mean, and name two English words from it. (\textbf{To drag}; \emph{tractor, attract, abstract, retreat}.) Which form of \emph{traer} misbehaves, and which verb showed you that same misbehaviour first? (\textbf{Traigo}; \emph{oigo}.) And say you are standing. (\emph{Estoy de pie}.)
+\end{tcolorbox}
+\section[conseguir]{conseguir — \textquotedblleft{}to get\textquotedblright{}, by following a thing until you have it}
+
+\label{lesson:ES-C39-conseguir}
+
+
 
 \begin{quote}
-\textbf{Llovía}. Me \textbf{levanté}, \textbf{luego} \textbf{bebí} café. No \textbf{corrí}, \textbf{porque} \textbf{llovía} mucho. Me \textbf{senté} y \textbf{leí}.
+\emph{Traigo} carries a thing that is already yours. \emph{Coger} grabs what is in front of you. This verb is for the getting that took some work.
 \end{quote}
 
->
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{g-hard} — the \emph{gu} in \emph{conseguir} is one hard \emph{g}; the \emph{u} is silent.
+  \item \texttt{s-clear} — a clean hissing \emph{s}: \emph{con-se-GEER}.
+\end{itemize}
+\end{sounds}
 
-\begin{quote}
-\emph{It was raining. I got up, then I drank coffee. I didn't run, because it was raining hard. I sat down and read.}
-\end{quote}
+\begin{cousinweb}
+\textbf{conseguir} (\textquotedblleft{}\textbf{to get, to obtain, to manage to}\textquotedblright{}) $\leftarrow$ Latin \textbf{cōnsequī}: \emph{com-} (\textquotedblleft{}along with\textquotedblright{}) + \textbf{sequī}, \textquotedblleft{}\textbf{to follow}\textquotedblright{}. You got a thing by following it until it was yours.
 
-Watch the two pasts divide the work. \emph{\textbf{Llovía}} — imperfect, holding the scene still. \emph{\textbf{Me levanté\emph{, }bebí\emph{, }me senté\emph{, }leí}} — preterite, dropping events in. \emph{Luego} orders them; \emph{porque} explains one.
+\emph{Sequī} is one of Latin's great English suppliers: \textbf{sequence}, \textbf{sequel}, \textbf{consequence}, \textbf{subsequent}, \textbf{consecutive}; \textbf{second}, from \emph{secundus}, \textquotedblleft{}the one following\textquotedblright{}; \textbf{execute} and \textbf{prosecute}; \textbf{obsequious}, following someone about; and through French, \textbf{pursue}, \textbf{ensue} and \textbf{suit}.
 
-That is a narration, and every word in it is one this book has taught you.
+Spanish also keeps the formal partner \textbf{obtener} $\leftarrow$ \emph{obtinēre}, \textquotedblleft{}to hold onto\textquotedblright{} — English \textbf{obtain}. It behaves exactly like \emph{tener}, so its \emph{yo}-form is \emph{obtengo}. \emph{Conseguir} is the everyday one.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the third crack, and a silent u that leaves}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{person} & \textbf{form} \\
+\midrule
+yo & \textbf{consigo} \\
+tú & \textbf{consigues} \\
+él/ella/usted & \textbf{consigue} \\
+nosotros & \textbf{conseguimos} \\
+ellos/ustedes & \textbf{consiguen} \\
+\bottomrule
+\end{tabularx}
+
+You have met \emph{dormir} breaking \textbf{o$\to$ue} and \emph{pido} quietly breaking \textbf{e$\to$i}. Here is that third pattern in full: stress on the stem turns \emph{e} into \emph{i}, and \emph{conseguimos} stays plain because the stress moved to the ending.
+
+Now the spelling. Spanish writes \emph{gu} only to keep a \emph{g} hard in front of \emph{e} and \emph{i}. Once the \emph{e} becomes \emph{i}, there is nothing in front to guard against, so the \emph{u} has no job and goes: \textbf{consigo}, not \emph{consiguo}. Two changes, one form, and only one of them is a sound.
 \end{grammarlens}
 
 \subsection*{Your turn}
@@ -263,13 +126,130 @@ Say these aloud:
 
 \begin{itemize}
 \raggedright
-  \item \textquotedblleft{}cuento, cuentas, cuenta, contamos, cuentan\textquotedblright{}
-  \item \textquotedblleft{}Cuento hasta cinco.\textquotedblright{} — I count to five. Same verb.
-  \item the scene, then the event — \textquotedblleft{}Llovía. Luego me levanté.\textquotedblright{}
-  \item the whole thing — \textquotedblleft{}Llovía. Me levanté, luego bebí café. No corrí, porque llovía mucho.\textquotedblright{}
-  \item \textquotedblleft{}contar\textquotedblright{} then English \textquotedblleft{}count, account, recount, teller\textquotedblright{}
+  \item \textquotedblleft{}consigo, consigues, consigue, conseguimos, consiguen\textquotedblright{}
+  \item \textquotedblleft{}Traigo el café\textquotedblright{} then \textquotedblleft{}Consigo el café\textquotedblright{} — carried, then obtained
+  \item \textquotedblleft{}sequī, sequence, second\textquotedblright{} then \textquotedblleft{}conseguir\textquotedblright{}
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-\emph{Contar} does two jobs — which two, and what Latin verb explains both? (\textbf{Count} and \textbf{tell}; \emph{\textbf{computāre}}, \textquotedblleft{}to reckon up\textquotedblright{}.) Which English word carries the same double sense? (\textbf{Recount} — or \emph{an account}; and \emph{tell} itself, as in a bank \emph{teller}.) In your story, which tense held the rain and which one poured the coffee? (\textbf{Imperfect} \emph{llovía}; \textbf{preterite} \emph{bebí}.) Name the two joining words you used. (\emph{\textbf{Luego}} for order, \emph{\textbf{porque}} for reason.)
+What did \emph{sequī} mean, and name two English words from it. (\textbf{To follow}; \emph{sequence, second, consequence, pursue}.) Why is it \emph{consigo} and not \emph{consiguo}? (The \emph{u} only guards a hard \emph{g} before \emph{e} and \emph{i}.) Name the three stem cracks you now have, with a verb for each. (\emph{Cerrar} \textbf{e$\to$ie}, \emph{dormir} \textbf{o$\to$ue}, \emph{conseguir} \textbf{e$\to$i}.) And which Latin verb is behind \emph{traer}? (\textbf{Trahere}.)
+\end{tcolorbox}
+\section[jugar]{jugar — \textquotedblleft{}to play\textquotedblright{}, and the only verb of its kind}
+
+\label{lesson:ES-C39-jugar}
+
+
+
+\begin{quote}
+\emph{Consigo} cracked its \emph{e} to \emph{i}. Here is a verb that cracks a vowel no other verb in Spanish cracks — and it started life as a joke.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{j-jota} — the \emph{j} is scraped at the back of the throat: \emph{khoo-GAR}.
+  \item \texttt{diphthong-ue} — \emph{juego} is three beats, \emph{KHWE-go}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{jugar} (\textquotedblleft{}\textbf{to play}\textquotedblright{}) $\leftarrow$ Latin \textbf{iocārī}, \textquotedblleft{}\textbf{to joke, to jest}\textquotedblright{}, built on the noun \textbf{iocus}, \textquotedblleft{}a joke\textquotedblright{}. Playing and joking were one word, and Spanish kept the joking one for both.
+
+English holds \emph{iocus} in several shapes: \textbf{joke}; through French \textbf{jocular}; \textbf{juggler}, from \emph{ioculātor}, an entertainer; and \textbf{jeopardy}, from Old French \emph{jeu parti}, \textquotedblleft{}an evenly divided game\textquotedblright{} — a position so balanced that either side might lose. The Spanish family stays close: \textbf{el juego}, a game; \textbf{el juguete}, a toy.
+\end{cousinweb}
+
+\begin{culture}
+Latin's ordinary word for playing was \textbf{lūdere}, and Spanish dropped it exactly as it dropped \emph{claudere} for shutting doors. English kept the whole family instead: \textbf{illusion}, \textbf{allude}, \textbf{elude}, \textbf{delude}, \textbf{collude}, \textbf{prelude}, \textbf{interlude}, \textbf{ludicrous}.
+
+\emph{Claudere} and \emph{lūdere} tell one story: the large English family belongs to the Latin verb Spanish walked away from.
+\end{culture}
+
+\begin{grammarlens}[title={Grammar Lens: the fourth crack, with one member}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{person} & \textbf{form} \\
+\midrule
+yo & \textbf{juego} \\
+tú & \textbf{juegas} \\
+él/ella/usted & \textbf{juega} \\
+nosotros & \textbf{jugamos} \\
+ellos/ustedes & \textbf{juegan} \\
+\bottomrule
+\end{tabularx}
+
+\emph{Dormir} breaks \textbf{o$\to$ue}. \emph{Jugar} breaks \textbf{u$\to$ue}, and it is the \textbf{only verb in Spanish that does}: the \emph{o} of \emph{iocārī} had already slid irregularly to \emph{u}, so the crack landed on a vowel no other verb offers. \emph{Jugamos} stays plain, because the stress moves to the ending.
+
+One more habit: Spanish plays \textbf{at} a thing rather than simply playing it. \emph{El fútbol} is football, and you say \emph{juego \textbf{al} fútbol}, with \emph{a} + \emph{el} fused into \emph{al}. With a companion rather than a game it is \emph{con}: \emph{juego con el perro}, I play with the dog.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}juego, juegas, juega, jugamos, juegan\textquotedblright{}
+  \item \textquotedblleft{}Juego con el perro\textquotedblright{}
+  \item \textquotedblleft{}duermo\textquotedblright{} then \textquotedblleft{}juego\textquotedblright{} — o to ue, then u to ue
+  \item \textquotedblleft{}iocus, joke, jocular, juggler\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What did \emph{iocārī} mean, and which English words carry it? (\textbf{To joke}; \emph{joke, jocular, juggler, jeopardy}.) What is unusual about \emph{juego} among Spanish verbs? (\textbf{U$\to$ue}, and no other verb does it.) Which two Latin verbs did Spanish drop while English kept their families? (\emph{Claudere} and \emph{lūdere}.) And which vowel does \emph{conseguir} break? (\textbf{E to i}.)
+\end{tcolorbox}
+\section[conocer]{conocer — \textquotedblleft{}to meet\textquotedblright{}, because knowing has a first moment}
+
+\label{lesson:ES-C39-conocer}
+
+
+
+\begin{quote}
+\emph{Juego} — the one \emph{u$\to$ue} in the language. Now the chapter's last verb, and its oddity is not in the vowel but in what the word means.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{soft-c} — \emph{conoces} has a soft second \emph{c}: a \emph{th} in Spain, an \emph{s} elsewhere.
+  \item \texttt{k-hard} — but \emph{conozco} is \emph{ko-NOTH-ko}, soft then hard, back to back.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{conocer} $\leftarrow$ Latin \textbf{cognōscere}, \emph{com-} + \emph{(g)nōscere}. Its \emph{-sc-} is Latin's \textbf{\textquotedblleft{}begin to\textquotedblright{} marker}, so \emph{nōscere} was never \textquotedblleft{}to know\textquotedblright{} — it was \textquotedblleft{}\textbf{to come to know}\textquotedblright{}. Latin said \emph{nōvī}, \textquotedblleft{}I have come to know\textquotedblright{}, for actually knowing a thing.
+
+Spanish built its verb from the \emph{beginning} half. That is the whole lesson: \emph{conocer a alguien} is \textbf{to meet} someone, and Spanish puts a small \textbf{a} before a person who is the object — \emph{conozco a María}.
+
+The root fills English: \textbf{cognition}, \textbf{recognize}, \textbf{incognito}, and through French \textbf{notice}, \textbf{notion}, \textbf{notorious} and \textbf{noble}, \textquotedblleft{}the knowable one\textquotedblright{}. English \textbf{know} and \textbf{ken} are its Germanic siblings — the same standing that \emph{padre} has beside English \emph{father}, neither one borrowed from the other.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: conocer and saber}]
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{what you know} & \textbf{verb} \\
+\midrule
+a person, a city, a book & \textbf{conocer} \\
+a fact, or how to do something & \textbf{saber} \\
+\bottomrule
+\end{tabularx}
+
+English says \emph{know} for both. Spanish will not: \textbf{conocer} is being \textbf{acquainted} — you have met the thing. \textbf{Saber} is having the information. \emph{Conozco Madrid} means I have been there; \emph{sé dónde está} means I have the fact.
+
+The \emph{yo}-form keeps a hard cluster the rest lost: \textbf{conozco, conoces, conoce, conocemos, conocen}. Every \emph{-cer} verb after a vowel does the same, and it is a third kind of odd \emph{yo}-form beside \emph{traigo} and \emph{oigo}.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}conozco, conoces, conoce, conocemos, conocen\textquotedblright{}
+  \item \textquotedblleft{}Conozco a María\textquotedblright{} then \textquotedblleft{}Conozco Madrid\textquotedblright{}
+  \item \textquotedblleft{}traigo, consigo, juego, conozco\textquotedblright{} — the chapter's four \emph{yo}-forms
+  \item \textquotedblleft{}padre, father\textquotedblright{} then \textquotedblleft{}conocer, know\textquotedblright{} — siblings, not borrowings
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say the chapter's four verbs in the \emph{yo}, then say what each one does to itself. (\emph{Traigo} grows a hard \emph{g}; \emph{consigo} breaks \emph{e$\to$i} and loses a silent \emph{u}; \emph{juego} breaks \emph{u$\to$ue}, alone in the language; \emph{conozco} keeps a hard cluster.) Name their four Latin roots and what each meant. (\textbf{Trahere} to drag, \textbf{cōnsequī} to follow, \textbf{iocārī} to joke, \textbf{cognōscere} to begin to know.) Which verb do you use for a person, and which for a fact? (\emph{Conocer}; \emph{saber}.) And which of the four moves a thing toward you? (\emph{Traer} — \emph{llevar} goes away.)
 \end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch40-wait-answer-buy.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch40-wait-answer-buy.tex
@@ -1,65 +1,161 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:1734ff08f45ebaae
-% canonical-lessons: ES-C39-traer, ES-C39-conseguir, ES-C39-jugar, ES-C39-conocer
+% canonical-source-hash: fnv1a64:650e2d332d10835d
+% canonical-lessons: ES-C40-esperar, ES-C40-contestar, ES-C40-comprar
 
 \chapter{Waiting, Answering, Buying}
 \label{ch:spanish-wait-answer-buy}
 
 \begin{chapteropening}
-\textbf{By the end of this chapter:} \emph{I can say I bring, get, play and meet in Spanish, and name what each verb does to its yo-form or its stem: traigo grows a hard g, consigo breaks e to i and drops a silent u, juego breaks u to ue alone in the language, and conozco keeps a cluster the other forms lost.}
+\textbf{By the end of this chapter:} \emph{I can say I wait, answer and buy in Spanish — three verbs whose endings never surprise me — and I know that esperar alone carries wait, hope and expect, so context does the work English hands to three separate verbs.}
 
-Run the chapter's four verbs in the yo-form — traigo, consigo, juego, conozco — and say what each one does to itself, then name its Latin root and what that root meant: trahere to drag, cōnsequī to follow, iocārī to joke, cognōscere to begin to know. Choose conocer for a person and saber for a fact, and say which of the four carries a thing toward you rather than away. The chapter also reaches back for oigo, the yo-form that first grew a hard g, and for padre beside English father, the model for saying that Spanish and English words can be siblings rather than borrowings.
+Run espero, contesto and compro — three verbs that break nothing, whose whole difficulty is meaning — and give each root and its sense: spērāre to hope, contestārī to call witnesses, comparāre to procure. Refuse the lookalike: English compare descends from a different Latin comparāre built on compār, so it is not a relative. Then buy — compro el pan, el vino y un café, por favor — and reach back for what pānis gave compañero, which English words vīnum reached, why café is masculine, and what por favor says word for word.
 \end{chapteropening}
 
-\section[traer]{traer — \textquotedblleft{}to bring\textquotedblright{}, and the direction baked into it}
+\section[esperar]{esperar — one verb for waiting, hoping and expecting}
 
-\label{lesson:ES-C39-traer}
+\label{lesson:ES-C40-esperar}
 
 
 
 \begin{quote}
-\emph{Me levanto}, and now \emph{estoy de pie}. Up, and carrying something. The verb for that has a direction inside it that English leaves open.
+Four verbs that each did something odd to themselves — \emph{juego} the strangest of them. Here is one that does nothing odd at all, and is still the hardest word in these two chapters.
 \end{quote}
 
 \begin{sounds}
 \begin{itemize}
 \raggedright
-  \item \texttt{r-tap} — one flick of the tongue: \emph{tra-ER}, two beats.
-  \item \texttt{g-hard} — the \emph{g} of \emph{traigo} is hard, as in English \emph{go}.
+  \item \texttt{st-no-e} — the \emph{e-} is a run-up: \emph{es-pe-RAR}, never \emph{spe-}.
+  \item \texttt{r-tap} — one flick for the \emph{r} in the middle.
 \end{itemize}
 \end{sounds}
 
 \begin{cousinweb}
-\textbf{traer} (\textquotedblleft{}\textbf{to bring}\textquotedblright{}) $\leftarrow$ Latin \textbf{trahere}, \textquotedblleft{}\textbf{to drag, to pull}\textquotedblright{}. Bringing started out as hauling.
+\textbf{esperar} $\leftarrow$ Latin \textbf{spērāre}, \textquotedblleft{}\textbf{to hope}\textquotedblright{}, from \textbf{spēs}, \textquotedblleft{}hope\textquotedblright{}. That front \emph{e-} is the same run-up that turned \emph{scrībere} into \emph{escribir} and \emph{studēre} into \emph{estudiar}: Spanish will not start a word with \emph{s} plus a consonant.
 
-Latin built a second stem, \emph{tract-}, and English helped itself to both: \textbf{tractor}, \textbf{traction}, \textbf{attract}, \textbf{contract}, \textbf{subtract}, \textbf{extract}, \textbf{distract}, \textbf{retract} — and \textbf{abstract}, \emph{abs-} + \emph{trahere}, something \textquotedblleft{}dragged away\textquotedblright{} from anything particular.
+English took the root by its negative: \textbf{despair} $\leftarrow$ \textbf{dēspērāre}, \emph{dē-} + \emph{spērāre} — literally \textbf{to un-hope} — and with it \textbf{desperate}, and \textbf{desperado}, which English shaped from Spanish \emph{desesperado}. \textbf{Prosper} is traditionally read as \emph{prō} + \emph{spēs}, \textquotedblleft{}according to one's hope\textquotedblright{}, though that reading is the traditional one rather than a settled one.
 
-Then the worn-down half, through French: \textbf{trace}, \textbf{train} (what is dragged along behind), \textbf{trail}, \textbf{portray} $\leftarrow$ \emph{prōtrahere}, \textquotedblleft{}to draw forth\textquotedblright{}, and \textbf{retreat} $\leftarrow$ \emph{retrahere}, \textquotedblleft{}to draw back\textquotedblright{}.
+Spanish keeps the hope in plain sight: \textbf{la esperanza}. So does \textbf{Esperanto} — its inventor published as \emph{Doktoro Esperanto}, \textquotedblleft{}Doctor One-Who-Hopes\textquotedblright{}.
 \end{cousinweb}
 
-\begin{grammarlens}[title={Grammar Lens: the hard g, for the second time}]
+\begin{grammarlens}[title={Grammar Lens: three English verbs, one Spanish word}]
 \noindent
 \begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
 \toprule
-\textbf{person} & \textbf{form} \\
+\textbf{Spanish} & \textbf{what it means} \\
 \midrule
-yo & \textbf{traigo} \\
-tú & \textbf{traes} \\
-él/ella/usted & \textbf{trae} \\
-nosotros & \textbf{traemos} \\
-ellos/ustedes & \textbf{traen} \\
+\textbf{Espero a María} & I am \textbf{waiting} for María \\
+\textbf{Espero el pan} & I am \textbf{expecting} the bread \\
+\textbf{Espero que sí} & I \textbf{hope} so \\
 \bottomrule
 \end{tabularx}
 
-\emph{Oír} grew a hard \textbf{-g-} in \emph{oigo} and nowhere else in its present. \emph{Traer} does the identical thing: \textbf{traigo}, and then four ordinary \emph{-er} endings. One club, two members so far, and neither one announces itself.
+One verb, three English words, and nothing in the Spanish tells them apart. Context does all of it, and a learner has to stop translating and start reading the situation. \emph{Hope} and \emph{expect} were never far from waiting: to wait for a thing is to think it is coming.
+
+Note the small \textbf{a} before a person, the same one that stands in \emph{conozco a María}. And after three chapters of cracking stems, \emph{esperar} is perfectly regular: \textbf{espero, esperas, espera, esperamos, esperan}.
 \end{grammarlens}
 
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}espero, esperas, espera, esperamos, esperan\textquotedblright{}
+  \item \textquotedblleft{}Espero a María\textquotedblright{} then \textquotedblleft{}Espero el pan\textquotedblright{} then \textquotedblleft{}Espero que sí\textquotedblright{}
+  \item \textquotedblleft{}spērāre, esperanza\textquotedblright{} then English \textquotedblleft{}despair, desperate\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Give the three English verbs \emph{esperar} covers. (\textbf{Wait}, \textbf{hope}, \textbf{expect}.) What does \emph{dēspērāre} take apart into? (\emph{Dē-} + \emph{spērāre}, \textbf{to un-hope}.) Name two other Spanish verbs whose \emph{e-} is a run-up, with their Latin roots. (\emph{Escribir} $\leftarrow$ \emph{scrībere}, \emph{estudiar} $\leftarrow$ \emph{studēre}.) Would you use \emph{conocer} or \emph{saber} for a city? (\emph{Conocer}.) And what did the \emph{-sc-} inside \emph{cognōscere} mark? (\textbf{Beginning} — to \emph{come} to know.)
+\end{tcolorbox}
+\section[contestar]{contestar — \textquotedblleft{}to answer\textquotedblright{}, from a Roman courtroom}
+
+\label{lesson:ES-C40-contestar}
+
+
+
+\begin{quote}
+\emph{Pregunto} pushes the pole down to sound the water. \emph{Espero} waits. Now the other half of a conversation — and a word that began as an oath.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{s-clear} — a clean \emph{s} in the middle: \emph{con-tes-TAR}.
+  \item \texttt{stress-final} — the beat lands on the last syllable, with no written accent.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{contestar} (\textquotedblleft{}\textbf{to answer}\textquotedblright{}) $\leftarrow$ Latin \textbf{contestārī}, \textquotedblleft{}\textbf{to call witnesses}\textquotedblright{}: \emph{com-} + \emph{testārī}, from \textbf{testis}, \textquotedblleft{}a witness\textquotedblright{}. In Roman law, \emph{contestārī lītem} was the formal opening of a lawsuit — both sides calling their witnesses so the argument could begin.
+
+From that one act the two languages walked in opposite directions. \textbf{English kept the fight}: to \emph{contest} a thing is to dispute it. \textbf{Spanish kept the reply} — first \textquotedblleft{}say back what the other side said\textquotedblright{}, then simply \emph{answer}.
+
+The \emph{testis} family is shared: \textbf{testify}, \textbf{testimony}, \textbf{testament}, \textbf{attest}, \textbf{protest}, \textbf{detest}.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: contestar and responder}]
+Spanish has a second answering verb, and it is built on a different promise.
+
+\textbf{responder} $\leftarrow$ Latin \textbf{respondēre}, \emph{re-} + \textbf{spondēre}, \textquotedblleft{}to pledge solemnly\textquotedblright{}. Answering is pledging \emph{back}. English holds that whole branch: \textbf{respond}, \textbf{response}, \textbf{responsible}, \textbf{sponsor}, and \textbf{spouse}, from \emph{spōnsus}, \textquotedblleft{}one who has been pledged\textquotedblright{}.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{verb} & \textbf{where it lives} \\
+\midrule
+\textbf{contestar} & the everyday one: a question, the phone, a letter \\
+\textbf{responder} & weightier — responding \emph{to} something \\
+\bottomrule
+\end{tabularx}
+
+Both are regular, one \emph{-ar} and one \emph{-er}: \textbf{contesto, contestas, contesta, contestamos, contestan}; \textbf{respondo, respondes, responde}. The noun is the odd part: the answer is \textbf{la respuesta}, borrowed from \emph{responder}, never from \emph{contestar}.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}contesto, contestas, contesta, contestamos, contestan\textquotedblright{}
+  \item \textquotedblleft{}Te pregunto la hora y me contestas\textquotedblright{}
+  \item \textquotedblleft{}testis, testify, contest\textquotedblright{} then \textquotedblleft{}contestar\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What did \emph{contestārī} mean literally, and what did English make of it? (\textbf{To call witnesses}; \emph{contest}.) What does \emph{respondēre} take apart into? (\emph{Re-} + \emph{spondēre}, \textbf{to pledge back}.) Which verb asks for information and which asks for a thing? (\emph{Preguntar}; \emph{pedir}.) And name the three English verbs inside \emph{esperar}. (\textbf{Wait, hope, expect}.)
+\end{tcolorbox}
+\section[comprar]{comprar — \textquotedblleft{}to buy\textquotedblright{}, and a cousin that is not one}
+
+\label{lesson:ES-C40-comprar}
+
+
+
+\begin{quote}
+You can ask, answer and wait. Now pay for the bread, with a verb whose obvious English relative turns out to be a stranger.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{pr-cluster} — \emph{-pr-} is one beat: \emph{kom-PRAR}, never \emph{kom-pe-rar}.
+  \item \texttt{vowel-o} — a short pure \emph{o}, with no glide toward \emph{ow}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{comprar} (\textquotedblleft{}\textbf{to buy}\textquotedblright{}) $\leftarrow$ Latin \textbf{comparāre}: \emph{com-} + \textbf{parāre}, \textquotedblleft{}\textbf{to make ready, to furnish, to procure}\textquotedblright{}. Latin already used it for buying — you procured a thing — and the middle syllable wore away, \emph{comparāre} to \emph{comprar}.
+
+\emph{Parāre} stocked English well: \textbf{prepare}, \textbf{repair}, \textbf{apparatus}, \textbf{apparel}, \textbf{separate}, \textbf{parade}, and \textbf{emperor}, from \emph{imperāre}, \textquotedblleft{}to give orders\textquotedblright{}. Spanish keeps \emph{preparar}, and \emph{parar}, \textquotedblleft{}to stop\textquotedblright{}.
+
+That \emph{com-} is the same one already inside \emph{compañero} — \textquotedblleft{}the one you share bread with\textquotedblright{} — and inside \emph{conseguir}, \emph{conocer} and \emph{contestar}.
+\end{cousinweb}
+
 \begin{culture}
-English lets one verb wander: \emph{bring me the bread}, \emph{bring it to the café} — same word, opposite journeys. Spanish will not.
+English \textbf{compare} looks like the obvious relative. It is not one.
 
-\textbf{Traer} moves a thing \textbf{toward you}. \textbf{Llevar} moves it \textbf{away}. \emph{Traigo el pan} is the bread arriving here; \emph{llevo el pan} is the bread leaving with me. You choose by where you are standing, never by what you are carrying.
+Latin had \textbf{two} verbs spelled \emph{comparāre}. One is \emph{com-} + \emph{parāre}, \textquotedblleft{}procure\textquotedblright{}, and Spanish \emph{comprar} comes from it. The other is built on \textbf{compār}, \textquotedblleft{}equal, matched\textquotedblright{}, and means \textquotedblleft{}to set side by side\textquotedblright{} — that is the one English \emph{compare} comes from. Two different words that fell together in spelling.
 
-And \textbf{llevar} $\leftarrow$ Latin \textbf{levāre}, \textquotedblleft{}to raise\textquotedblright{} — the verb already behind \emph{levantarse}. To carry a load was first to lift it.
+\emph{Comprender} is a stranger too: it is \emph{comprehendere}, \textquotedblleft{}to seize together\textquotedblright{}. Same prefix, unrelated second halves. A resemblance is a question, never an answer.
 \end{culture}
 
 \subsection*{Your turn}
@@ -67,189 +163,12 @@ Say these aloud:
 
 \begin{itemize}
 \raggedright
-  \item \textquotedblleft{}traigo, traes, trae, traemos, traen\textquotedblright{}
-  \item \textquotedblleft{}Traigo el pan\textquotedblright{} then \textquotedblleft{}Llevo el pan\textquotedblright{} — here, then away
-  \item \textquotedblleft{}oigo\textquotedblright{} then \textquotedblleft{}traigo\textquotedblright{} — the same hard g
-  \item \textquotedblleft{}traer\textquotedblright{} then English \textquotedblleft{}tractor, attract, abstract\textquotedblright{}
+  \item \textquotedblleft{}compro, compras, compra, compramos, compran\textquotedblright{}
+  \item \textquotedblleft{}Compro el pan y el vino\textquotedblright{}
+  \item \textquotedblleft{}Un café, por favor\textquotedblright{}
+  \item \textquotedblleft{}parāre, prepare, repair\textquotedblright{} then \textquotedblleft{}comprar\textquotedblright{}
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Which way does \emph{traer} carry a thing, and which verb goes the other way? (\textbf{Toward you}; \emph{llevar}.) What did \emph{trahere} mean, and name two English words from it. (\textbf{To drag}; \emph{tractor, attract, abstract, retreat}.) Which form of \emph{traer} misbehaves, and which verb showed you that same misbehaviour first? (\textbf{Traigo}; \emph{oigo}.) And say you are standing. (\emph{Estoy de pie}.)
-\end{tcolorbox}
-\section[conseguir]{conseguir — \textquotedblleft{}to get\textquotedblright{}, by following a thing until you have it}
-
-\label{lesson:ES-C39-conseguir}
-
-
-
-\begin{quote}
-\emph{Traigo} carries a thing that is already yours. \emph{Coger} grabs what is in front of you. This verb is for the getting that took some work.
-\end{quote}
-
-\begin{sounds}
-\begin{itemize}
-\raggedright
-  \item \texttt{g-hard} — the \emph{gu} in \emph{conseguir} is one hard \emph{g}; the \emph{u} is silent.
-  \item \texttt{s-clear} — a clean hissing \emph{s}: \emph{con-se-GEER}.
-\end{itemize}
-\end{sounds}
-
-\begin{cousinweb}
-\textbf{conseguir} (\textquotedblleft{}\textbf{to get, to obtain, to manage to}\textquotedblright{}) $\leftarrow$ Latin \textbf{cōnsequī}: \emph{com-} (\textquotedblleft{}along with\textquotedblright{}) + \textbf{sequī}, \textquotedblleft{}\textbf{to follow}\textquotedblright{}. You got a thing by following it until it was yours.
-
-\emph{Sequī} is one of Latin's great English suppliers: \textbf{sequence}, \textbf{sequel}, \textbf{consequence}, \textbf{subsequent}, \textbf{consecutive}; \textbf{second}, from \emph{secundus}, \textquotedblleft{}the one following\textquotedblright{}; \textbf{execute} and \textbf{prosecute}; \textbf{obsequious}, following someone about; and through French, \textbf{pursue}, \textbf{ensue} and \textbf{suit}.
-
-Spanish also keeps the formal partner \textbf{obtener} $\leftarrow$ \emph{obtinēre}, \textquotedblleft{}to hold onto\textquotedblright{} — English \textbf{obtain}. It behaves exactly like \emph{tener}, so its \emph{yo}-form is \emph{obtengo}. \emph{Conseguir} is the everyday one.
-\end{cousinweb}
-
-\begin{grammarlens}[title={Grammar Lens: the third crack, and a silent u that leaves}]
-\noindent
-\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
-\toprule
-\textbf{person} & \textbf{form} \\
-\midrule
-yo & \textbf{consigo} \\
-tú & \textbf{consigues} \\
-él/ella/usted & \textbf{consigue} \\
-nosotros & \textbf{conseguimos} \\
-ellos/ustedes & \textbf{consiguen} \\
-\bottomrule
-\end{tabularx}
-
-You have met \emph{dormir} breaking \textbf{o$\to$ue} and \emph{pido} quietly breaking \textbf{e$\to$i}. Here is that third pattern in full: stress on the stem turns \emph{e} into \emph{i}, and \emph{conseguimos} stays plain because the stress moved to the ending.
-
-Now the spelling. Spanish writes \emph{gu} only to keep a \emph{g} hard in front of \emph{e} and \emph{i}. Once the \emph{e} becomes \emph{i}, there is nothing in front to guard against, so the \emph{u} has no job and goes: \textbf{consigo}, not \emph{consiguo}. Two changes, one form, and only one of them is a sound.
-\end{grammarlens}
-
-\subsection*{Your turn}
-Say these aloud:
-
-\begin{itemize}
-\raggedright
-  \item \textquotedblleft{}consigo, consigues, consigue, conseguimos, consiguen\textquotedblright{}
-  \item \textquotedblleft{}Traigo el café\textquotedblright{} then \textquotedblleft{}Consigo el café\textquotedblright{} — carried, then obtained
-  \item \textquotedblleft{}sequī, sequence, second\textquotedblright{} then \textquotedblleft{}conseguir\textquotedblright{}
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-What did \emph{sequī} mean, and name two English words from it. (\textbf{To follow}; \emph{sequence, second, consequence, pursue}.) Why is it \emph{consigo} and not \emph{consiguo}? (The \emph{u} only guards a hard \emph{g} before \emph{e} and \emph{i}.) Name the three stem cracks you now have, with a verb for each. (\emph{Cerrar} \textbf{e$\to$ie}, \emph{dormir} \textbf{o$\to$ue}, \emph{conseguir} \textbf{e$\to$i}.) And which Latin verb is behind \emph{traer}? (\textbf{Trahere}.)
-\end{tcolorbox}
-\section[jugar]{jugar — \textquotedblleft{}to play\textquotedblright{}, and the only verb of its kind}
-
-\label{lesson:ES-C39-jugar}
-
-
-
-\begin{quote}
-\emph{Consigo} cracked its \emph{e} to \emph{i}. Here is a verb that cracks a vowel no other verb in Spanish cracks — and it started life as a joke.
-\end{quote}
-
-\begin{sounds}
-\begin{itemize}
-\raggedright
-  \item \texttt{j-jota} — the \emph{j} is scraped at the back of the throat: \emph{khoo-GAR}.
-  \item \texttt{diphthong-ue} — \emph{juego} is three beats, \emph{KHWE-go}.
-\end{itemize}
-\end{sounds}
-
-\begin{cousinweb}
-\textbf{jugar} (\textquotedblleft{}\textbf{to play}\textquotedblright{}) $\leftarrow$ Latin \textbf{iocārī}, \textquotedblleft{}\textbf{to joke, to jest}\textquotedblright{}, built on the noun \textbf{iocus}, \textquotedblleft{}a joke\textquotedblright{}. Playing and joking were one word, and Spanish kept the joking one for both.
-
-English holds \emph{iocus} in several shapes: \textbf{joke}; through French \textbf{jocular}; \textbf{juggler}, from \emph{ioculātor}, an entertainer; and \textbf{jeopardy}, from Old French \emph{jeu parti}, \textquotedblleft{}an evenly divided game\textquotedblright{} — a position so balanced that either side might lose. The Spanish family stays close: \textbf{el juego}, a game; \textbf{el juguete}, a toy.
-\end{cousinweb}
-
-\begin{culture}
-Latin's ordinary word for playing was \textbf{lūdere}, and Spanish dropped it exactly as it dropped \emph{claudere} for shutting doors. English kept the whole family instead: \textbf{illusion}, \textbf{allude}, \textbf{elude}, \textbf{delude}, \textbf{collude}, \textbf{prelude}, \textbf{interlude}, \textbf{ludicrous}.
-
-\emph{Claudere} and \emph{lūdere} tell one story: the large English family belongs to the Latin verb Spanish walked away from.
-\end{culture}
-
-\begin{grammarlens}[title={Grammar Lens: the fourth crack, with one member}]
-\noindent
-\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
-\toprule
-\textbf{person} & \textbf{form} \\
-\midrule
-yo & \textbf{juego} \\
-tú & \textbf{juegas} \\
-él/ella/usted & \textbf{juega} \\
-nosotros & \textbf{jugamos} \\
-ellos/ustedes & \textbf{juegan} \\
-\bottomrule
-\end{tabularx}
-
-\emph{Dormir} breaks \textbf{o$\to$ue}. \emph{Jugar} breaks \textbf{u$\to$ue}, and it is the \textbf{only verb in Spanish that does}: the \emph{o} of \emph{iocārī} had already slid irregularly to \emph{u}, so the crack landed on a vowel no other verb offers. \emph{Jugamos} stays plain, because the stress moves to the ending.
-
-One more habit: Spanish plays \textbf{at} a thing rather than simply playing it. \emph{El fútbol} is football, and you say \emph{juego \textbf{al} fútbol}, with \emph{a} + \emph{el} fused into \emph{al}. With a companion rather than a game it is \emph{con}: \emph{juego con el perro}, I play with the dog.
-\end{grammarlens}
-
-\subsection*{Your turn}
-Say these aloud:
-
-\begin{itemize}
-\raggedright
-  \item \textquotedblleft{}juego, juegas, juega, jugamos, juegan\textquotedblright{}
-  \item \textquotedblleft{}Juego con el perro\textquotedblright{}
-  \item \textquotedblleft{}duermo\textquotedblright{} then \textquotedblleft{}juego\textquotedblright{} — o to ue, then u to ue
-  \item \textquotedblleft{}iocus, joke, jocular, juggler\textquotedblright{}
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-What did \emph{iocārī} mean, and which English words carry it? (\textbf{To joke}; \emph{joke, jocular, juggler, jeopardy}.) What is unusual about \emph{juego} among Spanish verbs? (\textbf{U$\to$ue}, and no other verb does it.) Which two Latin verbs did Spanish drop while English kept their families? (\emph{Claudere} and \emph{lūdere}.) And which vowel does \emph{conseguir} break? (\textbf{E to i}.)
-\end{tcolorbox}
-\section[conocer]{conocer — \textquotedblleft{}to meet\textquotedblright{}, because knowing has a first moment}
-
-\label{lesson:ES-C39-conocer}
-
-
-
-\begin{quote}
-\emph{Juego} — the one \emph{u$\to$ue} in the language. Now the chapter's last verb, and its oddity is not in the vowel but in what the word means.
-\end{quote}
-
-\begin{sounds}
-\begin{itemize}
-\raggedright
-  \item \texttt{soft-c} — \emph{conoces} has a soft second \emph{c}: a \emph{th} in Spain, an \emph{s} elsewhere.
-  \item \texttt{k-hard} — but \emph{conozco} is \emph{ko-NOTH-ko}, soft then hard, back to back.
-\end{itemize}
-\end{sounds}
-
-\begin{cousinweb}
-\textbf{conocer} $\leftarrow$ Latin \textbf{cognōscere}, \emph{com-} + \emph{(g)nōscere}. Its \emph{-sc-} is Latin's \textbf{\textquotedblleft{}begin to\textquotedblright{} marker}, so \emph{nōscere} was never \textquotedblleft{}to know\textquotedblright{} — it was \textquotedblleft{}\textbf{to come to know}\textquotedblright{}. Latin said \emph{nōvī}, \textquotedblleft{}I have come to know\textquotedblright{}, for actually knowing a thing.
-
-Spanish built its verb from the \emph{beginning} half. That is the whole lesson: \emph{conocer a alguien} is \textbf{to meet} someone, and Spanish puts a small \textbf{a} before a person who is the object — \emph{conozco a María}.
-
-The root fills English: \textbf{cognition}, \textbf{recognize}, \textbf{incognito}, and through French \textbf{notice}, \textbf{notion}, \textbf{notorious} and \textbf{noble}, \textquotedblleft{}the knowable one\textquotedblright{}. English \textbf{know} and \textbf{ken} are its Germanic siblings — the same standing that \emph{padre} has beside English \emph{father}, neither one borrowed from the other.
-\end{cousinweb}
-
-\begin{grammarlens}[title={Grammar Lens: conocer and saber}]
-\noindent
-\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
-\toprule
-\textbf{what you know} & \textbf{verb} \\
-\midrule
-a person, a city, a book & \textbf{conocer} \\
-a fact, or how to do something & \textbf{saber} \\
-\bottomrule
-\end{tabularx}
-
-English says \emph{know} for both. Spanish will not: \textbf{conocer} is being \textbf{acquainted} — you have met the thing. \textbf{Saber} is having the information. \emph{Conozco Madrid} means I have been there; \emph{sé dónde está} means I have the fact.
-
-The \emph{yo}-form keeps a hard cluster the rest lost: \textbf{conozco, conoces, conoce, conocemos, conocen}. Every \emph{-cer} verb after a vowel does the same, and it is a third kind of odd \emph{yo}-form beside \emph{traigo} and \emph{oigo}.
-\end{grammarlens}
-
-\subsection*{Your turn}
-Say these aloud:
-
-\begin{itemize}
-\raggedright
-  \item \textquotedblleft{}conozco, conoces, conoce, conocemos, conocen\textquotedblright{}
-  \item \textquotedblleft{}Conozco a María\textquotedblright{} then \textquotedblleft{}Conozco Madrid\textquotedblright{}
-  \item \textquotedblleft{}traigo, consigo, juego, conozco\textquotedblright{} — the chapter's four \emph{yo}-forms
-  \item \textquotedblleft{}padre, father\textquotedblright{} then \textquotedblleft{}conocer, know\textquotedblright{} — siblings, not borrowings
-\end{itemize}
-
-\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Say the chapter's four verbs in the \emph{yo}, then say what each one does to itself. (\emph{Traigo} grows a hard \emph{g}; \emph{consigo} breaks \emph{e$\to$i} and loses a silent \emph{u}; \emph{juego} breaks \emph{u$\to$ue}, alone in the language; \emph{conozco} keeps a hard cluster.) Name their four Latin roots and what each meant. (\textbf{Trahere} to drag, \textbf{cōnsequī} to follow, \textbf{iocārī} to joke, \textbf{cognōscere} to begin to know.) Which verb do you use for a person, and which for a fact? (\emph{Conocer}; \emph{saber}.) And which of the four moves a thing toward you? (\emph{Traer} — \emph{llevar} goes away.)
+Run the chapter: \emph{espero}, \emph{contesto}, \emph{compro} — three verbs that break nothing, whose difficulty is meaning. Give each root and what it meant. (\textbf{Spērāre} to hope, \textbf{contestārī} to call witnesses, \textbf{comparāre} to procure.) Is English \emph{compare} a relative of \emph{comprar}? (\textbf{No} — a different Latin \emph{comparāre}, built on \emph{compār}, \textquotedblleft{}equal\textquotedblright{}.) Now buy: \emph{compro el pan, el vino y un café, por favor} — then say what \emph{pānis} gave \emph{compañero}, which English words \emph{vīnum} reached, why \emph{café} is masculine, and what \emph{por favor} is word for word. (\textbf{One who shares bread}; \emph{wine, vine, vinegar}; \emph{café} arrived as a masculine loan out of Arabic \emph{qahwa}; \textquotedblleft{}for a favour\textquotedblright{}.) And which verb gets a thing by following it? (\emph{Conseguir}.)
 \end{tcolorbox}

--- a/code/learning/human-languages/spanish/book/chapters/ch41-giving-reasons.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch41-giving-reasons.tex
@@ -1,0 +1,297 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:2ba56f5f98a0e31a
+% canonical-lessons: ES-C41-creer, ES-C41-asi-que, ES-C41-deber, ES-C41-explicar
+
+\chapter{Saying Why}
+\label{ch:spanish-giving-reasons}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can give a reason for what I think and what I plan — stating an opinion with creo que, running forward to its consequence with así que, and naming an obligation with debo.}
+
+Answer ¿Por qué no corres? in four moves — Creo que llueve. No corro porque llueve, así que leo. Debo estudiar. Opinion, cause, consequence, obligation, each with its own word, and every word in it taught by this book.
+\end{chapteropening}
+
+\section[creer]{creer — to put your heart somewhere}
+
+\label{lesson:ES-C41-creer}
+
+
+
+\begin{quote}
+You have \textbf{pensar} — to think, and underneath it \emph{pēnsāre}, \textquotedblleft{}to weigh\textquotedblright{}. Spanish has a second verb for the inside of your head, and it does a different job. Where \emph{pensar} weighs, this one commits.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{hiatus-ee} — the two \emph{e}'s do not merge: \textbf{creer} = \emph{kreh-EHR}, two beats.
+  \item \texttt{r-tap} — a single flick, not the rolled \emph{rr}.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{creer} = \textquotedblleft{}to believe\textquotedblright{}, and in everyday use \textquotedblleft{}to think\textquotedblright{} in the sense of \emph{hold an opinion}.
+
+It comes from Latin \emph{\textbf{crēdere}}, \textquotedblleft{}to entrust, to believe\textquotedblright{} — and \emph{crēdere} is a compound so old that Latin had already forgotten it was one. It is PIE \emph{\textbf{*\'{k}red-d\textsuperscript{h}eh\textsubscript{1}-}}: "\textbf{to put} \emph{\textbf{*\'{k}red-}}".
+
+What is that first half? Traditionally, the \textbf{heart} word — the root of Latin \emph{\textbf{cor}}, \emph{\textbf{cordis}} and of English \textbf{heart}. Be honest that the step is \textbf{disputed}: that root normally appears as \emph{*\'{k}\'{\={e}}r}, never \emph{*\'{k}red-}. The compound is not in doubt; only what it was built on.
+
+Taking the traditional reading:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{from \emph{crēdere}} & \textbf{from \emph{cor, cordis}} \\
+\midrule
+\textbf{credit}, \textbf{creed}, \textbf{credo} & \textbf{cordial}, \textbf{courage} \\
+\textbf{credential}, \textbf{incredible} & \textbf{record}, \textbf{accord}, \textbf{discord} \\
+\bottomrule
+\end{tabularx}
+
+To \textbf{record} is to bring something back to the \emph{cor} — for a Roman the seat of \textbf{memory}, not of feeling. To have \textbf{courage} is to have heart.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: creer que}]
+\emph{Creer} almost always drags a \textbf{que} behind it, and then a whole clause:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+\textbf{Creo que} llueve. & I think it's raining. \\
+\textbf{Creo que} hace frío. & I think it's cold. \\
+\textbf{No creo que} llu\textbf{e}va. & I don't think it's raining. \\
+\bottomrule
+\end{tabularx}
+
+Look hard at that third row. \emph{Creo que} \textbf{llueve} — but \emph{no creo que} \textbf{llueva}. Negating \emph{creer} flips the clause into the \textbf{subjunctive} from chapter eighteen: stop vouching for something and Spanish stops using the tense that states facts.
+
+\emph{\textbf{Pienso}} is the weighing; \emph{\textbf{creo}} is where it landed. Treat that as a way to feel the difference, not a rule — both take \emph{que} and a clause, and a speaker may use either. But \emph{creo que} is the ordinary opening for an opinion.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}creer\textquotedblright{} — \emph{kreh-EHR}, two beats, not one
+  \item \textquotedblleft{}Creo que llueve.\textquotedblright{}
+  \item the pair — \textquotedblleft{}pienso\textquotedblright{} (I weigh) then \textquotedblleft{}creo\textquotedblright{} (I hold)
+  \item \textquotedblleft{}creer\textquotedblright{} then English \textquotedblleft{}credit, creed, cordial, record\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What shape is \emph{crēdere}, under the surface? (\textbf{A compound} — \emph{*\'{k}red-} + \emph{d\textsuperscript{h}eh\textsubscript{1}-}, "to put \emph{*\'{k}red-}".) What is the traditional reading of that first half, and why hedge it? (\textbf{Heart} — but the heart root is \emph{*\'{k}\'{\={e}}r}, never \emph{*\'{k}red-}, so the step is disputed.) \emph{Pensar} weighs; what does \emph{creer} do? (It \textbf{lands} — it holds the opinion the weighing produced.)
+\end{tcolorbox}
+\section[así]{así que — \textquotedblleft{}so\textquotedblright{}, and a word you have been saying since yes}
+
+\label{lesson:ES-C41-asi-que}
+
+
+
+\begin{quote}
+\emph{Porque} runs from a claim back to its reason. This runs the other way — from the reason forward to what follows. Same two facts, opposite arrow, and you need both to explain anything.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{s-clear} — a clean hiss in \textbf{así}, never a \emph{z} buzz.
+  \item \texttt{k-hard} — \emph{qu} is a plain \emph{k}; the \emph{u} is silent.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{así} = \textquotedblleft{}so, thus, in that way\textquotedblright{}. \textbf{así que} = \textquotedblleft{}so, and therefore\textquotedblright{}.
+
+\emph{Así} is Latin \emph{\textbf{sīc}}, \textquotedblleft{}thus\textquotedblright{} — with an \emph{a-} that Spanish added later, the same one it put on \emph{apenas} and \emph{afuera}. And you have met \emph{sīc} before: it is the whole of Spanish \textbf{sí}, \textquotedblleft{}yes\textquotedblright{}. Latin \emph{sīc} meant \textquotedblleft{}thus, in this way\textquotedblright{}, and saying \emph{thus} in answer to a question is how a language gets a word for yes.
+
+So \emph{sí} and \emph{así} are the same Latin adverb, one bare and one with the \emph{a-} attached. English borrowed it raw and never translated it: \emph{\textbf{sic}}, the mark an editor puts after a quoted mistake — \textquotedblleft{}thus it stood\textquotedblright{}.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the two arrows}]
+The pair is worth drilling as a pair, because they carry the same two facts in opposite orders:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+No corro \textbf{porque} llueve. & I'm not running \textbf{because} it's raining. \\
+Llueve, \textbf{así que} no corro. & It's raining, \textbf{so} I'm not running. \\
+\bottomrule
+\end{tabularx}
+
+\emph{Porque} points \textbf{backwards} to the cause. \emph{Así que} points \textbf{forwards} to the consequence. Which you reach for depends only on which fact you want to say first — and that is a choice about emphasis, not about grammar.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+Hace frío, \textbf{así que} bebo café. & It's cold, so I drink coffee. \\
+\textbf{Creo que} llueve, \textbf{así que} leo. & I think it's raining, so I read. \\
+\bottomrule
+\end{tabularx}
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}sí\textquotedblright{} then \textquotedblleft{}así\textquotedblright{} — the same Latin word, one with an \emph{a-} on the front
+  \item \textquotedblleft{}Llueve, así que no corro.\textquotedblright{}
+  \item the same two facts the other way — \textquotedblleft{}No corro porque llueve.\textquotedblright{}
+  \item \textquotedblleft{}Creo que hace frío, así que bebo café.\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which Latin adverb is hiding in both \emph{sí} and \emph{así}? (\emph{\textbf{Sīc}}, \textquotedblleft{}thus\textquotedblright{}.) Which way does \emph{porque} point, and which way \emph{así que}? (\emph{Porque} \textbf{backwards} to the cause; \emph{así que} \textbf{forwards} to the consequence.) What does an editor's \emph{sic} mean? (\textbf{Thus it stood} — the same word, borrowed whole.)
+\end{tcolorbox}
+\section[deber]{deber — to owe, and therefore to ought}
+
+\label{lesson:ES-C41-deber}
+
+
+
+\begin{quote}
+You can now say what you think and what follows from it. This verb adds the third move in any explanation: what somebody \textbf{ought} to do about it. It gets there from an unexpected direction — money.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{b-soft} — between vowels the \emph{b} softens: \textbf{deber} = \emph{deh-BEHR}.
+  \item \texttt{r-tap} — one flick at the end, not a roll.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{deber} does two jobs: \textquotedblleft{}\textbf{to owe}\textquotedblright{}, and \textquotedblleft{}\textbf{ought to, should}\textquotedblright{}.
+
+Latin \emph{\textbf{dēbēre}} explains both, because it is a compound: \emph{\textbf{dē-}} (\textquotedblleft{}from\textquotedblright{}) plus \emph{\textbf{habēre}} (\textquotedblleft{}to have\textquotedblright{}). To \emph{dēbēre} something is \textbf{to have it from someone} — which is exactly what owing is. You are holding what is theirs.
+
+English helped itself to this verb four times over — three of them from the participle \emph{dēbitum} rather than the verb — and the spellings record each route:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{English} & \textbf{how it came} \\
+\midrule
+\textbf{debt} & through French, then re-spelled to show the Latin \emph{b} \\
+\textbf{debit} & straight from Latin bookkeeping \\
+\textbf{due} & through French \emph{deü}, the \emph{b} worn away \\
+\textbf{duty} & built on \emph{due} \\
+\bottomrule
+\end{tabularx}
+
+One more came the long way round, and not by borrowing. French turned \emph{dēbēre} into \emph{devoir}, \textquotedblleft{}duty\textquotedblright{}. English \textbf{translated} the phrase \emph{mettre en devoir} — to put oneself under an obligation — half-way, as \emph{put in dever}, and the last two words later fused into \textbf{endeavour}.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: debo + infinitive}]
+\emph{Deber} is regular, and for \textquotedblleft{}ought to\textquotedblright{} it takes a bare infinitive straight after it — no \emph{que}, no preposition:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{person} & \textbf{form} \\
+\midrule
+yo & \textbf{debo} \\
+tú & \textbf{debes} \\
+él/ella/usted & \textbf{debe} \\
+nosotros & \textbf{debemos} \\
+ellos/ustedes & \textbf{deben} \\
+\bottomrule
+\end{tabularx}
+
+\textbf{Debo estudiar.} — I ought to study. \textbf{Llueve, así que debo leer.} — It's raining, so I ought to read.
+
+The obligation is softer than a command and firmer than a wish, which is the register an explanation usually wants.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}debo, debes, debe, debemos, deben\textquotedblright{}
+  \item \textquotedblleft{}Debo trabajar.\textquotedblright{}
+  \item \textquotedblleft{}Hace frío, así que debo beber café.\textquotedblright{}
+  \item \textquotedblleft{}Creo que llueve, así que debo leer.\textquotedblright{}
+  \item \textquotedblleft{}deber\textquotedblright{} then English \textquotedblleft{}debt, debit, due, duty\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What two Latin pieces build \emph{dēbēre}, and what do they say together? (\emph{\textbf{Dē-}} + \emph{\textbf{habēre}} — \textquotedblleft{}to have \textbf{from} someone\textquotedblright{}, which is owing.) Name two of the four English words it became. (Any of \textbf{debt}, \textbf{debit}, \textbf{due}, \textbf{duty}.) What follows \emph{debo} — a \emph{que}, or a bare infinitive? (\textbf{A bare infinitive}: \emph{debo estudiar}.)
+\end{tcolorbox}
+\section[explicar]{explicar — to unfold}
+
+\label{lesson:ES-C41-explicar}
+
+
+
+\begin{quote}
+Three pieces are in your hands: \emph{creo que} to state an opinion, \emph{así que} to run forward to what follows, \emph{debo} to say what ought to happen. This lesson puts all three in a row, under the verb that names the act.
+\end{quote}
+
+\begin{sounds}
+\begin{itemize}
+\raggedright
+  \item \texttt{k-hard} — \emph{c} before \emph{a} is a hard \emph{k}: \textbf{explicar} = \emph{eks-plee-KAR}.
+  \item \texttt{l-clear} — a clean \emph{l} in the \emph{pl}, no vowel slipped in between.
+\end{itemize}
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{explicar} = Latin \emph{\textbf{explicāre}}: \emph{\textbf{ex-}} (\textquotedblleft{}out\textquotedblright{}) + \emph{\textbf{plicāre}} (\textquotedblleft{}to fold\textquotedblright{}). \textbf{To explain is to unfold} — something was folded shut, and you open it.
+
+\emph{Plicāre} is one of the great suppliers of English. Some came from Latin directly, some through French, and the sound changed on the way:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{straight from Latin} & \textbf{through French} \\
+\midrule
+\textbf{explicate} & \textbf{explicit}, \textbf{application} \\
+\textbf{complicated} (\emph{com-} + fold) & \textbf{employ}, \textbf{deploy} \\
+\textbf{duplicate} & \textbf{display} — a doublet of \emph{deploy} \\
+\bottomrule
+\end{tabularx}
+
+And \textbf{simple} is \emph{sim-plex} — \textquotedblleft{}\textbf{one}-fold\textquotedblright{}. Something simple has been folded only once. Something \textbf{complicated} has been folded \emph{together}, over and over, which is why it needs unfolding. The metaphor is consistent all the way down, and Spanish keeps it in the plainest verb of the set.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: the shape of an explanation}]
+\emph{Explicar} is regular — it takes the plain \emph{-ar} endings of \emph{hablar}, with no stem change at all: \textbf{explico}, \textbf{explicas}, \textbf{explica}, \textbf{explicamos}, \textbf{explican}. (\emph{Contar}, back in chapter 38, breaks its \emph{o} to \emph{ue}; this one does not, and there is nothing to remember.)
+
+Here is a whole explanation, with every piece something this book has taught:
+
+\begin{quote}
+— ¿Por qué no corres? — \textbf{Creo que} llueve. No corro \textbf{porque} llueve, \textbf{así que} leo. \textbf{Debo} estudiar.
+\end{quote}
+
+>
+
+\begin{quote}
+\emph{— Why aren't you running?} \emph{— I think it's raining. I'm not running because it's raining, so I read. I ought to study.}
+\end{quote}
+
+Four moves, four words: an \textbf{opinion} (\emph{creo que}), a \textbf{cause} (\emph{porque}), a \textbf{consequence} (\emph{así que}), an \textbf{obligation} (\emph{debo}). That is what an explanation is made of, and you can now build one in either direction — cause first or claim first — because \emph{porque} and \emph{así que} let you choose.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}explico, explicas, explica, explicamos, explican\textquotedblright{}
+  \item \textquotedblleft{}Explico bien.\textquotedblright{} — I explain well.
+  \item the four moves — \textquotedblleft{}Creo que llueve, porque hace frío, así que debo leer.\textquotedblright{}
+  \item \textquotedblleft{}explicar\textquotedblright{} then English \textquotedblleft{}explicit, complicated, simple, display\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What does \emph{explicāre} literally say? (\textbf{To fold out} — \emph{ex-} + \emph{plicāre}.) What is \emph{simple}, folded? (\textbf{Once} — \emph{sim-plex}; \emph{complicated} is folded together, again and again.) Name the four moves of an explanation and the word for each. (Opinion \emph{\textbf{creo que}}, cause \emph{\textbf{porque}}, consequence \emph{\textbf{así que}}, obligation \emph{\textbf{debo}}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/spanish/chapters.json
+++ b/code/learning/human-languages/spanish/chapters.json
@@ -647,6 +647,31 @@
           "ES-LEX-CONSEGUIR-04"
         ]
       }
+    },
+    {
+      "chapter": 41,
+      "title": "Saying Why",
+      "label": "ch:spanish-giving-reasons",
+      "canDo": "I can give a reason for what I think and what I plan — stating an opinion with creo que, running forward to its consequence with así que, and naming an obligation with debo.",
+      "spineNodes": [
+        "SPINE-GIVE-REASONS"
+      ],
+      "payoff": {
+        "lesson": "ES-C41-explicar",
+        "kind": "task",
+        "summary": "Answer ¿Por qué no corres? in four moves — Creo que llueve. No corro porque llueve, así que leo. Debo estudiar. Opinion, cause, consequence, obligation, each with its own word, and every word in it taught by this book.",
+        "assesses": [
+          "ES-LEX-CREER-01",
+          "ES-ETYMON-CREDERE-02",
+          "ES-LEX-ASI-QUE-03",
+          "ES-ETYMON-SIC-04",
+          "ES-LEX-DEBER-05",
+          "ES-ETYMON-DEBERE-06",
+          "ES-LEX-EXPLICAR-07",
+          "ES-ETYMON-PLICARE-08",
+          "ES-GRAMMAR-REASON-CHAIN-09"
+        ]
+      }
     }
   ]
 }

--- a/code/learning/human-languages/spanish/curriculum.json
+++ b/code/learning/human-languages/spanish/curriculum.json
@@ -520,6 +520,19 @@
       "before": [],
       "inline": [],
       "after": []
+    },
+    {
+      "id": "ES-PATH-037",
+      "spine_node": "SPINE-GIVE-REASONS",
+      "lessons": [
+        "ES-C41-creer",
+        "ES-C41-asi-que",
+        "ES-C41-deber",
+        "ES-C41-explicar"
+      ],
+      "before": [],
+      "inline": [],
+      "after": []
     }
   ],
   "spine": {
@@ -704,13 +717,10 @@
       "relocates": {}
     },
     "SPINE-GIVE-REASONS": {
-      "segments": [],
-      "omits": [
-        "OPINION-I-THINK",
-        "CONNECTIVE-SO",
-        "MODAL-SHOULD",
-        "EXPLANATION-GIVE"
+      "segments": [
+        "ES-PATH-037"
       ],
+      "omits": [],
       "relocates": {}
     },
     "SPINE-HANDLE-TRAVEL": {

--- a/code/learning/human-languages/spanish/lessons/ES-C41-asi-que.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C41-asi-que.md
@@ -1,0 +1,95 @@
+---
+schema_version: 2
+id: ES-C41-asi-que
+spine_node: SPINE-GIVE-REASONS
+sequence: 1890
+chapter: 41
+type: word
+headword: así
+gloss: thus, in that way — and with que after it, "so"; built on the same sīc that gave you sí
+concept_tag: CONNECTIVE-SO
+prerequisites: [ES-C41-creer, ES-C19-si]
+sounds: [s-clear, k-hard]
+roots: [sic-latin]
+etymology_hook: "así ← Latin sīc, 'thus, in that way' (the a- is a Romance accretion, on the pattern of apenas and afuera) — and that sīc is the very word you already met behind sí 'yes'; the same Latin adverb is borrowed raw into English as sic, the editor's mark meaning 'thus it stood'"
+duration:
+  max_seconds: 260
+requires:
+  knowledge: [ES-LEX-SI-01, ES-ETYMON-SI-02, ES-LEX-CREER-01, ES-LEX-PORQUE-03]
+introduces:
+  knowledge: [ES-LEX-ASI-QUE-03, ES-ETYMON-SIC-04]
+practises:
+  knowledge: [ES-LEX-SI-01, ES-ETYMON-SI-02, ES-LEX-CREER-01, ES-LEX-PORQUE-03, ES-LEX-ASI-QUE-03, ES-ETYMON-SIC-04]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C19-si, ES-C38-porque, ES-C41-creer]
+---
+
+# así que — "so", and a word you have been saying since yes
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-PORQUE-03] -->
+
+[PAUSE 2s] *Porque* runs from a claim back to its reason. This runs the other
+way — from the reason forward to what follows. Same two facts, opposite arrow,
+and you need both to explain anything.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `s-clear` — a clean hiss in **así**, never a *z* buzz.
+- `k-hard` — *qu* is a plain *k*; the *u* is silent.
+
+## The phrase, taken apart: así que
+<!-- hl-knowledge: introduces=[ES-LEX-ASI-QUE-03, ES-ETYMON-SIC-04]; assesses=[ES-LEX-SI-01, ES-ETYMON-SI-02] -->
+
+**así** = "so, thus, in that way". **así que** = "so, and therefore".
+
+*Así* is Latin ***sīc***, "thus" — with an *a-* that Spanish added later, the same
+one it put on *apenas* and *afuera*. And you have met *sīc* before:
+it is the whole of Spanish **sí**, "yes". Latin *sīc* meant "thus, in this way",
+and saying *thus* in answer to a question is how a language gets a word for yes.
+
+So *sí* and *así* are the same Latin adverb, one bare and one with the *a-*
+attached. English borrowed it raw and never translated it: ***sic***, the
+mark an editor puts after a quoted mistake — "thus it stood".
+
+## Grammar Lens: the two arrows
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ASI-QUE-03, ES-LEX-PORQUE-03, ES-LEX-CREER-01] -->
+
+The pair is worth drilling as a pair, because they carry the same two facts in
+opposite orders:
+
+| | |
+|---|---|
+| No corro **porque** llueve. | I'm not running **because** it's raining. |
+| Llueve, **así que** no corro. | It's raining, **so** I'm not running. |
+
+*Porque* points **backwards** to the cause. *Así que* points **forwards** to the
+consequence. Which you reach for depends only on which fact you want to say
+first — and that is a choice about emphasis, not about grammar.
+
+| | |
+|---|---|
+| Hace frío, **así que** bebo café. | It's cold, so I drink coffee. |
+| **Creo que** llueve, **así que** leo. | I think it's raining, so I read. |
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ASI-QUE-03, ES-ETYMON-SIC-04, ES-LEX-PORQUE-03, ES-LEX-CREER-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: "sí" then "así" — the same Latin word, one with an *a-* on the front]
+- [YOU SAY: "Llueve, así que no corro."]
+- [YOU SAY: the same two facts the other way — "No corro porque llueve."]
+- [YOU SAY: "Creo que hace frío, así que bebo café."]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ASI-QUE-03, ES-ETYMON-SIC-04, ES-ETYMON-SI-02, ES-LEX-PORQUE-03] -->
+
+[PAUSE 3s] Which Latin adverb is hiding in both *sí* and *así*? (***Sīc***,
+"thus".) Which way does *porque* point, and which way *así que*? (*Porque*
+**backwards** to the cause; *así que* **forwards** to the consequence.) What does
+an editor's *sic* mean? (**Thus it stood** — the same word, borrowed whole.)

--- a/code/learning/human-languages/spanish/lessons/ES-C41-creer.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C41-creer.md
@@ -1,0 +1,107 @@
+---
+schema_version: 2
+id: ES-C41-creer
+spine_node: SPINE-GIVE-REASONS
+sequence: 1880
+chapter: 41
+type: word
+headword: creer
+gloss: to believe, to think — putting your heart somewhere, where pensar weighs it up
+concept_tag: OPINION-I-THINK
+prerequisites: [ES-C34-pensar, ES-C38-contar]
+sounds: [hiatus-ee, r-tap]
+roots: [credere-latin, kerd-pie]
+etymology_hook: "creer ← Latin crēdere 'to entrust, believe', from PIE *ḱred-dʰeh₁-, 'to put *ḱred-' — traditionally read as 'to put HEART', tying *ḱred- to Latin cor, cordis and English heart, though that step is disputed on vocalism; the compound itself is secure, and creer sits in one family with credit, creed, credential and incredible"
+duration:
+  max_seconds: 260
+requires:
+  knowledge: [ES-LEX-PENSAR-01, ES-ETYMON-PENSAR-02]
+introduces:
+  knowledge: [ES-LEX-CREER-01, ES-ETYMON-CREDERE-02]
+practises:
+  knowledge: [ES-LEX-PENSAR-01, ES-ETYMON-PENSAR-02, ES-LEX-CREER-01, ES-ETYMON-CREDERE-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C34-pensar]
+---
+
+# creer — to put your heart somewhere
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-PENSAR-01, ES-ETYMON-PENSAR-02] -->
+
+[PAUSE 2s] You have **pensar** — to think, and underneath it *pēnsāre*, "to
+weigh". Spanish has a second verb for the inside of your head, and it does a
+different job. Where *pensar* weighs, this one commits.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `hiatus-ee` — the two *e*'s do not merge: **creer** = *kreh-EHR*, two beats.
+- `r-tap` — a single flick, not the rolled *rr*.
+
+## The word, taken apart: creer
+<!-- hl-knowledge: introduces=[ES-LEX-CREER-01, ES-ETYMON-CREDERE-02]; assesses=[] -->
+
+**creer** = "to believe", and in everyday use "to think" in the sense of *hold an
+opinion*.
+
+It comes from Latin ***crēdere***, "to entrust, to believe" — and *crēdere* is a
+compound so old that Latin had already forgotten it was one. It is PIE
+***\*ḱred-dʰeh₁-***: "**to put** ***\*ḱred-***".
+
+What is that first half? Traditionally, the **heart** word — the root of Latin
+***cor***, ***cordis*** and of English **heart**. Be honest that the step is
+**disputed**: that root normally appears as *\*ḱḗr*, never *\*ḱred-*. The compound
+is not in doubt; only what it was built on.
+
+Taking the traditional reading:
+
+| from *crēdere* | from *cor, cordis* |
+|---|---|
+| **credit**, **creed**, **credo** | **cordial**, **courage** |
+| **credential**, **incredible** | **record**, **accord**, **discord** |
+
+To **record** is to bring something back to the *cor* — for a Roman the seat of
+**memory**, not of feeling. To have **courage** is to have heart.
+
+## Grammar Lens: creer que
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CREER-01, ES-LEX-PENSAR-01] -->
+
+*Creer* almost always drags a **que** behind it, and then a whole clause:
+
+| | |
+|---|---|
+| **Creo que** llueve. | I think it's raining. |
+| **Creo que** hace frío. | I think it's cold. |
+| **No creo que** llu**e**va. | I don't think it's raining. |
+
+Look hard at that third row. *Creo que* **llueve** — but *no creo que*
+**llueva**. Negating *creer* flips the clause into the **subjunctive** from
+chapter eighteen: stop vouching for something and Spanish stops using the tense
+that states facts.
+
+***Pienso*** is the weighing; ***creo*** is where it landed. Treat that as a way
+to feel the difference, not a rule — both take *que* and a clause, and a speaker
+may use either. But *creo que* is the ordinary opening for an opinion.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CREER-01, ES-ETYMON-CREDERE-02, ES-LEX-PENSAR-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: "creer" — *kreh-EHR*, two beats, not one]
+- [YOU SAY: "Creo que llueve."]
+- [YOU SAY: the pair — "pienso" (I weigh) then "creo" (I hold)]
+- [YOU SAY: "creer" then English "credit, creed, cordial, record"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CREER-01, ES-ETYMON-CREDERE-02, ES-LEX-PENSAR-01, ES-ETYMON-PENSAR-02] -->
+
+[PAUSE 3s] What shape is *crēdere*, under the surface? (**A compound** — *\*ḱred-*
++ *dʰeh₁-*, "to put *\*ḱred-*".) What is the traditional reading of that first
+half, and why hedge it? (**Heart** — but the heart root is *\*ḱḗr*, never
+*\*ḱred-*, so the step is disputed.) *Pensar* weighs; what does *creer* do?
+(It **lands** — it holds the opinion the weighing produced.)

--- a/code/learning/human-languages/spanish/lessons/ES-C41-deber.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C41-deber.md
@@ -1,0 +1,107 @@
+---
+schema_version: 2
+id: ES-C41-deber
+spine_node: SPINE-GIVE-REASONS
+sequence: 1900
+chapter: 41
+type: word
+headword: deber
+gloss: should, ought to — and to owe, because the word is literally "to have something from someone"
+concept_tag: MODAL-SHOULD
+prerequisites: [ES-C41-asi-que]
+sounds: [b-soft, r-tap]
+roots: [debere-latin, habere-latin]
+etymology_hook: "deber ← Latin dēbēre, itself dē- ('from') + habēre ('to have') — 'to have something from someone', which is what owing is; English took the same verb four times over as debt, debit, due and duty, and English calqued the French phrase mettre en devoir into put in dever, which fused into endeavour"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [ES-LEX-ASI-QUE-03, ES-LEX-CREER-01]
+introduces:
+  knowledge: [ES-LEX-DEBER-05, ES-ETYMON-DEBERE-06]
+practises:
+  knowledge: [ES-LEX-ASI-QUE-03, ES-LEX-CREER-01, ES-LEX-DEBER-05, ES-ETYMON-DEBERE-06]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C41-asi-que, ES-C41-creer]
+---
+
+# deber — to owe, and therefore to ought
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-ASI-QUE-03, ES-LEX-CREER-01] -->
+
+[PAUSE 2s] You can now say what you think and what follows from it. This verb
+adds the third move in any explanation: what somebody **ought** to do about it.
+It gets there from an unexpected direction — money.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `b-soft` — between vowels the *b* softens: **deber** = *deh-BEHR*.
+- `r-tap` — one flick at the end, not a roll.
+
+## The word, taken apart: deber
+<!-- hl-knowledge: introduces=[ES-LEX-DEBER-05, ES-ETYMON-DEBERE-06]; assesses=[] -->
+
+**deber** does two jobs: "**to owe**", and "**ought to, should**".
+
+Latin ***dēbēre*** explains both, because it is a compound: ***dē-*** ("from")
+plus ***habēre*** ("to have"). To *dēbēre* something is **to have it from
+someone** — which is exactly what owing is. You are holding what is theirs.
+
+English helped itself to this verb four times over — three of them from the
+participle *dēbitum* rather than the verb — and the spellings record each route:
+
+| English | how it came |
+|---|---|
+| **debt** | through French, then re-spelled to show the Latin *b* |
+| **debit** | straight from Latin bookkeeping |
+| **due** | through French *deü*, the *b* worn away |
+| **duty** | built on *due* |
+
+One more came the long way round, and not by borrowing. French turned *dēbēre*
+into *devoir*, "duty". English **translated** the phrase *mettre en devoir* — to
+put oneself under an obligation — half-way, as *put in dever*, and the last two
+words later fused into **endeavour**.
+
+## Grammar Lens: debo + infinitive
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-DEBER-05, ES-LEX-ASI-QUE-03] -->
+
+*Deber* is regular, and for "ought to" it takes a bare infinitive straight after
+it — no *que*, no preposition:
+
+| person | form |
+|---|---|
+| yo | **debo** |
+| tú | **debes** |
+| él/ella/usted | **debe** |
+| nosotros | **debemos** |
+| ellos/ustedes | **deben** |
+
+**Debo estudiar.** — I ought to study.
+**Llueve, así que debo leer.** — It's raining, so I ought to read.
+
+The obligation is softer than a command and firmer than a wish, which is the
+register an explanation usually wants.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-DEBER-05, ES-ETYMON-DEBERE-06, ES-LEX-ASI-QUE-03] -->
+
+[PAUSE 1s]
+- [YOU SAY: "debo, debes, debe, debemos, deben"]
+- [YOU SAY: "Debo trabajar."]
+- [YOU SAY: "Hace frío, así que debo beber café."]
+- [YOU SAY: "Creo que llueve, así que debo leer."]
+- [YOU SAY: "deber" then English "debt, debit, due, duty"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-DEBER-05, ES-ETYMON-DEBERE-06, ES-LEX-ASI-QUE-03, ES-LEX-CREER-01] -->
+
+[PAUSE 3s] What two Latin pieces build *dēbēre*, and what do they say together?
+(***Dē-*** + ***habēre*** — "to have **from** someone", which is owing.) Name two
+of the four English words it became. (Any of **debt**, **debit**, **due**,
+**duty**.) What follows *debo* — a *que*, or a bare infinitive? (**A bare
+infinitive**: *debo estudiar*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C41-explicar.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C41-explicar.md
@@ -1,0 +1,105 @@
+---
+schema_version: 2
+id: ES-C41-explicar
+spine_node: SPINE-GIVE-REASONS
+sequence: 1910
+chapter: 41
+type: word
+headword: explicar
+gloss: to explain — literally to unfold, and the verb that names what this whole chapter has been building
+concept_tag: EXPLANATION-GIVE
+prerequisites: [ES-C41-deber, ES-C41-asi-que, ES-C41-creer]
+sounds: [k-hard, l-clear]
+roots: [explicare-latin, plicare-latin]
+etymology_hook: "explicar ← Latin explicāre = ex- ('out') + plicāre ('to fold') — to explain is to UNFOLD; plicāre is one of the great English suppliers, giving explicate, complicated, simple (sim-plex, 'one-fold') and duplicate straight from Latin, and through French explicit, application, employ, deploy and display"
+duration:
+  max_seconds: 295
+requires:
+  knowledge: [ES-LEX-DEBER-05, ES-LEX-ASI-QUE-03, ES-LEX-CREER-01, ES-LEX-PORQUE-03]
+introduces:
+  knowledge: [ES-LEX-EXPLICAR-07, ES-ETYMON-PLICARE-08, ES-GRAMMAR-REASON-CHAIN-09]
+practises:
+  knowledge: [ES-LEX-DEBER-05, ES-ETYMON-DEBERE-06, ES-LEX-ASI-QUE-03, ES-ETYMON-SIC-04, ES-LEX-CREER-01, ES-ETYMON-CREDERE-02, ES-LEX-PORQUE-03, ES-LEX-EXPLICAR-07, ES-ETYMON-PLICARE-08, ES-GRAMMAR-REASON-CHAIN-09]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: general
+reviews_of: [ES-C41-deber, ES-C41-asi-que, ES-C41-creer, ES-C38-porque]
+---
+
+# explicar — to unfold
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-CREER-01, ES-LEX-ASI-QUE-03, ES-LEX-DEBER-05] -->
+
+[PAUSE 2s] Three pieces are in your hands: *creo que* to state an opinion, *así
+que* to run forward to what follows, *debo* to say what ought to happen. This
+lesson puts all three in a row, under the verb that names the act.
+
+## Sounds you'll need
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+- `k-hard` — *c* before *a* is a hard *k*: **explicar** = *eks-plee-KAR*.
+- `l-clear` — a clean *l* in the *pl*, no vowel slipped in between.
+
+## The word, taken apart: explicar
+<!-- hl-knowledge: introduces=[ES-LEX-EXPLICAR-07, ES-ETYMON-PLICARE-08]; assesses=[] -->
+
+**explicar** = Latin ***explicāre***: ***ex-*** ("out") + ***plicāre*** ("to
+fold"). **To explain is to unfold** — something was folded shut, and you open it.
+
+*Plicāre* is one of the great suppliers of English. Some came from Latin
+directly, some through French, and the sound changed on the way:
+
+| straight from Latin | through French |
+|---|---|
+| **explicate** | **explicit**, **application** |
+| **complicated** (*com-* + fold) | **employ**, **deploy** |
+| **duplicate** | **display** — a doublet of *deploy* |
+
+And **simple** is *sim-plex* — "**one**-fold". Something simple has been folded
+only once. Something **complicated** has been folded *together*, over and over,
+which is why it needs unfolding. The metaphor is consistent all the way down,
+and Spanish keeps it in the plainest verb of the set.
+
+## Grammar Lens: the shape of an explanation
+<!-- hl-knowledge: introduces=[ES-GRAMMAR-REASON-CHAIN-09]; assesses=[ES-LEX-CREER-01, ES-LEX-ASI-QUE-03, ES-LEX-DEBER-05, ES-LEX-PORQUE-03] -->
+
+*Explicar* is regular — it takes the plain *-ar* endings of *hablar*, with no
+stem change at all: **explico**, **explicas**, **explica**, **explicamos**,
+**explican**. (*Contar*, back in chapter 38, breaks its *o* to *ue*; this one does
+not, and there is nothing to remember.)
+
+Here is a whole explanation, with every piece something this book has taught:
+
+> — ¿Por qué no corres?
+> — **Creo que** llueve. No corro **porque** llueve, **así que** leo. **Debo**
+> estudiar.
+>
+> *— Why aren't you running?*
+> *— I think it's raining. I'm not running because it's raining, so I read. I
+> ought to study.*
+
+Four moves, four words: an **opinion** (*creo que*), a **cause** (*porque*), a
+**consequence** (*así que*), an **obligation** (*debo*). That is what an
+explanation is made of, and you can now build one in either direction — cause
+first or claim first — because *porque* and *así que* let you choose.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-EXPLICAR-07, ES-ETYMON-PLICARE-08, ES-GRAMMAR-REASON-CHAIN-09, ES-LEX-CREER-01, ES-LEX-ASI-QUE-03] -->
+
+[PAUSE 1s]
+- [YOU SAY: "explico, explicas, explica, explicamos, explican"]
+- [YOU SAY: "Explico bien." — I explain well.]
+- [YOU SAY: the four moves — "Creo que llueve, porque hace frío, así que debo leer."]
+- [YOU SAY: "explicar" then English "explicit, complicated, simple, display"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[ES-LEX-EXPLICAR-07, ES-ETYMON-PLICARE-08, ES-GRAMMAR-REASON-CHAIN-09, ES-LEX-CREER-01, ES-ETYMON-CREDERE-02, ES-LEX-ASI-QUE-03, ES-ETYMON-SIC-04, ES-LEX-DEBER-05, ES-ETYMON-DEBERE-06, ES-LEX-PORQUE-03] -->
+
+[PAUSE 3s] What does *explicāre* literally say? (**To fold out** — *ex-* +
+*plicāre*.) What is *simple*, folded? (**Once** — *sim-plex*; *complicated* is
+folded together, again and again.) Name the four moves of an explanation and the
+word for each. (Opinion ***creo que***, cause ***porque***, consequence ***así
+que***, obligation ***debo***.)

--- a/code/learning/human-languages/spanish/narration/ch41.json
+++ b/code/learning/human-languages/spanish/narration/ch41.json
@@ -1,0 +1,750 @@
+{
+  "version": 1,
+  "language": "spanish",
+  "chapter": 41,
+  "title": "Saying Why",
+  "drivablePrefix": 4,
+  "sourceHash": "fnv1a64:aaf392ed71c29d4f",
+  "lessons": [
+    {
+      "id": "ES-C41-creer",
+      "sequence": 1880,
+      "title": "creer — to put your heart somewhere",
+      "headword": "creer",
+      "romanization": "creer",
+      "gloss": "to believe, to think — putting your heart somewhere, where pensar weighs it up",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:3ee4a04c90402814",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You have pensar — to think, and underneath it pēnsāre, \"to weigh\". Spanish has a second verb for the inside of your head, and it does a different job. Where pensar weighs, this one commits."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "hiatus-ee — the two e's do not merge: creer = kreh-EHR, two beats."
+            },
+            {
+              "kind": "speech",
+              "text": "r-tap — a single flick, not the rolled rr."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: creer",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "creer = \"to believe\", and in everyday use \"to think\" in the sense of hold an opinion."
+            },
+            {
+              "kind": "speech",
+              "text": "It comes from Latin crēdere, \"to entrust, to believe\" — and crēdere is a compound so old that Latin had already forgotten it was one. It is PIE ḱred-dʰeh₁-: \"to put ḱred-\"."
+            },
+            {
+              "kind": "speech",
+              "text": "What is that first half? Traditionally, the heart word — the root of Latin cor, cordis and of English heart. Be honest that the step is disputed: that root normally appears as ḱḗr, never ḱred-. The compound is not in doubt; only what it was built on."
+            },
+            {
+              "kind": "speech",
+              "text": "Taking the traditional reading:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "from crēdere",
+                "from cor, cordis"
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "from crēdere: credit, creed, credo. from cor, cordis: cordial, courage.",
+                "from crēdere: credential, incredible. from cor, cordis: record, accord, discord."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "To record is to bring something back to the cor — for a Roman the seat of memory, not of feeling. To have courage is to have heart."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: creer que",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Creer almost always drags a que behind it, and then a whole clause:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 3,
+              "utterances": [
+                "Creo que llueve., I think it's raining.",
+                "Creo que hace frío., I think it's cold.",
+                "No creo que llueva., I don't think it's raining."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Look hard at that third row. Creo que llueve — but no creo que llueva. Negating creer flips the clause into the subjunctive from chapter eighteen: stop vouching for something and Spanish stops using the tense that states facts."
+            },
+            {
+              "kind": "speech",
+              "text": "Pienso is the weighing; creo is where it landed. Treat that as a way to feel the difference, not a rule — both take que and a clause, and a speaker may use either. But creo que is the ordinary opening for an opinion."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"creer\" — kreh-EHR, two beats, not one",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"creer\" — *kreh-EHR*, two beats, not one]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Creo que llueve.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Creo que llueve.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the pair — \"pienso\" (I weigh) then \"creo\" (I hold)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the pair — \"pienso\" (I weigh) then \"creo\" (I hold)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"creer\" then English \"credit, creed, cordial, record\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"creer\" then English \"credit, creed, cordial, record\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What shape is crēdere, under the surface? (A compound — ḱred-."
+            },
+            {
+              "kind": "speech",
+              "text": "dʰeh₁-, \"to put ḱred-\".) What is the traditional reading of that first half, and why hedge it? (Heart — but the heart root is ḱḗr, never ḱred-, so the step is disputed.) Pensar weighs; what does creer do? (It lands — it holds the opinion the weighing produced.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C41-asi-que",
+      "sequence": 1890,
+      "title": "así que — \"so\", and a word you have been saying since yes",
+      "headword": "así",
+      "romanization": "así",
+      "gloss": "thus, in that way — and with que after it, \"so\"; built on the same sīc that gave you sí",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:ed35ac545ee26f56",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Porque runs from a claim back to its reason. This runs the other way — from the reason forward to what follows. Same two facts, opposite arrow, and you need both to explain anything."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "s-clear — a clean hiss in así, never a z buzz."
+            },
+            {
+              "kind": "speech",
+              "text": "k-hard — qu is a plain k; the u is silent."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The phrase, taken apart: así que",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "así = \"so, thus, in that way\". así que = \"so, and therefore\"."
+            },
+            {
+              "kind": "speech",
+              "text": "Así is Latin sīc, \"thus\" — with an a- that Spanish added later, the same one it put on apenas and afuera. And you have met sīc before: it is the whole of Spanish sí, \"yes\". Latin sīc meant \"thus, in this way\", and saying thus in answer to a question is how a language gets a word for yes."
+            },
+            {
+              "kind": "speech",
+              "text": "So sí and así are the same Latin adverb, one bare and one with the a- attached. English borrowed it raw and never translated it: sic, the mark an editor puts after a quoted mistake — \"thus it stood\"."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the two arrows",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The pair is worth drilling as a pair, because they carry the same two facts in opposite orders:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "No corro porque llueve., I'm not running because it's raining.",
+                "Llueve, así que no corro., It's raining, so I'm not running."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Porque points backwards to the cause. Así que points forwards to the consequence. Which you reach for depends only on which fact you want to say first — and that is a choice about emphasis, not about grammar."
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "Hace frío, así que bebo café., It's cold, so I drink coffee.",
+                "Creo que llueve, así que leo., I think it's raining, so I read."
+              ]
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sí\" then \"así\" — the same Latin word, one with an a- on the front",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sí\" then \"así\" — the same Latin word, one with an *a-* on the front]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Llueve, así que no corro.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Llueve, así que no corro.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the same two facts the other way — \"No corro porque llueve.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the same two facts the other way — \"No corro porque llueve.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Creo que hace frío, así que bebo café.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Creo que hace frío, así que bebo café.\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Which Latin adverb is hiding in both sí and así? (Sīc, \"thus\".) Which way does porque point, and which way así que? (Porque backwards to the cause; así que forwards to the consequence.) What does an editor's sic mean? (Thus it stood — the same word, borrowed whole.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C41-deber",
+      "sequence": 1900,
+      "title": "deber — to owe, and therefore to ought",
+      "headword": "deber",
+      "romanization": "deber",
+      "gloss": "should, ought to — and to owe, because the word is literally \"to have something from someone\"",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:09df6b06ec0fe3c8",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You can now say what you think and what follows from it. This verb adds the third move in any explanation: what somebody ought to do about it. It gets there from an unexpected direction — money."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "b-soft — between vowels the b softens: deber = deh-BEHR."
+            },
+            {
+              "kind": "speech",
+              "text": "r-tap — one flick at the end, not a roll."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: deber",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "deber does two jobs: \"to owe\", and \"ought to, should\"."
+            },
+            {
+              "kind": "speech",
+              "text": "Latin dēbēre explains both, because it is a compound: dē- (\"from\") plus habēre (\"to have\"). To dēbēre something is to have it from someone — which is exactly what owing is. You are holding what is theirs."
+            },
+            {
+              "kind": "speech",
+              "text": "English helped itself to this verb four times over — three of them from the participle dēbitum rather than the verb — and the spellings record each route:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "English",
+                "how it came"
+              ],
+              "columns": 2,
+              "rowCount": 4,
+              "utterances": [
+                "English: debt. how it came: through French, then re-spelled to show the Latin b.",
+                "English: debit. how it came: straight from Latin bookkeeping.",
+                "English: due. how it came: through French deü, the b worn away.",
+                "English: duty. how it came: built on due."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "One more came the long way round, and not by borrowing. French turned dēbēre into devoir, \"duty\". English translated the phrase mettre en devoir — to put oneself under an obligation — half-way, as put in dever, and the last two words later fused into endeavour."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: debo + infinitive",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Deber is regular, and for \"ought to\" it takes a bare infinitive straight after it — no que, no preposition:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "person",
+                "form"
+              ],
+              "columns": 2,
+              "rowCount": 5,
+              "utterances": [
+                "person: yo. form: debo.",
+                "person: tú. form: debes.",
+                "person: él/ella/usted. form: debe.",
+                "person: nosotros. form: debemos.",
+                "person: ellos/ustedes. form: deben."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Debo estudiar. — I ought to study. Llueve, así que debo leer. — It's raining, so I ought to read."
+            },
+            {
+              "kind": "speech",
+              "text": "The obligation is softer than a command and firmer than a wish, which is the register an explanation usually wants."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"debo, debes, debe, debemos, deben\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"debo, debes, debe, debemos, deben\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Debo trabajar.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Debo trabajar.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Hace frío, así que debo beber café.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Hace frío, así que debo beber café.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Creo que llueve, así que debo leer.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Creo que llueve, así que debo leer.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"deber\" then English \"debt, debit, due, duty\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"deber\" then English \"debt, debit, due, duty\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What two Latin pieces build dēbēre, and what do they say together? (Dē- + habēre — \"to have from someone\", which is owing.) Name two of the four English words it became. (Any of debt, debit, due, duty.) What follows debo — a que, or a bare infinitive? (A bare infinitive: debo estudiar.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ES-C41-explicar",
+      "sequence": 1910,
+      "title": "explicar — to unfold",
+      "headword": "explicar",
+      "romanization": "explicar",
+      "gloss": "to explain — literally to unfold, and the verb that names what this whole chapter has been building",
+      "script": "latin",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:46ebaea1981bf7f9",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Three pieces are in your hands: creo que to state an opinion, así que to run forward to what follows, debo to say what ought to happen. This lesson puts all three in a row, under the verb that names the act."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "pronunciation",
+          "title": "Sounds you'll need",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "k-hard — c before a is a hard k: explicar = eks-plee-KAR."
+            },
+            {
+              "kind": "speech",
+              "text": "l-clear — a clean l in the pl, no vowel slipped in between."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: explicar",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "explicar = Latin explicāre: ex- (\"out\") + plicāre (\"to fold\"). To explain is to unfold — something was folded shut, and you open it."
+            },
+            {
+              "kind": "speech",
+              "text": "Plicāre is one of the great suppliers of English. Some came from Latin directly, some through French, and the sound changed on the way:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "straight from Latin",
+                "through French"
+              ],
+              "columns": 2,
+              "rowCount": 3,
+              "utterances": [
+                "straight from Latin: explicate. through French: explicit, application.",
+                "straight from Latin: complicated (com- + fold). through French: employ, deploy.",
+                "straight from Latin: duplicate. through French: display — a doublet of deploy."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "And simple is sim-plex — \"one-fold\". Something simple has been folded only once. Something complicated has been folded together, over and over, which is why it needs unfolding. The metaphor is consistent all the way down, and Spanish keeps it in the plainest verb of the set."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the shape of an explanation",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Explicar is regular — it takes the plain -ar endings of hablar, with no stem change at all: explico, explicas, explica, explicamos, explican. (Contar, back in chapter 38, breaks its o to ue; this one does not, and there is nothing to remember.)"
+            },
+            {
+              "kind": "speech",
+              "text": "Here is a whole explanation, with every piece something this book has taught:"
+            },
+            {
+              "kind": "speech",
+              "text": "— ¿Por qué no corres? — Creo que llueve. No corro porque llueve, así que leo. Debo estudiar. — Why aren't you running? — I think it's raining. I'm not running because it's raining, so I read. I ought to study."
+            },
+            {
+              "kind": "speech",
+              "text": "Four moves, four words: an opinion (creo que), a cause (porque), a consequence (así que), an obligation (debo). That is what an explanation is made of, and you can now build one in either direction — cause first or claim first — because porque and así que let you choose."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"explico, explicas, explica, explicamos, explican\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"explico, explicas, explica, explicamos, explican\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"Explico bien.\" — I explain well.",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"Explico bien.\" — I explain well.]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the four moves — \"Creo que llueve, porque hace frío, así que debo leer.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the four moves — \"Creo que llueve, porque hace frío, así que debo leer.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"explicar\" then English \"explicit, complicated, simple, display\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"explicar\" then English \"explicit, complicated, simple, display\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does explicāre literally say? (To fold out — ex- + plicāre.) What is simple, folded? (Once — sim-plex; complicated is folded together, again and again.) Name the four moves of an explanation and the word for each. (Opinion creo que, cause porque, consequence así que, obligation debo.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/spanish/narration/ch41.txt
+++ b/code/learning/human-languages/spanish/narration/ch41.txt
@@ -1,0 +1,184 @@
+Spanish, chapter 41: Saying Why.
+4 lessons. All 4 can be done entirely by ear.
+
+
+Lesson 1 of 4.
+creer — to put your heart somewhere.
+
+Warm-up.
+[pause 2 seconds]
+You have pensar — to think, and underneath it pēnsāre, "to weigh". Spanish has a second verb for the inside of your head, and it does a different job. Where pensar weighs, this one commits.
+
+Sounds you'll need.
+hiatus-ee — the two e's do not merge: creer = kreh-EHR, two beats.
+r-tap — a single flick, not the rolled rr.
+
+The word, taken apart: creer.
+creer = "to believe", and in everyday use "to think" in the sense of hold an opinion.
+It comes from Latin crēdere, "to entrust, to believe" — and crēdere is a compound so old that Latin had already forgotten it was one. It is PIE ḱred-dʰeh₁-: "to put ḱred-".
+What is that first half? Traditionally, the heart word — the root of Latin cor, cordis and of English heart. Be honest that the step is disputed: that root normally appears as ḱḗr, never ḱred-. The compound is not in doubt; only what it was built on.
+Taking the traditional reading:
+[a table of 2 rows, read aloud]
+from crēdere: credit, creed, credo. from cor, cordis: cordial, courage.
+from crēdere: credential, incredible. from cor, cordis: record, accord, discord.
+To record is to bring something back to the cor — for a Roman the seat of memory, not of feeling. To have courage is to have heart.
+
+Grammar Lens: creer que.
+Creer almost always drags a que behind it, and then a whole clause:
+[a table of 3 rows, read aloud]
+Creo que llueve., I think it's raining.
+Creo que hace frío., I think it's cold.
+No creo que llueva., I don't think it's raining.
+Look hard at that third row. Creo que llueve — but no creo que llueva. Negating creer flips the clause into the subjunctive from chapter eighteen: stop vouching for something and Spanish stops using the tense that states facts.
+Pienso is the weighing; creo is where it landed. Treat that as a way to feel the difference, not a rule — both take que and a clause, and a speaker may use either. But creo que is the ordinary opening for an opinion.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "creer" — kreh-EHR, two beats, not one]
+[pause 8 seconds for the answer]
+[your turn — say: "Creo que llueve."]
+[pause 8 seconds for the answer]
+[your turn — say: the pair — "pienso" (I weigh) then "creo" (I hold)]
+[pause 8 seconds for the answer]
+[your turn — say: "creer" then English "credit, creed, cordial, record"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What shape is crēdere, under the surface? (A compound — ḱred-.
+dʰeh₁-, "to put ḱred-".) What is the traditional reading of that first half, and why hedge it? (Heart — but the heart root is ḱḗr, never ḱred-, so the step is disputed.) Pensar weighs; what does creer do? (It lands — it holds the opinion the weighing produced.)
+
+
+Lesson 2 of 4.
+así que — "so", and a word you have been saying since yes.
+
+Warm-up.
+[pause 2 seconds]
+Porque runs from a claim back to its reason. This runs the other way — from the reason forward to what follows. Same two facts, opposite arrow, and you need both to explain anything.
+
+Sounds you'll need.
+s-clear — a clean hiss in así, never a z buzz.
+k-hard — qu is a plain k; the u is silent.
+
+The phrase, taken apart: así que.
+así = "so, thus, in that way". así que = "so, and therefore".
+Así is Latin sīc, "thus" — with an a- that Spanish added later, the same one it put on apenas and afuera. And you have met sīc before: it is the whole of Spanish sí, "yes". Latin sīc meant "thus, in this way", and saying thus in answer to a question is how a language gets a word for yes.
+So sí and así are the same Latin adverb, one bare and one with the a- attached. English borrowed it raw and never translated it: sic, the mark an editor puts after a quoted mistake — "thus it stood".
+
+Grammar Lens: the two arrows.
+The pair is worth drilling as a pair, because they carry the same two facts in opposite orders:
+[a table of 2 rows, read aloud]
+No corro porque llueve., I'm not running because it's raining.
+Llueve, así que no corro., It's raining, so I'm not running.
+Porque points backwards to the cause. Así que points forwards to the consequence. Which you reach for depends only on which fact you want to say first — and that is a choice about emphasis, not about grammar.
+[a table of 2 rows, read aloud]
+Hace frío, así que bebo café., It's cold, so I drink coffee.
+Creo que llueve, así que leo., I think it's raining, so I read.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "sí" then "así" — the same Latin word, one with an a- on the front]
+[pause 8 seconds for the answer]
+[your turn — say: "Llueve, así que no corro."]
+[pause 8 seconds for the answer]
+[your turn — say: the same two facts the other way — "No corro porque llueve."]
+[pause 8 seconds for the answer]
+[your turn — say: "Creo que hace frío, así que bebo café."]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Which Latin adverb is hiding in both sí and así? (Sīc, "thus".) Which way does porque point, and which way así que? (Porque backwards to the cause; así que forwards to the consequence.) What does an editor's sic mean? (Thus it stood — the same word, borrowed whole.)
+
+
+Lesson 3 of 4.
+deber — to owe, and therefore to ought.
+
+Warm-up.
+[pause 2 seconds]
+You can now say what you think and what follows from it. This verb adds the third move in any explanation: what somebody ought to do about it. It gets there from an unexpected direction — money.
+
+Sounds you'll need.
+b-soft — between vowels the b softens: deber = deh-BEHR.
+r-tap — one flick at the end, not a roll.
+
+The word, taken apart: deber.
+deber does two jobs: "to owe", and "ought to, should".
+Latin dēbēre explains both, because it is a compound: dē- ("from") plus habēre ("to have"). To dēbēre something is to have it from someone — which is exactly what owing is. You are holding what is theirs.
+English helped itself to this verb four times over — three of them from the participle dēbitum rather than the verb — and the spellings record each route:
+[a table of 4 rows, read aloud]
+English: debt. how it came: through French, then re-spelled to show the Latin b.
+English: debit. how it came: straight from Latin bookkeeping.
+English: due. how it came: through French deü, the b worn away.
+English: duty. how it came: built on due.
+One more came the long way round, and not by borrowing. French turned dēbēre into devoir, "duty". English translated the phrase mettre en devoir — to put oneself under an obligation — half-way, as put in dever, and the last two words later fused into endeavour.
+
+Grammar Lens: debo + infinitive.
+Deber is regular, and for "ought to" it takes a bare infinitive straight after it — no que, no preposition:
+[a table of 5 rows, read aloud]
+person: yo. form: debo.
+person: tú. form: debes.
+person: él/ella/usted. form: debe.
+person: nosotros. form: debemos.
+person: ellos/ustedes. form: deben.
+Debo estudiar. — I ought to study. Llueve, así que debo leer. — It's raining, so I ought to read.
+The obligation is softer than a command and firmer than a wish, which is the register an explanation usually wants.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "debo, debes, debe, debemos, deben"]
+[pause 8 seconds for the answer]
+[your turn — say: "Debo trabajar."]
+[pause 8 seconds for the answer]
+[your turn — say: "Hace frío, así que debo beber café."]
+[pause 8 seconds for the answer]
+[your turn — say: "Creo que llueve, así que debo leer."]
+[pause 8 seconds for the answer]
+[your turn — say: "deber" then English "debt, debit, due, duty"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What two Latin pieces build dēbēre, and what do they say together? (Dē- + habēre — "to have from someone", which is owing.) Name two of the four English words it became. (Any of debt, debit, due, duty.) What follows debo — a que, or a bare infinitive? (A bare infinitive: debo estudiar.)
+
+
+Lesson 4 of 4.
+explicar — to unfold.
+
+Warm-up.
+[pause 2 seconds]
+Three pieces are in your hands: creo que to state an opinion, así que to run forward to what follows, debo to say what ought to happen. This lesson puts all three in a row, under the verb that names the act.
+
+Sounds you'll need.
+k-hard — c before a is a hard k: explicar = eks-plee-KAR.
+l-clear — a clean l in the pl, no vowel slipped in between.
+
+The word, taken apart: explicar.
+explicar = Latin explicāre: ex- ("out") + plicāre ("to fold"). To explain is to unfold — something was folded shut, and you open it.
+Plicāre is one of the great suppliers of English. Some came from Latin directly, some through French, and the sound changed on the way:
+[a table of 3 rows, read aloud]
+straight from Latin: explicate. through French: explicit, application.
+straight from Latin: complicated (com- + fold). through French: employ, deploy.
+straight from Latin: duplicate. through French: display — a doublet of deploy.
+And simple is sim-plex — "one-fold". Something simple has been folded only once. Something complicated has been folded together, over and over, which is why it needs unfolding. The metaphor is consistent all the way down, and Spanish keeps it in the plainest verb of the set.
+
+Grammar Lens: the shape of an explanation.
+Explicar is regular — it takes the plain -ar endings of hablar, with no stem change at all: explico, explicas, explica, explicamos, explican. (Contar, back in chapter 38, breaks its o to ue; this one does not, and there is nothing to remember.)
+Here is a whole explanation, with every piece something this book has taught:
+— ¿Por qué no corres? — Creo que llueve. No corro porque llueve, así que leo. Debo estudiar. — Why aren't you running? — I think it's raining. I'm not running because it's raining, so I read. I ought to study.
+Four moves, four words: an opinion (creo que), a cause (porque), a consequence (así que), an obligation (debo). That is what an explanation is made of, and you can now build one in either direction — cause first or claim first — because porque and así que let you choose.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "explico, explicas, explica, explicamos, explican"]
+[pause 8 seconds for the answer]
+[your turn — say: "Explico bien." — I explain well.]
+[pause 8 seconds for the answer]
+[your turn — say: the four moves — "Creo que llueve, porque hace frío, así que debo leer."]
+[pause 8 seconds for the answer]
+[your turn — say: "explicar" then English "explicit, complicated, simple, display"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does explicāre literally say? (To fold out — ex- + plicāre.) What is simple, folded? (Once — sim-plex; complicated is folded together, again and again.) Name the four moves of an explanation and the word for each. (Opinion creo que, cause porque, consequence así que, obligation debo.)

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,82 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Fixed — the Spanish book was printing chapter 38 twice and dropping chapter 40
+
+Found while wiring chapter 41 next to it, and pre-existing on `main`. The Spanish
+entries in `core/book-generation.json` had drifted one out of step: the target whose
+`output` is `ch39-bring-get-play-meet.tex` declared `"chapter": 38`, and the one for
+`ch40-wait-answer-buy.tex` declared `"chapter": 39`. No target declared chapter 40.
+
+The consequences were invisible to every check. `ch39-bring-get-play-meet.tex` was
+**byte-identical in content** to `ch38-narrating.tex` — same `canonical-source-hash`,
+same ES-C38 lessons — with only the title and label swapped, so a reader got chapter
+38 twice under two names. Chapter 40's four lessons reached no book chapter at all.
+
+`check:books` passed throughout, because it validates the targets that are declared,
+not whether the declarations cover the corpus. `chapters.json` was correct the whole
+time; only the book manifest was wrong. Each of the four chapters now renders its own
+lessons under its own hash.
+
+### Added — Spanish chapter 41, the second B1 rung (SPINE-GIVE-REASONS)
+
+**"Saying Why"** — four lessons, one concept each, etymology in every one, ending in
+a four-move explanation the reader can build in either direction.
+
+| lesson | concept | what is new |
+|---|---|---|
+| `ES-C41-creer` | OPINION-I-THINK | stating an opinion, against `pensar`'s weighing |
+| `ES-C41-asi-que` | CONNECTIVE-SO | the forward arrow, where `porque` points back |
+| `ES-C41-deber` | MODAL-SHOULD | obligation, from a word that means *to owe* |
+| `ES-C41-explicar` | EXPLANATION-GIVE | the synthesis: opinion, cause, consequence, obligation |
+
+Spanish now realizes **two** of the seventeen B1–C2 nodes. `attained` is still null.
+
+The chapter-38 review's four failure classes were each checked for up front, and three
+held: nothing here re-teaches owned material (`creer`, `deber`, `explicar`, `así` and
+`entonces` appear nowhere else in the track), every word in the payoff is taught, and
+the book wiring — target, `\input`, generated `.tex` — went in with the chapter rather
+than after it.
+
+### Note — the fourth class did not hold: five etymological errors
+
+Same shape as chapter 38's: **right family, wrong route or wrong strength.**
+
+- *"`así` ← Latin **`ad sīc`**"* — the weakest of four proposals. The DLE now gives
+  plain `sīc`; the `a-` is a Romance accretion, on the pattern of *apenas*, *afuera*.
+- *"`*ḱred-` **is** the heart word"* — traditional but **disputed**: the heart root is
+  `*ḱḗr`, never `*ḱred-`. The compound is secure; the identification is not. Now hedged
+  in the lesson rather than asserted, and the recall question asks *why* to hedge.
+- *"`endeavour` **reached English** via French `devoir`"* — no French word `endeavour`
+  ever existed. English **calqued** `mettre en devoir` as *put in dever*, which fused.
+- *"**explicit**, **application** — straight from Latin"* — both came through French.
+- *"`comply` from `plicāre`"* — it is from `complēre`, "to fill", a different PIE root
+  that the French verb ending disguises. Exactly the trap the lesson otherwise teaches.
+
+### Fixed — three defects that reached the reader, and one the TTS would have spoken
+
+- **`explicar` was said to "take the same shape as `contar`"** — but chapter 38 teaches
+  `contar` as an o→ue stem-changer, three chapters earlier. `explicar` is plain `-ar`.
+  It now points at `hablar` and says explicitly that `contar` does the other thing.
+- **`No creo que …`** sat bare between two indicative rows. Negating `creer` takes the
+  **subjunctive** — *no creo que llueva* — which chapter 18 already taught. Completed
+  and tied back rather than dropped.
+- **`pr-cluster`** was tagged on the *pl* of `explicar`; that tag is defined elsewhere
+  as *pr* with a tapped *r*. Now `l-clear`.
+- **A Greek capital beta (U+0392)** had crept into `deber`'s pronunciation hint, and
+  propagated into `narration/ch41.txt` — a file fed to text-to-speech.
+
+### Changed — a headword narrowed to stop nine false positives
+
+The connective lesson was first written with the multi-word headword **`así que`**.
+`taughtWords` strips a leading word of ≤3 characters — a heuristic meant for articles —
+so it registered **`que`** as first taught at chapter 41 and flagged all nine earlier
+lessons containing it. `que` is genuinely taught at chapter 7.
+
+The headword is now **`así`**, the only word that is actually new, with the gloss
+carrying the `que`. `forwardReferences` holds flat at 524. The loader heuristic is the
+real bug and is recorded as such in the pin comment.
+
 ### Added — the first content above A2: Spanish chapter 38 (HL09, SPINE-NARRATE-EVENTS)
 
 The B1–C2 spine landed with all 17 nodes declared as gaps in all 22 tracks. This

--- a/code/packages/typescript/human-language-data/tests/chapters.test.ts
+++ b/code/packages/typescript/human-language-data/tests/chapters.test.ts
@@ -225,11 +225,11 @@ describe("corpus snapshot", () => {
     // bookChapters 377 -> 378, declaredChapters 279 -> 280, chaptersWithoutCapability
     // holds at 98. A new chapter that shipped without a `canDo`/`payoff` would have
     // pushed the debt to 99, which is exactly what this trio is here to catch.
-    expect(report.summary.bookChapters).toBe(451); // +1: Spanish ch38 reaches the BOOK
+    expect(report.summary.bookChapters).toBe(452); // +1: Spanish ch41, the second B1 chapter
     // 317 -> 318 when russian chapter 3 gained a capability. It was the only
     // generated chapter with no HL05 entry, so it was also the only generated chapter
     // the book could not give an opening to.
-    expect(report.summary.declaredChapters).toBe(353); // +1: Spanish ch38, the B1 pilot
+    expect(report.summary.declaredChapters).toBe(354); // +1: Spanish ch41, the second B1 chapter
     expect(report.summary.chaptersWithoutCapability).toBe(98);
     expect(report.summary.payoffsNotClosed).toBe(0);
     expect(report.summary.unknownPayoffLessons).toBe(0);

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -264,8 +264,8 @@ describe("the real corpus", () => {
     // lesson's own, structurally unreachable), Bengali 12 of 18 -> 4 of 35, Tamil 53% ->
     // 38%, Arabic four ch28-30 atoms off zero. Adding vocabulary and reducing orphans at
     // the same time is the whole point; a corpus that only grows is not a course.
-    expect(report.summary.atomsTaught).toBe(2014); // +9: the four Spanish B1 lessons
-    expect(report.summary.atomsNeverRevisited).toBe(514);
+    expect(report.summary.atomsTaught).toBe(2023); // +9: Spanish ch41's nine atoms // +9: the four Spanish B1 lessons
+    expect(report.summary.atomsNeverRevisited).toBe(516);
     expect(report.summary.neverRevisitedPercent).toBe(26);
 
     // 509 -> 517, and the eight split into TWO DIFFERENT PHENOMENA this number conflates.
@@ -297,6 +297,14 @@ describe("the real corpus", () => {
     // Note it keys on the HEADWORD, not the atom — chapter 38 introduces only
     // ES-GRAMMAR-LUEGO-CONNECTIVE-01 and requires chapter 5's ES-LEX-LUEGO, yet the
     // count is unchanged by that wiring.
+    //
+    // Spanish chapter 41 adds ZERO, and that took one deliberate change. Its connective
+    // lesson was first written with the multi-word headword "así que"; `taughtWords`
+    // strips a leading word of <=3 chars (`/^(\S{1,3})\s+(.+)$/`, meant for articles),
+    // so it registered *que* as first taught there and flagged all 9 earlier lessons
+    // containing it. *Que* is genuinely taught at chapter 7. Narrowing the headword to
+    // *así* — the only word that IS new, with the gloss carrying the *que* — removed
+    // nine false positives. The loader heuristic is the real bug; this is a workaround.
     expect(report.summary.forwardReferences).toBe(524);
 
     // HL09 step 3 closed 17 R1 windows in chapters 3-6, measured on the corpus of the
@@ -314,8 +322,8 @@ describe("the real corpus", () => {
     // So this is not a cost the new chapter incurred; it is a debt the old chapters
     // already had, which only became measurable once something followed them. Any
     // chapter appended to any track will do this, and the number is honest either way.
-    expect(report.summary.missedByWindow.R1).toBe(785);
-    expect(report.summary.missedByWindow.R2).toBe(1294);
+    expect(report.summary.missedByWindow.R1).toBe(788);
+    expect(report.summary.missedByWindow.R2).toBe(1305);
   });
 
   it("shows what a declared reading order was worth", () => {
@@ -341,11 +349,11 @@ describe("the real corpus", () => {
       // Chapter 38 added four lessons and ten atoms. The two ORDER numbers did not
       // move -- no new unsequenced lesson, no new forward prerequisite -- which is the
       // point of the pin: new content is supposed to leave the walk alone.
-      lessonCount: 173,
+      lessonCount: 177,
       lessonsWithoutSequence: 6,
       forwardPrerequisites: 5,
-      atomsTaught: 251,
-      atomsNeverRevisited: 68,
+      atomsTaught: 260,
+      atomsNeverRevisited: 70,
     });
   });
 

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -104,7 +104,7 @@ describe("real curriculum", () => {
     // 40 (esperar, contestar, comprar). Two sessions authored a chapter 38 in parallel;
     // the collision surfaced as a merge conflict on chapters.json rather than silently,
     // because both sides must edit it.
-    expect(books.books.find((book) => book.language === "spanish")?.chapters.length).toBe(40);
+    expect(books.books.find((book) => book.language === "spanish")?.chapters.length).toBe(41);
     expect(
       books.books
         .find((book) => book.language === "persian")

--- a/code/packages/typescript/human-language-data/tests/level-gate.test.ts
+++ b/code/packages/typescript/human-language-data/tests/level-gate.test.ts
@@ -72,7 +72,7 @@ describe("the gate that would have caught the A2 claim", () => {
     // catch — a number meaning "everything taught" published against one meaning
     // "by the end of pre-A1".
     expect(vocab.shortfall).toBe(256);
-    expect(spanish.vocabulary).toBe(132);
+    expect(spanish.vocabulary).toBe(136);
     expect(vocab.shortfall).toBeGreaterThan(LEVEL_VOCABULARY["pre-A1"] - spanish.vocabulary);
   });
 

--- a/code/packages/typescript/human-language-data/tests/levels.test.ts
+++ b/code/packages/typescript/human-language-data/tests/levels.test.ts
@@ -220,9 +220,10 @@ describe("corpus snapshot", () => {
     expect(summary.byLevel["pre-A1"]).toBe(650);
     expect(summary.byLevel.A1).toBe(297);
     expect(summary.byLevel.A2).toBe(350);
-    // 4, not 0: Spanish chapter 38 realizes SPINE-NARRATE-EVENTS, the first B1 node
-    // any track has touched. B2-C2 remain authored-but-unrealized.
-    expect(summary.byLevel.B1).toBe(4);
+    // 8, not 0: Spanish chapters 38 and 41 realize SPINE-NARRATE-EVENTS and
+    // SPINE-GIVE-REASONS, four lessons each — the only B1 nodes any track has touched.
+    // B2-C2 remain authored-but-unrealized, in every track.
+    expect(summary.byLevel.B1).toBe(8);
     expect(summary.byLevel.B2).toBe(0);
     expect(summary.byLevel.C1).toBe(0);
     expect(summary.byLevel.C2).toBe(0);

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -792,16 +792,16 @@ describe("corpus regression", () => {
     // headline per-track number is the standing recommendation; until then, expect this
     // figure to rise whenever a non-Latin track authors honestly.
     expect(manifest.summary).toEqual({
-      // All four Spanish B1 lessons are ear-only, so the B1 pilot is fully drivable
-      // and nudges the whole-corpus figure from 66% to 67%.
-      totalLessons: 1449,
-      voice: 973,
+      // Both Spanish B1 chapters, 38 and 41, are entirely ear-only, so each is fully
+      // drivable. They are what moved the whole-corpus figure from 66% to 67%.
+      totalLessons: 1453,
+      voice: 977,
       sight: 423,
       pen: 53,
-      drivableLessons: 973,
+      drivableLessons: 977,
       drivablePercent: 67,
       trackCount: 22,
-      chapterCount: 451,
+      chapterCount: 452,
       // Prerequisite order still costs a commuter 132 of the 965 ear-only lessons:
       // they sit behind a blocker in their own chapter and stay unreachable in the car
       // until HL-C17 reshapes the remaining wide tables.
@@ -810,8 +810,8 @@ describe("corpus regression", () => {
       // and the alphabetical fallback it replaced had been flattering this number by
       // putting eyes-needed lessons later than they really come. The real order is
       // worse, which is the measurement becoming honest, not the corpus regressing.
-      drivablePrefixTotal: 790,
-      fullyDrivableChapters: 306,
+      drivablePrefixTotal: 794,
+      fullyDrivableChapters: 307,
       unstartableChapters: 108,
       overriddenLessons: 0,
       lessonsWithoutChapter: 0,

--- a/code/packages/typescript/human-language-data/tests/narration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/narration.test.ts
@@ -608,7 +608,7 @@ describe("the whole corpus", () => {
     // 378, not the 375 this was authored against: HL-C39 and HL-C40 each added a
     // Chapter 1 (Mandarin Chinese and Japanese) while this branch waited to merge, and
     // the Latin core-verb chapter (chapter 37, eight verb lessons) added one more.
-    expect(chapters).toHaveLength(451);
+    expect(chapters).toHaveLength(452);
   });
 
   it("leaves no Markdown typography in the spoken script", () => {

--- a/lessons.md
+++ b/lessons.md
@@ -2962,3 +2962,31 @@ payoff story used five words the course teaches nowhere, printed directly under 
 sentence "every word is one you already own". The `forwardReferences` metric cannot
 catch this: its blind spot is vocabulary the corpus never teaches at all. Diff the
 story's words against the track's headword list by hand.
+
+## A cousin list needs the ROUTE checked, not just the family
+
+Chapter 41's etymologies were all in the right families and five were still wrong,
+because a word can reach English from Latin by more than one road and the road
+changes what is true:
+
+- **`explicit`** and **`application`** were filed under "straight from Latin". Both
+  came through French. The family was right; the column was not.
+- **`comply`** was listed under `plicāre` "fold". It is from `complēre` "fill" — a
+  different PIE root, disguised by a shared French verb ending. That is precisely the
+  look-alike trap the lesson was written to teach.
+- **`endeavour`** was said to have "reached English" from French. No French word
+  `endeavour` ever existed; English **calqued** the phrase `mettre en devoir`.
+- **`ad sīc`** was given as `así`'s etymon. It is the weakest of four proposals and
+  the dictionary of record no longer prints it.
+- **`*ḱred-` = heart** was stated flat. It is traditional and *disputed*: the heart
+  root is `*ḱḗr`, never `*ḱred-`.
+
+**Rule:** for every cousin, ask three questions, not one. Same root? Same *route*
+(direct, through French, calqued, coined)? And is the etymon the *current* consensus
+or a superseded proposal? A lesson that teaches learners to spot false friends has to
+hold itself to the standard it is teaching.
+
+**Corollary — check a new lesson against the chapters it names.** Chapter 41 said
+`explicar` "takes the same shape as `contar`" — but chapter 38 teaches `contar` as a
+stem-changer, and `explicar` is not one. A reader coming through in order would have
+hit the contradiction and trusted the book a little less.


### PR DESCRIPTION
**"Saying Why"** realizes `SPINE-GIVE-REASONS` — four lessons, one concept each, etymology in every one, ending in a four-move explanation the reader can build in either direction.

| lesson | concept | what is new |
|---|---|---|
| `ES-C41-creer` | OPINION-I-THINK | stating an opinion, against `pensar`'s weighing |
| `ES-C41-asi-que` | CONNECTIVE-SO | the forward arrow, where `porque` points back |
| `ES-C41-deber` | MODAL-SHOULD | obligation, from a word that means *to owe* |
| `ES-C41-explicar` | EXPLANATION-GIVE | the synthesis: opinion, cause, consequence, obligation |

Spanish now realizes **two** of the seventeen B1–C2 nodes. `attained` is still null.

Supersedes #10070 — that branch was authored as chapter 39, then [HL-C51](https://github.com/adhithyan15/coding-adventures/pull/10068) landed and took Spanish 39 and 40. Re-applied onto current main rather than rebased through fifteen conflicts.

## Also fixed: the Spanish book was printing chapter 38 twice and dropping chapter 40

Pre-existing on `main`, found while wiring chapter 41 beside it. The Spanish entries in `core/book-generation.json` had drifted one out of step:

| output file | declared chapter | should be |
|---|---|---|
| `ch39-bring-get-play-meet.tex` | 38 | **39** |
| `ch40-wait-answer-buy.tex` | 39 | **40** |

`ch39-bring-get-play-meet.tex` was **content-identical** to `ch38-narrating.tex` — same `canonical-source-hash`, same ES-C38 lessons — with only the title and label swapped. Chapter 40's four lessons reached no book chapter at all.

`check:books` passed the whole time, because it validates the targets that *are* declared, not whether the declarations cover the corpus. `chapters.json` was correct throughout; only the book manifest was wrong. Each of the four chapters now renders its own lessons under its own hash.

## Three of chapter 38's four failure classes held

Grepped the track first, so nothing re-teaches owned material — `creer` is built as a **contrast** with `pensar` (ch34) rather than a duplicate. Every payoff word is taught. Book wiring went in *with* the chapter.

## The fourth did not: five wrong etymologies

All right-family, wrong **route** or **strength** — `explicit` and `application` filed as straight-from-Latin when both came through French; `comply` filed under *plicāre* "fold" when it is from *complēre* "fill"; `endeavour` called a borrowing when English *calqued* the French phrase; `ad sīc` given as an etymon the DLE no longer prints; `*ḱred- = heart` stated flat when it is disputed.

`lessons.md` now carries the rule: **same root, same route, current consensus.**

## Three defects reached the reader; one would have been spoken

- `explicar` said to take `contar`'s shape — `contar` is a stem-changer and `explicar` is not
- `No creo que …` sat bare; negating `creer` takes the **subjunctive** chapter 18 already taught
- A **Greek capital beta** in a pronunciation hint, propagated into `narration/ch41.txt`, which feeds TTS

## A headword narrowed to stop nine false positives

`taughtWords` strips a leading word of ≤3 characters — a heuristic meant for articles — so the multi-word headword `así que` registered **`que`** as first taught here and flagged nine earlier lessons. `que` is taught at chapter 7. Headword is now `así`; `forwardReferences` holds flat at 524. The heuristic is the real bug and the pin comment records it.

## Verification

396 tests pass. `check:books`, `check:narration`, `check:modality` clean, and a full regeneration leaves the tree unchanged. All four lessons under the 5-minute ceiling and voice-drivable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
