### PR TITLE
test(human-language-data): make the book manifest's coverage checkable

### DIFF
--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,22 +4,48 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
-### Fixed — the Spanish book was printing chapter 38 twice and dropping chapter 40
+### Added — coverage assertions for the book manifest (HL-C50)
 
-Found while wiring chapter 41 next to it, and pre-existing on `main`. The Spanish
-entries in `core/book-generation.json` had drifted one out of step: the target whose
-`output` is `ch39-bring-get-play-meet.tex` declared `"chapter": 38`, and the one for
-`ch40-wait-answer-buy.tex` declared `"chapter": 39`. No target declared chapter 40.
+The Spanish book was printing chapter 38 twice and dropping chapter 40, and **every
+check passed** while it did. That defect is fixed; these are the assertions that would
+have caught it, plus an audit confirming no other track carries the same drift.
 
-The consequences were invisible to every check. `ch39-bring-get-play-meet.tex` was
-**byte-identical in content** to `ch38-narrating.tex` — same `canonical-source-hash`,
-same ES-C38 lessons — with only the title and label swapped, so a reader got chapter
-38 twice under two names. Chapter 40's four lessons reached no book chapter at all.
+The gap was structural. `check:books` compares each **declared** target against what
+the generator produces, so a manifest declaring the wrong chapter round-trips
+perfectly. `titleDrift` stayed 0 because each file took its title from its own
+(correct) target. Narration and modality read the corpus directly and never consult
+the manifest. Nothing asked the coverage question: *do the declarations line up with
+the corpus?*
 
-`check:books` passed throughout, because it validates the targets that are declared,
-not whether the declarations cover the corpus. `chapters.json` was correct the whole
-time; only the book manifest was wrong. Each of the four chapters now renders its own
-lessons under its own hash.
+Five assertions now do, in `book-cli.test.ts`'s existing manifest block:
+
+1. **No chapter number declared twice in a track** — the drift's direct signature.
+2. **Every filename agrees with its declared chapter** — `ch39-*.tex` must not be
+   declared as chapter 38. The cheapest tripwire, and it would have fired the instant
+   the drift was written.
+3. **Every declaration stays inside its own track's directory** — a target writing
+   into another track's folder passes every other check while silently adding a
+   chapter to a book nobody edited.
+4. **No two declarations write the same path** — the loser vanishes silently.
+5. **Every ledgered chapter is `\input` into its book**, not merely present on disk.
+   "Reaches a file" is the weaker claim, and the weaker claim is what let the original
+   bug through in spirit.
+
+**They run over `targets` and `handwritten` together**, which matters more than it
+sounds: the manifest's `handwritten[]` array holds 105 of the 452 declarations, and the
+identical drift there was invisible to every test in the package. Keeping the two
+halves apart is what allowed that.
+
+Each assertion was proven to fire before being trusted. Reintroducing the exact
+Spanish drift trips three; the same drift in `handwritten[]` trips two; a target
+escaping its track trips two; deleting a declaration trips two; and removing an
+`\input` while leaving the file on disk trips the fifth alone.
+
+**Audit result: no other track is affected.** Across all 22 — and across both arrays —
+there are no duplicate declarations, no filename/chapter mismatches, no path
+collisions, and no ledgered chapter missing from its book. Seven chapters have no
+generation target (hindi 1–2, latin 1, persian 2, russian 2, tamil 1, urdu 2); all
+seven are hand-authored, declared in `handwritten[]`, and `\input` into their books.
 
 ### Added — Spanish chapter 41, the second B1 rung (SPINE-GIVE-REASONS)
 

--- a/code/packages/typescript/human-language-data/tests/book-cli.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book-cli.test.ts
@@ -15,7 +15,7 @@ import {
   handwrittenBookChapters,
   runBookGeneration,
 } from "../src/book-cli.js";
-import { defaultCurriculumRoot } from "../src/loader.js";
+import { defaultCurriculumRoot, loadTrackChapters } from "../src/loader.js";
 
 const roots: string[] = [];
 
@@ -303,5 +303,122 @@ describe("hand-written chapters", () => {
         );
       }
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Does the manifest COVER the corpus?
+//
+// The book is manifest-driven; narration and modality are corpus-driven. That
+// asymmetry hid a real defect. `core/book-generation.json`'s Spanish entries drifted
+// one out of step — the target whose `output` was `ch39-bring-get-play-meet.tex`
+// declared `"chapter": 38`, and `ch40-wait-answer-buy.tex` declared 39, with nothing
+// declaring 40. The book printed chapter 38 TWICE (ch39's file came out
+// content-identical to ch38's, same canonical-source-hash) and dropped chapter 40.
+//
+// Every check passed. `check:books` verifies each DECLARED target round-trips, so a
+// manifest naming the wrong chapter round-trips perfectly. `titleDrift` stayed 0
+// because each file took its title from its own (correct) target. Nothing asked
+// whether the declarations line up with the corpus at all.
+//
+// These run over targets AND handwritten together. Keeping them apart is what let the
+// handwritten half — 105 of the 452 declarations — go unchecked for the same class.
+// ---------------------------------------------------------------------------
+describe("the manifest covers the corpus", () => {
+  const root = defaultCurriculumRoot();
+  const config = JSON.parse(
+    readFileSync(join(root, "core", "book-generation.json"), "utf8"),
+  ) as {
+    targets: { language: string; chapter: number; output: string }[];
+    handwritten: { language: string; chapter: number; output: string }[];
+  };
+  const declared = [...config.targets, ...(config.handwritten ?? [])];
+
+  /** `ch38-narrating.tex` -> 38. Appendices parse to null and are skipped. */
+  function chapterInFilename(output: string): number | null {
+    const match = /^ch0*(\d+)/.exec(output.split("/").pop() ?? "");
+    return match ? Number(match[1]) : null;
+  }
+
+  it("never declares one chapter number twice in a track", () => {
+    // The drift's direct signature: two declarations claiming chapter 38.
+    const seen = new Map<string, string>();
+    const offenders: string[] = [];
+    for (const entry of declared) {
+      const key = `${entry.language}#${entry.chapter}`;
+      const previous = seen.get(key);
+      if (previous) offenders.push(`${key}: ${previous} and ${entry.output}`);
+      seen.set(key, entry.output);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("gives every declaration a filename that agrees with its chapter number", () => {
+    // The cheapest tripwire, and it would have fired the instant the drift was
+    // written: `ch39-*.tex` must not be declared as chapter 38. The filename is what
+    // a maintainer reads; the number is what the generator obeys.
+    const offenders = declared
+      .filter((entry) => {
+        const inName = chapterInFilename(entry.output);
+        return inName !== null && inName !== entry.chapter;
+      })
+      .map((entry) => `${entry.language}: ${entry.output} declares chapter ${entry.chapter}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps every declaration inside its own track's directory", () => {
+    // A target writing into another track's folder passes every other check while
+    // silently adding a chapter to a book nobody edited.
+    const offenders = declared
+      .filter((entry) => !entry.output.startsWith(`${entry.language}/book/chapters/`))
+      .map((entry) => `${entry.language} ch${entry.chapter} -> ${entry.output}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it("writes every declaration to a distinct file", () => {
+    // Two declarations on one path means whichever runs last silently wins.
+    const seen = new Map<string, string>();
+    const offenders: string[] = [];
+    for (const entry of declared) {
+      const previous = seen.get(entry.output);
+      if (previous) offenders.push(`${entry.output}: ${previous} and ${entry.language} ch${entry.chapter}`);
+      seen.set(entry.output, `${entry.language} ch${entry.chapter}`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("puts every ledgered chapter into its book, not merely into a file", () => {
+    // "Reaches a file" is the weaker claim, and the weaker claim is what let the
+    // original bug through in spirit: a chapter can have a declaration, and a file on
+    // disk, and still be invisible because `book.tex` never \input's it.
+    const byLanguage = new Map<string, Set<number>>();
+    for (const entry of declared) {
+      const set = byLanguage.get(entry.language) ?? new Set<number>();
+      set.add(entry.chapter);
+      byLanguage.set(entry.language, set);
+    }
+    const inputs = new Map<string, string>();
+    const offenders: string[] = [];
+    for (const track of loadTrackChapters()) {
+      const language = track.language;
+      if (!inputs.has(language)) {
+        inputs.set(language, readFileSync(join(root, language, "book", "book.tex"), "utf8"));
+      }
+      const bookTex = inputs.get(language)!;
+      for (const entry of track.chapters) {
+        const match = declared.find(
+          (d) => d.language === language && d.chapter === entry.chapter,
+        );
+        if (!match) {
+          offenders.push(`${language} ch${entry.chapter}: no declaration`);
+          continue;
+        }
+        const stem = (match.output.split("/").pop() ?? "").replace(/\.tex$/, "");
+        if (!bookTex.includes(`\\input{chapters/${stem}}`)) {
+          offenders.push(`${language} ch${entry.chapter}: ${stem} is never \\input into book.tex`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
   });
 });


### PR DESCRIPTION
The Spanish book was printing chapter 38 twice and dropping chapter 40, and **every check passed** while it did. That defect is fixed in #10071; this is the pin that would have caught it, plus an audit confirming no other track carries it.

## Why nothing caught it

The gap was structural, not an oversight:

- `check:books` compares each **declared** target against what the generator produces — so a manifest naming the wrong chapter round-trips perfectly.
- `titleDrift` stayed 0, because each file took its title from its own (correct) target.
- Narration and modality read the corpus directly and never consult the manifest at all.

Nothing asked the coverage question: *do the declarations line up with the corpus?*

## Five assertions that do

1. **No chapter number declared twice in a track** — the drift's direct signature.
2. **Every output filename agrees with its declared chapter** — `ch39-*.tex` must not be declared as chapter 38. The cheapest tripwire, and it would have fired the instant the drift was written.
3. **Every declaration stays inside its own track's directory** — a target writing into another track's folder passes every other check while silently adding a chapter to a book nobody edited.
4. **No two declarations write the same path** — the loser vanishes silently.
5. **Every ledgered chapter is `\input` into its book**, not merely present on disk. *"Reaches a file"* is the weaker claim, and the weaker claim is what let the original bug through in spirit.

## The substantive part: they run over both arrays

The manifest's `handwritten[]` holds **105 of the 452 declarations**, and the identical drift there was **invisible to every test in the package**. Keeping the two halves apart is what allowed that — so these live in `book-cli.test.ts` beside the handwritten block that already loads the same file, rather than in a new file that would have repeated the split.

## Each proven to fire before being trusted

| reintroduced defect | assertions that fire |
|---|---|
| the exact Spanish drift | **3** |
| the same drift in `handwritten[]` *(previously invisible)* | **2** |
| a target escaping into another track's directory | **2** |
| a declaration deleted entirely | **2** |
| an `\input` removed while the file stays on disk | **1** |

## Audit: no other track is affected

Across all 22 tracks and both arrays — no duplicate declarations, no filename/chapter mismatches, no path collisions, no ledgered chapter missing from its book.

Seven chapters have no generation target (hindi 1–2, latin 1, persian 2, russian 2, tamil 1, urdu 2). All seven are hand-authored, declared in `handwritten[]`, and `\input` into their books — which is why assertion 5 admits them.

401 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
