### PR TITLE
feat(task-app): rename the app's on-screen brand from Planner to Trestle

### DIFF
--- a/code/programs/mosaic/task-app/BACKLOG.md
+++ b/code/programs/mosaic/task-app/BACKLOG.md
@@ -7,13 +7,7 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 
 ## Next up (priority order)
 
-1. **Rename off "Planner".** (User decision, 2026-08-06, still open — needs the user
-   awake to review.) "Planner" collides with an existing trademark (Microsoft Planner et
-   al.) — needs a new, trademark-safe name. User wants a **short list of alternatives
-   proposed**, not "Travail" locked in unilaterally. Not started: this needs the user's
-   input, not something to advance solo.
-
-2. **Design-fidelity gap, remaining items.** The clear value mismatches (colors that
+1. **Design-fidelity gap, remaining items.** The clear value mismatches (colors that
    didn't match a design token, collapsed-to-uniform spacing, drifted shadow alpha
    values) are closed — see `CHANGELOG.md`'s "re-closed the design-fidelity gap" entry.
    What's left needs either a product decision or real feature work, not a value fix:
@@ -35,7 +29,7 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
    - Calendar view — shipped since (Phase 7, see Resolved below); the mock's calendar
      was corroborating evidence for that roadmap phase, not a separate design-fidelity task.
 
-3. **Phase 9 — per-project/task complexity config (board-only ↔ full CPM).** The
+2. **Phase 9 — per-project/task complexity config (board-only ↔ full CPM).** The
    nested-project tree half of Phase 9 shipped as `mosaic-pkg-project-nav` (see Resolved
    below); this is what's left. The spec calls it "the single most important product
    rule" (§2.3) but doesn't define what "board only" actually hides (Timeline tab?
@@ -88,6 +82,14 @@ Each item, once picked up, follows: spec-sync → tests → implementation → C
 
 ## Resolved (kept for traceability, not actionable)
 
+- **Rename off "Planner".** Renamed the app's on-screen brand to **Trestle**
+  (2026-08-06, user picked from a proposed shortlist of Cadence / Waypoint /
+  Keel / Trestle). "Planner" collided with Microsoft Planner and others; the
+  name was never baked into any spec or package/directory path — only the
+  `TaskApp.mll` `brand-name` `Text` node and the `design/ui-prototype.html`
+  mock displayed it, so this was a small, contained value change, not a
+  structural rename. Verified live in both themes after rebuilding the web
+  bundle; zero console errors.
 - **Notes attach-to-task + task-detail notes paragraph.** Closes the gap the
   dependency-list entry below disclosed. `mosaic-pkg-notes` 0.2.0 gained a
   minimal "Attach to task" text field (task NAME, resolved to

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Changed - renamed the app's on-screen brand from "Planner" to "Trestle"
+
+"Planner" collided with an existing trademark (Microsoft Planner et al.).
+Presented the user a short list of trademark-safe alternatives (Cadence,
+Waypoint, Keel, Trestle) rather than locking one in unilaterally, per
+`BACKLOG.md`'s "Rename off Planner" item; the user picked **Trestle**.
+
+The name was never baked into any spec, package name, or directory path —
+only two files displayed it as a literal string: `TaskApp.mll`'s
+`brand-name` `Text` node (the single source of truth the React components
+are compiled from) and `design/ui-prototype.html`'s historical design
+mock (`<title>` and the rail's `.name` div). Rebuilt the web bundle
+(`scripts/build-web.sh`) to regenerate `host/web/src/TaskApp.{light,dark}.tsx`
+from the updated source — those two files are gitignored build output, not
+committed, so no other file needed touching. Verified live in both themes
+after rebuild: brand text reads "Trestle", zero console errors.
+
 ### Added - minimal notes attachment + notes paragraph in the task-detail panel
 
 Closes the gap the dependency-list entry below disclosed: `Note.attached_task`

--- a/code/programs/mosaic/task-app/design/ui-prototype.html
+++ b/code/programs/mosaic/task-app/design/ui-prototype.html
@@ -1,4 +1,4 @@
-<title>Planner — task &amp; project design</title>
+<title>Trestle — task &amp; project design</title>
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
   /* ============================================================
@@ -503,7 +503,7 @@
   <aside class="rail">
     <div class="brand">
       <div class="mark" aria-hidden="true"></div>
-      <div class="name">Planner</div>
+      <div class="name">Trestle</div>
     </div>
 
     <nav>

--- a/code/programs/mosaic/task-app/src/TaskApp.mll
+++ b/code/programs/mosaic/task-app/src/TaskApp.mll
@@ -14,7 +14,7 @@ layout TaskApp {
     Column [ rail ] {
       Row [ brand ] {
         Box [ brand-mark ] { }
-        Text [ brand-name ] ( content : "Planner" )
+        Text [ brand-name ] ( content : "Trestle" )
       }
 
       // The nested-project tree + add-project composer, extracted verbatim

--- a/code/specs/task-app-project-nav-v1.md
+++ b/code/specs/task-app-project-nav-v1.md
@@ -21,9 +21,10 @@ this repackages; nothing about its behavior changes here.
 ## What stays in TaskApp, and why
 
 - **The brand row** (logo mark + app name) — app identity, not project
-  navigation. Also the one thing the still-open "rename off Planner"
-  backlog item touches; keeping it out of this package means that
-  decision, whenever it lands, doesn't ripple through a package boundary.
+  navigation. Also the one thing the "rename off Planner" backlog item
+  touched (now resolved — the app is named Trestle); keeping it out of
+  this package meant that decision didn't ripple through a package
+  boundary when it landed.
 - **The view-switcher** (the segmented List/Board/Sheet/Calendar/Notes/
   Timeline tab row) — named alongside "nested-project tree" in the same
   roadmap bullet, but deliberately NOT extracted here. It's a single,


### PR DESCRIPTION
## Summary
- "Planner" collided with an existing trademark (Microsoft Planner et al.) — flagged as a blocking backlog item requiring the user's choice, not something to advance solo.
- Presented a short list of trademark-safe alternatives (Cadence, Waypoint, Keel, Trestle); the user picked **Trestle**.
- The name was never baked into any spec, package name, or directory path — only two files displayed it as a literal string: `TaskApp.mll`'s `brand-name` `Text` node (source of truth) and `design/ui-prototype.html`'s historical mock. Rebuilt the web bundle to regenerate the gitignored `TaskApp.{light,dark}.tsx` build output.
- Updated `BACKLOG.md` (moved item to Resolved), `CHANGELOG.md`, and a stale cross-reference in `code/specs/task-app-project-nav-v1.md`.

## Test plan
- [x] `cargo test` in `code/programs/mosaic/task-app` — 2/2 pass
- [x] `npx vitest run` in `host/web` — 28/28 pass
- [x] Live browser verification: brand text reads "Trestle" in both light and dark themes, zero console errors
- [x] `/security-review` — passed, no findings

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>