### PR TITLE
fix(human-language-data): taughtWords stripped any short word, masking a second bug

### DIFF
--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -2982,7 +2982,7 @@
     {
       "language": "spanish",
       "chapter": 41,
-      "sourceHash": "fnv1a64:2ba56f5f98a0e31a",
+      "sourceHash": "fnv1a64:2cda836feeb6efda",
       "lessonIds": [
         "ES-C41-creer",
         "ES-C41-asi-que",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -6126,7 +6126,7 @@
     {
       "language": "spanish",
       "chapter": 41,
-      "sourceHash": "fnv1a64:aaf392ed71c29d4f",
+      "sourceHash": "fnv1a64:173e1962b10e4f5b",
       "lessonIds": [
         "ES-C41-creer",
         "ES-C41-asi-que",
@@ -6138,7 +6138,7 @@
       "text": "spanish/narration/ch41.txt",
       "json": "spanish/narration/ch41.json",
       "textHash": "fnv1a64:cf2b639c3ae23d4e",
-      "jsonHash": "fnv1a64:c513701f04d28793"
+      "jsonHash": "fnv1a64:9a2700c2d2904ab3"
     },
     {
       "language": "tamil",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:9d4f556624b18a5c",
+  "sourceHash": "fnv1a64:750c2d646de5f7f8",
   "summary": {
     "totalLessons": 1453,
     "voice": 977,
@@ -31267,7 +31267,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ed35ac545ee26f56"
+      "sourceHash": "fnv1a64:9a66f2e2999d5c08"
     },
     {
       "id": "ES-C41-deber",

--- a/code/learning/human-languages/spanish/book/chapters/ch41-giving-reasons.tex
+++ b/code/learning/human-languages/spanish/book/chapters/ch41-giving-reasons.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:2ba56f5f98a0e31a
+% canonical-source-hash: fnv1a64:2cda836feeb6efda
 % canonical-lessons: ES-C41-creer, ES-C41-asi-que, ES-C41-deber, ES-C41-explicar
 
 \chapter{Saying Why}
@@ -84,7 +84,7 @@ Say these aloud:
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 What shape is \emph{crēdere}, under the surface? (\textbf{A compound} — \emph{*\'{k}red-} + \emph{d\textsuperscript{h}eh\textsubscript{1}-}, "to put \emph{*\'{k}red-}".) What is the traditional reading of that first half, and why hedge it? (\textbf{Heart} — but the heart root is \emph{*\'{k}\'{\={e}}r}, never \emph{*\'{k}red-}, so the step is disputed.) \emph{Pensar} weighs; what does \emph{creer} do? (It \textbf{lands} — it holds the opinion the weighing produced.)
 \end{tcolorbox}
-\section[así]{así que — \textquotedblleft{}so\textquotedblright{}, and a word you have been saying since yes}
+\section[así que]{así que — \textquotedblleft{}so\textquotedblright{}, and a word you have been saying since yes}
 
 \label{lesson:ES-C41-asi-que}
 

--- a/code/learning/human-languages/spanish/lessons/ES-C41-asi-que.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C41-asi-que.md
@@ -4,8 +4,8 @@ id: ES-C41-asi-que
 spine_node: SPINE-GIVE-REASONS
 sequence: 1890
 chapter: 41
-type: word
-headword: así
+type: phrase
+headword: así que
 gloss: thus, in that way — and with que after it, "so"; built on the same sīc that gave you sí
 concept_tag: CONNECTIVE-SO
 prerequisites: [ES-C41-creer, ES-C19-si]

--- a/code/learning/human-languages/spanish/narration/ch41.json
+++ b/code/learning/human-languages/spanish/narration/ch41.json
@@ -4,7 +4,7 @@
   "chapter": 41,
   "title": "Saying Why",
   "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:aaf392ed71c29d4f",
+  "sourceHash": "fnv1a64:173e1962b10e4f5b",
   "lessons": [
     {
       "id": "ES-C41-creer",
@@ -203,8 +203,8 @@
       "id": "ES-C41-asi-que",
       "sequence": 1890,
       "title": "así que — \"so\", and a word you have been saying since yes",
-      "headword": "así",
-      "romanization": "así",
+      "headword": "así que",
+      "romanization": "así que",
       "gloss": "thus, in that way — and with que after it, \"so\"; built on the same sīc that gave you sí",
       "script": "latin",
       "modality": "voice",
@@ -212,7 +212,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ed35ac545ee26f56",
+      "sourceHash": "fnv1a64:9a66f2e2999d5c08",
       "notice": null,
       "blocks": [
         {

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Fixed — `taughtWords` stripped any short word, and that masked a second bug
+
+A headword carries its article — *el pan*, *la casa* — and a body saying *bebo agua*
+is using the same word, so the bare noun has to match too. The rule that did this
+stripped **any leading word of three characters or fewer**.
+
+A census of the corpus's own headwords shows what that meant: the rule fired on
+**227 of 1,453 lessons** (247 headword parts), and only **49 lessons** (64 parts)
+actually begin with an article. It was registering
+
+- `llamo` as taught by *me llamo*, `favor` by *por favor*, `dia` by *bom dia*,
+- `piace` by *mi piace*, `heiße…` by *ich heiße…*, `wiedersehen` by *auf wiedersehen*,
+- and the night- and afternoon-word of every ശുഭ / शुभ / శుభ / ಶುಭ greeting across
+  Malayalam, Hindi, Telugu and Kannada — because all those openers are three
+  characters.
+
+The rule is now an **allowlist of real definite articles, per language**, taken from
+that census rather than from a length guess. Two deliberate exclusions: Spanish
+**`lo`** (it *is* a neuter article, but the corpus's only `lo `-headword is *lo
+siento*, where it is a pronoun) and Italian **`a`** (*a domani*, *a presto* are
+prepositions). A track absent from the map never has anything stripped, which is right
+for Latin, Arabic, the Indic tracks and every other language whose headwords carry no
+article — Arabic's `ال` is prefixed without a space, so neither rule ever reached it.
+
+### …and the second bug, which only became visible once the first was fixed
+
+The bad strip had been seeding each lesson's own word set with the stripped tail, which
+incidentally stopped it reporting itself. Removing the strip removed that accident, and
+**four lessons began being reported for a word sitting in their own headword** —
+`مع السلامة` for `السلامة`, `bom dia` for `dia` — which is exactly what this module's
+docstring says must not happen.
+
+`ownHeadwordTokens` now does it deliberately, and completely. The accident only ever
+covered the tail after the first word, so 45 self-references it had never caught are
+gone too; every one was verified to be a token of the reporting lesson's own headword.
+
+**`forwardReferences`: 524 → 443, and none of the 81 was a real finding.** What remains
+is a claim about the corpus rather than about the matcher.
+
+**The workaround this forced is removed.** Spanish chapter 41's connective lesson had
+been renamed from `así que` to `así` purely to dodge the bug — `así` is three
+characters, so `que` registered as first taught there and flagged ten earlier lessons.
+The true headword is restored, and the full result set is byte-identical either way.
+
+Four unit tests pin the behaviour. Three of them fail if the length rule comes back;
+the fourth asserts the *positive* case — that `el pan` still registers `pan` — and
+fails if `taughtWords` returns nothing. Both directions were checked by stubbing.
+
 ### Added — coverage assertions for the book manifest (HL-C50)
 
 The Spanish book was printing chapter 38 twice and dropping chapter 40, and **every

--- a/code/packages/typescript/human-language-data/src/continuity.ts
+++ b/code/packages/typescript/human-language-data/src/continuity.ts
@@ -161,6 +161,22 @@ function declaredSequence(lesson: ParsedLesson): number | null {
 }
 
 /**
+ * Definite articles that may precede a headword, by track.
+ *
+ * Only languages whose headwords actually carry an article appear here; a track
+ * absent from this map never has a leading word stripped. Every entry was taken from
+ * a census of the corpus's own headwords, so the map describes what is written rather
+ * than what the language could in principle write.
+ */
+const DEFINITE_ARTICLES: Partial<Record<string, Set<string>>> = {
+  spanish: new Set(["el", "la", "los", "las"]),
+  italian: new Set(["il", "lo", "la", "i", "gli", "le"]),
+  french: new Set(["le", "la", "les"]),
+  portuguese: new Set(["o", "a", "os", "as"]),
+  german: new Set(["der", "die", "das"]),
+};
+
+/**
  * Headwords, normalised for matching, that a lesson teaches.
  *
  * A multi-word headword ("buenos días") is kept whole: matching its parts
@@ -178,15 +194,50 @@ function taughtWords(lesson: ParsedLesson): string[] {
 
   const out = new Set(parts);
   for (const part of parts) {
-    // Headwords carry their article: "el pan", "el agua", "la casa". A body that
-    // says "bebo agua" is using the same word, so the bare noun must match too.
-    // Only a SHORT leading function word is stripped, which leaves "buenos días"
-    // whole — splitting that would report `días` from every lesson mentioning it.
-    const match = /^(\S{1,3})\s+(.+)$/.exec(part);
-    if (match) out.add(match[2]!.trim());
+    // Headwords carry their article: "el pan", "la casa". A body saying "bebo agua"
+    // is using the same word, so the bare noun has to match too.
+    //
+    // This used to strip ANY leading word of three characters or fewer. A census of the
+    // corpus's own headwords shows that rule firing on 227 of 1,453 lessons (247
+    // headword parts), of which only 49 lessons (64 parts) actually begin with an
+    // article. It was registering `llamo` as taught by "me llamo", `favor` by "por
+    // favor", `dia` by "bom dia", and the night- and afternoon-word of every
+    // ശുഭ / शुभ / శుభ / ಶುಭ greeting in Malayalam, Hindi, Telugu and Kannada — because
+    // all those openers are three characters.
+    //
+    // The failure that surfaced it: "así que" is a legitimate headword, `así` is three
+    // characters, so `que` got registered as first taught there — reporting ten earlier
+    // lessons that use `que` as forward references to it. The lesson had to be renamed
+    // to work around the measurement.
+    //
+    // So the rule is an ALLOWLIST of actual definite articles, per language, grounded
+    // in that census rather than in a length guess. Spanish `lo` is deliberately absent
+    // — in "lo siento" it is a pronoun, and stripping it would register `siento`.
+    // Italian `a` likewise: "a domani" is a preposition, not an article.
+    const articles = DEFINITE_ARTICLES[lesson.language];
+    if (!articles) continue;
+    const match = /^(\S+)\s+(.+)$/.exec(part);
+    if (match && articles.has(match[1]!)) out.add(match[2]!.trim());
   }
   return [...out].filter((word) => word.length > 0);
 }
+
+/**
+ * Every whitespace-separated token of a lesson's own headword, however it is written.
+ *
+ * Distinct from `taughtWords`, which decides what a lesson TEACHES to the rest of the
+ * corpus and so is deliberately conservative. This decides only what a lesson may not
+ * be accused of borrowing from someone else, and there conservatism is the wrong
+ * direction: any token of "mع السلامة" is that lesson's own material.
+ */
+function ownHeadwordTokens(lesson: ParsedLesson): string[] {
+  const headword = (lesson.realization.headword ?? "").toLowerCase();
+  return headword
+    .split(/[/,\u060C\u061B]|\s+y\s+|\s*[\u2014\u2013-]\s*|\s+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+}
+
 
 /**
  * English words that are also common target-language headwords.
@@ -417,7 +468,13 @@ export function measureContinuity(lessons: ParsedLesson[]): ContinuityReport {
     ordered.forEach((lesson, index) => {
       const body = lesson.body.toLowerCase();
       const emphasised = emphasisedRuns(lesson.body);
-      const own = new Set(taughtWords(lesson));
+      // A lesson can never forward-reference a word sitting in its own headword —
+      // `mع السلامة` contains `السلامة`, `bom dia` contains `dia`. The old strip
+      // seeded these incidentally; the allowlist does not, so they are added
+      // explicitly. Without this, four lessons were reported as borrowing a word they
+      // were themselves teaching, which is exactly what this module's own docstring
+      // says must not happen.
+      const own = new Set([...taughtWords(lesson), ...ownHeadwordTokens(lesson)]);
       const reported = new Set<string>();
 
       for (const [word, teaching] of earliestTeaching) {

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -93,6 +93,67 @@ describe("order integrity", () => {
   });
 });
 
+describe("a headword's article, and only its article", () => {
+  /** A lesson whose headword is `headword`, with `body` as its only prose. */
+  function withHeadword(id: string, sequence: number, headword: string, body: string, language = "spanish") {
+    return parseLesson(
+      `---\nschema_version: 2\nid: ${id}\nchapter: 1\nsequence: ${sequence}\ntype: phrase\n` +
+        `headword: "${headword}"\ngloss: x\nconcept_tag: GREETING-HELLO\n---\n\n` +
+        `# ${id}\n\n## Warm-up\n\n${body}\n`,
+      language,
+    );
+  }
+
+  it("strips a real article so the bare noun is still matched", () => {
+    // The behaviour the rule exists for, asserted POSITIVELY: "el pan" must register
+    // `pan`, so an EARLIER lesson using the bare noun is caught borrowing it. Asserting
+    // zero with the teaching lesson first would have been true however taughtWords
+    // behaved — including if it returned nothing at all.
+    const report = measureContinuity([
+      withHeadword("ES-1", 10, "comer", "Como **pan** hoy."),
+      withHeadword("ES-2", 20, "el pan", "Bread."),
+    ]);
+    expect(report.summary.forwardReferences).toBe(1);
+    expect(report.forwardReferences[0]).toMatchObject({ lessonId: "ES-1", word: "pan" });
+  });
+
+  it("does NOT strip a three-letter word that is not an article", () => {
+    // The bug this replaced: `/^(\S{1,3})\s+(.+)$/` stripped any short leading word,
+    // so "así que" registered `que` as first taught at the later lesson and reported
+    // every earlier lesson using `que` as a forward reference to it. A census found
+    // the rule firing on 246 of 1,453 headwords with only ~55 real articles among them.
+    // The earlier lesson must EMPHASISE `que`: a word under four characters counts as
+    // a forward reference only in marked text, which is why all nine real hits were.
+    const report = measureContinuity([
+      withHeadword("ES-1", 10, "hablar", "Hablo, y creo **que** bien."),
+      withHeadword("ES-2", 20, "así que", "Llueve, así que leo."),
+    ]);
+    expect(report.summary.forwardReferences).toBe(0);
+  });
+
+  it("leaves a pronoun attached even where the same string is an article elsewhere", () => {
+    // Spanish `lo` IS a neuter article, but in "lo siento" it is a pronoun, so it is
+    // deliberately absent from the allowlist. Stripping it would register `siento`.
+    const report = measureContinuity([
+      withHeadword("ES-1", 10, "sentir", "Siento."),
+      withHeadword("ES-2", 20, "lo siento", "Lo siento."),
+    ]);
+    expect(report.summary.forwardReferences).toBe(0);
+  });
+
+  it("keeps a track out of it entirely when its headwords carry no articles", () => {
+    // Latin has no articles, so nothing may be stripped from a Latin headword —
+    // "sex septem" must not register `septem` as a word LA-2 teaches.
+    // LA-1's own headword must NOT be `septem`, or `earliestTeaching` resolves to it
+    // either way and the test cannot tell the two rules apart.
+    const report = measureContinuity([
+      withHeadword("LA-1", 10, "unus", "Unus, **septem**.", "latin"),
+      withHeadword("LA-2", 20, "sex septem", "Sex septem.", "latin"),
+    ]);
+    expect(report.summary.forwardReferences).toBe(0);
+  });
+});
+
 describe("reinforcement windows", () => {
   it("flags an atom that is never practised again", () => {
     const report = measureContinuity([
@@ -298,14 +359,24 @@ describe("the real corpus", () => {
     // ES-GRAMMAR-LUEGO-CONNECTIVE-01 and requires chapter 5's ES-LEX-LUEGO, yet the
     // count is unchanged by that wiring.
     //
-    // Spanish chapter 41 adds ZERO, and that took one deliberate change. Its connective
-    // lesson was first written with the multi-word headword "así que"; `taughtWords`
-    // strips a leading word of <=3 chars (`/^(\S{1,3})\s+(.+)$/`, meant for articles),
-    // so it registered *que* as first taught there and flagged all 9 earlier lessons
-    // containing it. *Que* is genuinely taught at chapter 7. Narrowing the headword to
-    // *así* — the only word that IS new, with the gloss carrying the *que* — removed
-    // nine false positives. The loader heuristic is the real bug; this is a workaround.
-    expect(report.summary.forwardReferences).toBe(524);
+    // 524 -> 443, and none of the 81 was a real finding. Two distinct problems, one of
+    // which had been masking the other.
+    //
+    // First, `taughtWords` stripped ANY leading word of three characters or fewer,
+    // meaning to remove articles. A census found it firing on 227 of 1,453 lessons
+    // while only 49 of those begin with one — registering `llamo` as taught by "me
+    // llamo", `favor` by "por favor", `dia` by "bom dia", and the night-word of every
+    // ശുഭ / शुभ / శుభ / ಶುಭ greeting. The rule is now an allowlist of real articles.
+    //
+    // Second, and only visible once the first was fixed: the bad strip had been
+    // seeding a lesson's OWN word set with the stripped tail, which incidentally
+    // stopped it reporting itself. Removing the strip removed that accident, and four
+    // lessons started being reported for a word sitting in their own headword —
+    // exactly what this module's docstring says must not happen. `ownHeadwordTokens`
+    // now does it deliberately, and completely: the accident only ever covered the
+    // tail after the first word, so 45 self-references it had never caught are gone
+    // too. Every one was verified to be a token of the reporting lesson's own headword.
+    expect(report.summary.forwardReferences).toBe(443);
 
     // HL09 step 3 closed 17 R1 windows in chapters 3-6, measured on the corpus of the
     // day as 766 -> 749. The absolute figures drift as main lands lessons; what the


### PR DESCRIPTION
A headword carries its article — *el pan*, *la casa* — and a body saying *bebo agua* is using the same word, so the bare noun has to match too. The rule doing this stripped **any leading word of three characters or fewer**.

## What the census found

The rule fired on **227 of 1,453 lessons** (247 headword parts), and only **49 lessons** (64 parts) actually begin with an article. It was registering:

- `llamo` as taught by *me llamo*, `favor` by *por favor*, `dia` by *bom dia*
- `piace` by *mi piace*, `heiße…` by *ich heiße…*, `wiedersehen` by *auf wiedersehen*
- the night- and afternoon-word of **every** ശുഭ / शुभ / శుభ / ಶುಭ greeting across Malayalam, Hindi, Telugu and Kannada — all three-character openers

Any lesson using one of those earlier was then reported as borrowing it from a phrase that never taught it.

The rule is now an **allowlist of real definite articles, per language**, from that census rather than a length guess. Spanish **`lo`** is deliberately excluded — it *is* a neuter article, but the corpus's only `lo `-headword is *lo siento*, where it's a pronoun. Italian **`a`** likewise (*a domani* is a preposition). A track absent from the map never has anything stripped, which is right for Latin, Arabic and the Indic tracks — Arabic's `ال` is prefixed without a space, so neither rule ever reached it.

## Fixing that exposed a second bug it had been masking

The bad strip seeded each lesson's own word set with the stripped tail, which *incidentally* stopped the lesson reporting itself. Removing the strip removed the accident, and **four lessons began being reported for a word sitting in their own headword** — `مع السلامة` for `السلامة`, `bom dia` for `dia`. That is precisely what this module's own docstring says must not happen.

`ownHeadwordTokens` now does it deliberately, and completely: the accident only ever covered the tail after the first word, so 45 self-references it had never caught are gone too. Every one was verified to be a token of the reporting lesson's own headword, and **zero non-self-references were suppressed**.

**`forwardReferences`: 524 → 443, and none of the 81 was a real finding.**

## The workaround is removed

Spanish chapter 41's connective lesson had been renamed from `así que` to `así` purely to dodge this bug. The true headword is restored, and the full result set is **byte-identical** either way.

## Tests

Four unit tests. Three fail if the length rule returns; the fourth asserts the *positive* case — that `el pan` still registers `pan` — and fails if `taughtWords` returns nothing. Both directions checked by stubbing.

That mattered: an earlier draft had **two tests that passed for the wrong reason** — one because the teaching lesson came first so the assertion could never fail, one because a word under four characters only counts as a forward reference when *emphasised*. Both were caught by running the old rule against them rather than trusting green.

405 tests pass. `check:books`, `check:narration`, `check:modality` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
