### PR TITLE
fix(human-language-data): waive etymology from the reinforcement criterion

### DIFF
--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,55 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Changed — an etymology is a hook, so the gate stops demanding it be drilled
+
+Project owner's directive: *"Etymology should only be mentioned once. I do not want
+that re-emphasized again and again. It is mostly a memory hook for me."*
+
+**The gate was manufacturing the repetition.** HL09 §3.1 requires every atom to be
+revisited at least twice, and for an etymon the only way to satisfy that was to
+re-state it in the Guided Practice and again in the Wrap-up Recall. The prose was
+shaped by the measurement, so the measurement had to change first.
+
+Etymology atoms — `*-ETYMON-*`, a naming convention every track already follows — are
+now **waived from the reinforcement criterion**. Spanish's pre-A1 reinforcement blocker
+goes from 87 atoms to 53, and says so: *"53 atom(s) at or below pre-A1 are revisited
+fewer than twice (35 etymology hook(s) waived)."*
+
+This also settles a question open for weeks: the once-cited `ES-ETYMON-*` atoms should
+be **waived, not re-cited**.
+
+**The waiver lives in `level-gate.ts`, not in `continuity.ts`, on purpose.**
+`measureContinuity` goes on reporting every atom truthfully, so `atomsTaught`,
+`atomsNeverRevisited` and the R-window counts keep meaning what they say, the gap
+report stays honest, and **no pinned corpus figure moves**. Only the level *claim*
+ignores them — the one place the decision actually applies — and the waiver is printed
+in the blocker rather than silently absent.
+
+The `-ETYMON-` convention is not enforced by schema, and a census found a few atoms
+that arguably qualify and are not matched (`ES-HISTORY-AL-ANDALUS-LOANS`,
+`SA-SOUND-PIE-KW-OUTCOMES`). Naming those consistently is the fix; widening the regex
+is not.
+
+### Not done here: removing the repetition already written
+
+The prose still re-states etymology in Guided Practice and Wrap-up Recall blocks. An
+automated sweep over chapters 1–3 was attempted and **reverted** — review found it
+corrupted a URL and an `i.e.` by inserting spaces inside them, deleted 23 load-bearing
+`[PAUSE 3s]` cues that `explicitPauseSeconds` and the narration script both consume,
+glued four headings, left dangling connectives ("Two things:" above one question), took
+eleven questions that were testing real skills, and in about ten files removed the
+lesson's single *teaching* of an etymology while keeping the *drill* — the exact
+inverse of the directive.
+
+Two lessons from that: in Arabic and the other Semitic tracks **"root" means the
+three-consonant root system**, which is core grammar and not an etymology hook, so a
+matcher keyed on the word cannot be trusted; and a recall paragraph cannot be re-flowed
+freely, because `countPromptLines` counts lines containing a question mark and a
+re-wrap therefore changes the computed duration.
+
+That work needs to be done by hand, per track, and is not attempted here.
+
 ### Fixed — `taughtWords` stripped any short word, and that masked a second bug
 
 A headword carries its article — *el pan*, *la casa* — and a body saying *bebo agua*

--- a/code/packages/typescript/human-language-data/src/level-gate.ts
+++ b/code/packages/typescript/human-language-data/src/level-gate.ts
@@ -49,6 +49,19 @@ export const LEVEL_VOCABULARY: Record<CefrLevel, number> = {
   C2: 16000,
 };
 
+/**
+ * Is this atom an etymology hook rather than a skill?
+ *
+ * Every track names them the same way — `ES-ETYMON-CREDERE-02`, `TA-ETYMON-NAL-01` —
+ * so the id carries the fact. Note this is a CONVENTION, not an enforced schema: an
+ * etymology atom named some other way is not waived, and a census found a handful
+ * (`ES-HISTORY-AL-ANDALUS-LOANS`, `SA-SOUND-PIE-KW-OUTCOMES`) that arguably qualify
+ * and are not matched. Naming them consistently is the fix, not widening this regex.
+ */
+export function isEtymologyAtom(atom: string): boolean {
+  return /-ETYMON-/.test(atom);
+}
+
 /** Which of the four criteria a level failed, and by how much. */
 export interface LevelBlocker {
   criterion: "spine-nodes" | "vocabulary" | "atom-budget" | "reinforcement";
@@ -241,13 +254,29 @@ export function runLevelGate(input: LevelGateInput): LevelGateReport {
 
       // §3.1 asks for TWO revisits, so `revisits < 2` — not `=== 0`. Measuring
       // zero-revisit atoms only would have hidden 51 of Spanish's 141 failures.
-      const thin = underReinforced.filter(
-        (d) => d.revisits < 2 && atOrBelow(d.introducedBy, level),
-      );
+      //
+      // Etymology atoms are WAIVED here, by the project owner's decision: an etymology
+      // is a memory hook, read once, not a skill to be drilled. Before this, the gate
+      // demanded every atom be revisited twice, and the only way to satisfy that for an
+      // etymon was to re-state it in the Guided Practice and again in the Wrap-up
+      // Recall — so the gate was manufacturing the repetition the owner asked to
+      // remove.
+      //
+      // The waiver lives HERE and not in `continuity.ts` on purpose. `measureContinuity`
+      // goes on reporting every atom truthfully, so `atomsTaught`,
+      // `atomsNeverRevisited` and the R-window counts keep meaning what they say and
+      // the gap report stays honest. Only the LEVEL CLAIM ignores them, which is the
+      // one place the decision actually applies — and it is visible in
+      // `waivedEtymologyAtoms` rather than silently absent.
+      const relevant = underReinforced.filter((d) => atOrBelow(d.introducedBy, level));
+      const waived = relevant.filter((d) => isEtymologyAtom(d.atom));
+      const thin = relevant.filter((d) => d.revisits < 2 && !isEtymologyAtom(d.atom));
       if (thin.length > 0) {
         failures.push({
           criterion: "reinforcement",
-          detail: `${thin.length} atom(s) at or below ${level} are revisited fewer than twice`,
+          detail:
+            `${thin.length} atom(s) at or below ${level} are revisited fewer than twice` +
+            (waived.length > 0 ? ` (${waived.length} etymology hook(s) waived)` : ""),
           shortfall: thin.length,
         });
       }

--- a/code/packages/typescript/human-language-data/tests/level-gate.test.ts
+++ b/code/packages/typescript/human-language-data/tests/level-gate.test.ts
@@ -3,7 +3,7 @@
 import { describe, expect, it } from "vitest";
 import { loadEverything, loadChapterPolicy, loadTrackChapters } from "../src/loader.js";
 import { buildCurriculumGapReport } from "../src/report.js";
-import { LEVEL_VOCABULARY, runLevelGate } from "../src/level-gate.js";
+import { LEVEL_VOCABULARY, runLevelGate, isEtymologyAtom } from "../src/level-gate.js";
 import { summarizeLevels } from "../src/levels.js";
 import { measureRamp } from "../src/ramp.js";
 import { measureContinuity } from "../src/continuity.js";
@@ -117,6 +117,50 @@ describe("the gate that would have caught the A2 claim", () => {
       if (track.inProgressAt !== null) expect(track.blockers.length).toBeGreaterThan(0);
       if (track.attained === null) expect(track.inProgressAt).toBe("pre-A1");
     }
+  });
+});
+
+describe("etymology is a hook, not a skill", () => {
+  it("waives etymology atoms from the reinforcement criterion, and says how many", () => {
+    // The owner's decision: an etymology is read once, not drilled. Before this the
+    // gate demanded every atom be revisited twice, and the only way to satisfy that
+    // for an etymon was to re-state it in the Guided Practice and again in the
+    // Wrap-up Recall -- so the GATE was manufacturing the repetition.
+    const gate = realReport().levelGate!;
+    const spanish = gate.tracks.find((t) => t.language === "spanish")!;
+    const reinforcement = spanish.blockers.find((b) => b.criterion === "reinforcement")!;
+
+    // The waiver must be VISIBLE. A silently loosened gate is worse than a strict one.
+    expect(reinforcement.detail).toMatch(/etymology hook\(s\) waived/);
+    // And it must BITE, which needs a number the waiver actually changes. Two earlier
+    // versions of this assertion did not: `shortfall < shortfall + waived` is true of
+    // any number, and comparing against a whole-track count could not fail because the
+    // gate scopes to pre-A1. Both passed with the waiver deleted. So pin the figure:
+    // Spanish has 87 under-reinforced atoms at or below pre-A1; 34 of them are
+    // etymology hooks. Delete the waiver and this reads 87. (The detail says 35
+    // waived, not 34, because `waived` counts every etymology atom in scope — one of
+    // them is already revisited twice and was never in the shortfall.)
+    expect(reinforcement.shortfall).toBe(53);
+    expect(reinforcement.detail).toContain("35 etymology hook(s) waived");
+  });
+
+  it("leaves continuity's own numbers alone", () => {
+    // The waiver lives at the GATE on purpose. `measureContinuity` still reports every
+    // atom, so the gap report and every pinned corpus figure keep meaning what they
+    // say. If this ever fails, the waiver has leaked into the measurement.
+    const e = loadEverything();
+    const continuity = measureContinuity(e.lessons);
+    const etymons = continuity.reinforcement.filter((d) => isEtymologyAtom(d.atom));
+    expect(etymons.length).toBeGreaterThan(0);
+  });
+
+  it("matches the id convention and nothing else", () => {
+    expect(isEtymologyAtom("ES-ETYMON-CREDERE-02")).toBe(true);
+    expect(isEtymologyAtom("TA-ETYMON-NAL-01")).toBe(true);
+    // A skill atom that merely mentions a language or a sound is NOT waived.
+    expect(isEtymologyAtom("ES-LEX-DE-PIE-11")).toBe(false);
+    expect(isEtymologyAtom("SA-SOUND-PIE-KW-OUTCOMES")).toBe(false);
+    expect(isEtymologyAtom("ES-GRAMMAR-AGREEMENT-MASCULINE-PLURAL")).toBe(false);
   });
 });
 


### PR DESCRIPTION
> *"Etymology should only be mentioned once. I do not want that re-emphasized again and again. It is mostly a memory hook for me."*

**The gate was manufacturing the repetition.** HL09 §3.1 requires every atom to be revisited at least twice, and for an etymon the only way to satisfy that was to re-state it in the Guided Practice and again in the Wrap-up Recall. The prose was being shaped by the measurement, so the measurement changes first.

Etymology atoms — `*-ETYMON-*`, a naming convention every track already follows — are now waived from the reinforcement criterion. Spanish's pre-A1 blocker goes **87 → 53** and prints the waiver:

> `53 atom(s) at or below pre-A1 are revisited fewer than twice (35 etymology hook(s) waived)`

This also settles a question that had been open for weeks: the once-cited `ES-ETYMON-*` atoms are **waived, not re-cited**.

## The waiver is at the gate, not in the measurement

`measureContinuity` goes on reporting every atom truthfully, so `atomsTaught`, `atomsNeverRevisited` and the R-window counts keep meaning what they say, the gap report stays honest, and **no pinned corpus figure moves**. Only the level *claim* ignores them — the one place the decision actually applies — and the waiver is printed rather than silently absent.

## The assertion took three attempts to make discriminate

Worth recording, because two versions passed while the waiver was **deleted**:

1. `shortfall < shortfall + waived` — true of any number.
2. Compared against a whole-track count — couldn't fail, because the gate scopes to pre-A1.
3. Pins 53 against the 87 the gate reports without the waiver. This one fails.

## Not done here: removing the repetition already written

An automated sweep over chapters 1–3 was attempted and **reverted**. Review found it:

- corrupted a URL and an `i.e.` by inserting spaces inside them — the URL then vanished from the generated book
- deleted **23 load-bearing `[PAUSE 3s]` cues**, which `explicitPauseSeconds` and the narration script both consume
- glued four headings, left dangling connectives (*"Two things:"* above one question)
- took **eleven questions testing real skills** — Arabic morphology, a Tamil handwriting stroke, Spanish gender and article
- in ~10 files removed a lesson's single **teaching** of an etymology while keeping the **drill** — the inverse of the directive

Two things learned and recorded:

- In Arabic and the other Semitic tracks, **"root" means the three-consonant root system** — core grammar, not an etymology hook. A matcher keyed on that word cannot be trusted.
- A recall paragraph **cannot be re-flowed freely**: `countPromptLines` counts lines containing a question mark, so a pure re-wrap changes the computed duration and pushed one lesson over the 300-second ceiling.

That work needs doing by hand, per track.

## Verification

408 tests pass. **No corpus file changed** — two source files and the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
