### PR TITLE
feat(human-languages): the pre-A1 vocabulary probe — mechanism confirmed, cost measured (HL-C53)

### DIFF
--- a/code/learning/human-languages/arabic/CHANGELOG.md
+++ b/code/learning/human-languages/arabic/CHANGELOG.md
@@ -1,5 +1,112 @@
 # Changelog
 
+## Chapters 33–36 — the pre-A1 noun tranche, and what the level gate actually counts (2026-08-07)
+
+- Added fifteen everyday-noun lessons across four chapters, all filed under
+  **pre-A1** spine nodes: `AR-C33-shay`, `AR-C33-halib`, `AR-C33-sukkar`,
+  `AR-C33-qahwa` (drinks); `AR-C34-milh`, `AR-C34-lahm`, `AR-C34-jubn`,
+  `AR-C34-taam` (food); `AR-C35-jar`, `AR-C35-ibn-bint`, `AR-C35-sadiq`
+  (people); `AR-C36-zayt`, `AR-C36-kub`, `AR-C36-tabaq`, `AR-C36-milaqa`
+  (vessels and plurals). Chapters 33, 34 and 36 realize
+  `SPINE-POLITE-REQUEST-REPAIR` — these are the things you ask for across a
+  counter — and Chapter 35 realizes `SPINE-EXCHANGE-NAMES`, the people you
+  introduce.
+
+- **This tranche was a measurement probe, and it answers its question.** For
+  Arabic, `levelGate.tracks[arabic]` moves as follows:
+
+  | figure | before | after |
+  |---|---|---|
+  | vocabulary blocker (headwords at or below pre-A1) | 33 of 300 | 48 of 300 |
+  | vocabulary shortfall | 267 | 252 |
+  | reinforcement blocker (pre-A1 atoms revisited < 2) | 60 | 49 |
+  | `vocabulary` field (whole track, every level) | 65 | 80 |
+
+  So yes: track-local pre-A1 vocabulary does move the gate. But it moves it
+  **one headword per lesson**, because `vocabularyOf` in `src/level-gate.ts`
+  counts *distinct `headword` frontmatter strings*, not words taught. A lesson
+  whose body hands the learner *ṭaʿām*, *ṭaʿima*, *ṭaʿm* and *maṭʿam* still
+  contributes exactly one. Closing pre-A1 at the present target therefore costs
+  roughly **252 more lessons** for this track alone.
+
+- **What actually levels a lesson is `path[].lessons`, not the extension.**
+  `lessonSpineNodes` walks only `curriculum.path[].lessons`; it never reads
+  `extensions[]`, nor `before`/`inline`/`after`. An `AR-EXT-*` entry is still
+  required — `validateCurriculum` errors with
+  `unclassified-curriculum-extension-lesson` for any content lesson whose
+  namespaced `concept_tag` no spine node owns — but it contributes nothing to
+  the level. Both wirings are present here: segments `AR-PATH-030`–`033` and
+  extensions `AR-EXT-030`–`033-LANGUAGE-SPECIFIC`, all staged `pre-A1`.
+
+- **Words the brief proposed that the track already taught, and which were
+  therefore not duplicated:** *māʾ* and *khubz* (`AR-C13-maa-khubz`), *ism*
+  (`AR-C02-ism`), *ab* and *umm* (`AR-C10-ab-umm`), *akh* and *ukht*
+  (`AR-C10-akh-ukht`). *Kitāb* is not a headword anywhere, but
+  `AR-C31-kataba` already derives it, *kātib*, *maktūb*, *maktab* and
+  *maktaba* in full, so a *kitāb* lesson would have re-taught that lesson's
+  payoff; it is reached back to instead.
+
+- **Words that do not honestly serve any pre-A1 node, and were left out.**
+  The seven pre-A1 nodes are all social transaction — greet, thank, yes/no,
+  exchange names, check wellbeing, request/repair, take leave — and their 34
+  concepts contain no concrete object at all. *Bayt* (house), *bāb* (door),
+  *kursī* (chair), *ṭāwila* (table), *miftāḥ* (key), *madrasa* (school) and
+  *sūq* (market) belong to "describe where I am", whose nearest spine node,
+  `SPINE-ASK-LOCATION`, is **A1**. Putting them at pre-A1 would have inflated
+  the gate rather than satisfied it.
+
+- **Arabic's signature, used rather than described.** `AR-C34-taam` pours the
+  new root **ط-ع-م** through the *ma-* place shape the learner already owns
+  from *maktab* (Ch. 31) and *madhhab* (Ch. 28) and hands back **مَطْعَم**
+  (*maṭʿam*, "a restaurant") without teaching it. `AR-C36-milaqa` sets the
+  *mi-* **tool** shape (*mirʾāh* from Ch. 29, *milʿaqa*) against that *ma-*
+  **place** shape. The **فَعيل** (*faʿīl*) pattern is named once and then
+  collected across three chapters — *ḥalīb*, *malīḥ*, *ṣadīq*. **لحم** is
+  taught as **ملح** reordered, which is the root system stated in one line.
+  Sound and broken plurals are named in Chapter 36: *akwāb*, *aṭbāq* and
+  *malāʿiq* re-poured against *qahawāt* and *ṣadīqāt* merely suffixed.
+
+- **Gender is taught as a rule you can apply on sight**, not a list: the
+  *tāʾ marbūṭa* **ة** marks *qahwa*, *ṣadīqa*, *ṭabaqa* and *milʿaqa*
+  feminine, and it is the tied form of the plain **ت** that already separated
+  *akh* from *ukht* and now separates *ibn* from *bint*.
+
+- **Honesty kept, three times.** `AR-C34-jubn` refuses to make one root of
+  *jubn* "cheese" and *jubn* "cowardice"; `AR-C36-kub` refuses to claim
+  descent from Latin *cuppa*; `AR-C33-halib` refuses the milk story told about
+  Aleppo, whose name predates Arabic. `AR-C35-ibn-bint` gives the grammarians'
+  **ب-ن-ي** derivation and then says why comparative Semitists hold it loosely.
+
+- **Reach-back at two cadences.** Every lesson practises the preceding one to
+  three lessons' atoms, so each new atom is revisited at least twice inside
+  R1 (n+1…n+3); each chapter payoff additionally rescues atoms several chapters
+  back. Ten previously never-revisited pre-A1 atoms leave the blocker:
+  `AR-CONCEPT-C04-AL-SALAMA-01`, `C06-MIN-FADLIK-01`, `C10-AB-UMM-01`,
+  `C10-AKH-UKHT-01`, `C13-MAA-KHUBZ-01`, `C13-MAA-KHUBZ-02`, `C23-AFWAN-01`,
+  `W07-HOOK-FAMILY-HA-KHA-01`, `W08-KAF-AND-RA-01/-02`,
+  `W11-HA-AND-TA-MARBUTA-02`. The tranche adds none of its own.
+
+- **The script-section inconsistency in this track is real and is recorded.**
+  Chapters 28–30 head their inline-letters section `## You'll want to know —
+  The letters in this word`, which `classifyBlock` types `input` — not
+  detachable, so the letter shapes sit in the lesson's **core** and the lesson
+  is not drivable. Chapters 31–32 use the canonical `## The letters in this
+  word`, typed `script` and detachable, so the core stays `voice`. All fifteen
+  new lessons use the canonical heading; all fifteen have a `voice` core. The
+  six Chapter 28–30 lessons are **not** fixed here and remain measurable debt.
+
+- Wiring: `chapters.json` gains four HL05 ledgers with capabilities and
+  payoffs; `core/book-generation.json` gains four `arabic-main` targets;
+  `book/book.tex` inputs the four new chapters. The whole book compiles under
+  XeLaTeX at **164 pages with zero `Missing character` warnings**. Narration
+  regenerated for `ch33`–`ch36`; no lesson carries a table, so nothing is
+  narrated as a grid.
+
+- All fifteen lessons are under the five-minute computed ceiling (265–298
+  effective seconds) and inside `maxNewAtomsPerLesson: 3` and
+  `maxNewAtomsPerChapter: 12` — each chapter introduces 8, except Chapter 35,
+  which introduces 6.
+
 ## Chapters 31–32 — the eight-verb tranche, and the root system paying out (2026-08-07)
 
 - Added eight lessons, one verb each, realizing the eight canonical `VERB-*`

--- a/code/learning/human-languages/arabic/README.md
+++ b/code/learning/human-languages/arabic/README.md
@@ -81,30 +81,87 @@ Two more things:
   the **Saudi** in Saudi Arabia, while *fahima*, *fakkara*, *kataba*,
   *ʾakhadha*, *saʾala* and *ʾaḥabba* have **no English relative at all**, which
   each lesson says outright. In the book.
+- **Chapters 33–36 — Everyday nouns, filed at pre-A1**
+  ([`lessons/AR-C{33,34,35,36}-*`](./lessons/)): the drinks you ask for —
+  **shāy**, **ḥalīb**, **sukkar**, **qahwa**; the food — **milḥ**, **laḥm**,
+  **jubn**, **ṭaʿām**; the people you introduce — **jār**, **ibn**/**bint**,
+  **ṣadīq**; and the vessels — **zayt**, **kūb**, **ṭabaq**, **milʿaqa**.
+  Chapters 33, 34 and 36 realize `SPINE-POLITE-REQUEST-REPAIR`; Chapter 35
+  realizes `SPINE-EXCHANGE-NAMES`. The root engine keeps paying: **ط-ع-م**
+  poured through the *ma-* place shape of *maktab* returns **مَطْعَم**
+  (*maṭʿam*, "a restaurant") with nothing new to learn, and *milʿaqa* sets the
+  *mi-* **tool** shape beside it. **لحم** is **ملح** reordered — the root
+  system in one line — and Hebrew *leḥem* means *bread* off that same root,
+  with **Bethlehem** sitting on the seam. Gender becomes a rule you apply on
+  sight: **ة** marks *qahwa*, *ṣadīqa* and *milʿaqa* feminine. Chapter 36 names
+  the **broken** plural (*akwāb*, *aṭbāq*, *malāʿiq*) against the **sound** one
+  (*qahawāt*, *ṣadīqāt*). Cousins are claimed only where they are real —
+  *qahwa* really did become English **coffee**, and *as-sukkar* and *az-zayt*
+  really are the **azúcar** and **aceite** of Spanish — and refused where they
+  are not: *jubn* "cheese" and *jubn* "cowardice" are **not** one root,
+  *kūb* is **not** claimed from Latin *cuppa*, and Aleppo is **not** named for
+  milk. In the book.
 
-All fifty-nine lessons in Chapters 3–32 remain below five effective minutes.
+All seventy-four lessons in Chapters 3–36 remain below five effective minutes.
+
+## What the level gate says, and what it counts
+
+`src/level-gate.ts` reports Arabic as **in progress at pre-A1**, blocked on two
+of the four HL09 §3.1 criteria:
+
+| criterion | before Chapters 33–36 | after |
+|---|---|---|
+| vocabulary at or below pre-A1 | 33 of 300 | 48 of 300 |
+| pre-A1 atoms revisited fewer than twice | 60 | 49 |
+
+Two things are worth stating plainly, because both are easy to misread.
+
+**The gate counts headwords, not words.** `vocabularyOf` collects distinct
+`headword:` strings from `word` and `phrase` lessons. `AR-C34-taam` teaches
+*ṭaʿām*, *ṭaʿima*, *ṭaʿm* and *maṭʿam* and counts as **one**. Fifteen lessons
+therefore moved the number by exactly fifteen, and closing pre-A1 at the
+present target of 300 would cost roughly **252 more lessons** in this track.
+
+**What levels a lesson is the path segment, not the extension.**
+`lessonSpineNodes` walks `curriculum.path[].lessons` only. An `AR-EXT-*`
+extension is separately required — a content lesson with a track-local
+`concept_tag` that no spine node owns must belong to exactly one, or
+`validateCurriculum` rejects it — but it does not place the lesson at a level.
+Chapters 33–36 carry both: segments `AR-PATH-030`–`033`, extensions
+`AR-EXT-030`–`033-LANGUAGE-SPECIFIC`.
+
+**Why there are no household nouns here.** The seven pre-A1 spine nodes are all
+social transaction and hold no concrete object among their 34 concepts. *Bayt*,
+*bāb*, *kursī*, *ṭāwila* and *miftāḥ* belong with "say where I am", whose
+nearest node — `SPINE-ASK-LOCATION` — is **A1**. Filing them at pre-A1 would
+have inflated this table rather than satisfied it.
 
 ## Can you learn this track in the car?
 
 Mostly. Under [`HL08`](../../../specs/HL08-modality-gentle-ramp-and-the-drivable-course.md)
 each lesson is `voice` 🚗, `sight` 👁 or `pen` ✍ at **full** modality, and
-Arabic measures 44 / 25 / 16 — but 20 of those `sight` lessons carry their
-visual load entirely inside a **detachable** block, so **56 of 85 lessons have
-a `voice` core (75% drivable)**, with 56 reachable in chapter-prefix order.
+Arabic measures 44 / 40 / 16 — but 34 of those `sight` lessons carry their
+visual load entirely inside a **detachable** block, so **78 of 100 lessons have
+a `voice` core (78% drivable)**, with 69 reachable in chapter-prefix order.
 
-The eight verb lessons of Chapters 31–32 sit in exactly that group. Each uses
+The eight verb lessons of Chapters 31–32, and all fifteen noun lessons of
+Chapters 33–36, sit in exactly that group. Each uses
 the canonical `## The letters in this word` heading, which types as a `script`
 block: honest at full modality (a letter shape is not a sound), detachable for
 a hands-free renderer, so their `coreModality` is `voice`. The cost is
-visible and deliberate — Arabic's `sight` count rises by eight and two more
-chapters become "unstartable" at full modality — and the alternative was the
+visible and deliberate — Arabic's `sight` count rises with every such lesson
+and those chapters become "unstartable" at full modality — and the alternative was the
 older habit of hiding the letters section behind a non-script heading, which
 made the number look better without making the lesson more listenable.
 
-Chapters 3, 4 and 8 are prefix 0 at full modality, and so are Chapters 31 and
-32 — the latter two only because every lesson in them opens on its detachable
-letters block, which is why they still count as fully drivable once that block
-is set aside. Chapters 3 and 4 are the real blocks: each opens on a `pen`
+Chapters 3, 4 and 8 are prefix 0 at full modality, and so are Chapters 31–36 —
+the latter only because every lesson in them opens on its detachable letters
+block, which is why they still count as fully drivable once that block is set
+aside. Chapters 28–30 are the exception in the other direction: they head that
+same section `## You'll want to know — The letters in this word`, which
+`classifyBlock` types `input` rather than `script`, so it is **not** detachable
+and their cores are `sight`. That inconsistency is real, is still in the book,
+and is not fixed here. Chapters 3 and 4 are the real blocks: each opens on a `pen`
 writing lesson that later lessons
 depend on: a chapter's drivable prefix can only start with a lesson that has no
 in-chapter prerequisite, and Chapter 4's only such lesson is `AR-W10-ayn`,
@@ -148,7 +205,7 @@ finishing that chapter lets them do, and names the lesson that proves it:
 ```
 
 The file is **authored intent**, not a derived cache — no validator may rewrite
-it. Chapters 3–32 are covered. Chapters 1 and 2 are deliberately left out: their
+it. Chapters 3–36 are covered. Chapters 1 and 2 are deliberately left out: their
 recap lessons are still schema v1 with no declared knowledge atoms, so a payoff
 there could only be invented. That absence is honest, measurable debt and is
 reported as such.

--- a/code/learning/human-languages/arabic/book/book.tex
+++ b/code/learning/human-languages/arabic/book/book.tex
@@ -143,6 +143,14 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/ch32-taking-thinking-helping-loving}
 
+\input{chapters/ch33-asking-for-a-drink}
+
+\input{chapters/ch34-asking-for-food}
+
+\input{chapters/ch35-people-you-introduce}
+
+\input{chapters/ch36-cups-plates-and-more-than-one}
+
 \backmatter
 
 \input{chapters/appendix-pronunciation}

--- a/code/learning/human-languages/arabic/book/chapters/ch33-asking-for-a-drink.tex
+++ b/code/learning/human-languages/arabic/book/chapters/ch33-asking-for-a-drink.tex
@@ -1,0 +1,196 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:f3a63219618807ba
+% canonical-lessons: AR-C33-shay, AR-C33-halib, AR-C33-sukkar, AR-C33-qahwa
+
+\chapter{Asking for a Drink}
+\label{ch:ar-asking-for-a-drink}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can name tea, milk, sugar and coffee in Arabic and ask for any of them politely, and I can tell at sight whether an Arabic noun is feminine.}
+
+Say the chapter's drinks and name which of them Arabic built and which it borrowed — ḥalīb from ḥalaba, 'he milked', against shāy and sukkar, which arrived with no root at all — then read the \ar{ة} off qahwa as a gender marker, place it beside maktaba and as-salāma, and order each drink with min faḍlik, answering ʿafwan.
+\end{chapteropening}
+
+\section[shāy]{\ar{شاي} (shāy) — \textquotedblleft{}tea,\textquotedblright{} and a word with no root}
+
+\label{lesson:AR-C33-shay}
+
+
+
+\begin{quote}
+Every Arabic word you have taken apart so far had a root under it. This one does not — and that absence is the lesson.
+\end{quote}
+
+\subsection*{The letters in this word}
+Nothing new. \textbf{\ar{ش}} (\emph{shīn}) has been on the page since \textbf{\ar{شكرا}} (\emph{shukran}): the \emph{sīn} skeleton with three dots above it. Then \textbf{\ar{ا}} (\emph{alif}), the non-joiner, and \textbf{\ar{ي}} (\emph{yāʾ}).
+
+So \textbf{\ar{شاي}} breaks where \emph{alif} forces it to break: \textbf{\ar{شا}}, then \textbf{\ar{ي}}. That is the same two-piece split you met in \textbf{\ar{أحبّ}} — \textbf{\ar{أ}} standing alone, then \textbf{\ar{حبّ}}.
+
+\begin{cousinweb}
+\textbf{\ar{شاي}} (\emph{shāy}) = \textquotedblleft{}\textbf{tea}.\textquotedblright{}
+
+Now the honest part. Take \textbf{\ar{كتب}} (\emph{kataba}): its root pours into \textbf{\ar{كِتاب}} (\emph{kitāb}, a book), \textbf{\ar{كاتِب}} (\emph{kātib}, a writer), \textbf{\ar{مَكْتَب}} (\emph{maktab}, an office) and \textbf{\ar{مَكْتَبة}} (\emph{maktaba}, a library). Try that with \emph{shāy} and nothing comes out. There is no shape it fills, no doer, no place, no done-to.
+
+That is because \textbf{shāy is borrowed}, and a borrowed word arrives without a root. Arabic took it through Persian \textbf{\ar{چای}} (\emph{chāy}), which took it from the \textbf{northern Chinese} \emph{chá}.
+
+Your own language took the same Chinese word by the other road. Traders on the southern coast of China said it \emph{tê}, Dutch ships carried that form to Europe, and it became English \textbf{tea}, French \textbf{thé}, German \textbf{Tee}. Overland through Persia it stayed \emph{chá}: Russian \textbf{chay}, Turkish \textbf{çay}, Arabic \textbf{shāy}.
+
+So \emph{shāy} and \emph{tea} are not merely similar. They are the two ends of one word, separated by which way it left China.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item shīn, alif, yāʾ — \textquotedblleft{}shāy,\textquotedblright{} tea
+  \item where it breaks — shā, then yāʾ, as \ar{أحبّ} broke after the alif
+  \item what a root gives — kitāb, kātib, maktab, maktaba
+  \item what shāy gives — nothing, because it was borrowed
+  \item the overland road — Chinese chá, Persian chāy, Arabic shāy
+  \item the sea road — Hokkien tê, Dutch, English tea
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Why can you not build a word family from \textbf{\ar{شاي}}? (\textbf{It has no Arabic root} — it was borrowed, and borrowed words arrive without one.) Name what \textbf{\ar{ك}-\ar{ت}-\ar{ب}} builds, for contrast. (\emph{\textbf{Kitāb}}, \emph{\textbf{kātib}}, \emph{\textbf{maktab}}, \emph{\textbf{maktaba}}.) Which language handed \emph{shāy} to Arabic, and which language did that one take it from? (\textbf{Persian}, from \textbf{Chinese}.) Is English \emph{tea} a relative? (\textbf{Yes} — the same Chinese word, carried by sea rather than overland.)
+\end{tcolorbox}
+\section[ḥalīb]{\ar{حليب} (ḥalīb) — \textquotedblleft{}milk,\textquotedblright{} and the verb underneath it}
+
+\label{lesson:AR-C33-halib}
+
+
+
+\begin{quote}
+Yesterday's word had no root to stand on. This one has a root so plain you can hear the verb inside the noun.
+\end{quote}
+
+\subsection*{The letters in this word}
+Nothing new again. \textbf{\ar{ح}} (\emph{ḥāʾ}) is the undotted member of the hook-and-tail family — the body it shares with \textbf{\ar{خ}} (\emph{khāʾ}, one dot above) and \textbf{\ar{ج}} (\emph{jīm}, one dot below). It is the hard breath from deep in the throat that opens \textbf{\ar{أحبّ}} (\emph{ʾaḥabba}).
+
+Then \textbf{\ar{ل}} (\emph{lām}), \textbf{\ar{ي}} (\emph{yāʾ}) carrying the long \textbf{ī}, and \textbf{\ar{ب}} (\emph{bāʾ}).
+
+All four join, so \textbf{\ar{حليب}} runs as one unbroken stroke — the opposite of \textbf{\ar{شاي}}, which had to stop at its \emph{alif}.
+
+\begin{cousinweb}
+\textbf{\ar{حَليب}} (\emph{ḥalīb}) = \textquotedblleft{}\textbf{milk}.\textquotedblright{} Root \textbf{\ar{ح}-\ar{ل}-\ar{ب}}, and its verb is \textbf{\ar{حَلَبَ}} (\emph{ḥalaba}), \textquotedblleft{}\textbf{he milked}.\textquotedblright{} So the noun is simply the milked thing.
+
+You have met this exact transparency before. \textbf{\ar{خبز}} (\emph{khubz}, bread) sits on \textbf{\ar{خ}-\ar{ب}-\ar{ز}}, \textquotedblleft{}to bake\textquotedblright{}: the baked thing. Arabic does this constantly — name the action, and the everyday noun falls out of it.
+
+The pattern \emph{ḥalīb} wears, \textbf{\ar{فَعيل}} (\emph{faʿīl}), is one to keep. It takes a root and hands back a quality or a result you can hold.
+
+Hebrew has the word unchanged: \textbf{\he{חָלָב}} (\emph{ḥalav}), \textquotedblleft{}milk,\textquotedblright{} the same root doing the same job — the family resemblance already heard in \emph{salām} and \emph{shalom}.
+
+One caution, because a good story is not the same as a true one. The Syrian city \textbf{\ar{حَلَب}} (\emph{Ḥalab}, English \textbf{Aleppo}) is often explained as a milk name. It is not: \emph{Ḥalab} appears in Bronze Age records centuries before Arabic was written, so the milk account is a later invention hung on a name that already existed. No English word descends from \textbf{\ar{ح}-\ar{ل}-\ar{ب}} at all.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item the hook family — ḥāʾ no dot, khāʾ one above, jīm one below
+  \item ḥāʾ, lām, yāʾ, bāʾ — \textquotedblleft{}ḥalīb,\textquotedblright{} milk
+  \item the verb under it — \textquotedblleft{}ḥalaba,\textquotedblright{} he milked
+  \item the same move in bread — khubz, from kh-b-z, to bake
+  \item the pattern — faʿīl, as in ḥalīb
+  \item the borrowed one against the built one — shāy, then ḥalīb
+  \item the Hebrew twin — ḥalav
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What does the root \textbf{\ar{ح}-\ar{ل}-\ar{ب}} mean as a verb? (\textbf{To milk} — so \emph{ḥalīb} is the milked thing.) Which earlier word works the same way? (\emph{\textbf{Khubz}} — bread, from \emph{kh-b-z}, to bake.) Which of the chapter's words so far has no root at all? (\emph{\textbf{Shāy}} — it was borrowed.) Is Aleppo named for milk? (\textbf{No} — the name is far older than Arabic; that story is folk etymology.)
+\end{tcolorbox}
+\section[sukkar]{\ar{سكر} (sukkar) — \textquotedblleft{}sugar,\textquotedblright{} and an Arabic article stuck to a Spanish word}
+
+\label{lesson:AR-C33-sukkar}
+
+
+
+\begin{quote}
+Another traveller — and this one left a piece of Arabic grammar behind in Spain.
+\end{quote}
+
+\subsection*{The letters in this word}
+Nothing new. \textbf{\ar{س}} (\emph{sīn}), the low comb; \textbf{\ar{ك}} (\emph{kāf}), the angular \emph{k}; and \textbf{\ar{ر}} (\emph{rā}), the little downward curve that \textbf{breaks} — a non-joiner, like \emph{alif}. So \textbf{\ar{سكر}} joins from \emph{sīn} to \emph{kāf}, and \emph{rā} hangs off the end.
+
+Written fully it is \textbf{\ar{سُكَّر}}, and the mark over the \textbf{\ar{ك}} is the \textbf{shadda}. You have seen it do two jobs. On \textbf{\ar{فكّر}} (\emph{fakkara}) it built a new verb out of an old root. Here it does the quieter job it did on \textbf{\ar{أحبّ}}: it spells a letter the word already owns twice over — \emph{suk-kar}.
+
+\begin{cousinweb}
+\textbf{\ar{سُكَّر}} (\emph{sukkar}) = \textquotedblleft{}\textbf{sugar}.\textquotedblright{} Like \emph{shāy}, and unlike \emph{ḥalīb}, it is \textbf{borrowed}: no Arabic root, no family of shapes.
+
+Its road west starts in \textbf{Sanskrit}, where \textbf{śarkarā} meant \textquotedblleft{}grit, gravel\textquotedblright{} — sugar named for its coarse grains. \textbf{Persian} took it as \emph{shakar}, Arabic as \emph{sukkar}, and Arabic carried it into medieval \textbf{Latin} as \emph{succarum}. From there: Italian \textbf{zucchero}, French \textbf{sucre}, German \textbf{Zucker}, English \textbf{sugar}.
+
+Then \textbf{Spanish}, which shows what the others hide. Spanish for sugar is \textbf{azúcar} — and that opening \emph{a-z-} is Arabic's own \textbf{\ar{الـ}} (\emph{al-}), the article, welded onto the front of the noun. Spanish borrowed \textbf{al-sukkar} whole and never took it apart.
+
+You know why the \emph{l} vanished: \textbf{\ar{س}} is a \textbf{sun letter}, so \emph{al-} + \emph{sukkar} is said \textbf{as-sukkar}, as \emph{al-} + \emph{salām} is said \textbf{as-salām}. Spanish kept the sound, not the spelling. English holds \emph{algebra} and \emph{alcohol}.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item sīn, kāf, rā — and rā breaks, so nothing joins after it
+  \item \textquotedblleft{}sukkar,\textquotedblright{} sugar — the shadda doubling the kāf, suk-kar
+  \item the shadda's two jobs — fakkara built a verb, ʾaḥabba spelled one
+  \item the road — Sanskrit śarkarā, Persian shakar, Arabic sukkar
+  \item the article that stayed — as-sukkar, Spanish azúcar
+  \item the sun letter — al- plus salām said as-salām
+  \item borrowed, borrowed, built — shāy, sukkar, ḥalīb
+  \item the letters before it — shīn, alif, yāʾ; then ḥāʾ, lām, yāʾ, bāʾ
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which letter in \textbf{\ar{سكر}} refuses to join what follows? (\emph{\textbf{Rā}}.) What is the shadda doing here, and which earlier verb used it the same way? (\textbf{Only spelling a doubled letter} — as in \emph{\textbf{ʾaḥabba}}, not as in \emph{fakkara}.) What language did \emph{sukkar} come from before Persian? (\textbf{Sanskrit} — \emph{śarkarā}, \textquotedblleft{}grit.\textquotedblright{}) What is hiding at the front of Spanish \textbf{azúcar}? (\textbf{Arabic \emph{al-}}, said \emph{as-} before a sun letter.)
+\end{tcolorbox}
+\section[qahwa]{\ar{قهوة} (qahwa) — \textquotedblleft{}coffee,\textquotedblright{} the tied tāʾ, and asking for all of it}
+
+\label{lesson:AR-C33-qahwa}
+
+
+
+\begin{quote}
+The chapter closes on a word your own language already borrowed — and on the small letter at its end that tells you the word is feminine.
+\end{quote}
+
+\subsection*{The letters in this word}
+Nothing new. \textbf{\ar{ق}} (\emph{qāf}, two dots above), the \emph{k} made far back in the throat; \textbf{\ar{ه}} (\emph{hāʾ}), the loop that changes shape wherever it stands; \textbf{\ar{و}} (\emph{wāw}), a non-joiner like \emph{rā}; and then \textbf{\ar{ة}}.
+
+\textbf{\ar{ة}} is the \textbf{tāʾ marbūṭa}, the \textquotedblleft{}tied \emph{tāʾ}\textquotedblright{} — an \textbf{\ar{ه}} with \emph{tāʾ}'s two dots on it. It appears only at the end of a word.
+
+\begin{cousinweb}
+\textbf{\ar{قَهْوة}} (\emph{qahwa}) = \textquotedblleft{}\textbf{coffee}.\textquotedblright{}
+
+Here is what the \textbf{\ar{ة}} buys you. Arabic nouns carry \textbf{gender}, and Arabic usually \textbf{shows} you which is which: a noun ending in \textbf{\ar{ة}} is almost always \textbf{feminine}. That is a rule you apply on sight, not a list to memorise.
+
+You have watched it work already:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ar{مَكْتَب}} (\emph{maktab}), an office, becomes \textbf{\ar{مَكْتَبة}} (\emph{maktaba}), a library.
+  \item \textbf{\ar{سَلام}} (\emph{salām}), peace, becomes \textbf{\ar{السَّلامة}} (\emph{as-salāma}), the safety — the root \textbf{\ar{س}-\ar{ل}-\ar{م}} wearing an ending and a pattern.
+\end{itemize}
+
+So \emph{qahwa} is feminine, while \emph{shāy}, \emph{ḥalīb} and \emph{sukkar} are masculine — and the ending alone told you.
+
+The road out of Arabic is short and well lit. Ottoman \textbf{Turkish} took \emph{qahwa} as \textbf{kahve}; Venetian traders took \emph{kahve} as Italian \textbf{caffè}; from Italian came French \textbf{café}, German \textbf{Kaffee} and English \textbf{coffee}. The English word in your mouth is this Arabic one.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item qāf, hāʾ, wāw, tāʾ marbūṭa — \textquotedblleft{}qahwa,\textquotedblright{} coffee
+  \item the tied tāʾ — an hāʾ wearing tāʾ's two dots, only at a word's end
+  \item what it marks — feminine; maktab becomes maktaba, salām becomes as-salāma
+  \item gendered — qahwa feminine; shāy, ḥalīb, sukkar masculine
+  \item order each — \textquotedblleft{}shāy, min faḍlik\textquotedblright{}; \textquotedblleft{}qahwa, min faḍlik\textquotedblright{}; \textquotedblleft{}ḥalīb, min faḍlik\textquotedblright{}; \textquotedblleft{}sukkar, min faḍlik\textquotedblright{}
+  \item the answer to thanks — \textquotedblleft{}ʿafwan,\textquotedblright{} think nothing of it
+  \item ḥalīb joined throughout, sukkar's rā broke, and the wāw breaks here
+  \item built against borrowed — ḥalaba gave ḥalīb; shāy and sukkar gave nothing
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which of this chapter's words is feminine, and how can you tell? (\emph{\textbf{Qahwa}} — \textbf{it ends in \ar{ة}}.) Name two earlier words with that ending. (\emph{\textbf{Maktaba}} and \emph{\textbf{as-salāma}}.) Ask for each drink politely. (\emph{\textbf{Shāy}}, \emph{\textbf{qahwa}}, \emph{\textbf{ḥalīb}}, \emph{\textbf{sukkar}} — each with \emph{\textbf{min faḍlik}}, \textquotedblleft{}from your grace.\textquotedblright{}) What do you answer when someone thanks you? (\emph{\textbf{ʿAfwan}}.) Which word here was built from a verb? (\emph{\textbf{Ḥalīb}}, from \emph{ḥalaba} — the others travelled in.)
+\end{tcolorbox}

--- a/code/learning/human-languages/arabic/book/chapters/ch34-asking-for-food.tex
+++ b/code/learning/human-languages/arabic/book/chapters/ch34-asking-for-food.tex
@@ -1,0 +1,209 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:140140ef03991197
+% canonical-lessons: AR-C34-milh, AR-C34-lahm, AR-C34-jubn, AR-C34-taam
+
+\chapter{Asking for Food}
+\label{ch:ar-asking-for-food}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can ask for salt, meat, cheese and food in Arabic, and I can build the word for a restaurant myself out of a root and the ma- place shape.}
+
+Name \ar{ط} as the emphatic partner of \ar{ت} beside \ar{ص} under \ar{س} and \ar{ض} under \ar{د}, then pour \ar{ط}-\ar{ع}-\ar{م} through the ma- place shape that already gave maktab and madhhab to generate maṭʿam, 'a restaurant', and ask for the chapter's foods with min faḍlik.
+\end{chapteropening}
+
+\section[milḥ]{\ar{ملح} (milḥ) — \textquotedblleft{}salt,\textquotedblright{} and the sailor hiding in it}
+
+\label{lesson:AR-C34-milh}
+
+
+
+\begin{quote}
+A word for something you can hold in one hand — whose root stretches from a mineral to the open sea to a compliment.
+\end{quote}
+
+\subsection*{The letters in this word}
+Nothing new, but one shape is worth a second look. \textbf{\ar{م}} (\emph{mīm}), \textbf{\ar{ل}} (\emph{lām}), \textbf{\ar{ح}} (\emph{ḥāʾ}) — all three join, so \textbf{\ar{ملح}} is one run of pen.
+
+The \textbf{\ar{ح}} is the hook-and-tail letter that opened \textbf{\ar{حليب}} (\emph{ḥalīb}), but at the \textbf{end} of a word it grows its full tail and swings below the line: open at the start of \emph{ḥalīb}, closed and tailed at the end of \emph{milḥ}.
+
+\textbf{\ar{قهوة}} made the same point at the other end of a word: \textbf{\ar{ة}} exists only in final position.
+
+\begin{cousinweb}
+\textbf{\ar{مِلْح}} (\emph{milḥ}) = \textquotedblleft{}\textbf{salt}.\textquotedblright{} Root \textbf{\ar{م}-\ar{ل}-\ar{ح}}, and this is a root that has gone travelling inside its own language:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ar{مَلّاح}} (\emph{mallāḥ}) — \textquotedblleft{}\textbf{a sailor}.\textquotedblright{} The man of the salt water. It wears the doubled \emph{lām} shape Arabic keeps for trades and habits.
+  \item \textbf{\ar{مَليح}} (\emph{malīḥ}) — \textquotedblleft{}\textbf{handsome, pleasant}.\textquotedblright{} Salty, said of a person. Arabic reached for the same idea English reaches for when it calls a person \emph{the salt of the earth}.
+\end{itemize}
+
+Note \emph{malīḥ}'s shape: \textbf{\ar{فَعيل}} (\emph{faʿīl}), the same pattern that gave you \textbf{\ar{حَليب}} (\emph{ḥalīb}). A root plus that pattern hands back a quality.
+
+Hebrew has \textbf{\he{מֶלַח}} (\emph{melaḥ}), \textquotedblleft{}salt,\textquotedblright{} unchanged — one more Semitic twin. English is \textbf{not} in this family: \emph{salt} comes down from Latin \textbf{sāl} and its Germanic cousins. And unlike \emph{sukkar}, nothing here was borrowed.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item mīm, lām, ḥāʾ — \textquotedblleft{}milḥ,\textquotedblright{} salt
+  \item ḥāʾ in two places — opening ḥalīb, closing milḥ with its tail
+  \item the root's reach — mallāḥ, a sailor; malīḥ, handsome
+  \item the faʿīl pattern twice — ḥalīb, malīḥ
+  \item the Hebrew twin — melaḥ; and no English relative, only Latin sāl
+  \item the borrowed one for contrast — sukkar, from Sanskrit by way of Persian
+  \item the letters just behind — sīn, kāf, rā; qāf, hāʾ, wāw, tāʾ marbūṭa
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What else does \textbf{\ar{م}-\ar{ل}-\ar{ح}} give besides salt? (\emph{\textbf{Mallāḥ}}, a sailor, and \emph{\textbf{malīḥ}}, handsome.) Which pattern do \emph{malīḥ} and \emph{ḥalīb} share? (\emph{\textbf{Faʿīl}}.) Why does the \textbf{\ar{ح}} of \emph{milḥ} not look like the \textbf{\ar{ح}} of \emph{ḥalīb}? (\textbf{It is at the end of the word}, so it takes its full tailed shape.) Does English \emph{salt} belong to this family? (\textbf{No} — it descends from Latin \emph{sāl}.)
+\end{tcolorbox}
+\section[laḥm]{\ar{لحم} (laḥm) — \textquotedblleft{}meat,\textquotedblright{} and the town on the seam}
+
+\label{lesson:AR-C34-lahm}
+
+
+
+\begin{quote}
+This word and its Hebrew twin are the same root — and they mean different foods. There is a town whose name proves it.
+\end{quote}
+
+\subsection*{The letters in this word}
+Nothing new, and something pleasing: \textbf{\ar{لحم}} is \textbf{\ar{ملح}} read the other way about. The same shapes — \textbf{\ar{ل}} (\emph{lām}), \textbf{\ar{ح}} (\emph{ḥāʾ}), \textbf{\ar{م}} (\emph{mīm}) — in a different order, and so a different root and a different word.
+
+That is the root system stated as plainly as it can be. The letters are not the word. The \textbf{order} is the word.
+
+Here \emph{ḥāʾ} sits in the \textbf{middle}, so it wears its joined-both-sides shape: neither \emph{ḥalīb}'s open opening nor \emph{milḥ}'s tailed ending.
+
+\begin{cousinweb}
+\textbf{\ar{لَحْم}} (\emph{laḥm}) = \textquotedblleft{}\textbf{meat}.\textquotedblright{} Root \textbf{\ar{ل}-\ar{ح}-\ar{م}}.
+
+Now the twin, and it is the best one in this book. Hebrew's \textbf{\he{לֶחֶם}} (\emph{leḥem}) is the same root — and it means \textbf{bread}.
+
+Neither language changed the meaning. The old Semitic root named \textbf{the staple food}, and each people filled it with whatever theirs was: meat where herds mattered, bread where grain did.
+
+English already owns the proof. The town is \textbf{\ar{بيت} \ar{لحم}} (\emph{Bayt Laḥm}) in Arabic and \textbf{\he{בֵּית} \he{לֶחֶם}} (\emph{Bēt Leḥem}) in Hebrew — one name, in which \emph{bayt} and \emph{bēt} both mean \textquotedblleft{}a house of.\textquotedblright{} English calls it \textbf{Bethlehem}: house of bread on one side of the seam, house of meat on the other.
+
+And notice what Arabic did \textbf{not} do. It had this root available for bread and did not use it. Arabic's bread is \textbf{\ar{خبز}} (\emph{khubz}), built on \textbf{\ar{خ}-\ar{ب}-\ar{ز}}, \textquotedblleft{}to bake\textquotedblright{} — the baked thing, as \emph{ḥalīb} is the milked thing.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item lām, ḥāʾ, mīm — \textquotedblleft{}laḥm,\textquotedblright{} meat
+  \item the same shapes reordered — mīm, lām, ḥāʾ is \textquotedblleft{}milḥ,\textquotedblright{} salt
+  \item ḥāʾ in the middle, joined on both sides
+  \item the twin that shifted — laḥm is meat, Hebrew leḥem is bread
+  \item the town on the seam — Bayt Laḥm, Bēt Leḥem, Bethlehem
+  \item Arabic's own bread — khubz, from kh-b-z, to bake
+  \item the salt root's reach — mallāḥ, malīḥ
+  \item qahwa's letters and its feminine ending — qāf, hāʾ, wāw, tāʾ marbūṭa
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What separates \textbf{\ar{لحم}} from \textbf{\ar{ملح}}? (\textbf{Only the order of the letters} — the whole root system.) What does Hebrew \emph{leḥem} mean, and why is that no contradiction? (\textbf{Bread} — the root named the \textbf{staple food}.) Which English place name carries both? (\textbf{Bethlehem}.) What is Arabic's own word for bread, and where from? (\emph{\textbf{Khubz}}, from \textbf{\ar{خ}-\ar{ب}-\ar{ز}}, \textquotedblleft{}to bake.\textquotedblright{})
+\end{tcolorbox}
+\section[jubn]{\ar{جبن} (jubn) — \textquotedblleft{}cheese,\textquotedblright{} and where the root system stops}
+
+\label{lesson:AR-C34-jubn}
+
+
+
+\begin{quote}
+The root system has been paying you back for chapters. This word is where it politely declines to.
+\end{quote}
+
+\subsection*{The letters in this word}
+Nothing new. \textbf{\ar{ج}} (\emph{jīm}) is the third of the hook-and-tail family: the body of \textbf{\ar{ح}} (\emph{ḥāʾ}) and \textbf{\ar{خ}} (\emph{khāʾ}), marked by one dot \textbf{below}. Then \textbf{\ar{ب}} (\emph{bāʾ}), one dot below, and \textbf{\ar{ن}} (\emph{nūn}), one dot above.
+
+Dots are the whole difference here, as they were between the \emph{ḥāʾ} of \textbf{\ar{لحم}} and the \emph{khāʾ} of \textbf{\ar{خبز}}.
+
+\begin{cousinweb}
+\textbf{\ar{جُبْن}} (\emph{jubn}) = \textquotedblleft{}\textbf{cheese}.\textquotedblright{} In everyday speech you will more often hear \textbf{\ar{جِبْنة}} (\emph{jibna}) — and that ending is the \textbf{\ar{ة}} you now recognise on sight, doing its usual work.
+
+Now the honest part, because you have been taught to trust roots and this is where that trust needs a limit.
+
+\textbf{\ar{جُبْن}} also means \textquotedblleft{}\textbf{cowardice},\textquotedblright{} and \textbf{\ar{جَبان}} (\emph{jabān}) is \textquotedblleft{}\textbf{a coward}.\textquotedblright{} Same letters, same order. So is a cheese a coward?
+
+\textbf{No.} Arabic's dictionaries list these as \textbf{separate entries} — words spelled alike, not one idea branching. Compare a real root: \textbf{\ar{م}-\ar{ل}-\ar{ح}} carries salt into \emph{mallāḥ}, the sailor of salt water, and into \emph{malīḥ}, a salty compliment. You can feel the thread. Between cheese and cowardice there is none, and inventing one would be the mistake the milk story made of Aleppo.
+
+Two words can share three letters by accident. Arabic has many roots and few letters.
+
+English took none of this: \textbf{cheese} comes from Latin \textbf{cāseus}.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item jīm, bāʾ, nūn — \textquotedblleft{}jubn,\textquotedblright{} cheese
+  \item the hook family by dots — ḥāʾ none, khāʾ one above, jīm one below
+  \item the everyday form — jibna, with the tied tāʾ
+  \item the accident — jubn is also cowardice, jabān a coward
+  \item the verdict — separate words, not one root branching
+  \item a real branching — milḥ, mallāḥ, malīḥ
+  \item meat and salt — laḥm, milḥ, the same shapes reordered
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What separates \textbf{\ar{ج}} from \textbf{\ar{ح}} and \textbf{\ar{خ}}? (\textbf{One dot below}.) What else do the letters of \emph{jubn} spell? (\textbf{Cowardice} — \emph{jabān} is a coward.) Are cheese and cowardice one root? (\textbf{No} — separate words that look alike.) Name a root that really does branch. (\textbf{\ar{م}-\ar{ل}-\ar{ح}} — \emph{milḥ}, \emph{mallāḥ}, \emph{malīḥ}.) What does the ending on \emph{jibna} tell you? (\textbf{Feminine}, as \emph{qahwa} is.)
+\end{tcolorbox}
+\section[ṭaʿām]{\ar{طعام} (ṭaʿām) — \textquotedblleft{}food,\textquotedblright{} and a restaurant you can build yourself}
+
+\label{lesson:AR-C34-taam}
+
+
+
+\begin{quote}
+A new root, a new letter — and a word you will not have to be taught, because you already own the shape it comes in.
+\end{quote}
+
+\subsection*{The letters in this word}
+One letter to name at last. \textbf{\ar{ط}} is \textbf{ṭāʾ}, the \textbf{emphatic} partner of \textbf{\ar{ت}} (\emph{tāʾ}): the same \emph{t}, said with the tongue flat, so the syllable goes dark around it.
+
+Arabic keeps a small set of emphatic pairs, and you have met the others without being told they were a set:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ar{ص}} (\emph{ṣād}) is the emphatic \textbf{\ar{س}} (\emph{sīn}) — the \ar{ص} of \textbf{\ar{صباح}} (\emph{ṣabāḥ}).
+  \item \textbf{\ar{ض}} (\emph{ḍād}) is the emphatic \textbf{\ar{د}} (\emph{dāl}) — the \ar{ض} of \textbf{\ar{من} \ar{فضلك}} (\emph{min faḍlik}).
+  \item \textbf{\ar{ط}} (\emph{ṭāʾ}) is the emphatic \textbf{\ar{ت}} (\emph{tāʾ}) — this one.
+\end{itemize}
+
+Then \textbf{\ar{ع}} (\emph{ʿayn}), the throat sound already named, \textbf{\ar{ا}} (\emph{alif}) and \textbf{\ar{م}} (\emph{mīm}). \emph{Ṭāʾ} joins; \emph{alif} does not, so \textbf{\ar{طعام}} runs \textbf{\ar{طعا}}, then \textbf{\ar{م}}.
+
+\begin{cousinweb}
+\textbf{\ar{طَعام}} (\emph{ṭaʿām}) = \textquotedblleft{}\textbf{food}.\textquotedblright{} Root \textbf{\ar{ط}-\ar{ع}-\ar{م}}, whose verb \textbf{\ar{طَعِمَ}} (\emph{ṭaʿima}) means \textquotedblleft{}\textbf{he tasted},\textquotedblright{} and whose bare noun \textbf{\ar{طَعْم}} (\emph{ṭaʿm}) is \textquotedblleft{}\textbf{taste, flavour}.\textquotedblright{}
+
+So Arabic has two ways to speak of eating. \textbf{\ar{أَكَلَ}} (\emph{akala}) is the plain act — he ate. \textbf{\ar{ط}-\ar{ع}-\ar{م}} goes through the tongue: tasting, and so the food that gets tasted.
+
+Now take the \textbf{\ar{مَـ} place shape} you own. It made \textbf{\ar{مَكْتَب}} (\emph{maktab}), the place of writing, from \textbf{\ar{ك}-\ar{ت}-\ar{ب}}, and \textbf{\ar{مَذْهَب}} (\emph{madhhab}) from \textbf{\ar{ذ}-\ar{ه}-\ar{ب}}. Put \textbf{\ar{ط}-\ar{ع}-\ar{م}} through it:
+
+\textbf{\ar{مَطْعَم}} (\emph{maṭʿam}) — the place of eating. \textbf{A restaurant.}
+
+Nobody taught you that word. The pattern did.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item ṭāʾ, ʿayn, alif, mīm — \textquotedblleft{}ṭaʿām,\textquotedblright{} food
+  \item the emphatic set — ṣād under sīn, ḍād under dāl, ṭāʾ under tāʾ
+  \item where you had them — ṣabāḥ, min faḍlik, now ṭaʿām
+  \item the verb and the bare noun — ṭaʿima, he tasted; ṭaʿm, taste
+  \item two ways to eat — akala the act, ṭaʿima the tasting
+  \item the ma- place shape — madhhab, maktab, so maṭʿam, a restaurant
+  \item the chapter's foods — milḥ, laḥm reversing its letters, jubn, ṭaʿām
+  \item order them — \textquotedblleft{}laḥm, min faḍlik\textquotedblright{}; \textquotedblleft{}jubn, min faḍlik\textquotedblright{}
+  \item and the odd old one — māʾ, water, whose plural miyāh keeps no pattern
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which plain letter is \textbf{\ar{ط}} the emphatic partner of, and name the other pairs. (\textbf{\ar{ت}} — with \textbf{\ar{ص}} under \textbf{\ar{س}} and \textbf{\ar{ض}} under \textbf{\ar{د}}.) What does \textbf{\ar{ط}-\ar{ع}-\ar{م}} mean as a verb? (\textbf{To taste}.) Build \textquotedblleft{}restaurant\textquotedblright{} from it, and name the earlier words in that shape. (\emph{\textbf{Maṭʿam}} — like \emph{\textbf{maktab}} and \emph{\textbf{madhhab}}.) Ask for the chapter's foods politely. (\emph{\textbf{Milḥ}}, \emph{\textbf{laḥm}}, \emph{\textbf{jubn}}, \emph{\textbf{ṭaʿām}} — each with \emph{\textbf{min faḍlik}}, \textquotedblleft{}from your grace.\textquotedblright{}) Which everyday word keeps no pattern at all? (\emph{\textbf{Māʾ}} — its plural \emph{miyāh} is irregular.)
+\end{tcolorbox}

--- a/code/learning/human-languages/arabic/book/chapters/ch35-people-you-introduce.tex
+++ b/code/learning/human-languages/arabic/book/chapters/ch35-people-you-introduce.tex
@@ -1,0 +1,161 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:bc0d1c1b8dd13f35
+% canonical-lessons: AR-C35-jar, AR-C35-ibn-bint, AR-C35-sadiq
+
+\chapter{The People You Introduce}
+\label{ch:ar-people-you-introduce}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can name and introduce a neighbour, a son, a daughter and a friend in Arabic, and say what single letter genders a pair of them.}
+
+Take ṣadīq back to \ar{ص}-\ar{د}-\ar{ق}, 'to be truthful', and run the family ṣidq, ṣādiq, ṣadaqa and aṣdiqāʾ, naming the faʿīl pattern it shares with ḥalīb and malīḥ and the doer shape it shares with qāʾil and kātib, then line up the people already owned — ab, umm, akh, ukht — against jārī, ibn, bint and ṣadīqī.
+\end{chapteropening}
+
+\section[jār]{\ar{جار} (jār) — \textquotedblleft{}neighbour,\textquotedblright{} and a root with a letter in hiding}
+
+\label{lesson:AR-C35-jar}
+
+
+
+\begin{quote}
+After a chapter of things you order, a chapter of people you introduce — starting with the one who lives next door.
+\end{quote}
+
+\subsection*{The letters in this word}
+Nothing new, and it is short: \textbf{\ar{ج}} (\emph{jīm}, the hook-and-tail body with one dot below), \textbf{\ar{ا}} (\emph{alif}) and \textbf{\ar{ر}} (\emph{rā}). Both \textbf{\ar{ا}} and \textbf{\ar{ر}} are non-joiners, so \textbf{\ar{جار}} barely joins at all — compare \textbf{\ar{طعام}}, which broke once before its \emph{mīm}.
+
+\begin{cousinweb}
+\textbf{\ar{جار}} (\emph{jār}) = \textquotedblleft{}\textbf{a neighbour}.\textquotedblright{} Add the \textquotedblleft{}my\textquotedblright{} ending of \textbf{\ar{اسمي}} (\emph{ismī}) and you have \textbf{\ar{جاري}} (\emph{jārī}), \textquotedblleft{}\textbf{my neighbour}\textquotedblright{} — which is how the word usually arrives in a conversation.
+
+Now listen to the root. You can hear only \emph{j} and \emph{r}. But an Arabic root wants three consonants, and the missing one is in hiding: the root is \textbf{\ar{ج}-\ar{و}-\ar{ر}}, and its \textbf{\ar{و}} has collapsed into that long \textbf{\ar{ا}}.
+
+You have watched this before. \textbf{\ar{قال}} (\emph{qāla}), \textquotedblleft{}he said,\textquotedblright{} is \textbf{\ar{ق}-\ar{و}-\ar{ل}} with the same disappearing \textbf{\ar{و}}. Arabic calls these \textbf{hollow} roots, and the hidden letter comes back when the word changes shape:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ar{جاوَرَ}} (\emph{jāwara}) — \textquotedblleft{}he lived alongside.\textquotedblright{} There is the \textbf{\ar{و}}, in the open.
+  \item \textbf{\ar{جيران}} (\emph{jīrān}) — \textquotedblleft{}\textbf{neighbours},\textquotedblright{} where it returns as a long \textbf{ī}.
+\end{itemize}
+
+Hebrew's \textbf{\he{גֵּר}} (\emph{ger}), a resident outsider living among a people, comes from the same Semitic root for dwelling alongside.
+
+English \textbf{neighbour} is no relative — it is Germanic, the \emph{nigh-dweller}. Two unrelated languages built one word out of one idea, worth noticing \textbf{because} it is not descent.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item jīm, alif, rā — \textquotedblleft{}jār,\textquotedblright{} a neighbour
+  \item with the my ending — \textquotedblleft{}jārī,\textquotedblright{} my neighbour, as ismī is my name
+  \item the hidden letter — the root is j-w-r, and the wāw is inside the alif
+  \item the same hiding place — qāla, he said, from q-w-l
+  \item where it comes back — jāwara; jīrān, neighbours
+  \item the hook family by dots — ḥāʾ, khāʾ, jīm
+  \item the restaurant you built — maṭʿam, the place of eating
+  \item the honest non-cousin — English neighbour, the nigh-dweller
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What is \textbf{\ar{جار}}'s third root letter, and where has it gone? (\textbf{\ar{و}} — collapsed into the long \emph{alif}, as in \emph{\textbf{qāla}} from \textbf{\ar{ق}-\ar{و}-\ar{ل}}.) Where does it resurface? (\textbf{In \emph{jāwara} and \emph{jīrān}.}) How do you say \textquotedblleft{}my neighbour\textquotedblright{}? (\emph{\textbf{Jārī}} — the ending of \emph{ismī}.) Is English \emph{neighbour} related? (\textbf{No} — Germanic, the \emph{nigh-dweller}.)
+\end{tcolorbox}
+\section[ibn, bint]{\ar{ابن}, \ar{بنت} (ibn, bint) — son and daughter, one letter apart}
+
+\label{lesson:AR-C35-ibn-bint}
+
+
+
+\begin{quote}
+A pair you can learn in one move, because Arabic has already shown you the move it uses.
+\end{quote}
+
+\subsection*{The letters in this word}
+Nothing new in either. \textbf{\ar{ابن}} is \textbf{\ar{ا}} (\emph{alif}), \textbf{\ar{ب}} (\emph{bāʾ}, one dot below) and \textbf{\ar{ن}} (\emph{nūn}, one dot above) — two letters that share a bowl and differ only by where the dot sits.
+
+\textbf{\ar{بنت}} is the same \textbf{\ar{ب}} and \textbf{\ar{ن}}, then \textbf{\ar{ت}} (\emph{tāʾ}, two dots above) on the end. Both words join throughout, unlike \textbf{\ar{جار}}, which stopped twice.
+
+\begin{cousinweb}
+\textbf{\ar{ابن}} (\emph{ibn}) = \textquotedblleft{}\textbf{a son}.\textquotedblright{} \textbf{\ar{بنت}} (\emph{bint}) = \textquotedblleft{}\textbf{a daughter}.\textquotedblright{}
+
+What separates them is \textbf{one \ar{ت}}, and nothing else.
+
+You have met that letter doing that job. \textbf{\ar{أخ}} (\emph{akh}) is a brother; \textbf{\ar{أخت}} (\emph{ukht}) is a sister. Same word, one \textbf{\ar{ت}} added for the feminine. Arabic does not build a separate word for the woman; it marks the word it has. (This is the bare cousin of the \textbf{\ar{ة}} that marks \emph{qahwa} feminine — same letter, tied instead of open.)
+
+On the root, tradition and comparison disagree. Arab grammarians file \textbf{\ar{ابن}} under \textbf{\ar{ب}-\ar{ن}-\ar{ي}}, \textquotedblleft{}\textbf{to build}\textquotedblright{} — a son as what a house is built of, which is a lovely idea. Comparative scholars are less sure: Hebrew \textbf{\he{בֵּן}} (\emph{ben}) and \textbf{\he{בַּת}} (\emph{bat}) show the same bare shape, more like a very old primitive word than something derived from a verb. Hold it loosely.
+
+Hebrew \emph{bat} is \emph{bint} with the \textbf{n} swallowed into the \textbf{t}. And \emph{ibn} stands in plain sight inside names English carries: \textbf{Ibn Sīnā}, the physician the Latin west called Avicenna. No English \textbf{word} descends from it.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item alif, bāʾ, nūn — \textquotedblleft{}ibn,\textquotedblright{} a son
+  \item bāʾ, nūn, tāʾ — \textquotedblleft{}bint,\textquotedblright{} a daughter
+  \item the dots that separate bāʾ and nūn — one below, one above
+  \item the move you already knew — akh, then ukht
+  \item and the parents beside them — ab, a father; umm, a mother
+  \item the loosely held root — b-n-y, to build, as the grammarians have it
+  \item the Hebrew pair — ben, bat
+  \item the neighbour, and the emphatic ṭāʾ of ṭaʿām — jārī; ṭaʿām, maṭʿam
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What is the only difference between \textbf{\ar{ابن}} and \textbf{\ar{بنت}}? (\textbf{An added \ar{ت}} — as with \emph{\textbf{akh}} and \emph{\textbf{ukht}}.) And the parents? (\emph{\textbf{Ab}} and \emph{\textbf{umm}}.) What root do grammarians give \emph{ibn}, and why hold it loosely? (\textbf{\ar{ب}-\ar{ن}-\ar{ي}, \textquotedblleft{}to build\textquotedblright{}} — but Hebrew \emph{ben} and \emph{bat} suggest an older bare word.) Where does \emph{ibn} appear in a name English knows? (\emph{\textbf{Ibn Sīnā}}, Avicenna.)
+\end{tcolorbox}
+\section[ṣadīq]{\ar{صديق} (ṣadīq) — \textquotedblleft{}friend,\textquotedblright{} the one who is true to you}
+
+\label{lesson:AR-C35-sadiq}
+
+
+
+\begin{quote}
+The chapter closes on a word whose root is not about company at all. It is about telling the truth.
+\end{quote}
+
+\subsection*{The letters in this word}
+Nothing new. \textbf{\ar{ص}} (\emph{ṣād}) is the emphatic \textbf{\ar{س}}, first met in \textbf{\ar{صباح}} (\emph{ṣabāḥ}) — heavy and dark where \emph{sīn} is light. Then \textbf{\ar{د}} (\emph{dāl}), \textbf{\ar{ي}} (\emph{yāʾ}) carrying the long \textbf{ī}, and \textbf{\ar{ق}} (\emph{qāf}). \textbf{\ar{د}} is a non-joiner, so \textbf{\ar{صديق}} breaks after it: \textbf{\ar{صد}}, then \textbf{\ar{يق}}.
+
+The feminine is \textbf{\ar{صَديقة}} (\emph{ṣadīqa}) — the \textbf{\ar{ة}}, tied on the end, doing what it did to \emph{qahwa}: the open \textbf{\ar{ت}} of \textbf{\ar{بنت}} and \textbf{\ar{أخت}} in its tied form.
+
+\begin{cousinweb}
+\textbf{\ar{صَديق}} (\emph{ṣadīq}) = \textquotedblleft{}\textbf{a friend}.\textquotedblright{} Root \textbf{\ar{ص}-\ar{د}-\ar{ق}}, and the root means \textquotedblleft{}\textbf{to be truthful, to be sincere}.\textquotedblright{}
+
+A friend, in Arabic, is defined by honesty rather than proximity. The family agrees:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ar{صِدْق}} (\emph{ṣidq}) — \textquotedblleft{}\textbf{truth}, sincerity.\textquotedblright{}
+  \item \textbf{\ar{صادِق}} (\emph{ṣādiq}) — \textquotedblleft{}\textbf{truthful},\textquotedblright{} the \textbf{doer} shape worn by \textbf{\ar{قائِل}} (\emph{qāʾil}, a sayer) and \textbf{\ar{كاتِب}} (\emph{kātib}, a writer).
+  \item \textbf{\ar{صَدَقة}} (\emph{ṣadaqa}) — \textquotedblleft{}\textbf{voluntary alms}.\textquotedblright{} A gift given for its own sake: a \textbf{true} gift, as against one owed.
+  \item \textbf{\ar{أَصْدِقاء}} (\emph{aṣdiqāʾ}) — \textquotedblleft{}\textbf{friends}.\textquotedblright{}
+\end{itemize}
+
+And now the pattern. \textbf{\ar{صَديق}} is \textbf{\ar{فَعيل}} (\emph{faʿīl}) — the shape of \textbf{\ar{حَليب}} (\emph{ḥalīb}), the milked thing, and \textbf{\ar{مَليح}} (\emph{malīḥ}), the salty one. Root plus \emph{faʿīl} hands back a quality made into a person or a thing.
+
+This is the machinery that turned \textbf{\ar{سَلام}} (\emph{salām}) into \textbf{\ar{السَّلامة}} (\emph{as-salāma}): one root, several patterns, several words.
+
+English took nothing from \textbf{\ar{ص}-\ar{د}-\ar{ق}}. \emph{Friend} is Germanic, from an old word for loving.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item ṣād, dāl, yāʾ, qāf — \textquotedblleft{}ṣadīq,\textquotedblright{} a friend
+  \item the emphatic pair — sīn light, ṣād heavy, as in ṣabāḥ
+  \item what the root means — to be truthful; a friend is one who is true
+  \item the family — ṣidq, ṣādiq, ṣadaqa, aṣdiqāʾ
+  \item the doer shape — qāʾil, kātib, ṣādiq
+  \item the faʿīl shape — ḥalīb, malīḥ, ṣadīq
+  \item the feminine — ṣadīqa, tied tāʾ, as as-salāma has it
+  \item this chapter's people — jārī with its two non-joiners, ibn, bint, ṣadīqī
+  \item and the family you had — ab, umm, akh, ukht
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What does \textbf{\ar{ص}-\ar{د}-\ar{ق}} mean, and what does that make a friend? (\textbf{To be truthful} — the one who is true to you.) Name the family. (\emph{\textbf{Ṣidq}}, \emph{\textbf{ṣādiq}}, \emph{\textbf{ṣadaqa}}, \emph{\textbf{aṣdiqāʾ}}.) Which earlier words wear \emph{ṣadīq}'s \emph{faʿīl} pattern, and which wear \emph{ṣādiq}'s doer shape? (\emph{\textbf{Ḥalīb}} and \emph{\textbf{malīḥ}}; \emph{\textbf{qāʾil}} and \emph{\textbf{kātib}}.) Introduce the people you can now name. (\emph{\textbf{Jārī}}, \emph{\textbf{ibn}}, \emph{\textbf{bint}}, \emph{\textbf{ṣadīqī}} — beside \emph{\textbf{ab}}, \emph{\textbf{umm}}, \emph{\textbf{akh}}, \emph{\textbf{ukht}}.) What does the \textbf{\ar{ة}} of \emph{ṣadīqa} do? (\textbf{Marks it feminine} — as on \emph{qahwa} and \emph{as-salāma}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/arabic/book/chapters/ch36-cups-plates-and-more-than-one.tex
+++ b/code/learning/human-languages/arabic/book/chapters/ch36-cups-plates-and-more-than-one.tex
@@ -1,0 +1,222 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:6b0582f629a90a18
+% canonical-lessons: AR-C36-zayt, AR-C36-kub, AR-C36-tabaq, AR-C36-milaqa
+
+\chapter{Cups, Plates, and More Than One}
+\label{ch:ar-cups-plates-and-more-than-one}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can ask for oil, a cup, a plate and a spoon in Arabic, and I can tell a broken plural from a sound one and say which kind of noun usually takes which.}
+
+Set the mi- tool shape of milʿaqa and mirʾāh against the ma- place shape of maṭʿam and maktab, then sort the plurals: akwāb, aṭbāq and malāʿiq re-poured into a new shape against qahawāt and ṣadīqāt, which only add an ending — and ask for each thing with min faḍlik.
+\end{chapteropening}
+
+\section[zayt]{\ar{زيت} (zayt) — \textquotedblleft{}oil,\textquotedblright{} and a letter you already knew}
+
+\label{lesson:AR-C36-zayt}
+
+
+
+\begin{quote}
+One new letter to name — and you will find you already own it, because it is an old letter wearing a dot.
+\end{quote}
+
+\subsection*{The letters in this word}
+\textbf{\ar{ز}} is \textbf{zāy}, the \emph{z}. And here is all there is to it: \textbf{\ar{ز}} is \textbf{\ar{ر}} (\emph{rā}) with \textbf{one dot above}.
+
+That is the abjad's favourite trick. \textbf{\ar{ب}}, \textbf{\ar{ن}} and \textbf{\ar{ت}} share one bowl and differ by dots. \textbf{\ar{ح}}, \textbf{\ar{خ}} and \textbf{\ar{ج}} share one hook. Now \textbf{\ar{ر}} and \textbf{\ar{ز}} share one curve.
+
+Everything \emph{rā} does, \emph{zāy} does: it hangs below the line and \textbf{refuses to join} what follows — the non-joiner that ended \textbf{\ar{سكر}}.
+
+Then \textbf{\ar{ي}} (\emph{yāʾ}) and \textbf{\ar{ت}} (\emph{tāʾ}). So \textbf{\ar{زيت}} is \textbf{\ar{ز}} alone, then \textbf{\ar{يت}} joined.
+
+\begin{cousinweb}
+\textbf{\ar{زَيْت}} (\emph{zayt}) = \textquotedblleft{}\textbf{oil}\textquotedblright{} — in the first place olive oil, and by extension oil of any kind. Root \textbf{\ar{ز}-\ar{ي}-\ar{ت}}, which also gives:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ar{زَيْتون}} (\emph{zaytūn}) — \textquotedblleft{}\textbf{olives}.\textquotedblright{}
+  \item \textbf{\ar{زَيْتونة}} (\emph{zaytūna}) — \textquotedblleft{}\textbf{an olive},\textquotedblright{} one of them, with the tied \textbf{\ar{ة}} making the single thing out of the collective.
+\end{itemize}
+
+And now Spain. You met \textbf{azúcar} and found Arabic's \textbf{al-} welded onto its front. The same thing happened here, twice over:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ar{الزَّيت}} (\emph{az-zayt}) became Spanish \textbf{aceite}, \textquotedblleft{}oil.\textquotedblright{}
+  \item \textbf{\ar{الزَّيتونة}} (\emph{az-zaytūna}) became Spanish \textbf{aceituna}, \textquotedblleft{}an olive.\textquotedblright{}
+\end{itemize}
+
+\textbf{\ar{ز}} is a \textbf{sun letter}, which is why \emph{al-} is said \emph{az-} — the assimilation that makes \emph{al-} + \emph{sukkar} into \emph{as-sukkar}. Spanish took the sound it heard, article and all. Portuguese did the same with \textbf{azeite}.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item zāy is rā plus one dot above, and it breaks as rā breaks
+  \item the dot families — bāʾ, nūn, tāʾ; ḥāʾ, khāʾ, jīm; rā and zāy
+  \item zāy, yāʾ, tāʾ — \textquotedblleft{}zayt,\textquotedblright{} oil
+  \item the olives — zaytūn; one olive, zaytūna
+  \item the welded article — az-zayt gave aceite, as-sukkar gave azúcar
+  \item the friend and his root — ṣadīq, from ṣ-d-q, to be true
+  \item the pair one letter apart — ibn, bint
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What is \textbf{\ar{ز}}, described from a letter you had? (\emph{\textbf{Rā}} \textbf{with one dot above} — and it breaks the same way.) What does \textbf{\ar{ز}-\ar{ي}-\ar{ت}} give besides oil? (\emph{\textbf{Zaytūn}} and \emph{\textbf{zaytūna}}.) Which Spanish words carry this root with Arabic's article stuck on, and which one did \emph{sukkar} give? (\emph{\textbf{Aceite}} and \emph{\textbf{aceituna}}; \emph{\textbf{azúcar}}.) Why \emph{az-} rather than \emph{al-}? (\textbf{\ar{ز} is a sun letter}.)
+\end{tcolorbox}
+\section[kūb]{\ar{كوب} (kūb) — \textquotedblleft{}a cup,\textquotedblright{} and more than one of them}
+
+\label{lesson:AR-C36-kub}
+
+
+
+\begin{quote}
+A short, useful word — and the door into the thing about Arabic nouns that surprises every learner.
+\end{quote}
+
+\subsection*{The letters in this word}
+Nothing new. \textbf{\ar{ك}} (\emph{kāf}), the angular \emph{k}; \textbf{\ar{و}} (\emph{wāw}), here carrying the long \textbf{ū}; and \textbf{\ar{ب}} (\emph{bāʾ}).
+
+\textbf{\ar{و}} is a non-joiner, so \textbf{\ar{كوب}} goes \textbf{\ar{كو}}, break, \textbf{\ar{ب}}. Another non-joiner: \textbf{\ar{ر}} ended \emph{sukkar}, \textbf{\ar{ز}} opened \emph{zayt}, and \textbf{\ar{و}} splits this.
+
+\begin{cousinweb}
+\textbf{\ar{كوب}} (\emph{kūb}) = \textquotedblleft{}\textbf{a cup}.\textquotedblright{} Root \textbf{\ar{ك}-\ar{و}-\ar{ب}}.
+
+Now say \textquotedblleft{}cups.\textquotedblright{} In English you add an \emph{s}. In Arabic you do something else entirely:
+
+\textbf{\ar{أَكْواب}} (\emph{akwāb}).
+
+Nothing was added to the end. The root \textbf{\ar{ك}-\ar{و}-\ar{ب}} was taken out of one shape and \textbf{poured into another}, \textbf{\ar{أَفْعال}} (\emph{afʿāl}). Arabic calls this a \textbf{broken plural}, and it is not an exception — it is how most ordinary Arabic nouns make their plurals.
+
+You have seen a root move between shapes many times: \textbf{\ar{ك}-\ar{ت}-\ar{ب}} became \emph{kitāb}, \emph{kātib}, \emph{maktab}, \emph{maktaba}. A broken plural is that same machinery pointed at number instead of meaning. So this is not a new rule to learn. It is a rule you already have, doing a job you did not expect it to do.
+
+On where \emph{kūb} came from, honesty first. It sits close to a cup-word that travelled all round the Mediterranean — Latin \textbf{cuppa}, behind English \textbf{cup} and French \textbf{coupe}. Whether Arabic took it from that family, or the resemblance is coincidence, is \textbf{not settled}: a resemblance worth knowing, not a descent worth claiming.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item kāf, wāw, bāʾ — \textquotedblleft{}kūb,\textquotedblright{} a cup
+  \item more than one — \textquotedblleft{}akwāb,\textquotedblright{} and nothing was added to the end
+  \item what happened instead — the root was poured into the shape afʿāl
+  \item the same machinery you had — kitāb, kātib, maktab, maktaba
+  \item ask for one — \textquotedblleft{}kūb māʾ, min faḍlik\textquotedblright{} — a cup of water, from your grace
+  \item and answer the thanks — \textquotedblleft{}ʿafwan\textquotedblright{}
+  \item the odd old word for water — māʾ, whose plural miyāh follows no pattern
+  \item the non-joiners — zāy in zayt, dāl in ṣadīq, wāw here
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+How does Arabic make \textquotedblleft{}cups\textquotedblright{} out of \textbf{\ar{كوب}}? (\emph{\textbf{Akwāb}} — the root is \textbf{re-poured into a new shape}, not given an ending. That is a \textbf{broken plural}.) Which earlier root shows the same shape-changing machinery? (\textbf{\ar{ك}-\ar{ت}-\ar{ب}} — \emph{kitāb}, \emph{kātib}, \emph{maktab}, \emph{maktaba}.) Ask for a cup of water politely. (\emph{\textbf{Kūb māʾ, min faḍlik}}.) And reply to thanks? (\emph{\textbf{ʿAfwan}}.) Did Arabic get \emph{kūb} from Latin \emph{cuppa}? (\textbf{Unsettled} — a resemblance, not a claim.)
+\end{tcolorbox}
+\section[ṭabaq]{\ar{طبق} (ṭabaq) — \textquotedblleft{}a plate,\textquotedblright{} and a broken plural that repeats}
+
+\label{lesson:AR-C36-tabaq}
+
+
+
+\begin{quote}
+One broken plural is a surprise. Two in the same shape is a pattern — and a pattern you can use.
+\end{quote}
+
+\subsection*{The letters in this word}
+Nothing new. \textbf{\ar{ط}} (\emph{ṭāʾ}) is the emphatic \textbf{\ar{ت}}, named when you built \textbf{\ar{طعام}} (\emph{ṭaʿām}) — the dark, flat-tongued \emph{t}, standing beside \textbf{\ar{ص}} under \textbf{\ar{س}} and \textbf{\ar{ض}} under \textbf{\ar{د}}.
+
+Then \textbf{\ar{ب}} (\emph{bāʾ}) and \textbf{\ar{ق}} (\emph{qāf}). All three join, so \textbf{\ar{طبق}} runs unbroken — unlike \textbf{\ar{كوب}}, which had to stop at its \emph{wāw}.
+
+\begin{cousinweb}
+\textbf{\ar{طَبَق}} (\emph{ṭabaq}) = \textquotedblleft{}\textbf{a plate, a dish}.\textquotedblright{} Root \textbf{\ar{ط}-\ar{ب}-\ar{ق}}.
+
+Its plural is \textbf{\ar{أَطْباق}} (\emph{aṭbāq}).
+
+Say that beside \textbf{\ar{أَكْواب}} (\emph{akwāb}) and listen. Same opening \textbf{\ar{أَ}}, same long \textbf{ā} before the last letter, same nothing-added-at-the-end. Both are the shape \textbf{\ar{أَفْعال}} (\emph{afʿāl}). So the broken plural is not chaos: it is a small set of shapes, and you have now met the commonest one twice.
+
+The root itself means \textbf{to cover, to lie in layers} — a plate being the flat thing that covers. Which is why the same root gives:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ar{طابِق}} (\emph{ṭābiq}) — \textquotedblleft{}\textbf{a storey}\textquotedblright{} of a building. A layer of house. And notice its shape: that is the \textbf{doer} form of \emph{ṣādiq} and \emph{kātib}.
+  \item \textbf{\ar{طَبَقة}} (\emph{ṭabaqa}) — \textquotedblleft{}\textbf{a layer},\textquotedblright{} and so \textquotedblleft{}\textbf{a social class},\textquotedblright{} with the tied \textbf{\ar{ة}} on the end.
+\end{itemize}
+
+A plate, a floor and a social class, off one idea about layers. And the plates themselves belong somewhere you already built: \textbf{\ar{مَطْعَم}} (\emph{maṭʿam}), the place of eating.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item ṭāʾ, bāʾ, qāf — \textquotedblleft{}ṭabaq,\textquotedblright{} a plate
+  \item the emphatic set once more — ṣād, ḍād, ṭāʾ
+  \item the two broken plurals — akwāb, aṭbāq, both in the shape afʿāl
+  \item what the root means — to cover, to lie in layers
+  \item its other children — ṭābiq, a storey; ṭabaqa, a layer or a class
+  \item where the plates live — maṭʿam, the place of eating
+  \item the oil, whose zāy is rā plus a dot — zayt, zaytūn
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What shape do \textbf{\ar{أكواب}} and \textbf{\ar{أطباق}} share? (\emph{\textbf{Afʿāl}} — the broken plural you have now met twice.) What does \textbf{\ar{ط}-\ar{ب}-\ar{ق}} mean? (\textbf{To cover, to lie in layers}.) Name two more words it builds. (\emph{\textbf{Ṭābiq}}, a storey, and \emph{\textbf{ṭabaqa}}, a layer or a class.) Which plain letter is \textbf{\ar{ط}} the emphatic partner of? (\emph{\textbf{Tāʾ}}.) Where would you find a stack of \emph{aṭbāq}? (\textbf{In a \emph{maṭʿam}} — the place of eating.)
+\end{tcolorbox}
+\section[milʿaqa]{\ar{ملعقة} (milʿaqa) — \textquotedblleft{}a spoon,\textquotedblright{} the tool shape, and two ways to say more than one}
+
+\label{lesson:AR-C36-milaqa}
+
+
+
+\begin{quote}
+The last word, and it pays two debts at once: the shape that makes tools, and the question of how Arabic counts past one.
+\end{quote}
+
+\subsection*{The letters in this word}
+Nothing new: \textbf{\ar{م}} (\emph{mīm}), \textbf{\ar{ل}} (\emph{lām}), \textbf{\ar{ع}} (\emph{ʿayn}, the throat sound), \textbf{\ar{ق}} (\emph{qāf}) — and then \textbf{\ar{ة}}, the tied \emph{tāʾ}.
+
+That \textbf{\ar{ة}} tells you, before anything else, that \textbf{\ar{ملعقة}} is \textbf{feminine} — the signal you read off \textbf{\ar{قهوة}} (\emph{qahwa}), \textbf{\ar{صديقة}} (\emph{ṣadīqa}) and \textbf{\ar{طَبَقة}} (\emph{ṭabaqa}).
+
+\begin{cousinweb}
+\textbf{\ar{مِلْعَقة}} (\emph{milʿaqa}) = \textquotedblleft{}\textbf{a spoon}.\textquotedblright{} Root \textbf{\ar{ل}-\ar{ع}-\ar{ق}}, whose verb \textbf{\ar{لَعِقَ}} (\emph{laʿiqa}) means \textquotedblleft{}\textbf{he licked, he lapped}.\textquotedblright{} A spoon is the thing you lap with.
+
+Two shapes now stand side by side, differing by one vowel:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ar{مَـ}}, the \textbf{place} shape: \textbf{\ar{مَكْتَب}} (\emph{maktab}), the place of writing; \textbf{\ar{مَطْعَم}} (\emph{maṭʿam}), the place of eating.
+  \item \textbf{\ar{مِـ}}, the \textbf{tool} shape: \textbf{\ar{مِرْآة}} (\emph{mirʾāh}), the thing you see with; \textbf{\ar{مِلْعَقة}} (\emph{milʿaqa}), the thing you lap with.
+\end{itemize}
+
+\emph{Ma-} builds a room. \emph{Mi-} puts something in your hand.
+
+Now the plurals this chapter has been circling.
+
+\textbf{Broken} — the root re-poured, nothing added: \textbf{\ar{أَكْواب}} (\emph{akwāb}), \textbf{\ar{أَطْباق}} (\emph{aṭbāq}), \textbf{\ar{مَلاعِق}} (\emph{malāʿiq}), spoons.
+
+\textbf{Sound} — an ending added, the word left intact. Arabic uses it for the \textbf{\ar{ة}} words: \textbf{\ar{قَهْوة}} gives \textbf{\ar{قَهَوات}} (\emph{qahawāt}), and \textbf{\ar{صَديقة}} gives \textbf{\ar{صَديقات}} (\emph{ṣadīqāt}).
+
+The rule of thumb: a noun in \textbf{\ar{ة}} usually takes the added ending, and most other everyday nouns break. \emph{Milʿaqa} is the honest reminder that \textquotedblleft{}usually\textquotedblright{} is doing work — it ends in \textbf{\ar{ة}} and breaks anyway.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item mīm, lām, ʿayn, qāf, tāʾ marbūṭa — \textquotedblleft{}milʿaqa,\textquotedblright{} a spoon
+  \item the verb under it — \textquotedblleft{}laʿiqa,\textquotedblright{} he lapped
+  \item the place shape — maktab, maṭʿam
+  \item the tool shape — mirʾāh, milʿaqa
+  \item the broken plurals — kūb with its breaking wāw gives akwāb; aṭbāq; malāʿiq
+  \item the sound plurals — qahwa gives qahawāt, ṣadīqa gives ṣadīqāt
+  \item the tied tāʾ marking feminine — qahwa, ṣadīqa, ṭabaqa, milʿaqa
+  \item ask for each — \textquotedblleft{}kūb, min faḍlik\textquotedblright{}; \textquotedblleft{}ṭabaq, min faḍlik\textquotedblright{}; \textquotedblleft{}milʿaqa, min faḍlik\textquotedblright{}
+  \item and the oil — zayt, whose Spanish child is aceite
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What separates \textbf{\ar{مَـ}} from \textbf{\ar{مِـ}}? (\emph{\textbf{Ma-}} \textbf{makes a place}, \emph{\textbf{mi-}} \textbf{a tool} — \emph{maktab} and \emph{maṭʿam} against \emph{mirʾāh} and \emph{milʿaqa}.) What does \textbf{\ar{ل}-\ar{ع}-\ar{ق}} mean? (\textbf{To lap}.) Name this chapter's broken plurals, and a sound one. (\emph{\textbf{Akwāb}}, \emph{\textbf{aṭbāq}}, \emph{\textbf{malāʿiq}}; \emph{\textbf{qahawāt}} or \emph{\textbf{ṣadīqāt}}.) What does the \textbf{\ar{ة}} on \emph{milʿaqa} tell you? (\textbf{Feminine} — and unusually for a \textbf{\ar{ة}} word, it still breaks.) Ask for a spoon politely. (\emph{\textbf{Milʿaqa, min faḍlik}}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/arabic/chapters.json
+++ b/code/learning/human-languages/arabic/chapters.json
@@ -551,6 +551,89 @@
           "AR-CONCEPT-C32-AKHADHA-02"
         ]
       }
+    },
+    {
+      "chapter": 33,
+      "title": "Asking for a Drink",
+      "label": "ch:ar-asking-for-a-drink",
+      "canDo": "I can name tea, milk, sugar and coffee in Arabic and ask for any of them politely, and I can tell at sight whether an Arabic noun is feminine.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "AR-C33-qahwa",
+        "kind": "production",
+        "summary": "Say the chapter's drinks and name which of them Arabic built and which it borrowed — ḥalīb from ḥalaba, 'he milked', against shāy and sukkar, which arrived with no root at all — then read the ة off qahwa as a gender marker, place it beside maktaba and as-salāma, and order each drink with min faḍlik, answering ʿafwan.",
+        "assesses": [
+          "AR-CONCEPT-C33-QAHWA-01",
+          "AR-CONCEPT-C33-QAHWA-02",
+          "AR-CONCEPT-C33-SUKKAR-02",
+          "AR-CONCEPT-C33-HALIB-02",
+          "AR-CONCEPT-C33-SHAY-02"
+        ]
+      }
+    },
+    {
+      "chapter": 34,
+      "title": "Asking for Food",
+      "label": "ch:ar-asking-for-food",
+      "canDo": "I can ask for salt, meat, cheese and food in Arabic, and I can build the word for a restaurant myself out of a root and the ma- place shape.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "AR-C34-taam",
+        "kind": "production",
+        "summary": "Name ط as the emphatic partner of ت beside ص under س and ض under د, then pour ط-ع-م through the ma- place shape that already gave maktab and madhhab to generate maṭʿam, 'a restaurant', and ask for the chapter's foods with min faḍlik.",
+        "assesses": [
+          "AR-CONCEPT-C34-TAAM-01",
+          "AR-CONCEPT-C34-TAAM-02",
+          "AR-CONCEPT-C34-JUBN-02",
+          "AR-CONCEPT-C34-LAHM-02",
+          "AR-CONCEPT-C34-MILH-02"
+        ]
+      }
+    },
+    {
+      "chapter": 35,
+      "title": "The People You Introduce",
+      "label": "ch:ar-people-you-introduce",
+      "canDo": "I can name and introduce a neighbour, a son, a daughter and a friend in Arabic, and say what single letter genders a pair of them.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "AR-C35-sadiq",
+        "kind": "production",
+        "summary": "Take ṣadīq back to ص-د-ق, 'to be truthful', and run the family ṣidq, ṣādiq, ṣadaqa and aṣdiqāʾ, naming the faʿīl pattern it shares with ḥalīb and malīḥ and the doer shape it shares with qāʾil and kātib, then line up the people already owned — ab, umm, akh, ukht — against jārī, ibn, bint and ṣadīqī.",
+        "assesses": [
+          "AR-CONCEPT-C35-SADIQ-01",
+          "AR-CONCEPT-C35-SADIQ-02",
+          "AR-CONCEPT-C35-IBN-BINT-02",
+          "AR-CONCEPT-C35-JAR-02"
+        ]
+      }
+    },
+    {
+      "chapter": 36,
+      "title": "Cups, Plates, and More Than One",
+      "label": "ch:ar-cups-plates-and-more-than-one",
+      "canDo": "I can ask for oil, a cup, a plate and a spoon in Arabic, and I can tell a broken plural from a sound one and say which kind of noun usually takes which.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "AR-C36-milaqa",
+        "kind": "production",
+        "summary": "Set the mi- tool shape of milʿaqa and mirʾāh against the ma- place shape of maṭʿam and maktab, then sort the plurals: akwāb, aṭbāq and malāʿiq re-poured into a new shape against qahawāt and ṣadīqāt, which only add an ending — and ask for each thing with min faḍlik.",
+        "assesses": [
+          "AR-CONCEPT-C36-MILAQA-01",
+          "AR-CONCEPT-C36-MILAQA-02",
+          "AR-CONCEPT-C36-TABAQ-02",
+          "AR-CONCEPT-C36-KUB-02",
+          "AR-CONCEPT-C36-ZAYT-02"
+        ]
+      }
     }
   ]
 }

--- a/code/learning/human-languages/arabic/curriculum.json
+++ b/code/learning/human-languages/arabic/curriculum.json
@@ -392,6 +392,65 @@
         "AR-EXT-029-LANGUAGE-SPECIFIC"
       ],
       "after": []
+    },
+    {
+      "id": "AR-PATH-030",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "AR-C33-shay",
+        "AR-C33-halib",
+        "AR-C33-sukkar",
+        "AR-C33-qahwa"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-030-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-031",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "AR-C34-milh",
+        "AR-C34-lahm",
+        "AR-C34-jubn",
+        "AR-C34-taam"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-031-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-032",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "AR-C35-jar",
+        "AR-C35-ibn-bint",
+        "AR-C35-sadiq"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-032-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "AR-PATH-033",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "AR-C36-zayt",
+        "AR-C36-kub",
+        "AR-C36-tabaq",
+        "AR-C36-milaqa"
+      ],
+      "before": [],
+      "inline": [
+        "AR-EXT-033-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
     }
   ],
   "spine": {
@@ -430,7 +489,8 @@
       "segments": [
         "AR-PATH-007",
         "AR-PATH-014",
-        "AR-PATH-019"
+        "AR-PATH-019",
+        "AR-PATH-032"
       ],
       "omits": [
         "PRONOUN-I",
@@ -454,7 +514,10 @@
     "SPINE-POLITE-REQUEST-REPAIR": {
       "segments": [
         "AR-PATH-011",
-        "AR-PATH-017"
+        "AR-PATH-017",
+        "AR-PATH-030",
+        "AR-PATH-031",
+        "AR-PATH-033"
       ],
       "omits": [],
       "relocates": {}
@@ -1050,6 +1113,61 @@
         "AR-C32-fakkara",
         "AR-C32-saada",
         "AR-C32-ahabba"
+      ]
+    },
+    {
+      "id": "AR-EXT-030-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can name tea, milk, sugar and coffee in Arabic, ask for any of them politely, and tell a borrowed word from one Arabic built on a root.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C33-shay",
+        "AR-C33-halib",
+        "AR-C33-sukkar",
+        "AR-C33-qahwa"
+      ]
+    },
+    {
+      "id": "AR-EXT-031-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can ask for salt, meat, cheese and food in Arabic, and I can build the word for a restaurant from a root using the ma- place shape.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C34-milh",
+        "AR-C34-lahm",
+        "AR-C34-jubn",
+        "AR-C34-taam"
+      ]
+    },
+    {
+      "id": "AR-EXT-032-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can name and introduce a neighbour, a son, a daughter and a friend in Arabic, and say which single letter genders each pair.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C35-jar",
+        "AR-C35-ibn-bint",
+        "AR-C35-sadiq"
+      ]
+    },
+    {
+      "id": "AR-EXT-033-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can ask for oil, a cup, a plate and a spoon in Arabic, and I can tell a broken plural from a sound one and say which nouns take which.",
+      "prerequisites": [],
+      "lessons": [
+        "AR-C36-zayt",
+        "AR-C36-kub",
+        "AR-C36-tabaq",
+        "AR-C36-milaqa"
       ]
     }
   ]

--- a/code/learning/human-languages/arabic/lessons/AR-C33-halib.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C33-halib.md
@@ -1,0 +1,94 @@
+---
+schema_version: 2
+id: AR-C33-halib
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 870
+chapter: 33
+type: word
+headword: حليب
+gloss: "milk" — the opposite case to shāy: a home-grown noun sitting straight on the verb for milking, and a Hebrew twin that is the same word
+concept_tag: AR-DRINK-MILK
+romanization: ḥalīb
+prerequisites: [AR-C33-shay, AR-W07-hook-family-ha-kha]
+sounds: [haa-pharyngeal, long-ii, rtl-known-letters]
+roots: [h-l-b]
+etymology_hook: "حليب (ḥalīb, 'milk') sits on the root ح-ل-ب, whose verb حَلَبَ (ḥalaba) means 'he milked', so the noun is 'the milked thing' — the same verb-to-noun transparency as خبز (khubz) on خ-ب-ز, 'to bake'; Hebrew חָלָב (ḥalav, 'milk') is the same Semitic root, while the Syrian city حَلَب (Ḥalab, Aleppo) only looks related, since the name is attested in Bronze Age records long before Arabic and the milk story told about it is folk etymology"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [AR-CONCEPT-C33-SHAY-02]
+introduces:
+  knowledge: [AR-CONCEPT-C33-HALIB-01, AR-CONCEPT-C33-HALIB-02]
+practises:
+  knowledge: [AR-CONCEPT-C33-HALIB-01, AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C33-SHAY-01, AR-CONCEPT-C33-SHAY-02, AR-CONCEPT-C13-MAA-KHUBZ-02, AR-CONCEPT-W07-HOOK-FAMILY-HA-KHA-01, AR-CONCEPT-C32-AHABBA-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: modern-standard-arabic
+reviews_of: [AR-C33-shay, AR-C13-maa-khubz, AR-W07-hook-family-ha-kha]
+---
+
+# حليب (ḥalīb) — "milk," and the verb underneath it
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] Yesterday's word had no root to stand on. This one has a root so
+plain you can hear the verb inside the noun.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C33-HALIB-01]; assesses=[AR-CONCEPT-W07-HOOK-FAMILY-HA-KHA-01, AR-CONCEPT-C32-AHABBA-01] -->
+
+Nothing new again. **ح** (*ḥāʾ*) is the undotted member of the hook-and-tail
+family — the body it shares with **خ** (*khāʾ*, one dot above) and **ج**
+(*jīm*, one dot below). It is the hard breath from deep in the throat that
+opens **أحبّ** (*ʾaḥabba*).
+
+Then **ل** (*lām*), **ي** (*yāʾ*) carrying the long **ī**, and **ب** (*bāʾ*).
+
+All four join, so **حليب** runs as one unbroken stroke — the opposite of
+**شاي**, which had to stop at its *alif*.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C33-HALIB-02]; assesses=[AR-CONCEPT-C13-MAA-KHUBZ-02] -->
+
+**حَليب** (*ḥalīb*) = "**milk**." Root **ح-ل-ب**, and its verb is **حَلَبَ**
+(*ḥalaba*), "**he milked**." So the noun is simply the milked thing.
+
+You have met this exact transparency before. **خبز** (*khubz*, bread) sits on
+**خ-ب-ز**, "to bake": the baked thing. Arabic does this constantly — name the
+action, and the everyday noun falls out of it.
+
+The pattern *ḥalīb* wears, **فَعيل** (*faʿīl*), is one to keep. It takes a root
+and hands back a quality or a result you can hold.
+
+Hebrew has the word unchanged: **חָלָב** (*ḥalav*), "milk," the same root doing
+the same job — the family resemblance already heard in *salām* and *shalom*.
+
+One caution, because a good story is not the same as a true one. The Syrian
+city **حَلَب** (*Ḥalab*, English **Aleppo**) is often explained as a milk name.
+It is not: *Ḥalab* appears in Bronze Age records centuries before Arabic was
+written, so the milk account is a later invention hung on a name that already
+existed. No English word descends from **ح-ل-ب** at all.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C33-HALIB-01, AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C33-SHAY-01, AR-CONCEPT-C33-SHAY-02, AR-CONCEPT-C13-MAA-KHUBZ-02, AR-CONCEPT-W07-HOOK-FAMILY-HA-KHA-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: the hook family — ḥāʾ no dot, khāʾ one above, jīm one below]
+- [YOU SAY: ḥāʾ, lām, yāʾ, bāʾ — "ḥalīb," milk]
+- [YOU SAY: the verb under it — "ḥalaba," he milked]
+- [YOU SAY: the same move in bread — khubz, from kh-b-z, to bake]
+- [YOU SAY: the pattern — faʿīl, as in ḥalīb]
+- [YOU SAY: the borrowed one against the built one — shāy, then ḥalīb]
+- [YOU SAY: the Hebrew twin — ḥalav]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C33-HALIB-01, AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C33-SHAY-02, AR-CONCEPT-C13-MAA-KHUBZ-02] -->
+
+[PAUSE 3s] What does the root **ح-ل-ب** mean as a verb? (**To milk** — so
+*ḥalīb* is the milked thing.) Which earlier word works the same way? (***Khubz***
+— bread, from *kh-b-z*, to bake.) Which of the chapter's words so far has no
+root at all? (***Shāy*** — it was borrowed.) Is Aleppo named for milk?
+(**No** — the name is far older than Arabic; that story is folk etymology.)

--- a/code/learning/human-languages/arabic/lessons/AR-C33-qahwa.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C33-qahwa.md
@@ -1,0 +1,96 @@
+---
+schema_version: 2
+id: AR-C33-qahwa
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 890
+chapter: 33
+type: word
+headword: قهوة
+gloss: "coffee" — the chapter's payoff, where the tied tāʾ finally earns its keep as Arabic's visible gender marker, and where you can order everything the chapter taught
+concept_tag: AR-DRINK-COFFEE
+romanization: qahwa
+prerequisites: [AR-C33-sukkar, AR-W11-ha-and-ta-marbuta, AR-C04-al-salama, AR-C23-afwan]
+sounds: [qaf, ta-marbuta, rtl-known-letters]
+roots: [q-h-w]
+etymology_hook: "قهوة (qahwa, 'coffee') ends in ة (tāʾ marbūṭa), the tied tāʾ that marks a noun feminine — the same ending that turns مَكْتَب (maktab, an office) into مَكْتَبة (maktaba, a library) and that sits on السلامة (as-salāma); the word travelled out of Arabic through Ottoman Turkish kahve into Italian caffè, French café, German Kaffee and English coffee, so a learner meeting قهوة is meeting a word their own language already borrowed"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [AR-CONCEPT-C33-SUKKAR-02]
+introduces:
+  knowledge: [AR-CONCEPT-C33-QAHWA-01, AR-CONCEPT-C33-QAHWA-02]
+practises:
+  knowledge: [AR-CONCEPT-C33-QAHWA-01, AR-CONCEPT-C33-QAHWA-02, AR-CONCEPT-C33-SUKKAR-01, AR-CONCEPT-C33-SUKKAR-02, AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C33-SHAY-02, AR-CONCEPT-W11-HA-AND-TA-MARBUTA-02, AR-CONCEPT-C04-AL-SALAMA-01, AR-CONCEPT-C06-MIN-FADLIK-01, AR-CONCEPT-C23-AFWAN-01, AR-CONCEPT-C33-HALIB-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: modern-standard-arabic
+reviews_of: [AR-C33-sukkar, AR-C33-halib, AR-C33-shay, AR-W11-ha-and-ta-marbuta, AR-C04-al-salama, AR-C06-min-fadlik, AR-C23-afwan]
+---
+
+# قهوة (qahwa) — "coffee," the tied tāʾ, and asking for all of it
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] The chapter closes on a word your own language already borrowed —
+and on the small letter at its end that tells you the word is feminine.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C33-QAHWA-01]; assesses=[AR-CONCEPT-W11-HA-AND-TA-MARBUTA-02, AR-CONCEPT-C33-SUKKAR-01] -->
+
+Nothing new. **ق** (*qāf*, two dots above), the *k* made far back in the
+throat; **ه** (*hāʾ*), the loop that changes shape wherever it stands; **و**
+(*wāw*), a non-joiner like *rā*; and then **ة**.
+
+**ة** is the **tāʾ marbūṭa**, the "tied *tāʾ*" — an **ه** with *tāʾ*'s two
+dots on it. It appears only at the end of a word.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C33-QAHWA-02]; assesses=[AR-CONCEPT-C04-AL-SALAMA-01, AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C33-SHAY-02] -->
+
+**قَهْوة** (*qahwa*) = "**coffee**."
+
+Here is what the **ة** buys you. Arabic nouns carry **gender**, and Arabic
+usually **shows** you which is which: a noun ending in **ة** is almost always
+**feminine**. That is a rule you apply on sight, not a list to memorise.
+
+You have watched it work already:
+
+- **مَكْتَب** (*maktab*), an office, becomes **مَكْتَبة** (*maktaba*), a
+  library.
+- **سَلام** (*salām*), peace, becomes **السَّلامة** (*as-salāma*), the safety —
+  the root **س-ل-م** wearing an ending and a pattern.
+
+So *qahwa* is feminine, while *shāy*, *ḥalīb* and *sukkar* are masculine — and
+the ending alone told you.
+
+The road out of Arabic is short and well lit. Ottoman **Turkish** took *qahwa*
+as **kahve**; Venetian traders took *kahve* as Italian **caffè**; from Italian
+came French **café**, German **Kaffee** and English **coffee**. The English
+word in your mouth is this Arabic one.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C33-QAHWA-01, AR-CONCEPT-C33-QAHWA-02, AR-CONCEPT-C33-SUKKAR-01, AR-CONCEPT-C33-SUKKAR-02, AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C33-SHAY-02, AR-CONCEPT-W11-HA-AND-TA-MARBUTA-02, AR-CONCEPT-C04-AL-SALAMA-01, AR-CONCEPT-C06-MIN-FADLIK-01, AR-CONCEPT-C23-AFWAN-01, AR-CONCEPT-C33-HALIB-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: qāf, hāʾ, wāw, tāʾ marbūṭa — "qahwa," coffee]
+- [YOU SAY: the tied tāʾ — an hāʾ wearing tāʾ's two dots, only at a word's end]
+- [YOU SAY: what it marks — feminine; maktab becomes maktaba, salām becomes as-salāma]
+- [YOU SAY: gendered — qahwa feminine; shāy, ḥalīb, sukkar masculine]
+- [YOU SAY: order each — "shāy, min faḍlik"; "qahwa, min faḍlik"; "ḥalīb, min faḍlik"; "sukkar, min faḍlik"]
+- [YOU SAY: the answer to thanks — "ʿafwan," think nothing of it]
+- [YOU SAY: ḥalīb joined throughout, sukkar's rā broke, and the wāw breaks here]
+- [YOU SAY: built against borrowed — ḥalaba gave ḥalīb; shāy and sukkar gave nothing]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C33-QAHWA-01, AR-CONCEPT-C33-QAHWA-02, AR-CONCEPT-C33-SUKKAR-02, AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C33-SHAY-02, AR-CONCEPT-W11-HA-AND-TA-MARBUTA-02, AR-CONCEPT-C06-MIN-FADLIK-01, AR-CONCEPT-C23-AFWAN-01] -->
+
+[PAUSE 3s] Which of this chapter's words is feminine, and how can you tell?
+(***Qahwa*** — **it ends in ة**.) Name two earlier words with that ending.
+(***Maktaba*** and ***as-salāma***.) Ask for each drink politely.
+(***Shāy***, ***qahwa***, ***ḥalīb***, ***sukkar*** — each with ***min
+faḍlik***, "from your grace.") What do you answer when someone thanks you?
+(***ʿAfwan***.) Which word here was built from a verb? (***Ḥalīb***, from
+*ḥalaba* — the others travelled in.)

--- a/code/learning/human-languages/arabic/lessons/AR-C33-shay.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C33-shay.md
@@ -1,0 +1,94 @@
+---
+schema_version: 2
+id: AR-C33-shay
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 860
+chapter: 33
+type: word
+headword: شاي
+gloss: "tea" — the first noun in this book with no Arabic root at all, and a word that reached Arabic and English from the same Chinese original by two different roads
+concept_tag: AR-DRINK-TEA
+romanization: shāy
+prerequisites: [AR-C32-ahabba]
+sounds: [shin, long-alif, rtl-known-letters]
+roots: [borrowed-no-arabic-root]
+etymology_hook: "شاي (shāy, 'tea') is a borrowed word with no Arabic root and therefore no pattern family — unlike كتب, which fills كِتاب, كاتِب and مَكْتَبة from one root; Arabic took it through Persian چای (chāy) from the northern Chinese chá, while English took the same Chinese word through the coastal Hokkien form tê carried by Dutch traders, so shāy and tea are the two ends of one word"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [AR-CONCEPT-C32-AHABBA-02]
+introduces:
+  knowledge: [AR-CONCEPT-C33-SHAY-01, AR-CONCEPT-C33-SHAY-02]
+practises:
+  knowledge: [AR-CONCEPT-C33-SHAY-01, AR-CONCEPT-C33-SHAY-02, AR-CONCEPT-C32-AHABBA-01, AR-CONCEPT-C32-AHABBA-02, AR-CONCEPT-C31-KATABA-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: modern-standard-arabic
+reviews_of: [AR-C32-ahabba, AR-C31-kataba]
+---
+
+# شاي (shāy) — "tea," and a word with no root
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] Every Arabic word you have taken apart so far had a root under it.
+This one does not — and that absence is the lesson.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C33-SHAY-01]; assesses=[AR-CONCEPT-C32-AHABBA-01] -->
+
+Nothing new. **ش** (*shīn*) has been on the page since **شكرا** (*shukran*):
+the *sīn* skeleton with three dots above it. Then **ا** (*alif*), the
+non-joiner, and **ي** (*yāʾ*).
+
+So **شاي** breaks where *alif* forces it to break: **شا**, then **ي**. That is
+the same two-piece split you met in **أحبّ** — **أ** standing alone, then
+**حبّ**.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C33-SHAY-02]; assesses=[AR-CONCEPT-C31-KATABA-02] -->
+
+**شاي** (*shāy*) = "**tea**."
+
+Now the honest part. Take **كتب** (*kataba*): its root pours into **كِتاب**
+(*kitāb*, a book), **كاتِب** (*kātib*, a writer), **مَكْتَب** (*maktab*, an
+office) and **مَكْتَبة** (*maktaba*, a library). Try that with *shāy* and
+nothing comes out. There is no shape it fills, no doer, no place, no done-to.
+
+That is because **shāy is borrowed**, and a borrowed word arrives without a
+root. Arabic took it through Persian **چای** (*chāy*), which took it from the
+**northern Chinese** *chá*.
+
+Your own language took the same Chinese word by the other road. Traders on the
+southern coast of China said it *tê*, Dutch ships carried that form to Europe,
+and it became English **tea**, French **thé**, German **Tee**. Overland through
+Persia it stayed *chá*: Russian **chay**, Turkish **çay**, Arabic
+**shāy**.
+
+So *shāy* and *tea* are not merely similar. They are the two ends of one word,
+separated by which way it left China.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C33-SHAY-01, AR-CONCEPT-C33-SHAY-02, AR-CONCEPT-C32-AHABBA-01, AR-CONCEPT-C32-AHABBA-02, AR-CONCEPT-C31-KATABA-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: shīn, alif, yāʾ — "shāy," tea]
+- [YOU SAY: where it breaks — shā, then yāʾ, as أحبّ broke after the alif]
+- [YOU SAY: what a root gives — kitāb, kātib, maktab, maktaba]
+- [YOU SAY: what shāy gives — nothing, because it was borrowed]
+- [YOU SAY: the overland road — Chinese chá, Persian chāy, Arabic shāy]
+- [YOU SAY: the sea road — Hokkien tê, Dutch, English tea]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C33-SHAY-01, AR-CONCEPT-C33-SHAY-02, AR-CONCEPT-C32-AHABBA-02, AR-CONCEPT-C31-KATABA-02] -->
+
+[PAUSE 3s] Why can you not build a word family from **شاي**? (**It has no
+Arabic root** — it was borrowed, and borrowed words arrive without one.) Name
+what **ك-ت-ب** builds, for contrast. (***Kitāb***, ***kātib***, ***maktab***,
+***maktaba***.) Which language handed *shāy* to Arabic, and which language did
+that one take it from? (**Persian**, from **Chinese**.) Is English *tea* a
+relative? (**Yes** — the same Chinese word, carried by sea rather than
+overland.)

--- a/code/learning/human-languages/arabic/lessons/AR-C33-sukkar.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C33-sukkar.md
@@ -1,0 +1,94 @@
+---
+schema_version: 2
+id: AR-C33-sukkar
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 880
+chapter: 33
+type: word
+headword: سكر
+gloss: "sugar" — a word that crossed Asia and Europe, and the one that shows Arabic's own al- fused onto the front of a Spanish noun
+concept_tag: AR-DRINK-SUGAR
+romanization: sukkar
+prerequisites: [AR-C33-halib, AR-W08-kaf-and-ra]
+sounds: [shadda, rtl-known-letters]
+roots: [borrowed-sanskrit-sarkara]
+etymology_hook: "سُكَّر (sukkar, 'sugar') is borrowed, from Persian shakar, from Sanskrit śarkarā, 'grit, gravel' — sugar named for the coarse grains it comes in; Arabic passed it to medieval Latin as succarum and from there to Italian zucchero, French sucre and English sugar, while Spanish azúcar keeps Arabic's own article al- welded onto the front, the same fusion visible in algebra and alcohol; its shadda doubles a letter the word itself owns, the أحبّ reason rather than the فكّر reason"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [AR-CONCEPT-C33-HALIB-02]
+introduces:
+  knowledge: [AR-CONCEPT-C33-SUKKAR-01, AR-CONCEPT-C33-SUKKAR-02]
+practises:
+  knowledge: [AR-CONCEPT-C33-SUKKAR-01, AR-CONCEPT-C33-SUKKAR-02, AR-CONCEPT-C33-HALIB-01, AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C33-SHAY-02, AR-CONCEPT-W08-KAF-AND-RA-01, AR-CONCEPT-W08-KAF-AND-RA-02, AR-CONCEPT-C32-AHABBA-01, AR-CONCEPT-C33-SHAY-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: modern-standard-arabic
+reviews_of: [AR-C33-halib, AR-C33-shay, AR-W08-kaf-and-ra, AR-C32-ahabba]
+---
+
+# سكر (sukkar) — "sugar," and an Arabic article stuck to a Spanish word
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] Another traveller — and this one left a piece of Arabic grammar
+behind in Spain.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C33-SUKKAR-01]; assesses=[AR-CONCEPT-W08-KAF-AND-RA-01, AR-CONCEPT-W08-KAF-AND-RA-02, AR-CONCEPT-C32-AHABBA-01] -->
+
+Nothing new. **س** (*sīn*), the low comb; **ك** (*kāf*), the angular *k*; and
+**ر** (*rā*), the little downward curve that **breaks** — a non-joiner, like
+*alif*. So **سكر** joins from *sīn* to *kāf*, and *rā* hangs off the end.
+
+Written fully it is **سُكَّر**, and the mark over the **ك** is the **shadda**.
+You have seen it do two jobs. On **فكّر** (*fakkara*) it built a new verb out
+of an old root. Here it does the quieter job it did on **أحبّ**: it spells a
+letter the word already owns twice over — *suk-kar*.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C33-SUKKAR-02]; assesses=[AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C33-SHAY-02] -->
+
+**سُكَّر** (*sukkar*) = "**sugar**." Like *shāy*, and unlike *ḥalīb*, it is
+**borrowed**: no Arabic root, no family of shapes.
+
+Its road west starts in **Sanskrit**, where **śarkarā** meant "grit,
+gravel" — sugar named for its coarse grains. **Persian**
+took it as *shakar*, Arabic as *sukkar*, and Arabic carried it into medieval
+**Latin** as *succarum*. From there: Italian **zucchero**, French **sucre**,
+German **Zucker**, English **sugar**.
+
+Then **Spanish**, which shows what the others hide. Spanish for sugar is
+**azúcar** — and that opening *a-z-* is Arabic's own **الـ** (*al-*), the
+article, welded onto the front of the noun. Spanish borrowed **al-sukkar**
+whole and never took it apart.
+
+You know why the *l* vanished: **س** is a **sun letter**, so *al-* + *sukkar*
+is said **as-sukkar**, as *al-* + *salām* is said **as-salām**. Spanish kept
+the sound, not the spelling. English holds *algebra* and *alcohol*.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C33-SUKKAR-01, AR-CONCEPT-C33-SUKKAR-02, AR-CONCEPT-C33-HALIB-01, AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C33-SHAY-02, AR-CONCEPT-W08-KAF-AND-RA-01, AR-CONCEPT-W08-KAF-AND-RA-02, AR-CONCEPT-C32-AHABBA-01, AR-CONCEPT-C33-SHAY-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: sīn, kāf, rā — and rā breaks, so nothing joins after it]
+- [YOU SAY: "sukkar," sugar — the shadda doubling the kāf, suk-kar]
+- [YOU SAY: the shadda's two jobs — fakkara built a verb, ʾaḥabba spelled one]
+- [YOU SAY: the road — Sanskrit śarkarā, Persian shakar, Arabic sukkar]
+- [YOU SAY: the article that stayed — as-sukkar, Spanish azúcar]
+- [YOU SAY: the sun letter — al- plus salām said as-salām]
+- [YOU SAY: borrowed, borrowed, built — shāy, sukkar, ḥalīb]
+- [YOU SAY: the letters before it — shīn, alif, yāʾ; then ḥāʾ, lām, yāʾ, bāʾ]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C33-SUKKAR-01, AR-CONCEPT-C33-SUKKAR-02, AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C33-SHAY-02, AR-CONCEPT-C32-AHABBA-01] -->
+
+[PAUSE 3s] Which letter in **سكر** refuses to join what follows? (***Rā***.)
+What is the shadda doing here, and which earlier verb used it the same way?
+(**Only spelling a doubled letter** — as in ***ʾaḥabba***, not as in
+*fakkara*.) What language did *sukkar* come from before Persian? (**Sanskrit**
+— *śarkarā*, "grit.") What is hiding at the front of Spanish **azúcar**?
+(**Arabic *al-***, said *as-* before a sun letter.)

--- a/code/learning/human-languages/arabic/lessons/AR-C34-jubn.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C34-jubn.md
@@ -1,0 +1,94 @@
+---
+schema_version: 2
+id: AR-C34-jubn
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 920
+chapter: 34
+type: word
+headword: جبن
+gloss: "cheese" — and an honest limit on the root system, because the very same three letters also spell cowardice and the two are not one idea
+concept_tag: AR-FOOD-CHEESE
+romanization: jubn
+prerequisites: [AR-C34-lahm, AR-W07-hook-family-ha-kha]
+sounds: [jim, rtl-known-letters]
+roots: [j-b-n]
+etymology_hook: "جُبْن (jubn, 'cheese') is written with the same letters as جُبْن ('cowardice', whose جَبان jabān is 'a coward'), and Arabic lexicographers list these as separate entries rather than one idea — a needed correction to the habit of reading every shared spelling as a shared root; Arabic's cheese word did not reach English, which took cheese from Latin cāseus, while the جِبْنة (jibna) of everyday speech shows the same tied tāʾ that marks قهوة feminine"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [AR-CONCEPT-C34-LAHM-02]
+introduces:
+  knowledge: [AR-CONCEPT-C34-JUBN-01, AR-CONCEPT-C34-JUBN-02]
+practises:
+  knowledge: [AR-CONCEPT-C34-JUBN-01, AR-CONCEPT-C34-JUBN-02, AR-CONCEPT-C34-LAHM-01, AR-CONCEPT-C34-LAHM-02, AR-CONCEPT-C34-MILH-02, AR-CONCEPT-C33-QAHWA-02, AR-CONCEPT-W07-HOOK-FAMILY-HA-KHA-01, AR-CONCEPT-C34-MILH-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: modern-standard-arabic
+reviews_of: [AR-C34-lahm, AR-C34-milh, AR-C33-qahwa, AR-W07-hook-family-ha-kha]
+---
+
+# جبن (jubn) — "cheese," and where the root system stops
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] The root system has been paying you back for chapters. This word is
+where it politely declines to.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C34-JUBN-01]; assesses=[AR-CONCEPT-W07-HOOK-FAMILY-HA-KHA-01, AR-CONCEPT-C34-LAHM-01] -->
+
+Nothing new. **ج** (*jīm*) is the third of the hook-and-tail family: the body
+of **ح** (*ḥāʾ*) and **خ** (*khāʾ*), marked by one dot **below**. Then **ب**
+(*bāʾ*), one dot below, and **ن** (*nūn*), one dot above.
+
+Dots are the whole difference here, as they were between the *ḥāʾ* of **لحم**
+and the *khāʾ* of **خبز**.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C34-JUBN-02]; assesses=[AR-CONCEPT-C34-LAHM-02, AR-CONCEPT-C34-MILH-02, AR-CONCEPT-C33-QAHWA-02] -->
+
+**جُبْن** (*jubn*) = "**cheese**." In everyday speech you will more often hear
+**جِبْنة** (*jibna*) — and that ending is the **ة** you now recognise on
+sight, doing its usual work.
+
+Now the honest part, because you have been taught to trust roots and this is
+where that trust needs a limit.
+
+**جُبْن** also means "**cowardice**," and **جَبان** (*jabān*) is "**a
+coward**." Same letters, same order. So is a cheese a coward?
+
+**No.** Arabic's dictionaries list these as **separate entries** — words spelled
+alike, not one idea branching. Compare a real root: **م-ل-ح** carries salt into
+*mallāḥ*, the sailor of salt water, and into *malīḥ*, a salty compliment. You
+can feel the thread. Between cheese and cowardice there is none, and inventing
+one would be the mistake the milk story made of Aleppo.
+
+Two words can share three letters by accident. Arabic has many roots and few
+letters.
+
+English took none of this: **cheese** comes from Latin **cāseus**.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C34-JUBN-01, AR-CONCEPT-C34-JUBN-02, AR-CONCEPT-C34-LAHM-01, AR-CONCEPT-C34-LAHM-02, AR-CONCEPT-C34-MILH-02, AR-CONCEPT-C33-QAHWA-02, AR-CONCEPT-W07-HOOK-FAMILY-HA-KHA-01, AR-CONCEPT-C34-MILH-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: jīm, bāʾ, nūn — "jubn," cheese]
+- [YOU SAY: the hook family by dots — ḥāʾ none, khāʾ one above, jīm one below]
+- [YOU SAY: the everyday form — jibna, with the tied tāʾ]
+- [YOU SAY: the accident — jubn is also cowardice, jabān a coward]
+- [YOU SAY: the verdict — separate words, not one root branching]
+- [YOU SAY: a real branching — milḥ, mallāḥ, malīḥ]
+- [YOU SAY: meat and salt — laḥm, milḥ, the same shapes reordered]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C34-JUBN-01, AR-CONCEPT-C34-JUBN-02, AR-CONCEPT-C34-LAHM-02, AR-CONCEPT-C34-MILH-02, AR-CONCEPT-C33-QAHWA-02] -->
+
+[PAUSE 3s] What separates **ج** from **ح** and **خ**? (**One dot below**.)
+What else do the letters of *jubn* spell? (**Cowardice** — *jabān* is a
+coward.) Are cheese and cowardice one root? (**No** — separate words that look
+alike.) Name a root that really does branch. (**م-ل-ح** — *milḥ*, *mallāḥ*,
+*malīḥ*.) What does the ending on *jibna* tell you? (**Feminine**, as *qahwa*
+is.)

--- a/code/learning/human-languages/arabic/lessons/AR-C34-lahm.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C34-lahm.md
@@ -1,0 +1,94 @@
+---
+schema_version: 2
+id: AR-C34-lahm
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 910
+chapter: 34
+type: word
+headword: لحم
+gloss: "meat" — one Semitic root that Arabic settled on meat and Hebrew settled on bread, with Bethlehem sitting on the seam between them
+concept_tag: AR-FOOD-MEAT
+romanization: laḥm
+prerequisites: [AR-C34-milh, AR-W07-hook-family-ha-kha]
+sounds: [haa-pharyngeal, rtl-known-letters]
+roots: [l-h-m]
+etymology_hook: "لَحْم (laḥm, 'meat') and Hebrew לֶחֶם (leḥem, 'bread') are the same Semitic root ل-ح-م, which named the staple food and let each people fill it with whatever their staple was; the town Arabic calls بيت لحم (Bayt Laḥm) is the town Hebrew calls בֵּית לֶחֶם (Bēt Leḥem) and English calls Bethlehem, so the seam runs straight through a place name English already owns, while خبز (khubz) shows Arabic naming bread from its own root خ-ب-ز instead"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [AR-CONCEPT-C34-MILH-02]
+introduces:
+  knowledge: [AR-CONCEPT-C34-LAHM-01, AR-CONCEPT-C34-LAHM-02]
+practises:
+  knowledge: [AR-CONCEPT-C34-LAHM-01, AR-CONCEPT-C34-LAHM-02, AR-CONCEPT-C34-MILH-01, AR-CONCEPT-C34-MILH-02, AR-CONCEPT-C33-QAHWA-02, AR-CONCEPT-C13-MAA-KHUBZ-02, AR-CONCEPT-W07-HOOK-FAMILY-HA-KHA-01, AR-CONCEPT-C33-QAHWA-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: modern-standard-arabic
+reviews_of: [AR-C34-milh, AR-C33-qahwa, AR-C13-maa-khubz, AR-W07-hook-family-ha-kha]
+---
+
+# لحم (laḥm) — "meat," and the town on the seam
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] This word and its Hebrew twin are the same root — and they mean
+different foods. There is a town whose name proves it.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C34-LAHM-01]; assesses=[AR-CONCEPT-W07-HOOK-FAMILY-HA-KHA-01, AR-CONCEPT-C34-MILH-01] -->
+
+Nothing new, and something pleasing: **لحم** is **ملح** read the other way
+about. The same shapes — **ل** (*lām*), **ح** (*ḥāʾ*), **م** (*mīm*) — in a
+different order, and so a different root and a different word.
+
+That is the root system stated as plainly as it can be. The letters are not the
+word. The **order** is the word.
+
+Here *ḥāʾ* sits in the **middle**, so it wears its joined-both-sides shape:
+neither *ḥalīb*'s open opening nor *milḥ*'s tailed ending.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C34-LAHM-02]; assesses=[AR-CONCEPT-C13-MAA-KHUBZ-02, AR-CONCEPT-C34-MILH-02] -->
+
+**لَحْم** (*laḥm*) = "**meat**." Root **ل-ح-م**.
+
+Now the twin, and it is the best one in this book. Hebrew's **לֶחֶם**
+(*leḥem*) is the same root — and it means **bread**.
+
+Neither language changed the meaning. The old Semitic root named **the staple
+food**, and each people filled it with whatever theirs was: meat where herds
+mattered, bread where grain did.
+
+English already owns the proof. The town is **بيت لحم** (*Bayt Laḥm*) in Arabic
+and **בֵּית לֶחֶם** (*Bēt Leḥem*) in Hebrew — one name, in which *bayt* and
+*bēt* both mean "a house of." English calls it **Bethlehem**: house of bread on
+one side of the seam, house of meat on the other.
+
+And notice what Arabic did **not** do. It had this root available for bread and
+did not use it. Arabic's bread is **خبز** (*khubz*), built on **خ-ب-ز**, "to
+bake" — the baked thing, as *ḥalīb* is the milked thing.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C34-LAHM-01, AR-CONCEPT-C34-LAHM-02, AR-CONCEPT-C34-MILH-01, AR-CONCEPT-C34-MILH-02, AR-CONCEPT-C33-QAHWA-02, AR-CONCEPT-C13-MAA-KHUBZ-02, AR-CONCEPT-W07-HOOK-FAMILY-HA-KHA-01, AR-CONCEPT-C33-QAHWA-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: lām, ḥāʾ, mīm — "laḥm," meat]
+- [YOU SAY: the same shapes reordered — mīm, lām, ḥāʾ is "milḥ," salt]
+- [YOU SAY: ḥāʾ in the middle, joined on both sides]
+- [YOU SAY: the twin that shifted — laḥm is meat, Hebrew leḥem is bread]
+- [YOU SAY: the town on the seam — Bayt Laḥm, Bēt Leḥem, Bethlehem]
+- [YOU SAY: Arabic's own bread — khubz, from kh-b-z, to bake]
+- [YOU SAY: the salt root's reach — mallāḥ, malīḥ]
+- [YOU SAY: qahwa's letters and its feminine ending — qāf, hāʾ, wāw, tāʾ marbūṭa]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C34-LAHM-01, AR-CONCEPT-C34-LAHM-02, AR-CONCEPT-C34-MILH-02, AR-CONCEPT-C33-QAHWA-02, AR-CONCEPT-C13-MAA-KHUBZ-02] -->
+
+[PAUSE 3s] What separates **لحم** from **ملح**? (**Only the order of the
+letters** — the whole root system.) What does Hebrew *leḥem* mean, and why is
+that no contradiction? (**Bread** — the root named the **staple food**.) Which
+English place name carries both? (**Bethlehem**.) What is Arabic's own word for
+bread, and where from? (***Khubz***, from **خ-ب-ز**, "to bake.")

--- a/code/learning/human-languages/arabic/lessons/AR-C34-milh.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C34-milh.md
@@ -1,0 +1,92 @@
+---
+schema_version: 2
+id: AR-C34-milh
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 900
+chapter: 34
+type: word
+headword: ملح
+gloss: "salt" — a plain Semitic word whose root also gives Arabic its sailor and its word for handsome, and which shows ḥāʾ in its final shape
+concept_tag: AR-FOOD-SALT
+romanization: milḥ
+prerequisites: [AR-C33-qahwa, AR-W07-hook-family-ha-kha]
+sounds: [haa-pharyngeal-final, rtl-known-letters]
+roots: [m-l-h]
+etymology_hook: "مِلْح (milḥ, 'salt') sits on the root م-ل-ح, which also yields مَلّاح (mallāḥ, 'a sailor' — the man of the salt water) and مَليح (malīḥ, 'handsome, pleasant'), so the root runs from a mineral to the sea to a compliment; Hebrew מֶלַח (melaḥ, 'salt') is the same word, and English took none of it — the English salt line comes from Latin sāl, an entirely separate family"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [AR-CONCEPT-C33-QAHWA-02]
+introduces:
+  knowledge: [AR-CONCEPT-C34-MILH-01, AR-CONCEPT-C34-MILH-02]
+practises:
+  knowledge: [AR-CONCEPT-C34-MILH-01, AR-CONCEPT-C34-MILH-02, AR-CONCEPT-C33-QAHWA-01, AR-CONCEPT-C33-QAHWA-02, AR-CONCEPT-C33-SUKKAR-02, AR-CONCEPT-W07-HOOK-FAMILY-HA-KHA-01, AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C33-SUKKAR-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: modern-standard-arabic
+reviews_of: [AR-C33-qahwa, AR-C33-sukkar, AR-C33-halib, AR-W07-hook-family-ha-kha]
+---
+
+# ملح (milḥ) — "salt," and the sailor hiding in it
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] A word for something you can hold in one hand — whose root
+stretches from a mineral to the open sea to a compliment.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C34-MILH-01]; assesses=[AR-CONCEPT-W07-HOOK-FAMILY-HA-KHA-01, AR-CONCEPT-C33-QAHWA-01] -->
+
+Nothing new, but one shape is worth a second look. **م** (*mīm*), **ل**
+(*lām*), **ح** (*ḥāʾ*) — all three join, so **ملح** is one run of pen.
+
+The **ح** is the hook-and-tail letter that opened **حليب** (*ḥalīb*), but at
+the **end** of a word it grows its full tail and swings below the line: open at
+the start of *ḥalīb*, closed and tailed at the end of *milḥ*.
+
+**قهوة** made the same point at the other end of a word: **ة** exists only in
+final position.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C34-MILH-02]; assesses=[AR-CONCEPT-C33-SUKKAR-02, AR-CONCEPT-C33-HALIB-02] -->
+
+**مِلْح** (*milḥ*) = "**salt**." Root **م-ل-ح**, and this is a root that has
+gone travelling inside its own language:
+
+- **مَلّاح** (*mallāḥ*) — "**a sailor**." The man of the salt water. It wears
+  the doubled *lām* shape Arabic keeps for trades and habits.
+- **مَليح** (*malīḥ*) — "**handsome, pleasant**." Salty, said of a person.
+  Arabic reached for the same idea English reaches for when it calls a person
+  *the salt of the earth*.
+
+Note *malīḥ*'s shape: **فَعيل** (*faʿīl*), the same pattern that gave you
+**حَليب** (*ḥalīb*). A root plus that pattern hands back a quality.
+
+Hebrew has **מֶלַח** (*melaḥ*), "salt," unchanged — one more Semitic twin.
+English is **not** in this family: *salt* comes down from Latin **sāl** and its
+Germanic cousins. And unlike *sukkar*, nothing here was borrowed.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C34-MILH-01, AR-CONCEPT-C34-MILH-02, AR-CONCEPT-C33-QAHWA-01, AR-CONCEPT-C33-QAHWA-02, AR-CONCEPT-C33-SUKKAR-02, AR-CONCEPT-W07-HOOK-FAMILY-HA-KHA-01, AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C33-SUKKAR-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: mīm, lām, ḥāʾ — "milḥ," salt]
+- [YOU SAY: ḥāʾ in two places — opening ḥalīb, closing milḥ with its tail]
+- [YOU SAY: the root's reach — mallāḥ, a sailor; malīḥ, handsome]
+- [YOU SAY: the faʿīl pattern twice — ḥalīb, malīḥ]
+- [YOU SAY: the Hebrew twin — melaḥ; and no English relative, only Latin sāl]
+- [YOU SAY: the borrowed one for contrast — sukkar, from Sanskrit by way of Persian]
+- [YOU SAY: the letters just behind — sīn, kāf, rā; qāf, hāʾ, wāw, tāʾ marbūṭa]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C34-MILH-01, AR-CONCEPT-C34-MILH-02, AR-CONCEPT-C33-QAHWA-02, AR-CONCEPT-C33-SUKKAR-02, AR-CONCEPT-C33-HALIB-02] -->
+
+[PAUSE 3s] What else does **م-ل-ح** give besides salt? (***Mallāḥ***, a
+sailor, and ***malīḥ***, handsome.) Which pattern do *malīḥ* and *ḥalīb*
+share? (***Faʿīl***.) Why does the **ح** of *milḥ* not look like the **ح** of
+*ḥalīb*? (**It is at the end of the word**, so it takes its full tailed
+shape.) Does English *salt* belong to this family? (**No** — it descends from
+Latin *sāl*.)

--- a/code/learning/human-languages/arabic/lessons/AR-C34-taam.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C34-taam.md
@@ -1,0 +1,101 @@
+---
+schema_version: 2
+id: AR-C34-taam
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 930
+chapter: 34
+type: word
+headword: طعام
+gloss: "food" — the chapter's payoff, where a root you have never met hands you the word for restaurant free of charge, because you already own the pattern
+concept_tag: AR-FOOD-GENERAL
+romanization: ṭaʿām
+prerequisites: [AR-C34-jubn]
+sounds: [taa-emphatic, ayn, rtl-known-letters]
+roots: [t-a-m]
+etymology_hook: "طَعام (ṭaʿām, 'food') is the root ط-ع-م, whose verb طَعِمَ (ṭaʿima) is 'he tasted' and whose noun طَعْم (ṭaʿm) is 'taste'; poured into the ma- place shape already met in مَكْتَب (maktab, an office) and مَذْهَب (madhhab), it gives مَطْعَم (maṭʿam, 'a restaurant' — the place of eating), so the learner generates the word rather than memorising it; its ط is the emphatic partner of ت, joining the ص of صباح and the ض of من فضلك"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [AR-CONCEPT-C34-JUBN-02]
+introduces:
+  knowledge: [AR-CONCEPT-C34-TAAM-01, AR-CONCEPT-C34-TAAM-02]
+practises:
+  knowledge: [AR-CONCEPT-C34-TAAM-01, AR-CONCEPT-C34-TAAM-02, AR-CONCEPT-C34-JUBN-01, AR-CONCEPT-C34-JUBN-02, AR-CONCEPT-C34-LAHM-02, AR-CONCEPT-C34-MILH-02, AR-CONCEPT-C31-KATABA-02, AR-CONCEPT-C30-AKALA-02, AR-CONCEPT-C13-MAA-KHUBZ-01, AR-CONCEPT-C06-MIN-FADLIK-01, AR-CONCEPT-C34-LAHM-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: modern-standard-arabic
+reviews_of: [AR-C34-jubn, AR-C34-lahm, AR-C34-milh, AR-C31-kataba, AR-C30-akala, AR-C13-maa-khubz, AR-C06-min-fadlik]
+---
+
+# طعام (ṭaʿām) — "food," and a restaurant you can build yourself
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] A new root, a new letter — and a word you will not have to be
+taught, because you already own the shape it comes in.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C34-TAAM-01]; assesses=[AR-CONCEPT-C34-JUBN-01] -->
+
+One letter to name at last. **ط** is **ṭāʾ**, the **emphatic** partner of
+**ت** (*tāʾ*): the same *t*, said with the tongue flat, so the syllable goes
+dark around it.
+
+Arabic keeps a small set of emphatic pairs, and you have met the others without
+being told they were a set:
+
+- **ص** (*ṣād*) is the emphatic **س** (*sīn*) — the ص of **صباح** (*ṣabāḥ*).
+- **ض** (*ḍād*) is the emphatic **د** (*dāl*) — the ض of **من فضلك** (*min
+  faḍlik*).
+- **ط** (*ṭāʾ*) is the emphatic **ت** (*tāʾ*) — this one.
+
+Then **ع** (*ʿayn*), the throat sound already named, **ا** (*alif*) and **م**
+(*mīm*). *Ṭāʾ* joins; *alif* does not, so **طعام** runs **طعا**, then **م**.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C34-TAAM-02]; assesses=[AR-CONCEPT-C31-KATABA-02, AR-CONCEPT-C30-AKALA-02] -->
+
+**طَعام** (*ṭaʿām*) = "**food**." Root **ط-ع-م**, whose verb **طَعِمَ**
+(*ṭaʿima*) means "**he tasted**," and whose bare noun **طَعْم** (*ṭaʿm*) is
+"**taste, flavour**."
+
+So Arabic has two ways to speak of eating. **أَكَلَ** (*akala*) is the plain
+act — he ate. **ط-ع-م** goes through the tongue: tasting, and so the food that
+gets tasted.
+
+Now take the **مَـ place shape** you own. It made **مَكْتَب** (*maktab*), the
+place of writing, from **ك-ت-ب**, and **مَذْهَب** (*madhhab*) from **ذ-ه-ب**.
+Put **ط-ع-م** through it:
+
+**مَطْعَم** (*maṭʿam*) — the place of eating. **A restaurant.**
+
+Nobody taught you that word. The pattern did.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C34-TAAM-01, AR-CONCEPT-C34-TAAM-02, AR-CONCEPT-C34-JUBN-01, AR-CONCEPT-C34-JUBN-02, AR-CONCEPT-C34-LAHM-02, AR-CONCEPT-C34-MILH-02, AR-CONCEPT-C31-KATABA-02, AR-CONCEPT-C30-AKALA-02, AR-CONCEPT-C13-MAA-KHUBZ-01, AR-CONCEPT-C06-MIN-FADLIK-01, AR-CONCEPT-C34-LAHM-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: ṭāʾ, ʿayn, alif, mīm — "ṭaʿām," food]
+- [YOU SAY: the emphatic set — ṣād under sīn, ḍād under dāl, ṭāʾ under tāʾ]
+- [YOU SAY: where you had them — ṣabāḥ, min faḍlik, now ṭaʿām]
+- [YOU SAY: the verb and the bare noun — ṭaʿima, he tasted; ṭaʿm, taste]
+- [YOU SAY: two ways to eat — akala the act, ṭaʿima the tasting]
+- [YOU SAY: the ma- place shape — madhhab, maktab, so maṭʿam, a restaurant]
+- [YOU SAY: the chapter's foods — milḥ, laḥm reversing its letters, jubn, ṭaʿām]
+- [YOU SAY: order them — "laḥm, min faḍlik"; "jubn, min faḍlik"]
+- [YOU SAY: and the odd old one — māʾ, water, whose plural miyāh keeps no pattern]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C34-TAAM-01, AR-CONCEPT-C34-TAAM-02, AR-CONCEPT-C34-JUBN-02, AR-CONCEPT-C34-LAHM-02, AR-CONCEPT-C34-MILH-02, AR-CONCEPT-C31-KATABA-02, AR-CONCEPT-C13-MAA-KHUBZ-01, AR-CONCEPT-C06-MIN-FADLIK-01] -->
+
+[PAUSE 3s] Which plain letter is **ط** the emphatic partner of, and name the
+other pairs. (**ت** — with **ص** under **س** and **ض** under **د**.) What does
+**ط-ع-م** mean as a verb? (**To taste**.) Build "restaurant" from it, and name
+the earlier words in that shape. (***Maṭʿam*** — like ***maktab*** and
+***madhhab***.) Ask for the chapter's foods politely. (***Milḥ***, ***laḥm***,
+***jubn***, ***ṭaʿām*** — each with ***min faḍlik***, "from your grace.") Which
+everyday word keeps no pattern at all? (***Māʾ*** — its plural *miyāh* is
+irregular.)

--- a/code/learning/human-languages/arabic/lessons/AR-C35-ibn-bint.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C35-ibn-bint.md
@@ -1,0 +1,93 @@
+---
+schema_version: 2
+id: AR-C35-ibn-bint
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 950
+chapter: 35
+type: word
+headword: ابن بنت
+gloss: son and daughter — one pair gendered by a single added ت, exactly as أخ and أخت were, and the ibn that stands in the middle of names English already knows
+concept_tag: AR-PERSON-CHILD
+romanization: ibn, bint
+prerequisites: [AR-C35-jar]
+sounds: [rtl-known-letters]
+roots: [b-n]
+etymology_hook: "ابن (ibn, 'son') and بنت (bint, 'daughter') are gendered by the added ت alone, the same single letter that separates أخ (akh) from أخت (ukht); Arab grammarians file them under ب-ن-ي, 'to build', but comparative Semitists suspect an older primitive noun instead, since Hebrew בֵּן (ben) and בַּת (bat, from an earlier bint whose ن assimilated) show the same bare shape; the word stands unchanged in Ibn Sīnā and Ibn Baṭṭūṭa, and no English word descends from it"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [AR-CONCEPT-C35-JAR-02]
+introduces:
+  knowledge: [AR-CONCEPT-C35-IBN-BINT-01, AR-CONCEPT-C35-IBN-BINT-02]
+practises:
+  knowledge: [AR-CONCEPT-C35-IBN-BINT-01, AR-CONCEPT-C35-IBN-BINT-02, AR-CONCEPT-C35-JAR-01, AR-CONCEPT-C35-JAR-02, AR-CONCEPT-C34-TAAM-02, AR-CONCEPT-C10-AKH-UKHT-01, AR-CONCEPT-C10-AB-UMM-01, AR-CONCEPT-C34-TAAM-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: modern-standard-arabic
+reviews_of: [AR-C35-jar, AR-C34-taam, AR-C10-akh-ukht, AR-C10-ab-umm]
+---
+
+# ابن, بنت (ibn, bint) — son and daughter, one letter apart
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] A pair you can learn in one move, because Arabic has already shown
+you the move it uses.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C35-IBN-BINT-01]; assesses=[AR-CONCEPT-C35-JAR-01] -->
+
+Nothing new in either. **ابن** is **ا** (*alif*), **ب** (*bāʾ*, one dot below)
+and **ن** (*nūn*, one dot above) — two letters that share a bowl and differ
+only by where the dot sits.
+
+**بنت** is the same **ب** and **ن**, then **ت** (*tāʾ*, two dots above) on the
+end. Both words join throughout, unlike **جار**, which stopped twice.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C35-IBN-BINT-02]; assesses=[AR-CONCEPT-C10-AKH-UKHT-01, AR-CONCEPT-C10-AB-UMM-01] -->
+
+**ابن** (*ibn*) = "**a son**." **بنت** (*bint*) = "**a daughter**."
+
+What separates them is **one ت**, and nothing else.
+
+You have met that letter doing that job. **أخ** (*akh*) is a brother; **أخت**
+(*ukht*) is a sister. Same word, one **ت** added for the feminine. Arabic does
+not build a separate word for the woman; it marks the word it has. (This is the
+bare cousin of the **ة** that marks *qahwa* feminine — same letter, tied
+instead of open.)
+
+On the root, tradition and comparison disagree. Arab grammarians file **ابن**
+under **ب-ن-ي**, "**to build**" — a son as what a house is built of, which is a
+lovely idea. Comparative scholars are less sure: Hebrew **בֵּן** (*ben*) and
+**בַּת** (*bat*) show the same bare shape, more like a very old primitive word
+than something derived from a verb. Hold it loosely.
+
+Hebrew *bat* is *bint* with the **n** swallowed into the **t**. And *ibn*
+stands in plain sight inside names English carries: **Ibn Sīnā**, the physician
+the Latin west called Avicenna. No English **word** descends from it.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C35-IBN-BINT-01, AR-CONCEPT-C35-IBN-BINT-02, AR-CONCEPT-C35-JAR-01, AR-CONCEPT-C35-JAR-02, AR-CONCEPT-C34-TAAM-02, AR-CONCEPT-C10-AKH-UKHT-01, AR-CONCEPT-C10-AB-UMM-01, AR-CONCEPT-C34-TAAM-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: alif, bāʾ, nūn — "ibn," a son]
+- [YOU SAY: bāʾ, nūn, tāʾ — "bint," a daughter]
+- [YOU SAY: the dots that separate bāʾ and nūn — one below, one above]
+- [YOU SAY: the move you already knew — akh, then ukht]
+- [YOU SAY: and the parents beside them — ab, a father; umm, a mother]
+- [YOU SAY: the loosely held root — b-n-y, to build, as the grammarians have it]
+- [YOU SAY: the Hebrew pair — ben, bat]
+- [YOU SAY: the neighbour, and the emphatic ṭāʾ of ṭaʿām — jārī; ṭaʿām, maṭʿam]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C35-IBN-BINT-01, AR-CONCEPT-C35-IBN-BINT-02, AR-CONCEPT-C35-JAR-02, AR-CONCEPT-C34-TAAM-02, AR-CONCEPT-C10-AKH-UKHT-01, AR-CONCEPT-C10-AB-UMM-01] -->
+
+[PAUSE 3s] What is the only difference between **ابن** and **بنت**? (**An
+added ت** — as with ***akh*** and ***ukht***.) And the parents? (***Ab*** and
+***umm***.) What root do grammarians give *ibn*, and why hold it loosely?
+(**ب-ن-ي, "to build"** — but Hebrew *ben* and *bat* suggest an older bare word.)
+Where does *ibn* appear in a name English knows? (***Ibn Sīnā***, Avicenna.)

--- a/code/learning/human-languages/arabic/lessons/AR-C35-jar.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C35-jar.md
@@ -1,0 +1,94 @@
+---
+schema_version: 2
+id: AR-C35-jar
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 940
+chapter: 35
+type: word
+headword: جار
+gloss: "neighbour" — the person you introduce most often, built on a hollow root whose middle letter hides exactly as qāla's does
+concept_tag: AR-PERSON-NEIGHBOUR
+romanization: jār
+prerequisites: [AR-C34-taam, AR-W07-hook-family-ha-kha]
+sounds: [jim, hollow-root-alif, rtl-known-letters]
+roots: [j-w-r]
+etymology_hook: "جار (jār, 'neighbour') is the hollow root ج-و-ر, whose و hides inside a long alif exactly as ق-و-ل hides its و inside قال (qāla, 'he said'); the root's verb جاوَرَ (jāwara) is 'he lived alongside', its plural is جيران (jīrān) where the hidden و resurfaces, and Hebrew's גֵּר (ger, 'a resident outsider') comes from the same Semitic root for dwelling alongside — while English neighbour is Germanic, the near-dweller, an unrelated word built on the identical idea"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [AR-CONCEPT-C34-TAAM-02]
+introduces:
+  knowledge: [AR-CONCEPT-C35-JAR-01, AR-CONCEPT-C35-JAR-02]
+practises:
+  knowledge: [AR-CONCEPT-C35-JAR-01, AR-CONCEPT-C35-JAR-02, AR-CONCEPT-C34-TAAM-01, AR-CONCEPT-C34-TAAM-02, AR-CONCEPT-C34-JUBN-02, AR-CONCEPT-C29-QALA-02, AR-CONCEPT-W07-HOOK-FAMILY-HA-KHA-01, AR-CONCEPT-C34-JUBN-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: modern-standard-arabic
+reviews_of: [AR-C34-taam, AR-C34-jubn, AR-C29-qala, AR-W07-hook-family-ha-kha]
+---
+
+# جار (jār) — "neighbour," and a root with a letter in hiding
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] After a chapter of things you order, a chapter of people you
+introduce — starting with the one who lives next door.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C35-JAR-01]; assesses=[AR-CONCEPT-W07-HOOK-FAMILY-HA-KHA-01, AR-CONCEPT-C34-TAAM-01] -->
+
+Nothing new, and it is short: **ج** (*jīm*, the hook-and-tail body with one
+dot below), **ا** (*alif*) and **ر** (*rā*). Both **ا** and **ر** are
+non-joiners, so **جار** barely joins at all — compare **طعام**, which broke
+once before its *mīm*.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C35-JAR-02]; assesses=[AR-CONCEPT-C29-QALA-02, AR-CONCEPT-C34-JUBN-02] -->
+
+**جار** (*jār*) = "**a neighbour**." Add the "my" ending of **اسمي** (*ismī*)
+and you have **جاري** (*jārī*), "**my neighbour**" — which is how the word
+usually arrives in a conversation.
+
+Now listen to the root. You can hear only *j* and *r*. But an Arabic root
+wants three consonants, and the missing one is in hiding: the root is
+**ج-و-ر**, and its **و** has collapsed into that long **ا**.
+
+You have watched this before. **قال** (*qāla*), "he said," is **ق-و-ل** with
+the same disappearing **و**. Arabic calls these **hollow** roots, and the
+hidden letter comes back when the word changes shape:
+
+- **جاوَرَ** (*jāwara*) — "he lived alongside." There is the **و**, in the
+  open.
+- **جيران** (*jīrān*) — "**neighbours**," where it returns as a long **ī**.
+
+Hebrew's **גֵּר** (*ger*), a resident outsider living among a people, comes
+from the same Semitic root for dwelling alongside.
+
+English **neighbour** is no relative — it is Germanic, the *nigh-dweller*. Two
+unrelated languages built one word out of one idea, worth noticing **because**
+it is not descent.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C35-JAR-01, AR-CONCEPT-C35-JAR-02, AR-CONCEPT-C34-TAAM-01, AR-CONCEPT-C34-TAAM-02, AR-CONCEPT-C34-JUBN-02, AR-CONCEPT-C29-QALA-02, AR-CONCEPT-W07-HOOK-FAMILY-HA-KHA-01, AR-CONCEPT-C34-JUBN-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: jīm, alif, rā — "jār," a neighbour]
+- [YOU SAY: with the my ending — "jārī," my neighbour, as ismī is my name]
+- [YOU SAY: the hidden letter — the root is j-w-r, and the wāw is inside the alif]
+- [YOU SAY: the same hiding place — qāla, he said, from q-w-l]
+- [YOU SAY: where it comes back — jāwara; jīrān, neighbours]
+- [YOU SAY: the hook family by dots — ḥāʾ, khāʾ, jīm]
+- [YOU SAY: the restaurant you built — maṭʿam, the place of eating]
+- [YOU SAY: the honest non-cousin — English neighbour, the nigh-dweller]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C35-JAR-01, AR-CONCEPT-C35-JAR-02, AR-CONCEPT-C34-TAAM-02, AR-CONCEPT-C34-JUBN-02, AR-CONCEPT-C29-QALA-02] -->
+
+[PAUSE 3s] What is **جار**'s third root letter, and where has it gone?
+(**و** — collapsed into the long *alif*, as in ***qāla*** from **ق-و-ل**.)
+Where does it resurface? (**In *jāwara* and *jīrān*.**) How do you say "my
+neighbour"? (***Jārī*** — the ending of *ismī*.) Is English *neighbour*
+related? (**No** — Germanic, the *nigh-dweller*.)

--- a/code/learning/human-languages/arabic/lessons/AR-C35-sadiq.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C35-sadiq.md
@@ -1,0 +1,101 @@
+---
+schema_version: 2
+id: AR-C35-sadiq
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 960
+chapter: 35
+type: word
+headword: صديق
+gloss: "friend" — the chapter's payoff, where a root meaning truth explains the word, the faʿīl pattern turns up for the third time, and every family word you own lines up behind it
+concept_tag: AR-PERSON-FRIEND
+romanization: ṣadīq
+prerequisites: [AR-C35-ibn-bint, AR-C04-al-salama]
+sounds: [sad-emphatic, long-ii, rtl-known-letters]
+roots: [s-d-q]
+etymology_hook: "صَديق (ṣadīq, 'friend') is the root ص-د-ق, 'to be truthful', in the فَعيل (faʿīl) pattern already worn by حَليب (ḥalīb) and مَليح (malīḥ) — so a friend is the one who is true to you; the same root gives صِدْق (ṣidq, 'truth'), صادِق (ṣādiq, 'truthful' — the doer shape of قائِل and كاتِب), صَدَقة (ṣadaqa, 'voluntary alms', a true gift) and the feminine صَديقة (ṣadīqa), while English took none of it"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [AR-CONCEPT-C35-IBN-BINT-02]
+introduces:
+  knowledge: [AR-CONCEPT-C35-SADIQ-01, AR-CONCEPT-C35-SADIQ-02]
+practises:
+  knowledge: [AR-CONCEPT-C35-SADIQ-01, AR-CONCEPT-C35-SADIQ-02, AR-CONCEPT-C35-IBN-BINT-01, AR-CONCEPT-C35-IBN-BINT-02, AR-CONCEPT-C35-JAR-02, AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C31-KATABA-02, AR-CONCEPT-C10-AKH-UKHT-01, AR-CONCEPT-C10-AB-UMM-01, AR-CONCEPT-C04-AL-SALAMA-01, AR-CONCEPT-C35-JAR-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: modern-standard-arabic
+reviews_of: [AR-C35-ibn-bint, AR-C35-jar, AR-C33-halib, AR-C31-kataba, AR-C10-akh-ukht, AR-C10-ab-umm, AR-C04-al-salama]
+---
+
+# صديق (ṣadīq) — "friend," the one who is true to you
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] The chapter closes on a word whose root is not about company at
+all. It is about telling the truth.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C35-SADIQ-01]; assesses=[AR-CONCEPT-C35-IBN-BINT-01] -->
+
+Nothing new. **ص** (*ṣād*) is the emphatic **س**, first met in **صباح**
+(*ṣabāḥ*) — heavy and dark where *sīn* is light. Then **د** (*dāl*), **ي**
+(*yāʾ*) carrying the long **ī**, and **ق** (*qāf*). **د** is a non-joiner, so
+**صديق** breaks after it: **صد**, then **يق**.
+
+The feminine is **صَديقة** (*ṣadīqa*) — the **ة**, tied on the end, doing what
+it did to *qahwa*: the open **ت** of **بنت** and **أخت** in its tied form.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C35-SADIQ-02]; assesses=[AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C31-KATABA-02, AR-CONCEPT-C04-AL-SALAMA-01] -->
+
+**صَديق** (*ṣadīq*) = "**a friend**." Root **ص-د-ق**, and the root means
+"**to be truthful, to be sincere**."
+
+A friend, in Arabic, is defined by honesty rather than proximity. The family
+agrees:
+
+- **صِدْق** (*ṣidq*) — "**truth**, sincerity."
+- **صادِق** (*ṣādiq*) — "**truthful**," the **doer** shape worn by **قائِل**
+  (*qāʾil*, a sayer) and **كاتِب** (*kātib*, a writer).
+- **صَدَقة** (*ṣadaqa*) — "**voluntary alms**." A gift given for its own sake:
+  a **true** gift, as against one owed.
+- **أَصْدِقاء** (*aṣdiqāʾ*) — "**friends**."
+
+And now the pattern. **صَديق** is **فَعيل** (*faʿīl*) — the shape of
+**حَليب** (*ḥalīb*), the milked thing, and **مَليح** (*malīḥ*), the salty one.
+Root plus *faʿīl* hands back a quality made into a person or a thing.
+
+This is the machinery that turned **سَلام** (*salām*) into **السَّلامة**
+(*as-salāma*): one root, several patterns, several words.
+
+English took nothing from **ص-د-ق**. *Friend* is Germanic, from an old word
+for loving.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C35-SADIQ-01, AR-CONCEPT-C35-SADIQ-02, AR-CONCEPT-C35-IBN-BINT-01, AR-CONCEPT-C35-IBN-BINT-02, AR-CONCEPT-C35-JAR-02, AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C31-KATABA-02, AR-CONCEPT-C10-AKH-UKHT-01, AR-CONCEPT-C10-AB-UMM-01, AR-CONCEPT-C04-AL-SALAMA-01, AR-CONCEPT-C35-JAR-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: ṣād, dāl, yāʾ, qāf — "ṣadīq," a friend]
+- [YOU SAY: the emphatic pair — sīn light, ṣād heavy, as in ṣabāḥ]
+- [YOU SAY: what the root means — to be truthful; a friend is one who is true]
+- [YOU SAY: the family — ṣidq, ṣādiq, ṣadaqa, aṣdiqāʾ]
+- [YOU SAY: the doer shape — qāʾil, kātib, ṣādiq]
+- [YOU SAY: the faʿīl shape — ḥalīb, malīḥ, ṣadīq]
+- [YOU SAY: the feminine — ṣadīqa, tied tāʾ, as as-salāma has it]
+- [YOU SAY: this chapter's people — jārī with its two non-joiners, ibn, bint, ṣadīqī]
+- [YOU SAY: and the family you had — ab, umm, akh, ukht]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C35-SADIQ-01, AR-CONCEPT-C35-SADIQ-02, AR-CONCEPT-C35-IBN-BINT-02, AR-CONCEPT-C35-JAR-02, AR-CONCEPT-C33-HALIB-02, AR-CONCEPT-C10-AKH-UKHT-01, AR-CONCEPT-C10-AB-UMM-01, AR-CONCEPT-C04-AL-SALAMA-01] -->
+
+[PAUSE 3s] What does **ص-د-ق** mean, and what does that make a friend?
+(**To be truthful** — the one who is true to you.) Name the family.
+(***Ṣidq***, ***ṣādiq***, ***ṣadaqa***, ***aṣdiqāʾ***.) Which earlier words
+wear *ṣadīq*'s *faʿīl* pattern, and which wear *ṣādiq*'s doer shape?
+(***Ḥalīb*** and ***malīḥ***; ***qāʾil*** and ***kātib***.) Introduce the
+people you can now name. (***Jārī***, ***ibn***, ***bint***, ***ṣadīqī*** —
+beside ***ab***, ***umm***, ***akh***, ***ukht***.) What does the **ة** of
+*ṣadīqa* do? (**Marks it feminine** — as on *qahwa* and *as-salāma*.)

--- a/code/learning/human-languages/arabic/lessons/AR-C36-kub.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C36-kub.md
@@ -1,0 +1,97 @@
+---
+schema_version: 2
+id: AR-C36-kub
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 980
+chapter: 36
+type: word
+headword: كوب
+gloss: "a cup" — the word that opens Arabic's broken plural, where more than one is not made by adding anything but by re-pouring the word into a new shape
+concept_tag: AR-OBJECT-CUP
+romanization: kūb
+prerequisites: [AR-C36-zayt, AR-C23-afwan]
+sounds: [long-uu, rtl-known-letters]
+roots: [k-w-b]
+etymology_hook: "كوب (kūb, 'a cup') has the plural أكواب (akwāb), which adds nothing to the end but re-pours the root ك-و-ب into the shape أَفْعال — Arabic's broken plural, and the first the learner meets head on; the word sits close to a cup-word that travelled the whole Mediterranean, Latin cuppa behind English cup, but whether Arabic borrowed it or merely resembles it is not settled, so it is offered as a resemblance rather than a descent"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [AR-CONCEPT-C36-ZAYT-02]
+introduces:
+  knowledge: [AR-CONCEPT-C36-KUB-01, AR-CONCEPT-C36-KUB-02]
+practises:
+  knowledge: [AR-CONCEPT-C36-KUB-01, AR-CONCEPT-C36-KUB-02, AR-CONCEPT-C36-ZAYT-01, AR-CONCEPT-C36-ZAYT-02, AR-CONCEPT-C35-SADIQ-02, AR-CONCEPT-C13-MAA-KHUBZ-01, AR-CONCEPT-C06-MIN-FADLIK-01, AR-CONCEPT-C23-AFWAN-01, AR-CONCEPT-C35-SADIQ-01, AR-CONCEPT-W08-KAF-AND-RA-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: modern-standard-arabic
+reviews_of: [AR-C36-zayt, AR-C35-sadiq, AR-C13-maa-khubz, AR-C06-min-fadlik, AR-C23-afwan]
+---
+
+# كوب (kūb) — "a cup," and more than one of them
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] A short, useful word — and the door into the thing about Arabic
+nouns that surprises every learner.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C36-KUB-01]; assesses=[AR-CONCEPT-C36-ZAYT-01] -->
+
+Nothing new. **ك** (*kāf*), the angular *k*; **و** (*wāw*), here carrying the
+long **ū**; and **ب** (*bāʾ*).
+
+**و** is a non-joiner, so **كوب** goes **كو**, break, **ب**. Another
+non-joiner: **ر** ended *sukkar*, **ز** opened *zayt*, and **و** splits this.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C36-KUB-02]; assesses=[AR-CONCEPT-C36-ZAYT-02, AR-CONCEPT-C13-MAA-KHUBZ-01] -->
+
+**كوب** (*kūb*) = "**a cup**." Root **ك-و-ب**.
+
+Now say "cups." In English you add an *s*. In Arabic you do something else
+entirely:
+
+**أَكْواب** (*akwāb*).
+
+Nothing was added to the end. The root **ك-و-ب** was taken out of one shape and
+**poured into another**, **أَفْعال** (*afʿāl*). Arabic calls this a **broken
+plural**, and it is not an exception — it is how most ordinary Arabic nouns
+make their plurals.
+
+You have seen a root move between shapes many times: **ك-ت-ب** became *kitāb*,
+*kātib*, *maktab*, *maktaba*. A broken plural is that same machinery pointed at
+number instead of meaning. So this is not a new rule to learn. It is a rule you
+already have, doing a job you did not expect it to do.
+
+On where *kūb* came from, honesty first. It sits close to a cup-word that
+travelled all round the Mediterranean — Latin **cuppa**, behind English **cup**
+and French **coupe**. Whether Arabic took it from that family, or the
+resemblance is coincidence, is **not settled**: a resemblance worth knowing,
+not a descent worth claiming.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C36-KUB-01, AR-CONCEPT-C36-KUB-02, AR-CONCEPT-C36-ZAYT-01, AR-CONCEPT-C36-ZAYT-02, AR-CONCEPT-C35-SADIQ-02, AR-CONCEPT-C13-MAA-KHUBZ-01, AR-CONCEPT-C06-MIN-FADLIK-01, AR-CONCEPT-C23-AFWAN-01, AR-CONCEPT-C35-SADIQ-01, AR-CONCEPT-W08-KAF-AND-RA-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: kāf, wāw, bāʾ — "kūb," a cup]
+- [YOU SAY: more than one — "akwāb," and nothing was added to the end]
+- [YOU SAY: what happened instead — the root was poured into the shape afʿāl]
+- [YOU SAY: the same machinery you had — kitāb, kātib, maktab, maktaba]
+- [YOU SAY: ask for one — "kūb māʾ, min faḍlik" — a cup of water, from your grace]
+- [YOU SAY: and answer the thanks — "ʿafwan"]
+- [YOU SAY: the odd old word for water — māʾ, whose plural miyāh follows no pattern]
+- [YOU SAY: the non-joiners — zāy in zayt, dāl in ṣadīq, wāw here]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C36-KUB-01, AR-CONCEPT-C36-KUB-02, AR-CONCEPT-C36-ZAYT-02, AR-CONCEPT-C13-MAA-KHUBZ-01, AR-CONCEPT-C06-MIN-FADLIK-01, AR-CONCEPT-C23-AFWAN-01] -->
+
+[PAUSE 3s] How does Arabic make "cups" out of **كوب**? (***Akwāb*** — the root
+is **re-poured into a new shape**, not given an ending. That is a **broken
+plural**.) Which earlier root shows the same shape-changing machinery?
+(**ك-ت-ب** — *kitāb*, *kātib*, *maktab*, *maktaba*.) Ask for a cup of water
+politely. (***Kūb māʾ, min faḍlik***.) And reply to thanks? (***ʿAfwan***.) Did
+Arabic get *kūb* from Latin *cuppa*? (**Unsettled** — a resemblance, not a
+claim.)

--- a/code/learning/human-languages/arabic/lessons/AR-C36-milaqa.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C36-milaqa.md
@@ -1,0 +1,102 @@
+---
+schema_version: 2
+id: AR-C36-milaqa
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 1000
+chapter: 36
+type: word
+headword: ملعقة
+gloss: "a spoon" — the closing payoff, where the mi- tool shape stands beside the ma- place shape you already own, and where sound and broken plurals finally sort themselves out
+concept_tag: AR-OBJECT-SPOON
+romanization: milʿaqa
+prerequisites: [AR-C36-tabaq, AR-W11-ha-and-ta-marbuta]
+sounds: [ayn, ta-marbuta, rtl-known-letters]
+roots: [l-a-q]
+etymology_hook: "مِلْعَقة (milʿaqa, 'a spoon') is the root ل-ع-ق, 'to lick, to lap', in the مِفْعَلة tool shape — the same mi- shape that made مِرْآة (mirʾāh, 'a mirror') the thing you see with, standing against the ma- place shape of مَطْعَم (maṭʿam) and مَكْتَب (maktab); its plural مَلاعِق (malāʿiq) is broken like أكواب and أطباق, while the ة nouns قهوة and صديقة take the added ending of قهوات and صديقات instead, which is the sound plural"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [AR-CONCEPT-C36-TABAQ-02]
+introduces:
+  knowledge: [AR-CONCEPT-C36-MILAQA-01, AR-CONCEPT-C36-MILAQA-02]
+practises:
+  knowledge: [AR-CONCEPT-C36-MILAQA-01, AR-CONCEPT-C36-MILAQA-02, AR-CONCEPT-C36-TABAQ-01, AR-CONCEPT-C36-TABAQ-02, AR-CONCEPT-C36-KUB-02, AR-CONCEPT-C36-ZAYT-02, AR-CONCEPT-C34-TAAM-02, AR-CONCEPT-C33-QAHWA-02, AR-CONCEPT-C29-RAA-02, AR-CONCEPT-W11-HA-AND-TA-MARBUTA-02, AR-CONCEPT-C06-MIN-FADLIK-01, AR-CONCEPT-C36-KUB-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: modern-standard-arabic
+reviews_of: [AR-C36-tabaq, AR-C36-kub, AR-C36-zayt, AR-C34-taam, AR-C33-qahwa, AR-C29-raa, AR-W11-ha-and-ta-marbuta, AR-C06-min-fadlik]
+---
+
+# ملعقة (milʿaqa) — "a spoon," the tool shape, and two ways to say more than one
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] The last word, and it pays two debts at once: the shape that makes
+tools, and the question of how Arabic counts past one.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C36-MILAQA-01]; assesses=[AR-CONCEPT-W11-HA-AND-TA-MARBUTA-02, AR-CONCEPT-C36-TABAQ-01] -->
+
+Nothing new: **م** (*mīm*), **ل** (*lām*), **ع** (*ʿayn*, the throat sound),
+**ق** (*qāf*) — and then **ة**, the tied *tāʾ*.
+
+That **ة** tells you, before anything else, that **ملعقة** is **feminine** —
+the signal you read off **قهوة** (*qahwa*), **صديقة** (*ṣadīqa*) and
+**طَبَقة** (*ṭabaqa*).
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C36-MILAQA-02]; assesses=[AR-CONCEPT-C29-RAA-02, AR-CONCEPT-C34-TAAM-02, AR-CONCEPT-C33-QAHWA-02, AR-CONCEPT-C36-KUB-02] -->
+
+**مِلْعَقة** (*milʿaqa*) = "**a spoon**." Root **ل-ع-ق**, whose verb
+**لَعِقَ** (*laʿiqa*) means "**he licked, he lapped**." A spoon is the thing
+you lap with.
+
+Two shapes now stand side by side, differing by one vowel:
+
+- **مَـ**, the **place** shape: **مَكْتَب** (*maktab*), the place of writing;
+  **مَطْعَم** (*maṭʿam*), the place of eating.
+- **مِـ**, the **tool** shape: **مِرْآة** (*mirʾāh*), the thing you see with;
+  **مِلْعَقة** (*milʿaqa*), the thing you lap with.
+
+*Ma-* builds a room. *Mi-* puts something in your hand.
+
+Now the plurals this chapter has been circling.
+
+**Broken** — the root re-poured, nothing added: **أَكْواب** (*akwāb*),
+**أَطْباق** (*aṭbāq*), **مَلاعِق** (*malāʿiq*), spoons.
+
+**Sound** — an ending added, the word left intact. Arabic uses it for the
+**ة** words: **قَهْوة** gives **قَهَوات** (*qahawāt*), and **صَديقة** gives
+**صَديقات** (*ṣadīqāt*).
+
+The rule of thumb: a noun in **ة** usually takes the added ending, and most
+other everyday nouns break. *Milʿaqa* is the honest reminder that "usually" is
+doing work — it ends in **ة** and breaks anyway.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C36-MILAQA-01, AR-CONCEPT-C36-MILAQA-02, AR-CONCEPT-C36-TABAQ-01, AR-CONCEPT-C36-TABAQ-02, AR-CONCEPT-C36-KUB-02, AR-CONCEPT-C36-ZAYT-02, AR-CONCEPT-C34-TAAM-02, AR-CONCEPT-C33-QAHWA-02, AR-CONCEPT-C29-RAA-02, AR-CONCEPT-W11-HA-AND-TA-MARBUTA-02, AR-CONCEPT-C06-MIN-FADLIK-01, AR-CONCEPT-C36-KUB-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: mīm, lām, ʿayn, qāf, tāʾ marbūṭa — "milʿaqa," a spoon]
+- [YOU SAY: the verb under it — "laʿiqa," he lapped]
+- [YOU SAY: the place shape — maktab, maṭʿam]
+- [YOU SAY: the tool shape — mirʾāh, milʿaqa]
+- [YOU SAY: the broken plurals — kūb with its breaking wāw gives akwāb; aṭbāq; malāʿiq]
+- [YOU SAY: the sound plurals — qahwa gives qahawāt, ṣadīqa gives ṣadīqāt]
+- [YOU SAY: the tied tāʾ marking feminine — qahwa, ṣadīqa, ṭabaqa, milʿaqa]
+- [YOU SAY: ask for each — "kūb, min faḍlik"; "ṭabaq, min faḍlik"; "milʿaqa, min faḍlik"]
+- [YOU SAY: and the oil — zayt, whose Spanish child is aceite]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C36-MILAQA-01, AR-CONCEPT-C36-MILAQA-02, AR-CONCEPT-C36-TABAQ-02, AR-CONCEPT-C36-KUB-02, AR-CONCEPT-C36-ZAYT-02, AR-CONCEPT-C34-TAAM-02, AR-CONCEPT-C33-QAHWA-02, AR-CONCEPT-C29-RAA-02, AR-CONCEPT-W11-HA-AND-TA-MARBUTA-02, AR-CONCEPT-C06-MIN-FADLIK-01] -->
+
+[PAUSE 3s] What separates **مَـ** from **مِـ**? (***Ma-*** **makes a place**,
+***mi-*** **a tool** — *maktab* and *maṭʿam* against *mirʾāh* and *milʿaqa*.)
+What does **ل-ع-ق** mean? (**To lap**.) Name this chapter's broken plurals, and
+a sound one. (***Akwāb***, ***aṭbāq***, ***malāʿiq***; ***qahawāt*** or
+***ṣadīqāt***.) What does the **ة** on *milʿaqa* tell you? (**Feminine** — and
+unusually for a **ة** word, it still breaks.) Ask for a spoon politely.
+(***Milʿaqa, min faḍlik***.)

--- a/code/learning/human-languages/arabic/lessons/AR-C36-tabaq.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C36-tabaq.md
@@ -1,0 +1,94 @@
+---
+schema_version: 2
+id: AR-C36-tabaq
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 990
+chapter: 36
+type: word
+headword: طبق
+gloss: "a plate" — a second broken plural in the very same shape as akwāb, which turns a surprise into a pattern, and a root whose other child is a storey of a building
+concept_tag: AR-OBJECT-PLATE
+romanization: ṭabaq
+prerequisites: [AR-C36-kub]
+sounds: [taa-emphatic, qaf, rtl-known-letters]
+roots: [t-b-q]
+etymology_hook: "طَبَق (ṭabaq, 'a plate, a dish') pluralises to أَطْباق (aṭbāq) in exactly the shape أَفْعال that gave أكواب (akwāb), so the broken plural stops being a surprise and becomes a pattern; the root ط-ب-ق means to cover or to lie in layers, which is why it also gives طابِق (ṭābiq, 'a storey of a building') and طَبَقة (ṭabaqa, 'a layer, a social class'), and its ط is the same emphatic tāʾ first named in طعام"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [AR-CONCEPT-C36-KUB-02]
+introduces:
+  knowledge: [AR-CONCEPT-C36-TABAQ-01, AR-CONCEPT-C36-TABAQ-02]
+practises:
+  knowledge: [AR-CONCEPT-C36-TABAQ-01, AR-CONCEPT-C36-TABAQ-02, AR-CONCEPT-C36-KUB-01, AR-CONCEPT-C36-KUB-02, AR-CONCEPT-C36-ZAYT-02, AR-CONCEPT-C34-TAAM-01, AR-CONCEPT-C34-TAAM-02, AR-CONCEPT-C36-ZAYT-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: modern-standard-arabic
+reviews_of: [AR-C36-kub, AR-C36-zayt, AR-C34-taam]
+---
+
+# طبق (ṭabaq) — "a plate," and a broken plural that repeats
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] One broken plural is a surprise. Two in the same shape is a
+pattern — and a pattern you can use.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C36-TABAQ-01]; assesses=[AR-CONCEPT-C34-TAAM-01, AR-CONCEPT-C36-KUB-01] -->
+
+Nothing new. **ط** (*ṭāʾ*) is the emphatic **ت**, named when you built
+**طعام** (*ṭaʿām*) — the dark, flat-tongued *t*, standing beside **ص** under
+**س** and **ض** under **د**.
+
+Then **ب** (*bāʾ*) and **ق** (*qāf*). All three join, so **طبق** runs unbroken
+— unlike **كوب**, which had to stop at its *wāw*.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C36-TABAQ-02]; assesses=[AR-CONCEPT-C36-KUB-02, AR-CONCEPT-C36-ZAYT-02, AR-CONCEPT-C34-TAAM-02] -->
+
+**طَبَق** (*ṭabaq*) = "**a plate, a dish**." Root **ط-ب-ق**.
+
+Its plural is **أَطْباق** (*aṭbāq*).
+
+Say that beside **أَكْواب** (*akwāb*) and listen. Same opening **أَ**, same
+long **ā** before the last letter, same nothing-added-at-the-end. Both are the
+shape **أَفْعال** (*afʿāl*). So the broken plural is not chaos: it is a small
+set of shapes, and you have now met the commonest one twice.
+
+The root itself means **to cover, to lie in layers** — a plate being the flat
+thing that covers. Which is why the same root gives:
+
+- **طابِق** (*ṭābiq*) — "**a storey**" of a building. A layer of house. And
+  notice its shape: that is the **doer** form of *ṣādiq* and *kātib*.
+- **طَبَقة** (*ṭabaqa*) — "**a layer**," and so "**a social class**," with the
+  tied **ة** on the end.
+
+A plate, a floor and a social class, off one idea about layers. And the plates
+themselves belong somewhere you already built: **مَطْعَم** (*maṭʿam*), the
+place of eating.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C36-TABAQ-01, AR-CONCEPT-C36-TABAQ-02, AR-CONCEPT-C36-KUB-01, AR-CONCEPT-C36-KUB-02, AR-CONCEPT-C36-ZAYT-02, AR-CONCEPT-C34-TAAM-01, AR-CONCEPT-C34-TAAM-02, AR-CONCEPT-C36-ZAYT-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: ṭāʾ, bāʾ, qāf — "ṭabaq," a plate]
+- [YOU SAY: the emphatic set once more — ṣād, ḍād, ṭāʾ]
+- [YOU SAY: the two broken plurals — akwāb, aṭbāq, both in the shape afʿāl]
+- [YOU SAY: what the root means — to cover, to lie in layers]
+- [YOU SAY: its other children — ṭābiq, a storey; ṭabaqa, a layer or a class]
+- [YOU SAY: where the plates live — maṭʿam, the place of eating]
+- [YOU SAY: the oil, whose zāy is rā plus a dot — zayt, zaytūn]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C36-TABAQ-01, AR-CONCEPT-C36-TABAQ-02, AR-CONCEPT-C36-KUB-02, AR-CONCEPT-C36-ZAYT-02, AR-CONCEPT-C34-TAAM-01, AR-CONCEPT-C34-TAAM-02] -->
+
+[PAUSE 3s] What shape do **أكواب** and **أطباق** share? (***Afʿāl*** — the
+broken plural you have now met twice.) What does **ط-ب-ق** mean? (**To cover,
+to lie in layers**.) Name two more words it builds. (***Ṭābiq***, a storey, and
+***ṭabaqa***, a layer or a class.) Which plain letter is **ط** the emphatic
+partner of? (***Tāʾ***.) Where would you find a stack of *aṭbāq*? (**In a
+*maṭʿam*** — the place of eating.)

--- a/code/learning/human-languages/arabic/lessons/AR-C36-zayt.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C36-zayt.md
@@ -1,0 +1,96 @@
+---
+schema_version: 2
+id: AR-C36-zayt
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 970
+chapter: 36
+type: word
+headword: زيت
+gloss: "oil" — one new letter that is only rā wearing a dot, and a second Spanish word carrying Arabic's article welded to its front
+concept_tag: AR-FOOD-OIL
+romanization: zayt
+prerequisites: [AR-C35-sadiq, AR-W08-kaf-and-ra]
+sounds: [zay, rtl-known-letters]
+roots: [z-y-t]
+etymology_hook: "زَيْت (zayt, 'oil') and زَيْتون (zaytūn, 'olives') sit on the root ز-ي-ت, and Spanish borrowed both of them with the article still attached: الزَّيت (az-zayt) became aceite, 'oil', and الزَّيتونة (az-zaytūna) became aceituna, 'an olive' — the same welding already seen in azúcar; the letter ز (zāy) is simply ر (rā) with one dot above it, and like rā it refuses to join what follows"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [AR-CONCEPT-C35-SADIQ-02]
+introduces:
+  knowledge: [AR-CONCEPT-C36-ZAYT-01, AR-CONCEPT-C36-ZAYT-02]
+practises:
+  knowledge: [AR-CONCEPT-C36-ZAYT-01, AR-CONCEPT-C36-ZAYT-02, AR-CONCEPT-C35-SADIQ-01, AR-CONCEPT-C35-SADIQ-02, AR-CONCEPT-C35-IBN-BINT-02, AR-CONCEPT-C33-SUKKAR-02, AR-CONCEPT-W08-KAF-AND-RA-02, AR-CONCEPT-C35-IBN-BINT-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: modern-standard-arabic
+reviews_of: [AR-C35-sadiq, AR-C35-ibn-bint, AR-C33-sukkar, AR-W08-kaf-and-ra]
+---
+
+# زيت (zayt) — "oil," and a letter you already knew
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+[PAUSE 2s] One new letter to name — and you will find you already own it,
+because it is an old letter wearing a dot.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C36-ZAYT-01]; assesses=[AR-CONCEPT-W08-KAF-AND-RA-02, AR-CONCEPT-C35-SADIQ-01] -->
+
+**ز** is **zāy**, the *z*. And here is all there is to it: **ز** is **ر**
+(*rā*) with **one dot above**.
+
+That is the abjad's favourite trick. **ب**, **ن** and **ت** share one bowl and
+differ by dots. **ح**, **خ** and **ج** share one hook. Now **ر** and **ز**
+share one curve.
+
+Everything *rā* does, *zāy* does: it hangs below the line and **refuses to
+join** what follows — the non-joiner that ended **سكر**.
+
+Then **ي** (*yāʾ*) and **ت** (*tāʾ*). So **زيت** is **ز** alone, then **يت**
+joined.
+
+## The word, taken apart
+<!-- hl-knowledge: introduces=[AR-CONCEPT-C36-ZAYT-02]; assesses=[AR-CONCEPT-C33-SUKKAR-02, AR-CONCEPT-C35-IBN-BINT-02] -->
+
+**زَيْت** (*zayt*) = "**oil**" — in the first place olive oil, and by extension
+oil of any kind. Root **ز-ي-ت**, which also gives:
+
+- **زَيْتون** (*zaytūn*) — "**olives**."
+- **زَيْتونة** (*zaytūna*) — "**an olive**," one of them, with the tied **ة**
+  making the single thing out of the collective.
+
+And now Spain. You met **azúcar** and found Arabic's **al-** welded onto its
+front. The same thing happened here, twice over:
+
+- **الزَّيت** (*az-zayt*) became Spanish **aceite**, "oil."
+- **الزَّيتونة** (*az-zaytūna*) became Spanish **aceituna**, "an olive."
+
+**ز** is a **sun letter**, which is why *al-* is said *az-* — the assimilation
+that makes *al-* + *sukkar* into *as-sukkar*. Spanish took the sound it heard,
+article and all. Portuguese did the same with **azeite**.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C36-ZAYT-01, AR-CONCEPT-C36-ZAYT-02, AR-CONCEPT-C35-SADIQ-01, AR-CONCEPT-C35-SADIQ-02, AR-CONCEPT-C35-IBN-BINT-02, AR-CONCEPT-C33-SUKKAR-02, AR-CONCEPT-W08-KAF-AND-RA-02, AR-CONCEPT-C35-IBN-BINT-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: zāy is rā plus one dot above, and it breaks as rā breaks]
+- [YOU SAY: the dot families — bāʾ, nūn, tāʾ; ḥāʾ, khāʾ, jīm; rā and zāy]
+- [YOU SAY: zāy, yāʾ, tāʾ — "zayt," oil]
+- [YOU SAY: the olives — zaytūn; one olive, zaytūna]
+- [YOU SAY: the welded article — az-zayt gave aceite, as-sukkar gave azúcar]
+- [YOU SAY: the friend and his root — ṣadīq, from ṣ-d-q, to be true]
+- [YOU SAY: the pair one letter apart — ibn, bint]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[AR-CONCEPT-C36-ZAYT-01, AR-CONCEPT-C36-ZAYT-02, AR-CONCEPT-C35-SADIQ-02, AR-CONCEPT-C35-IBN-BINT-02, AR-CONCEPT-C33-SUKKAR-02, AR-CONCEPT-W08-KAF-AND-RA-02] -->
+
+[PAUSE 3s] What is **ز**, described from a letter you had? (***Rā*** **with
+one dot above** — and it breaks the same way.) What does **ز-ي-ت** give besides
+oil? (***Zaytūn*** and ***zaytūna***.) Which Spanish words carry this root with
+Arabic's article stuck on, and which one did *sukkar* give? (***Aceite*** and
+***aceituna***; ***azúcar***.) Why *az-* rather than *al-*? (**ز is a sun
+letter**.)

--- a/code/learning/human-languages/arabic/narration/ch33.json
+++ b/code/learning/human-languages/arabic/narration/ch33.json
@@ -1,0 +1,744 @@
+{
+  "version": 1,
+  "language": "arabic",
+  "chapter": 33,
+  "title": "Asking for a Drink",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:3e7842268901fc1c",
+  "lessons": [
+    {
+      "id": "AR-C33-shay",
+      "sequence": 860,
+      "title": "شاي (shāy) — \"tea,\" and a word with no root",
+      "headword": "شاي",
+      "romanization": "shāy",
+      "gloss": "\"tea\" — the first noun in this book with no Arabic root at all, and a word that reached Arabic and English from the same Chinese original by two different roads",
+      "script": "arabic",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:d386b81660d43aa0",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Every Arabic word you have taken apart so far had a root under it. This one does not — and that absence is the lesson."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Nothing new. ش (shīn) has been on the page since شكرا (shukran): the sīn skeleton with three dots above it. Then ا (alif), the non-joiner, and ي (yāʾ)."
+            },
+            {
+              "kind": "speech",
+              "text": "So شاي (shāy) breaks where alif forces it to break: شا, then ي. That is the same two-piece split you met in أحبّ — أ standing alone, then حبّ."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "شاي (shāy) = \"tea.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Now the honest part. Take كتب (kataba): its root pours into كِتاب (kitāb, a book), كاتِب (kātib, a writer), مَكْتَب (maktab, an office) and مَكْتَبة (maktaba, a library). Try that with shāy and nothing comes out. There is no shape it fills, no doer, no place, no done-to."
+            },
+            {
+              "kind": "speech",
+              "text": "That is because shāy is borrowed, and a borrowed word arrives without a root. Arabic took it through Persian چای (chāy), which took it from the northern Chinese chá."
+            },
+            {
+              "kind": "speech",
+              "text": "Your own language took the same Chinese word by the other road. Traders on the southern coast of China said it tê, Dutch ships carried that form to Europe, and it became English tea, French thé, German Tee. Overland through Persia it stayed chá: Russian chay, Turkish çay, Arabic shāy."
+            },
+            {
+              "kind": "speech",
+              "text": "So shāy and tea are not merely similar. They are the two ends of one word, separated by which way it left China."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "shīn, alif, yāʾ — \"shāy,\" tea",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: shīn, alif, yāʾ — \"shāy,\" tea]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "where it breaks — shā, then yāʾ, as أحبّ broke after the alif",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: where it breaks — shā, then yāʾ, as أحبّ broke after the alif]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what a root gives — kitāb, kātib, maktab, maktaba",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what a root gives — kitāb, kātib, maktab, maktaba]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what shāy gives — nothing, because it was borrowed",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what shāy gives — nothing, because it was borrowed]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the overland road — Chinese chá, Persian chāy, Arabic shāy",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the overland road — Chinese chá, Persian chāy, Arabic shāy]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the sea road — Hokkien tê, Dutch, English tea",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the sea road — Hokkien tê, Dutch, English tea]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Why can you not build a word family from شاي? (It has no Arabic root — it was borrowed, and borrowed words arrive without one.) Name what ك-ت-ب builds, for contrast. (Kitāb, kātib, maktab, maktaba.) Which language handed shāy to Arabic, and which language did that one take it from? (Persian, from Chinese.) Is English tea a relative? (Yes — the same Chinese word, carried by sea rather than overland.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "AR-C33-halib",
+      "sequence": 870,
+      "title": "حليب (ḥalīb) — \"milk,\" and the verb underneath it",
+      "headword": "حليب",
+      "romanization": "ḥalīb",
+      "gloss": "\"milk\" — the opposite case to shāy: a home-grown noun sitting straight on the verb for milking, and a Hebrew twin that is the same word",
+      "script": "arabic",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:28e14939b0409873",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Yesterday's word had no root to stand on. This one has a root so plain you can hear the verb inside the noun."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Nothing new again. ح (ḥāʾ) is the undotted member of the hook-and-tail family — the body it shares with خ (khāʾ, one dot above) and ج (jīm, one dot below). It is the hard breath from deep in the throat that opens أحبّ (ʾaḥabba)."
+            },
+            {
+              "kind": "speech",
+              "text": "Then ل (lām), ي (yāʾ) carrying the long ī, and ب (bāʾ)."
+            },
+            {
+              "kind": "speech",
+              "text": "All four join, so حليب (ḥalīb) runs as one unbroken stroke — the opposite of شاي (shāy), which had to stop at its alif."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "حَليب (ḥalīb) = \"milk.\" Root ح-ل-ب, and its verb is حَلَبَ (ḥalaba), \"he milked.\" So the noun is simply the milked thing."
+            },
+            {
+              "kind": "speech",
+              "text": "You have met this exact transparency before. خبز (khubz, bread) sits on خ-ب-ز, \"to bake\": the baked thing. Arabic does this constantly — name the action, and the everyday noun falls out of it."
+            },
+            {
+              "kind": "speech",
+              "text": "The pattern ḥalīb wears, فَعيل (faʿīl), is one to keep. It takes a root and hands back a quality or a result you can hold."
+            },
+            {
+              "kind": "speech",
+              "text": "Hebrew has the word unchanged: חָלָב (ḥalav), \"milk,\" the same root doing the same job — the family resemblance already heard in salām and shalom."
+            },
+            {
+              "kind": "speech",
+              "text": "One caution, because a good story is not the same as a true one. The Syrian city حَلَب (Ḥalab, English Aleppo) is often explained as a milk name. It is not: Ḥalab appears in Bronze Age records centuries before Arabic was written, so the milk account is a later invention hung on a name that already existed. No English word descends from ح-ل-ب at all."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the hook family — ḥāʾ no dot, khāʾ one above, jīm one below",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the hook family — ḥāʾ no dot, khāʾ one above, jīm one below]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ḥāʾ, lām, yāʾ, bāʾ — \"ḥalīb,\" milk",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: ḥāʾ, lām, yāʾ, bāʾ — \"ḥalīb,\" milk]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the verb under it — \"ḥalaba,\" he milked",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the verb under it — \"ḥalaba,\" he milked]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the same move in bread — khubz, from kh-b-z, to bake",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the same move in bread — khubz, from kh-b-z, to bake]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the pattern — faʿīl, as in ḥalīb",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the pattern — faʿīl, as in ḥalīb]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the borrowed one against the built one — shāy, then ḥalīb",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the borrowed one against the built one — shāy, then ḥalīb]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the Hebrew twin — ḥalav",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the Hebrew twin — ḥalav]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does the root ح-ل-ب mean as a verb? (To milk — so ḥalīb is the milked thing.) Which earlier word works the same way? (Khubz — bread, from kh-b-z, to bake.) Which of the chapter's words so far has no root at all? (Shāy — it was borrowed.) Is Aleppo named for milk? (No — the name is far older than Arabic; that story is folk etymology.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "AR-C33-sukkar",
+      "sequence": 880,
+      "title": "سكر (sukkar) — \"sugar,\" and an Arabic article stuck to a Spanish word",
+      "headword": "سكر",
+      "romanization": "sukkar",
+      "gloss": "\"sugar\" — a word that crossed Asia and Europe, and the one that shows Arabic's own al- fused onto the front of a Spanish noun",
+      "script": "arabic",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:db0d13a9953e0c80",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Another traveller — and this one left a piece of Arabic grammar behind in Spain."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Nothing new. س (sīn), the low comb; ك (kāf), the angular k; and ر (rā), the little downward curve that breaks — a non-joiner, like alif. So سكر (sukkar) joins from sīn to kāf, and rā hangs off the end."
+            },
+            {
+              "kind": "speech",
+              "text": "Written fully it is سُكَّر, and the mark over the ك is the shadda. You have seen it do two jobs. On فكّر (fakkara) it built a new verb out of an old root. Here it does the quieter job it did on أحبّ: it spells a letter the word already owns twice over — suk-kar."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "سُكَّر (sukkar) = \"sugar.\" Like shāy, and unlike ḥalīb, it is borrowed: no Arabic root, no family of shapes."
+            },
+            {
+              "kind": "speech",
+              "text": "Its road west starts in Sanskrit, where śarkarā meant \"grit, gravel\" — sugar named for its coarse grains. Persian took it as shakar, Arabic as sukkar, and Arabic carried it into medieval Latin as succarum. From there: Italian zucchero, French sucre, German Zucker, English sugar."
+            },
+            {
+              "kind": "speech",
+              "text": "Then Spanish, which shows what the others hide. Spanish for sugar is azúcar — and that opening a-z- is Arabic's own الـ (al-), the article, welded onto the front of the noun. Spanish borrowed al-sukkar whole and never took it apart."
+            },
+            {
+              "kind": "speech",
+              "text": "You know why the l vanished: س is a sun letter, so al- + sukkar is said as-sukkar, as al- + salām is said as-salām. Spanish kept the sound, not the spelling. English holds algebra and alcohol."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "sīn, kāf, rā — and rā breaks, so nothing joins after it",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: sīn, kāf, rā — and rā breaks, so nothing joins after it]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sukkar,\" sugar — the shadda doubling the kāf, suk-kar",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sukkar,\" sugar — the shadda doubling the kāf, suk-kar]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the shadda's two jobs — fakkara built a verb, ʾaḥabba spelled one",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the shadda's two jobs — fakkara built a verb, ʾaḥabba spelled one]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the road — Sanskrit śarkarā, Persian shakar, Arabic sukkar",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the road — Sanskrit śarkarā, Persian shakar, Arabic sukkar]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the article that stayed — as-sukkar, Spanish azúcar",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the article that stayed — as-sukkar, Spanish azúcar]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the sun letter — al- plus salām said as-salām",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the sun letter — al- plus salām said as-salām]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "borrowed, borrowed, built — shāy, sukkar, ḥalīb",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: borrowed, borrowed, built — shāy, sukkar, ḥalīb]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the letters before it — shīn, alif, yāʾ; then ḥāʾ, lām, yāʾ, bāʾ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the letters before it — shīn, alif, yāʾ; then ḥāʾ, lām, yāʾ, bāʾ]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Which letter in سكر refuses to join what follows? (Rā.) What is the shadda doing here, and which earlier verb used it the same way? (Only spelling a doubled letter — as in ʾaḥabba, not as in fakkara.) What language did sukkar come from before Persian? (Sanskrit — śarkarā, \"grit.\") What is hiding at the front of Spanish azúcar? (Arabic al-, said as- before a sun letter.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "AR-C33-qahwa",
+      "sequence": 890,
+      "title": "قهوة (qahwa) — \"coffee,\" the tied tāʾ, and asking for all of it",
+      "headword": "قهوة",
+      "romanization": "qahwa",
+      "gloss": "\"coffee\" — the chapter's payoff, where the tied tāʾ finally earns its keep as Arabic's visible gender marker, and where you can order everything the chapter taught",
+      "script": "arabic",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:537116d3714fb966",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The chapter closes on a word your own language already borrowed — and on the small letter at its end that tells you the word is feminine."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Nothing new. ق (qāf, two dots above), the k made far back in the throat; ه (hāʾ), the loop that changes shape wherever it stands; و (wāw), a non-joiner like rā; and then ة."
+            },
+            {
+              "kind": "speech",
+              "text": "ة is the tāʾ marbūṭa, the \"tied tāʾ\" — an ه with tāʾ's two dots on it. It appears only at the end of a word."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "قَهْوة (qahwa) = \"coffee.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Here is what the ة buys you. Arabic nouns carry gender, and Arabic usually shows you which is which: a noun ending in ة is almost always feminine. That is a rule you apply on sight, not a list to memorise."
+            },
+            {
+              "kind": "speech",
+              "text": "You have watched it work already:"
+            },
+            {
+              "kind": "speech",
+              "text": "مَكْتَب (maktab), an office, becomes مَكْتَبة (maktaba), a library."
+            },
+            {
+              "kind": "speech",
+              "text": "سَلام (salām), peace, becomes السَّلامة (as-salāma), the safety — the root س-ل-م wearing an ending and a pattern."
+            },
+            {
+              "kind": "speech",
+              "text": "So qahwa is feminine, while shāy, ḥalīb and sukkar are masculine — and the ending alone told you."
+            },
+            {
+              "kind": "speech",
+              "text": "The road out of Arabic is short and well lit. Ottoman Turkish took qahwa as kahve; Venetian traders took kahve as Italian caffè; from Italian came French café, German Kaffee and English coffee. The English word in your mouth is this Arabic one."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "qāf, hāʾ, wāw, tāʾ marbūṭa — \"qahwa,\" coffee",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: qāf, hāʾ, wāw, tāʾ marbūṭa — \"qahwa,\" coffee]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the tied tāʾ — an hāʾ wearing tāʾ's two dots, only at a word's end",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the tied tāʾ — an hāʾ wearing tāʾ's two dots, only at a word's end]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what it marks — feminine; maktab becomes maktaba, salām becomes as-salāma",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what it marks — feminine; maktab becomes maktaba, salām becomes as-salāma]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "gendered — qahwa feminine; shāy, ḥalīb, sukkar masculine",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: gendered — qahwa feminine; shāy, ḥalīb, sukkar masculine]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "order each — \"shāy, min faḍlik\"; \"qahwa, min faḍlik\"; \"ḥalīb, min faḍlik\"; \"sukkar, min faḍlik\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: order each — \"shāy, min faḍlik\"; \"qahwa, min faḍlik\"; \"ḥalīb, min faḍlik\"; \"sukkar, min faḍlik\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the answer to thanks — \"ʿafwan,\" think nothing of it",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the answer to thanks — \"ʿafwan,\" think nothing of it]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ḥalīb joined throughout, sukkar's rā broke, and the wāw breaks here",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: ḥalīb joined throughout, sukkar's rā broke, and the wāw breaks here]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "built against borrowed — ḥalaba gave ḥalīb; shāy and sukkar gave nothing",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: built against borrowed — ḥalaba gave ḥalīb; shāy and sukkar gave nothing]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Which of this chapter's words is feminine, and how can you tell? (Qahwa — it ends in ة.) Name two earlier words with that ending. (Maktaba and as-salāma.) Ask for each drink politely. (Shāy, qahwa, ḥalīb, sukkar — each with min faḍlik, \"from your grace.\") What do you answer when someone thanks you? (ʿAfwan.) Which word here was built from a verb? (Ḥalīb, from ḥalaba — the others travelled in.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/arabic/narration/ch33.txt
+++ b/code/learning/human-languages/arabic/narration/ch33.txt
@@ -1,0 +1,174 @@
+Arabic, chapter 33: Asking for a Drink.
+4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+
+
+Lesson 1 of 4.
+شاي (shāy) — "tea," and a word with no root.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Every Arabic word you have taken apart so far had a root under it. This one does not — and that absence is the lesson.
+
+The letters in this word.
+Nothing new. ش (shīn) has been on the page since شكرا (shukran): the sīn skeleton with three dots above it. Then ا (alif), the non-joiner, and ي (yāʾ).
+So شاي (shāy) breaks where alif forces it to break: شا, then ي. That is the same two-piece split you met in أحبّ — أ standing alone, then حبّ.
+
+The word, taken apart.
+شاي (shāy) = "tea."
+Now the honest part. Take كتب (kataba): its root pours into كِتاب (kitāb, a book), كاتِب (kātib, a writer), مَكْتَب (maktab, an office) and مَكْتَبة (maktaba, a library). Try that with shāy and nothing comes out. There is no shape it fills, no doer, no place, no done-to.
+That is because shāy is borrowed, and a borrowed word arrives without a root. Arabic took it through Persian چای (chāy), which took it from the northern Chinese chá.
+Your own language took the same Chinese word by the other road. Traders on the southern coast of China said it tê, Dutch ships carried that form to Europe, and it became English tea, French thé, German Tee. Overland through Persia it stayed chá: Russian chay, Turkish çay, Arabic shāy.
+So shāy and tea are not merely similar. They are the two ends of one word, separated by which way it left China.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: shīn, alif, yāʾ — "shāy," tea]
+[pause 8 seconds for the answer]
+[your turn — say: where it breaks — shā, then yāʾ, as أحبّ broke after the alif]
+[pause 8 seconds for the answer]
+[your turn — say: what a root gives — kitāb, kātib, maktab, maktaba]
+[pause 8 seconds for the answer]
+[your turn — say: what shāy gives — nothing, because it was borrowed]
+[pause 8 seconds for the answer]
+[your turn — say: the overland road — Chinese chá, Persian chāy, Arabic shāy]
+[pause 8 seconds for the answer]
+[your turn — say: the sea road — Hokkien tê, Dutch, English tea]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Why can you not build a word family from شاي? (It has no Arabic root — it was borrowed, and borrowed words arrive without one.) Name what ك-ت-ب builds, for contrast. (Kitāb, kātib, maktab, maktaba.) Which language handed shāy to Arabic, and which language did that one take it from? (Persian, from Chinese.) Is English tea a relative? (Yes — the same Chinese word, carried by sea rather than overland.)
+
+
+Lesson 2 of 4.
+حليب (ḥalīb) — "milk," and the verb underneath it.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Yesterday's word had no root to stand on. This one has a root so plain you can hear the verb inside the noun.
+
+The letters in this word.
+Nothing new again. ح (ḥāʾ) is the undotted member of the hook-and-tail family — the body it shares with خ (khāʾ, one dot above) and ج (jīm, one dot below). It is the hard breath from deep in the throat that opens أحبّ (ʾaḥabba).
+Then ل (lām), ي (yāʾ) carrying the long ī, and ب (bāʾ).
+All four join, so حليب (ḥalīb) runs as one unbroken stroke — the opposite of شاي (shāy), which had to stop at its alif.
+
+The word, taken apart.
+حَليب (ḥalīb) = "milk." Root ح-ل-ب, and its verb is حَلَبَ (ḥalaba), "he milked." So the noun is simply the milked thing.
+You have met this exact transparency before. خبز (khubz, bread) sits on خ-ب-ز, "to bake": the baked thing. Arabic does this constantly — name the action, and the everyday noun falls out of it.
+The pattern ḥalīb wears, فَعيل (faʿīl), is one to keep. It takes a root and hands back a quality or a result you can hold.
+Hebrew has the word unchanged: חָלָב (ḥalav), "milk," the same root doing the same job — the family resemblance already heard in salām and shalom.
+One caution, because a good story is not the same as a true one. The Syrian city حَلَب (Ḥalab, English Aleppo) is often explained as a milk name. It is not: Ḥalab appears in Bronze Age records centuries before Arabic was written, so the milk account is a later invention hung on a name that already existed. No English word descends from ح-ل-ب at all.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the hook family — ḥāʾ no dot, khāʾ one above, jīm one below]
+[pause 8 seconds for the answer]
+[your turn — say: ḥāʾ, lām, yāʾ, bāʾ — "ḥalīb," milk]
+[pause 8 seconds for the answer]
+[your turn — say: the verb under it — "ḥalaba," he milked]
+[pause 8 seconds for the answer]
+[your turn — say: the same move in bread — khubz, from kh-b-z, to bake]
+[pause 8 seconds for the answer]
+[your turn — say: the pattern — faʿīl, as in ḥalīb]
+[pause 8 seconds for the answer]
+[your turn — say: the borrowed one against the built one — shāy, then ḥalīb]
+[pause 8 seconds for the answer]
+[your turn — say: the Hebrew twin — ḥalav]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does the root ح-ل-ب mean as a verb? (To milk — so ḥalīb is the milked thing.) Which earlier word works the same way? (Khubz — bread, from kh-b-z, to bake.) Which of the chapter's words so far has no root at all? (Shāy — it was borrowed.) Is Aleppo named for milk? (No — the name is far older than Arabic; that story is folk etymology.)
+
+
+Lesson 3 of 4.
+سكر (sukkar) — "sugar," and an Arabic article stuck to a Spanish word.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Another traveller — and this one left a piece of Arabic grammar behind in Spain.
+
+The letters in this word.
+Nothing new. س (sīn), the low comb; ك (kāf), the angular k; and ر (rā), the little downward curve that breaks — a non-joiner, like alif. So سكر (sukkar) joins from sīn to kāf, and rā hangs off the end.
+Written fully it is سُكَّر, and the mark over the ك is the shadda. You have seen it do two jobs. On فكّر (fakkara) it built a new verb out of an old root. Here it does the quieter job it did on أحبّ: it spells a letter the word already owns twice over — suk-kar.
+
+The word, taken apart.
+سُكَّر (sukkar) = "sugar." Like shāy, and unlike ḥalīb, it is borrowed: no Arabic root, no family of shapes.
+Its road west starts in Sanskrit, where śarkarā meant "grit, gravel" — sugar named for its coarse grains. Persian took it as shakar, Arabic as sukkar, and Arabic carried it into medieval Latin as succarum. From there: Italian zucchero, French sucre, German Zucker, English sugar.
+Then Spanish, which shows what the others hide. Spanish for sugar is azúcar — and that opening a-z- is Arabic's own الـ (al-), the article, welded onto the front of the noun. Spanish borrowed al-sukkar whole and never took it apart.
+You know why the l vanished: س is a sun letter, so al- + sukkar is said as-sukkar, as al- + salām is said as-salām. Spanish kept the sound, not the spelling. English holds algebra and alcohol.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: sīn, kāf, rā — and rā breaks, so nothing joins after it]
+[pause 8 seconds for the answer]
+[your turn — say: "sukkar," sugar — the shadda doubling the kāf, suk-kar]
+[pause 8 seconds for the answer]
+[your turn — say: the shadda's two jobs — fakkara built a verb, ʾaḥabba spelled one]
+[pause 8 seconds for the answer]
+[your turn — say: the road — Sanskrit śarkarā, Persian shakar, Arabic sukkar]
+[pause 8 seconds for the answer]
+[your turn — say: the article that stayed — as-sukkar, Spanish azúcar]
+[pause 8 seconds for the answer]
+[your turn — say: the sun letter — al- plus salām said as-salām]
+[pause 8 seconds for the answer]
+[your turn — say: borrowed, borrowed, built — shāy, sukkar, ḥalīb]
+[pause 8 seconds for the answer]
+[your turn — say: the letters before it — shīn, alif, yāʾ; then ḥāʾ, lām, yāʾ, bāʾ]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Which letter in سكر refuses to join what follows? (Rā.) What is the shadda doing here, and which earlier verb used it the same way? (Only spelling a doubled letter — as in ʾaḥabba, not as in fakkara.) What language did sukkar come from before Persian? (Sanskrit — śarkarā, "grit.") What is hiding at the front of Spanish azúcar? (Arabic al-, said as- before a sun letter.)
+
+
+Lesson 4 of 4.
+قهوة (qahwa) — "coffee," the tied tāʾ, and asking for all of it.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The chapter closes on a word your own language already borrowed — and on the small letter at its end that tells you the word is feminine.
+
+The letters in this word.
+Nothing new. ق (qāf, two dots above), the k made far back in the throat; ه (hāʾ), the loop that changes shape wherever it stands; و (wāw), a non-joiner like rā; and then ة.
+ة is the tāʾ marbūṭa, the "tied tāʾ" — an ه with tāʾ's two dots on it. It appears only at the end of a word.
+
+The word, taken apart.
+قَهْوة (qahwa) = "coffee."
+Here is what the ة buys you. Arabic nouns carry gender, and Arabic usually shows you which is which: a noun ending in ة is almost always feminine. That is a rule you apply on sight, not a list to memorise.
+You have watched it work already:
+مَكْتَب (maktab), an office, becomes مَكْتَبة (maktaba), a library.
+سَلام (salām), peace, becomes السَّلامة (as-salāma), the safety — the root س-ل-م wearing an ending and a pattern.
+So qahwa is feminine, while shāy, ḥalīb and sukkar are masculine — and the ending alone told you.
+The road out of Arabic is short and well lit. Ottoman Turkish took qahwa as kahve; Venetian traders took kahve as Italian caffè; from Italian came French café, German Kaffee and English coffee. The English word in your mouth is this Arabic one.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: qāf, hāʾ, wāw, tāʾ marbūṭa — "qahwa," coffee]
+[pause 8 seconds for the answer]
+[your turn — say: the tied tāʾ — an hāʾ wearing tāʾ's two dots, only at a word's end]
+[pause 8 seconds for the answer]
+[your turn — say: what it marks — feminine; maktab becomes maktaba, salām becomes as-salāma]
+[pause 8 seconds for the answer]
+[your turn — say: gendered — qahwa feminine; shāy, ḥalīb, sukkar masculine]
+[pause 8 seconds for the answer]
+[your turn — say: order each — "shāy, min faḍlik"; "qahwa, min faḍlik"; "ḥalīb, min faḍlik"; "sukkar, min faḍlik"]
+[pause 8 seconds for the answer]
+[your turn — say: the answer to thanks — "ʿafwan," think nothing of it]
+[pause 8 seconds for the answer]
+[your turn — say: ḥalīb joined throughout, sukkar's rā broke, and the wāw breaks here]
+[pause 8 seconds for the answer]
+[your turn — say: built against borrowed — ḥalaba gave ḥalīb; shāy and sukkar gave nothing]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Which of this chapter's words is feminine, and how can you tell? (Qahwa — it ends in ة.) Name two earlier words with that ending. (Maktaba and as-salāma.) Ask for each drink politely. (Shāy, qahwa, ḥalīb, sukkar — each with min faḍlik, "from your grace.") What do you answer when someone thanks you? (ʿAfwan.) Which word here was built from a verb? (Ḥalīb, from ḥalaba — the others travelled in.)

--- a/code/learning/human-languages/arabic/narration/ch34.json
+++ b/code/learning/human-languages/arabic/narration/ch34.json
@@ -1,0 +1,782 @@
+{
+  "version": 1,
+  "language": "arabic",
+  "chapter": 34,
+  "title": "Asking for Food",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:136f91c8179d610f",
+  "lessons": [
+    {
+      "id": "AR-C34-milh",
+      "sequence": 900,
+      "title": "ملح (milḥ) — \"salt,\" and the sailor hiding in it",
+      "headword": "ملح",
+      "romanization": "milḥ",
+      "gloss": "\"salt\" — a plain Semitic word whose root also gives Arabic its sailor and its word for handsome, and which shows ḥāʾ in its final shape",
+      "script": "arabic",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:0f5ea9c24ee5e175",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A word for something you can hold in one hand — whose root stretches from a mineral to the open sea to a compliment."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Nothing new, but one shape is worth a second look. م (mīm), ل (lām), ح (ḥāʾ) — all three join, so ملح (milḥ) is one run of pen."
+            },
+            {
+              "kind": "speech",
+              "text": "The ح is the hook-and-tail letter that opened حليب (ḥalīb), but at the end of a word it grows its full tail and swings below the line: open at the start of ḥalīb, closed and tailed at the end of milḥ."
+            },
+            {
+              "kind": "speech",
+              "text": "قهوة made the same point at the other end of a word: ة exists only in final position."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "مِلْح (milḥ) = \"salt.\" Root م-ل-ح, and this is a root that has gone travelling inside its own language:"
+            },
+            {
+              "kind": "speech",
+              "text": "مَلّاح (mallāḥ) — \"a sailor.\" The man of the salt water. It wears the doubled lām shape Arabic keeps for trades and habits."
+            },
+            {
+              "kind": "speech",
+              "text": "مَليح (malīḥ) — \"handsome, pleasant.\" Salty, said of a person. Arabic reached for the same idea English reaches for when it calls a person the salt of the earth."
+            },
+            {
+              "kind": "speech",
+              "text": "Note malīḥ's shape: فَعيل (faʿīl), the same pattern that gave you حَليب (ḥalīb). A root plus that pattern hands back a quality."
+            },
+            {
+              "kind": "speech",
+              "text": "Hebrew has מֶלַח (melaḥ), \"salt,\" unchanged — one more Semitic twin. English is not in this family: salt comes down from Latin sāl and its Germanic cousins. And unlike sukkar, nothing here was borrowed."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "mīm, lām, ḥāʾ — \"milḥ,\" salt",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: mīm, lām, ḥāʾ — \"milḥ,\" salt]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ḥāʾ in two places — opening ḥalīb, closing milḥ with its tail",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: ḥāʾ in two places — opening ḥalīb, closing milḥ with its tail]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the root's reach — mallāḥ, a sailor; malīḥ, handsome",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the root's reach — mallāḥ, a sailor; malīḥ, handsome]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the faʿīl pattern twice — ḥalīb, malīḥ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the faʿīl pattern twice — ḥalīb, malīḥ]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the Hebrew twin — melaḥ; and no English relative, only Latin sāl",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the Hebrew twin — melaḥ; and no English relative, only Latin sāl]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the borrowed one for contrast — sukkar, from Sanskrit by way of Persian",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the borrowed one for contrast — sukkar, from Sanskrit by way of Persian]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the letters just behind — sīn, kāf, rā; qāf, hāʾ, wāw, tāʾ marbūṭa",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the letters just behind — sīn, kāf, rā; qāf, hāʾ, wāw, tāʾ marbūṭa]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What else does م-ل-ح give besides salt? (Mallāḥ, a sailor, and malīḥ, handsome.) Which pattern do malīḥ and ḥalīb share? (Faʿīl.) Why does the ح of milḥ not look like the ح of ḥalīb? (It is at the end of the word, so it takes its full tailed shape.) Does English salt belong to this family? (No — it descends from Latin sāl.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "AR-C34-lahm",
+      "sequence": 910,
+      "title": "لحم (laḥm) — \"meat,\" and the town on the seam",
+      "headword": "لحم",
+      "romanization": "laḥm",
+      "gloss": "\"meat\" — one Semitic root that Arabic settled on meat and Hebrew settled on bread, with Bethlehem sitting on the seam between them",
+      "script": "arabic",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:fc6790ceb65f68c5",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "This word and its Hebrew twin are the same root — and they mean different foods. There is a town whose name proves it."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Nothing new, and something pleasing: لحم (laḥm) is ملح (milḥ) read the other way about. The same shapes — ل (lām), ح (ḥāʾ), م (mīm) — in a different order, and so a different root and a different word."
+            },
+            {
+              "kind": "speech",
+              "text": "That is the root system stated as plainly as it can be. The letters are not the word. The order is the word."
+            },
+            {
+              "kind": "speech",
+              "text": "Here ḥāʾ sits in the middle, so it wears its joined-both-sides shape: neither ḥalīb's open opening nor milḥ's tailed ending."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "لَحْم (laḥm) = \"meat.\" Root ل-ح-م."
+            },
+            {
+              "kind": "speech",
+              "text": "Now the twin, and it is the best one in this book. Hebrew's לֶחֶם (leḥem) is the same root — and it means bread."
+            },
+            {
+              "kind": "speech",
+              "text": "Neither language changed the meaning. The old Semitic root named the staple food, and each people filled it with whatever theirs was: meat where herds mattered, bread where grain did."
+            },
+            {
+              "kind": "speech",
+              "text": "English already owns the proof. The town is بيت لحم (laḥm) (Bayt Laḥm) in Arabic and בֵּית לֶחֶם (Bēt Leḥem) in Hebrew — one name, in which bayt and bēt both mean \"a house of.\" English calls it Bethlehem: house of bread on one side of the seam, house of meat on the other."
+            },
+            {
+              "kind": "speech",
+              "text": "And notice what Arabic did not do. It had this root available for bread and did not use it. Arabic's bread is خبز (khubz), built on خ-ب-ز, \"to bake\" — the baked thing, as ḥalīb is the milked thing."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "lām, ḥāʾ, mīm — \"laḥm,\" meat",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: lām, ḥāʾ, mīm — \"laḥm,\" meat]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the same shapes reordered — mīm, lām, ḥāʾ is \"milḥ,\" salt",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the same shapes reordered — mīm, lām, ḥāʾ is \"milḥ,\" salt]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ḥāʾ in the middle, joined on both sides",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: ḥāʾ in the middle, joined on both sides]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the twin that shifted — laḥm is meat, Hebrew leḥem is bread",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the twin that shifted — laḥm is meat, Hebrew leḥem is bread]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the town on the seam — Bayt Laḥm, Bēt Leḥem, Bethlehem",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the town on the seam — Bayt Laḥm, Bēt Leḥem, Bethlehem]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "Arabic's own bread — khubz, from kh-b-z, to bake",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: Arabic's own bread — khubz, from kh-b-z, to bake]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the salt root's reach — mallāḥ, malīḥ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the salt root's reach — mallāḥ, malīḥ]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "qahwa's letters and its feminine ending — qāf, hāʾ, wāw, tāʾ marbūṭa",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: qahwa's letters and its feminine ending — qāf, hāʾ, wāw, tāʾ marbūṭa]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What separates لحم (laḥm) from ملح (milḥ)? (Only the order of the letters — the whole root system.) What does Hebrew leḥem mean, and why is that no contradiction? (Bread — the root named the staple food.) Which English place name carries both? (Bethlehem.) What is Arabic's own word for bread, and where from? (Khubz, from خ-ب-ز, \"to bake.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "AR-C34-jubn",
+      "sequence": 920,
+      "title": "جبن (jubn) — \"cheese,\" and where the root system stops",
+      "headword": "جبن",
+      "romanization": "jubn",
+      "gloss": "\"cheese\" — and an honest limit on the root system, because the very same three letters also spell cowardice and the two are not one idea",
+      "script": "arabic",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:23468191710d0fc0",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The root system has been paying you back for chapters. This word is where it politely declines to."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Nothing new. ج (jīm) is the third of the hook-and-tail family: the body of ح (ḥāʾ) and خ (khāʾ), marked by one dot below. Then ب (bāʾ), one dot below, and ن (nūn), one dot above."
+            },
+            {
+              "kind": "speech",
+              "text": "Dots are the whole difference here, as they were between the ḥāʾ of لحم (laḥm) and the khāʾ of خبز."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "جُبْن (jubn) = \"cheese.\" In everyday speech you will more often hear جِبْنة (jibna) — and that ending is the ة you now recognise on sight, doing its usual work."
+            },
+            {
+              "kind": "speech",
+              "text": "Now the honest part, because you have been taught to trust roots and this is where that trust needs a limit."
+            },
+            {
+              "kind": "speech",
+              "text": "جُبْن also means \"cowardice,\" and جَبان (jabān) is \"a coward.\" Same letters, same order. So is a cheese a coward?"
+            },
+            {
+              "kind": "speech",
+              "text": "No. Arabic's dictionaries list these as separate entries — words spelled alike, not one idea branching. Compare a real root: م-ل-ح carries salt into mallāḥ, the sailor of salt water, and into malīḥ, a salty compliment. You can feel the thread. Between cheese and cowardice there is none, and inventing one would be the mistake the milk story made of Aleppo."
+            },
+            {
+              "kind": "speech",
+              "text": "Two words can share three letters by accident. Arabic has many roots and few letters."
+            },
+            {
+              "kind": "speech",
+              "text": "English took none of this: cheese comes from Latin cāseus."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "jīm, bāʾ, nūn — \"jubn,\" cheese",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: jīm, bāʾ, nūn — \"jubn,\" cheese]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the hook family by dots — ḥāʾ none, khāʾ one above, jīm one below",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the hook family by dots — ḥāʾ none, khāʾ one above, jīm one below]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the everyday form — jibna, with the tied tāʾ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the everyday form — jibna, with the tied tāʾ]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the accident — jubn is also cowardice, jabān a coward",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the accident — jubn is also cowardice, jabān a coward]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the verdict — separate words, not one root branching",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the verdict — separate words, not one root branching]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "a real branching — milḥ, mallāḥ, malīḥ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: a real branching — milḥ, mallāḥ, malīḥ]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "meat and salt — laḥm, milḥ, the same shapes reordered",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: meat and salt — laḥm, milḥ, the same shapes reordered]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What separates ج from ح and خ? (One dot below.) What else do the letters of jubn spell? (Cowardice — jabān is a coward.) Are cheese and cowardice one root? (No — separate words that look alike.) Name a root that really does branch. (م-ل-ح — milḥ, mallāḥ, malīḥ.) What does the ending on jibna tell you? (Feminine, as qahwa is.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "AR-C34-taam",
+      "sequence": 930,
+      "title": "طعام (ṭaʿām) — \"food,\" and a restaurant you can build yourself",
+      "headword": "طعام",
+      "romanization": "ṭaʿām",
+      "gloss": "\"food\" — the chapter's payoff, where a root you have never met hands you the word for restaurant free of charge, because you already own the pattern",
+      "script": "arabic",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:4a7d4b03514270ed",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A new root, a new letter — and a word you will not have to be taught, because you already own the shape it comes in."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "One letter to name at last. ط is ṭāʾ, the emphatic partner of ت (tāʾ): the same t, said with the tongue flat, so the syllable goes dark around it."
+            },
+            {
+              "kind": "speech",
+              "text": "Arabic keeps a small set of emphatic pairs, and you have met the others without being told they were a set:"
+            },
+            {
+              "kind": "speech",
+              "text": "ص (ṣād) is the emphatic س (sīn) — the ص of صباح (ṣabāḥ)."
+            },
+            {
+              "kind": "speech",
+              "text": "ض (ḍād) is the emphatic د (dāl) — the ض of من فضلك (min faḍlik)."
+            },
+            {
+              "kind": "speech",
+              "text": "ط (ṭāʾ) is the emphatic ت (tāʾ) — this one."
+            },
+            {
+              "kind": "speech",
+              "text": "Then ع (ʿayn), the throat sound already named, ا (alif) and م (mīm). Ṭāʾ joins; alif does not, so طعام (ṭaʿām) runs طعا, then م."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "طَعام (ṭaʿām) = \"food.\" Root ط-ع-م, whose verb طَعِمَ (ṭaʿima) means \"he tasted,\" and whose bare noun طَعْم (ṭaʿm) is \"taste, flavour.\""
+            },
+            {
+              "kind": "speech",
+              "text": "So Arabic has two ways to speak of eating. أَكَلَ (akala) is the plain act — he ate. ط-ع-م goes through the tongue: tasting, and so the food that gets tasted."
+            },
+            {
+              "kind": "speech",
+              "text": "Now take the مَـ place shape you own. It made مَكْتَب (maktab), the place of writing, from ك-ت-ب, and مَذْهَب (madhhab) from ذ-ه-ب. Put ط-ع-م through it:"
+            },
+            {
+              "kind": "speech",
+              "text": "مَطْعَم (maṭʿam) — the place of eating. A restaurant."
+            },
+            {
+              "kind": "speech",
+              "text": "Nobody taught you that word. The pattern did."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ṭāʾ, ʿayn, alif, mīm — \"ṭaʿām,\" food",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: ṭāʾ, ʿayn, alif, mīm — \"ṭaʿām,\" food]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the emphatic set — ṣād under sīn, ḍād under dāl, ṭāʾ under tāʾ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the emphatic set — ṣād under sīn, ḍād under dāl, ṭāʾ under tāʾ]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "where you had them — ṣabāḥ, min faḍlik, now ṭaʿām",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: where you had them — ṣabāḥ, min faḍlik, now ṭaʿām]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the verb and the bare noun — ṭaʿima, he tasted; ṭaʿm, taste",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the verb and the bare noun — ṭaʿima, he tasted; ṭaʿm, taste]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "two ways to eat — akala the act, ṭaʿima the tasting",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: two ways to eat — akala the act, ṭaʿima the tasting]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the ma- place shape — madhhab, maktab, so maṭʿam, a restaurant",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the ma- place shape — madhhab, maktab, so maṭʿam, a restaurant]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the chapter's foods — milḥ, laḥm reversing its letters, jubn, ṭaʿām",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the chapter's foods — milḥ, laḥm reversing its letters, jubn, ṭaʿām]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "order them — \"laḥm, min faḍlik\"; \"jubn, min faḍlik\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: order them — \"laḥm, min faḍlik\"; \"jubn, min faḍlik\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "and the odd old one — māʾ, water, whose plural miyāh keeps no pattern",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: and the odd old one — māʾ, water, whose plural miyāh keeps no pattern]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Which plain letter is ط the emphatic partner of, and name the other pairs. (ت — with ص under س and ض under د.) What does ط-ع-م mean as a verb? (To taste.) Build \"restaurant\" from it, and name the earlier words in that shape. (Maṭʿam — like maktab and madhhab.) Ask for the chapter's foods politely. (Milḥ, laḥm, jubn, ṭaʿām — each with min faḍlik, \"from your grace.\") Which everyday word keeps no pattern at all? (Māʾ — its plural miyāh is irregular.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/arabic/narration/ch34.txt
+++ b/code/learning/human-languages/arabic/narration/ch34.txt
@@ -1,0 +1,183 @@
+Arabic, chapter 34: Asking for Food.
+4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+
+
+Lesson 1 of 4.
+ملح (milḥ) — "salt," and the sailor hiding in it.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+A word for something you can hold in one hand — whose root stretches from a mineral to the open sea to a compliment.
+
+The letters in this word.
+Nothing new, but one shape is worth a second look. م (mīm), ل (lām), ح (ḥāʾ) — all three join, so ملح (milḥ) is one run of pen.
+The ح is the hook-and-tail letter that opened حليب (ḥalīb), but at the end of a word it grows its full tail and swings below the line: open at the start of ḥalīb, closed and tailed at the end of milḥ.
+قهوة made the same point at the other end of a word: ة exists only in final position.
+
+The word, taken apart.
+مِلْح (milḥ) = "salt." Root م-ل-ح, and this is a root that has gone travelling inside its own language:
+مَلّاح (mallāḥ) — "a sailor." The man of the salt water. It wears the doubled lām shape Arabic keeps for trades and habits.
+مَليح (malīḥ) — "handsome, pleasant." Salty, said of a person. Arabic reached for the same idea English reaches for when it calls a person the salt of the earth.
+Note malīḥ's shape: فَعيل (faʿīl), the same pattern that gave you حَليب (ḥalīb). A root plus that pattern hands back a quality.
+Hebrew has מֶלַח (melaḥ), "salt," unchanged — one more Semitic twin. English is not in this family: salt comes down from Latin sāl and its Germanic cousins. And unlike sukkar, nothing here was borrowed.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: mīm, lām, ḥāʾ — "milḥ," salt]
+[pause 8 seconds for the answer]
+[your turn — say: ḥāʾ in two places — opening ḥalīb, closing milḥ with its tail]
+[pause 8 seconds for the answer]
+[your turn — say: the root's reach — mallāḥ, a sailor; malīḥ, handsome]
+[pause 8 seconds for the answer]
+[your turn — say: the faʿīl pattern twice — ḥalīb, malīḥ]
+[pause 8 seconds for the answer]
+[your turn — say: the Hebrew twin — melaḥ; and no English relative, only Latin sāl]
+[pause 8 seconds for the answer]
+[your turn — say: the borrowed one for contrast — sukkar, from Sanskrit by way of Persian]
+[pause 8 seconds for the answer]
+[your turn — say: the letters just behind — sīn, kāf, rā; qāf, hāʾ, wāw, tāʾ marbūṭa]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What else does م-ل-ح give besides salt? (Mallāḥ, a sailor, and malīḥ, handsome.) Which pattern do malīḥ and ḥalīb share? (Faʿīl.) Why does the ح of milḥ not look like the ح of ḥalīb? (It is at the end of the word, so it takes its full tailed shape.) Does English salt belong to this family? (No — it descends from Latin sāl.)
+
+
+Lesson 2 of 4.
+لحم (laḥm) — "meat," and the town on the seam.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+This word and its Hebrew twin are the same root — and they mean different foods. There is a town whose name proves it.
+
+The letters in this word.
+Nothing new, and something pleasing: لحم (laḥm) is ملح (milḥ) read the other way about. The same shapes — ل (lām), ح (ḥāʾ), م (mīm) — in a different order, and so a different root and a different word.
+That is the root system stated as plainly as it can be. The letters are not the word. The order is the word.
+Here ḥāʾ sits in the middle, so it wears its joined-both-sides shape: neither ḥalīb's open opening nor milḥ's tailed ending.
+
+The word, taken apart.
+لَحْم (laḥm) = "meat." Root ل-ح-م.
+Now the twin, and it is the best one in this book. Hebrew's לֶחֶם (leḥem) is the same root — and it means bread.
+Neither language changed the meaning. The old Semitic root named the staple food, and each people filled it with whatever theirs was: meat where herds mattered, bread where grain did.
+English already owns the proof. The town is بيت لحم (laḥm) (Bayt Laḥm) in Arabic and בֵּית לֶחֶם (Bēt Leḥem) in Hebrew — one name, in which bayt and bēt both mean "a house of." English calls it Bethlehem: house of bread on one side of the seam, house of meat on the other.
+And notice what Arabic did not do. It had this root available for bread and did not use it. Arabic's bread is خبز (khubz), built on خ-ب-ز, "to bake" — the baked thing, as ḥalīb is the milked thing.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: lām, ḥāʾ, mīm — "laḥm," meat]
+[pause 8 seconds for the answer]
+[your turn — say: the same shapes reordered — mīm, lām, ḥāʾ is "milḥ," salt]
+[pause 8 seconds for the answer]
+[your turn — say: ḥāʾ in the middle, joined on both sides]
+[pause 8 seconds for the answer]
+[your turn — say: the twin that shifted — laḥm is meat, Hebrew leḥem is bread]
+[pause 8 seconds for the answer]
+[your turn — say: the town on the seam — Bayt Laḥm, Bēt Leḥem, Bethlehem]
+[pause 8 seconds for the answer]
+[your turn — say: Arabic's own bread — khubz, from kh-b-z, to bake]
+[pause 8 seconds for the answer]
+[your turn — say: the salt root's reach — mallāḥ, malīḥ]
+[pause 8 seconds for the answer]
+[your turn — say: qahwa's letters and its feminine ending — qāf, hāʾ, wāw, tāʾ marbūṭa]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What separates لحم (laḥm) from ملح (milḥ)? (Only the order of the letters — the whole root system.) What does Hebrew leḥem mean, and why is that no contradiction? (Bread — the root named the staple food.) Which English place name carries both? (Bethlehem.) What is Arabic's own word for bread, and where from? (Khubz, from خ-ب-ز, "to bake.")
+
+
+Lesson 3 of 4.
+جبن (jubn) — "cheese," and where the root system stops.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The root system has been paying you back for chapters. This word is where it politely declines to.
+
+The letters in this word.
+Nothing new. ج (jīm) is the third of the hook-and-tail family: the body of ح (ḥāʾ) and خ (khāʾ), marked by one dot below. Then ب (bāʾ), one dot below, and ن (nūn), one dot above.
+Dots are the whole difference here, as they were between the ḥāʾ of لحم (laḥm) and the khāʾ of خبز.
+
+The word, taken apart.
+جُبْن (jubn) = "cheese." In everyday speech you will more often hear جِبْنة (jibna) — and that ending is the ة you now recognise on sight, doing its usual work.
+Now the honest part, because you have been taught to trust roots and this is where that trust needs a limit.
+جُبْن also means "cowardice," and جَبان (jabān) is "a coward." Same letters, same order. So is a cheese a coward?
+No. Arabic's dictionaries list these as separate entries — words spelled alike, not one idea branching. Compare a real root: م-ل-ح carries salt into mallāḥ, the sailor of salt water, and into malīḥ, a salty compliment. You can feel the thread. Between cheese and cowardice there is none, and inventing one would be the mistake the milk story made of Aleppo.
+Two words can share three letters by accident. Arabic has many roots and few letters.
+English took none of this: cheese comes from Latin cāseus.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: jīm, bāʾ, nūn — "jubn," cheese]
+[pause 8 seconds for the answer]
+[your turn — say: the hook family by dots — ḥāʾ none, khāʾ one above, jīm one below]
+[pause 8 seconds for the answer]
+[your turn — say: the everyday form — jibna, with the tied tāʾ]
+[pause 8 seconds for the answer]
+[your turn — say: the accident — jubn is also cowardice, jabān a coward]
+[pause 8 seconds for the answer]
+[your turn — say: the verdict — separate words, not one root branching]
+[pause 8 seconds for the answer]
+[your turn — say: a real branching — milḥ, mallāḥ, malīḥ]
+[pause 8 seconds for the answer]
+[your turn — say: meat and salt — laḥm, milḥ, the same shapes reordered]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What separates ج from ح and خ? (One dot below.) What else do the letters of jubn spell? (Cowardice — jabān is a coward.) Are cheese and cowardice one root? (No — separate words that look alike.) Name a root that really does branch. (م-ل-ح — milḥ, mallāḥ, malīḥ.) What does the ending on jibna tell you? (Feminine, as qahwa is.)
+
+
+Lesson 4 of 4.
+طعام (ṭaʿām) — "food," and a restaurant you can build yourself.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+A new root, a new letter — and a word you will not have to be taught, because you already own the shape it comes in.
+
+The letters in this word.
+One letter to name at last. ط is ṭāʾ, the emphatic partner of ت (tāʾ): the same t, said with the tongue flat, so the syllable goes dark around it.
+Arabic keeps a small set of emphatic pairs, and you have met the others without being told they were a set:
+ص (ṣād) is the emphatic س (sīn) — the ص of صباح (ṣabāḥ).
+ض (ḍād) is the emphatic د (dāl) — the ض of من فضلك (min faḍlik).
+ط (ṭāʾ) is the emphatic ت (tāʾ) — this one.
+Then ع (ʿayn), the throat sound already named, ا (alif) and م (mīm). Ṭāʾ joins; alif does not, so طعام (ṭaʿām) runs طعا, then م.
+
+The word, taken apart.
+طَعام (ṭaʿām) = "food." Root ط-ع-م, whose verb طَعِمَ (ṭaʿima) means "he tasted," and whose bare noun طَعْم (ṭaʿm) is "taste, flavour."
+So Arabic has two ways to speak of eating. أَكَلَ (akala) is the plain act — he ate. ط-ع-م goes through the tongue: tasting, and so the food that gets tasted.
+Now take the مَـ place shape you own. It made مَكْتَب (maktab), the place of writing, from ك-ت-ب, and مَذْهَب (madhhab) from ذ-ه-ب. Put ط-ع-م through it:
+مَطْعَم (maṭʿam) — the place of eating. A restaurant.
+Nobody taught you that word. The pattern did.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: ṭāʾ, ʿayn, alif, mīm — "ṭaʿām," food]
+[pause 8 seconds for the answer]
+[your turn — say: the emphatic set — ṣād under sīn, ḍād under dāl, ṭāʾ under tāʾ]
+[pause 8 seconds for the answer]
+[your turn — say: where you had them — ṣabāḥ, min faḍlik, now ṭaʿām]
+[pause 8 seconds for the answer]
+[your turn — say: the verb and the bare noun — ṭaʿima, he tasted; ṭaʿm, taste]
+[pause 8 seconds for the answer]
+[your turn — say: two ways to eat — akala the act, ṭaʿima the tasting]
+[pause 8 seconds for the answer]
+[your turn — say: the ma- place shape — madhhab, maktab, so maṭʿam, a restaurant]
+[pause 8 seconds for the answer]
+[your turn — say: the chapter's foods — milḥ, laḥm reversing its letters, jubn, ṭaʿām]
+[pause 8 seconds for the answer]
+[your turn — say: order them — "laḥm, min faḍlik"; "jubn, min faḍlik"]
+[pause 8 seconds for the answer]
+[your turn — say: and the odd old one — māʾ, water, whose plural miyāh keeps no pattern]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Which plain letter is ط the emphatic partner of, and name the other pairs. (ت — with ص under س and ض under د.) What does ط-ع-م mean as a verb? (To taste.) Build "restaurant" from it, and name the earlier words in that shape. (Maṭʿam — like maktab and madhhab.) Ask for the chapter's foods politely. (Milḥ, laḥm, jubn, ṭaʿām — each with min faḍlik, "from your grace.") Which everyday word keeps no pattern at all? (Māʾ — its plural miyāh is irregular.)

--- a/code/learning/human-languages/arabic/narration/ch35.json
+++ b/code/learning/human-languages/arabic/narration/ch35.json
@@ -1,0 +1,604 @@
+{
+  "version": 1,
+  "language": "arabic",
+  "chapter": 35,
+  "title": "The People You Introduce",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:b4d4d18659fdeeb2",
+  "lessons": [
+    {
+      "id": "AR-C35-jar",
+      "sequence": 940,
+      "title": "جار (jār) — \"neighbour,\" and a root with a letter in hiding",
+      "headword": "جار",
+      "romanization": "jār",
+      "gloss": "\"neighbour\" — the person you introduce most often, built on a hollow root whose middle letter hides exactly as qāla's does",
+      "script": "arabic",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:c3b5d894189ce2e2",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "After a chapter of things you order, a chapter of people you introduce — starting with the one who lives next door."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Nothing new, and it is short: ج (jīm, the hook-and-tail body with one dot below), ا (alif) and ر (rā). Both ا and ر are non-joiners, so جار (jār) barely joins at all — compare طعام, which broke once before its mīm."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "جار (jār) = \"a neighbour.\" Add the \"my\" ending of اسمي (ismī) and you have جاري (jārī), \"my neighbour\" — which is how the word usually arrives in a conversation."
+            },
+            {
+              "kind": "speech",
+              "text": "Now listen to the root. You can hear only j and r. But an Arabic root wants three consonants, and the missing one is in hiding: the root is ج-و-ر, and its و has collapsed into that long ا."
+            },
+            {
+              "kind": "speech",
+              "text": "You have watched this before. قال (qāla), \"he said,\" is ق-و-ل with the same disappearing و. Arabic calls these hollow roots, and the hidden letter comes back when the word changes shape:"
+            },
+            {
+              "kind": "speech",
+              "text": "جاوَرَ (jāwara) — \"he lived alongside.\" There is the و, in the open."
+            },
+            {
+              "kind": "speech",
+              "text": "جيران (jīrān) — \"neighbours,\" where it returns as a long ī."
+            },
+            {
+              "kind": "speech",
+              "text": "Hebrew's גֵּר (ger), a resident outsider living among a people, comes from the same Semitic root for dwelling alongside."
+            },
+            {
+              "kind": "speech",
+              "text": "English neighbour is no relative — it is Germanic, the nigh-dweller. Two unrelated languages built one word out of one idea, worth noticing because it is not descent."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "jīm, alif, rā — \"jār,\" a neighbour",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: jīm, alif, rā — \"jār,\" a neighbour]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "with the my ending — \"jārī,\" my neighbour, as ismī is my name",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: with the my ending — \"jārī,\" my neighbour, as ismī is my name]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the hidden letter — the root is j-w-r, and the wāw is inside the alif",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the hidden letter — the root is j-w-r, and the wāw is inside the alif]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the same hiding place — qāla, he said, from q-w-l",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the same hiding place — qāla, he said, from q-w-l]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "where it comes back — jāwara; jīrān, neighbours",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: where it comes back — jāwara; jīrān, neighbours]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the hook family by dots — ḥāʾ, khāʾ, jīm",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the hook family by dots — ḥāʾ, khāʾ, jīm]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the restaurant you built — maṭʿam, the place of eating",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the restaurant you built — maṭʿam, the place of eating]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the honest non-cousin — English neighbour, the nigh-dweller",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the honest non-cousin — English neighbour, the nigh-dweller]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What is جار (jār)'s third root letter, and where has it gone? (و — collapsed into the long alif, as in qāla from ق-و-ل.) Where does it resurface? (In jāwara and jīrān.) How do you say \"my neighbour\"? (Jārī — the ending of ismī.) Is English neighbour related? (No — Germanic, the nigh-dweller.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "AR-C35-ibn-bint",
+      "sequence": 950,
+      "title": "ابن, بنت (ibn, bint) — son and daughter, one letter apart",
+      "headword": "ابن بنت",
+      "romanization": "ibn, bint",
+      "gloss": "son and daughter — one pair gendered by a single added ت, exactly as أخ and أخت were, and the ibn that stands in the middle of names English already knows",
+      "script": "arabic",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:e34369727aec4468",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A pair you can learn in one move, because Arabic has already shown you the move it uses."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Nothing new in either. ابن is ا (alif), ب (bāʾ, one dot below) and ن (nūn, one dot above) — two letters that share a bowl and differ only by where the dot sits."
+            },
+            {
+              "kind": "speech",
+              "text": "بنت is the same ب and ن, then ت (tāʾ, two dots above) on the end. Both words join throughout, unlike جار (jār), which stopped twice."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ابن (ibn) = \"a son.\" بنت (bint) = \"a daughter.\""
+            },
+            {
+              "kind": "speech",
+              "text": "What separates them is one ت, and nothing else."
+            },
+            {
+              "kind": "speech",
+              "text": "You have met that letter doing that job. أخ (akh) is a brother; أخت (ukht) is a sister. Same word, one ت added for the feminine. Arabic does not build a separate word for the woman; it marks the word it has. (This is the bare cousin of the ة that marks qahwa feminine — same letter, tied instead of open.)"
+            },
+            {
+              "kind": "speech",
+              "text": "On the root, tradition and comparison disagree. Arab grammarians file ابن under ب-ن-ي, \"to build\" — a son as what a house is built of, which is a lovely idea. Comparative scholars are less sure: Hebrew בֵּן (ben) and בַּת (bat) show the same bare shape, more like a very old primitive word than something derived from a verb. Hold it loosely."
+            },
+            {
+              "kind": "speech",
+              "text": "Hebrew bat is bint with the n swallowed into the t. And ibn stands in plain sight inside names English carries: Ibn Sīnā, the physician the Latin west called Avicenna. No English word descends from it."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "alif, bāʾ, nūn — \"ibn,\" a son",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: alif, bāʾ, nūn — \"ibn,\" a son]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "bāʾ, nūn, tāʾ — \"bint,\" a daughter",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: bāʾ, nūn, tāʾ — \"bint,\" a daughter]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the dots that separate bāʾ and nūn — one below, one above",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the dots that separate bāʾ and nūn — one below, one above]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the move you already knew — akh, then ukht",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the move you already knew — akh, then ukht]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "and the parents beside them — ab, a father; umm, a mother",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: and the parents beside them — ab, a father; umm, a mother]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the loosely held root — b-n-y, to build, as the grammarians have it",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the loosely held root — b-n-y, to build, as the grammarians have it]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the Hebrew pair — ben, bat",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the Hebrew pair — ben, bat]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the neighbour, and the emphatic ṭāʾ of ṭaʿām — jārī; ṭaʿām, maṭʿam",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the neighbour, and the emphatic ṭāʾ of ṭaʿām — jārī; ṭaʿām, maṭʿam]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What is the only difference between ابن and بنت? (An added ت — as with akh and ukht.) And the parents? (Ab and umm.) What root do grammarians give ibn, and why hold it loosely? (ب-ن-ي, \"to build\" — but Hebrew ben and bat suggest an older bare word.) Where does ibn appear in a name English knows? (Ibn Sīnā, Avicenna.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "AR-C35-sadiq",
+      "sequence": 960,
+      "title": "صديق (ṣadīq) — \"friend,\" the one who is true to you",
+      "headword": "صديق",
+      "romanization": "ṣadīq",
+      "gloss": "\"friend\" — the chapter's payoff, where a root meaning truth explains the word, the faʿīl pattern turns up for the third time, and every family word you own lines up behind it",
+      "script": "arabic",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:59ffe28814224473",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The chapter closes on a word whose root is not about company at all. It is about telling the truth."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Nothing new. ص (ṣād) is the emphatic س, first met in صباح (ṣabāḥ) — heavy and dark where sīn is light. Then د (dāl), ي (yāʾ) carrying the long ī, and ق (qāf). د is a non-joiner, so صديق (ṣadīq) breaks after it: صد, then يق."
+            },
+            {
+              "kind": "speech",
+              "text": "The feminine is صَديقة (ṣadīqa) — the ة, tied on the end, doing what it did to qahwa: the open ت of بنت and أخت in its tied form."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "صَديق (ṣadīq) = \"a friend.\" Root ص-د-ق, and the root means \"to be truthful, to be sincere.\""
+            },
+            {
+              "kind": "speech",
+              "text": "A friend, in Arabic, is defined by honesty rather than proximity. The family agrees:"
+            },
+            {
+              "kind": "speech",
+              "text": "صِدْق (ṣidq) — \"truth, sincerity.\""
+            },
+            {
+              "kind": "speech",
+              "text": "صادِق (ṣādiq) — \"truthful,\" the doer shape worn by قائِل (qāʾil, a sayer) and كاتِب (kātib, a writer)."
+            },
+            {
+              "kind": "speech",
+              "text": "صَدَقة (ṣadaqa) — \"voluntary alms.\" A gift given for its own sake: a true gift, as against one owed."
+            },
+            {
+              "kind": "speech",
+              "text": "أَصْدِقاء (aṣdiqāʾ) — \"friends.\""
+            },
+            {
+              "kind": "speech",
+              "text": "And now the pattern. صَديق is فَعيل (faʿīl) — the shape of حَليب (ḥalīb), the milked thing, and مَليح (malīḥ), the salty one. Root plus faʿīl hands back a quality made into a person or a thing."
+            },
+            {
+              "kind": "speech",
+              "text": "This is the machinery that turned سَلام (salām) into السَّلامة (as-salāma): one root, several patterns, several words."
+            },
+            {
+              "kind": "speech",
+              "text": "English took nothing from ص-د-ق. Friend is Germanic, from an old word for loving."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ṣād, dāl, yāʾ, qāf — \"ṣadīq,\" a friend",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: ṣād, dāl, yāʾ, qāf — \"ṣadīq,\" a friend]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the emphatic pair — sīn light, ṣād heavy, as in ṣabāḥ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the emphatic pair — sīn light, ṣād heavy, as in ṣabāḥ]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what the root means — to be truthful; a friend is one who is true",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what the root means — to be truthful; a friend is one who is true]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the family — ṣidq, ṣādiq, ṣadaqa, aṣdiqāʾ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the family — ṣidq, ṣādiq, ṣadaqa, aṣdiqāʾ]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the doer shape — qāʾil, kātib, ṣādiq",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the doer shape — qāʾil, kātib, ṣādiq]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the faʿīl shape — ḥalīb, malīḥ, ṣadīq",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the faʿīl shape — ḥalīb, malīḥ, ṣadīq]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the feminine — ṣadīqa, tied tāʾ, as as-salāma has it",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the feminine — ṣadīqa, tied tāʾ, as as-salāma has it]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "this chapter's people — jārī with its two non-joiners, ibn, bint, ṣadīqī",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: this chapter's people — jārī with its two non-joiners, ibn, bint, ṣadīqī]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "and the family you had — ab, umm, akh, ukht",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: and the family you had — ab, umm, akh, ukht]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does ص-د-ق mean, and what does that make a friend? (To be truthful — the one who is true to you.) Name the family. (Ṣidq, ṣādiq, ṣadaqa, aṣdiqāʾ.) Which earlier words wear ṣadīq's faʿīl pattern, and which wear ṣādiq's doer shape? (Ḥalīb and malīḥ; qāʾil and kātib.) Introduce the people you can now name. (Jārī, ibn, bint, ṣadīqī — beside ab, umm, akh, ukht.) What does the ة of ṣadīqa do? (Marks it feminine — as on qahwa and as-salāma.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/arabic/narration/ch35.txt
+++ b/code/learning/human-languages/arabic/narration/ch35.txt
@@ -1,0 +1,141 @@
+Arabic, chapter 35: The People You Introduce.
+3 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+
+
+Lesson 1 of 3.
+جار (jār) — "neighbour," and a root with a letter in hiding.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+After a chapter of things you order, a chapter of people you introduce — starting with the one who lives next door.
+
+The letters in this word.
+Nothing new, and it is short: ج (jīm, the hook-and-tail body with one dot below), ا (alif) and ر (rā). Both ا and ر are non-joiners, so جار (jār) barely joins at all — compare طعام, which broke once before its mīm.
+
+The word, taken apart.
+جار (jār) = "a neighbour." Add the "my" ending of اسمي (ismī) and you have جاري (jārī), "my neighbour" — which is how the word usually arrives in a conversation.
+Now listen to the root. You can hear only j and r. But an Arabic root wants three consonants, and the missing one is in hiding: the root is ج-و-ر, and its و has collapsed into that long ا.
+You have watched this before. قال (qāla), "he said," is ق-و-ل with the same disappearing و. Arabic calls these hollow roots, and the hidden letter comes back when the word changes shape:
+جاوَرَ (jāwara) — "he lived alongside." There is the و, in the open.
+جيران (jīrān) — "neighbours," where it returns as a long ī.
+Hebrew's גֵּר (ger), a resident outsider living among a people, comes from the same Semitic root for dwelling alongside.
+English neighbour is no relative — it is Germanic, the nigh-dweller. Two unrelated languages built one word out of one idea, worth noticing because it is not descent.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: jīm, alif, rā — "jār," a neighbour]
+[pause 8 seconds for the answer]
+[your turn — say: with the my ending — "jārī," my neighbour, as ismī is my name]
+[pause 8 seconds for the answer]
+[your turn — say: the hidden letter — the root is j-w-r, and the wāw is inside the alif]
+[pause 8 seconds for the answer]
+[your turn — say: the same hiding place — qāla, he said, from q-w-l]
+[pause 8 seconds for the answer]
+[your turn — say: where it comes back — jāwara; jīrān, neighbours]
+[pause 8 seconds for the answer]
+[your turn — say: the hook family by dots — ḥāʾ, khāʾ, jīm]
+[pause 8 seconds for the answer]
+[your turn — say: the restaurant you built — maṭʿam, the place of eating]
+[pause 8 seconds for the answer]
+[your turn — say: the honest non-cousin — English neighbour, the nigh-dweller]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What is جار (jār)'s third root letter, and where has it gone? (و — collapsed into the long alif, as in qāla from ق-و-ل.) Where does it resurface? (In jāwara and jīrān.) How do you say "my neighbour"? (Jārī — the ending of ismī.) Is English neighbour related? (No — Germanic, the nigh-dweller.)
+
+
+Lesson 2 of 3.
+ابن, بنت (ibn, bint) — son and daughter, one letter apart.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+A pair you can learn in one move, because Arabic has already shown you the move it uses.
+
+The letters in this word.
+Nothing new in either. ابن is ا (alif), ب (bāʾ, one dot below) and ن (nūn, one dot above) — two letters that share a bowl and differ only by where the dot sits.
+بنت is the same ب and ن, then ت (tāʾ, two dots above) on the end. Both words join throughout, unlike جار (jār), which stopped twice.
+
+The word, taken apart.
+ابن (ibn) = "a son." بنت (bint) = "a daughter."
+What separates them is one ت, and nothing else.
+You have met that letter doing that job. أخ (akh) is a brother; أخت (ukht) is a sister. Same word, one ت added for the feminine. Arabic does not build a separate word for the woman; it marks the word it has. (This is the bare cousin of the ة that marks qahwa feminine — same letter, tied instead of open.)
+On the root, tradition and comparison disagree. Arab grammarians file ابن under ب-ن-ي, "to build" — a son as what a house is built of, which is a lovely idea. Comparative scholars are less sure: Hebrew בֵּן (ben) and בַּת (bat) show the same bare shape, more like a very old primitive word than something derived from a verb. Hold it loosely.
+Hebrew bat is bint with the n swallowed into the t. And ibn stands in plain sight inside names English carries: Ibn Sīnā, the physician the Latin west called Avicenna. No English word descends from it.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: alif, bāʾ, nūn — "ibn," a son]
+[pause 8 seconds for the answer]
+[your turn — say: bāʾ, nūn, tāʾ — "bint," a daughter]
+[pause 8 seconds for the answer]
+[your turn — say: the dots that separate bāʾ and nūn — one below, one above]
+[pause 8 seconds for the answer]
+[your turn — say: the move you already knew — akh, then ukht]
+[pause 8 seconds for the answer]
+[your turn — say: and the parents beside them — ab, a father; umm, a mother]
+[pause 8 seconds for the answer]
+[your turn — say: the loosely held root — b-n-y, to build, as the grammarians have it]
+[pause 8 seconds for the answer]
+[your turn — say: the Hebrew pair — ben, bat]
+[pause 8 seconds for the answer]
+[your turn — say: the neighbour, and the emphatic ṭāʾ of ṭaʿām — jārī; ṭaʿām, maṭʿam]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What is the only difference between ابن and بنت? (An added ت — as with akh and ukht.) And the parents? (Ab and umm.) What root do grammarians give ibn, and why hold it loosely? (ب-ن-ي, "to build" — but Hebrew ben and bat suggest an older bare word.) Where does ibn appear in a name English knows? (Ibn Sīnā, Avicenna.)
+
+
+Lesson 3 of 3.
+صديق (ṣadīq) — "friend," the one who is true to you.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The chapter closes on a word whose root is not about company at all. It is about telling the truth.
+
+The letters in this word.
+Nothing new. ص (ṣād) is the emphatic س, first met in صباح (ṣabāḥ) — heavy and dark where sīn is light. Then د (dāl), ي (yāʾ) carrying the long ī, and ق (qāf). د is a non-joiner, so صديق (ṣadīq) breaks after it: صد, then يق.
+The feminine is صَديقة (ṣadīqa) — the ة, tied on the end, doing what it did to qahwa: the open ت of بنت and أخت in its tied form.
+
+The word, taken apart.
+صَديق (ṣadīq) = "a friend." Root ص-د-ق, and the root means "to be truthful, to be sincere."
+A friend, in Arabic, is defined by honesty rather than proximity. The family agrees:
+صِدْق (ṣidq) — "truth, sincerity."
+صادِق (ṣādiq) — "truthful," the doer shape worn by قائِل (qāʾil, a sayer) and كاتِب (kātib, a writer).
+صَدَقة (ṣadaqa) — "voluntary alms." A gift given for its own sake: a true gift, as against one owed.
+أَصْدِقاء (aṣdiqāʾ) — "friends."
+And now the pattern. صَديق is فَعيل (faʿīl) — the shape of حَليب (ḥalīb), the milked thing, and مَليح (malīḥ), the salty one. Root plus faʿīl hands back a quality made into a person or a thing.
+This is the machinery that turned سَلام (salām) into السَّلامة (as-salāma): one root, several patterns, several words.
+English took nothing from ص-د-ق. Friend is Germanic, from an old word for loving.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: ṣād, dāl, yāʾ, qāf — "ṣadīq," a friend]
+[pause 8 seconds for the answer]
+[your turn — say: the emphatic pair — sīn light, ṣād heavy, as in ṣabāḥ]
+[pause 8 seconds for the answer]
+[your turn — say: what the root means — to be truthful; a friend is one who is true]
+[pause 8 seconds for the answer]
+[your turn — say: the family — ṣidq, ṣādiq, ṣadaqa, aṣdiqāʾ]
+[pause 8 seconds for the answer]
+[your turn — say: the doer shape — qāʾil, kātib, ṣādiq]
+[pause 8 seconds for the answer]
+[your turn — say: the faʿīl shape — ḥalīb, malīḥ, ṣadīq]
+[pause 8 seconds for the answer]
+[your turn — say: the feminine — ṣadīqa, tied tāʾ, as as-salāma has it]
+[pause 8 seconds for the answer]
+[your turn — say: this chapter's people — jārī with its two non-joiners, ibn, bint, ṣadīqī]
+[pause 8 seconds for the answer]
+[your turn — say: and the family you had — ab, umm, akh, ukht]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does ص-د-ق mean, and what does that make a friend? (To be truthful — the one who is true to you.) Name the family. (Ṣidq, ṣādiq, ṣadaqa, aṣdiqāʾ.) Which earlier words wear ṣadīq's faʿīl pattern, and which wear ṣādiq's doer shape? (Ḥalīb and malīḥ; qāʾil and kātib.) Introduce the people you can now name. (Jārī, ibn, bint, ṣadīqī — beside ab, umm, akh, ukht.) What does the ة of ṣadīqa do? (Marks it feminine — as on qahwa and as-salāma.)

--- a/code/learning/human-languages/arabic/narration/ch36.json
+++ b/code/learning/human-languages/arabic/narration/ch36.json
@@ -1,0 +1,798 @@
+{
+  "version": 1,
+  "language": "arabic",
+  "chapter": 36,
+  "title": "Cups, Plates, and More Than One",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:9e09dda9d25a9e04",
+  "lessons": [
+    {
+      "id": "AR-C36-zayt",
+      "sequence": 970,
+      "title": "زيت (zayt) — \"oil,\" and a letter you already knew",
+      "headword": "زيت",
+      "romanization": "zayt",
+      "gloss": "\"oil\" — one new letter that is only rā wearing a dot, and a second Spanish word carrying Arabic's article welded to its front",
+      "script": "arabic",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:389576737b14f3e0",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "One new letter to name — and you will find you already own it, because it is an old letter wearing a dot."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ز is zāy, the z. And here is all there is to it: ز is ر (rā) with one dot above."
+            },
+            {
+              "kind": "speech",
+              "text": "That is the abjad's favourite trick. ب, ن and ت share one bowl and differ by dots. ح, خ and ج share one hook. Now ر and ز share one curve."
+            },
+            {
+              "kind": "speech",
+              "text": "Everything rā does, zāy does: it hangs below the line and refuses to join what follows — the non-joiner that ended سكر."
+            },
+            {
+              "kind": "speech",
+              "text": "Then ي (yāʾ) and ت (tāʾ). So زيت (zayt) is ز alone, then يت joined."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "زَيْت (zayt) = \"oil\" — in the first place olive oil, and by extension oil of any kind. Root ز-ي-ت, which also gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "زَيْتون (zaytūn) — \"olives.\""
+            },
+            {
+              "kind": "speech",
+              "text": "زَيْتونة (zaytūna) — \"an olive,\" one of them, with the tied ة making the single thing out of the collective."
+            },
+            {
+              "kind": "speech",
+              "text": "And now Spain. You met azúcar and found Arabic's al- welded onto its front. The same thing happened here, twice over:"
+            },
+            {
+              "kind": "speech",
+              "text": "الزَّيت (az-zayt) became Spanish aceite, \"oil.\""
+            },
+            {
+              "kind": "speech",
+              "text": "الزَّيتونة (az-zaytūna) became Spanish aceituna, \"an olive.\""
+            },
+            {
+              "kind": "speech",
+              "text": "ز is a sun letter, which is why al- is said az- — the assimilation that makes al- + sukkar into as-sukkar. Spanish took the sound it heard, article and all. Portuguese did the same with azeite."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "zāy is rā plus one dot above, and it breaks as rā breaks",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: zāy is rā plus one dot above, and it breaks as rā breaks]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the dot families — bāʾ, nūn, tāʾ; ḥāʾ, khāʾ, jīm; rā and zāy",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the dot families — bāʾ, nūn, tāʾ; ḥāʾ, khāʾ, jīm; rā and zāy]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "zāy, yāʾ, tāʾ — \"zayt,\" oil",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: zāy, yāʾ, tāʾ — \"zayt,\" oil]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the olives — zaytūn; one olive, zaytūna",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the olives — zaytūn; one olive, zaytūna]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the welded article — az-zayt gave aceite, as-sukkar gave azúcar",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the welded article — az-zayt gave aceite, as-sukkar gave azúcar]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the friend and his root — ṣadīq, from ṣ-d-q, to be true",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the friend and his root — ṣadīq, from ṣ-d-q, to be true]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the pair one letter apart — ibn, bint",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the pair one letter apart — ibn, bint]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What is ز, described from a letter you had? (Rā with one dot above — and it breaks the same way.) What does ز-ي-ت give besides oil? (Zaytūn and zaytūna.) Which Spanish words carry this root with Arabic's article stuck on, and which one did sukkar give? (Aceite and aceituna; azúcar.) Why az- rather than al-? (ز is a sun letter.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "AR-C36-kub",
+      "sequence": 980,
+      "title": "كوب (kūb) — \"a cup,\" and more than one of them",
+      "headword": "كوب",
+      "romanization": "kūb",
+      "gloss": "\"a cup\" — the word that opens Arabic's broken plural, where more than one is not made by adding anything but by re-pouring the word into a new shape",
+      "script": "arabic",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:51a3d21b81556a2a",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A short, useful word — and the door into the thing about Arabic nouns that surprises every learner."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Nothing new. ك (kāf), the angular k; و (wāw), here carrying the long ū; and ب (bāʾ)."
+            },
+            {
+              "kind": "speech",
+              "text": "و is a non-joiner, so كوب (kūb) goes كو, break, ب. Another non-joiner: ر ended sukkar, ز opened zayt, and و splits this."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "كوب (kūb) = \"a cup.\" Root ك-و-ب."
+            },
+            {
+              "kind": "speech",
+              "text": "Now say \"cups.\" In English you add an s. In Arabic you do something else entirely:"
+            },
+            {
+              "kind": "speech",
+              "text": "أَكْواب (akwāb)."
+            },
+            {
+              "kind": "speech",
+              "text": "Nothing was added to the end. The root ك-و-ب was taken out of one shape and poured into another, أَفْعال (afʿāl). Arabic calls this a broken plural, and it is not an exception — it is how most ordinary Arabic nouns make their plurals."
+            },
+            {
+              "kind": "speech",
+              "text": "You have seen a root move between shapes many times: ك-ت-ب became kitāb, kātib, maktab, maktaba. A broken plural is that same machinery pointed at number instead of meaning. So this is not a new rule to learn. It is a rule you already have, doing a job you did not expect it to do."
+            },
+            {
+              "kind": "speech",
+              "text": "On where kūb came from, honesty first. It sits close to a cup-word that travelled all round the Mediterranean — Latin cuppa, behind English cup and French coupe. Whether Arabic took it from that family, or the resemblance is coincidence, is not settled: a resemblance worth knowing, not a descent worth claiming."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "kāf, wāw, bāʾ — \"kūb,\" a cup",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: kāf, wāw, bāʾ — \"kūb,\" a cup]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "more than one — \"akwāb,\" and nothing was added to the end",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: more than one — \"akwāb,\" and nothing was added to the end]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what happened instead — the root was poured into the shape afʿāl",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what happened instead — the root was poured into the shape afʿāl]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the same machinery you had — kitāb, kātib, maktab, maktaba",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the same machinery you had — kitāb, kātib, maktab, maktaba]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ask for one — \"kūb māʾ, min faḍlik\" — a cup of water, from your grace",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: ask for one — \"kūb māʾ, min faḍlik\" — a cup of water, from your grace]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "and answer the thanks — \"ʿafwan\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: and answer the thanks — \"ʿafwan\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the odd old word for water — māʾ, whose plural miyāh follows no pattern",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the odd old word for water — māʾ, whose plural miyāh follows no pattern]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the non-joiners — zāy in zayt, dāl in ṣadīq, wāw here",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the non-joiners — zāy in zayt, dāl in ṣadīq, wāw here]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "How does Arabic make \"cups\" out of كوب? (Akwāb — the root is re-poured into a new shape, not given an ending. That is a broken plural.) Which earlier root shows the same shape-changing machinery? (ك-ت-ب — kitāb, kātib, maktab, maktaba.) Ask for a cup of water politely. (Kūb māʾ, min faḍlik.) And reply to thanks? (ʿAfwan.) Did Arabic get kūb from Latin cuppa? (Unsettled — a resemblance, not a claim.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "AR-C36-tabaq",
+      "sequence": 990,
+      "title": "طبق (ṭabaq) — \"a plate,\" and a broken plural that repeats",
+      "headword": "طبق",
+      "romanization": "ṭabaq",
+      "gloss": "\"a plate\" — a second broken plural in the very same shape as akwāb, which turns a surprise into a pattern, and a root whose other child is a storey of a building",
+      "script": "arabic",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:c79df8d04f7b28f9",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "One broken plural is a surprise. Two in the same shape is a pattern — and a pattern you can use."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Nothing new. ط (ṭāʾ) is the emphatic ت, named when you built طعام (ṭaʿām) — the dark, flat-tongued t, standing beside ص under س and ض under د."
+            },
+            {
+              "kind": "speech",
+              "text": "Then ب (bāʾ) and ق (qāf). All three join, so طبق (ṭabaq) runs unbroken — unlike كوب (kūb), which had to stop at its wāw."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "طَبَق (ṭabaq) = \"a plate, a dish.\" Root ط-ب-ق."
+            },
+            {
+              "kind": "speech",
+              "text": "Its plural is أَطْباق (aṭbāq)."
+            },
+            {
+              "kind": "speech",
+              "text": "Say that beside أَكْواب (akwāb) and listen. Same opening أَ, same long ā before the last letter, same nothing-added-at-the-end. Both are the shape أَفْعال (afʿāl). So the broken plural is not chaos: it is a small set of shapes, and you have now met the commonest one twice."
+            },
+            {
+              "kind": "speech",
+              "text": "The root itself means to cover, to lie in layers — a plate being the flat thing that covers. Which is why the same root gives:"
+            },
+            {
+              "kind": "speech",
+              "text": "طابِق (ṭābiq) — \"a storey\" of a building. A layer of house. And notice its shape: that is the doer form of ṣādiq and kātib."
+            },
+            {
+              "kind": "speech",
+              "text": "طَبَقة (ṭabaqa) — \"a layer,\" and so \"a social class,\" with the tied ة on the end."
+            },
+            {
+              "kind": "speech",
+              "text": "A plate, a floor and a social class, off one idea about layers. And the plates themselves belong somewhere you already built: مَطْعَم (maṭʿam), the place of eating."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ṭāʾ, bāʾ, qāf — \"ṭabaq,\" a plate",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: ṭāʾ, bāʾ, qāf — \"ṭabaq,\" a plate]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the emphatic set once more — ṣād, ḍād, ṭāʾ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the emphatic set once more — ṣād, ḍād, ṭāʾ]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two broken plurals — akwāb, aṭbāq, both in the shape afʿāl",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two broken plurals — akwāb, aṭbāq, both in the shape afʿāl]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what the root means — to cover, to lie in layers",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what the root means — to cover, to lie in layers]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "its other children — ṭābiq, a storey; ṭabaqa, a layer or a class",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: its other children — ṭābiq, a storey; ṭabaqa, a layer or a class]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "where the plates live — maṭʿam, the place of eating",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: where the plates live — maṭʿam, the place of eating]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the oil, whose zāy is rā plus a dot — zayt, zaytūn",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the oil, whose zāy is rā plus a dot — zayt, zaytūn]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What shape do أكواب and أطباق share? (Afʿāl — the broken plural you have now met twice.) What does ط-ب-ق mean? (To cover, to lie in layers.) Name two more words it builds. (Ṭābiq, a storey, and ṭabaqa, a layer or a class.) Which plain letter is ط the emphatic partner of? (Tāʾ.) Where would you find a stack of aṭbāq? (In a maṭʿam — the place of eating.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "AR-C36-milaqa",
+      "sequence": 1000,
+      "title": "ملعقة (milʿaqa) — \"a spoon,\" the tool shape, and two ways to say more than one",
+      "headword": "ملعقة",
+      "romanization": "milʿaqa",
+      "gloss": "\"a spoon\" — the closing payoff, where the mi- tool shape stands beside the ma- place shape you already own, and where sound and broken plurals finally sort themselves out",
+      "script": "arabic",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:001d3e7108432439",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The last word, and it pays two debts at once: the shape that makes tools, and the question of how Arabic counts past one."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Nothing new: م (mīm), ل (lām), ع (ʿayn, the throat sound), ق (qāf) — and then ة, the tied tāʾ."
+            },
+            {
+              "kind": "speech",
+              "text": "That ة tells you, before anything else, that ملعقة (milʿaqa) is feminine — the signal you read off قهوة (qahwa), صديقة (ṣadīqa) and طَبَقة (ṭabaqa)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "مِلْعَقة (milʿaqa) = \"a spoon.\" Root ل-ع-ق, whose verb لَعِقَ (laʿiqa) means \"he licked, he lapped.\" A spoon is the thing you lap with."
+            },
+            {
+              "kind": "speech",
+              "text": "Two shapes now stand side by side, differing by one vowel:"
+            },
+            {
+              "kind": "speech",
+              "text": "مَـ, the place shape: مَكْتَب (maktab), the place of writing; مَطْعَم (maṭʿam), the place of eating."
+            },
+            {
+              "kind": "speech",
+              "text": "مِـ, the tool shape: مِرْآة (mirʾāh), the thing you see with; مِلْعَقة (milʿaqa), the thing you lap with."
+            },
+            {
+              "kind": "speech",
+              "text": "Ma- builds a room. Mi- puts something in your hand."
+            },
+            {
+              "kind": "speech",
+              "text": "Now the plurals this chapter has been circling."
+            },
+            {
+              "kind": "speech",
+              "text": "Broken — the root re-poured, nothing added: أَكْواب (akwāb), أَطْباق (aṭbāq), مَلاعِق (malāʿiq), spoons."
+            },
+            {
+              "kind": "speech",
+              "text": "Sound — an ending added, the word left intact. Arabic uses it for the ة words: قَهْوة gives قَهَوات (qahawāt), and صَديقة gives صَديقات (ṣadīqāt)."
+            },
+            {
+              "kind": "speech",
+              "text": "The rule of thumb: a noun in ة usually takes the added ending, and most other everyday nouns break. Milʿaqa is the honest reminder that \"usually\" is doing work — it ends in ة and breaks anyway."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "mīm, lām, ʿayn, qāf, tāʾ marbūṭa — \"milʿaqa,\" a spoon",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: mīm, lām, ʿayn, qāf, tāʾ marbūṭa — \"milʿaqa,\" a spoon]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the verb under it — \"laʿiqa,\" he lapped",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the verb under it — \"laʿiqa,\" he lapped]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the place shape — maktab, maṭʿam",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the place shape — maktab, maṭʿam]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the tool shape — mirʾāh, milʿaqa",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the tool shape — mirʾāh, milʿaqa]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the broken plurals — kūb with its breaking wāw gives akwāb; aṭbāq; malāʿiq",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the broken plurals — kūb with its breaking wāw gives akwāb; aṭbāq; malāʿiq]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the sound plurals — qahwa gives qahawāt, ṣadīqa gives ṣadīqāt",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the sound plurals — qahwa gives qahawāt, ṣadīqa gives ṣadīqāt]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the tied tāʾ marking feminine — qahwa, ṣadīqa, ṭabaqa, milʿaqa",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the tied tāʾ marking feminine — qahwa, ṣadīqa, ṭabaqa, milʿaqa]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ask for each — \"kūb, min faḍlik\"; \"ṭabaq, min faḍlik\"; \"milʿaqa, min faḍlik\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: ask for each — \"kūb, min faḍlik\"; \"ṭabaq, min faḍlik\"; \"milʿaqa, min faḍlik\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "and the oil — zayt, whose Spanish child is aceite",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: and the oil — zayt, whose Spanish child is aceite]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What separates مَـ from مِـ? (Ma- makes a place, mi- a tool — maktab and maṭʿam against mirʾāh and milʿaqa.) What does ل-ع-ق mean? (To lap.) Name this chapter's broken plurals, and a sound one. (Akwāb, aṭbāq, malāʿiq; qahawāt or ṣadīqāt.) What does the ة on milʿaqa tell you? (Feminine — and unusually for a ة word, it still breaks.) Ask for a spoon politely. (Milʿaqa, min faḍlik.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/arabic/narration/ch36.txt
+++ b/code/learning/human-languages/arabic/narration/ch36.txt
@@ -1,0 +1,187 @@
+Arabic, chapter 36: Cups, Plates, and More Than One.
+4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+
+
+Lesson 1 of 4.
+زيت (zayt) — "oil," and a letter you already knew.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+One new letter to name — and you will find you already own it, because it is an old letter wearing a dot.
+
+The letters in this word.
+ز is zāy, the z. And here is all there is to it: ز is ر (rā) with one dot above.
+That is the abjad's favourite trick. ب, ن and ت share one bowl and differ by dots. ح, خ and ج share one hook. Now ر and ز share one curve.
+Everything rā does, zāy does: it hangs below the line and refuses to join what follows — the non-joiner that ended سكر.
+Then ي (yāʾ) and ت (tāʾ). So زيت (zayt) is ز alone, then يت joined.
+
+The word, taken apart.
+زَيْت (zayt) = "oil" — in the first place olive oil, and by extension oil of any kind. Root ز-ي-ت, which also gives:
+زَيْتون (zaytūn) — "olives."
+زَيْتونة (zaytūna) — "an olive," one of them, with the tied ة making the single thing out of the collective.
+And now Spain. You met azúcar and found Arabic's al- welded onto its front. The same thing happened here, twice over:
+الزَّيت (az-zayt) became Spanish aceite, "oil."
+الزَّيتونة (az-zaytūna) became Spanish aceituna, "an olive."
+ز is a sun letter, which is why al- is said az- — the assimilation that makes al- + sukkar into as-sukkar. Spanish took the sound it heard, article and all. Portuguese did the same with azeite.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: zāy is rā plus one dot above, and it breaks as rā breaks]
+[pause 8 seconds for the answer]
+[your turn — say: the dot families — bāʾ, nūn, tāʾ; ḥāʾ, khāʾ, jīm; rā and zāy]
+[pause 8 seconds for the answer]
+[your turn — say: zāy, yāʾ, tāʾ — "zayt," oil]
+[pause 8 seconds for the answer]
+[your turn — say: the olives — zaytūn; one olive, zaytūna]
+[pause 8 seconds for the answer]
+[your turn — say: the welded article — az-zayt gave aceite, as-sukkar gave azúcar]
+[pause 8 seconds for the answer]
+[your turn — say: the friend and his root — ṣadīq, from ṣ-d-q, to be true]
+[pause 8 seconds for the answer]
+[your turn — say: the pair one letter apart — ibn, bint]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What is ز, described from a letter you had? (Rā with one dot above — and it breaks the same way.) What does ز-ي-ت give besides oil? (Zaytūn and zaytūna.) Which Spanish words carry this root with Arabic's article stuck on, and which one did sukkar give? (Aceite and aceituna; azúcar.) Why az- rather than al-? (ز is a sun letter.)
+
+
+Lesson 2 of 4.
+كوب (kūb) — "a cup," and more than one of them.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+A short, useful word — and the door into the thing about Arabic nouns that surprises every learner.
+
+The letters in this word.
+Nothing new. ك (kāf), the angular k; و (wāw), here carrying the long ū; and ب (bāʾ).
+و is a non-joiner, so كوب (kūb) goes كو, break, ب. Another non-joiner: ر ended sukkar, ز opened zayt, and و splits this.
+
+The word, taken apart.
+كوب (kūb) = "a cup." Root ك-و-ب.
+Now say "cups." In English you add an s. In Arabic you do something else entirely:
+أَكْواب (akwāb).
+Nothing was added to the end. The root ك-و-ب was taken out of one shape and poured into another, أَفْعال (afʿāl). Arabic calls this a broken plural, and it is not an exception — it is how most ordinary Arabic nouns make their plurals.
+You have seen a root move between shapes many times: ك-ت-ب became kitāb, kātib, maktab, maktaba. A broken plural is that same machinery pointed at number instead of meaning. So this is not a new rule to learn. It is a rule you already have, doing a job you did not expect it to do.
+On where kūb came from, honesty first. It sits close to a cup-word that travelled all round the Mediterranean — Latin cuppa, behind English cup and French coupe. Whether Arabic took it from that family, or the resemblance is coincidence, is not settled: a resemblance worth knowing, not a descent worth claiming.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: kāf, wāw, bāʾ — "kūb," a cup]
+[pause 8 seconds for the answer]
+[your turn — say: more than one — "akwāb," and nothing was added to the end]
+[pause 8 seconds for the answer]
+[your turn — say: what happened instead — the root was poured into the shape afʿāl]
+[pause 8 seconds for the answer]
+[your turn — say: the same machinery you had — kitāb, kātib, maktab, maktaba]
+[pause 8 seconds for the answer]
+[your turn — say: ask for one — "kūb māʾ, min faḍlik" — a cup of water, from your grace]
+[pause 8 seconds for the answer]
+[your turn — say: and answer the thanks — "ʿafwan"]
+[pause 8 seconds for the answer]
+[your turn — say: the odd old word for water — māʾ, whose plural miyāh follows no pattern]
+[pause 8 seconds for the answer]
+[your turn — say: the non-joiners — zāy in zayt, dāl in ṣadīq, wāw here]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+How does Arabic make "cups" out of كوب? (Akwāb — the root is re-poured into a new shape, not given an ending. That is a broken plural.) Which earlier root shows the same shape-changing machinery? (ك-ت-ب — kitāb, kātib, maktab, maktaba.) Ask for a cup of water politely. (Kūb māʾ, min faḍlik.) And reply to thanks? (ʿAfwan.) Did Arabic get kūb from Latin cuppa? (Unsettled — a resemblance, not a claim.)
+
+
+Lesson 3 of 4.
+طبق (ṭabaq) — "a plate," and a broken plural that repeats.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+One broken plural is a surprise. Two in the same shape is a pattern — and a pattern you can use.
+
+The letters in this word.
+Nothing new. ط (ṭāʾ) is the emphatic ت, named when you built طعام (ṭaʿām) — the dark, flat-tongued t, standing beside ص under س and ض under د.
+Then ب (bāʾ) and ق (qāf). All three join, so طبق (ṭabaq) runs unbroken — unlike كوب (kūb), which had to stop at its wāw.
+
+The word, taken apart.
+طَبَق (ṭabaq) = "a plate, a dish." Root ط-ب-ق.
+Its plural is أَطْباق (aṭbāq).
+Say that beside أَكْواب (akwāb) and listen. Same opening أَ, same long ā before the last letter, same nothing-added-at-the-end. Both are the shape أَفْعال (afʿāl). So the broken plural is not chaos: it is a small set of shapes, and you have now met the commonest one twice.
+The root itself means to cover, to lie in layers — a plate being the flat thing that covers. Which is why the same root gives:
+طابِق (ṭābiq) — "a storey" of a building. A layer of house. And notice its shape: that is the doer form of ṣādiq and kātib.
+طَبَقة (ṭabaqa) — "a layer," and so "a social class," with the tied ة on the end.
+A plate, a floor and a social class, off one idea about layers. And the plates themselves belong somewhere you already built: مَطْعَم (maṭʿam), the place of eating.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: ṭāʾ, bāʾ, qāf — "ṭabaq," a plate]
+[pause 8 seconds for the answer]
+[your turn — say: the emphatic set once more — ṣād, ḍād, ṭāʾ]
+[pause 8 seconds for the answer]
+[your turn — say: the two broken plurals — akwāb, aṭbāq, both in the shape afʿāl]
+[pause 8 seconds for the answer]
+[your turn — say: what the root means — to cover, to lie in layers]
+[pause 8 seconds for the answer]
+[your turn — say: its other children — ṭābiq, a storey; ṭabaqa, a layer or a class]
+[pause 8 seconds for the answer]
+[your turn — say: where the plates live — maṭʿam, the place of eating]
+[pause 8 seconds for the answer]
+[your turn — say: the oil, whose zāy is rā plus a dot — zayt, zaytūn]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What shape do أكواب and أطباق share? (Afʿāl — the broken plural you have now met twice.) What does ط-ب-ق mean? (To cover, to lie in layers.) Name two more words it builds. (Ṭābiq, a storey, and ṭabaqa, a layer or a class.) Which plain letter is ط the emphatic partner of? (Tāʾ.) Where would you find a stack of aṭbāq? (In a maṭʿam — the place of eating.)
+
+
+Lesson 4 of 4.
+ملعقة (milʿaqa) — "a spoon," the tool shape, and two ways to say more than one.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The last word, and it pays two debts at once: the shape that makes tools, and the question of how Arabic counts past one.
+
+The letters in this word.
+Nothing new: م (mīm), ل (lām), ع (ʿayn, the throat sound), ق (qāf) — and then ة, the tied tāʾ.
+That ة tells you, before anything else, that ملعقة (milʿaqa) is feminine — the signal you read off قهوة (qahwa), صديقة (ṣadīqa) and طَبَقة (ṭabaqa).
+
+The word, taken apart.
+مِلْعَقة (milʿaqa) = "a spoon." Root ل-ع-ق, whose verb لَعِقَ (laʿiqa) means "he licked, he lapped." A spoon is the thing you lap with.
+Two shapes now stand side by side, differing by one vowel:
+مَـ, the place shape: مَكْتَب (maktab), the place of writing; مَطْعَم (maṭʿam), the place of eating.
+مِـ, the tool shape: مِرْآة (mirʾāh), the thing you see with; مِلْعَقة (milʿaqa), the thing you lap with.
+Ma- builds a room. Mi- puts something in your hand.
+Now the plurals this chapter has been circling.
+Broken — the root re-poured, nothing added: أَكْواب (akwāb), أَطْباق (aṭbāq), مَلاعِق (malāʿiq), spoons.
+Sound — an ending added, the word left intact. Arabic uses it for the ة words: قَهْوة gives قَهَوات (qahawāt), and صَديقة gives صَديقات (ṣadīqāt).
+The rule of thumb: a noun in ة usually takes the added ending, and most other everyday nouns break. Milʿaqa is the honest reminder that "usually" is doing work — it ends in ة and breaks anyway.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: mīm, lām, ʿayn, qāf, tāʾ marbūṭa — "milʿaqa," a spoon]
+[pause 8 seconds for the answer]
+[your turn — say: the verb under it — "laʿiqa," he lapped]
+[pause 8 seconds for the answer]
+[your turn — say: the place shape — maktab, maṭʿam]
+[pause 8 seconds for the answer]
+[your turn — say: the tool shape — mirʾāh, milʿaqa]
+[pause 8 seconds for the answer]
+[your turn — say: the broken plurals — kūb with its breaking wāw gives akwāb; aṭbāq; malāʿiq]
+[pause 8 seconds for the answer]
+[your turn — say: the sound plurals — qahwa gives qahawāt, ṣadīqa gives ṣadīqāt]
+[pause 8 seconds for the answer]
+[your turn — say: the tied tāʾ marking feminine — qahwa, ṣadīqa, ṭabaqa, milʿaqa]
+[pause 8 seconds for the answer]
+[your turn — say: ask for each — "kūb, min faḍlik"; "ṭabaq, min faḍlik"; "milʿaqa, min faḍlik"]
+[pause 8 seconds for the answer]
+[your turn — say: and the oil — zayt, whose Spanish child is aceite]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What separates مَـ from مِـ? (Ma- makes a place, mi- a tool — maktab and maṭʿam against mirʾāh and milʿaqa.) What does ل-ع-ق mean? (To lap.) Name this chapter's broken plurals, and a sound one. (Akwāb, aṭbāq, malāʿiq; qahawāt or ṣadīqāt.) What does the ة on milʿaqa tell you? (Feminine — and unusually for a ة word, it still breaks.) Ask for a spoon politely. (Milʿaqa, min faḍlik.)

--- a/code/learning/human-languages/arabic/roadmap.md
+++ b/code/learning/human-languages/arabic/roadmap.md
@@ -161,11 +161,58 @@ word lessons — never as a gated reading course.
   *ḥabīb*) and refused where they are false (*ahav* is **not** related).
   *ʾaḥabba* is the payoff and names all four shapes together. **Authored.**
 
+- **Ch. 33 — Asking for a drink** (`SPINE-POLITE-REQUEST-REPAIR`): **شاي**
+  (*shāy*) → **حليب** (*ḥalīb*) → **سكر** (*sukkar*) → **قهوة** (*qahwa*). The
+  chapter's subject is **what a root is for**, shown by contrast: *shāy* and
+  *sukkar* were **borrowed** and so have no root and no family, while *ḥalīb*
+  sits straight on **ح-ل-ب**, "to milk," the same verb-to-noun transparency as
+  *khubz* on **خ-ب-ز**. *Qahwa* is the payoff and names the **ة** as Arabic's
+  visible gender marker. Cousins are real throughout — *qahwa* → Turkish
+  *kahve* → Italian *caffè* → English **coffee**; *as-sukkar* → Spanish
+  **azúcar**, article and all — and the Aleppo milk story is refused as folk
+  etymology. **Authored.**
+
+- **Ch. 34 — Asking for food** (`SPINE-POLITE-REQUEST-REPAIR`): **ملح**
+  (*milḥ*) → **لحم** (*laḥm*) → **جبن** (*jubn*) → **طعام** (*ṭaʿām*). *Laḥm* is
+  *milḥ* reordered, which states the root system in one line, and its Hebrew
+  twin **לֶחֶם** (*leḥem*) means *bread* off the same root — the seam running
+  straight through **Bethlehem**. *Jubn* is the chapter's honest limit: the same
+  letters spell "cowardice," and the lesson refuses to make one root of them.
+  *Ṭaʿām* is the payoff, naming **ط** as the emphatic partner of **ت** beside
+  **ص** and **ض**, then pouring **ط-ع-م** through the *ma-* place shape of
+  *maktab* to **generate** **مَطْعَم** (*maṭʿam*), "a restaurant." **Authored.**
+
+- **Ch. 35 — The people you introduce** (`SPINE-EXCHANGE-NAMES`): **جار**
+  (*jār*) → **ابن**/**بنت** (*ibn*, *bint*) → **صديق** (*ṣadīq*). *Jār* is a
+  **hollow** root — **ج-و-ر** with its **و** collapsed into a long *alif*,
+  exactly as *qāla* hides **ق-و-ل** — and the hidden letter resurfaces in
+  *jāwara* and *jīrān*. *Ibn* and *bint* are gendered by one added **ت**, the
+  move *akh*/*ukht* already made; the grammarians' **ب-ن-ي** derivation is given
+  and then held loosely against Hebrew *ben*/*bat*. *Ṣadīq* is the payoff: root
+  **ص-د-ق**, "to be truthful," so a friend is the one who is *true* to you —
+  with *ṣidq*, *ṣādiq* (the doer shape of *qāʾil* and *kātib*), *ṣadaqa* and
+  *aṣdiqāʾ*, and the **فَعيل** (*faʿīl*) pattern collected for the third time
+  after *ḥalīb* and *malīḥ*. **Authored.**
+
+- **Ch. 36 — Cups, plates, and more than one** (`SPINE-POLITE-REQUEST-REPAIR`):
+  **زيت** (*zayt*) → **كوب** (*kūb*) → **طبق** (*ṭabaq*) → **ملعقة**
+  (*milʿaqa*). **ز** (*zāy*) is named as **ر** plus one dot — the dots-family
+  trick a third time — and *az-zayt* and *az-zaytūna* are shown surviving as
+  Spanish **aceite** and **aceituna**. The chapter's real subject is the
+  **plural**: *kūb* → *akwāb* and *ṭabaq* → *aṭbāq* in one shape,
+  **أَفْعال**, so the **broken** plural is a pattern rather than chaos.
+  *Milʿaqa* is the payoff, setting the *mi-* **tool** shape (*mirʾāh*,
+  *milʿaqa*) against the *ma-* **place** shape (*maktab*, *maṭʿam*) and sorting
+  broken against **sound** plurals (*qahawāt*, *ṣadīqāt*). *Kūb*'s resemblance
+  to Latin *cuppa* is offered as unsettled, not claimed. **Authored.**
+
 ## Planned
 
 | Chapter | Theme |
 |---|---|
-| 33+ | The rest of the core verb set, the present tense, negation, and the remaining derived forms (V–X) — always with the root engine and the Spanish-loanword thread |
+| 37+ | The rest of the core verb set, the present tense, negation, and the remaining derived forms (V–X) — always with the root engine and the Spanish-loanword thread |
+| pre-A1 backfill | The vocabulary criterion is short by **252 headwords** and the gate counts **one per lesson**, so this is the long pole. Household and place nouns (*bayt*, *bāb*, *kursī*, *ṭāwila*, *miftāḥ*) wait on an honest home: the nearest spine node, `SPINE-ASK-LOCATION`, is **A1**, and the seven pre-A1 nodes hold no concrete object among their 34 concepts |
+| Chapters 28–30 | Reheading their `## You'll want to know — The letters in this word` sections to the canonical `## The letters in this word`, so the letters become detachable and the six lessons regain a `voice` core |
 
 Note: Arabic marks **gender on "you"** (*anta* to a man, *anti* to a woman) —
 a different axis from the Spanish/French/German formal-vs-informal split.

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -2536,6 +2536,38 @@
       "scriptSet": "tamil-comparisons"
     },
     {
+      "language": "tamil",
+      "chapter": 35,
+      "title": "Arriving at a House",
+      "label": "ch:ta-arriving-at-a-house",
+      "output": "tamil/book/chapters/ch35-arriving-at-a-house.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 36,
+      "title": "What You Are Offered",
+      "label": "ch:ta-what-you-are-offered",
+      "output": "tamil/book/chapters/ch36-what-you-are-offered.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 37,
+      "title": "Your Town, Your Friend",
+      "label": "ch:ta-your-town-your-friend",
+      "output": "tamil/book/chapters/ch37-your-town-your-friend.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "tamil",
+      "chapter": 38,
+      "title": "Keeping Well, and Leaving",
+      "label": "ch:ta-keeping-well-and-leaving",
+      "output": "tamil/book/chapters/ch38-keeping-well-and-leaving.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
       "language": "telugu",
       "chapter": 6,
       "title": "Case Endings and Dative Subjects",

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -862,6 +862,38 @@
       "scriptSet": "hindi-main"
     },
     {
+      "language": "hindi",
+      "chapter": 36,
+      "title": "One House, Four Languages",
+      "label": "ch:hi-one-house-four-languages",
+      "output": "hindi/book/chapters/ch36-one-house-four-languages.tex",
+      "scriptSet": "hindi-main"
+    },
+    {
+      "language": "hindi",
+      "chapter": 37,
+      "title": "One Tea, Please",
+      "label": "ch:hi-one-tea-please",
+      "output": "hindi/book/chapters/ch37-one-tea-please.tex",
+      "scriptSet": "hindi-main"
+    },
+    {
+      "language": "hindi",
+      "chapter": 38,
+      "title": "Six Words for Where It Hurts",
+      "label": "ch:hi-where-it-hurts",
+      "output": "hindi/book/chapters/ch38-where-it-hurts.tex",
+      "scriptSet": "hindi-main"
+    },
+    {
+      "language": "hindi",
+      "chapter": 39,
+      "title": "The People Around You",
+      "label": "ch:hi-people-around-you",
+      "output": "hindi/book/chapters/ch39-people-around-you.tex",
+      "scriptSet": "hindi-main"
+    },
+    {
       "language": "italian",
       "chapter": 2,
       "title": "How Are You?",

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -387,6 +387,38 @@
       "scriptSet": "arabic-main"
     },
     {
+      "language": "arabic",
+      "chapter": 33,
+      "title": "Asking for a Drink",
+      "label": "ch:ar-asking-for-a-drink",
+      "output": "arabic/book/chapters/ch33-asking-for-a-drink.tex",
+      "scriptSet": "arabic-main"
+    },
+    {
+      "language": "arabic",
+      "chapter": 34,
+      "title": "Asking for Food",
+      "label": "ch:ar-asking-for-food",
+      "output": "arabic/book/chapters/ch34-asking-for-food.tex",
+      "scriptSet": "arabic-main"
+    },
+    {
+      "language": "arabic",
+      "chapter": 35,
+      "title": "The People You Introduce",
+      "label": "ch:ar-people-you-introduce",
+      "output": "arabic/book/chapters/ch35-people-you-introduce.tex",
+      "scriptSet": "arabic-main"
+    },
+    {
+      "language": "arabic",
+      "chapter": 36,
+      "title": "Cups, Plates, and More Than One",
+      "label": "ch:ar-cups-plates-and-more-than-one",
+      "output": "arabic/book/chapters/ch36-cups-plates-and-more-than-one.tex",
+      "scriptSet": "arabic-main"
+    },
+    {
       "language": "bengali",
       "chapter": 6,
       "title": "Numbers One to Five",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -302,6 +302,53 @@
       "tex": "arabic/book/chapters/ch32-taking-thinking-helping-loving.tex"
     },
     {
+      "language": "arabic",
+      "chapter": 33,
+      "sourceHash": "fnv1a64:f3a63219618807ba",
+      "lessonIds": [
+        "AR-C33-shay",
+        "AR-C33-halib",
+        "AR-C33-sukkar",
+        "AR-C33-qahwa"
+      ],
+      "tex": "arabic/book/chapters/ch33-asking-for-a-drink.tex"
+    },
+    {
+      "language": "arabic",
+      "chapter": 34,
+      "sourceHash": "fnv1a64:140140ef03991197",
+      "lessonIds": [
+        "AR-C34-milh",
+        "AR-C34-lahm",
+        "AR-C34-jubn",
+        "AR-C34-taam"
+      ],
+      "tex": "arabic/book/chapters/ch34-asking-for-food.tex"
+    },
+    {
+      "language": "arabic",
+      "chapter": 35,
+      "sourceHash": "fnv1a64:bc0d1c1b8dd13f35",
+      "lessonIds": [
+        "AR-C35-jar",
+        "AR-C35-ibn-bint",
+        "AR-C35-sadiq"
+      ],
+      "tex": "arabic/book/chapters/ch35-people-you-introduce.tex"
+    },
+    {
+      "language": "arabic",
+      "chapter": 36,
+      "sourceHash": "fnv1a64:6b0582f629a90a18",
+      "lessonIds": [
+        "AR-C36-zayt",
+        "AR-C36-kub",
+        "AR-C36-tabaq",
+        "AR-C36-milaqa"
+      ],
+      "tex": "arabic/book/chapters/ch36-cups-plates-and-more-than-one.tex"
+    },
+    {
       "language": "bengali",
       "chapter": 6,
       "sourceHash": "fnv1a64:922476792193ab33",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -976,7 +976,7 @@
     {
       "language": "hindi",
       "chapter": 36,
-      "sourceHash": "fnv1a64:d6ea031f2071a150",
+      "sourceHash": "fnv1a64:d7b8aea5442f7154",
       "lessonIds": [
         "HI-C36-ghar",
         "HI-C36-darvaaza",
@@ -3378,7 +3378,7 @@
     {
       "language": "tamil",
       "chapter": 35,
-      "sourceHash": "fnv1a64:9b721566605c8133",
+      "sourceHash": "fnv1a64:dc38c4fb1b2e3bc9",
       "lessonIds": [
         "TA-C35-veedu",
         "TA-C35-kadavu",
@@ -3390,7 +3390,7 @@
     {
       "language": "tamil",
       "chapter": 36,
-      "sourceHash": "fnv1a64:71c92947d2d24ca0",
+      "sourceHash": "fnv1a64:231ca7f273eff40e",
       "lessonIds": [
         "TA-C36-teneer",
         "TA-C36-paal",
@@ -3402,7 +3402,7 @@
     {
       "language": "tamil",
       "chapter": 37,
-      "sourceHash": "fnv1a64:977ef60cd0294c2e",
+      "sourceHash": "fnv1a64:2a3905874c0757ce",
       "lessonIds": [
         "TA-C37-uur",
         "TA-C37-nanban",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -3270,6 +3270,53 @@
       "tex": "tamil/book/chapters/ch34-verbs-between-people.tex"
     },
     {
+      "language": "tamil",
+      "chapter": 35,
+      "sourceHash": "fnv1a64:9b721566605c8133",
+      "lessonIds": [
+        "TA-C35-veedu",
+        "TA-C35-kadavu",
+        "TA-C35-arai",
+        "TA-C35-naarkaali"
+      ],
+      "tex": "tamil/book/chapters/ch35-arriving-at-a-house.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 36,
+      "sourceHash": "fnv1a64:71c92947d2d24ca0",
+      "lessonIds": [
+        "TA-C36-teneer",
+        "TA-C36-paal",
+        "TA-C36-unavu",
+        "TA-C36-tavaru"
+      ],
+      "tex": "tamil/book/chapters/ch36-what-you-are-offered.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 37,
+      "sourceHash": "fnv1a64:977ef60cd0294c2e",
+      "lessonIds": [
+        "TA-C37-uur",
+        "TA-C37-nanban",
+        "TA-C37-ivar",
+        "TA-C37-ivar-en-nanbar"
+      ],
+      "tex": "tamil/book/chapters/ch37-your-town-your-friend.tex"
+    },
+    {
+      "language": "tamil",
+      "chapter": 38,
+      "sourceHash": "fnv1a64:cdf9a751033520e6",
+      "lessonIds": [
+        "TA-C38-udambu",
+        "TA-C38-sugam",
+        "TA-C38-vidai"
+      ],
+      "tex": "tamil/book/chapters/ch38-keeping-well-and-leaving.tex"
+    },
+    {
       "language": "telugu",
       "chapter": 6,
       "sourceHash": "fnv1a64:2f73ec5d662719c4",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -927,6 +927,54 @@
       "tex": "hindi/book/chapters/ch35-pasand.tex"
     },
     {
+      "language": "hindi",
+      "chapter": 36,
+      "sourceHash": "fnv1a64:d6ea031f2071a150",
+      "lessonIds": [
+        "HI-C36-ghar",
+        "HI-C36-darvaaza",
+        "HI-C36-kamra",
+        "HI-C36-kursi"
+      ],
+      "tex": "hindi/book/chapters/ch36-one-house-four-languages.tex"
+    },
+    {
+      "language": "hindi",
+      "chapter": 37,
+      "sourceHash": "fnv1a64:ebf952fd9155efa9",
+      "lessonIds": [
+        "HI-C37-chai",
+        "HI-C37-dudh",
+        "HI-C37-khaana",
+        "HI-C37-kitaab"
+      ],
+      "tex": "hindi/book/chapters/ch37-one-tea-please.tex"
+    },
+    {
+      "language": "hindi",
+      "chapter": 38,
+      "sourceHash": "fnv1a64:f7ff13f56a78a073",
+      "lessonIds": [
+        "HI-C38-aankh",
+        "HI-C38-daant",
+        "HI-C38-pair",
+        "HI-C38-pet"
+      ],
+      "tex": "hindi/book/chapters/ch38-where-it-hurts.tex"
+    },
+    {
+      "language": "hindi",
+      "chapter": 39,
+      "sourceHash": "fnv1a64:5a01181601c965b8",
+      "lessonIds": [
+        "HI-C39-dost",
+        "HI-C39-baccha",
+        "HI-C39-aadmi",
+        "HI-C39-aurat"
+      ],
+      "tex": "hindi/book/chapters/ch39-people-around-you.tex"
+    },
+    {
       "language": "italian",
       "chapter": 2,
       "sourceHash": "fnv1a64:bdc42ed768d3dffb",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -2351,7 +2351,7 @@
     {
       "language": "hindi",
       "chapter": 36,
-      "sourceHash": "fnv1a64:653dbf1b0b6bc8a9",
+      "sourceHash": "fnv1a64:451b541e2e9dd5a5",
       "lessonIds": [
         "HI-C36-ghar",
         "HI-C36-darvaaza",
@@ -2362,8 +2362,8 @@
       "drivablePrefix": 0,
       "text": "hindi/narration/ch36.txt",
       "json": "hindi/narration/ch36.json",
-      "textHash": "fnv1a64:e44857285fd03acd",
-      "jsonHash": "fnv1a64:4198446cda3e697c"
+      "textHash": "fnv1a64:82edfe031d597cb4",
+      "jsonHash": "fnv1a64:45be1c1589e719f7"
     },
     {
       "language": "hindi",
@@ -6817,7 +6817,7 @@
     {
       "language": "tamil",
       "chapter": 35,
-      "sourceHash": "fnv1a64:c346ffee5ae76309",
+      "sourceHash": "fnv1a64:2703e3459eee5f3a",
       "lessonIds": [
         "TA-C35-veedu",
         "TA-C35-kadavu",
@@ -6828,13 +6828,13 @@
       "drivablePrefix": 0,
       "text": "tamil/narration/ch35.txt",
       "json": "tamil/narration/ch35.json",
-      "textHash": "fnv1a64:6f13d636837a03df",
-      "jsonHash": "fnv1a64:c2a101abd187509e"
+      "textHash": "fnv1a64:73c0cbf33267d147",
+      "jsonHash": "fnv1a64:7316a8120132566d"
     },
     {
       "language": "tamil",
       "chapter": 36,
-      "sourceHash": "fnv1a64:670535ac9b63a59a",
+      "sourceHash": "fnv1a64:f2d3d5c13c0737fe",
       "lessonIds": [
         "TA-C36-teneer",
         "TA-C36-paal",
@@ -6845,13 +6845,13 @@
       "drivablePrefix": 0,
       "text": "tamil/narration/ch36.txt",
       "json": "tamil/narration/ch36.json",
-      "textHash": "fnv1a64:25cdbf4d49b812d5",
-      "jsonHash": "fnv1a64:6845d2405f768be0"
+      "textHash": "fnv1a64:0939422c53d55470",
+      "jsonHash": "fnv1a64:eaecb9427be3c9af"
     },
     {
       "language": "tamil",
       "chapter": 37,
-      "sourceHash": "fnv1a64:7d37f287632fb94f",
+      "sourceHash": "fnv1a64:956feb3bb64ab0cb",
       "lessonIds": [
         "TA-C37-uur",
         "TA-C37-nanban",
@@ -6862,8 +6862,8 @@
       "drivablePrefix": 0,
       "text": "tamil/narration/ch37.txt",
       "json": "tamil/narration/ch37.json",
-      "textHash": "fnv1a64:a51f01fcd1b4bfe7",
-      "jsonHash": "fnv1a64:363128adfbc4bcc4"
+      "textHash": "fnv1a64:ac8790b0e34fcd44",
+      "jsonHash": "fnv1a64:9935f52d6ca83937"
     },
     {
       "language": "tamil",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -505,6 +505,73 @@
       "jsonHash": "fnv1a64:5fbad3ebf5b3dc89"
     },
     {
+      "language": "arabic",
+      "chapter": 33,
+      "sourceHash": "fnv1a64:3e7842268901fc1c",
+      "lessonIds": [
+        "AR-C33-shay",
+        "AR-C33-halib",
+        "AR-C33-sukkar",
+        "AR-C33-qahwa"
+      ],
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
+      "text": "arabic/narration/ch33.txt",
+      "json": "arabic/narration/ch33.json",
+      "textHash": "fnv1a64:3fbe254299914906",
+      "jsonHash": "fnv1a64:b99b8de44fe468da"
+    },
+    {
+      "language": "arabic",
+      "chapter": 34,
+      "sourceHash": "fnv1a64:136f91c8179d610f",
+      "lessonIds": [
+        "AR-C34-milh",
+        "AR-C34-lahm",
+        "AR-C34-jubn",
+        "AR-C34-taam"
+      ],
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
+      "text": "arabic/narration/ch34.txt",
+      "json": "arabic/narration/ch34.json",
+      "textHash": "fnv1a64:e8a2785242d78fca",
+      "jsonHash": "fnv1a64:0f2897564f2861d3"
+    },
+    {
+      "language": "arabic",
+      "chapter": 35,
+      "sourceHash": "fnv1a64:b4d4d18659fdeeb2",
+      "lessonIds": [
+        "AR-C35-jar",
+        "AR-C35-ibn-bint",
+        "AR-C35-sadiq"
+      ],
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
+      "text": "arabic/narration/ch35.txt",
+      "json": "arabic/narration/ch35.json",
+      "textHash": "fnv1a64:20ab0ec36923c3d4",
+      "jsonHash": "fnv1a64:7288bc000dfb5ab4"
+    },
+    {
+      "language": "arabic",
+      "chapter": 36,
+      "sourceHash": "fnv1a64:9e09dda9d25a9e04",
+      "lessonIds": [
+        "AR-C36-zayt",
+        "AR-C36-kub",
+        "AR-C36-tabaq",
+        "AR-C36-milaqa"
+      ],
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
+      "text": "arabic/narration/ch36.txt",
+      "json": "arabic/narration/ch36.json",
+      "textHash": "fnv1a64:6c4026d17057d9f2",
+      "jsonHash": "fnv1a64:5aef7ba16320a2f7"
+    },
+    {
       "language": "bengali",
       "chapter": 1,
       "sourceHash": "fnv1a64:fee72d60309a5ae8",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -2282,6 +2282,74 @@
       "jsonHash": "fnv1a64:d2e4dc0f3a88294d"
     },
     {
+      "language": "hindi",
+      "chapter": 36,
+      "sourceHash": "fnv1a64:653dbf1b0b6bc8a9",
+      "lessonIds": [
+        "HI-C36-ghar",
+        "HI-C36-darvaaza",
+        "HI-C36-kamra",
+        "HI-C36-kursi"
+      ],
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
+      "text": "hindi/narration/ch36.txt",
+      "json": "hindi/narration/ch36.json",
+      "textHash": "fnv1a64:e44857285fd03acd",
+      "jsonHash": "fnv1a64:4198446cda3e697c"
+    },
+    {
+      "language": "hindi",
+      "chapter": 37,
+      "sourceHash": "fnv1a64:2db6148216359b7d",
+      "lessonIds": [
+        "HI-C37-chai",
+        "HI-C37-dudh",
+        "HI-C37-khaana",
+        "HI-C37-kitaab"
+      ],
+      "voiceLessons": 2,
+      "drivablePrefix": 2,
+      "text": "hindi/narration/ch37.txt",
+      "json": "hindi/narration/ch37.json",
+      "textHash": "fnv1a64:38eedeb6f5199103",
+      "jsonHash": "fnv1a64:7790b8c287a803bb"
+    },
+    {
+      "language": "hindi",
+      "chapter": 38,
+      "sourceHash": "fnv1a64:c24fc0097c1f0772",
+      "lessonIds": [
+        "HI-C38-aankh",
+        "HI-C38-daant",
+        "HI-C38-pair",
+        "HI-C38-pet"
+      ],
+      "voiceLessons": 1,
+      "drivablePrefix": 0,
+      "text": "hindi/narration/ch38.txt",
+      "json": "hindi/narration/ch38.json",
+      "textHash": "fnv1a64:bd290b4fb6df788e",
+      "jsonHash": "fnv1a64:3a231321af214a3f"
+    },
+    {
+      "language": "hindi",
+      "chapter": 39,
+      "sourceHash": "fnv1a64:8caddac03ed8c336",
+      "lessonIds": [
+        "HI-C39-dost",
+        "HI-C39-baccha",
+        "HI-C39-aadmi",
+        "HI-C39-aurat"
+      ],
+      "voiceLessons": 3,
+      "drivablePrefix": 0,
+      "text": "hindi/narration/ch39.txt",
+      "json": "hindi/narration/ch39.json",
+      "textHash": "fnv1a64:18ec7f15cf7441fb",
+      "jsonHash": "fnv1a64:eb372939873bf487"
+    },
+    {
       "language": "italian",
       "chapter": 1,
       "sourceHash": "fnv1a64:3e905f2b1c3dd36b",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -6663,6 +6663,73 @@
       "jsonHash": "fnv1a64:46adf7fdfc05b3c6"
     },
     {
+      "language": "tamil",
+      "chapter": 35,
+      "sourceHash": "fnv1a64:c346ffee5ae76309",
+      "lessonIds": [
+        "TA-C35-veedu",
+        "TA-C35-kadavu",
+        "TA-C35-arai",
+        "TA-C35-naarkaali"
+      ],
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
+      "text": "tamil/narration/ch35.txt",
+      "json": "tamil/narration/ch35.json",
+      "textHash": "fnv1a64:6f13d636837a03df",
+      "jsonHash": "fnv1a64:c2a101abd187509e"
+    },
+    {
+      "language": "tamil",
+      "chapter": 36,
+      "sourceHash": "fnv1a64:670535ac9b63a59a",
+      "lessonIds": [
+        "TA-C36-teneer",
+        "TA-C36-paal",
+        "TA-C36-unavu",
+        "TA-C36-tavaru"
+      ],
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
+      "text": "tamil/narration/ch36.txt",
+      "json": "tamil/narration/ch36.json",
+      "textHash": "fnv1a64:25cdbf4d49b812d5",
+      "jsonHash": "fnv1a64:6845d2405f768be0"
+    },
+    {
+      "language": "tamil",
+      "chapter": 37,
+      "sourceHash": "fnv1a64:7d37f287632fb94f",
+      "lessonIds": [
+        "TA-C37-uur",
+        "TA-C37-nanban",
+        "TA-C37-ivar",
+        "TA-C37-ivar-en-nanbar"
+      ],
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
+      "text": "tamil/narration/ch37.txt",
+      "json": "tamil/narration/ch37.json",
+      "textHash": "fnv1a64:a51f01fcd1b4bfe7",
+      "jsonHash": "fnv1a64:363128adfbc4bcc4"
+    },
+    {
+      "language": "tamil",
+      "chapter": 38,
+      "sourceHash": "fnv1a64:d9d5146731ccd6eb",
+      "lessonIds": [
+        "TA-C38-udambu",
+        "TA-C38-sugam",
+        "TA-C38-vidai"
+      ],
+      "voiceLessons": 0,
+      "drivablePrefix": 0,
+      "text": "tamil/narration/ch38.txt",
+      "json": "tamil/narration/ch38.json",
+      "textHash": "fnv1a64:a5992018dceb6f58",
+      "jsonHash": "fnv1a64:b69a57e66c22ac5f"
+    },
+    {
       "language": "telugu",
       "chapter": 1,
       "sourceHash": "fnv1a64:1e014704b06c6363",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,30 +7,30 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:91118e65c81835b4",
+  "sourceHash": "fnv1a64:9a6a2b3c253d9d88",
   "summary": {
-    "totalLessons": 1449,
+    "totalLessons": 1464,
     "voice": 973,
-    "sight": 423,
+    "sight": 438,
     "pen": 53,
     "drivableLessons": 973,
-    "drivablePercent": 67,
+    "drivablePercent": 66,
     "trackCount": 22,
-    "chapterCount": 451,
+    "chapterCount": 455,
     "drivablePrefixTotal": 790,
     "fullyDrivableChapters": 306,
-    "unstartableChapters": 108,
+    "unstartableChapters": 112,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
   },
   "tracks": [
     {
       "language": "arabic",
-      "lessonCount": 85,
+      "lessonCount": 100,
       "voice": 44,
-      "sight": 25,
+      "sight": 40,
       "pen": 16,
-      "drivablePercent": 52,
+      "drivablePercent": 44,
       "drivablePrefixTotal": 32,
       "modalities": [
         "voice",
@@ -549,6 +549,62 @@
           ],
           "drivablePrefix": 0,
           "firstNonVoiceLesson": "AR-C32-akhadha",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 33,
+          "lessonCount": 4,
+          "voice": 0,
+          "sight": 4,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "AR-C33-shay",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 34,
+          "lessonCount": 4,
+          "voice": 0,
+          "sight": 4,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "AR-C34-milh",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 35,
+          "lessonCount": 3,
+          "voice": 0,
+          "sight": 3,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "AR-C35-jar",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 36,
+          "lessonCount": 4,
+          "voice": 0,
+          "sight": 4,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "AR-C36-zayt",
           "drivable": false,
           "drivableLessonIds": []
         }
@@ -9554,6 +9610,321 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:2c4164cd56e38bb1",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C33-shay",
+      "language": "arabic",
+      "chapter": 33,
+      "sequence": 860,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:d386b81660d43aa0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C33-halib",
+      "language": "arabic",
+      "chapter": 33,
+      "sequence": 870,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:28e14939b0409873",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C33-sukkar",
+      "language": "arabic",
+      "chapter": 33,
+      "sequence": 880,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:db0d13a9953e0c80",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C33-qahwa",
+      "language": "arabic",
+      "chapter": 33,
+      "sequence": 890,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:537116d3714fb966",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C34-milh",
+      "language": "arabic",
+      "chapter": 34,
+      "sequence": 900,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0f5ea9c24ee5e175",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C34-lahm",
+      "language": "arabic",
+      "chapter": 34,
+      "sequence": 910,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:fc6790ceb65f68c5",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C34-jubn",
+      "language": "arabic",
+      "chapter": 34,
+      "sequence": 920,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:23468191710d0fc0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C34-taam",
+      "language": "arabic",
+      "chapter": 34,
+      "sequence": 930,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4a7d4b03514270ed",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C35-jar",
+      "language": "arabic",
+      "chapter": 35,
+      "sequence": 940,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c3b5d894189ce2e2",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C35-ibn-bint",
+      "language": "arabic",
+      "chapter": 35,
+      "sequence": 950,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e34369727aec4468",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C35-sadiq",
+      "language": "arabic",
+      "chapter": 35,
+      "sequence": 960,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:59ffe28814224473",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C36-zayt",
+      "language": "arabic",
+      "chapter": 36,
+      "sequence": 970,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:389576737b14f3e0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C36-kub",
+      "language": "arabic",
+      "chapter": 36,
+      "sequence": 980,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:51a3d21b81556a2a",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C36-tabaq",
+      "language": "arabic",
+      "chapter": 36,
+      "sequence": 990,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c79df8d04f7b28f9",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C36-milaqa",
+      "language": "arabic",
+      "chapter": 36,
+      "sequence": 1000,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:001d3e7108432439",
       "detachableSegments": [
         "The letters in this word"
       ]

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,19 +7,19 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:91118e65c81835b4",
+  "sourceHash": "fnv1a64:b777144ee21a5da7",
   "summary": {
-    "totalLessons": 1449,
+    "totalLessons": 1464,
     "voice": 973,
-    "sight": 423,
+    "sight": 438,
     "pen": 53,
     "drivableLessons": 973,
-    "drivablePercent": 67,
+    "drivablePercent": 66,
     "trackCount": 22,
-    "chapterCount": 451,
+    "chapterCount": 455,
     "drivablePrefixTotal": 790,
     "fullyDrivableChapters": 306,
-    "unstartableChapters": 108,
+    "unstartableChapters": 112,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
   },
@@ -6652,11 +6652,11 @@
     },
     {
       "language": "tamil",
-      "lessonCount": 97,
+      "lessonCount": 112,
       "voice": 53,
-      "sight": 36,
+      "sight": 51,
       "pen": 8,
-      "drivablePercent": 55,
+      "drivablePercent": 47,
       "drivablePrefixTotal": 42,
       "modalities": [
         "voice",
@@ -7214,6 +7214,62 @@
           ],
           "drivablePrefix": 0,
           "firstNonVoiceLesson": "TA-C34-edu",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 35,
+          "lessonCount": 4,
+          "voice": 0,
+          "sight": 4,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "TA-C35-veedu",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 36,
+          "lessonCount": 4,
+          "voice": 0,
+          "sight": 4,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "TA-C36-teneer",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 37,
+          "lessonCount": 4,
+          "voice": 0,
+          "sight": 4,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "TA-C37-uur",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 38,
+          "lessonCount": 3,
+          "voice": 0,
+          "sight": 3,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "TA-C38-udambu",
           "drivable": false,
           "drivableLessonIds": []
         }
@@ -33096,6 +33152,321 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:1480cdf0e8dbdd75"
+    },
+    {
+      "id": "TA-C35-veedu",
+      "language": "tamil",
+      "chapter": 35,
+      "sequence": 750,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:297479db3d817cd4",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C35-kadavu",
+      "language": "tamil",
+      "chapter": 35,
+      "sequence": 760,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c1a0f46c867a9c03",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C35-arai",
+      "language": "tamil",
+      "chapter": 35,
+      "sequence": 770,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:34d173f2cce6d96f",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C35-naarkaali",
+      "language": "tamil",
+      "chapter": 35,
+      "sequence": 780,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f68ff6aa061a196c",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C36-teneer",
+      "language": "tamil",
+      "chapter": 36,
+      "sequence": 790,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:fbaac7d8134225e1",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C36-paal",
+      "language": "tamil",
+      "chapter": 36,
+      "sequence": 800,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:6a72f2af11ebc2dc",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C36-unavu",
+      "language": "tamil",
+      "chapter": 36,
+      "sequence": 810,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:79a09af6b5c1e1fd",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C36-tavaru",
+      "language": "tamil",
+      "chapter": 36,
+      "sequence": 820,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:46edc651e85b20f4",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C37-uur",
+      "language": "tamil",
+      "chapter": 37,
+      "sequence": 830,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3393a38bd4aca7f7",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C37-nanban",
+      "language": "tamil",
+      "chapter": 37,
+      "sequence": 840,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5b1b5f724e390f6b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C37-ivar",
+      "language": "tamil",
+      "chapter": 37,
+      "sequence": 850,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9ca3f8708b12b192",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C37-ivar-en-nanbar",
+      "language": "tamil",
+      "chapter": 37,
+      "sequence": 860,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a2e2284ae61b8a8e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C38-udambu",
+      "language": "tamil",
+      "chapter": 38,
+      "sequence": 870,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4c3a8be338bc60b3",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C38-sugam",
+      "language": "tamil",
+      "chapter": 38,
+      "sequence": 880,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e334b1613ee920fd",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C38-vidai",
+      "language": "tamil",
+      "chapter": 38,
+      "sequence": 890,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f9300ce323ff2a68",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
     },
     {
       "id": "TE-C01-avunu",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,30 +7,30 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:a90e7cf5c3b4fdab",
+  "sourceHash": "fnv1a64:16968fe4391d74bc",
   "summary": {
-    "totalLessons": 1468,
-    "voice": 977,
-    "sight": 438,
+    "totalLessons": 1499,
+    "voice": 983,
+    "sight": 463,
     "pen": 53,
-    "drivableLessons": 977,
-    "drivablePercent": 67,
+    "drivableLessons": 983,
+    "drivablePercent": 66,
     "trackCount": 22,
-    "chapterCount": 456,
-    "drivablePrefixTotal": 794,
+    "chapterCount": 464,
+    "drivablePrefixTotal": 796,
     "fullyDrivableChapters": 307,
-    "unstartableChapters": 112,
+    "unstartableChapters": 119,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
   },
   "tracks": [
     {
       "language": "arabic",
-      "lessonCount": 85,
+      "lessonCount": 100,
       "voice": 44,
-      "sight": 25,
+      "sight": 40,
       "pen": 16,
-      "drivablePercent": 52,
+      "drivablePercent": 44,
       "drivablePrefixTotal": 32,
       "modalities": [
         "voice",
@@ -549,6 +549,62 @@
           ],
           "drivablePrefix": 0,
           "firstNonVoiceLesson": "AR-C32-akhadha",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 33,
+          "lessonCount": 4,
+          "voice": 0,
+          "sight": 4,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "AR-C33-shay",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 34,
+          "lessonCount": 4,
+          "voice": 0,
+          "sight": 4,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "AR-C34-milh",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 35,
+          "lessonCount": 3,
+          "voice": 0,
+          "sight": 3,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "AR-C35-jar",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 36,
+          "lessonCount": 4,
+          "voice": 0,
+          "sight": 4,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "AR-C36-zayt",
           "drivable": false,
           "drivableLessonIds": []
         }
@@ -1883,12 +1939,12 @@
     },
     {
       "language": "hindi",
-      "lessonCount": 93,
-      "voice": 53,
-      "sight": 29,
+      "lessonCount": 109,
+      "voice": 59,
+      "sight": 39,
       "pen": 11,
-      "drivablePercent": 57,
-      "drivablePrefixTotal": 40,
+      "drivablePercent": 54,
+      "drivablePrefixTotal": 42,
       "modalities": [
         "voice",
         "sight",
@@ -2463,6 +2519,68 @@
           "drivableLessonIds": [
             "HI-C35-lena"
           ]
+        },
+        {
+          "chapter": 36,
+          "lessonCount": 4,
+          "voice": 0,
+          "sight": 4,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "HI-C36-ghar",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 37,
+          "lessonCount": 4,
+          "voice": 2,
+          "sight": 2,
+          "pen": 0,
+          "modalities": [
+            "voice",
+            "sight"
+          ],
+          "drivablePrefix": 2,
+          "firstNonVoiceLesson": "HI-C37-khaana",
+          "drivable": false,
+          "drivableLessonIds": [
+            "HI-C37-chai",
+            "HI-C37-dudh"
+          ]
+        },
+        {
+          "chapter": 38,
+          "lessonCount": 4,
+          "voice": 1,
+          "sight": 3,
+          "pen": 0,
+          "modalities": [
+            "voice",
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "HI-C38-aankh",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 39,
+          "lessonCount": 4,
+          "voice": 3,
+          "sight": 1,
+          "pen": 0,
+          "modalities": [
+            "voice",
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "HI-C39-dost",
+          "drivable": false,
+          "drivableLessonIds": []
         }
       ]
     },
@@ -9634,6 +9752,321 @@
       ]
     },
     {
+      "id": "AR-C33-shay",
+      "language": "arabic",
+      "chapter": 33,
+      "sequence": 860,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:d386b81660d43aa0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C33-halib",
+      "language": "arabic",
+      "chapter": 33,
+      "sequence": 870,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:28e14939b0409873",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C33-sukkar",
+      "language": "arabic",
+      "chapter": 33,
+      "sequence": 880,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:db0d13a9953e0c80",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C33-qahwa",
+      "language": "arabic",
+      "chapter": 33,
+      "sequence": 890,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:537116d3714fb966",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C34-milh",
+      "language": "arabic",
+      "chapter": 34,
+      "sequence": 900,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0f5ea9c24ee5e175",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C34-lahm",
+      "language": "arabic",
+      "chapter": 34,
+      "sequence": 910,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:fc6790ceb65f68c5",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C34-jubn",
+      "language": "arabic",
+      "chapter": 34,
+      "sequence": 920,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:23468191710d0fc0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C34-taam",
+      "language": "arabic",
+      "chapter": 34,
+      "sequence": 930,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:4a7d4b03514270ed",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C35-jar",
+      "language": "arabic",
+      "chapter": 35,
+      "sequence": 940,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c3b5d894189ce2e2",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C35-ibn-bint",
+      "language": "arabic",
+      "chapter": 35,
+      "sequence": 950,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e34369727aec4468",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C35-sadiq",
+      "language": "arabic",
+      "chapter": 35,
+      "sequence": 960,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:59ffe28814224473",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C36-zayt",
+      "language": "arabic",
+      "chapter": 36,
+      "sequence": 970,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:389576737b14f3e0",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C36-kub",
+      "language": "arabic",
+      "chapter": 36,
+      "sequence": 980,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:51a3d21b81556a2a",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C36-tabaq",
+      "language": "arabic",
+      "chapter": 36,
+      "sequence": 990,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c79df8d04f7b28f9",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "AR-C36-milaqa",
+      "language": "arabic",
+      "chapter": 36,
+      "sequence": 1000,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:001d3e7108432439",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
       "id": "BN-C01-achchha",
       "language": "bengali",
       "chapter": 1,
@@ -16635,6 +17068,324 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:4625fc75bef6bc43"
+    },
+    {
+      "id": "HI-C36-ghar",
+      "language": "hindi",
+      "chapter": 36,
+      "sequence": 690,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e1bda72998180443",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C36-darvaaza",
+      "language": "hindi",
+      "chapter": 36,
+      "sequence": 700,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:cc3dacc2fb708c31",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C36-kamra",
+      "language": "hindi",
+      "chapter": 36,
+      "sequence": 710,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:437068c5d1bd4e49",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C36-kursi",
+      "language": "hindi",
+      "chapter": 36,
+      "sequence": 720,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:146ec51e225cc113",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C37-chai",
+      "language": "hindi",
+      "chapter": 37,
+      "sequence": 730,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e3443c65fcf7c40f"
+    },
+    {
+      "id": "HI-C37-dudh",
+      "language": "hindi",
+      "chapter": 37,
+      "sequence": 740,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b0053e335d327c38"
+    },
+    {
+      "id": "HI-C37-khaana",
+      "language": "hindi",
+      "chapter": 37,
+      "sequence": 750,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c20131f51974a639",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C37-kitaab",
+      "language": "hindi",
+      "chapter": 37,
+      "sequence": 760,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1b10f6f9c32998db",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C38-aankh",
+      "language": "hindi",
+      "chapter": 38,
+      "sequence": 770,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:90b1e52415eb4bdd",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C38-daant",
+      "language": "hindi",
+      "chapter": 38,
+      "sequence": 780,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:cb862bd64f6b136b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C38-pair",
+      "language": "hindi",
+      "chapter": 38,
+      "sequence": 790,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:adb4e1318685cd65"
+    },
+    {
+      "id": "HI-C38-pet",
+      "language": "hindi",
+      "chapter": 38,
+      "sequence": 800,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0605633691de8b02",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C39-dost",
+      "language": "hindi",
+      "chapter": 39,
+      "sequence": 810,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:245865f8519a8100",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C39-baccha",
+      "language": "hindi",
+      "chapter": 39,
+      "sequence": 820,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:585b746e54384286"
+    },
+    {
+      "id": "HI-C39-aadmi",
+      "language": "hindi",
+      "chapter": 39,
+      "sequence": 830,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5b0959e1158d768d"
+    },
+    {
+      "id": "HI-C39-aurat",
+      "language": "hindi",
+      "chapter": 39,
+      "sequence": 840,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:78acad32b8b61cfe"
     },
     {
       "id": "IT-C01-buongiorno",
@@ -33281,7 +34032,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c1a0f46c867a9c03",
+      "sourceHash": "fnv1a64:563406c98419bdc3",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -33386,7 +34137,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:79a09af6b5c1e1fd",
+      "sourceHash": "fnv1a64:044f1ad4f016e2c5",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -33449,7 +34200,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:5b1b5f724e390f6b",
+      "sourceHash": "fnv1a64:e3f3e23276e44561",
       "detachableSegments": [
         "The letters in this word"
       ]

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,19 +7,19 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:91118e65c81835b4",
+  "sourceHash": "fnv1a64:0039cceb8030c298",
   "summary": {
-    "totalLessons": 1449,
-    "voice": 973,
-    "sight": 423,
+    "totalLessons": 1465,
+    "voice": 979,
+    "sight": 433,
     "pen": 53,
-    "drivableLessons": 973,
+    "drivableLessons": 979,
     "drivablePercent": 67,
     "trackCount": 22,
-    "chapterCount": 451,
-    "drivablePrefixTotal": 790,
+    "chapterCount": 455,
+    "drivablePrefixTotal": 792,
     "fullyDrivableChapters": 306,
-    "unstartableChapters": 108,
+    "unstartableChapters": 111,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
   },
@@ -1883,12 +1883,12 @@
     },
     {
       "language": "hindi",
-      "lessonCount": 93,
-      "voice": 53,
-      "sight": 29,
+      "lessonCount": 109,
+      "voice": 59,
+      "sight": 39,
       "pen": 11,
-      "drivablePercent": 57,
-      "drivablePrefixTotal": 40,
+      "drivablePercent": 54,
+      "drivablePrefixTotal": 42,
       "modalities": [
         "voice",
         "sight",
@@ -2463,6 +2463,68 @@
           "drivableLessonIds": [
             "HI-C35-lena"
           ]
+        },
+        {
+          "chapter": 36,
+          "lessonCount": 4,
+          "voice": 0,
+          "sight": 4,
+          "pen": 0,
+          "modalities": [
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "HI-C36-ghar",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 37,
+          "lessonCount": 4,
+          "voice": 2,
+          "sight": 2,
+          "pen": 0,
+          "modalities": [
+            "voice",
+            "sight"
+          ],
+          "drivablePrefix": 2,
+          "firstNonVoiceLesson": "HI-C37-khaana",
+          "drivable": false,
+          "drivableLessonIds": [
+            "HI-C37-chai",
+            "HI-C37-dudh"
+          ]
+        },
+        {
+          "chapter": 38,
+          "lessonCount": 4,
+          "voice": 1,
+          "sight": 3,
+          "pen": 0,
+          "modalities": [
+            "voice",
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "HI-C38-aankh",
+          "drivable": false,
+          "drivableLessonIds": []
+        },
+        {
+          "chapter": 39,
+          "lessonCount": 4,
+          "voice": 3,
+          "sight": 1,
+          "pen": 0,
+          "modalities": [
+            "voice",
+            "sight"
+          ],
+          "drivablePrefix": 0,
+          "firstNonVoiceLesson": "HI-C39-dost",
+          "drivable": false,
+          "drivableLessonIds": []
         }
       ]
     },
@@ -16560,6 +16622,324 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:4625fc75bef6bc43"
+    },
+    {
+      "id": "HI-C36-ghar",
+      "language": "hindi",
+      "chapter": 36,
+      "sequence": 690,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e1bda72998180443",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C36-darvaaza",
+      "language": "hindi",
+      "chapter": 36,
+      "sequence": 700,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:400e1a65c0cf63ef",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C36-kamra",
+      "language": "hindi",
+      "chapter": 36,
+      "sequence": 710,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:437068c5d1bd4e49",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C36-kursi",
+      "language": "hindi",
+      "chapter": 36,
+      "sequence": 720,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:146ec51e225cc113",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C37-chai",
+      "language": "hindi",
+      "chapter": 37,
+      "sequence": 730,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:e3443c65fcf7c40f"
+    },
+    {
+      "id": "HI-C37-dudh",
+      "language": "hindi",
+      "chapter": 37,
+      "sequence": 740,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b0053e335d327c38"
+    },
+    {
+      "id": "HI-C37-khaana",
+      "language": "hindi",
+      "chapter": 37,
+      "sequence": 750,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c20131f51974a639",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C37-kitaab",
+      "language": "hindi",
+      "chapter": 37,
+      "sequence": 760,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:1b10f6f9c32998db",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C38-aankh",
+      "language": "hindi",
+      "chapter": 38,
+      "sequence": 770,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:90b1e52415eb4bdd",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C38-daant",
+      "language": "hindi",
+      "chapter": 38,
+      "sequence": 780,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:cb862bd64f6b136b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C38-pair",
+      "language": "hindi",
+      "chapter": 38,
+      "sequence": 790,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:adb4e1318685cd65"
+    },
+    {
+      "id": "HI-C38-pet",
+      "language": "hindi",
+      "chapter": 38,
+      "sequence": 800,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:0605633691de8b02",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C39-dost",
+      "language": "hindi",
+      "chapter": 39,
+      "sequence": 810,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:245865f8519a8100",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "HI-C39-baccha",
+      "language": "hindi",
+      "chapter": 39,
+      "sequence": 820,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:585b746e54384286"
+    },
+    {
+      "id": "HI-C39-aadmi",
+      "language": "hindi",
+      "chapter": 39,
+      "sequence": 830,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5b0959e1158d768d"
+    },
+    {
+      "id": "HI-C39-aurat",
+      "language": "hindi",
+      "chapter": 39,
+      "sequence": 840,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:78acad32b8b61cfe"
     },
     {
       "id": "IT-C01-buongiorno",

--- a/code/learning/human-languages/hindi/CHANGELOG.md
+++ b/code/learning/human-languages/hindi/CHANGELOG.md
@@ -1,5 +1,98 @@
 # Changelog
 
+## Chapters 36–39 — the pre-A1 noun tranche, and what it measured
+
+Sixteen everyday nouns, four chapters of four lessons. This wave was authored as
+a **measurement probe** as much as content: `src/level-gate.ts` reported that no
+track had attained even pre-A1, and that Hindi's binding blockers were
+`vocabulary` and `reinforcement`. The question was whether track-local lessons
+attached to pre-A1 spine nodes through the `HI-EXT-*` mechanism actually move
+those numbers.
+
+**They do.** Measured with `buildCurriculumGapReport` before and after:
+
+| `levelGate.tracks[hindi]` | before | after |
+|---|---|---|
+| `vocabulary` (whole track, any level) | 70 | 86 |
+| headwords at or below pre-A1 | 34 | 50 |
+| `vocabulary` shortfall (target 300) | 266 | 250 |
+| `reinforcement` shortfall | 39 | **4** |
+| `attained` / `inProgressAt` | null / pre-A1 | null / pre-A1 |
+
+The vocabulary criterion counts **distinct headwords on `word`/`phrase` lessons
+whose spine node sits at or below the level**. Sixteen new `word` lessons in
+path segments pointing at pre-A1 nodes therefore moved it by exactly sixteen —
+one per lesson, no more. That is the honest exchange rate: **closing pre-A1 on
+vocabulary alone needs another 250 lessons of this shape**, and nothing about
+the mechanism makes it cheaper. Lesson count, not authoring cleverness, is the
+whole cost.
+
+The reinforcement number is where the leverage was. All **39** pre-A1 atoms the
+continuity ledger reported as revisited fewer than twice are now practised at
+least twice — the yes/no words, कृपया and माफ़ कीजिए, the family and body
+lessons, पानी/रोटी, शुभ रात्रि, and the entire W01–W05 writing series, rescued
+inside "The letters in this word" sections that also carry their own word. The
+remaining 4 are atoms introduced by these chapters' own final lessons, which no
+later lesson exists to revisit.
+
+**Where the four chapters hang, and what would not hang honestly.** The seven
+pre-A1 spine nodes are all **speech acts** — greet, thank, respond, exchange
+names, check wellbeing, request, take leave. Four of them take nouns without
+strain: MEET-GREET holds what you are received into and offered (घर, दरवाज़ा,
+कमरा, कुर्सी); POLITE-REQUEST-REPAIR holds what you ask for (चाय, दूध, खाना,
+किताब); CHECK-WELLBEING already held सिर and हाथ, so body words extend it
+(आँख, दाँत, पैर, पेट); EXCHANGE-NAMES holds the people you introduce (दोस्त,
+बच्चा, आदमी, औरत). **There is no pre-A1 node for naming a thing in front of
+you.** मेज़ (table), खिड़की (window), सड़क (road), गाड़ी (vehicle) and कागज़
+(paper) were on the shortlist and were dropped rather than forced: no honest
+reading of a greeting-or-request node covers them. If pre-A1 is to reach 300
+headwords, the spine needs a node for plain naming. That is a finding about the
+spine, not about the words.
+
+Not duplicated: पानी and रोटी (Ch. 15), नाम (Ch. 2), पिता/माता and भाई/बहन
+(Ch. 12) were already taught, so the brief's suggested list shrank by six before
+authoring began. माँ was dropped for the same reason — Ch. 12 covers "mother".
+
+**Gender is the atom, not a footnote.** Every lesson teaches its noun's gender
+where the noun is taught, because Hindi gender is not recoverable from meaning
+and only partly from shape. The chapters build and then break the rule of thumb
+deliberately: Ch. 36 establishes long **-ā** masculine / long **-ī** feminine
+and shows घर outside it; Ch. 37 breaks it with **चाय** and **किताब**, feminine
+with no **-ī** to show for it; Ch. 38 sets **आँख** (f.) against **दाँत** (m.),
+identical in shape; Ch. 39 breaks it the other way with **आदमी**, masculine
+*with* an **-ī**, and shows **दोस्त** taking its possessive from the person
+rather than the word. The thread is carried by **मेरा / मेरी**, and it finally
+keeps the promise Ch. 2 made in writing: *"You'll meet merī at your first
+feminine noun."*
+
+**Corrections made during authoring, all against sources.** Several attractive
+etymologies did not survive checking and are recorded here so they are not
+reintroduced: गृह is **not** from √*grah* "to seize" (that is a grammarians'
+root-assignment; the real root is \**gʰerdʰ-* "enclosure"); पैर is **not** from
+*pāda* (पाँव is); पेट is **not** demonstrably from *peṭaka* "basket" (Turner
+notes a resemblance and derives nothing; the mainstream account is a Dravidian
+loan); Persian *bacca* is a **sister** of Sanskrit *vatsa*, not a descendant;
+the Hebrew *ʾādām* / *ʾadāmāh* "ground" link is Genesis making a deliberate pun,
+not the etymology; the Greek cognate of अक्षि is *ósse*, **not** *ophthalmós*;
+English *dough* is unrelated to दूध (*doughty* is the real cousin); and the
+tea *chá*/*tê* split is about which Chinese **port** a trader used, not overland
+versus sea, since Portuguese *chá* came by sea. One usage correction too:
+**कृपया** is written register — signage and announcements — and **एक चाय
+दीजिए** is what is actually said, so the chapter says so.
+
+**Fonts.** Latin Modern has no Greek, Hebrew or Han. The first draft quoted
+Greek *odoús* and *ósse*, Hebrew *ʾādām* and *ʾadāmāh*, and the Chinese
+character for tea in their own scripts; a XeLaTeX run reported **28** dropped
+glyphs against a track baseline of **zero**. All are now romanization only. The
+39-chapter book compiles to 164 pages with **zero** missing characters.
+
+**Gates.** Zero chapter-gate findings for 36–39; each payoff assesses every atom
+its own chapter introduces plus its reach-back list. Zero duration violations
+(every lesson computes under 300s). Zero new atom-budget violations — the one
+Hindi ramp violation, `HI-C22-gyarah-bees`, pre-dates this branch. Zero
+script-ramp violations. `attained` is still `null` and honestly so: pre-A1 is
+250 headwords away.
+
 ## Chapters 34–35 — the second verb tranche, and thirteen rescued atoms
 
 Hindi sat at **4 of the shared spine's 40 core verbs**, the thinnest coverage of

--- a/code/learning/human-languages/hindi/README.md
+++ b/code/learning/human-languages/hindi/README.md
@@ -59,6 +59,14 @@ Two things shape this track.
   English **pray**), मदद करना (help — an Arabic noun plus native करना, Hindi's
   conjunct-verb engine), and पसंद, which is **not a verb at all**: *mujhe roṭī
   pasand hai* is "to me, bread is pleasing." In the book.
+- **Chapters 36–39 — the pre-A1 noun tranche** ([`lessons/HI-C36-*`](./lessons/)
+  through `HI-C39-*`): sixteen everyday nouns, four per chapter, each taught
+  **with its grammatical gender as part of the atom** rather than as an
+  afterthought — घर दरवाज़ा कमरा कुर्सी (a house and what is in it); चाय दूध
+  खाना किताब (what you ask for, and how you actually ask); आँख दाँत पैर पेट
+  (six body words, three of them exact Indo-European cousins and one with no
+  traceable ancestry); दोस्त बच्चा आदमी औरत (the people around you). All four
+  chapters hang off **pre-A1** spine nodes. In the book.
 - **Writing companions W01–W05** ([`lessons/HI-W*`](./lessons/)): eleven short
   steps introduce the headline, letter bodies, inherent vowel, mātrās,
   preposed short **ि**, spineless letters, virama, conjuncts, and finally whole
@@ -82,7 +90,7 @@ shared-spine nodes it realises, and the **payoff** lesson that proves the
 promise, with the exact knowledge atoms that lesson practises. It is authored
 intent, not a derived cache — no validator may rewrite it.
 
-Thirty-two of the thirty-five chapters are authored. Three are honestly missing:
+Thirty-six of the thirty-nine chapters are authored. Three are honestly missing:
 
 - **Chapters 3, 4, and 5 have no entry.** Every lesson in them is still schema
   v1 with no `practises.knowledge`, so a payoff there could not name a single
@@ -98,17 +106,27 @@ chapter introduces and will be reported under the 0.5 representativeness
 threshold once the HL05 gates land. The cure is a real terminal consolidation
 lesson in each, not a broader claim here. Chapters 34 and 35 fire **no** gate
 findings: each payoff closes over its own chapter (5 of 8 atoms, and 6 of 9)
-and every atom it names was taught by that chapter or earlier.
+and every atom it names was taught by that chapter or earlier. Chapters 36–39
+also fire **no** findings, and each of their payoffs assesses **every** atom its
+own chapter introduces plus a reach-back list drawn from earlier chapters.
 
 ## Book / fonts
 
-The 35-chapter book compiles with XeLaTeX using **vendored** Noto Sans
+The 39-chapter book compiles with XeLaTeX using **vendored** Noto Sans
 Devanagari, Noto Naskh Arabic, and Noto Sans Cyrillic fonts (`../../_fonts/`),
 loaded by relative path — so it builds identically locally and in CI, with no
-system-font dependency. Chapters 6–35 are generated from canonical lesson ASTs
-and checked against Language Ladder source hashes. A forced 124-page build
-reports **zero** missing characters and zero errors; the one overfull and one
-underfull box both pre-date chapters 34–35. `latexmk -xelatex book.tex`.
+system-font dependency. Chapters 6–39 are generated from canonical lesson ASTs
+and checked against Language Ladder source hashes. A 164-page build reports
+**zero** missing characters and zero errors. `latexmk -xelatex book.tex`.
+
+**What the main font cannot set.** The book's main face is Latin Modern, and it
+has no Greek, no Hebrew and no Han. Chapters 36–39 were drafted quoting Greek
+*odoús* and *ósse*, Hebrew *ʾādām*, and the Chinese character for tea in their
+own scripts; a XeLaTeX run reported 28 dropped glyphs, against a track baseline
+of zero. All of them are now given in **romanization only**, which is why those
+lessons name Greek and Hebrew forms without showing them. Only Devanagari
+(including nuqta letters and conjuncts) and Perso-Arabic have vendored fonts and
+may be set in script.
 
 ## Files
 

--- a/code/learning/human-languages/hindi/book/book.tex
+++ b/code/learning/human-languages/hindi/book/book.tex
@@ -145,6 +145,14 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/ch35-pasand}
 
+\input{chapters/ch36-one-house-four-languages}
+
+\input{chapters/ch37-one-tea-please}
+
+\input{chapters/ch38-where-it-hurts}
+
+\input{chapters/ch39-people-around-you}
+
 \backmatter
 
 \input{chapters/appendix-pronunciation}

--- a/code/learning/human-languages/hindi/book/chapters/ch36-one-house-four-languages.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch36-one-house-four-languages.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:d6ea031f2071a150
+% canonical-source-hash: fnv1a64:d7b8aea5442f7154
 % canonical-lessons: HI-C36-ghar, HI-C36-darvaaza, HI-C36-kamra, HI-C36-kursi
 
 \chapter{One House, Four Languages}
@@ -78,7 +78,7 @@ A nuqta is a small confession in ink: \emph{this sound came from somewhere else.
 \begin{grammarlens}[title={Grammar Lens: the shape that usually tells you}]
 \textbf{\hi{दरवाज़ा}} (\emph{darvāzā}) = \textquotedblleft{}\textbf{door},\textquotedblright{} and it is \textbf{masculine} — so \textbf{\hi{मेरा} \hi{दरवाज़ा}}.
 
-Here is your first piece of help. A noun ending in long \textbf{-ā} is usually masculine, and \emph{darvāzā} ends in \textbf{-\hi{ा}}. Keep it as a lean, not a law: this course will show you where it fails, in both directions.
+Here is your first piece of help. A noun ending in long \textbf{-ā} is usually masculine, and \emph{darvāzā} ends in \textbf{-\hi{ा}}. Keep it as a lean, not a law: later chapters will show you where it fails, in both directions.
 
 \textbf{\hi{घर}} ends in a consonant and is masculine too — so a consonant ending tells you nothing at all. That one you simply learn.
 \end{grammarlens}

--- a/code/learning/human-languages/hindi/book/chapters/ch36-one-house-four-languages.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch36-one-house-four-languages.tex
@@ -1,0 +1,207 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:d6ea031f2071a150
+% canonical-lessons: HI-C36-ghar, HI-C36-darvaaza, HI-C36-kamra, HI-C36-kursi
+
+\chapter{One House, Four Languages}
+\label{ch:hi-one-house-four-languages}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can name a house, its door, a room and the chair I am offered, give each one the possessive its gender demands, and say where each of the four words came from — Sanskrit, Persian, Portuguese and Arabic.}
+
+Run \hi{घर}, \hi{दरवाज़ा}, \hi{कमरा} and \hi{कुर्सी} with the right possessive — and hear \hi{मेरा} turn into \hi{मेरी} at the first feminine noun, the promise chapter 2 made and never kept. Then name the four languages one room drew on, spell \hi{कुर्सी} with its virāma and its conjunct, and say \hi{नमस्ते} at the door coming in and \hi{शुभ} \hi{रात्रि} going out.
+\end{chapteropening}
+
+\section[\hi{घर}]{\hi{घर} (ghar) — \textquotedblleft{}house,\textquotedblright{} and the fence that came first}
+
+\label{lesson:HI-C36-ghar}
+
+
+
+\begin{quote}
+You can say your name. Now say where you live — and meet the one thing every Hindi noun carries that English nouns do not.
+\end{quote}
+
+\subsection*{The letters in this word}
+Two letters. \textbf{\hi{घ}} (\emph{gha}), the breathy pair of \emph{ga}, then \textbf{\hi{र}} (\emph{ra}), already yours from \textbf{\hi{मेरा}}.
+
+\textbf{\hi{र}} is the spineless one: no upright stroke of its own, so the \textbf{\hi{शिरोरेखा}}, the head-line, is all that ties it to its neighbour. Both letters keep their inherent \emph{a} $\to$ \textbf{\hi{घर}}, \emph{ghar}.
+
+\begin{grammarlens}[title={Grammar Lens: the word arrives with a gender}]
+\textbf{\hi{घर}} (\emph{ghar}) = \textquotedblleft{}\textbf{house, home}.\textquotedblright{} And it is \textbf{masculine}.
+
+Every Hindi noun is masculine or feminine. Not the thing — the \textbf{word}. There is nothing manly about a house; the gender is a fact about \emph{ghar} the way its spelling is, and you learn the two together or you learn them twice.
+
+It is not decoration: it changes the words around the noun. Because \emph{ghar} is masculine, \textquotedblleft{}my house\textquotedblright{} is \textbf{\hi{मेरा} \hi{घर}} (\emph{merā ghar}), the masculine \textbf{\hi{मेरा}}, exactly as in \textbf{\hi{मेरा} \hi{नाम}}.
+
+Whole sentence: \textbf{\hi{यह} \hi{मेरा} \hi{घर} \hi{है}} (\emph{yah merā ghar hai}), \textquotedblleft{}\textbf{this is my house}.\textquotedblright{}
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{\hi{घर}} comes from Sanskrit \textbf{\hi{गृह}} (\emph{gṛha}), worn smooth through Prakrit \emph{ghara} into the short word you just said. Hindi kept \textbf{\hi{गृह}} too, borrowed back out of Sanskrit for formal use, so both shapes survive.
+
+Further back, \emph{gṛha} descends from an ancient root meaning \textbf{enclosure}, \emph{\textbf{g\textsuperscript{h}erd\textsuperscript{h}-}} — and English holds two plain descendants of it: \textbf{yard} and \textbf{garden}. Slavic holds the \emph{-grad} in \textbf{Belgrade}, \textquotedblleft{}town.\textquotedblright{}
+
+So the oldest sense is not walls and a roof. It is \textbf{a fenced-in piece of ground}. You enclose the land first; the house is what goes inside afterwards.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \emph{ghar} — house; then \emph{merā ghar}; then \emph{yah merā ghar hai}
+  \item \emph{merā nām} and \emph{merā ghar} one after the other — the same \emph{merā}, because both nouns are masculine
+  \item the two letters, \emph{gha} and \emph{ra}, and which of them has no spine
+  \item \emph{gṛha}, then \emph{ghar} — the Sanskrit shape and the worn one; then the old meaning, \emph{enclosure}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Is \textbf{\hi{घर}} masculine or feminine, and how do you know from the sentence? (\textbf{Masculine} — \emph{merā}, not \emph{merī}.) What did the root behind \emph{gṛha} mean before it meant a building? (\textbf{An enclosure} — the root behind \emph{yard} and \emph{garden}.) Which of \textbf{\hi{घ}} and \textbf{\hi{र}} hangs from the head-line without a spine of its own? (\textbf{\hi{र}}.)
+\end{tcolorbox}
+\section[\hi{दरवाज़ा}]{\hi{दरवाज़ा} (darvāzā) — the door, and the oldest word you already know}
+
+\label{lesson:HI-C36-darvaaza}
+
+
+
+\begin{quote}
+You have a house. This is what you stand at to be let into one — and it is where \textbf{\hi{नमस्ते}} is said and where \textbf{\hi{शुभ} \hi{रात्रि}} is said back.
+\end{quote}
+
+\subsection*{The letters in this word}
+\textbf{\hi{द}·\hi{र}·\hi{वा}·\hi{ज़ा}} — and the \textbf{\hi{ा}} you already write does two of the four.
+
+The new mark is the dot under \textbf{\hi{ज़}}: the \textbf{nuqta}. Plain \textbf{\hi{ज}} is \emph{ja}. Persian arrived carrying a \textbf{z} Devanagari had no letter for, so the script put a dot beneath the nearest shape and made one — \textbf{\hi{ज़}}, \emph{za}. The same dot makes \textbf{\hi{फ़}} (\emph{fa}) and \textbf{\hi{ख़}}, the sound in \textbf{\hi{ख़ुशी}}.
+
+A nuqta is a small confession in ink: \emph{this sound came from somewhere else.}
+
+\begin{grammarlens}[title={Grammar Lens: the shape that usually tells you}]
+\textbf{\hi{दरवाज़ा}} (\emph{darvāzā}) = \textquotedblleft{}\textbf{door},\textquotedblright{} and it is \textbf{masculine} — so \textbf{\hi{मेरा} \hi{दरवाज़ा}}.
+
+Here is your first piece of help. A noun ending in long \textbf{-ā} is usually masculine, and \emph{darvāzā} ends in \textbf{-\hi{ा}}. Keep it as a lean, not a law: this course will show you where it fails, in both directions.
+
+\textbf{\hi{घर}} ends in a consonant and is masculine too — so a consonant ending tells you nothing at all. That one you simply learn.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{\hi{दरवाज़ा}} is \textbf{Persian}, \textbf{\ar{دروازه}} (\emph{darvāza}), and its first syllable is where this gets remarkable. Persian \textbf{\ar{در}} (\emph{dar}) means \textquotedblleft{}\textbf{door},\textquotedblright{} and it descends from the ancient root \emph{\textbf{d\textsuperscript{h}wer-}} — as do English \textbf{door}, Latin \textbf{forēs}, Greek \textbf{thúrā} and Sanskrit \textbf{\hi{द्वार}} (\emph{dvāra}).
+
+Now the twist. Hindi \emph{also} has \textbf{\hi{द्वार}} (\emph{dvār}), taken straight out of Sanskrit for formal use. So the borrowed Persian word and the learned Sanskrit one are \textbf{the same ancient word, arrived twice}, by two roads, centuries apart.
+
+The \textbf{-vāza} part is less settled: usually connected to a Persian word for \textquotedblleft{}\textbf{open},\textquotedblright{} but disputed, and worth leaving open.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \emph{darvāzā}, then \emph{merā darvāzā}, then \emph{merā ghar} — one \emph{merā}, two masculine nouns
+  \item the arrival and the leaving at the same door — \emph{namaste} going in, \emph{shubh rātri} going out
+  \item \emph{ja}, then \emph{za} — the letter, then the letter with the dot
+  \item \emph{dar}, \emph{door}, \emph{thúrā}, \emph{dvāra} — one word, four languages
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What does the dot under \textbf{\hi{ज़}} tell you? (That the sound is \textbf{borrowed} — Devanagari had no \emph{z}.) Persian \emph{dar} and English \emph{door} — coincidence or cousins? (\textbf{Cousins}, from \emph{\textbf{d\textsuperscript{h}wer-}} — and Hindi's own \textbf{\hi{द्वार}} is the third.) Which ending gives you a fair guess at masculine? (\textbf{Long -ā}, as in \emph{darvāzā}. A consonant ending, as in \emph{ghar}, tells you nothing.)
+\end{tcolorbox}
+\section[\hi{कमरा}]{\hi{कमरा} (kamrā) — the room that is also a camera}
+
+\label{lesson:HI-C36-kamra}
+
+
+
+\begin{quote}
+Through the door, and into this. A short, ordinary word — which travelled to India by sea, on Portuguese ships.
+\end{quote}
+
+\subsection*{The letters in this word}
+\textbf{\hi{क}·\hi{म}·\hi{रा}} — and \textbf{\hi{म}} (\emph{ma}) is one of the first two letters you ever wrote, beside \textbf{\hi{न}}.
+
+Both of those hang from the head-line and both stand on a right-hand spine; that upright is what your eye follows along a line of Devanagari. \textbf{\hi{क}} and \textbf{\hi{र}} you have as well, so this word costs you nothing new — only the \textbf{\hi{ा}} riding on the final \textbf{\hi{र}}.
+
+\begin{grammarlens}[title={Grammar Lens: the lean holds}]
+\textbf{\hi{कमरा}} (\emph{kamrā}) = \textquotedblleft{}\textbf{room},\textquotedblright{} and it is \textbf{masculine} — \textbf{\hi{मेरा} \hi{कमरा}}.
+
+Long \textbf{-ā}, masculine again, exactly as \textbf{\hi{दरवाज़ा}} was. Three nouns in, and the possessive has not changed once: \emph{merā ghar}, \emph{merā darvāzā}, \emph{merā kamrā}.
+
+Hold on to that flatness. It is about to break.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{\hi{कमरा}} is neither Sanskrit nor Persian. It is \textbf{Portuguese} — \textbf{câmara}, \textquotedblleft{}chamber, room\textquotedblright{} — left behind on India's western coast by the traders who ran that shore from the sixteenth century, along with \textbf{\hi{चाबी}} (\emph{chābī}, \textquotedblleft{}key\textquotedblright{}) and \textbf{\hi{अलमारी}} (\emph{almārī}, \textquotedblleft{}cupboard\textquotedblright{}).
+
+Portuguese \emph{câmara} is Latin \textbf{camera}, \textquotedblleft{}a vaulted chamber,\textquotedblright{} and Latin took it from Greek \textbf{kamára} — where the trail honestly stops; the Greek word's own origin is unknown.
+
+Then the good part. English \textbf{camera} is that same Latin word: a \emph{camera obscura} was literally a \textquotedblleft{}dark room,\textquotedblright{} and when the dark room shrank into a box the name went with it. And Hindi later borrowed it back through English as \textbf{\hi{कैमरा}} (\emph{kaimrā}) for the device.
+
+So \textbf{\hi{कमरा}} and \textbf{\hi{कैमरा}} are the \emph{same Latin word}, arrived twice by two different routes — the second time carrying a machine that did not exist when the first one landed.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \emph{kamrā}, then \emph{merā kamrā}
+  \item the three so far, in one breath — \emph{merā ghar, merā darvāzā, merā kamrā}
+  \item \emph{kamrā} and \emph{kaimrā} — one Latin word, two arrivals
+  \item where each of the three came from — Sanskrit, Persian, Portuguese
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which language handed Hindi \textbf{\hi{कमरा}}, and how did it get there? (\textbf{Portuguese}, by sea, on the western coast.) What does \emph{kamrā} share with English \emph{camera}? (\textbf{One Latin word}, \emph{camera}, \textquotedblleft{}vaulted chamber\textquotedblright{} — Hindi has it twice, as \emph{kamrā} and \emph{kaimrā}.) Say \textquotedblleft{}my house, my door, my room.\textquotedblright{} (\emph{Merā ghar, merā darvāzā, merā kamrā}.)
+\end{tcolorbox}
+\section[\hi{कुर्सी}]{\hi{कुर्सी} (kursī) — sit down, and watch \hi{मेरा} change}
+
+\label{lesson:HI-C36-kursi}
+
+
+
+\begin{quote}
+House, door, room — and now what you are offered once inside. This word breaks the pattern the other three set.
+\end{quote}
+
+\subsection*{The letters in this word}
+\textbf{\hi{कु}·\hi{र्}·\hi{सी}} — three old letters, \textbf{\hi{क}}, \textbf{\hi{र}}, \textbf{\hi{स}}, and two working marks.
+
+\textbf{\hi{क}} takes \textbf{\hi{ु}} for \emph{ku}. Then \textbf{\hi{र}} with the \textbf{virāma}, the stroke that kills a consonant's built-in \emph{a}: a bare \textbf{\hi{र्}} cannot stand alone, so it fuses with the \textbf{\hi{स}}, and the hook above \textbf{\hi{स}} \emph{is} that \textbf{\hi{र}} — the fusing you met in \textbf{\hi{स्त}}.
+
+Then \textbf{\hi{सी}}: the long \textbf{\hi{ी}} stands after its consonant and sounds after it, while \textbf{\hi{ि}} stands before and still sounds after. One of the two lies to your eye.
+
+\begin{grammarlens}[title={Grammar Lens: your first feminine noun}]
+\textbf{\hi{कुर्सी}} (\emph{kursī}) = \textquotedblleft{}\textbf{chair},\textquotedblright{} and it is \textbf{feminine}.
+
+So \textbf{\hi{मेरी} \hi{कुर्सी}}, not \emph{merā}. When you learnt \textbf{\hi{मेरा}} you were told you would meet \textbf{\hi{मेरी}} at your first feminine noun. Here it is.
+
+Nothing about a chair is female. The gender belongs to the \textbf{word}, and it changes \textbf{\hi{मेरा}}. Get it wrong and every word beside the noun goes wrong too.
+\end{grammarlens}
+
+\begin{grammarlens}[title={Grammar Lens: the lean, and where it leans wrong}]
+The rule of thumb: \textbf{long -ā tends masculine, long -ī tends feminine, a consonant ending tells you nothing.} A lean, not a law: \emph{darvāzā}, \emph{kamrā} and \emph{kursī} obey it, \emph{ghar} sits outside it, and later words will disobey it outright.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{\hi{कुर्सी}} is \textbf{Arabic}, \textbf{\ar{كرسي}} (\emph{kursī}), \textquotedblleft{}seat, throne,\textquotedblright{} reaching Hindi through \textbf{Persian}, the road most Arabic words took.
+
+Arabic did not invent it either. It has passed along the Near East for four thousand years: Sumerian \textbf{guza}, Akkadian \textbf{kussû}, then Ugaritic, Hebrew and Aramaic, Arabic most likely taking it from \textbf{Aramaic}. Not one family — the word crossed between unrelated families because the object did.
+
+English \textbf{chair}? Greek \textbf{kathédra}, through Latin and French. No relation at all.
+
+And what this chapter has done: \textbf{\hi{घर}} Sanskrit, \textbf{\hi{दरवाज़ा}} Persian, \textbf{\hi{कमरा}} Portuguese, \textbf{\hi{कुर्सी}} Arabic. One room, four languages — that is Hindi, not an accident of these four words.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \emph{merī kursī}, then \emph{merā kamrā} — one possessive, two shapes
+  \item the chapter — \emph{merā ghar, merā darvāzā, merā kamrā, merī kursī}
+  \item each word's source — Sanskrit, Persian, Portuguese, Arabic
+  \item \emph{namaste} at the \emph{darvāzā}, then \emph{shubh rātri} at the same door
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Why \textbf{\hi{मेरी} \hi{कुर्सी}}? (\textbf{\hi{कुर्सी} is feminine}; the possessive agrees with the noun.) How far back does \emph{kursī} go, and did it stay in one family? (\textbf{Sumerian} — and no, it crossed unrelated families.) Name the chapter's four sources. (\textbf{Sanskrit, Persian, Portuguese, Arabic}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/hindi/book/chapters/ch37-one-tea-please.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch37-one-tea-please.tex
@@ -1,0 +1,219 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:ebf952fd9155efa9
+% canonical-lessons: HI-C37-chai, HI-C37-dudh, HI-C37-khaana, HI-C37-kitaab
+
+\chapter{One Tea, Please}
+\label{ch:hi-one-tea-please}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can ask for tea, milk, food or a book in the words Hindi speakers actually use rather than the dictionary's, I know that \hi{कृपया} belongs on a sign and \hi{दीजिए} in the street, and I can name which of the four nouns take \hi{मेरी}.}
+
+Ask for all four — \hi{एक} \hi{चाय} \hi{दीजिए}, \hi{एक} \hi{दूध} \hi{दीजिए}, \hi{खाना} \hi{दीजिए}, and the \hi{किताब} that is \hi{मेरी} — then unpack the Arabic root k-t-b into book, scribe and school, and place \hi{कृपया} where it belongs, beside \hi{पुस्तक} at the formal end of the language.
+\end{chapteropening}
+
+\section[\hi{चाय}]{\hi{चाय} (chāy) — tea, and how to actually ask for one}
+
+\label{lesson:HI-C37-chai}
+
+
+
+\begin{quote}
+You are in the chair, in the room Portuguese named. Somebody is about to offer you this — and by the end of these few minutes you will be able to ask for it yourself, in the words people actually use.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: the lean fails, quietly}]
+\textbf{\hi{चाय}} (\emph{chāy}) = \textquotedblleft{}\textbf{tea},\textquotedblright{} and it is \textbf{feminine}.
+
+Nothing outside the word says so. It does not end in \textbf{-\hi{ी}} the way \textbf{\hi{कुर्सी}} does; it ends in a consonant, and the lean warned you a consonant ending tells you nothing. \textbf{\hi{चाय}} is feminine and you simply learn it — now, with the word.
+\end{grammarlens}
+
+\subsection*{You'll want to know — how you really ask}
+\textbf{\hi{एक} \hi{चाय} \hi{दीजिए}} (\emph{ek chāy dījie}) — \textquotedblleft{}\textbf{one tea, please}.\textquotedblright{}
+
+\textbf{\hi{दीजिए}} is \textquotedblleft{}give\textquotedblright{} spoken to \textbf{\hi{आप}}: the polite request form. That \textbf{-\hi{िए}} ending \emph{is} the politeness. Nothing else is needed.
+
+Which means a correction. You learnt \textbf{\hi{कृपया}} as \textquotedblleft{}please,\textquotedblright{} and it is a real word — but it belongs to \textbf{signs, forms and station announcements}. Across a counter it lands like \emph{kindly furnish me with tea}.
+
+So: \textbf{\hi{कृपया}} when you write, \textbf{\hi{दीजिए}} when you speak. And you already have the shape — \textbf{\hi{माफ़} \hi{कीजिए}} carries the very same \textbf{-\hi{िए}}.
+
+\begin{cousinweb}
+\textbf{\hi{चाय}} is \textbf{Chinese}. In most of China the word for the leaf is \textbf{chá}, which Persian took as \textbf{\ar{چای}} (\emph{chāy}) and handed to Hindi.
+
+Now the English word: \textbf{tea}. French \textbf{thé}, Dutch \textbf{thee} — a different sound entirely, for the identical leaf.
+
+They are the same word. China writes it with one character everywhere, but reads that character differently: in the Hokkien of the south-eastern coast it is \textbf{tê}, and Dutch ships bought their tea \emph{there}.
+
+The tempting story is overland versus sea. It is wrong: Portuguese say \textbf{chá}, and Portuguese tea came by sea. The variable is \textbf{which Chinese port a trader dealt with}. Your word for tea records a harbour.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \emph{chāy}; then \emph{ek chāy dījie}
+  \item the same request for water — \emph{ek pānī dījie}
+  \item \emph{dījie} and \emph{māf kījie} one after the other — hear the shared \emph{-ie}
+  \item \emph{chā} and \emph{tê} — the two Chinese pronunciations, and which one English bought
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Is \textbf{\hi{चाय}} masculine or feminine, and does its ending help? (\textbf{Feminine} — and no, a consonant ending never does.) Where does \textbf{\hi{कृपया}} belong, and what carries the politeness when you speak? (\textbf{Signs and announcements} — in speech the \textbf{-\hi{िए}} of \emph{dījie} does it.) Are \emph{chāy} and \emph{tea} related? (\textbf{The same Chinese word}, bought at two different ports.)
+\end{tcolorbox}
+\section[\hi{दूध}]{\hi{दूध} (dūdh) — \textquotedblleft{}milk,\textquotedblright{} which is really a verb wearing a noun's coat}
+
+\label{lesson:HI-C37-dudh}
+
+
+
+\begin{quote}
+What goes into the tea. And it is named the same sly way \textbf{\hi{पानी}} was — by what happens to it, not by what it is.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: the pair that disagrees}]
+\textbf{\hi{दूध}} (\emph{dūdh}) = \textquotedblleft{}\textbf{milk},\textquotedblright{} and it is \textbf{masculine}.
+
+Which makes these two a useful pair, because they sit side by side in every cup and disagree: \textbf{\hi{चाय}} feminine — the leaf that came by way of a Chinese port — and \textbf{\hi{दूध}} masculine. Both end in consonants. Neither ending tells you anything. This is the ordinary state of a Hindi noun, and it is why the gender is part of the word, not an afterthought.
+
+\textbf{\hi{एक} \hi{दूध} \hi{दीजिए}} — same request, new noun.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{\hi{दूध}} comes from Sanskrit \textbf{\hi{दुग्ध}} (\emph{dugdha}) — and \emph{dugdha} is not a noun at all. It is a \textbf{past participle} of the verb \textbf{\hi{दुह्}} (\emph{duh-}), \textquotedblleft{}to milk.\textquotedblright{} It means \textquotedblleft{}\textbf{milked}.\textquotedblright{}
+
+So the substance is named for the act. Somebody said \textquotedblleft{}the milked\textquotedblright{} often enough that the adjective hardened into a thing. You have seen this exact move already: \textbf{\hi{पानी}} is \emph{pānīya}, \textquotedblleft{}\textbf{the drinkable}.\textquotedblright{} Hindi's two commonest liquids are both named by what is done to them.
+
+Behind \emph{duh-} stands the old root \emph{\textbf{d\textsuperscript{h}ewg\textsuperscript{h}-}}, and its meaning is broader than milk: \textquotedblleft{}\textbf{to yield, to be strong, to be of use}.\textquotedblright{} Greek \textbf{teúkhein}, \textquotedblleft{}to produce,\textquotedblright{} is from it, and so is English \textbf{doughty}, \textquotedblleft{}stout, valiant.\textquotedblright{}
+
+One trap, since the shape invites it: English \textbf{dough} is \textbf{not} related. It comes from a different root meaning \textquotedblleft{}to knead, to form.\textquotedblright{} \emph{Dūdh} and \emph{dough} look like cousins and are strangers.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \emph{dūdh}; then \emph{ek dūdh dījie}
+  \item the disagreeing pair — \emph{chāy} feminine, \emph{dūdh} masculine
+  \item what each one literally is — \emph{dugdha}, \textquotedblleft{}the milked\textquotedblright{}; \emph{pānīya}, \textquotedblleft{}the drinkable\textquotedblright{}
+  \item \emph{dūdh} and \emph{dough} — and that they are not related
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What part of speech was \emph{dugdha} before it was milk? (\textbf{A past participle} — \textquotedblleft{}milked.\textquotedblright{}) Which Hindi word plays the same trick, and how? (\textbf{\hi{पानी}} — \emph{pānīya}, \textquotedblleft{}the drinkable thing.\textquotedblright{}) Is English \emph{dough} a cousin of \emph{dūdh}? (\textbf{No} — different root; \emph{doughty} is the real one.)
+\end{tcolorbox}
+\section[\hi{खाना}]{\hi{खाना} (khānā) — \textquotedblleft{}food,\textquotedblright{} and the dot that separates it from a house}
+
+\label{lesson:HI-C37-khaana}
+
+
+
+\begin{quote}
+Drink is behind you. This is the general word for what you eat — and it has a twin on the page that means something else entirely.
+\end{quote}
+
+\subsection*{The letters in this word}
+\textbf{\hi{खा}·\hi{ना}} — two syllables, and the \textbf{\hi{ा}} does both.
+
+\textbf{\hi{ख}} (\emph{kha}) takes \textbf{\hi{ा}} $\to$ \textbf{\hi{खा}}. Then \textbf{\hi{न}} (\emph{na}), your very first letter, takes \textbf{\hi{ा}} $\to$ \textbf{\hi{ना}}. The \textbf{\hi{ा}} is the mātrā that replaces a consonant's built-in \emph{a} with a long one, exactly as in \textbf{\hi{नाम}}.
+
+Two consonants, one mark used twice, and the word is yours.
+
+\begin{grammarlens}[title={Grammar Lens: one word doing two jobs}]
+\textbf{\hi{खाना}} (\emph{khānā}) = \textquotedblleft{}\textbf{food},\textquotedblright{} and it is \textbf{masculine} — long \textbf{-ā}, and this time the lean holds. Unlike \textbf{\hi{दूध}}, whose name is a participle, this one is plainly a thing.
+
+It is also the verb \textquotedblleft{}\textbf{to eat}.\textquotedblright{} Same spelling, same sound: the infinitive doubles as a noun, the way English says \emph{the eating was good}.
+
+So \textbf{\hi{खाना} \hi{दीजिए}} is \textquotedblleft{}give me food,\textquotedblright{} and \textbf{\hi{खाना}} alone can be the act. Which one you mean, the sentence decides.
+\end{grammarlens}
+
+\begin{cousinweb}
+Both come from Sanskrit \textbf{\hi{खाद्}} (\emph{khād-}), \textquotedblleft{}to eat\textquotedblright{} — the noun through \textbf{\hi{खादन}} (\emph{khādana}), \textquotedblleft{}the act of eating, food,\textquotedblright{} and the verb through \textbf{\hi{खादति}} (\emph{khādati}), \textquotedblleft{}eats.\textquotedblright{}
+
+Now the twin. Hindi also has \textbf{\hi{ख़ाना}} (\emph{khāna}) — with the \textbf{nuqta} under the first letter — and it is \textbf{Persian}, \textbf{\ar{خانه}} (\emph{xāna}), \textquotedblleft{}\textbf{house, compartment, section}.\textquotedblright{} You meet it inside \textbf{\hi{दवाख़ाना}} (\emph{davākhāna}), a \textquotedblleft{}medicine-house\textquotedblright{}: a pharmacy.
+
+Two unrelated words, one from Sanskrit and one from Persian, separated on the page by a single dot. And here is the honest part: \textbf{that dot is very often left off}. In ordinary printing and handwriting both are simply written \textbf{\hi{खाना}}, and the reader is expected to sort it out from context. The nuqta tells you where a sound came from — when somebody bothers to write it.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \emph{khānā}; then \emph{khānā dījie}
+  \item the three requests together — \emph{ek chāy dījie, ek dūdh dījie, khānā dījie}
+  \item \emph{roṭī} and \emph{khānā} — the particular bread and the general word for food
+  \item \emph{khānā} and \emph{khāna} — food and house; then \emph{davākhāna}, the medicine-house
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What two jobs does \textbf{\hi{खाना}} do? (\textbf{Food}, and the verb \textbf{to eat}.) What is \textbf{\hi{ख़ाना}}, and where does it come from? (\textbf{House, compartment} — Persian \textbf{\ar{خانه}}, as in \emph{davākhāna}.) Can you always tell them apart on the page? (\textbf{No} — the nuqta is often dropped, and context decides.)
+\end{tcolorbox}
+\section[\hi{किताब}]{\hi{किताब} (kitāb) — a book, and the root it is cut from}
+
+\label{lesson:HI-C37-kitaab}
+
+
+
+\begin{quote}
+Not something to eat — something to ask for. Its Arabic root hands you three more words free.
+\end{quote}
+
+\subsection*{The letters in this word}
+\textbf{\hi{कि}·\hi{ता}·\hi{ब}} — the first mark is the tricky one.
+
+\textbf{\hi{क}} with the short \textbf{\hi{ि}} gives \textbf{\hi{कि}} (\emph{ki}): the \textbf{\hi{ि}} is drawn to the \textbf{left} of \textbf{\hi{क}} and sounded \textbf{after} it, never \emph{ik}. Then \textbf{\hi{ता}}, then \textbf{\hi{ब}} keeping its built-in \emph{a}.
+
+\textbf{\hi{क}} and \textbf{\hi{त}} showed you Devanagari's mouth-map: \textbf{\hi{क}} far back at the soft palate, \textbf{\hi{त}} at the teeth. Say \emph{ki-tā-b} and feel the tongue travel.
+
+\begin{grammarlens}[title={Grammar Lens: feminine, and no ending to prove it}]
+\textbf{\hi{किताब}} (\emph{kitāb}) = \textquotedblleft{}\textbf{book},\textquotedblright{} and it is \textbf{feminine} — \textbf{\hi{मेरी} \hi{किताब}}.
+
+The second consonant-final noun to turn out feminine, after \textbf{\hi{चाय}}. Two of this chapter's four disobey any guess their shape allows.
+
+Which is the real lesson: \textbf{Hindi gender is information about the word, not the thing and not the spelling.}
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{\hi{किताब}} is \textbf{Arabic}, \textbf{\ar{كتاب}}, come by the Persian road \textbf{\hi{कुर्सी}} took.
+
+Arabic builds words on \textbf{three-consonant roots}, and this one is \textbf{k-t-b}, \textquotedblleft{}write.\textquotedblright{} Slot those three into different patterns and a family appears:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ar{كتاب}} \emph{kitāb} — a \textbf{book}, the thing written.
+  \item \textbf{\ar{كاتب}} \emph{kātib} — a \textbf{scribe}, the one writing.
+  \item \textbf{\ar{مكتب}} \emph{maktab} — a \textbf{place} of writing: an office, a school.
+\end{itemize}
+
+Learn the root and you have a family, which is how much of Hindi's Perso-Arabic vocabulary is built underneath.
+\end{cousinweb}
+
+\subsection*{You'll want to know — three books, three registers}
+Hindi has three words for a book, and they are not synonyms — they are \textbf{registers}.
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\hi{किताब}} — Perso-Arabic, the ordinary word. Say this one.
+  \item \textbf{\hi{पुस्तक}} (\emph{pustak}) — straight out of Sanskrit. Libraries, textbooks, formal writing.
+  \item \textbf{\hi{पोथा}} (\emph{pothā}) — the inherited descendant of that Sanskrit word. Old, homely, a bit dusty.
+\end{itemize}
+
+You have met this split: \textbf{\hi{कृपया}} is the \emph{pustak} end of \textquotedblleft{}please,\textquotedblright{} \textbf{\hi{दीजिए}} the \emph{kitāb} end.
+
+And that is the chapter — \textbf{\hi{चाय}} from a Chinese port, \textbf{\hi{दूध}} named for what was done to it, \textbf{\hi{खाना}} shadowed by a Persian house, \textbf{\hi{किताब}} cut from an Arabic root.
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \emph{kitāb}, then \emph{merī kitāb}
+  \item the chapter's four — \emph{merī chāy, merā dūdh, merā khānā, merī kitāb}
+  \item the k-t-b family — \emph{kitāb}, \emph{kātib}, \emph{maktab}
+  \item \emph{kṛpayā} for the sign; \emph{ek chāy dījie} and \emph{māf kījie} for the street
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Which two words here are feminine, and does their shape say so? (\textbf{\hi{चाय}} and \textbf{\hi{किताब}} — no, both end in consonants.) Give the k-t-b family. (\emph{Kitāb}, \emph{kātib}, \emph{maktab}.) Which word for \textquotedblleft{}book\textquotedblright{} do you say, and which belongs with \textbf{\hi{कृपया}}? (\textbf{\hi{किताब}} — \textbf{\hi{पुस्तक}} is the formal one.)
+\end{tcolorbox}

--- a/code/learning/human-languages/hindi/book/chapters/ch38-where-it-hurts.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch38-where-it-hurts.tex
@@ -1,0 +1,224 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:f7ff13f56a78a073
+% canonical-lessons: HI-C38-aankh, HI-C38-daant, HI-C38-pair, HI-C38-pet
+
+\chapter{Six Words for Where It Hurts}
+\label{ch:hi-where-it-hurts}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can name six parts of my body, say that one of them is not well, and tell which three are word-for-word cousins of their English translations — and which one has no traceable ancestry at all.}
+
+Say all six body words with the possessive each one demands — \hi{मेरा} \hi{सिर}, \hi{मेरा} \hi{हाथ}, \hi{मेरी} \hi{आँख}, \hi{मेरा} \hi{दाँत}, \hi{मेरा} \hi{पैर}, \hi{मेरा} \hi{पेट} — then say \hi{मेरा} \hi{पेट} \hi{ठीक} \hi{नहीं} \hi{है}, and separate the three exact Indo-European cousins from the two words, \hi{पेट} and \hi{रोटी}, whose histories genuinely stop.
+\end{chapteropening}
+
+\section[\hi{आँख}]{\hi{आँख} (āṁkh) — the eye, which is the same word in English}
+
+\label{lesson:HI-C38-aankh}
+
+
+
+\begin{quote}
+You have a head and a hand. Here is the part of the face — and this one is not merely \emph{related} to its English translation. It is the same word.
+\end{quote}
+
+\subsection*{The letters in this word}
+\textbf{\hi{आँ}·\hi{ख}} — and the mark on top is an old friend.
+
+\textbf{\hi{आ}} is the standalone long \emph{ā}. Over it sits \textbf{\hi{ँ}}, the \textbf{chandrabindu}, the moon-dot, which sends the vowel up through the nose — exactly what it does in \textbf{\hi{हाँ}}. Then \textbf{\hi{ख}} (\emph{kha}), breathy, with its inherent \emph{a} still attached.
+
+So the word is a nasalised \emph{ā} followed by \emph{kh}: \textbf{āṁkh}, humming at the start.
+
+\begin{grammarlens}[title={Grammar Lens: feminine, and one you will use daily}]
+\textbf{\hi{आँख}} (\emph{āṁkh}) = \textquotedblleft{}\textbf{eye},\textquotedblright{} and it is \textbf{feminine} — \textbf{\hi{मेरी} \hi{आँख}}.
+
+Third feminine noun, third consonant ending: \textbf{\hi{चाय}}, \textbf{\hi{किताब}}, \textbf{\hi{आँख}}. If you were still hoping the spelling would rescue you, let this settle it.
+
+And it is worth the effort, because these are the words a doctor asks about. \textbf{\hi{मेरी} \hi{आँख} \hi{ठीक} \hi{नहीं} \hi{है}} — \textquotedblleft{}my eye is not well.\textquotedblright{}
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{\hi{आँख}} comes from Sanskrit \textbf{\hi{अक्षि}} (\emph{akṣi}), \textquotedblleft{}eye\textquotedblright{} — and \emph{akṣi} comes from the root \emph{\textbf{h\textsubscript{3}ek\textsuperscript{w}-}}, which is one of the securest words in the whole family.
+
+Its descendants:
+
+\begin{itemize}
+\raggedright
+  \item Latin \textbf{oculus} — inside English \textbf{ocular}, \textbf{monocle}, \textbf{binoculars}.
+  \item Old English \textbf{ēage}, which is English \textbf{eye} itself.
+  \item Lithuanian \textbf{akìs}, Armenian \textbf{akn}, and Greek \textbf{ósse}, the old dual form meaning \textquotedblleft{}the two eyes.\textquotedblright{}
+\end{itemize}
+
+A caution on the Greek, because the obvious candidate is a trap: \textbf{ophthalmós} is \emph{usually} connected here, but its first part has never been explained, and serious opinion treats it as a pre-Greek word. Cite \textbf{ósse} and stay honest.
+
+\textbf{\hi{हाथ}} had to travel a long, battered road from \emph{hasta}. \textbf{\hi{आँख}} barely travelled at all — \emph{akṣi} to \emph{āṁkh} is a short, clean walk, and at the far end of it an English speaker is saying a version of the same word.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \emph{āṁkh}, then \emph{merī āṁkh}
+  \item the three body words you now have — \emph{sir}, \emph{hāth}, \emph{āṁkh}
+  \item \emph{hāṁ} and \emph{āṁkh} — the same moon-dot, the same hum
+  \item \emph{akṣi}, \emph{oculus}, \emph{eye} — one root, three languages
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Is \textbf{\hi{आँख}} masculine or feminine? (\textbf{Feminine} — \emph{merī āṁkh}.) Which Greek word is the safe cousin, and which is the trap? (\textbf{ósse} is safe; \textbf{ophthalmós} is unexplained.) What does the \textbf{\hi{ँ}} over the \textbf{\hi{आ}} do, and where did you first meet it? (\textbf{Nasalises} the vowel — on \textbf{\hi{हाँ}}.)
+\end{tcolorbox}
+\section[\hi{दाँत}]{\hi{दाँत} (dāṁt) — the tooth, and the gender trap of this chapter}
+
+\label{lesson:HI-C38-daant}
+
+
+
+\begin{quote}
+Built like the last word, spelled like the last word, and the opposite gender. This is the pair learners get wrong most often.
+\end{quote}
+
+\subsection*{The letters in this word}
+\textbf{\hi{दाँ}·\hi{त}} — three known parts and no new letter at all.
+
+\textbf{\hi{द}} (\emph{da}) takes \textbf{\hi{ा}}, and the \textbf{\hi{ँ}} rides above the head-line for the nasal hum — the same \textbf{chandrabindu} that turns \textbf{\hi{ह}} into \textbf{\hi{हाँ}}, \textquotedblleft{}yes.\textquotedblright{} Then \textbf{\hi{त}} (\emph{ta}).
+
+Both \textbf{\hi{द}} and \textbf{\hi{त}} are made at the \textbf{teeth} — which is the whole point of Devanagari's mouth-map. The word for \emph{tooth} is spelled with the two consonants your tongue makes \emph{against your teeth}. Say \emph{dāṁt} and feel where it happens.
+
+\begin{grammarlens}[title={Grammar Lens: the trap}]
+\textbf{\hi{दाँत}} (\emph{dāṁt}) = \textquotedblleft{}\textbf{tooth},\textquotedblright{} and it is \textbf{masculine} — \textbf{\hi{मेरा} \hi{दाँत}}.
+
+Now put the two side by side. \textbf{\hi{आँख}} and \textbf{\hi{दाँत}}: same long \emph{ā}, same chandrabindu, same single final consonant, both parts of the body, both everyday. \textbf{\hi{आँख}} is feminine. \textbf{\hi{दाँत}} is masculine.
+
+There is no rule underneath that. There is no reasoning that gets you from one to the other. This is the pair to hold up whenever you are tempted to guess: \textbf{\hi{मेरी} \hi{आँख}}, \textbf{\hi{मेरा} \hi{दाँत}}.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{\hi{दाँत}} is Sanskrit \textbf{\hi{दन्त}} (\emph{danta}), from \emph{\textbf{h\textsubscript{3}dónts}} — and like \emph{akṣi} this is one of the family's best-attested words.
+
+\begin{itemize}
+\raggedright
+  \item Latin \textbf{dēns}, stem \emph{dentis} — English \textbf{dentist}, \textbf{dental}, \textbf{trident} (a \textquotedblleft{}three-tooth\textquotedblright{}).
+  \item Greek \textbf{odoús} — English \textbf{odontology}.
+  \item Old English \textbf{tōþ}, which is \textbf{tooth}.
+\end{itemize}
+
+Two body parts in a row, both plain cousins of their English translations. That is not a coincidence about eyes and teeth; it is what a core inherited vocabulary looks like from the inside.
+
+And the older reading of \emph{\textbf{h\textsubscript{3}dónts}} makes it a participle of \emph{\textbf{h\textsubscript{3}ed-}}, \textquotedblleft{}to bite\textquotedblright{} — so a tooth is \textquotedblleft{}\textbf{the biting one},\textquotedblright{} which is what \textbf{\hi{खाना}} needs it for. Same move as \textbf{\hi{दूध}}, \textquotedblleft{}the milked one\textquotedblright{}: name the thing after what happens.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \emph{dāṁt}, then \emph{merā dāṁt}
+  \item the trap pair, twice — \emph{merī āṁkh, merā dāṁt}; again
+  \item \emph{hāṁ}, then \emph{dāṁt} — the same moon-dot doing the same job
+  \item \emph{danta}, \emph{dēns}, \emph{odoús}, \emph{tooth} — one word, four languages
+  \item the two \textquotedblleft{}named for the action\textquotedblright{} words — \emph{dugdha}, the milked; the tooth, the biting one
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+\textbf{\hi{आँख}} and \textbf{\hi{दाँत}} look alike — do they share a gender? (\textbf{No} — \emph{merī āṁkh}, \emph{merā dāṁt}.) Which English words carry the Latin form? (\textbf{Dentist}, \textbf{dental}, \textbf{trident}.) What does the older reading make a tooth? (\textbf{The biting one} — from a root meaning \textquotedblleft{}to bite.\textquotedblright{})
+\end{tcolorbox}
+\section[\hi{पैर}]{\hi{पैर} (pair) — the foot, and the ancestor it does not have}
+
+\label{lesson:HI-C38-pair}
+
+
+
+\begin{quote}
+Down from the head, past the hand, to what carries you. And this word's obvious ancestor turns out to belong to a different Hindi word.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: masculine, and the sentence that uses it}]
+\textbf{\hi{पैर}} (\emph{pair}) = \textquotedblleft{}\textbf{foot},\textquotedblright{} and it is \textbf{masculine} — \textbf{\hi{मेरा} \hi{पैर}}.
+
+The \textbf{\hi{ै}} is a single mātrā for one vowel, \emph{ai} — not \emph{a} then \emph{i}. One sign, one sound, sitting above the head-line on \textbf{\hi{प}}.
+
+Now the sentence you would actually say to a doctor, using the \textbf{\hi{नहीं}} you already have: \textbf{\hi{मेरा} \hi{पैर} \hi{ठीक} \hi{नहीं} \hi{है}} — \textquotedblleft{}\textbf{my foot is not well}.\textquotedblright{} Watch the \textbf{\hi{नहीं}} sit directly before \textbf{\hi{है}}, which is where Hindi puts its negation.
+\end{grammarlens}
+
+\begin{cousinweb}
+Here is the obvious guess, and it is wrong. Sanskrit has \textbf{\hi{पाद}} (\emph{pāda}), \textquotedblleft{}foot\textquotedblright{} — long \emph{ā}, famous, the source of English's borrowed \emph{pada-} words. It looks like it must be the parent of \emph{pair}. It is not.
+
+\textbf{\hi{पाँव}} (\emph{pāṁv}), Hindi's \emph{other} everyday word for foot, is the descendant of \textbf{\hi{पाद}}. \textbf{\hi{पैर}} comes from the shorter Sanskrit stem \textbf{\hi{पद्}} (\emph{pad-}), through Prakrit \emph{paya}, picking up a Middle Indo-Aryan \textbf{-ra-} ending on the way.
+
+So Hindi inherited the same body part \textbf{twice}, down two different stems of the same word — and both survive, side by side, meaning the same thing.
+
+Further back both are \emph{\textbf{ped-}}, \textquotedblleft{}to walk, to tread\textquotedblright{}:
+
+\begin{itemize}
+\raggedright
+  \item Latin \textbf{pēs}, stem \emph{pedis} — \textbf{pedal}, \textbf{pedestrian}, \textbf{pedicure}.
+  \item Greek \textbf{poús}, stem \emph{podós} — \textbf{podium}, and the eight of an \textbf{octopus}.
+  \item Old English \textbf{fōt}, which is \textbf{foot}.
+\end{itemize}
+
+Three body words in three lessons, and every one of them is the same word your own language uses. \textbf{\hi{हाथ}} had to be argued for through a sound change. These three simply \emph{are} the cousins.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \emph{pair}, then \emph{merā pair}
+  \item the four body words with their possessives — \emph{merā hāth, merī āṁkh, merā dāṁt, merā pair}
+  \item \emph{merā pair ṭhīk nahīṁ hai} — and hear where the \emph{nahīṁ} sits
+  \item which Hindi word came from \emph{pāda}, and which from \emph{pad-} (\emph{pāṁv}; \emph{pair})
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Does \textbf{\hi{पैर}} come from \textbf{\hi{पाद}}? (\textbf{No} — from \textbf{\hi{पद्}}; \textbf{\hi{पाँव}} is the \emph{pāda} one.) Which English words carry the Latin and Greek forms? (\textbf{Pedal}, \textbf{pedestrian}; \textbf{podium}, \textbf{octopus}.) Say \textquotedblleft{}my foot is not well,\textquotedblright{} and say where \textbf{\hi{नहीं}} goes. (\emph{Merā pair ṭhīk nahīṁ hai} — immediately before \textbf{\hi{है}}.)
+\end{tcolorbox}
+\section[\hi{पेट}]{\hi{पेट} (peṭ) — the belly, and a trail that genuinely stops}
+
+\label{lesson:HI-C38-pet}
+
+
+
+\begin{quote}
+Three clean cousins in a row. This one breaks the run — and the break is worth more than another neat answer.
+\end{quote}
+
+\subsection*{The letters in this word}
+\textbf{\hi{पे}·\hi{ट}} — one known letter, one known mātrā, one consonant to feel.
+
+\textbf{\hi{प}} takes \textbf{\hi{े}}, the mātrā that perches on the head-line and turns the built-in \emph{a} into \emph{e} — the second of the two vowel signs you practised on \textbf{\hi{नाम}} and \textbf{\hi{मेरा}}.
+
+Then \textbf{\hi{ट}}: a \textbf{retroflex} \emph{ṭ}, tongue-tip curled back, not the \textbf{\hi{त}} of \textbf{\hi{दाँत}} made flat against the teeth. Say \emph{dāṁt}, then \emph{peṭ}.
+
+\begin{grammarlens}[title={Grammar Lens: masculine, and the whole set together}]
+\textbf{\hi{पेट}} (\emph{peṭ}) = \textquotedblleft{}\textbf{stomach, belly},\textquotedblright{} and it is \textbf{masculine} — \textbf{\hi{मेरा} \hi{पेट}}.
+
+Now you can answer a doctor, and exactly one of the six takes \textbf{\hi{मेरी}}: \emph{merā sir}, \emph{merā hāth}, \textbf{merī āṁkh}, \emph{merā dāṁt}, \emph{merā pair}, \emph{merā peṭ} — feminine company for \textbf{\hi{कुर्सी}} and \textbf{\hi{किताब}}.
+
+The sentence, with \textbf{\hi{नहीं}} in its usual place just before \textbf{\hi{है}}: \textbf{\hi{मेरा} \hi{पेट} \hi{ठीक} \hi{नहीं} \hi{है}} — which, said in India, means what it says and rather more.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{\hi{पेट}} goes back to Prakrit \textbf{\hi{पेट्ट}} (\emph{peṭṭa}) — and there the clean line ends.
+
+The mainstream account treats it as a \textbf{Dravidian} word taken into Indo-Aryan; compare reconstructed Dravidian \textbf{*poṭṭ-}. Turner's comparative dictionary does not name Dravidian, but neither does he derive \emph{peṭṭa} from any Sanskrit word: he only remarks that it sits close to Indo-Aryan words for \textquotedblleft{}\textbf{basket}.\textquotedblright{} That resemblance is a note, not a derivation, and it is often quoted as one.
+
+So: \textbf{the origin of \hi{पेट} is unsettled}, with Dravidian leading — the honesty \textbf{\hi{रोटी}} needed, one lesson away from \textbf{\hi{पानी}}, whose story is exact. A language is made of what people said, and some of that came from neighbours speaking something else.
+
+There is even a fingerprint: the \textbf{retroflex} consonants, the \textbf{\hi{ट}} you just curled your tongue for, are the feature of Indian Indo-Aryan most often credited to long contact with Dravidian.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item all six — \emph{merā sir, merā hāth, merī āṁkh, merā dāṁt, merā pair, merā peṭ}
+  \item \emph{merā peṭ ṭhīk nahīṁ hai}; then \emph{merī āṁkh ṭhīk nahīṁ hai}
+  \item every feminine noun you own — \emph{kursī}, \emph{chāy}, \emph{kitāb}, \emph{āṁkh}
+  \item the three exact ancestries — \emph{āṁkh}, \emph{dāṁt}, \emph{pair}; then the two unsettled — \emph{peṭ}, \emph{roṭī}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Where does \textbf{\hi{पेट}} come from? (\textbf{Unsettled} — Prakrit \emph{peṭṭa}, most likely a \textbf{Dravidian} loan; the \textquotedblleft{}basket\textquotedblright{} link is a resemblance.) Of your six body words, which takes \textbf{\hi{मेरी}}? (\textbf{\hi{आँख}}.) Which earlier word had the same honest dead end? (\textbf{\hi{रोटी}}, beside \textbf{\hi{पानी}}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/hindi/book/chapters/ch39-people-around-you.tex
+++ b/code/learning/human-languages/hindi/book/chapters/ch39-people-around-you.tex
@@ -1,0 +1,209 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:5a01181601c965b8
+% canonical-lessons: HI-C39-dost, HI-C39-baccha, HI-C39-aadmi, HI-C39-aurat
+
+\chapter{The People Around You}
+\label{ch:hi-people-around-you}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can name the friend, the child, the man and the woman around me, I know that \hi{दोस्त} takes its possessive from the person while \hi{आँख} never does, and I can choose between \hi{औरत} and \hi{महिला} by register.}
+
+Say the whole household with every possessive right — \hi{मेरा} \hi{पिता}, \hi{मेरी} \hi{माता}, \hi{मेरा} \hi{भाई}, \hi{मेरी} \hi{बहन}, \hi{मेरा} \hi{बच्चा}, \hi{मेरी} \hi{बच्ची} — then \hi{मेरा} \hi{दोस्त} or \hi{मेरी} \hi{दोस्त} depending on who the friend is, and say why Arabic ʿawra does not mean “woman” even though \hi{औरत} does.
+\end{chapteropening}
+
+\section[\hi{दोस्त}]{\hi{दोस्त} (dost) — the friend, who is \textquotedblleft{}the one chosen\textquotedblright{}}
+
+\label{lesson:HI-C39-dost}
+
+
+
+\begin{quote}
+You can name a brother and a sister. Here is the person you picked rather than were given, and the word says exactly that.
+\end{quote}
+
+\subsection*{The letters in this word}
+\textbf{\hi{दो}·\hi{स्त}} — an ending you have already assembled by hand.
+
+\textbf{\hi{द}} with \textbf{\hi{ो}} gives \textbf{\hi{दो}}. Then \textbf{\hi{स्त}} — \textbf{\hi{स}} stripped of its built-in \emph{a} by the \textbf{virāma}, fusing with \textbf{\hi{त}} into one conjunct: the cluster inside \textbf{\hi{नमस्ते}}, the first conjunct you ever wrote.
+
+So \textbf{\hi{मेरा} \hi{दोस्त}} is built entirely from strokes already yours.
+
+\begin{grammarlens}[title={Grammar Lens: the noun that leans on who you mean}]
+\textbf{\hi{दोस्त}} (\emph{dost}) = \textquotedblleft{}\textbf{friend},\textquotedblright{} and in the dictionary it is \textbf{masculine} — \textbf{\hi{मेरा} \hi{दोस्त}}.
+
+But it bends. When the friend is a woman, ordinary modern Hindi says \textbf{\hi{मेरी} \hi{दोस्त}}. The word has not changed shape; the \textbf{possessive} followed the person. Both are current; neither is a mistake.
+
+That is unlike everything so far. \textbf{\hi{आँख}} is feminine whatever you mean. \textbf{\hi{दोस्त}} takes its gender from \textbf{who the friend is}.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{\hi{दोस्त}} is \textbf{Persian}, \textbf{\ar{دوست}} (\emph{dōst}); Old Persian had \textbf{dauštā}, an agent noun, \textquotedblleft{}\textbf{the one held dear}.\textquotedblright{}
+
+Its root is \emph{\textbf{ǵews-}}, and the old meaning is not \textquotedblleft{}love\textquotedblright{} but \textquotedblleft{}\textbf{to taste, to try, to choose}.\textquotedblright{} Sanskrit inherited it as \textbf{\hi{जुष्}} (\emph{juṣ-}). Latin has \textbf{gustāre} — English \textbf{gusto}, \textbf{disgust} — and English \textbf{choose} is the same root.
+
+So a \emph{dōst} is one you have \textbf{tried and chosen}; the narrowing to \textquotedblleft{}beloved\textquotedblright{} happened inside the Indo-Iranian branch alone.
+\end{cousinweb}
+
+\subsection*{You'll want to know — why it starts with a d}
+The consonant at the front of this root came out as \textbf{z-} in Avestan and \textbf{d-} in \textbf{Old Persian}, by a regular sound law across the vocabulary.
+
+Which is why \textquotedblleft{}friend\textquotedblright{} starts with \textbf{\hi{द}} in Persian and Hindi while its Sanskrit cousin \emph{juṣ-} starts with something else. An initial consonant is a passport stamp: it says which road the word came by.
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \emph{merā dost} for a man, \emph{merī dost} for a woman
+  \item the given and the chosen — \emph{merā bhāī, merī bahin, merā dost}
+  \item \emph{namaste}, then \emph{dost} — one conjunct
+  \item \emph{dōst}, \emph{juṣ-}, \emph{gustāre}, \emph{choose}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+How do you say \textquotedblleft{}my friend\textquotedblright{} about a woman? (\textbf{\hi{मेरी} \hi{दोस्त}} — the possessive follows the person.) What did the root behind \emph{dōst} first mean? (\textbf{To taste, try, choose}.) Why does Persian say \emph{d-} where Avestan says \emph{z-}? (\textbf{A regular sound law}.)
+\end{tcolorbox}
+\section[\hi{बच्चा}]{\hi{बच्चा} (bacchā) — the child, who is a \textquotedblleft{}yearling\textquotedblright{}}
+
+\label{lesson:HI-C39-baccha}
+
+
+
+\begin{quote}
+You have \textbf{\hi{पिता}} and \textbf{\hi{माता}}. Here is the third person at that table — and this word finally lets the masculine and feminine forms stand side by side.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: a pair you can see}]
+\textbf{\hi{बच्चा}} (\emph{bacchā}) = \textquotedblleft{}\textbf{child},\textquotedblright{} \textbf{masculine} — \textbf{\hi{मेरा} \hi{बच्चा}}.
+
+Here the lean does real work at last. Swap the final \textbf{-\hi{ा}} for \textbf{-\hi{ी}} and you get \textbf{\hi{बच्ची}} (\emph{bacchī}), a girl child, \textbf{feminine} — \textbf{\hi{मेरी} \hi{बच्ची}}.
+
+This is what \textbf{\hi{दरवाज़ा}} and \textbf{\hi{कुर्सी}} only hinted at: for \emph{this} class of noun \textbf{-ā}/\textbf{-ī} is not a lean but the machinery, and the word changes with the person. Which is exactly what \textbf{\hi{दोस्त}} would not do.
+
+You already know how to ask this child's age: \textbf{\hi{कितने} \hi{साल} \hi{के} \hi{हो}?} — how many years someone \emph{is of}, rather than how many they \emph{have}.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{\hi{बच्चा}} is \textbf{Persian}, \textbf{\ar{بچه}} (\emph{bacca}) — and the obvious story is wrong.
+
+Persian \emph{bacca} did \textbf{not} come from Sanskrit \textbf{\hi{वत्स}} (\emph{vatsa}), \textquotedblleft{}calf, young one.\textquotedblright{} The two are \textbf{sisters}: one Indo-Iranian word inherited down two separate branches. Centuries later the Persian one was borrowed into Hindi — which had \emph{already} inherited the Sanskrit one as \textbf{\hi{बछड़ा}} (\emph{bachṛā}), \textquotedblleft{}calf.\textquotedblright{}
+
+So Hindi holds both, the same ancient word by two roads — the pattern \textbf{\hi{दरवाज़ा}} and \textbf{\hi{द्वार}} showed you, running again, and the same Persian relay that brought \textbf{\hi{दोस्त}}.
+
+Behind both stands \emph{\textbf{wet-}}, \textquotedblleft{}\textbf{year}.\textquotedblright{} Latin \textbf{vetus}, \textquotedblleft{}old,\textquotedblright{} is from it — English \textbf{veteran} — and so are Latin \textbf{vitulus}, \textquotedblleft{}calf,\textquotedblright{} and English \textbf{wether}, a yearling sheep.
+
+A child, at the root, is a \textbf{yearling}. \textbf{\hi{पिता}} and \textbf{\hi{माता}} are named by relationship; \textbf{\hi{बच्चा}} is named by age.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \emph{bacchā} and \emph{bacchī}; then \emph{merā bacchā}, \emph{merī bacchī}
+  \item the family — \emph{merā pitā, merī mātā, merā bacchā}
+  \item the two roads — \emph{bacchā} from Persian, \emph{bachṛā} inherited; one word
+  \item \emph{vetus}, \emph{vitulus}, \emph{wether} — and the meaning under all of them (year)
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What is the feminine of \textbf{\hi{बच्चा}}, and how does the possessive move? (\textbf{\hi{बच्ची}} — \emph{merā bacchā}, \emph{merī bacchī}.) Is Persian \emph{bacca} descended from Sanskrit \emph{vatsa}? (\textbf{No} — they are \textbf{sisters}; Hindi's inherited cousin is \textbf{\hi{बछड़ा}}.) What does the root mean? (\textbf{Year} — a child is a yearling.)
+\end{tcolorbox}
+\section[\hi{आदमी}]{\hi{आदमी} (ādmī) — the man, and the lean breaking backwards}
+
+\label{lesson:HI-C39-aadmi}
+
+
+
+\begin{quote}
+The child has grown up. And this word does what none so far has — it ends in \textbf{-\hi{ी}} and is masculine anyway.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: the lean breaks the other way}]
+\textbf{\hi{आदमी}} (\emph{ādmī}) = \textquotedblleft{}\textbf{man, person},\textquotedblright{} and it is \textbf{masculine}. Say \textbf{\hi{एक} \hi{आदमी}} — it is also the ordinary word for \textquotedblleft{}person\textquotedblright{} in general, and stays masculine doing that. Ask \textbf{\hi{कितने} \hi{साल} \hi{के} \hi{हो}?} of him and you are asking how many years he \emph{is of}, the way Hindi counts age.
+
+A warning before you reach for the possessive: \textbf{\hi{मेरा} \hi{आदमी}} is real Hindi but means what English's \emph{my man} means. Keep \textbf{\hi{एक} \hi{आदमी}}.
+
+The gender still shows the instant anything agrees with the noun. Put it beside \textbf{\hi{कुर्सी}}: both end in long \textbf{-\hi{ी}}, one is feminine, one masculine, and no reasoning takes you from the ending to the answer. Beside \textbf{\hi{बच्चा}} / \textbf{\hi{बच्ची}}, where the ending \emph{does} carry the gender, the contrast is sharper.
+
+So the lean has failed in \textbf{both} directions: \textbf{\hi{चाय}} and \textbf{\hi{किताब}} feminine with no \textbf{-\hi{ी}}, \textbf{\hi{आदमी}} masculine with one.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{\hi{आदमी}} is \textbf{Arabic}, \textbf{\ar{آدمي}} (\emph{ādamī}), and it came the Persian way — the road of \textbf{\hi{कुर्सी}} and \textbf{\hi{किताब}}.
+
+Now the ending. That \textbf{-ī} is not Hindi at all. It is the \textbf{Arabic ending meaning \textquotedblleft{}belonging to, of the kind of.\textquotedblright{}} Attach it to \textbf{\ar{آدم}} (\emph{Ādam}) and you get \textquotedblleft{}\textbf{of Adam}.\textquotedblright{} A human being, in this word, is one of Adam's.
+
+\textbf{\ar{آدم}} is Hebrew \emph{\textbf{ʾādām}}, and here care is needed. You have probably heard that \emph{ʾādām} comes from \emph{\textbf{ʾadāmāh}}, \textquotedblleft{}ground\textquotedblright{} — man made of earth. Genesis sets the two side by side and means you to notice: a \textbf{deliberate pun}, and a famous one.
+
+It is not the etymology. The prevailing view links the root \textbf{ʾ-d-m} to \textbf{redness} — behind Hebrew \emph{ʾādōm}, \textquotedblleft{}red,\textquotedblright{} and \textbf{Edom}. Beyond that, unsettled.
+
+Worth keeping: \textbf{a wordplay a text makes on purpose is not where a word came from.}
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \emph{ādmī}, then \emph{ek ādmī}
+  \item \emph{kursī} feminine, \emph{ādmī} masculine; then \emph{merī kursī}, and stop
+  \item the lean, and both ways it fails — \emph{chāy}, \emph{kitāb}, \emph{ādmī}
+  \item what the \textbf{-ī} on \emph{ādamī} means
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+\textbf{\hi{कुर्सी}} and \textbf{\hi{आदमी}} end alike — same gender? (\textbf{No}.) What is the \textbf{-ī} of \emph{ādamī} doing? (\textbf{Arabic \textquotedblleft{}belonging to\textquotedblright{}} — \textquotedblleft{}of Adam.\textquotedblright{}) Is \emph{ʾādām} from the word for ground? (\textbf{No} — Genesis is making a deliberate pun; the root is usually connected to \textbf{redness}.)
+\end{tcolorbox}
+\section[\hi{औरत}]{\hi{औरत} (aurat) — the word for \textquotedblleft{}woman,\textquotedblright{} and which one to use}
+
+\label{lesson:HI-C39-aurat}
+
+
+
+\begin{quote}
+The last word of the chapter, and the one where Hindi hands you a choice rather than a word.
+\end{quote}
+
+\begin{grammarlens}[title={Grammar Lens: the pair, and the family complete}]
+\textbf{\hi{औरत}} (\emph{aurat}) = \textquotedblleft{}\textbf{woman},\textquotedblright{} and it is \textbf{feminine}. Say \textbf{\hi{एक} \hi{औरत}} — and for the reason \textbf{\hi{एक} \hi{आदमी}} was the safe phrase, leave \textbf{\hi{मेरी} \hi{औरत}} alone: it means \emph{my woman}, a wife. \textbf{\hi{औ}} is one vowel letter, \emph{au}, standing alone.
+
+Consonant ending, feminine — as \textbf{\hi{चाय}}, \textbf{\hi{किताब}} and \textbf{\hi{आँख}} were. Beside it \textbf{\hi{आदमी}}: \textbf{-\hi{ी}} ending, masculine. Neither adult's gender is reachable from spelling. Where you \emph{can} hear the agreement is on the child: \textbf{\hi{मेरा} \hi{बच्चा}}, \textbf{\hi{मेरी} \hi{बच्ची}}, the yearling who takes the ending seriously.
+
+The family: \textbf{\hi{पिता}}, \textbf{\hi{माता}}, \textbf{\hi{भाई}}, \textbf{\hi{बहन}}, \textbf{\hi{बच्चा}}, \textbf{\hi{आदमी}}, \textbf{\hi{औरत}} — and the chosen one, \textbf{\hi{दोस्त}}.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{\hi{औरत}} is \textbf{Arabic}, \textbf{\ar{عورة}} (\emph{ʿawra}), on the three-consonant root \textbf{ʿ-w-r} — built the way \textbf{k-t-b} built \textbf{\hi{किताब}} — whose senses run to \emph{a weak point, a gap in a defence, something left uncovered}.
+
+Then the fact that changes what you do with all that: \textbf{Arabic ʿawra does not mean \textquotedblleft{}woman.\textquotedblright{}} That sense is a \textbf{Persian} development. Persian moved the noun to mean a woman or a wife and handed \emph{that} to Hindi and Urdu, on record from around 1420 — the same Persian relay that carried \textbf{\hi{दोस्त}}.
+
+So the harsh root sense is not a claim Arabic makes about women. It is the earlier life of a word another language repurposed.
+\end{cousinweb}
+
+\subsection*{You'll want to know — three words, and which to say}
+Three words, and the choice is \textbf{register}, exactly as for \textbf{\hi{किताब}} / \textbf{\hi{पुस्तक}} / \textbf{\hi{पोथा}}.
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\hi{औरत}} — Perso-Arabic, plain and everyday. Common in speech; some speakers avoid it formally, partly because of the origin above.
+  \item \textbf{\hi{महिला}} (\emph{mahilā}) — a Sanskrit borrowing, the \textbf{respectful, public} word: signs, announcements, official prose. Its Sanskrit origin is \textbf{uncertain}; one serious proposal traces it to Dravidian.
+  \item \textbf{\hi{स्त्री}} (\emph{strī}) — Sanskrit, older and literary. Secure back to Indo-Iranian, no further.
+\end{itemize}
+
+\textbf{\hi{महिला}} where you would write, \textbf{\hi{औरत}} where you would talk.
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \emph{ek aurat}, then \emph{ek ādmī} — neither ending gives its gender away
+  \item \emph{merā pitā, merī mātā, merā bhāī, merī bahin, merā bacchā, merī bacchī}
+  \item \emph{merā dost}, then \emph{merī dost}
+  \item every feminine noun you own — \emph{kursī, chāy, kitāb, āṁkh, bacchī}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Does Arabic \textbf{\ar{عورة}} mean \textquotedblleft{}woman\textquotedblright{}? (\textbf{No} — that sense is \textbf{Persian}.) Which goes on a public sign, which in conversation? (\textbf{\hi{महिला}} written; \textbf{\hi{औरत}} spoken.) Your family, minding every possessive? (\emph{Merā pitā, merī mātā, merā bhāī, merī bahin, merā bacchā}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/hindi/chapters.json
+++ b/code/learning/human-languages/hindi/chapters.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "language": "hindi",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 3, 4 and 5 are deliberately absent — every lesson in them is still schema v1 with no practises.knowledge, so no payoff could name a real atom, and a stub would destroy the very signal the gap report exists to carry. Chapters 34 and 35 are the second verb tranche and are schema v2 throughout, so their payoffs name real atoms. Chapters 1 and 2 have no schema-v2 terminal consolidation lesson either: their HI-C01/HI-C02 practice lessons are schema v1, so the payoff falls back to the chapter's last lesson by sequence, which in both cases is a Devanagari writing lesson. Those are recorded as kind 'task' and described as hand-writing work rather than dressed up as spoken dialogue.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 3, 4 and 5 are deliberately absent — every lesson in them is still schema v1 with no practises.knowledge, so no payoff could name a real atom, and a stub would destroy the very signal the gap report exists to carry. Chapters 34 and 35 are the second verb tranche and are schema v2 throughout, so their payoffs name real atoms. Chapters 1 and 2 have no schema-v2 terminal consolidation lesson either: their HI-C01/HI-C02 practice lessons are schema v1, so the payoff falls back to the chapter's last lesson by sequence, which in both cases is a Devanagari writing lesson. Those are recorded as kind 'task' and described as hand-writing work rather than dressed up as spoken dialogue. Chapters 36 to 39 are the pre-A1 noun tranche: four chapters of four word lessons each, every lesson carrying its noun's grammatical gender as part of the atom, and each payoff reaching back past its own chapter to atoms the ledger showed were never revisited.",
   "chapters": [
     {
       "chapter": 1,
@@ -587,6 +587,150 @@
           "HI-CONCEPT-C35-PASAND-01",
           "HI-CONCEPT-C35-PASAND-02",
           "HI-CONCEPT-C35-PASAND-03"
+        ]
+      }
+    },
+    {
+      "chapter": 36,
+      "title": "One House, Four Languages",
+      "label": "ch:hi-one-house-four-languages",
+      "canDo": "I can name a house, its door, a room and the chair I am offered, give each one the possessive its gender demands, and say where each of the four words came from — Sanskrit, Persian, Portuguese and Arabic.",
+      "spineNodes": [
+        "SPINE-MEET-GREET"
+      ],
+      "payoff": {
+        "lesson": "HI-C36-kursi",
+        "kind": "task",
+        "summary": "Run घर, दरवाज़ा, कमरा and कुर्सी with the right possessive — and hear मेरा turn into मेरी at the first feminine noun, the promise chapter 2 made and never kept. Then name the four languages one room drew on, spell कुर्सी with its virāma and its conjunct, and say नमस्ते at the door coming in and शुभ रात्रि going out.",
+        "assesses": [
+          "HI-CONCEPT-C36-GHAR-01",
+          "HI-CONCEPT-C36-GHAR-02",
+          "HI-CONCEPT-C36-DARVAAZA-01",
+          "HI-CONCEPT-C36-DARVAAZA-02",
+          "HI-CONCEPT-C36-DARVAAZA-03",
+          "HI-CONCEPT-C36-KAMRA-01",
+          "HI-CONCEPT-C36-KAMRA-02",
+          "HI-CONCEPT-C36-KURSI-01",
+          "HI-CONCEPT-C36-KURSI-02",
+          "HI-CONCEPT-C36-KURSI-03",
+          "HI-CONCEPT-W02-ABUGIDA-KA-TA-01",
+          "HI-CONCEPT-W02-ABUGIDA-KA-TA-02",
+          "HI-CONCEPT-W03-PREPOSED-I-01",
+          "HI-CONCEPT-W04-RA-SA-MERA-NAAM-01",
+          "HI-CONCEPT-W04-RA-SA-MERA-NAAM-02",
+          "HI-CONCEPT-W05-CONJUNCTS-01",
+          "HI-CONCEPT-W05-CONJUNCTS-02",
+          "HI-CONCEPT-W05-VIRAMA-NAMASTE-01",
+          "HI-CONCEPT-C27-SHUBH-RAATRI-01",
+          "HI-CONCEPT-C27-SHUBH-RAATRI-02"
+        ]
+      }
+    },
+    {
+      "chapter": 37,
+      "title": "One Tea, Please",
+      "label": "ch:hi-one-tea-please",
+      "canDo": "I can ask for tea, milk, food or a book in the words Hindi speakers actually use rather than the dictionary's, I know that कृपया belongs on a sign and दीजिए in the street, and I can name which of the four nouns take मेरी.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "HI-C37-kitaab",
+        "kind": "task",
+        "summary": "Ask for all four — एक चाय दीजिए, एक दूध दीजिए, खाना दीजिए, and the किताब that is मेरी — then unpack the Arabic root k-t-b into book, scribe and school, and place कृपया where it belongs, beside पुस्तक at the formal end of the language.",
+        "assesses": [
+          "HI-CONCEPT-C37-CHAI-01",
+          "HI-CONCEPT-C37-CHAI-02",
+          "HI-CONCEPT-C37-CHAI-03",
+          "HI-CONCEPT-C37-DUDH-01",
+          "HI-CONCEPT-C37-DUDH-02",
+          "HI-CONCEPT-C37-KHAANA-01",
+          "HI-CONCEPT-C37-KHAANA-02",
+          "HI-CONCEPT-C37-KITAAB-01",
+          "HI-CONCEPT-C37-KITAAB-02",
+          "HI-CONCEPT-C37-KITAAB-03",
+          "HI-CONCEPT-C36-KURSI-01",
+          "HI-CONCEPT-C36-KURSI-02",
+          "HI-CONCEPT-C36-KURSI-03",
+          "HI-CONCEPT-C08-KRIPAYA-01",
+          "HI-CONCEPT-C08-KRIPAYA-02",
+          "HI-CONCEPT-C09-MAAF-KIJIYE-02",
+          "HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-01",
+          "HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-02",
+          "HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-03",
+          "HI-CONCEPT-W03-PREPOSED-I-01"
+        ]
+      }
+    },
+    {
+      "chapter": 38,
+      "title": "Six Words for Where It Hurts",
+      "label": "ch:hi-where-it-hurts",
+      "canDo": "I can name six parts of my body, say that one of them is not well, and tell which three are word-for-word cousins of their English translations — and which one has no traceable ancestry at all.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "HI-C38-pet",
+        "kind": "task",
+        "summary": "Say all six body words with the possessive each one demands — मेरा सिर, मेरा हाथ, मेरी आँख, मेरा दाँत, मेरा पैर, मेरा पेट — then say मेरा पेट ठीक नहीं है, and separate the three exact Indo-European cousins from the two words, पेट and रोटी, whose histories genuinely stop.",
+        "assesses": [
+          "HI-CONCEPT-C38-AANKH-01",
+          "HI-CONCEPT-C38-AANKH-02",
+          "HI-CONCEPT-C38-DAANT-01",
+          "HI-CONCEPT-C38-DAANT-02",
+          "HI-CONCEPT-C38-PAIR-01",
+          "HI-CONCEPT-C38-PAIR-02",
+          "HI-CONCEPT-C38-PET-01",
+          "HI-CONCEPT-C38-PET-02",
+          "HI-CONCEPT-C13-SIR-01",
+          "HI-CONCEPT-C13-HAATH-01",
+          "HI-CONCEPT-C13-HAATH-02",
+          "HI-CONCEPT-C07-NAHIN-02",
+          "HI-CONCEPT-C07-NAHIN-03",
+          "HI-CONCEPT-C15-PAANI-ROTI-01",
+          "HI-CONCEPT-C15-PAANI-ROTI-02",
+          "HI-CONCEPT-W03-MATRAS-NAAM-01",
+          "HI-CONCEPT-W03-MATRAS-NAAM-02",
+          "HI-CONCEPT-W03-MATRAS-NAAM-03",
+          "HI-CONCEPT-C37-KITAAB-01",
+          "HI-CONCEPT-C36-KURSI-01"
+        ]
+      }
+    },
+    {
+      "chapter": 39,
+      "title": "The People Around You",
+      "label": "ch:hi-people-around-you",
+      "canDo": "I can name the friend, the child, the man and the woman around me, I know that दोस्त takes its possessive from the person while आँख never does, and I can choose between औरत and महिला by register.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "HI-C39-aurat",
+        "kind": "task",
+        "summary": "Say the whole household with every possessive right — मेरा पिता, मेरी माता, मेरा भाई, मेरी बहन, मेरा बच्चा, मेरी बच्ची — then मेरा दोस्त or मेरी दोस्त depending on who the friend is, and say why Arabic ʿawra does not mean “woman” even though औरत does.",
+        "assesses": [
+          "HI-CONCEPT-C39-DOST-01",
+          "HI-CONCEPT-C39-DOST-02",
+          "HI-CONCEPT-C39-DOST-03",
+          "HI-CONCEPT-C39-BACCHA-01",
+          "HI-CONCEPT-C39-BACCHA-02",
+          "HI-CONCEPT-C39-AADMI-01",
+          "HI-CONCEPT-C39-AADMI-02",
+          "HI-CONCEPT-C39-AURAT-01",
+          "HI-CONCEPT-C39-AURAT-02",
+          "HI-CONCEPT-C39-AURAT-03",
+          "HI-CONCEPT-C12-BHAAI-BAHIN-01",
+          "HI-CONCEPT-C12-BHAAI-BAHIN-02",
+          "HI-CONCEPT-C12-PITAA-MAATAA-01",
+          "HI-CONCEPT-C12-PITAA-MAATAA-02",
+          "HI-CONCEPT-C37-KITAAB-01",
+          "HI-CONCEPT-C37-KITAAB-03",
+          "HI-CONCEPT-C36-KURSI-01",
+          "HI-CONCEPT-C36-KURSI-03",
+          "HI-CONCEPT-C38-AANKH-01",
+          "HI-CONCEPT-C37-CHAI-01"
         ]
       }
     }

--- a/code/learning/human-languages/hindi/curriculum.json
+++ b/code/learning/human-languages/hindi/curriculum.json
@@ -389,12 +389,73 @@
       "before": [],
       "inline": [],
       "after": []
+    },
+    {
+      "id": "HI-PATH-030",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "HI-C36-ghar",
+        "HI-C36-darvaaza",
+        "HI-C36-kamra",
+        "HI-C36-kursi"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-030-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-031",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "HI-C37-chai",
+        "HI-C37-dudh",
+        "HI-C37-khaana",
+        "HI-C37-kitaab"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-031-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-032",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "HI-C38-aankh",
+        "HI-C38-daant",
+        "HI-C38-pair",
+        "HI-C38-pet"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-032-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "HI-PATH-033",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "HI-C39-dost",
+        "HI-C39-baccha",
+        "HI-C39-aadmi",
+        "HI-C39-aurat"
+      ],
+      "before": [],
+      "inline": [
+        "HI-EXT-033-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
     }
   ],
   "spine": {
     "SPINE-MEET-GREET": {
       "segments": [
-        "HI-PATH-001"
+        "HI-PATH-001",
+        "HI-PATH-030"
       ],
       "omits": [
         "GREETING-PEACE",
@@ -425,7 +486,8 @@
         "HI-PATH-004",
         "HI-PATH-007",
         "HI-PATH-015",
-        "HI-PATH-020"
+        "HI-PATH-020",
+        "HI-PATH-033"
       ],
       "omits": [
         "PRONOUN-ME"
@@ -436,7 +498,8 @@
       "segments": [
         "HI-PATH-006",
         "HI-PATH-027",
-        "HI-PATH-016"
+        "HI-PATH-016",
+        "HI-PATH-032"
       ],
       "omits": [
         "WORD-GOOD",
@@ -447,7 +510,8 @@
     "SPINE-POLITE-REQUEST-REPAIR": {
       "segments": [
         "HI-PATH-012",
-        "HI-PATH-018"
+        "HI-PATH-018",
+        "HI-PATH-031"
       ],
       "omits": [],
       "relocates": {}
@@ -1005,6 +1069,62 @@
       "prerequisites": [],
       "lessons": [
         "HI-C05-bolta-hun"
+      ]
+    },
+    {
+      "id": "HI-EXT-030-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can name the house, the door, the room and the chair I am shown to, and give each one the possessive its gender demands.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C36-ghar",
+        "HI-C36-darvaaza",
+        "HI-C36-kamra",
+        "HI-C36-kursi"
+      ]
+    },
+    {
+      "id": "HI-EXT-031-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can ask for tea, milk, food or a book in the words a Hindi speaker actually uses, and I know which noun takes मेरी.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C37-chai",
+        "HI-C37-dudh",
+        "HI-C37-khaana",
+        "HI-C37-kitaab"
+      ]
+    },
+    {
+      "id": "HI-EXT-032-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can name six parts of my body and say that one of them is not well.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C38-aankh",
+        "HI-C38-daant",
+        "HI-C38-pair",
+        "HI-C38-pet"
+      ]
+    },
+    {
+      "id": "HI-EXT-033-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can name the people around me — friend, child, man, woman — and I know which of them take their gender from the person rather than the word.",
+      "prerequisites": [],
+      "lessons": [
+        "HI-C39-dost",
+        "HI-C39-baccha",
+        "HI-C39-aadmi",
+        "HI-C39-aurat"
       ]
     }
   ]

--- a/code/learning/human-languages/hindi/lessons/HI-C36-darvaaza.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C36-darvaaza.md
@@ -55,8 +55,7 @@ A nuqta is a small confession in ink: *this sound came from somewhere else.*
 दरवाज़ा**.
 
 Here is your first piece of help. A noun ending in long **-ā** is usually
-masculine, and *darvāzā* ends in **-ा**. Keep it as a lean, not a law: this
-course will show you where it fails, in both directions.
+masculine, and *darvāzā* ends in **-ा**. Keep it as a lean, not a law: later chapters will show you where it fails, in both directions.
 
 **घर** ends in a consonant and is masculine too — so a consonant ending tells
 you nothing at all. That one you simply learn.

--- a/code/learning/human-languages/hindi/lessons/HI-C36-darvaaza.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C36-darvaaza.md
@@ -1,0 +1,98 @@
+---
+schema_version: 2
+id: HI-C36-darvaaza
+spine_node: SPINE-MEET-GREET
+sequence: 700
+chapter: 36
+type: word
+headword: दरवाज़ा
+gloss: door — masculine, a Persian loan whose first syllable is the same ancient word as English "door"
+concept_tag: HI-HOME-DOOR
+prerequisites: [HI-C36-ghar, HI-W05-write-namaste, HI-C27-shubh-raatri]
+sounds: [nuqta-za, devanagari-long-aa]
+roots: [persian-dar, pie-dhwer]
+etymology_hook: "दरवाज़ा (darvāzā) is Persian دروازه — and Persian dar 'door' descends from the same PIE *dʰwer- as English door, Latin forēs, Greek thúrā and Sanskrit द्वार dvāra, so the borrowed word and Hindi's own inherited द्वार are one ancient word arriving twice by different roads; the second element is usually connected to a Persian word for 'open' but its source is disputed, and the ज़ carries a nuqta because Persian brought a z Devanagari had no letter for"
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [HI-CONCEPT-C36-GHAR-01, HI-CONCEPT-C36-GHAR-02, HI-CONCEPT-W03-MATRAS-NAAM-01, HI-CONCEPT-W03-MATRAS-NAAM-02, HI-CONCEPT-W03-MATRAS-NAAM-03, HI-CONCEPT-W05-WRITE-NAMASTE-01, HI-CONCEPT-W05-WRITE-NAMASTE-02, HI-CONCEPT-C27-SHUBH-RAATRI-01, HI-CONCEPT-C27-SHUBH-RAATRI-02]
+introduces:
+  knowledge: [HI-CONCEPT-C36-DARVAAZA-01, HI-CONCEPT-C36-DARVAAZA-02, HI-CONCEPT-C36-DARVAAZA-03]
+practises:
+  knowledge: [HI-CONCEPT-C36-DARVAAZA-01, HI-CONCEPT-C36-DARVAAZA-02, HI-CONCEPT-C36-DARVAAZA-03, HI-CONCEPT-C36-GHAR-01, HI-CONCEPT-C36-GHAR-02, HI-CONCEPT-W03-MATRAS-NAAM-01, HI-CONCEPT-W03-MATRAS-NAAM-02, HI-CONCEPT-W03-MATRAS-NAAM-03, HI-CONCEPT-W05-WRITE-NAMASTE-01, HI-CONCEPT-W05-WRITE-NAMASTE-02, HI-CONCEPT-C27-SHUBH-RAATRI-01, HI-CONCEPT-C27-SHUBH-RAATRI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-C36-ghar, HI-W03-matras-naam, HI-W05-write-namaste, HI-C27-shubh-raatri]
+---
+
+# दरवाज़ा (darvāzā) — the door, and the oldest word you already know
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C36-GHAR-01, HI-CONCEPT-W05-WRITE-NAMASTE-01] -->
+
+[PAUSE 2s] You have a house. This is what you stand at to be let into one —
+and it is where **नमस्ते** is said and where **शुभ रात्रि** is said back.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C36-DARVAAZA-03]; assesses=[HI-CONCEPT-W03-MATRAS-NAAM-01, HI-CONCEPT-W03-MATRAS-NAAM-02, HI-CONCEPT-W03-MATRAS-NAAM-03, HI-CONCEPT-W05-WRITE-NAMASTE-02] -->
+
+**द·र·वा·ज़ा** — and the **ा** you already write does two of the four.
+
+The new mark is the dot under **ज़**: the **nuqta**. Plain **ज** is *ja*. Persian
+arrived carrying a **z** Devanagari had no letter for, so the script put a dot
+beneath the nearest shape and made one — **ज़**, *za*. The same dot makes **फ़**
+(*fa*) and **ख़**, the sound in **ख़ुशी**.
+
+A nuqta is a small confession in ink: *this sound came from somewhere else.*
+
+## Grammar Lens: the shape that usually tells you
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C36-DARVAAZA-01]; assesses=[HI-CONCEPT-C36-GHAR-01] -->
+
+**दरवाज़ा** (*darvāzā*) = "**door**," and it is **masculine** — so **मेरा
+दरवाज़ा**.
+
+Here is your first piece of help. A noun ending in long **-ā** is usually
+masculine, and *darvāzā* ends in **-ा**. Keep it as a lean, not a law: this
+course will show you where it fails, in both directions.
+
+**घर** ends in a consonant and is masculine too — so a consonant ending tells
+you nothing at all. That one you simply learn.
+
+## The word, taken apart: दरवाज़ा
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C36-DARVAAZA-02]; assesses=[HI-CONCEPT-C36-DARVAAZA-01, HI-CONCEPT-C36-GHAR-02] -->
+
+**दरवाज़ा** is **Persian**, **دروازه** (*darvāza*), and its first syllable is
+where this gets remarkable. Persian **در** (*dar*) means "**door**," and it
+descends from the ancient root ***dʰwer-*** — as do English **door**, Latin
+**forēs**, Greek **thúrā** and Sanskrit **द्वार** (*dvāra*).
+
+Now the twist. Hindi *also* has **द्वार** (*dvār*), taken straight out of
+Sanskrit for formal use. So the borrowed Persian word and the learned Sanskrit
+one are **the same ancient word, arrived twice**, by two roads, centuries apart.
+
+The **-vāza** part is less settled: usually connected to a Persian word for
+"**open**," but disputed, and worth leaving open.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C36-DARVAAZA-01, HI-CONCEPT-C36-DARVAAZA-02, HI-CONCEPT-C36-DARVAAZA-03, HI-CONCEPT-C36-GHAR-01, HI-CONCEPT-C27-SHUBH-RAATRI-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: *darvāzā*, then *merā darvāzā*, then *merā ghar* — one *merā*, two
+  masculine nouns]
+- [YOU SAY: the arrival and the leaving at the same door — *namaste* going in,
+  *shubh rātri* going out]
+- [YOU SAY: *ja*, then *za* — the letter, then the letter with the dot]
+- [YOU SAY: *dar*, *door*, *thúrā*, *dvāra* — one word, four languages]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C36-DARVAAZA-01, HI-CONCEPT-C36-DARVAAZA-02, HI-CONCEPT-C36-DARVAAZA-03, HI-CONCEPT-C27-SHUBH-RAATRI-02] -->
+
+[PAUSE 3s] What does the dot under **ज़** tell you? (That the sound is
+**borrowed** — Devanagari had no *z*.)
+Persian *dar* and English *door* — coincidence or cousins? (**Cousins**, from
+***dʰwer-*** — and Hindi's own **द्वार** is the third.)
+Which ending gives you a fair guess at masculine? (**Long -ā**, as in
+*darvāzā*. A consonant ending, as in *ghar*, tells you nothing.)

--- a/code/learning/human-languages/hindi/lessons/HI-C36-ghar.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C36-ghar.md
@@ -1,0 +1,97 @@
+---
+schema_version: 2
+id: HI-C36-ghar
+spine_node: SPINE-MEET-GREET
+sequence: 690
+chapter: 36
+type: word
+headword: घर
+gloss: house, home — masculine, and from a Sanskrit word that meant a fenced enclosure before it meant a building
+concept_tag: HI-HOME-HOUSE
+prerequisites: [HI-C04-phir-milenge, HI-W04-write-mera-naam]
+sounds: [aspirated-gha, spineless-ra]
+roots: [grha-sanskrit, pie-gherdh]
+etymology_hook: "घर (ghar) is Sanskrit गृह (gṛha), and गृह is not built on 'to hold' the way the old grammarians' root-lists suggest — it goes back to a PIE root *gʰerdʰ- meaning ENCLOSURE, the root behind English yard and garden and the -grad in Belgrade; a house was first of all a fenced-in piece of ground, and the building came second; the everyday Hindi word is the worn-down inheritance (गृह → Prakrit ghara → घर) while गृह itself is still used in Hindi as a formal borrowing back out of Sanskrit"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [HI-CONCEPT-W01-SHIROREKHA-NA-MA-01, HI-CONCEPT-W04-RA-SA-MERA-NAAM-01, HI-CONCEPT-W04-RA-SA-MERA-NAAM-02, HI-CONCEPT-W04-WRITE-MERA-NAAM-01]
+introduces:
+  knowledge: [HI-CONCEPT-C36-GHAR-01, HI-CONCEPT-C36-GHAR-02]
+practises:
+  knowledge: [HI-CONCEPT-C36-GHAR-01, HI-CONCEPT-C36-GHAR-02, HI-CONCEPT-W01-SHIROREKHA-NA-MA-01, HI-CONCEPT-W04-RA-SA-MERA-NAAM-01, HI-CONCEPT-W04-RA-SA-MERA-NAAM-02, HI-CONCEPT-W04-WRITE-MERA-NAAM-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-W04-ra-sa-mera-naam, HI-W04-write-mera-naam]
+---
+
+# घर (ghar) — "house," and the fence that came first
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-W04-WRITE-MERA-NAAM-01] -->
+
+[PAUSE 2s] You can say your name. Now say where you live — and meet the one
+thing every Hindi noun carries that English nouns do not.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-W01-SHIROREKHA-NA-MA-01, HI-CONCEPT-W04-RA-SA-MERA-NAAM-01, HI-CONCEPT-W04-RA-SA-MERA-NAAM-02] -->
+
+Two letters. **घ** (*gha*), the breathy pair of *ga*, then **र** (*ra*), already
+yours from **मेरा**.
+
+**र** is the spineless one: no upright stroke of its own, so the **शिरोरेखा**,
+the head-line, is all that ties it to its neighbour. Both letters keep their
+inherent *a* → **घर**, *ghar*.
+
+## Grammar Lens: the word arrives with a gender
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C36-GHAR-01]; assesses=[] -->
+
+**घर** (*ghar*) = "**house, home**." And it is **masculine**.
+
+Every Hindi noun is masculine or feminine. Not the thing — the **word**. There
+is nothing manly about a house; the gender is a fact about *ghar* the way its
+spelling is, and you learn the two together or you learn them twice.
+
+It is not decoration: it changes the words around the noun. Because *ghar* is
+masculine, "my house" is **मेरा घर** (*merā ghar*), the masculine **मेरा**,
+exactly as in **मेरा नाम**.
+
+Whole sentence: **यह मेरा घर है** (*yah merā ghar hai*), "**this is my house**."
+
+## The word, taken apart: घर
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C36-GHAR-02]; assesses=[HI-CONCEPT-C36-GHAR-01] -->
+
+**घर** comes from Sanskrit **गृह** (*gṛha*), worn smooth through Prakrit *ghara*
+into the short word you just said. Hindi kept **गृह** too, borrowed back out of
+Sanskrit for formal use, so both shapes survive.
+
+Further back, *gṛha* descends from an ancient root meaning **enclosure**,
+***gʰerdʰ-*** — and English holds two plain descendants of it: **yard** and
+**garden**. Slavic holds the *-grad* in **Belgrade**, "town."
+
+So the oldest sense is not walls and a roof. It is **a fenced-in piece of
+ground**. You enclose the land first; the house is what goes inside afterwards.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C36-GHAR-01, HI-CONCEPT-C36-GHAR-02, HI-CONCEPT-W04-RA-SA-MERA-NAAM-01, HI-CONCEPT-W04-WRITE-MERA-NAAM-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: *ghar* — house; then *merā ghar*; then *yah merā ghar hai*]
+- [YOU SAY: *merā nām* and *merā ghar* one after the other — the same *merā*,
+  because both nouns are masculine]
+- [YOU SAY: the two letters, *gha* and *ra*, and which of them has no spine]
+- [YOU SAY: *gṛha*, then *ghar* — the Sanskrit shape and the worn one; then the
+  old meaning, *enclosure*]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C36-GHAR-01, HI-CONCEPT-C36-GHAR-02, HI-CONCEPT-W01-SHIROREKHA-NA-MA-01] -->
+
+[PAUSE 3s] Is **घर** masculine or feminine, and how do you know from the
+sentence? (**Masculine** — *merā*, not *merī*.)
+What did the root behind *gṛha* mean before it meant a building? (**An
+enclosure** — the root behind *yard* and *garden*.)
+Which of **घ** and **र** hangs from the head-line without a spine of its own?
+(**र**.)

--- a/code/learning/human-languages/hindi/lessons/HI-C36-kamra.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C36-kamra.md
@@ -1,0 +1,98 @@
+---
+schema_version: 2
+id: HI-C36-kamra
+spine_node: SPINE-MEET-GREET
+sequence: 710
+chapter: 36
+type: word
+headword: कमरा
+gloss: room — masculine, and the same Latin word as English "camera", brought to India by Portuguese ships
+concept_tag: HI-HOME-ROOM
+prerequisites: [HI-C36-darvaaza, HI-W01-na-ma]
+sounds: [devanagari-long-aa, dental-ma]
+roots: [portuguese-camara, latin-camera]
+etymology_hook: "कमरा (kamrā) is Portuguese câmara, from Latin camera 'vaulted chamber' — so Hindi's ordinary word for a room and English camera are the same Latin word, and Hindi has borrowed it a second time as कैमरा for the device, making the two a doublet; Portuguese traders on the western coast also left चाबी (key) and अलमारी (cupboard), a third source of Hindi vocabulary beside Sanskrit and Persian"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [HI-CONCEPT-C36-DARVAAZA-01, HI-CONCEPT-C36-DARVAAZA-02, HI-CONCEPT-C36-GHAR-01, HI-CONCEPT-W01-NA-MA-01, HI-CONCEPT-W01-NA-MA-02, HI-CONCEPT-W01-NA-MA-03]
+introduces:
+  knowledge: [HI-CONCEPT-C36-KAMRA-01, HI-CONCEPT-C36-KAMRA-02]
+practises:
+  knowledge: [HI-CONCEPT-C36-KAMRA-01, HI-CONCEPT-C36-KAMRA-02, HI-CONCEPT-C36-DARVAAZA-01, HI-CONCEPT-C36-DARVAAZA-02, HI-CONCEPT-C36-GHAR-01, HI-CONCEPT-W01-NA-MA-01, HI-CONCEPT-W01-NA-MA-02, HI-CONCEPT-W01-NA-MA-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-C36-darvaaza, HI-C36-ghar, HI-W01-na-ma]
+---
+
+# कमरा (kamrā) — the room that is also a camera
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C36-DARVAAZA-01] -->
+
+[PAUSE 2s] Through the door, and into this. A short, ordinary word — which
+travelled to India by sea, on Portuguese ships.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-W01-NA-MA-01, HI-CONCEPT-W01-NA-MA-02, HI-CONCEPT-W01-NA-MA-03] -->
+
+**क·म·रा** — and **म** (*ma*) is one of the first two letters you ever wrote,
+beside **न**.
+
+Both of those hang from the head-line and both stand on a right-hand spine;
+that upright is what your eye follows along a line of Devanagari. **क** and
+**र** you have as well, so this word costs you nothing new — only the **ा**
+riding on the final **र**.
+
+## Grammar Lens: the lean holds
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C36-KAMRA-01]; assesses=[HI-CONCEPT-C36-DARVAAZA-01, HI-CONCEPT-C36-GHAR-01] -->
+
+**कमरा** (*kamrā*) = "**room**," and it is **masculine** — **मेरा कमरा**.
+
+Long **-ā**, masculine again, exactly as **दरवाज़ा** was. Three nouns in, and
+the possessive has not changed once: *merā ghar*, *merā darvāzā*, *merā kamrā*.
+
+Hold on to that flatness. It is about to break.
+
+## The word, taken apart: कमरा
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C36-KAMRA-02]; assesses=[HI-CONCEPT-C36-KAMRA-01, HI-CONCEPT-C36-DARVAAZA-02] -->
+
+**कमरा** is neither Sanskrit nor Persian. It is **Portuguese** — **câmara**,
+"chamber, room" — left behind on India's western coast by the traders who ran
+that shore from the sixteenth century, along with **चाबी** (*chābī*, "key") and
+**अलमारी** (*almārī*, "cupboard").
+
+Portuguese *câmara* is Latin **camera**, "a vaulted chamber," and Latin took it
+from Greek **kamára** — where the trail honestly stops; the Greek word's own
+origin is unknown.
+
+Then the good part. English **camera** is that same Latin word: a *camera
+obscura* was literally a "dark room," and when the dark room shrank into a box
+the name went with it. And Hindi later borrowed it back through English as
+**कैमरा** (*kaimrā*) for the device.
+
+So **कमरा** and **कैमरा** are the *same Latin word*, arrived twice by two
+different routes — the second time carrying a machine that did not exist when
+the first one landed.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C36-KAMRA-01, HI-CONCEPT-C36-KAMRA-02, HI-CONCEPT-C36-DARVAAZA-01, HI-CONCEPT-C36-DARVAAZA-02, HI-CONCEPT-C36-GHAR-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: *kamrā*, then *merā kamrā*]
+- [YOU SAY: the three so far, in one breath — *merā ghar, merā darvāzā, merā
+  kamrā*]
+- [YOU SAY: *kamrā* and *kaimrā* — one Latin word, two arrivals]
+- [YOU SAY: where each of the three came from — Sanskrit, Persian, Portuguese]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C36-KAMRA-01, HI-CONCEPT-C36-KAMRA-02, HI-CONCEPT-C36-GHAR-01] -->
+
+[PAUSE 3s] Which language handed Hindi **कमरा**, and how did it get there?
+(**Portuguese**, by sea, on the western coast.)
+What does *kamrā* share with English *camera*? (**One Latin word**, *camera*,
+"vaulted chamber" — Hindi has it twice, as *kamrā* and *kaimrā*.)
+Say "my house, my door, my room." (*Merā ghar, merā darvāzā, merā kamrā*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C36-kursi.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C36-kursi.md
@@ -1,0 +1,104 @@
+---
+schema_version: 2
+id: HI-C36-kursi
+spine_node: SPINE-MEET-GREET
+sequence: 720
+chapter: 36
+type: word
+headword: कुर्सी
+gloss: chair — your first feminine noun, and a word that has been passing between Middle Eastern languages for four thousand years
+concept_tag: HI-HOME-CHAIR
+prerequisites: [HI-C36-kamra, HI-W05-conjuncts, HI-C02-meraa]
+sounds: [repha-r, devanagari-long-ii]
+roots: [arabic-kursi, akkadian-kussu]
+etymology_hook: "कुर्सी (kursī) came from Arabic كرسي through Persian, and Arabic itself had it from Aramaic — part of a chain running back through Ugaritic and Akkadian kussû to Sumerian guza, a word for a seat handed between unrelated language families for four thousand years; English chair is no relation at all, coming from Greek kathédra, so the two words for the same object share nothing but the object"
+duration:
+  max_seconds: 260
+requires:
+  knowledge: [HI-CONCEPT-C36-KAMRA-01, HI-CONCEPT-C36-DARVAAZA-01, HI-CONCEPT-C36-GHAR-01, HI-CONCEPT-C36-GHAR-02, HI-CONCEPT-W02-ABUGIDA-KA-TA-01, HI-CONCEPT-W02-ABUGIDA-KA-TA-02, HI-CONCEPT-W03-PREPOSED-I-01, HI-CONCEPT-W04-RA-SA-MERA-NAAM-01, HI-CONCEPT-W04-RA-SA-MERA-NAAM-02, HI-CONCEPT-W05-CONJUNCTS-01, HI-CONCEPT-W05-CONJUNCTS-02, HI-CONCEPT-W05-VIRAMA-NAMASTE-01, HI-CONCEPT-C27-SHUBH-RAATRI-01, HI-CONCEPT-C27-SHUBH-RAATRI-02]
+introduces:
+  knowledge: [HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-02, HI-CONCEPT-C36-KURSI-03]
+practises:
+  knowledge: [HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-02, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C36-KAMRA-01, HI-CONCEPT-C36-KAMRA-02, HI-CONCEPT-C36-DARVAAZA-01, HI-CONCEPT-C36-DARVAAZA-02, HI-CONCEPT-C36-DARVAAZA-03, HI-CONCEPT-C36-GHAR-01, HI-CONCEPT-C36-GHAR-02, HI-CONCEPT-W02-ABUGIDA-KA-TA-01, HI-CONCEPT-W02-ABUGIDA-KA-TA-02, HI-CONCEPT-W03-PREPOSED-I-01, HI-CONCEPT-W04-RA-SA-MERA-NAAM-01, HI-CONCEPT-W04-RA-SA-MERA-NAAM-02, HI-CONCEPT-W05-CONJUNCTS-01, HI-CONCEPT-W05-CONJUNCTS-02, HI-CONCEPT-W05-VIRAMA-NAMASTE-01, HI-CONCEPT-C27-SHUBH-RAATRI-01, HI-CONCEPT-C27-SHUBH-RAATRI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-C36-kamra, HI-C36-darvaaza, HI-C36-ghar, HI-W05-conjuncts, HI-W05-virama-namaste, HI-W02-abugida-ka-ta, HI-C27-shubh-raatri]
+---
+
+# कुर्सी (kursī) — sit down, and watch मेरा change
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C36-KAMRA-01, HI-CONCEPT-C36-DARVAAZA-01] -->
+
+[PAUSE 2s] House, door, room — and now what you are offered once inside. This
+word breaks the pattern the other three set.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-W02-ABUGIDA-KA-TA-01, HI-CONCEPT-W02-ABUGIDA-KA-TA-02, HI-CONCEPT-W03-PREPOSED-I-01, HI-CONCEPT-W04-RA-SA-MERA-NAAM-01, HI-CONCEPT-W04-RA-SA-MERA-NAAM-02, HI-CONCEPT-W05-CONJUNCTS-01, HI-CONCEPT-W05-CONJUNCTS-02, HI-CONCEPT-W05-VIRAMA-NAMASTE-01] -->
+
+**कु·र्·सी** — three old letters, **क**, **र**, **स**, and two working marks.
+
+**क** takes **ु** for *ku*. Then **र** with the **virāma**, the stroke that kills
+a consonant's built-in *a*: a bare **र्** cannot stand alone, so it fuses with
+the **स**, and the hook above **स** *is* that **र** — the fusing you met in **स्त**.
+
+Then **सी**: the long **ी** stands after its consonant and sounds after it, while
+**ि** stands before and still sounds after. One of the two lies to your eye.
+
+## Grammar Lens: your first feminine noun
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C36-KURSI-01]; assesses=[HI-CONCEPT-C36-KAMRA-01, HI-CONCEPT-C36-GHAR-01] -->
+
+**कुर्सी** (*kursī*) = "**chair**," and it is **feminine**.
+
+So **मेरी कुर्सी**, not *merā*. When you learnt **मेरा** you were told you would
+meet **मेरी** at your first feminine noun. Here it is.
+
+Nothing about a chair is female. The gender belongs to the **word**, and it
+changes **मेरा**. Get it wrong and every word beside the noun goes wrong too.
+
+## Grammar Lens: the lean, and where it leans wrong
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C36-KURSI-03]; assesses=[HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-DARVAAZA-01] -->
+
+The rule of thumb: **long -ā tends masculine, long -ī tends feminine, a
+consonant ending tells you nothing.** A lean, not a law: *darvāzā*, *kamrā* and
+*kursī* obey it, *ghar* sits outside it, and later words will disobey it
+outright.
+
+## The word, taken apart: कुर्सी
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C36-KURSI-02]; assesses=[HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KAMRA-02, HI-CONCEPT-C36-DARVAAZA-02, HI-CONCEPT-C36-GHAR-02] -->
+
+**कुर्सी** is **Arabic**, **كرسي** (*kursī*), "seat, throne," reaching Hindi
+through **Persian**, the road most Arabic words took.
+
+Arabic did not invent it either. It has passed along the Near East for four
+thousand years: Sumerian **guza**, Akkadian **kussû**, then Ugaritic, Hebrew and
+Aramaic, Arabic most likely taking it from **Aramaic**. Not one family — the
+word crossed between unrelated families because the object did.
+
+English **chair**? Greek **kathédra**, through Latin and French. No relation at
+all.
+
+And what this chapter has done: **घर** Sanskrit, **दरवाज़ा** Persian, **कमरा**
+Portuguese, **कुर्सी** Arabic. One room, four languages — that is Hindi, not an
+accident of these four words.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-02, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C36-KAMRA-01, HI-CONCEPT-C36-KAMRA-02, HI-CONCEPT-C36-DARVAAZA-01, HI-CONCEPT-C36-DARVAAZA-02, HI-CONCEPT-C36-DARVAAZA-03, HI-CONCEPT-C36-GHAR-01, HI-CONCEPT-C36-GHAR-02, HI-CONCEPT-C27-SHUBH-RAATRI-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: *merī kursī*, then *merā kamrā* — one possessive, two shapes]
+- [YOU SAY: the chapter — *merā ghar, merā darvāzā, merā kamrā, merī kursī*]
+- [YOU SAY: each word's source — Sanskrit, Persian, Portuguese, Arabic]
+- [YOU SAY: *namaste* at the *darvāzā*, then *shubh rātri* at the same door]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-02, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C36-GHAR-01, HI-CONCEPT-C36-KAMRA-02, HI-CONCEPT-C27-SHUBH-RAATRI-02] -->
+
+[PAUSE 3s] Why **मेरी कुर्सी**? (**कुर्सी is feminine**; the possessive agrees
+with the noun.)
+How far back does *kursī* go, and did it stay in one family? (**Sumerian** —
+and no, it crossed unrelated families.)
+Name the chapter's four sources. (**Sanskrit, Persian, Portuguese, Arabic**.)

--- a/code/learning/human-languages/hindi/lessons/HI-C37-chai.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C37-chai.md
@@ -1,0 +1,99 @@
+---
+schema_version: 2
+id: HI-C37-chai
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 730
+chapter: 37
+type: word
+headword: चाय
+gloss: tea — feminine, and one of the two names the world uses for the same leaf
+concept_tag: HI-DRINK-TEA
+prerequisites: [HI-C36-kursi, HI-C08-kripaya, HI-C09-maaf-kijiye, HI-C15-paani-roti, HI-C06-numbers-1-5]
+sounds: [devanagari-long-aa, semivowel-ya]
+roots: [sinitic-cha, persian-chay]
+etymology_hook: "चाय (chāy) came from Sinitic chá through Persian چای — and English tea came from the same leaf by a different Chinese port, Hokkien tê carried west by Dutch ships; the split is not overland-versus-sea (Portuguese chá came by sea, via Macao) but which Chinese port a trader dealt with, so the name of your drink records the harbour your ancestors bought it in"
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C36-KAMRA-01, HI-CONCEPT-C36-KAMRA-02, HI-CONCEPT-C08-KRIPAYA-01, HI-CONCEPT-C08-KRIPAYA-02, HI-CONCEPT-C09-MAAF-KIJIYE-02, HI-CONCEPT-C15-PAANI-ROTI-01, HI-CONCEPT-C06-NUMBERS-1-5-01]
+introduces:
+  knowledge: [HI-CONCEPT-C37-CHAI-01, HI-CONCEPT-C37-CHAI-02, HI-CONCEPT-C37-CHAI-03]
+practises:
+  knowledge: [HI-CONCEPT-C37-CHAI-01, HI-CONCEPT-C37-CHAI-02, HI-CONCEPT-C37-CHAI-03, HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C36-KAMRA-01, HI-CONCEPT-C36-KAMRA-02, HI-CONCEPT-C08-KRIPAYA-01, HI-CONCEPT-C08-KRIPAYA-02, HI-CONCEPT-C09-MAAF-KIJIYE-02, HI-CONCEPT-C15-PAANI-ROTI-01, HI-CONCEPT-C06-NUMBERS-1-5-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-C36-kursi, HI-C08-kripaya, HI-C09-maaf-kijiye, HI-C15-paani-roti]
+---
+
+# चाय (chāy) — tea, and how to actually ask for one
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KAMRA-01, HI-CONCEPT-C36-KAMRA-02, HI-CONCEPT-C15-PAANI-ROTI-01] -->
+
+[PAUSE 2s] You are in the chair, in the room Portuguese named. Somebody is about
+to offer you this — and by the end of these few minutes you will be able to ask
+for it yourself, in the words people actually use.
+
+## Grammar Lens: the lean fails, quietly
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C37-CHAI-01]; assesses=[HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-03] -->
+
+**चाय** (*chāy*) = "**tea**," and it is **feminine**.
+
+Nothing outside the word says so. It does not end in **-ी** the way **कुर्सी**
+does; it ends in a consonant, and the lean warned you a consonant ending tells
+you nothing. **चाय** is feminine and you simply learn it — now, with the word.
+
+## You'll want to know — how you really ask
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C37-CHAI-02]; assesses=[HI-CONCEPT-C08-KRIPAYA-01, HI-CONCEPT-C08-KRIPAYA-02, HI-CONCEPT-C06-NUMBERS-1-5-01] -->
+
+**एक चाय दीजिए** (*ek chāy dījie*) — "**one tea, please**."
+
+**दीजिए** is "give" spoken to **आप**: the polite request form. That **-िए**
+ending *is* the politeness. Nothing else is needed.
+
+Which means a correction. You learnt **कृपया** as "please," and it is a real
+word — but it belongs to **signs, forms and station announcements**. Across a
+counter it lands like *kindly furnish me with tea*.
+
+So: **कृपया** when you write, **दीजिए** when you speak. And you already have the
+shape — **माफ़ कीजिए** carries the very same **-िए**.
+
+## The word, taken apart: चाय
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C37-CHAI-03]; assesses=[HI-CONCEPT-C37-CHAI-01] -->
+
+**चाय** is **Chinese**. In most of China the word for the leaf is **chá**,
+which Persian took as **چای** (*chāy*) and handed to Hindi.
+
+Now the English word: **tea**. French **thé**, Dutch **thee** — a different
+sound entirely, for the identical leaf.
+
+They are the same word. China writes it with one character everywhere, but reads
+that character differently: in the Hokkien of the south-eastern coast it is
+**tê**, and Dutch ships bought their tea *there*.
+
+The tempting story is overland versus sea. It is wrong: Portuguese say **chá**,
+and Portuguese tea came by sea. The variable is **which Chinese port a trader
+dealt with**. Your word for tea records a harbour.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C37-CHAI-01, HI-CONCEPT-C37-CHAI-02, HI-CONCEPT-C37-CHAI-03, HI-CONCEPT-C08-KRIPAYA-01, HI-CONCEPT-C09-MAAF-KIJIYE-02, HI-CONCEPT-C15-PAANI-ROTI-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: *chāy*; then *ek chāy dījie*]
+- [YOU SAY: the same request for water — *ek pānī dījie*]
+- [YOU SAY: *dījie* and *māf kījie* one after the other — hear the shared *-ie*]
+- [YOU SAY: *chā* and *tê* — the two Chinese pronunciations, and which one
+  English bought]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C37-CHAI-01, HI-CONCEPT-C37-CHAI-02, HI-CONCEPT-C37-CHAI-03, HI-CONCEPT-C08-KRIPAYA-02] -->
+
+[PAUSE 3s] Is **चाय** masculine or feminine, and does its ending help? (**Feminine**
+— and no, a consonant ending never does.)
+Where does **कृपया** belong, and what carries the politeness when you speak?
+(**Signs and announcements** — in speech the **-िए** of *dījie* does it.)
+Are *chāy* and *tea* related? (**The same Chinese word**, bought at two
+different ports.)

--- a/code/learning/human-languages/hindi/lessons/HI-C37-dudh.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C37-dudh.md
@@ -1,0 +1,90 @@
+---
+schema_version: 2
+id: HI-C37-dudh
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 740
+chapter: 37
+type: word
+headword: दूध
+gloss: milk — masculine, and literally "the milked thing", a past participle that hardened into a noun
+concept_tag: HI-DRINK-MILK
+prerequisites: [HI-C37-chai, HI-C15-paani-roti]
+sounds: [devanagari-long-uu, aspirated-dha]
+roots: [dugdha-sanskrit, pie-dhewgh]
+etymology_hook: "दूध (dūdh) is Sanskrit दुग्ध (dugdha), which is not a noun but a past participle — 'milked' — so दूध names the liquid by what was done to it, exactly the trick पानी plays by naming water 'the drinkable thing'; the root दुह् duh- goes back to PIE *dʰewgʰ- 'to be strong, to yield', which also gives Greek teúkhein and English doughty, though English dough is NOT related and comes from a different root entirely"
+duration:
+  max_seconds: 235
+requires:
+  knowledge: [HI-CONCEPT-C37-CHAI-01, HI-CONCEPT-C37-CHAI-02, HI-CONCEPT-C15-PAANI-ROTI-01, HI-CONCEPT-C36-KURSI-01]
+introduces:
+  knowledge: [HI-CONCEPT-C37-DUDH-01, HI-CONCEPT-C37-DUDH-02]
+practises:
+  knowledge: [HI-CONCEPT-C37-DUDH-01, HI-CONCEPT-C37-DUDH-02, HI-CONCEPT-C37-CHAI-01, HI-CONCEPT-C37-CHAI-02, HI-CONCEPT-C37-CHAI-03, HI-CONCEPT-C15-PAANI-ROTI-01, HI-CONCEPT-C36-KURSI-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-C37-chai, HI-C15-paani-roti, HI-C36-kursi]
+---
+
+# दूध (dūdh) — "milk," which is really a verb wearing a noun's coat
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C37-CHAI-01, HI-CONCEPT-C37-CHAI-02] -->
+
+[PAUSE 2s] What goes into the tea. And it is named the same sly way **पानी**
+was — by what happens to it, not by what it is.
+
+## Grammar Lens: the pair that disagrees
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C37-DUDH-01]; assesses=[HI-CONCEPT-C37-CHAI-01, HI-CONCEPT-C37-CHAI-03, HI-CONCEPT-C36-KURSI-01] -->
+
+**दूध** (*dūdh*) = "**milk**," and it is **masculine**.
+
+Which makes these two a useful pair, because they sit side by side in every cup
+and disagree: **चाय** feminine — the leaf that came by way of a Chinese port —
+and **दूध** masculine. Both end in consonants. Neither ending tells you
+anything. This is the ordinary state of a Hindi noun, and it is why the gender
+is part of the word, not an afterthought.
+
+**एक दूध दीजिए** — same request, new noun.
+
+## The word, taken apart: दूध
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C37-DUDH-02]; assesses=[HI-CONCEPT-C37-DUDH-01, HI-CONCEPT-C15-PAANI-ROTI-01] -->
+
+**दूध** comes from Sanskrit **दुग्ध** (*dugdha*) — and *dugdha* is not a noun at
+all. It is a **past participle** of the verb **दुह्** (*duh-*), "to milk." It
+means "**milked**."
+
+So the substance is named for the act. Somebody said "the milked" often enough
+that the adjective hardened into a thing. You have seen this exact move already:
+**पानी** is *pānīya*, "**the drinkable**." Hindi's two commonest liquids are
+both named by what is done to them.
+
+Behind *duh-* stands the old root ***dʰewgʰ-***, and its meaning is broader
+than milk: "**to yield, to be strong, to be of use**." Greek **teúkhein**, "to
+produce," is from it, and so is English **doughty**, "stout, valiant."
+
+One trap, since the shape invites it: English **dough** is **not** related. It
+comes from a different root meaning "to knead, to form." *Dūdh* and *dough* look
+like cousins and are strangers.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C37-DUDH-01, HI-CONCEPT-C37-DUDH-02, HI-CONCEPT-C37-CHAI-01, HI-CONCEPT-C37-CHAI-02, HI-CONCEPT-C15-PAANI-ROTI-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: *dūdh*; then *ek dūdh dījie*]
+- [YOU SAY: the disagreeing pair — *chāy* feminine, *dūdh* masculine]
+- [YOU SAY: what each one literally is — *dugdha*, "the milked"; *pānīya*, "the
+  drinkable"]
+- [YOU SAY: *dūdh* and *dough* — and that they are not related]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C37-DUDH-01, HI-CONCEPT-C37-DUDH-02, HI-CONCEPT-C37-CHAI-01] -->
+
+[PAUSE 3s] What part of speech was *dugdha* before it was milk? (**A past
+participle** — "milked.")
+Which Hindi word plays the same trick, and how? (**पानी** — *pānīya*, "the
+drinkable thing.")
+Is English *dough* a cousin of *dūdh*? (**No** — different root; *doughty* is
+the real one.)

--- a/code/learning/human-languages/hindi/lessons/HI-C37-khaana.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C37-khaana.md
@@ -1,0 +1,100 @@
+---
+schema_version: 2
+id: HI-C37-khaana
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 750
+chapter: 37
+type: word
+headword: खाना
+gloss: food — masculine, from a Sanskrit verb of eating, and not to be confused with its Persian look-alike meaning "house"
+concept_tag: HI-FOOD-MEAL
+prerequisites: [HI-C37-dudh, HI-W01-na-ma]
+sounds: [aspirated-kha, devanagari-long-aa]
+roots: [khadana-sanskrit, persian-khana]
+etymology_hook: "खाना (khānā) 'food' is Sanskrit खादन (khādana), 'the act of eating, food', from the root खाद् khād-, and the identical-sounding verb खाना 'to eat' is the same root through खादति khādati; but ख़ाना (khāna) with a nuqta is a completely different word, Persian خانه 'house, compartment', the one inside दवाख़ाना 'pharmacy' — and because the nuqta is so often left off in print, the two collapse on the page and only context tells them apart"
+duration:
+  max_seconds: 245
+requires:
+  knowledge: [HI-CONCEPT-C37-DUDH-01, HI-CONCEPT-C37-CHAI-02, HI-CONCEPT-C36-DARVAAZA-03, HI-CONCEPT-C15-PAANI-ROTI-02, HI-CONCEPT-W01-NA-MA-01, HI-CONCEPT-W01-NA-MA-02, HI-CONCEPT-W01-NA-MA-03, HI-CONCEPT-W03-MATRAS-NAAM-01, HI-CONCEPT-W03-MATRAS-NAAM-02, HI-CONCEPT-W03-MATRAS-NAAM-03]
+introduces:
+  knowledge: [HI-CONCEPT-C37-KHAANA-01, HI-CONCEPT-C37-KHAANA-02]
+practises:
+  knowledge: [HI-CONCEPT-C37-KHAANA-01, HI-CONCEPT-C37-KHAANA-02, HI-CONCEPT-C37-DUDH-01, HI-CONCEPT-C37-DUDH-02, HI-CONCEPT-C37-CHAI-02, HI-CONCEPT-C36-DARVAAZA-03, HI-CONCEPT-C15-PAANI-ROTI-02, HI-CONCEPT-W01-NA-MA-01, HI-CONCEPT-W01-NA-MA-02, HI-CONCEPT-W01-NA-MA-03, HI-CONCEPT-W03-MATRAS-NAAM-01, HI-CONCEPT-W03-MATRAS-NAAM-02, HI-CONCEPT-W03-MATRAS-NAAM-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-C37-dudh, HI-C37-chai, HI-C15-paani-roti, HI-W01-na-ma, HI-W03-matras-naam]
+---
+
+# खाना (khānā) — "food," and the dot that separates it from a house
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C37-DUDH-01, HI-CONCEPT-C15-PAANI-ROTI-02] -->
+
+[PAUSE 2s] Drink is behind you. This is the general word for what you eat —
+and it has a twin on the page that means something else entirely.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-W01-NA-MA-01, HI-CONCEPT-W01-NA-MA-02, HI-CONCEPT-W01-NA-MA-03, HI-CONCEPT-W03-MATRAS-NAAM-01, HI-CONCEPT-W03-MATRAS-NAAM-02, HI-CONCEPT-W03-MATRAS-NAAM-03] -->
+
+**खा·ना** — two syllables, and the **ा** does both.
+
+**ख** (*kha*) takes **ा** → **खा**. Then **न** (*na*), your very first letter,
+takes **ा** → **ना**. The **ा** is the mātrā that replaces a consonant's
+built-in *a* with a long one, exactly as in **नाम**.
+
+Two consonants, one mark used twice, and the word is yours.
+
+## Grammar Lens: one word doing two jobs
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C37-KHAANA-01]; assesses=[HI-CONCEPT-C37-DUDH-01, HI-CONCEPT-C37-DUDH-02, HI-CONCEPT-C37-CHAI-02] -->
+
+**खाना** (*khānā*) = "**food**," and it is **masculine** — long **-ā**, and this
+time the lean holds. Unlike **दूध**, whose name is a participle, this one is
+plainly a thing.
+
+It is also the verb "**to eat**." Same spelling, same sound: the infinitive
+doubles as a noun, the way English says *the eating was good*.
+
+So **खाना दीजिए** is "give me food," and **खाना** alone can be the act. Which
+one you mean, the sentence decides.
+
+## The word, taken apart: खाना — and its twin
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C37-KHAANA-02]; assesses=[HI-CONCEPT-C37-KHAANA-01, HI-CONCEPT-C36-DARVAAZA-03] -->
+
+Both come from Sanskrit **खाद्** (*khād-*), "to eat" — the noun through
+**खादन** (*khādana*), "the act of eating, food," and the verb through
+**खादति** (*khādati*), "eats."
+
+Now the twin. Hindi also has **ख़ाना** (*khāna*) — with the **nuqta** under the
+first letter — and it is **Persian**, **خانه** (*xāna*), "**house, compartment,
+section**." You meet it inside **दवाख़ाना** (*davākhāna*), a "medicine-house":
+a pharmacy.
+
+Two unrelated words, one from Sanskrit and one from Persian, separated on the
+page by a single dot. And here is the honest part: **that dot is very often
+left off**. In ordinary printing and handwriting both are simply written
+**खाना**, and the reader is expected to sort it out from context. The nuqta
+tells you where a sound came from — when somebody bothers to write it.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C37-KHAANA-01, HI-CONCEPT-C37-KHAANA-02, HI-CONCEPT-C37-DUDH-01, HI-CONCEPT-C37-CHAI-02, HI-CONCEPT-C15-PAANI-ROTI-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: *khānā*; then *khānā dījie*]
+- [YOU SAY: the three requests together — *ek chāy dījie, ek dūdh dījie, khānā
+  dījie*]
+- [YOU SAY: *roṭī* and *khānā* — the particular bread and the general word for
+  food]
+- [YOU SAY: *khānā* and *khāna* — food and house; then *davākhāna*, the
+  medicine-house]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C37-KHAANA-01, HI-CONCEPT-C37-KHAANA-02, HI-CONCEPT-C37-DUDH-01] -->
+
+[PAUSE 3s] What two jobs does **खाना** do? (**Food**, and the verb **to eat**.)
+What is **ख़ाना**, and where does it come from? (**House, compartment** — Persian
+**خانه**, as in *davākhāna*.)
+Can you always tell them apart on the page? (**No** — the nuqta is often
+dropped, and context decides.)

--- a/code/learning/human-languages/hindi/lessons/HI-C37-kitaab.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C37-kitaab.md
@@ -1,0 +1,113 @@
+---
+schema_version: 2
+id: HI-C37-kitaab
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 760
+chapter: 37
+type: word
+headword: किताब
+gloss: book — feminine, built on the Arabic root for writing, and one of three Hindi words for a book that differ by register
+concept_tag: HI-OBJECT-BOOK
+prerequisites: [HI-C37-khaana, HI-W03-preposed-i, HI-W02-ka-ta-mouth-order]
+sounds: [matra-i-preposed, devanagari-long-aa]
+roots: [arabic-ktb, sanskrit-pustaka]
+etymology_hook: "किताब (kitāb) is Arabic كتاب, reaching Hindi through Persian, and it sits on the three-consonant root k-t-b 'write' — the same root inside كاتب kātib 'scribe' and مكتب maktab 'school, office', so a whole family of words is visible from one; Hindi keeps two rivals, the Sanskrit borrowing पुस्तक (formal) and the inherited पोथा (old, homely), giving three words for one object separated purely by register"
+duration:
+  max_seconds: 265
+requires:
+  knowledge: [HI-CONCEPT-C37-KHAANA-01, HI-CONCEPT-C37-DUDH-01, HI-CONCEPT-C37-CHAI-01, HI-CONCEPT-C37-CHAI-02, HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C08-KRIPAYA-01, HI-CONCEPT-C08-KRIPAYA-02, HI-CONCEPT-C09-MAAF-KIJIYE-02, HI-CONCEPT-W02-ABUGIDA-KA-TA-01, HI-CONCEPT-W02-ABUGIDA-KA-TA-02, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-01, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-02, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-03, HI-CONCEPT-W03-PREPOSED-I-01]
+introduces:
+  knowledge: [HI-CONCEPT-C37-KITAAB-01, HI-CONCEPT-C37-KITAAB-02, HI-CONCEPT-C37-KITAAB-03]
+practises:
+  knowledge: [HI-CONCEPT-C37-KITAAB-01, HI-CONCEPT-C37-KITAAB-02, HI-CONCEPT-C37-KITAAB-03, HI-CONCEPT-C37-KHAANA-01, HI-CONCEPT-C37-KHAANA-02, HI-CONCEPT-C37-DUDH-01, HI-CONCEPT-C37-DUDH-02, HI-CONCEPT-C37-CHAI-01, HI-CONCEPT-C37-CHAI-02, HI-CONCEPT-C37-CHAI-03, HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-02, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C08-KRIPAYA-01, HI-CONCEPT-C08-KRIPAYA-02, HI-CONCEPT-C09-MAAF-KIJIYE-02, HI-CONCEPT-W02-ABUGIDA-KA-TA-01, HI-CONCEPT-W02-ABUGIDA-KA-TA-02, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-01, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-02, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-03, HI-CONCEPT-W03-PREPOSED-I-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-C37-khaana, HI-C37-dudh, HI-C37-chai, HI-C36-kursi, HI-C08-kripaya, HI-C09-maaf-kijiye, HI-W02-ka-ta-mouth-order, HI-W03-preposed-i]
+---
+
+# किताब (kitāb) — a book, and the root it is cut from
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C37-KHAANA-01, HI-CONCEPT-C37-CHAI-02] -->
+
+[PAUSE 2s] Not something to eat — something to ask for. Its Arabic root hands
+you three more words free.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-W02-ABUGIDA-KA-TA-01, HI-CONCEPT-W02-ABUGIDA-KA-TA-02, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-01, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-02, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-03, HI-CONCEPT-W03-PREPOSED-I-01] -->
+
+**कि·ता·ब** — the first mark is the tricky one.
+
+**क** with the short **ि** gives **कि** (*ki*): the **ि** is drawn to the
+**left** of **क** and sounded **after** it, never *ik*. Then **ता**, then **ब**
+keeping its built-in *a*.
+
+**क** and **त** showed you Devanagari's mouth-map: **क** far back at the soft
+palate, **त** at the teeth. Say *ki-tā-b* and feel the tongue travel.
+
+## Grammar Lens: feminine, and no ending to prove it
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C37-KITAAB-01]; assesses=[HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C37-CHAI-01] -->
+
+**किताब** (*kitāb*) = "**book**," and it is **feminine** — **मेरी किताब**.
+
+The second consonant-final noun to turn out feminine, after **चाय**. Two of
+this chapter's four disobey any guess their shape allows.
+
+Which is the real lesson: **Hindi gender is information about the word, not the
+thing and not the spelling.**
+
+## The word, taken apart: किताब
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C37-KITAAB-02]; assesses=[HI-CONCEPT-C37-KITAAB-01, HI-CONCEPT-C36-KURSI-02] -->
+
+**किताब** is **Arabic**, **كتاب**, come by the Persian road **कुर्सी** took.
+
+Arabic builds words on **three-consonant roots**, and this one is **k-t-b**,
+"write." Slot those three into different patterns and a family appears:
+
+- **كتاب** *kitāb* — a **book**, the thing written.
+- **كاتب** *kātib* — a **scribe**, the one writing.
+- **مكتب** *maktab* — a **place** of writing: an office, a school.
+
+Learn the root and you have a family, which is how much of Hindi's Perso-Arabic
+vocabulary is built underneath.
+
+## You'll want to know — three books, three registers
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C37-KITAAB-03]; assesses=[HI-CONCEPT-C37-KITAAB-02, HI-CONCEPT-C37-KHAANA-02, HI-CONCEPT-C37-DUDH-02, HI-CONCEPT-C37-CHAI-03, HI-CONCEPT-C08-KRIPAYA-01, HI-CONCEPT-C08-KRIPAYA-02] -->
+
+Hindi has three words for a book, and they are not synonyms — they are
+**registers**.
+
+- **किताब** — Perso-Arabic, the ordinary word. Say this one.
+- **पुस्तक** (*pustak*) — straight out of Sanskrit. Libraries, textbooks,
+  formal writing.
+- **पोथा** (*pothā*) — the inherited descendant of that Sanskrit word. Old,
+  homely, a bit dusty.
+
+You have met this split: **कृपया** is the *pustak* end of "please," **दीजिए**
+the *kitāb* end.
+
+And that is the chapter — **चाय** from a Chinese port, **दूध** named for what
+was done to it, **खाना** shadowed by a Persian house, **किताब** cut from an
+Arabic root.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C37-KITAAB-01, HI-CONCEPT-C37-KITAAB-02, HI-CONCEPT-C37-KITAAB-03, HI-CONCEPT-C37-KHAANA-01, HI-CONCEPT-C37-DUDH-01, HI-CONCEPT-C37-CHAI-01, HI-CONCEPT-C37-CHAI-02, HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C09-MAAF-KIJIYE-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: *kitāb*, then *merī kitāb*]
+- [YOU SAY: the chapter's four — *merī chāy, merā dūdh, merā khānā, merī
+  kitāb*]
+- [YOU SAY: the k-t-b family — *kitāb*, *kātib*, *maktab*]
+- [YOU SAY: *kṛpayā* for the sign; *ek chāy dījie* and *māf kījie* for the street]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C37-KITAAB-01, HI-CONCEPT-C37-KITAAB-02, HI-CONCEPT-C37-KITAAB-03, HI-CONCEPT-C37-CHAI-01, HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C08-KRIPAYA-01] -->
+
+[PAUSE 3s] Which two words here are feminine, and does their shape say so?
+(**चाय** and **किताब** — no, both end in consonants.)
+Give the k-t-b family. (*Kitāb*, *kātib*, *maktab*.)
+Which word for "book" do you say, and which belongs with **कृपया**? (**किताब** —
+**पुस्तक** is the formal one.)

--- a/code/learning/human-languages/hindi/lessons/HI-C38-aankh.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C38-aankh.md
@@ -1,0 +1,98 @@
+---
+schema_version: 2
+id: HI-C38-aankh
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 770
+chapter: 38
+type: word
+headword: आँख
+gloss: eye — feminine, and a word-for-word cousin of English "eye" and Latin "oculus"
+concept_tag: HI-BODY-EYE
+prerequisites: [HI-C37-kitaab, HI-C13-sir, HI-C07-haan]
+sounds: [chandrabindu-nasal, aspirated-kha]
+roots: [akshi-sanskrit, pie-hekw]
+etymology_hook: "आँख (āṁkh) is Sanskrit अक्षि (akṣi), from PIE *h₃ekʷ- — the root behind Latin oculus (→ ocular, monocle), Lithuanian akìs and English eye itself; the Greek cognate to cite is ósse, not ophthalmós, whose first element is unexplained and which is often treated as pre-Greek; and the ँ on आ is the same chandrabindu you first met on हाँ"
+duration:
+  max_seconds: 235
+requires:
+  knowledge: [HI-CONCEPT-C37-KITAAB-01, HI-CONCEPT-C13-SIR-01, HI-CONCEPT-C13-HAATH-01, HI-CONCEPT-C13-HAATH-02, HI-CONCEPT-C07-HAAN-01, HI-CONCEPT-C07-HAAN-02]
+introduces:
+  knowledge: [HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C38-AANKH-02]
+practises:
+  knowledge: [HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C38-AANKH-02, HI-CONCEPT-C37-KITAAB-01, HI-CONCEPT-C13-SIR-01, HI-CONCEPT-C13-HAATH-01, HI-CONCEPT-C13-HAATH-02, HI-CONCEPT-C07-HAAN-01, HI-CONCEPT-C07-HAAN-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-C37-kitaab, HI-C13-sir, HI-C13-haath, HI-C07-haan]
+---
+
+# आँख (āṁkh) — the eye, which is the same word in English
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C13-SIR-01, HI-CONCEPT-C13-HAATH-01] -->
+
+[PAUSE 2s] You have a head and a hand. Here is the part of the face — and this
+one is not merely *related* to its English translation. It is the same word.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C07-HAAN-01, HI-CONCEPT-C07-HAAN-02] -->
+
+**आँ·ख** — and the mark on top is an old friend.
+
+**आ** is the standalone long *ā*. Over it sits **ँ**, the **chandrabindu**, the
+moon-dot, which sends the vowel up through the nose — exactly what it does in
+**हाँ**. Then **ख** (*kha*), breathy, with its inherent *a* still attached.
+
+So the word is a nasalised *ā* followed by *kh*: **āṁkh**, humming at the start.
+
+## Grammar Lens: feminine, and one you will use daily
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C38-AANKH-01]; assesses=[HI-CONCEPT-C37-KITAAB-01, HI-CONCEPT-C13-HAATH-02] -->
+
+**आँख** (*āṁkh*) = "**eye**," and it is **feminine** — **मेरी आँख**.
+
+Third feminine noun, third consonant ending: **चाय**, **किताब**, **आँख**. If
+you were still hoping the spelling would rescue you, let this settle it.
+
+And it is worth the effort, because these are the words a doctor asks about.
+**मेरी आँख ठीक नहीं है** — "my eye is not well."
+
+## The word, taken apart: आँख
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C38-AANKH-02]; assesses=[HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C13-HAATH-02] -->
+
+**आँख** comes from Sanskrit **अक्षि** (*akṣi*), "eye" — and *akṣi* comes from
+the root ***h₃ekʷ-***, which is one of the securest words in the whole family.
+
+Its descendants:
+
+- Latin **oculus** — inside English **ocular**, **monocle**, **binoculars**.
+- Old English **ēage**, which is English **eye** itself.
+- Lithuanian **akìs**, Armenian **akn**, and Greek **ósse**, the old dual form
+  meaning "the two eyes."
+
+A caution on the Greek, because the obvious candidate is a trap: **ophthalmós**
+is *usually* connected here, but its first part has never been explained, and
+serious opinion treats it as a pre-Greek word. Cite **ósse** and stay honest.
+
+**हाथ** had to travel a long, battered road from *hasta*. **आँख** barely
+travelled at all — *akṣi* to *āṁkh* is a short, clean walk, and at the far end
+of it an English speaker is saying a version of the same word.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C38-AANKH-02, HI-CONCEPT-C13-SIR-01, HI-CONCEPT-C13-HAATH-01, HI-CONCEPT-C07-HAAN-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: *āṁkh*, then *merī āṁkh*]
+- [YOU SAY: the three body words you now have — *sir*, *hāth*, *āṁkh*]
+- [YOU SAY: *hāṁ* and *āṁkh* — the same moon-dot, the same hum]
+- [YOU SAY: *akṣi*, *oculus*, *eye* — one root, three languages]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C38-AANKH-02, HI-CONCEPT-C13-SIR-01, HI-CONCEPT-C07-HAAN-02] -->
+
+[PAUSE 3s] Is **आँख** masculine or feminine? (**Feminine** — *merī āṁkh*.)
+Which Greek word is the safe cousin, and which is the trap? (**ósse** is safe;
+**ophthalmós** is unexplained.)
+What does the **ँ** over the **आ** do, and where did you first meet it?
+(**Nasalises** the vowel — on **हाँ**.)

--- a/code/learning/human-languages/hindi/lessons/HI-C38-daant.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C38-daant.md
@@ -1,0 +1,103 @@
+---
+schema_version: 2
+id: HI-C38-daant
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 780
+chapter: 38
+type: word
+headword: दाँत
+gloss: tooth — masculine, though it is built exactly like the feminine आँख, and a cousin of Latin dēns and English tooth
+concept_tag: HI-BODY-TOOTH
+prerequisites: [HI-C38-aankh, HI-C37-khaana, HI-W01-shirorekha-na-ma]
+sounds: [chandrabindu-nasal, dental-ta]
+roots: [danta-sanskrit, pie-hdonts]
+etymology_hook: "दाँत (dāṁt) is Sanskrit दन्त (danta), from PIE *h₃dónts — the same word as Latin dēns/dentis (→ dentist, trident), Greek odoús (→ odontology) and English tooth; and the older analysis reads *h₃dónts as a participle of *h₃ed- 'to bite', making a tooth 'the biting one', which is a name for an action just as दूध was"
+duration:
+  max_seconds: 235
+requires:
+  knowledge: [HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C38-AANKH-02, HI-CONCEPT-C37-DUDH-02, HI-CONCEPT-C37-KHAANA-01, HI-CONCEPT-C37-KHAANA-02, HI-CONCEPT-C13-SIR-01, HI-CONCEPT-C07-HAAN-01, HI-CONCEPT-C07-HAAN-02, HI-CONCEPT-W01-SHIROREKHA-NA-MA-01, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-01, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-02, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-03]
+introduces:
+  knowledge: [HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C38-DAANT-02]
+practises:
+  knowledge: [HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C38-DAANT-02, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C38-AANKH-02, HI-CONCEPT-C37-DUDH-02, HI-CONCEPT-C37-KHAANA-01, HI-CONCEPT-C37-KHAANA-02, HI-CONCEPT-C13-SIR-01, HI-CONCEPT-C07-HAAN-01, HI-CONCEPT-C07-HAAN-02, HI-CONCEPT-W01-SHIROREKHA-NA-MA-01, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-01, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-02, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-C38-aankh, HI-C13-sir, HI-C07-haan, HI-W01-shirorekha-na-ma, HI-W02-ka-ta-mouth-order]
+---
+
+# दाँत (dāṁt) — the tooth, and the gender trap of this chapter
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C38-AANKH-01] -->
+
+[PAUSE 2s] Built like the last word, spelled like the last word, and the
+opposite gender. This is the pair learners get wrong most often.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-W01-SHIROREKHA-NA-MA-01, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-01, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-02, HI-CONCEPT-W02-KA-TA-MOUTH-ORDER-03, HI-CONCEPT-C07-HAAN-01, HI-CONCEPT-C07-HAAN-02] -->
+
+**दाँ·त** — three known parts and no new letter at all.
+
+**द** (*da*) takes **ा**, and the **ँ** rides above the head-line for the nasal
+hum — the same **chandrabindu** that turns **ह** into **हाँ**, "yes." Then **त**
+(*ta*).
+
+Both **द** and **त** are made at the **teeth** — which is the whole point of
+Devanagari's mouth-map. The word for *tooth* is spelled with the two consonants
+your tongue makes *against your teeth*. Say *dāṁt* and feel where it happens.
+
+## Grammar Lens: the trap
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C38-DAANT-01]; assesses=[HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C13-SIR-01] -->
+
+**दाँत** (*dāṁt*) = "**tooth**," and it is **masculine** — **मेरा दाँत**.
+
+Now put the two side by side. **आँख** and **दाँत**: same long *ā*, same
+chandrabindu, same single final consonant, both parts of the body, both
+everyday. **आँख** is feminine. **दाँत** is masculine.
+
+There is no rule underneath that. There is no reasoning that gets you from one
+to the other. This is the pair to hold up whenever you are tempted to guess:
+**मेरी आँख**, **मेरा दाँत**.
+
+## The word, taken apart: दाँत
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C38-DAANT-02]; assesses=[HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C38-AANKH-02, HI-CONCEPT-C37-DUDH-02, HI-CONCEPT-C37-KHAANA-01, HI-CONCEPT-C37-KHAANA-02] -->
+
+**दाँत** is Sanskrit **दन्त** (*danta*), from ***h₃dónts*** — and like *akṣi*
+this is one of the family's best-attested words.
+
+- Latin **dēns**, stem *dentis* — English **dentist**, **dental**, **trident**
+  (a "three-tooth").
+- Greek **odoús** — English **odontology**.
+- Old English **tōþ**, which is **tooth**.
+
+Two body parts in a row, both plain cousins of their English translations. That
+is not a coincidence about eyes and teeth; it is what a core inherited
+vocabulary looks like from the inside.
+
+And the older reading of ***h₃dónts*** makes it a participle of ***h₃ed-***, "to
+bite" — so a tooth is "**the biting one**," which is what **खाना** needs it for.
+Same move as **दूध**, "the milked one": name the thing after what happens.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C38-DAANT-02, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C38-AANKH-02, HI-CONCEPT-C13-SIR-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: *dāṁt*, then *merā dāṁt*]
+- [YOU SAY: the trap pair, twice — *merī āṁkh, merā dāṁt*; again]
+- [YOU SAY: *hāṁ*, then *dāṁt* — the same moon-dot doing the same job]
+- [YOU SAY: *danta*, *dēns*, *odoús*, *tooth* — one word, four languages]
+- [YOU SAY: the two "named for the action" words — *dugdha*, the milked; the
+  tooth, the biting one]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C38-DAANT-02, HI-CONCEPT-C38-AANKH-01] -->
+
+[PAUSE 3s] **आँख** and **दाँत** look alike — do they share a gender?
+(**No** — *merī āṁkh*, *merā dāṁt*.)
+Which English words carry the Latin form? (**Dentist**, **dental**,
+**trident**.)
+What does the older reading make a tooth? (**The biting one** — from a root
+meaning "to bite.")

--- a/code/learning/human-languages/hindi/lessons/HI-C38-pair.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C38-pair.md
@@ -1,0 +1,94 @@
+---
+schema_version: 2
+id: HI-C38-pair
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 790
+chapter: 38
+type: word
+headword: पैर
+gloss: foot — masculine, and NOT the descendant of Sanskrit pāda; that honour belongs to पाँव
+concept_tag: HI-BODY-FOOT
+prerequisites: [HI-C38-daant, HI-C13-haath, HI-C07-nahin]
+sounds: [matra-ai, spineless-ra]
+roots: [pad-sanskrit, pie-ped]
+etymology_hook: "पैर (pair) does NOT come from Sanskrit पाद pāda, the obvious candidate — it comes from the shorter stem पद् / पद (pad-) through Prakrit paya with a Middle Indo-Aryan -ra- suffix; पाँव (pāṁv) is the direct descendant of pāda, so Hindi has both stems side by side, and behind both stands PIE *ped- 'to walk', which gives Latin pēs/pedis (→ pedal, pedestrian), Greek poús (→ podium, octopus) and English foot"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C38-DAANT-02, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C13-HAATH-01, HI-CONCEPT-C13-HAATH-02, HI-CONCEPT-C07-NAHIN-02, HI-CONCEPT-C07-NAHIN-03]
+introduces:
+  knowledge: [HI-CONCEPT-C38-PAIR-01, HI-CONCEPT-C38-PAIR-02]
+practises:
+  knowledge: [HI-CONCEPT-C38-PAIR-01, HI-CONCEPT-C38-PAIR-02, HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C38-DAANT-02, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C13-HAATH-01, HI-CONCEPT-C13-HAATH-02, HI-CONCEPT-C07-NAHIN-02, HI-CONCEPT-C07-NAHIN-03]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-C38-daant, HI-C38-aankh, HI-C13-haath, HI-C07-nahin]
+---
+
+# पैर (pair) — the foot, and the ancestor it does not have
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C13-HAATH-01] -->
+
+[PAUSE 2s] Down from the head, past the hand, to what carries you. And this
+word's obvious ancestor turns out to belong to a different Hindi word.
+
+## Grammar Lens: masculine, and the sentence that uses it
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C38-PAIR-01]; assesses=[HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C07-NAHIN-02, HI-CONCEPT-C07-NAHIN-03] -->
+
+**पैर** (*pair*) = "**foot**," and it is **masculine** — **मेरा पैर**.
+
+The **ै** is a single mātrā for one vowel, *ai* — not *a* then *i*. One sign,
+one sound, sitting above the head-line on **प**.
+
+Now the sentence you would actually say to a doctor, using the **नहीं** you
+already have: **मेरा पैर ठीक नहीं है** — "**my foot is not well**." Watch the
+**नहीं** sit directly before **है**, which is where Hindi puts its negation.
+
+## The word, taken apart: पैर
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C38-PAIR-02]; assesses=[HI-CONCEPT-C38-PAIR-01, HI-CONCEPT-C38-DAANT-02, HI-CONCEPT-C13-HAATH-02] -->
+
+Here is the obvious guess, and it is wrong. Sanskrit has **पाद** (*pāda*),
+"foot" — long *ā*, famous, the source of English's borrowed *pada-* words. It
+looks like it must be the parent of *pair*. It is not.
+
+**पाँव** (*pāṁv*), Hindi's *other* everyday word for foot, is the descendant of
+**पाद**. **पैर** comes from the shorter Sanskrit stem **पद्** (*pad-*), through
+Prakrit *paya*, picking up a Middle Indo-Aryan **-ra-** ending on the way.
+
+So Hindi inherited the same body part **twice**, down two different stems of the
+same word — and both survive, side by side, meaning the same thing.
+
+Further back both are ***ped-***, "to walk, to tread":
+
+- Latin **pēs**, stem *pedis* — **pedal**, **pedestrian**, **pedicure**.
+- Greek **poús**, stem *podós* — **podium**, and the eight of an **octopus**.
+- Old English **fōt**, which is **foot**.
+
+Three body words in three lessons, and every one of them is the same word your
+own language uses. **हाथ** had to be argued for through a sound change. These
+three simply *are* the cousins.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C38-PAIR-01, HI-CONCEPT-C38-PAIR-02, HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C13-HAATH-01, HI-CONCEPT-C07-NAHIN-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: *pair*, then *merā pair*]
+- [YOU SAY: the four body words with their possessives — *merā hāth, merī āṁkh,
+  merā dāṁt, merā pair*]
+- [YOU SAY: *merā pair ṭhīk nahīṁ hai* — and hear where the *nahīṁ* sits]
+- [YOU SAY: which Hindi word came from *pāda*, and which from *pad-*
+  (*pāṁv*; *pair*)]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C38-PAIR-01, HI-CONCEPT-C38-PAIR-02, HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C07-NAHIN-03] -->
+
+[PAUSE 3s] Does **पैर** come from **पाद**? (**No** — from **पद्**; **पाँव** is
+the *pāda* one.)
+Which English words carry the Latin and Greek forms? (**Pedal**,
+**pedestrian**; **podium**, **octopus**.)
+Say "my foot is not well," and say where **नहीं** goes. (*Merā pair ṭhīk nahīṁ
+hai* — immediately before **है**.)

--- a/code/learning/human-languages/hindi/lessons/HI-C38-pet.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C38-pet.md
@@ -1,0 +1,100 @@
+---
+schema_version: 2
+id: HI-C38-pet
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 800
+chapter: 38
+type: word
+headword: पेट
+gloss: stomach, belly — masculine, and the one word in this chapter with no clean ancestry at all
+concept_tag: HI-BODY-BELLY
+prerequisites: [HI-C38-pair, HI-W03-matras-naam]
+sounds: [matra-e, retroflex-tta]
+roots: [prakrit-petta, dravidian-substrate]
+etymology_hook: "पेट (peṭ) comes through Prakrit पेट्ट (peṭṭa), and there the clean chain stops — the mainstream account treats it as a Dravidian loan into Indo-Aryan (compare Proto-Dravidian *poṭṭ-), while Turner's dictionary only notes a resemblance to Indo-Aryan words for 'basket' without deriving it from them; after three body words that were flawless Indo-European cousins, this is the honest counterexample, and the retroflex ट is itself the sound most often credited to Dravidian contact"
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [HI-CONCEPT-C38-PAIR-01, HI-CONCEPT-C38-PAIR-02, HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C38-DAANT-02, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C38-AANKH-02, HI-CONCEPT-C13-SIR-01, HI-CONCEPT-C13-HAATH-01, HI-CONCEPT-C13-HAATH-02, HI-CONCEPT-C07-NAHIN-02, HI-CONCEPT-C07-NAHIN-03, HI-CONCEPT-C15-PAANI-ROTI-01, HI-CONCEPT-C15-PAANI-ROTI-02, HI-CONCEPT-W03-MATRAS-NAAM-01, HI-CONCEPT-W03-MATRAS-NAAM-02, HI-CONCEPT-W03-MATRAS-NAAM-03]
+introduces:
+  knowledge: [HI-CONCEPT-C38-PET-01, HI-CONCEPT-C38-PET-02]
+practises:
+  knowledge: [HI-CONCEPT-C38-PET-01, HI-CONCEPT-C38-PET-02, HI-CONCEPT-C38-PAIR-01, HI-CONCEPT-C38-PAIR-02, HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C38-DAANT-02, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C38-AANKH-02, HI-CONCEPT-C13-SIR-01, HI-CONCEPT-C13-HAATH-01, HI-CONCEPT-C13-HAATH-02, HI-CONCEPT-C07-NAHIN-02, HI-CONCEPT-C07-NAHIN-03, HI-CONCEPT-C15-PAANI-ROTI-01, HI-CONCEPT-C15-PAANI-ROTI-02, HI-CONCEPT-W03-MATRAS-NAAM-01, HI-CONCEPT-W03-MATRAS-NAAM-02, HI-CONCEPT-W03-MATRAS-NAAM-03, HI-CONCEPT-C37-KITAAB-01, HI-CONCEPT-C36-KURSI-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-C38-pair, HI-C38-daant, HI-C38-aankh, HI-C13-sir, HI-C13-haath, HI-C07-nahin, HI-C15-paani-roti, HI-W03-matras-naam]
+---
+
+# पेट (peṭ) — the belly, and a trail that genuinely stops
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C38-PAIR-01, HI-CONCEPT-C38-AANKH-01] -->
+
+[PAUSE 2s] Three clean cousins in a row. This one breaks the run — and the
+break is worth more than another neat answer.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-W03-MATRAS-NAAM-01, HI-CONCEPT-W03-MATRAS-NAAM-02, HI-CONCEPT-W03-MATRAS-NAAM-03] -->
+
+**पे·ट** — one known letter, one known mātrā, one consonant to feel.
+
+**प** takes **े**, the mātrā that perches on the head-line and turns the built-in
+*a* into *e* — the second of the two vowel signs you practised on **नाम** and
+**मेरा**.
+
+Then **ट**: a **retroflex** *ṭ*, tongue-tip curled back, not the **त** of
+**दाँत** made flat against the teeth. Say *dāṁt*, then *peṭ*.
+
+## Grammar Lens: masculine, and the whole set together
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C38-PET-01]; assesses=[HI-CONCEPT-C38-PAIR-01, HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C13-SIR-01, HI-CONCEPT-C13-HAATH-01, HI-CONCEPT-C07-NAHIN-02, HI-CONCEPT-C07-NAHIN-03, HI-CONCEPT-C37-KITAAB-01, HI-CONCEPT-C36-KURSI-01] -->
+
+**पेट** (*peṭ*) = "**stomach, belly**," and it is **masculine** — **मेरा पेट**.
+
+Now you can answer a doctor, and exactly one of the six takes **मेरी**: *merā
+sir*, *merā hāth*, **merī āṁkh**, *merā dāṁt*, *merā pair*, *merā peṭ* — feminine
+company for **कुर्सी** and **किताब**.
+
+The sentence, with **नहीं** in its usual place just before **है**: **मेरा पेट
+ठीक नहीं है** — which, said in India, means what it says and rather more.
+
+## The word, taken apart: पेट
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C38-PET-02]; assesses=[HI-CONCEPT-C38-PET-01, HI-CONCEPT-C38-AANKH-02, HI-CONCEPT-C38-DAANT-02, HI-CONCEPT-C38-PAIR-02, HI-CONCEPT-C13-HAATH-02, HI-CONCEPT-C15-PAANI-ROTI-01, HI-CONCEPT-C15-PAANI-ROTI-02] -->
+
+**पेट** goes back to Prakrit **पेट्ट** (*peṭṭa*) — and there the clean line ends.
+
+The mainstream account treats it as a **Dravidian** word taken into Indo-Aryan;
+compare reconstructed Dravidian **\*poṭṭ-**. Turner's comparative dictionary does
+not name Dravidian, but neither does he derive *peṭṭa* from any Sanskrit word:
+he only remarks that it sits close to Indo-Aryan words for "**basket**." That
+resemblance is a note, not a derivation, and it is often quoted as one.
+
+So: **the origin of पेट is unsettled**, with Dravidian leading — the honesty
+**रोटी** needed, one lesson away from **पानी**, whose story is exact. A language
+is made of what people said, and some of that came from neighbours speaking
+something else.
+
+There is even a fingerprint: the **retroflex** consonants, the **ट** you just
+curled your tongue for, are the feature of Indian Indo-Aryan most often credited
+to long contact with Dravidian.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C38-PET-01, HI-CONCEPT-C38-PET-02, HI-CONCEPT-C38-PAIR-01, HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C13-SIR-01, HI-CONCEPT-C13-HAATH-01, HI-CONCEPT-C07-NAHIN-02, HI-CONCEPT-C15-PAANI-ROTI-01, HI-CONCEPT-C37-KITAAB-01, HI-CONCEPT-C36-KURSI-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: all six — *merā sir, merā hāth, merī āṁkh, merā dāṁt, merā pair,
+  merā peṭ*]
+- [YOU SAY: *merā peṭ ṭhīk nahīṁ hai*; then *merī āṁkh ṭhīk nahīṁ hai*]
+- [YOU SAY: every feminine noun you own — *kursī*, *chāy*, *kitāb*, *āṁkh*]
+- [YOU SAY: the three exact ancestries — *āṁkh*, *dāṁt*, *pair*; then the two
+  unsettled — *peṭ*, *roṭī*]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C38-PET-01, HI-CONCEPT-C38-PET-02, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C38-DAANT-01, HI-CONCEPT-C13-SIR-01, HI-CONCEPT-C15-PAANI-ROTI-01] -->
+
+[PAUSE 3s] Where does **पेट** come from? (**Unsettled** — Prakrit *peṭṭa*, most
+likely a **Dravidian** loan; the "basket" link is a resemblance.)
+Of your six body words, which takes **मेरी**? (**आँख**.)
+Which earlier word had the same honest dead end? (**रोटी**, beside **पानी**.)

--- a/code/learning/human-languages/hindi/lessons/HI-C39-aadmi.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C39-aadmi.md
@@ -1,0 +1,93 @@
+---
+schema_version: 2
+id: HI-C39-aadmi
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 830
+chapter: 39
+type: word
+headword: आदमी
+gloss: man, person — masculine despite its -ī ending, and literally "of Adam"
+concept_tag: HI-PERSON-MAN
+prerequisites: [HI-C39-baccha, HI-C36-kursi]
+sounds: [devanagari-long-ii, dental-ma]
+roots: [arabic-adami, hebrew-adam]
+etymology_hook: "आदमी (ādmī) is Arabic آدمي ādamī 'human', built with the Arabic -ī ending meaning 'belonging to', so the word is literally 'of Adam', and it reached Hindi through Persian; the familiar link between Hebrew ʾādām and ʾadāmāh 'ground' is a deliberate pun in Genesis rather than the historical derivation, and the mainstream view connects the root ʾ-d-m to redness instead"
+duration:
+  max_seconds: 245
+requires:
+  knowledge: [HI-CONCEPT-C39-BACCHA-01, HI-CONCEPT-C39-BACCHA-02, HI-CONCEPT-C39-DOST-01, HI-CONCEPT-C39-DOST-02, HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-02, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C37-KITAAB-02, HI-CONCEPT-C19-AGE-GRAMMAR-01]
+introduces:
+  knowledge: [HI-CONCEPT-C39-AADMI-01, HI-CONCEPT-C39-AADMI-02]
+practises:
+  knowledge: [HI-CONCEPT-C39-AADMI-01, HI-CONCEPT-C39-AADMI-02, HI-CONCEPT-C39-BACCHA-01, HI-CONCEPT-C39-BACCHA-02, HI-CONCEPT-C39-DOST-01, HI-CONCEPT-C39-DOST-02, HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-02, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C37-KITAAB-02, HI-CONCEPT-C19-AGE-GRAMMAR-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-C39-baccha, HI-C39-dost, HI-C36-kursi, HI-C37-kitaab, HI-C19-age-grammar]
+---
+
+# आदमी (ādmī) — the man, and the lean breaking backwards
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C39-BACCHA-01, HI-CONCEPT-C39-DOST-01] -->
+
+[PAUSE 2s] The child has grown up. And this word does what none so far has —
+it ends in **-ी** and is masculine anyway.
+
+## Grammar Lens: the lean breaks the other way
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C39-AADMI-01]; assesses=[HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C39-BACCHA-01, HI-CONCEPT-C39-BACCHA-02, HI-CONCEPT-C19-AGE-GRAMMAR-01] -->
+
+**आदमी** (*ādmī*) = "**man, person**," and it is **masculine**. Say **एक आदमी**
+— it is also the ordinary word for "person" in general, and stays masculine
+doing that. Ask **कितने साल के हो?** of him and you are asking how many years he
+*is of*, the way Hindi counts age.
+
+A warning before you reach for the possessive: **मेरा आदमी** is real Hindi but
+means what English's *my man* means. Keep **एक आदमी**.
+
+The gender still shows the instant anything agrees with the noun. Put it beside
+**कुर्सी**: both end in long **-ी**, one is feminine, one masculine, and no
+reasoning takes you from the ending to the answer. Beside **बच्चा** /
+**बच्ची**, where the ending *does* carry the gender, the contrast is sharper.
+
+So the lean has failed in **both** directions: **चाय** and **किताब** feminine
+with no **-ी**, **आदमी** masculine with one.
+
+## The word, taken apart: आदमी
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C39-AADMI-02]; assesses=[HI-CONCEPT-C39-AADMI-01, HI-CONCEPT-C37-KITAAB-02, HI-CONCEPT-C36-KURSI-02, HI-CONCEPT-C39-DOST-02] -->
+
+**आदमी** is **Arabic**, **آدمي** (*ādamī*), and it came the Persian way — the
+road of **कुर्सी** and **किताब**.
+
+Now the ending. That **-ī** is not Hindi at all. It is the **Arabic ending
+meaning "belonging to, of the kind of."** Attach it to **آدم** (*Ādam*) and you
+get "**of Adam**." A human being, in this word, is one of Adam's.
+
+**آدم** is Hebrew ***ʾādām***, and here care is needed. You have probably heard
+that *ʾādām* comes from ***ʾadāmāh***, "ground" — man made of earth. Genesis sets the two side by side and means you to notice: a
+**deliberate pun**, and a famous one.
+
+It is not the etymology. The prevailing view links the root **ʾ-d-m** to
+**redness** — behind Hebrew *ʾādōm*, "red," and **Edom**. Beyond that, unsettled.
+
+Worth keeping: **a wordplay a text makes on purpose is not where a word came
+from.**
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C39-AADMI-01, HI-CONCEPT-C39-AADMI-02, HI-CONCEPT-C39-BACCHA-01, HI-CONCEPT-C39-DOST-01, HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-03] -->
+
+[PAUSE 1s]
+- [YOU SAY: *ādmī*, then *ek ādmī*]
+- [YOU SAY: *kursī* feminine, *ādmī* masculine; then *merī kursī*, and stop]
+- [YOU SAY: the lean, and both ways it fails — *chāy*, *kitāb*, *ādmī*]
+- [YOU SAY: what the **-ī** on *ādamī* means]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C39-AADMI-01, HI-CONCEPT-C39-AADMI-02, HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C37-KITAAB-02] -->
+
+[PAUSE 3s] **कुर्सी** and **आदमी** end alike — same gender? (**No**.)
+What is the **-ī** of *ādamī* doing? (**Arabic "belonging to"** — "of Adam.")
+Is *ʾādām* from the word for ground? (**No** — Genesis is making a deliberate
+pun; the root is usually connected to **redness**.)

--- a/code/learning/human-languages/hindi/lessons/HI-C39-aurat.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C39-aurat.md
@@ -1,0 +1,103 @@
+---
+schema_version: 2
+id: HI-C39-aurat
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 840
+chapter: 39
+type: word
+headword: औरत
+gloss: woman — feminine, an Arabic word that only came to mean "woman" in Persian, and one of three Hindi words separated by register
+concept_tag: HI-PERSON-WOMAN
+prerequisites: [HI-C39-aadmi, HI-C12-bhaai-bahin, HI-C12-pitaa-maataa]
+sounds: [diphthong-au, spineless-ra]
+roots: [arabic-awra, sanskrit-mahila]
+etymology_hook: "औरत (aurat) is Arabic عورة ʿawra, on a root meaning a weak or exposed spot — but Arabic ʿawra does NOT mean 'woman'; that sense is a Persian development, and Persian handed the word to Hindi and Urdu, where it is attested from about 1420; the alternatives महिला (a Sanskrit borrowing whose own origin is uncertain, possibly Dravidian) and स्त्री (Sanskrit, secure back to Indo-Iranian) are the formal and literary ends of the same meaning"
+duration:
+  max_seconds: 265
+requires:
+  knowledge: [HI-CONCEPT-C39-AADMI-01, HI-CONCEPT-C39-AADMI-02, HI-CONCEPT-C39-BACCHA-01, HI-CONCEPT-C39-BACCHA-02, HI-CONCEPT-C39-DOST-01, HI-CONCEPT-C39-DOST-02, HI-CONCEPT-C39-DOST-03, HI-CONCEPT-C37-KITAAB-01, HI-CONCEPT-C37-KITAAB-02, HI-CONCEPT-C37-KITAAB-03, HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C12-BHAAI-BAHIN-01, HI-CONCEPT-C12-BHAAI-BAHIN-02, HI-CONCEPT-C12-PITAA-MAATAA-01, HI-CONCEPT-C12-PITAA-MAATAA-02]
+introduces:
+  knowledge: [HI-CONCEPT-C39-AURAT-01, HI-CONCEPT-C39-AURAT-02, HI-CONCEPT-C39-AURAT-03]
+practises:
+  knowledge: [HI-CONCEPT-C39-AURAT-01, HI-CONCEPT-C39-AURAT-02, HI-CONCEPT-C39-AURAT-03, HI-CONCEPT-C39-AADMI-01, HI-CONCEPT-C39-AADMI-02, HI-CONCEPT-C39-BACCHA-01, HI-CONCEPT-C39-BACCHA-02, HI-CONCEPT-C39-DOST-01, HI-CONCEPT-C39-DOST-02, HI-CONCEPT-C39-DOST-03, HI-CONCEPT-C37-KITAAB-01, HI-CONCEPT-C37-KITAAB-02, HI-CONCEPT-C37-KITAAB-03, HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C12-BHAAI-BAHIN-01, HI-CONCEPT-C12-BHAAI-BAHIN-02, HI-CONCEPT-C12-PITAA-MAATAA-01, HI-CONCEPT-C12-PITAA-MAATAA-02, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C37-CHAI-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-C39-aadmi, HI-C39-baccha, HI-C39-dost, HI-C37-kitaab, HI-C36-kursi, HI-C12-bhaai-bahin, HI-C12-pitaa-maataa]
+---
+
+# औरत (aurat) — the word for "woman," and which one to use
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C39-AADMI-01, HI-CONCEPT-C12-BHAAI-BAHIN-02] -->
+
+[PAUSE 2s] The last word of the chapter, and the one where Hindi hands you a
+choice rather than a word.
+
+## Grammar Lens: the pair, and the family complete
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C39-AURAT-01]; assesses=[HI-CONCEPT-C39-AADMI-01, HI-CONCEPT-C39-BACCHA-01, HI-CONCEPT-C39-BACCHA-02, HI-CONCEPT-C12-PITAA-MAATAA-01, HI-CONCEPT-C12-BHAAI-BAHIN-01, HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C37-CHAI-01, HI-CONCEPT-C37-KITAAB-01] -->
+
+**औरत** (*aurat*) = "**woman**," and it is **feminine**. Say **एक औरत** — and
+for the reason **एक आदमी** was the safe phrase, leave **मेरी औरत** alone: it
+means *my woman*, a wife. **औ** is one vowel letter, *au*, standing alone.
+
+Consonant ending, feminine — as **चाय**, **किताब** and **आँख** were. Beside it
+**आदमी**: **-ी** ending, masculine. Neither adult's gender is reachable from
+spelling. Where you *can* hear the agreement is on the child: **मेरा बच्चा**,
+**मेरी बच्ची**, the yearling who takes the ending seriously.
+
+The family: **पिता**, **माता**, **भाई**, **बहन**, **बच्चा**, **आदमी**, **औरत**
+— and the chosen one, **दोस्त**.
+
+## The word, taken apart: औरत
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C39-AURAT-02]; assesses=[HI-CONCEPT-C39-AURAT-01, HI-CONCEPT-C39-AADMI-02, HI-CONCEPT-C39-DOST-02, HI-CONCEPT-C39-DOST-03, HI-CONCEPT-C37-KITAAB-02] -->
+
+**औरत** is **Arabic**, **عورة** (*ʿawra*), on the three-consonant root **ʿ-w-r**
+— built the way **k-t-b** built **किताब** — whose senses run to *a weak point, a
+gap in a defence, something left uncovered*.
+
+Then the fact that changes what you do with all that: **Arabic ʿawra does not
+mean "woman."** That sense is a **Persian** development. Persian moved the noun
+to mean a woman or a wife and handed *that* to Hindi and Urdu, on record from
+around 1420 — the same Persian relay that carried **दोस्त**.
+
+So the harsh root sense is not a claim Arabic makes about women. It is the
+earlier life of a word another language repurposed.
+
+## You'll want to know — three words, and which to say
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C39-AURAT-03]; assesses=[HI-CONCEPT-C39-AURAT-02, HI-CONCEPT-C37-KITAAB-03, HI-CONCEPT-C12-BHAAI-BAHIN-02, HI-CONCEPT-C12-PITAA-MAATAA-02] -->
+
+Three words, and the choice is **register**, exactly as for **किताब** /
+**पुस्तक** / **पोथा**.
+
+- **औरत** — Perso-Arabic, plain and everyday. Common in speech; some speakers
+  avoid it formally, partly because of the origin above.
+- **महिला** (*mahilā*) — a Sanskrit borrowing, the **respectful, public** word:
+  signs, announcements, official prose. Its Sanskrit origin is **uncertain**;
+  one serious proposal traces it to Dravidian.
+- **स्त्री** (*strī*) — Sanskrit, older and literary. Secure back to
+  Indo-Iranian, no further.
+
+**महिला** where you would write, **औरत** where you would talk.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C39-AURAT-01, HI-CONCEPT-C39-AURAT-02, HI-CONCEPT-C39-AURAT-03, HI-CONCEPT-C39-AADMI-01, HI-CONCEPT-C39-AADMI-02, HI-CONCEPT-C39-BACCHA-01, HI-CONCEPT-C39-BACCHA-02, HI-CONCEPT-C39-DOST-01, HI-CONCEPT-C39-DOST-03, HI-CONCEPT-C12-BHAAI-BAHIN-01, HI-CONCEPT-C12-PITAA-MAATAA-01, HI-CONCEPT-C37-KITAAB-01, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C37-CHAI-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: *ek aurat*, then *ek ādmī* — neither ending gives its gender away]
+- [YOU SAY: *merā pitā, merī mātā, merā bhāī, merī bahin, merā bacchā, merī
+  bacchī*]
+- [YOU SAY: *merā dost*, then *merī dost*]
+- [YOU SAY: every feminine noun you own — *kursī, chāy, kitāb, āṁkh, bacchī*]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C39-AURAT-01, HI-CONCEPT-C39-AURAT-02, HI-CONCEPT-C39-AURAT-03, HI-CONCEPT-C39-AADMI-01, HI-CONCEPT-C39-DOST-01, HI-CONCEPT-C12-BHAAI-BAHIN-01, HI-CONCEPT-C12-PITAA-MAATAA-01] -->
+
+[PAUSE 3s] Does Arabic **عورة** mean "woman"? (**No** — that sense is
+**Persian**.)
+Which goes on a public sign, which in conversation? (**महिला** written;
+**औरत** spoken.)
+Your family, minding every possessive? (*Merā pitā, merī mātā, merā bhāī,
+merī bahin, merā bacchā*.)

--- a/code/learning/human-languages/hindi/lessons/HI-C39-baccha.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C39-baccha.md
@@ -1,0 +1,93 @@
+---
+schema_version: 2
+id: HI-C39-baccha
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 820
+chapter: 39
+type: word
+headword: बच्चा
+gloss: child — masculine, with a feminine बच्ची, and a Persian word that landed on top of an inherited Sanskrit cousin
+concept_tag: HI-PERSON-CHILD
+prerequisites: [HI-C39-dost, HI-C12-pitaa-maataa, HI-C19-age-grammar]
+sounds: [geminate-cca, devanagari-long-aa]
+roots: [persian-bacca, vatsa-sanskrit]
+etymology_hook: "बच्चा (bacchā) is the Persian بچه bacca, and Persian bacca is NOT descended from Sanskrit वत्स vatsa — the two are sister reflexes of one Indo-Iranian word, so the loan landed on top of a cousin Hindi had already inherited as बछड़ा bachṛā 'calf'; behind both stands PIE *wet- 'year', which also gives Latin vitulus 'calf' and vetus 'old' and English wether, so a child is literally a yearling"
+duration:
+  max_seconds: 245
+requires:
+  knowledge: [HI-CONCEPT-C39-DOST-01, HI-CONCEPT-C39-DOST-02, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C36-DARVAAZA-01, HI-CONCEPT-C12-PITAA-MAATAA-01, HI-CONCEPT-C12-PITAA-MAATAA-02, HI-CONCEPT-C19-AGE-GRAMMAR-01]
+introduces:
+  knowledge: [HI-CONCEPT-C39-BACCHA-01, HI-CONCEPT-C39-BACCHA-02]
+practises:
+  knowledge: [HI-CONCEPT-C39-BACCHA-01, HI-CONCEPT-C39-BACCHA-02, HI-CONCEPT-C39-DOST-01, HI-CONCEPT-C39-DOST-02, HI-CONCEPT-C39-DOST-03, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C36-DARVAAZA-01, HI-CONCEPT-C12-PITAA-MAATAA-01, HI-CONCEPT-C12-PITAA-MAATAA-02, HI-CONCEPT-C19-AGE-GRAMMAR-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-C39-dost, HI-C36-kursi, HI-C12-pitaa-maataa, HI-C19-umr, HI-C19-age-grammar]
+---
+
+# बच्चा (bacchā) — the child, who is a "yearling"
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C12-PITAA-MAATAA-01, HI-CONCEPT-C39-DOST-01] -->
+
+[PAUSE 2s] You have **पिता** and **माता**. Here is the third person at that
+table — and this word finally lets the masculine and feminine forms stand side
+by side.
+
+## Grammar Lens: a pair you can see
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C39-BACCHA-01]; assesses=[HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C36-DARVAAZA-01, HI-CONCEPT-C19-AGE-GRAMMAR-01] -->
+
+**बच्चा** (*bacchā*) = "**child**," **masculine** — **मेरा बच्चा**.
+
+Here the lean does real work at last. Swap the final **-ा** for **-ी** and you
+get **बच्ची** (*bacchī*), a girl child, **feminine** — **मेरी बच्ची**.
+
+This is what **दरवाज़ा** and **कुर्सी** only hinted at: for *this* class of noun
+**-ā**/**-ī** is not a lean but the machinery, and the word changes with the
+person. Which is exactly what **दोस्त** would not do.
+
+You already know how to ask this child's age: **कितने साल के हो?** — how many
+years someone *is of*, rather than how many they *have*.
+
+## The word, taken apart: बच्चा
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C39-BACCHA-02]; assesses=[HI-CONCEPT-C39-BACCHA-01, HI-CONCEPT-C39-DOST-02, HI-CONCEPT-C39-DOST-03, HI-CONCEPT-C12-PITAA-MAATAA-02] -->
+
+**बच्चा** is **Persian**, **بچه** (*bacca*) — and the obvious story is wrong.
+
+Persian *bacca* did **not** come from Sanskrit **वत्स** (*vatsa*), "calf, young
+one." The two are **sisters**: one Indo-Iranian word inherited down two separate
+branches. Centuries later the Persian one was borrowed into Hindi — which had
+*already* inherited the Sanskrit one as **बछड़ा** (*bachṛā*), "calf."
+
+So Hindi holds both, the same ancient word by two roads — the pattern
+**दरवाज़ा** and **द्वार** showed you, running again, and the same Persian relay
+that brought **दोस्त**.
+
+Behind both stands ***wet-***, "**year**." Latin **vetus**, "old," is from it —
+English **veteran** — and so are Latin **vitulus**, "calf," and English
+**wether**, a yearling sheep.
+
+A child, at the root, is a **yearling**. **पिता** and **माता** are named by
+relationship; **बच्चा** is named by age.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C39-BACCHA-01, HI-CONCEPT-C39-BACCHA-02, HI-CONCEPT-C39-DOST-01, HI-CONCEPT-C12-PITAA-MAATAA-01, HI-CONCEPT-C19-AGE-GRAMMAR-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: *bacchā* and *bacchī*; then *merā bacchā*, *merī bacchī*]
+- [YOU SAY: the family — *merā pitā, merī mātā, merā bacchā*]
+- [YOU SAY: the two roads — *bacchā* from Persian, *bachṛā* inherited; one word]
+- [YOU SAY: *vetus*, *vitulus*, *wether* — and the meaning under all of them
+  (year)]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C39-BACCHA-01, HI-CONCEPT-C39-BACCHA-02, HI-CONCEPT-C39-DOST-01, HI-CONCEPT-C12-PITAA-MAATAA-02] -->
+
+[PAUSE 3s] What is the feminine of **बच्चा**, and how does the possessive move?
+(**बच्ची** — *merā bacchā*, *merī bacchī*.)
+Is Persian *bacca* descended from Sanskrit *vatsa*? (**No** — they are
+**sisters**; Hindi's inherited cousin is **बछड़ा**.)
+What does the root mean? (**Year** — a child is a yearling.)

--- a/code/learning/human-languages/hindi/lessons/HI-C39-dost.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C39-dost.md
@@ -1,0 +1,102 @@
+---
+schema_version: 2
+id: HI-C39-dost
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 810
+chapter: 39
+type: word
+headword: दोस्त
+gloss: friend — a Persian word for "the one chosen", masculine by default but taking either possessive depending on who the friend is
+concept_tag: HI-PERSON-FRIEND
+prerequisites: [HI-C38-pet, HI-W05-conjuncts, HI-C12-bhaai-bahin]
+sounds: [conjunct-sta, devanagari-o]
+roots: [persian-dost, pie-gews]
+etymology_hook: "दोस्त (dost) is Persian دوست, from Old Persian dauštā 'beloved' — an agent noun on the root Sanskrit inherited as जुष् juṣ- 'to take pleasure in' and PIE had as *ǵews- 'to taste, try, choose', the root behind Latin gustāre and English choose; the d- is a sound law, not an accident, since the Indo-Iranian consonant that became z- in Avestan became d- in Old Persian"
+duration:
+  max_seconds: 255
+requires:
+  knowledge: [HI-CONCEPT-C38-PET-01, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C12-BHAAI-BAHIN-01, HI-CONCEPT-C12-BHAAI-BAHIN-02, HI-CONCEPT-W05-CONJUNCTS-01, HI-CONCEPT-W05-CONJUNCTS-02, HI-CONCEPT-W05-VIRAMA-NAMASTE-01, HI-CONCEPT-W05-WRITE-NAMASTE-01, HI-CONCEPT-W05-WRITE-NAMASTE-02, HI-CONCEPT-W04-WRITE-MERA-NAAM-01]
+introduces:
+  knowledge: [HI-CONCEPT-C39-DOST-01, HI-CONCEPT-C39-DOST-02, HI-CONCEPT-C39-DOST-03]
+practises:
+  knowledge: [HI-CONCEPT-C39-DOST-01, HI-CONCEPT-C39-DOST-02, HI-CONCEPT-C39-DOST-03, HI-CONCEPT-C38-PET-01, HI-CONCEPT-C38-AANKH-01, HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C12-BHAAI-BAHIN-01, HI-CONCEPT-C12-BHAAI-BAHIN-02, HI-CONCEPT-W05-CONJUNCTS-01, HI-CONCEPT-W05-CONJUNCTS-02, HI-CONCEPT-W05-VIRAMA-NAMASTE-01, HI-CONCEPT-W05-WRITE-NAMASTE-01, HI-CONCEPT-W05-WRITE-NAMASTE-02, HI-CONCEPT-W04-WRITE-MERA-NAAM-01]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-hindi
+reviews_of: [HI-C38-pet, HI-C36-kursi, HI-C12-bhaai-bahin, HI-W05-conjuncts, HI-W05-virama-namaste, HI-W05-write-namaste, HI-W04-write-mera-naam]
+---
+
+# दोस्त (dost) — the friend, who is "the one chosen"
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C12-BHAAI-BAHIN-01, HI-CONCEPT-C38-PET-01] -->
+
+[PAUSE 2s] You can name a brother and a sister. Here is the person you picked
+rather than were given, and the word says exactly that.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-W05-CONJUNCTS-01, HI-CONCEPT-W05-CONJUNCTS-02, HI-CONCEPT-W05-VIRAMA-NAMASTE-01, HI-CONCEPT-W05-WRITE-NAMASTE-01, HI-CONCEPT-W05-WRITE-NAMASTE-02, HI-CONCEPT-W04-WRITE-MERA-NAAM-01] -->
+
+**दो·स्त** — an ending you have already assembled by hand.
+
+**द** with **ो** gives **दो**. Then **स्त** — **स** stripped of its built-in *a*
+by the **virāma**, fusing with **त** into one conjunct: the cluster inside
+**नमस्ते**, the first conjunct you ever wrote.
+
+So **मेरा दोस्त** is built entirely from strokes already yours.
+
+## Grammar Lens: the noun that leans on who you mean
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C39-DOST-01]; assesses=[HI-CONCEPT-C36-KURSI-01, HI-CONCEPT-C36-KURSI-03, HI-CONCEPT-C38-AANKH-01] -->
+
+**दोस्त** (*dost*) = "**friend**," and in the dictionary it is **masculine** —
+**मेरा दोस्त**.
+
+But it bends. When the friend is a woman, ordinary modern Hindi says **मेरी
+दोस्त**. The word has not changed shape; the **possessive** followed the person.
+Both are current; neither is a mistake.
+
+That is unlike everything so far. **आँख** is feminine whatever you mean.
+**दोस्त** takes its gender from **who the friend is**.
+
+## The word, taken apart: दोस्त
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C39-DOST-02]; assesses=[HI-CONCEPT-C39-DOST-01] -->
+
+**दोस्त** is **Persian**, **دوست** (*dōst*); Old Persian had **dauštā**, an
+agent noun, "**the one held dear**."
+
+Its root is ***ǵews-***, and the old meaning is not "love" but "**to taste, to
+try, to choose**." Sanskrit inherited it as **जुष्** (*juṣ-*). Latin has
+**gustāre** — English **gusto**, **disgust** — and English **choose** is the
+same root.
+
+So a *dōst* is one you have **tried and chosen**; the narrowing to "beloved"
+happened inside the Indo-Iranian branch alone.
+
+## You'll want to know — why it starts with a d
+<!-- hl-knowledge: introduces=[HI-CONCEPT-C39-DOST-03]; assesses=[HI-CONCEPT-C39-DOST-02] -->
+
+The consonant at the front of this root came out as **z-** in Avestan and **d-**
+in **Old Persian**, by a regular sound law across the vocabulary.
+
+Which is why "friend" starts with **द** in Persian and Hindi while its Sanskrit
+cousin *juṣ-* starts with something else. An initial consonant is a passport
+stamp: it says which road the word came by.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C39-DOST-01, HI-CONCEPT-C39-DOST-02, HI-CONCEPT-C39-DOST-03, HI-CONCEPT-C12-BHAAI-BAHIN-01, HI-CONCEPT-C12-BHAAI-BAHIN-02, HI-CONCEPT-C36-KURSI-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: *merā dost* for a man, *merī dost* for a woman]
+- [YOU SAY: the given and the chosen — *merā bhāī, merī bahin, merā dost*]
+- [YOU SAY: *namaste*, then *dost* — one conjunct]
+- [YOU SAY: *dōst*, *juṣ-*, *gustāre*, *choose*]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[HI-CONCEPT-C39-DOST-01, HI-CONCEPT-C39-DOST-02, HI-CONCEPT-C39-DOST-03, HI-CONCEPT-C12-BHAAI-BAHIN-02] -->
+
+[PAUSE 3s] How do you say "my friend" about a woman? (**मेरी दोस्त** — the
+possessive follows the person.)
+What did the root behind *dōst* first mean? (**To taste, try, choose**.)
+Why does Persian say *d-* where Avestan says *z-*? (**A regular sound law**.)

--- a/code/learning/human-languages/hindi/narration/ch36.json
+++ b/code/learning/human-languages/hindi/narration/ch36.json
@@ -1,0 +1,694 @@
+{
+  "version": 1,
+  "language": "hindi",
+  "chapter": 36,
+  "title": "One House, Four Languages",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:653dbf1b0b6bc8a9",
+  "lessons": [
+    {
+      "id": "HI-C36-ghar",
+      "sequence": 690,
+      "title": "घर (ghar) — \"house,\" and the fence that came first",
+      "headword": "घर",
+      "romanization": "",
+      "gloss": "house, home — masculine, and from a Sanskrit word that meant a fenced enclosure before it meant a building",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:e1bda72998180443",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You can say your name. Now say where you live — and meet the one thing every Hindi noun carries that English nouns do not."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Two letters. घ (gha), the breathy pair of ga, then र (ra), already yours from मेरा."
+            },
+            {
+              "kind": "speech",
+              "text": "र is the spineless one: no upright stroke of its own, so the शिरोरेखा, the head-line, is all that ties it to its neighbour. Both letters keep their inherent a becomes घर, ghar."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: the word arrives with a gender",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "घर (ghar) = \"house, home.\" And it is masculine."
+            },
+            {
+              "kind": "speech",
+              "text": "Every Hindi noun is masculine or feminine. Not the thing — the word. There is nothing manly about a house; the gender is a fact about ghar the way its spelling is, and you learn the two together or you learn them twice."
+            },
+            {
+              "kind": "speech",
+              "text": "It is not decoration: it changes the words around the noun. Because ghar is masculine, \"my house\" is मेरा घर (merā ghar), the masculine मेरा, exactly as in मेरा नाम."
+            },
+            {
+              "kind": "speech",
+              "text": "Whole sentence: यह मेरा घर है (yah merā ghar hai), \"this is my house.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: घर",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "घर comes from Sanskrit गृह (gṛha), worn smooth through Prakrit ghara into the short word you just said. Hindi kept गृह too, borrowed back out of Sanskrit for formal use, so both shapes survive."
+            },
+            {
+              "kind": "speech",
+              "text": "Further back, gṛha descends from an ancient root meaning enclosure, gʰerdʰ- — and English holds two plain descendants of it: yard and garden. Slavic holds the -grad in Belgrade, \"town.\""
+            },
+            {
+              "kind": "speech",
+              "text": "So the oldest sense is not walls and a roof. It is a fenced-in piece of ground. You enclose the land first; the house is what goes inside afterwards."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ghar — house; then merā ghar; then yah merā ghar hai",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *ghar* — house; then *merā ghar*; then *yah merā ghar hai*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "merā nām and merā ghar one after the other — the same merā, because both nouns are masculine",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *merā nām* and *merā ghar* one after the other — the same *merā*, because both nouns are masculine]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two letters, gha and ra, and which of them has no spine",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two letters, *gha* and *ra*, and which of them has no spine]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "gṛha, then ghar — the Sanskrit shape and the worn one; then the old meaning, enclosure",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *gṛha*, then *ghar* — the Sanskrit shape and the worn one; then the old meaning, *enclosure*]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Is घर masculine or feminine, and how do you know from the sentence? (Masculine — merā, not merī.) What did the root behind gṛha mean before it meant a building? (An enclosure — the root behind yard and garden.) Which of घ and र hangs from the head-line without a spine of its own? (र.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C36-darvaaza",
+      "sequence": 700,
+      "title": "दरवाज़ा (darvāzā) — the door, and the oldest word you already know",
+      "headword": "दरवाज़ा",
+      "romanization": "",
+      "gloss": "door — masculine, a Persian loan whose first syllable is the same ancient word as English \"door\"",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:400e1a65c0cf63ef",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You have a house. This is what you stand at to be let into one — and it is where नमस्ते is said and where शुभ रात्रि is said back."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "द, र, वा, ज़ा — and the ा you already write does two of the four."
+            },
+            {
+              "kind": "speech",
+              "text": "The new mark is the dot under ज़: the nuqta. Plain ज is ja. Persian arrived carrying a z Devanagari had no letter for, so the script put a dot beneath the nearest shape and made one — ज़, za. The same dot makes फ़ (fa) and ख़, the sound in ख़ुशी."
+            },
+            {
+              "kind": "speech",
+              "text": "A nuqta is a small confession in ink: this sound came from somewhere else."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: the shape that usually tells you",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "दरवाज़ा (darvāzā) = \"door,\" and it is masculine — so मेरा दरवाज़ा."
+            },
+            {
+              "kind": "speech",
+              "text": "Here is your first piece of help. A noun ending in long -ā is usually masculine, and darvāzā ends in -ा. Keep it as a lean, not a law: this course will show you where it fails, in both directions."
+            },
+            {
+              "kind": "speech",
+              "text": "घर ends in a consonant and is masculine too — so a consonant ending tells you nothing at all. That one you simply learn."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: दरवाज़ा",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "दरवाज़ा is Persian, دروازه (darvāza), and its first syllable is where this gets remarkable. Persian در (dar) means \"door,\" and it descends from the ancient root dʰwer- — as do English door, Latin forēs, Greek thúrā and Sanskrit द्वार (dvāra)."
+            },
+            {
+              "kind": "speech",
+              "text": "Now the twist. Hindi also has द्वार (dvār), taken straight out of Sanskrit for formal use. So the borrowed Persian word and the learned Sanskrit one are the same ancient word, arrived twice, by two roads, centuries apart."
+            },
+            {
+              "kind": "speech",
+              "text": "The -vāza part is less settled: usually connected to a Persian word for \"open,\" but disputed, and worth leaving open."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "darvāzā, then merā darvāzā, then merā ghar — one merā, two masculine nouns",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *darvāzā*, then *merā darvāzā*, then *merā ghar* — one *merā*, two masculine nouns]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the arrival and the leaving at the same door — namaste going in, shubh rātri going out",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the arrival and the leaving at the same door — *namaste* going in, *shubh rātri* going out]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ja, then za — the letter, then the letter with the dot",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *ja*, then *za* — the letter, then the letter with the dot]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "dar, door, thúrā, dvāra — one word, four languages",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *dar*, *door*, *thúrā*, *dvāra* — one word, four languages]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does the dot under ज़ tell you? (That the sound is borrowed — Devanagari had no z.) Persian dar and English door — coincidence or cousins? (Cousins, from dʰwer- — and Hindi's own द्वार is the third.) Which ending gives you a fair guess at masculine? (Long -ā, as in darvāzā. A consonant ending, as in ghar, tells you nothing.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C36-kamra",
+      "sequence": 710,
+      "title": "कमरा (kamrā) — the room that is also a camera",
+      "headword": "कमरा",
+      "romanization": "",
+      "gloss": "room — masculine, and the same Latin word as English \"camera\", brought to India by Portuguese ships",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:437068c5d1bd4e49",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Through the door, and into this. A short, ordinary word — which travelled to India by sea, on Portuguese ships."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "क, म, रा — and म (ma) is one of the first two letters you ever wrote, beside न."
+            },
+            {
+              "kind": "speech",
+              "text": "Both of those hang from the head-line and both stand on a right-hand spine; that upright is what your eye follows along a line of Devanagari. क and र you have as well, so this word costs you nothing new — only the ा riding on the final र."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: the lean holds",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "कमरा (kamrā) = \"room,\" and it is masculine — मेरा कमरा."
+            },
+            {
+              "kind": "speech",
+              "text": "Long -ā, masculine again, exactly as दरवाज़ा was. Three nouns in, and the possessive has not changed once: merā ghar, merā darvāzā, merā kamrā."
+            },
+            {
+              "kind": "speech",
+              "text": "Hold on to that flatness. It is about to break."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: कमरा",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "कमरा is neither Sanskrit nor Persian. It is Portuguese — câmara, \"chamber, room\" — left behind on India's western coast by the traders who ran that shore from the sixteenth century, along with चाबी (chābī, \"key\") and अलमारी (almārī, \"cupboard\")."
+            },
+            {
+              "kind": "speech",
+              "text": "Portuguese câmara is Latin camera, \"a vaulted chamber,\" and Latin took it from Greek kamára — where the trail honestly stops; the Greek word's own origin is unknown."
+            },
+            {
+              "kind": "speech",
+              "text": "Then the good part. English camera is that same Latin word: a camera obscura was literally a \"dark room,\" and when the dark room shrank into a box the name went with it. And Hindi later borrowed it back through English as कैमरा (kaimrā) for the device."
+            },
+            {
+              "kind": "speech",
+              "text": "So कमरा and कैमरा are the same Latin word, arrived twice by two different routes — the second time carrying a machine that did not exist when the first one landed."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "kamrā, then merā kamrā",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *kamrā*, then *merā kamrā*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three so far, in one breath — merā ghar, merā darvāzā, merā kamrā",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three so far, in one breath — *merā ghar, merā darvāzā, merā kamrā*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "kamrā and kaimrā — one Latin word, two arrivals",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *kamrā* and *kaimrā* — one Latin word, two arrivals]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "where each of the three came from — Sanskrit, Persian, Portuguese",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: where each of the three came from — Sanskrit, Persian, Portuguese]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Which language handed Hindi कमरा, and how did it get there? (Portuguese, by sea, on the western coast.) What does kamrā share with English camera? (One Latin word, camera, \"vaulted chamber\" — Hindi has it twice, as kamrā and kaimrā.) Say \"my house, my door, my room.\" (Merā ghar, merā darvāzā, merā kamrā.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C36-kursi",
+      "sequence": 720,
+      "title": "कुर्सी (kursī) — sit down, and watch मेरा change",
+      "headword": "कुर्सी",
+      "romanization": "",
+      "gloss": "chair — your first feminine noun, and a word that has been passing between Middle Eastern languages for four thousand years",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:146ec51e225cc113",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "House, door, room — and now what you are offered once inside. This word breaks the pattern the other three set."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "कु, र्, सी — three old letters, क, र, स, and two working marks."
+            },
+            {
+              "kind": "speech",
+              "text": "क takes ु for ku. Then र with the virāma, the stroke that kills a consonant's built-in a: a bare र् cannot stand alone, so it fuses with the स, and the hook above स is that र — the fusing you met in स्त."
+            },
+            {
+              "kind": "speech",
+              "text": "Then सी: the long ी stands after its consonant and sounds after it, while ि stands before and still sounds after. One of the two lies to your eye."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: your first feminine noun",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "कुर्सी (kursī) = \"chair,\" and it is feminine."
+            },
+            {
+              "kind": "speech",
+              "text": "So मेरी कुर्सी, not merā. When you learnt मेरा you were told you would meet मेरी at your first feminine noun. Here it is."
+            },
+            {
+              "kind": "speech",
+              "text": "Nothing about a chair is female. The gender belongs to the word, and it changes मेरा. Get it wrong and every word beside the noun goes wrong too."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the lean, and where it leans wrong",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The rule of thumb: long -ā tends masculine, long -ī tends feminine, a consonant ending tells you nothing. A lean, not a law: darvāzā, kamrā and kursī obey it, ghar sits outside it, and later words will disobey it outright."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "etymology",
+          "title": "The word, taken apart: कुर्सी",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "कुर्सी is Arabic, كرسي (kursī), \"seat, throne,\" reaching Hindi through Persian, the road most Arabic words took."
+            },
+            {
+              "kind": "speech",
+              "text": "Arabic did not invent it either. It has passed along the Near East for four thousand years: Sumerian guza, Akkadian kussû, then Ugaritic, Hebrew and Aramaic, Arabic most likely taking it from Aramaic. Not one family — the word crossed between unrelated families because the object did."
+            },
+            {
+              "kind": "speech",
+              "text": "English chair? Greek kathédra, through Latin and French. No relation at all."
+            },
+            {
+              "kind": "speech",
+              "text": "And what this chapter has done: घर Sanskrit, दरवाज़ा Persian, कमरा Portuguese, कुर्सी Arabic. One room, four languages — that is Hindi, not an accident of these four words."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "merī kursī, then merā kamrā — one possessive, two shapes",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *merī kursī*, then *merā kamrā* — one possessive, two shapes]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the chapter — merā ghar, merā darvāzā, merā kamrā, merī kursī",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the chapter — *merā ghar, merā darvāzā, merā kamrā, merī kursī*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "each word's source — Sanskrit, Persian, Portuguese, Arabic",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: each word's source — Sanskrit, Persian, Portuguese, Arabic]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "namaste at the darvāzā, then shubh rātri at the same door",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *namaste* at the *darvāzā*, then *shubh rātri* at the same door]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Why मेरी कुर्सी? (कुर्सी is feminine; the possessive agrees with the noun.) How far back does kursī go, and did it stay in one family? (Sumerian — and no, it crossed unrelated families.) Name the chapter's four sources. (Sanskrit, Persian, Portuguese, Arabic.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/hindi/narration/ch36.json
+++ b/code/learning/human-languages/hindi/narration/ch36.json
@@ -4,7 +4,7 @@
   "chapter": 36,
   "title": "One House, Four Languages",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:653dbf1b0b6bc8a9",
+  "sourceHash": "fnv1a64:451b541e2e9dd5a5",
   "lessons": [
     {
       "id": "HI-C36-ghar",
@@ -186,7 +186,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:400e1a65c0cf63ef",
+      "sourceHash": "fnv1a64:cc3dacc2fb708c31",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -245,7 +245,7 @@
             },
             {
               "kind": "speech",
-              "text": "Here is your first piece of help. A noun ending in long -ā is usually masculine, and darvāzā ends in -ा. Keep it as a lean, not a law: this course will show you where it fails, in both directions."
+              "text": "Here is your first piece of help. A noun ending in long -ā is usually masculine, and darvāzā ends in -ा. Keep it as a lean, not a law: later chapters will show you where it fails, in both directions."
             },
             {
               "kind": "speech",

--- a/code/learning/human-languages/hindi/narration/ch36.txt
+++ b/code/learning/human-languages/hindi/narration/ch36.txt
@@ -58,7 +58,7 @@ A nuqta is a small confession in ink: this sound came from somewhere else.
 
 Grammar Lens: the shape that usually tells you.
 दरवाज़ा (darvāzā) = "door," and it is masculine — so मेरा दरवाज़ा.
-Here is your first piece of help. A noun ending in long -ā is usually masculine, and darvāzā ends in -ा. Keep it as a lean, not a law: this course will show you where it fails, in both directions.
+Here is your first piece of help. A noun ending in long -ā is usually masculine, and darvāzā ends in -ा. Keep it as a lean, not a law: later chapters will show you where it fails, in both directions.
 घर ends in a consonant and is masculine too — so a consonant ending tells you nothing at all. That one you simply learn.
 
 The word, taken apart: दरवाज़ा.

--- a/code/learning/human-languages/hindi/narration/ch36.txt
+++ b/code/learning/human-languages/hindi/narration/ch36.txt
@@ -1,0 +1,166 @@
+Hindi, chapter 36: One House, Four Languages.
+4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+
+
+Lesson 1 of 4.
+घर (ghar) — "house," and the fence that came first.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You can say your name. Now say where you live — and meet the one thing every Hindi noun carries that English nouns do not.
+
+The letters in this word.
+Two letters. घ (gha), the breathy pair of ga, then र (ra), already yours from मेरा.
+र is the spineless one: no upright stroke of its own, so the शिरोरेखा, the head-line, is all that ties it to its neighbour. Both letters keep their inherent a becomes घर, ghar.
+
+Grammar Lens: the word arrives with a gender.
+घर (ghar) = "house, home." And it is masculine.
+Every Hindi noun is masculine or feminine. Not the thing — the word. There is nothing manly about a house; the gender is a fact about ghar the way its spelling is, and you learn the two together or you learn them twice.
+It is not decoration: it changes the words around the noun. Because ghar is masculine, "my house" is मेरा घर (merā ghar), the masculine मेरा, exactly as in मेरा नाम.
+Whole sentence: यह मेरा घर है (yah merā ghar hai), "this is my house."
+
+The word, taken apart: घर.
+घर comes from Sanskrit गृह (gṛha), worn smooth through Prakrit ghara into the short word you just said. Hindi kept गृह too, borrowed back out of Sanskrit for formal use, so both shapes survive.
+Further back, gṛha descends from an ancient root meaning enclosure, gʰerdʰ- — and English holds two plain descendants of it: yard and garden. Slavic holds the -grad in Belgrade, "town."
+So the oldest sense is not walls and a roof. It is a fenced-in piece of ground. You enclose the land first; the house is what goes inside afterwards.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: ghar — house; then merā ghar; then yah merā ghar hai]
+[pause 8 seconds for the answer]
+[your turn — say: merā nām and merā ghar one after the other — the same merā, because both nouns are masculine]
+[pause 8 seconds for the answer]
+[your turn — say: the two letters, gha and ra, and which of them has no spine]
+[pause 8 seconds for the answer]
+[your turn — say: gṛha, then ghar — the Sanskrit shape and the worn one; then the old meaning, enclosure]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Is घर masculine or feminine, and how do you know from the sentence? (Masculine — merā, not merī.) What did the root behind gṛha mean before it meant a building? (An enclosure — the root behind yard and garden.) Which of घ and र hangs from the head-line without a spine of its own? (र.)
+
+
+Lesson 2 of 4.
+दरवाज़ा (darvāzā) — the door, and the oldest word you already know.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You have a house. This is what you stand at to be let into one — and it is where नमस्ते is said and where शुभ रात्रि is said back.
+
+The letters in this word.
+द, र, वा, ज़ा — and the ा you already write does two of the four.
+The new mark is the dot under ज़: the nuqta. Plain ज is ja. Persian arrived carrying a z Devanagari had no letter for, so the script put a dot beneath the nearest shape and made one — ज़, za. The same dot makes फ़ (fa) and ख़, the sound in ख़ुशी.
+A nuqta is a small confession in ink: this sound came from somewhere else.
+
+Grammar Lens: the shape that usually tells you.
+दरवाज़ा (darvāzā) = "door," and it is masculine — so मेरा दरवाज़ा.
+Here is your first piece of help. A noun ending in long -ā is usually masculine, and darvāzā ends in -ा. Keep it as a lean, not a law: this course will show you where it fails, in both directions.
+घर ends in a consonant and is masculine too — so a consonant ending tells you nothing at all. That one you simply learn.
+
+The word, taken apart: दरवाज़ा.
+दरवाज़ा is Persian, دروازه (darvāza), and its first syllable is where this gets remarkable. Persian در (dar) means "door," and it descends from the ancient root dʰwer- — as do English door, Latin forēs, Greek thúrā and Sanskrit द्वार (dvāra).
+Now the twist. Hindi also has द्वार (dvār), taken straight out of Sanskrit for formal use. So the borrowed Persian word and the learned Sanskrit one are the same ancient word, arrived twice, by two roads, centuries apart.
+The -vāza part is less settled: usually connected to a Persian word for "open," but disputed, and worth leaving open.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: darvāzā, then merā darvāzā, then merā ghar — one merā, two masculine nouns]
+[pause 8 seconds for the answer]
+[your turn — say: the arrival and the leaving at the same door — namaste going in, shubh rātri going out]
+[pause 8 seconds for the answer]
+[your turn — say: ja, then za — the letter, then the letter with the dot]
+[pause 8 seconds for the answer]
+[your turn — say: dar, door, thúrā, dvāra — one word, four languages]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does the dot under ज़ tell you? (That the sound is borrowed — Devanagari had no z.) Persian dar and English door — coincidence or cousins? (Cousins, from dʰwer- — and Hindi's own द्वार is the third.) Which ending gives you a fair guess at masculine? (Long -ā, as in darvāzā. A consonant ending, as in ghar, tells you nothing.)
+
+
+Lesson 3 of 4.
+कमरा (kamrā) — the room that is also a camera.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Through the door, and into this. A short, ordinary word — which travelled to India by sea, on Portuguese ships.
+
+The letters in this word.
+क, म, रा — and म (ma) is one of the first two letters you ever wrote, beside न.
+Both of those hang from the head-line and both stand on a right-hand spine; that upright is what your eye follows along a line of Devanagari. क and र you have as well, so this word costs you nothing new — only the ा riding on the final र.
+
+Grammar Lens: the lean holds.
+कमरा (kamrā) = "room," and it is masculine — मेरा कमरा.
+Long -ā, masculine again, exactly as दरवाज़ा was. Three nouns in, and the possessive has not changed once: merā ghar, merā darvāzā, merā kamrā.
+Hold on to that flatness. It is about to break.
+
+The word, taken apart: कमरा.
+कमरा is neither Sanskrit nor Persian. It is Portuguese — câmara, "chamber, room" — left behind on India's western coast by the traders who ran that shore from the sixteenth century, along with चाबी (chābī, "key") and अलमारी (almārī, "cupboard").
+Portuguese câmara is Latin camera, "a vaulted chamber," and Latin took it from Greek kamára — where the trail honestly stops; the Greek word's own origin is unknown.
+Then the good part. English camera is that same Latin word: a camera obscura was literally a "dark room," and when the dark room shrank into a box the name went with it. And Hindi later borrowed it back through English as कैमरा (kaimrā) for the device.
+So कमरा and कैमरा are the same Latin word, arrived twice by two different routes — the second time carrying a machine that did not exist when the first one landed.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: kamrā, then merā kamrā]
+[pause 8 seconds for the answer]
+[your turn — say: the three so far, in one breath — merā ghar, merā darvāzā, merā kamrā]
+[pause 8 seconds for the answer]
+[your turn — say: kamrā and kaimrā — one Latin word, two arrivals]
+[pause 8 seconds for the answer]
+[your turn — say: where each of the three came from — Sanskrit, Persian, Portuguese]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Which language handed Hindi कमरा, and how did it get there? (Portuguese, by sea, on the western coast.) What does kamrā share with English camera? (One Latin word, camera, "vaulted chamber" — Hindi has it twice, as kamrā and kaimrā.) Say "my house, my door, my room." (Merā ghar, merā darvāzā, merā kamrā.)
+
+
+Lesson 4 of 4.
+कुर्सी (kursī) — sit down, and watch मेरा change.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+House, door, room — and now what you are offered once inside. This word breaks the pattern the other three set.
+
+The letters in this word.
+कु, र्, सी — three old letters, क, र, स, and two working marks.
+क takes ु for ku. Then र with the virāma, the stroke that kills a consonant's built-in a: a bare र् cannot stand alone, so it fuses with the स, and the hook above स is that र — the fusing you met in स्त.
+Then सी: the long ी stands after its consonant and sounds after it, while ि stands before and still sounds after. One of the two lies to your eye.
+
+Grammar Lens: your first feminine noun.
+कुर्सी (kursī) = "chair," and it is feminine.
+So मेरी कुर्सी, not merā. When you learnt मेरा you were told you would meet मेरी at your first feminine noun. Here it is.
+Nothing about a chair is female. The gender belongs to the word, and it changes मेरा. Get it wrong and every word beside the noun goes wrong too.
+
+Grammar Lens: the lean, and where it leans wrong.
+The rule of thumb: long -ā tends masculine, long -ī tends feminine, a consonant ending tells you nothing. A lean, not a law: darvāzā, kamrā and kursī obey it, ghar sits outside it, and later words will disobey it outright.
+
+The word, taken apart: कुर्सी.
+कुर्सी is Arabic, كرسي (kursī), "seat, throne," reaching Hindi through Persian, the road most Arabic words took.
+Arabic did not invent it either. It has passed along the Near East for four thousand years: Sumerian guza, Akkadian kussû, then Ugaritic, Hebrew and Aramaic, Arabic most likely taking it from Aramaic. Not one family — the word crossed between unrelated families because the object did.
+English chair? Greek kathédra, through Latin and French. No relation at all.
+And what this chapter has done: घर Sanskrit, दरवाज़ा Persian, कमरा Portuguese, कुर्सी Arabic. One room, four languages — that is Hindi, not an accident of these four words.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: merī kursī, then merā kamrā — one possessive, two shapes]
+[pause 8 seconds for the answer]
+[your turn — say: the chapter — merā ghar, merā darvāzā, merā kamrā, merī kursī]
+[pause 8 seconds for the answer]
+[your turn — say: each word's source — Sanskrit, Persian, Portuguese, Arabic]
+[pause 8 seconds for the answer]
+[your turn — say: namaste at the darvāzā, then shubh rātri at the same door]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Why मेरी कुर्सी? (कुर्सी is feminine; the possessive agrees with the noun.) How far back does kursī go, and did it stay in one family? (Sumerian — and no, it crossed unrelated families.) Name the chapter's four sources. (Sanskrit, Persian, Portuguese, Arabic.)

--- a/code/learning/human-languages/hindi/narration/ch37.json
+++ b/code/learning/human-languages/hindi/narration/ch37.json
@@ -1,0 +1,693 @@
+{
+  "version": 1,
+  "language": "hindi",
+  "chapter": 37,
+  "title": "One Tea, Please",
+  "drivablePrefix": 2,
+  "sourceHash": "fnv1a64:2db6148216359b7d",
+  "lessons": [
+    {
+      "id": "HI-C37-chai",
+      "sequence": 730,
+      "title": "चाय (chāy) — tea, and how to actually ask for one",
+      "headword": "चाय",
+      "romanization": "",
+      "gloss": "tea — feminine, and one of the two names the world uses for the same leaf",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:e3443c65fcf7c40f",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You are in the chair, in the room Portuguese named. Somebody is about to offer you this — and by the end of these few minutes you will be able to ask for it yourself, in the words people actually use."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "grammar",
+          "title": "Grammar Lens: the lean fails, quietly",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "चाय (chāy) = \"tea,\" and it is feminine."
+            },
+            {
+              "kind": "speech",
+              "text": "Nothing outside the word says so. It does not end in -ी the way कुर्सी does; it ends in a consonant, and the lean warned you a consonant ending tells you nothing. चाय is feminine and you simply learn it — now, with the word."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "input",
+          "title": "You'll want to know — how you really ask",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "एक चाय दीजिए (ek chāy dījie) — \"one tea, please.\""
+            },
+            {
+              "kind": "speech",
+              "text": "दीजिए is \"give\" spoken to आप: the polite request form. That -िए ending is the politeness. Nothing else is needed."
+            },
+            {
+              "kind": "speech",
+              "text": "Which means a correction. You learnt कृपया as \"please,\" and it is a real word — but it belongs to signs, forms and station announcements. Across a counter it lands like kindly furnish me with tea."
+            },
+            {
+              "kind": "speech",
+              "text": "So: कृपया when you write, दीजिए when you speak. And you already have the shape — माफ़ कीजिए carries the very same -िए."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: चाय",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "चाय is Chinese. In most of China the word for the leaf is chá, which Persian took as چای (chāy) and handed to Hindi."
+            },
+            {
+              "kind": "speech",
+              "text": "Now the English word: tea. French thé, Dutch thee — a different sound entirely, for the identical leaf."
+            },
+            {
+              "kind": "speech",
+              "text": "They are the same word. China writes it with one character everywhere, but reads that character differently: in the Hokkien of the south-eastern coast it is tê, and Dutch ships bought their tea there."
+            },
+            {
+              "kind": "speech",
+              "text": "The tempting story is overland versus sea. It is wrong: Portuguese say chá, and Portuguese tea came by sea. The variable is which Chinese port a trader dealt with. Your word for tea records a harbour."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "chāy; then ek chāy dījie",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *chāy*; then *ek chāy dījie*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the same request for water — ek pānī dījie",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the same request for water — *ek pānī dījie*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "dījie and māf kījie one after the other — hear the shared -ie",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *dījie* and *māf kījie* one after the other — hear the shared *-ie*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "chā and tê — the two Chinese pronunciations, and which one English bought",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *chā* and *tê* — the two Chinese pronunciations, and which one English bought]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Is चाय masculine or feminine, and does its ending help? (Feminine — and no, a consonant ending never does.) Where does कृपया belong, and what carries the politeness when you speak? (Signs and announcements — in speech the -िए of dījie does it.) Are chāy and tea related? (The same Chinese word, bought at two different ports.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C37-dudh",
+      "sequence": 740,
+      "title": "दूध (dūdh) — \"milk,\" which is really a verb wearing a noun's coat",
+      "headword": "दूध",
+      "romanization": "",
+      "gloss": "milk — masculine, and literally \"the milked thing\", a past participle that hardened into a noun",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:b0053e335d327c38",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What goes into the tea. And it is named the same sly way पानी was — by what happens to it, not by what it is."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "grammar",
+          "title": "Grammar Lens: the pair that disagrees",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "दूध (dūdh) = \"milk,\" and it is masculine."
+            },
+            {
+              "kind": "speech",
+              "text": "Which makes these two a useful pair, because they sit side by side in every cup and disagree: चाय feminine — the leaf that came by way of a Chinese port — and दूध masculine. Both end in consonants. Neither ending tells you anything. This is the ordinary state of a Hindi noun, and it is why the gender is part of the word, not an afterthought."
+            },
+            {
+              "kind": "speech",
+              "text": "एक दूध दीजिए — same request, new noun."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: दूध",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "दूध comes from Sanskrit दुग्ध (dugdha) — and dugdha is not a noun at all. It is a past participle of the verb दुह् (duh-), \"to milk.\" It means \"milked.\""
+            },
+            {
+              "kind": "speech",
+              "text": "So the substance is named for the act. Somebody said \"the milked\" often enough that the adjective hardened into a thing. You have seen this exact move already: पानी is pānīya, \"the drinkable.\" Hindi's two commonest liquids are both named by what is done to them."
+            },
+            {
+              "kind": "speech",
+              "text": "Behind duh- stands the old root dʰewgʰ-, and its meaning is broader than milk: \"to yield, to be strong, to be of use.\" Greek teúkhein, \"to produce,\" is from it, and so is English doughty, \"stout, valiant.\""
+            },
+            {
+              "kind": "speech",
+              "text": "One trap, since the shape invites it: English dough is not related. It comes from a different root meaning \"to knead, to form.\" Dūdh and dough look like cousins and are strangers."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "dūdh; then ek dūdh dījie",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *dūdh*; then *ek dūdh dījie*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the disagreeing pair — chāy feminine, dūdh masculine",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the disagreeing pair — *chāy* feminine, *dūdh* masculine]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what each one literally is — dugdha, \"the milked\"; pānīya, \"the drinkable\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what each one literally is — *dugdha*, \"the milked\"; *pānīya*, \"the drinkable\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "dūdh and dough — and that they are not related",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *dūdh* and *dough* — and that they are not related]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What part of speech was dugdha before it was milk? (A past participle — \"milked.\") Which Hindi word plays the same trick, and how? (पानी — pānīya, \"the drinkable thing.\") Is English dough a cousin of dūdh? (No — different root; doughty is the real one.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C37-khaana",
+      "sequence": 750,
+      "title": "खाना (khānā) — \"food,\" and the dot that separates it from a house",
+      "headword": "खाना",
+      "romanization": "",
+      "gloss": "food — masculine, from a Sanskrit verb of eating, and not to be confused with its Persian look-alike meaning \"house\"",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:c20131f51974a639",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Drink is behind you. This is the general word for what you eat — and it has a twin on the page that means something else entirely."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "खा, ना — two syllables, and the ा does both."
+            },
+            {
+              "kind": "speech",
+              "text": "ख (kha) takes ा becomes खा. Then न (na), your very first letter, takes ा becomes ना. The ा is the mātrā that replaces a consonant's built-in a with a long one, exactly as in नाम."
+            },
+            {
+              "kind": "speech",
+              "text": "Two consonants, one mark used twice, and the word is yours."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: one word doing two jobs",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "खाना (khānā) = \"food,\" and it is masculine — long -ā, and this time the lean holds. Unlike दूध, whose name is a participle, this one is plainly a thing."
+            },
+            {
+              "kind": "speech",
+              "text": "It is also the verb \"to eat.\" Same spelling, same sound: the infinitive doubles as a noun, the way English says the eating was good."
+            },
+            {
+              "kind": "speech",
+              "text": "So खाना दीजिए is \"give me food,\" and खाना alone can be the act. Which one you mean, the sentence decides."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: खाना — and its twin",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Both come from Sanskrit खाद् (khād-), \"to eat\" — the noun through खादन (khādana), \"the act of eating, food,\" and the verb through खादति (khādati), \"eats.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Now the twin. Hindi also has ख़ाना (khāna) — with the nuqta under the first letter — and it is Persian, خانه (xāna), \"house, compartment, section.\" You meet it inside दवाख़ाना (davākhāna), a \"medicine-house\": a pharmacy."
+            },
+            {
+              "kind": "speech",
+              "text": "Two unrelated words, one from Sanskrit and one from Persian, separated on the page by a single dot. And here is the honest part: that dot is very often left off. In ordinary printing and handwriting both are simply written खाना, and the reader is expected to sort it out from context. The nuqta tells you where a sound came from — when somebody bothers to write it."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "khānā; then khānā dījie",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *khānā*; then *khānā dījie*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three requests together — ek chāy dījie, ek dūdh dījie, khānā dījie",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three requests together — *ek chāy dījie, ek dūdh dījie, khānā dījie*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "roṭī and khānā — the particular bread and the general word for food",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *roṭī* and *khānā* — the particular bread and the general word for food]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "khānā and khāna — food and house; then davākhāna, the medicine-house",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *khānā* and *khāna* — food and house; then *davākhāna*, the medicine-house]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What two jobs does खाना do? (Food, and the verb to eat.) What is ख़ाना, and where does it come from? (House, compartment — Persian خانه, as in davākhāna.) Can you always tell them apart on the page? (No — the nuqta is often dropped, and context decides.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C37-kitaab",
+      "sequence": 760,
+      "title": "किताब (kitāb) — a book, and the root it is cut from",
+      "headword": "किताब",
+      "romanization": "",
+      "gloss": "book — feminine, built on the Arabic root for writing, and one of three Hindi words for a book that differ by register",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:1b10f6f9c32998db",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Not something to eat — something to ask for. Its Arabic root hands you three more words free."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "कि, ता, ब — the first mark is the tricky one."
+            },
+            {
+              "kind": "speech",
+              "text": "क with the short ि gives कि (ki): the ि is drawn to the left of क and sounded after it, never ik. Then ता, then ब keeping its built-in a."
+            },
+            {
+              "kind": "speech",
+              "text": "क and त showed you Devanagari's mouth-map: क far back at the soft palate, त at the teeth. Say ki-tā-b and feel the tongue travel."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: feminine, and no ending to prove it",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "किताब (kitāb) = \"book,\" and it is feminine — मेरी किताब."
+            },
+            {
+              "kind": "speech",
+              "text": "The second consonant-final noun to turn out feminine, after चाय. Two of this chapter's four disobey any guess their shape allows."
+            },
+            {
+              "kind": "speech",
+              "text": "Which is the real lesson: Hindi gender is information about the word, not the thing and not the spelling."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: किताब",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "किताब is Arabic, كتاب, come by the Persian road कुर्सी took."
+            },
+            {
+              "kind": "speech",
+              "text": "Arabic builds words on three-consonant roots, and this one is k-t-b, \"write.\" Slot those three into different patterns and a family appears:"
+            },
+            {
+              "kind": "speech",
+              "text": "كتاب kitāb — a book, the thing written."
+            },
+            {
+              "kind": "speech",
+              "text": "كاتب kātib — a scribe, the one writing."
+            },
+            {
+              "kind": "speech",
+              "text": "مكتب maktab — a place of writing: an office, a school."
+            },
+            {
+              "kind": "speech",
+              "text": "Learn the root and you have a family, which is how much of Hindi's Perso-Arabic vocabulary is built underneath."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "input",
+          "title": "You'll want to know — three books, three registers",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Hindi has three words for a book, and they are not synonyms — they are registers."
+            },
+            {
+              "kind": "speech",
+              "text": "किताब — Perso-Arabic, the ordinary word. Say this one."
+            },
+            {
+              "kind": "speech",
+              "text": "पुस्तक (pustak) — straight out of Sanskrit. Libraries, textbooks, formal writing."
+            },
+            {
+              "kind": "speech",
+              "text": "पोथा (pothā) — the inherited descendant of that Sanskrit word. Old, homely, a bit dusty."
+            },
+            {
+              "kind": "speech",
+              "text": "You have met this split: कृपया is the pustak end of \"please,\" दीजिए the kitāb end."
+            },
+            {
+              "kind": "speech",
+              "text": "And that is the chapter — चाय from a Chinese port, दूध named for what was done to it, खाना shadowed by a Persian house, किताब cut from an Arabic root."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "kitāb, then merī kitāb",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *kitāb*, then *merī kitāb*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the chapter's four — merī chāy, merā dūdh, merā khānā, merī kitāb",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the chapter's four — *merī chāy, merā dūdh, merā khānā, merī kitāb*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the k-t-b family — kitāb, kātib, maktab",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the k-t-b family — *kitāb*, *kātib*, *maktab*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "kṛpayā for the sign; ek chāy dījie and māf kījie for the street",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *kṛpayā* for the sign; *ek chāy dījie* and *māf kījie* for the street]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Which two words here are feminine, and does their shape say so? (चाय and किताब — no, both end in consonants.) Give the k-t-b family. (Kitāb, kātib, maktab.) Which word for \"book\" do you say, and which belongs with कृपया? (किताब — पुस्तक is the formal one.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/hindi/narration/ch37.txt
+++ b/code/learning/human-languages/hindi/narration/ch37.txt
@@ -1,0 +1,166 @@
+Hindi, chapter 37: One Tea, Please.
+4 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
+
+
+Lesson 1 of 4.
+चाय (chāy) — tea, and how to actually ask for one.
+
+Warm-up.
+[pause 2 seconds]
+You are in the chair, in the room Portuguese named. Somebody is about to offer you this — and by the end of these few minutes you will be able to ask for it yourself, in the words people actually use.
+
+Grammar Lens: the lean fails, quietly.
+चाय (chāy) = "tea," and it is feminine.
+Nothing outside the word says so. It does not end in -ी the way कुर्सी does; it ends in a consonant, and the lean warned you a consonant ending tells you nothing. चाय is feminine and you simply learn it — now, with the word.
+
+You'll want to know — how you really ask.
+एक चाय दीजिए (ek chāy dījie) — "one tea, please."
+दीजिए is "give" spoken to आप: the polite request form. That -िए ending is the politeness. Nothing else is needed.
+Which means a correction. You learnt कृपया as "please," and it is a real word — but it belongs to signs, forms and station announcements. Across a counter it lands like kindly furnish me with tea.
+So: कृपया when you write, दीजिए when you speak. And you already have the shape — माफ़ कीजिए carries the very same -िए.
+
+The word, taken apart: चाय.
+चाय is Chinese. In most of China the word for the leaf is chá, which Persian took as چای (chāy) and handed to Hindi.
+Now the English word: tea. French thé, Dutch thee — a different sound entirely, for the identical leaf.
+They are the same word. China writes it with one character everywhere, but reads that character differently: in the Hokkien of the south-eastern coast it is tê, and Dutch ships bought their tea there.
+The tempting story is overland versus sea. It is wrong: Portuguese say chá, and Portuguese tea came by sea. The variable is which Chinese port a trader dealt with. Your word for tea records a harbour.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: chāy; then ek chāy dījie]
+[pause 8 seconds for the answer]
+[your turn — say: the same request for water — ek pānī dījie]
+[pause 8 seconds for the answer]
+[your turn — say: dījie and māf kījie one after the other — hear the shared -ie]
+[pause 8 seconds for the answer]
+[your turn — say: chā and tê — the two Chinese pronunciations, and which one English bought]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Is चाय masculine or feminine, and does its ending help? (Feminine — and no, a consonant ending never does.) Where does कृपया belong, and what carries the politeness when you speak? (Signs and announcements — in speech the -िए of dījie does it.) Are chāy and tea related? (The same Chinese word, bought at two different ports.)
+
+
+Lesson 2 of 4.
+दूध (dūdh) — "milk," which is really a verb wearing a noun's coat.
+
+Warm-up.
+[pause 2 seconds]
+What goes into the tea. And it is named the same sly way पानी was — by what happens to it, not by what it is.
+
+Grammar Lens: the pair that disagrees.
+दूध (dūdh) = "milk," and it is masculine.
+Which makes these two a useful pair, because they sit side by side in every cup and disagree: चाय feminine — the leaf that came by way of a Chinese port — and दूध masculine. Both end in consonants. Neither ending tells you anything. This is the ordinary state of a Hindi noun, and it is why the gender is part of the word, not an afterthought.
+एक दूध दीजिए — same request, new noun.
+
+The word, taken apart: दूध.
+दूध comes from Sanskrit दुग्ध (dugdha) — and dugdha is not a noun at all. It is a past participle of the verb दुह् (duh-), "to milk." It means "milked."
+So the substance is named for the act. Somebody said "the milked" often enough that the adjective hardened into a thing. You have seen this exact move already: पानी is pānīya, "the drinkable." Hindi's two commonest liquids are both named by what is done to them.
+Behind duh- stands the old root dʰewgʰ-, and its meaning is broader than milk: "to yield, to be strong, to be of use." Greek teúkhein, "to produce," is from it, and so is English doughty, "stout, valiant."
+One trap, since the shape invites it: English dough is not related. It comes from a different root meaning "to knead, to form." Dūdh and dough look like cousins and are strangers.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: dūdh; then ek dūdh dījie]
+[pause 8 seconds for the answer]
+[your turn — say: the disagreeing pair — chāy feminine, dūdh masculine]
+[pause 8 seconds for the answer]
+[your turn — say: what each one literally is — dugdha, "the milked"; pānīya, "the drinkable"]
+[pause 8 seconds for the answer]
+[your turn — say: dūdh and dough — and that they are not related]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What part of speech was dugdha before it was milk? (A past participle — "milked.") Which Hindi word plays the same trick, and how? (पानी — pānīya, "the drinkable thing.") Is English dough a cousin of dūdh? (No — different root; doughty is the real one.)
+
+
+Lesson 3 of 4.
+खाना (khānā) — "food," and the dot that separates it from a house.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Drink is behind you. This is the general word for what you eat — and it has a twin on the page that means something else entirely.
+
+The letters in this word.
+खा, ना — two syllables, and the ा does both.
+ख (kha) takes ा becomes खा. Then न (na), your very first letter, takes ा becomes ना. The ा is the mātrā that replaces a consonant's built-in a with a long one, exactly as in नाम.
+Two consonants, one mark used twice, and the word is yours.
+
+Grammar Lens: one word doing two jobs.
+खाना (khānā) = "food," and it is masculine — long -ā, and this time the lean holds. Unlike दूध, whose name is a participle, this one is plainly a thing.
+It is also the verb "to eat." Same spelling, same sound: the infinitive doubles as a noun, the way English says the eating was good.
+So खाना दीजिए is "give me food," and खाना alone can be the act. Which one you mean, the sentence decides.
+
+The word, taken apart: खाना — and its twin.
+Both come from Sanskrit खाद् (khād-), "to eat" — the noun through खादन (khādana), "the act of eating, food," and the verb through खादति (khādati), "eats."
+Now the twin. Hindi also has ख़ाना (khāna) — with the nuqta under the first letter — and it is Persian, خانه (xāna), "house, compartment, section." You meet it inside दवाख़ाना (davākhāna), a "medicine-house": a pharmacy.
+Two unrelated words, one from Sanskrit and one from Persian, separated on the page by a single dot. And here is the honest part: that dot is very often left off. In ordinary printing and handwriting both are simply written खाना, and the reader is expected to sort it out from context. The nuqta tells you where a sound came from — when somebody bothers to write it.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: khānā; then khānā dījie]
+[pause 8 seconds for the answer]
+[your turn — say: the three requests together — ek chāy dījie, ek dūdh dījie, khānā dījie]
+[pause 8 seconds for the answer]
+[your turn — say: roṭī and khānā — the particular bread and the general word for food]
+[pause 8 seconds for the answer]
+[your turn — say: khānā and khāna — food and house; then davākhāna, the medicine-house]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What two jobs does खाना do? (Food, and the verb to eat.) What is ख़ाना, and where does it come from? (House, compartment — Persian خانه, as in davākhāna.) Can you always tell them apart on the page? (No — the nuqta is often dropped, and context decides.)
+
+
+Lesson 4 of 4.
+किताब (kitāb) — a book, and the root it is cut from.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Not something to eat — something to ask for. Its Arabic root hands you three more words free.
+
+The letters in this word.
+कि, ता, ब — the first mark is the tricky one.
+क with the short ि gives कि (ki): the ि is drawn to the left of क and sounded after it, never ik. Then ता, then ब keeping its built-in a.
+क and त showed you Devanagari's mouth-map: क far back at the soft palate, त at the teeth. Say ki-tā-b and feel the tongue travel.
+
+Grammar Lens: feminine, and no ending to prove it.
+किताब (kitāb) = "book," and it is feminine — मेरी किताब.
+The second consonant-final noun to turn out feminine, after चाय. Two of this chapter's four disobey any guess their shape allows.
+Which is the real lesson: Hindi gender is information about the word, not the thing and not the spelling.
+
+The word, taken apart: किताब.
+किताब is Arabic, كتاب, come by the Persian road कुर्सी took.
+Arabic builds words on three-consonant roots, and this one is k-t-b, "write." Slot those three into different patterns and a family appears:
+كتاب kitāb — a book, the thing written.
+كاتب kātib — a scribe, the one writing.
+مكتب maktab — a place of writing: an office, a school.
+Learn the root and you have a family, which is how much of Hindi's Perso-Arabic vocabulary is built underneath.
+
+You'll want to know — three books, three registers.
+Hindi has three words for a book, and they are not synonyms — they are registers.
+किताब — Perso-Arabic, the ordinary word. Say this one.
+पुस्तक (pustak) — straight out of Sanskrit. Libraries, textbooks, formal writing.
+पोथा (pothā) — the inherited descendant of that Sanskrit word. Old, homely, a bit dusty.
+You have met this split: कृपया is the pustak end of "please," दीजिए the kitāb end.
+And that is the chapter — चाय from a Chinese port, दूध named for what was done to it, खाना shadowed by a Persian house, किताब cut from an Arabic root.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: kitāb, then merī kitāb]
+[pause 8 seconds for the answer]
+[your turn — say: the chapter's four — merī chāy, merā dūdh, merā khānā, merī kitāb]
+[pause 8 seconds for the answer]
+[your turn — say: the k-t-b family — kitāb, kātib, maktab]
+[pause 8 seconds for the answer]
+[your turn — say: kṛpayā for the sign; ek chāy dījie and māf kījie for the street]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Which two words here are feminine, and does their shape say so? (चाय and किताब — no, both end in consonants.) Give the k-t-b family. (Kitāb, kātib, maktab.) Which word for "book" do you say, and which belongs with कृपया? (किताब — पुस्तक is the formal one.)

--- a/code/learning/human-languages/hindi/narration/ch38.json
+++ b/code/learning/human-languages/hindi/narration/ch38.json
@@ -1,0 +1,712 @@
+{
+  "version": 1,
+  "language": "hindi",
+  "chapter": 38,
+  "title": "Six Words for Where It Hurts",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:c24fc0097c1f0772",
+  "lessons": [
+    {
+      "id": "HI-C38-aankh",
+      "sequence": 770,
+      "title": "आँख (āṁkh) — the eye, which is the same word in English",
+      "headword": "आँख",
+      "romanization": "",
+      "gloss": "eye — feminine, and a word-for-word cousin of English \"eye\" and Latin \"oculus\"",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:90b1e52415eb4bdd",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You have a head and a hand. Here is the part of the face — and this one is not merely related to its English translation. It is the same word."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "आँ, ख — and the mark on top is an old friend."
+            },
+            {
+              "kind": "speech",
+              "text": "आ is the standalone long ā. Over it sits ँ, the chandrabindu, the moon-dot, which sends the vowel up through the nose — exactly what it does in हाँ. Then ख (kha), breathy, with its inherent a still attached."
+            },
+            {
+              "kind": "speech",
+              "text": "So the word is a nasalised ā followed by kh: āṁkh, humming at the start."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: feminine, and one you will use daily",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "आँख (āṁkh) = \"eye,\" and it is feminine — मेरी आँख."
+            },
+            {
+              "kind": "speech",
+              "text": "Third feminine noun, third consonant ending: चाय, किताब, आँख. If you were still hoping the spelling would rescue you, let this settle it."
+            },
+            {
+              "kind": "speech",
+              "text": "And it is worth the effort, because these are the words a doctor asks about. मेरी आँख ठीक नहीं है — \"my eye is not well.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: आँख",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "आँख comes from Sanskrit अक्षि (akṣi), \"eye\" — and akṣi comes from the root h₃ekʷ-, which is one of the securest words in the whole family."
+            },
+            {
+              "kind": "speech",
+              "text": "Its descendants:"
+            },
+            {
+              "kind": "speech",
+              "text": "Latin oculus — inside English ocular, monocle, binoculars."
+            },
+            {
+              "kind": "speech",
+              "text": "Old English ēage, which is English eye itself."
+            },
+            {
+              "kind": "speech",
+              "text": "Lithuanian akìs, Armenian akn, and Greek ósse, the old dual form meaning \"the two eyes.\""
+            },
+            {
+              "kind": "speech",
+              "text": "A caution on the Greek, because the obvious candidate is a trap: ophthalmós is usually connected here, but its first part has never been explained, and serious opinion treats it as a pre-Greek word. Cite ósse and stay honest."
+            },
+            {
+              "kind": "speech",
+              "text": "हाथ had to travel a long, battered road from hasta. आँख barely travelled at all — akṣi to āṁkh is a short, clean walk, and at the far end of it an English speaker is saying a version of the same word."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "āṁkh, then merī āṁkh",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *āṁkh*, then *merī āṁkh*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three body words you now have — sir, hāth, āṁkh",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three body words you now have — *sir*, *hāth*, *āṁkh*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "hāṁ and āṁkh — the same moon-dot, the same hum",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *hāṁ* and *āṁkh* — the same moon-dot, the same hum]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "akṣi, oculus, eye — one root, three languages",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *akṣi*, *oculus*, *eye* — one root, three languages]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Is आँख masculine or feminine? (Feminine — merī āṁkh.) Which Greek word is the safe cousin, and which is the trap? (ósse is safe; ophthalmós is unexplained.) What does the ँ over the आ do, and where did you first meet it? (Nasalises the vowel — on हाँ.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C38-daant",
+      "sequence": 780,
+      "title": "दाँत (dāṁt) — the tooth, and the gender trap of this chapter",
+      "headword": "दाँत",
+      "romanization": "",
+      "gloss": "tooth — masculine, though it is built exactly like the feminine आँख, and a cousin of Latin dēns and English tooth",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:cb862bd64f6b136b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Built like the last word, spelled like the last word, and the opposite gender. This is the pair learners get wrong most often."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "दाँ, त — three known parts and no new letter at all."
+            },
+            {
+              "kind": "speech",
+              "text": "द (da) takes ा, and the ँ rides above the head-line for the nasal hum — the same chandrabindu that turns ह into हाँ, \"yes.\" Then त (ta)."
+            },
+            {
+              "kind": "speech",
+              "text": "Both द and त are made at the teeth — which is the whole point of Devanagari's mouth-map. The word for tooth is spelled with the two consonants your tongue makes against your teeth. Say dāṁt and feel where it happens."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: the trap",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "दाँत (dāṁt) = \"tooth,\" and it is masculine — मेरा दाँत."
+            },
+            {
+              "kind": "speech",
+              "text": "Now put the two side by side. आँख and दाँत: same long ā, same chandrabindu, same single final consonant, both parts of the body, both everyday. आँख is feminine. दाँत is masculine."
+            },
+            {
+              "kind": "speech",
+              "text": "There is no rule underneath that. There is no reasoning that gets you from one to the other. This is the pair to hold up whenever you are tempted to guess: मेरी आँख, मेरा दाँत."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: दाँत",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "दाँत is Sanskrit दन्त (danta), from h₃dónts — and like akṣi this is one of the family's best-attested words."
+            },
+            {
+              "kind": "speech",
+              "text": "Latin dēns, stem dentis — English dentist, dental, trident (a \"three-tooth\")."
+            },
+            {
+              "kind": "speech",
+              "text": "Greek odoús — English odontology."
+            },
+            {
+              "kind": "speech",
+              "text": "Old English tōþ, which is tooth."
+            },
+            {
+              "kind": "speech",
+              "text": "Two body parts in a row, both plain cousins of their English translations. That is not a coincidence about eyes and teeth; it is what a core inherited vocabulary looks like from the inside."
+            },
+            {
+              "kind": "speech",
+              "text": "And the older reading of h₃dónts makes it a participle of h₃ed-, \"to bite\" — so a tooth is \"the biting one,\" which is what खाना needs it for. Same move as दूध, \"the milked one\": name the thing after what happens."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "dāṁt, then merā dāṁt",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *dāṁt*, then *merā dāṁt*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the trap pair, twice — merī āṁkh, merā dāṁt; again",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the trap pair, twice — *merī āṁkh, merā dāṁt*; again]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "hāṁ, then dāṁt — the same moon-dot doing the same job",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *hāṁ*, then *dāṁt* — the same moon-dot doing the same job]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "danta, dēns, odoús, tooth — one word, four languages",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *danta*, *dēns*, *odoús*, *tooth* — one word, four languages]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two \"named for the action\" words — dugdha, the milked; the tooth, the biting one",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two \"named for the action\" words — *dugdha*, the milked; the tooth, the biting one]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "आँख and दाँत look alike — do they share a gender? (No — merī āṁkh, merā dāṁt.) Which English words carry the Latin form? (Dentist, dental, trident.) What does the older reading make a tooth? (The biting one — from a root meaning \"to bite.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C38-pair",
+      "sequence": 790,
+      "title": "पैर (pair) — the foot, and the ancestor it does not have",
+      "headword": "पैर",
+      "romanization": "",
+      "gloss": "foot — masculine, and NOT the descendant of Sanskrit pāda; that honour belongs to पाँव",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:adb4e1318685cd65",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Down from the head, past the hand, to what carries you. And this word's obvious ancestor turns out to belong to a different Hindi word."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "grammar",
+          "title": "Grammar Lens: masculine, and the sentence that uses it",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "पैर (pair) = \"foot,\" and it is masculine — मेरा पैर."
+            },
+            {
+              "kind": "speech",
+              "text": "The ै is a single mātrā for one vowel, ai — not a then i. One sign, one sound, sitting above the head-line on प."
+            },
+            {
+              "kind": "speech",
+              "text": "Now the sentence you would actually say to a doctor, using the नहीं you already have: मेरा पैर ठीक नहीं है — \"my foot is not well.\" Watch the नहीं sit directly before है, which is where Hindi puts its negation."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: पैर",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Here is the obvious guess, and it is wrong. Sanskrit has पाद (pāda), \"foot\" — long ā, famous, the source of English's borrowed pada- words. It looks like it must be the parent of pair. It is not."
+            },
+            {
+              "kind": "speech",
+              "text": "पाँव (pāṁv), Hindi's other everyday word for foot, is the descendant of पाद. पैर comes from the shorter Sanskrit stem पद् (pad-), through Prakrit paya, picking up a Middle Indo-Aryan -ra- ending on the way."
+            },
+            {
+              "kind": "speech",
+              "text": "So Hindi inherited the same body part twice, down two different stems of the same word — and both survive, side by side, meaning the same thing."
+            },
+            {
+              "kind": "speech",
+              "text": "Further back both are ped-, \"to walk, to tread\":"
+            },
+            {
+              "kind": "speech",
+              "text": "Latin pēs, stem pedis — pedal, pedestrian, pedicure."
+            },
+            {
+              "kind": "speech",
+              "text": "Greek poús, stem podós — podium, and the eight of an octopus."
+            },
+            {
+              "kind": "speech",
+              "text": "Old English fōt, which is foot."
+            },
+            {
+              "kind": "speech",
+              "text": "Three body words in three lessons, and every one of them is the same word your own language uses. हाथ had to be argued for through a sound change. These three simply are the cousins."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "pair, then merā pair",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *pair*, then *merā pair*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the four body words with their possessives — merā hāth, merī āṁkh, merā dāṁt, merā pair",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the four body words with their possessives — *merā hāth, merī āṁkh, merā dāṁt, merā pair*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "merā pair ṭhīk nahīṁ hai — and hear where the nahīṁ sits",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *merā pair ṭhīk nahīṁ hai* — and hear where the *nahīṁ* sits]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "which Hindi word came from pāda, and which from pad- (pāṁv; pair)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: which Hindi word came from *pāda*, and which from *pad-* (*pāṁv*; *pair*)]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Does पैर come from पाद? (No — from पद्; पाँव is the pāda one.) Which English words carry the Latin and Greek forms? (Pedal, pedestrian; podium, octopus.) Say \"my foot is not well,\" and say where नहीं goes. (Merā pair ṭhīk nahīṁ hai — immediately before है.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C38-pet",
+      "sequence": 800,
+      "title": "पेट (peṭ) — the belly, and a trail that genuinely stops",
+      "headword": "पेट",
+      "romanization": "",
+      "gloss": "stomach, belly — masculine, and the one word in this chapter with no clean ancestry at all",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:0605633691de8b02",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Three clean cousins in a row. This one breaks the run — and the break is worth more than another neat answer."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "पे, ट — one known letter, one known mātrā, one consonant to feel."
+            },
+            {
+              "kind": "speech",
+              "text": "प takes े, the mātrā that perches on the head-line and turns the built-in a into e — the second of the two vowel signs you practised on नाम and मेरा."
+            },
+            {
+              "kind": "speech",
+              "text": "Then ट: a retroflex ṭ, tongue-tip curled back, not the त of दाँत made flat against the teeth. Say dāṁt, then peṭ."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: masculine, and the whole set together",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "पेट (peṭ) = \"stomach, belly,\" and it is masculine — मेरा पेट."
+            },
+            {
+              "kind": "speech",
+              "text": "Now you can answer a doctor, and exactly one of the six takes मेरी: merā sir, merā hāth, merī āṁkh, merā dāṁt, merā pair, merā peṭ — feminine company for कुर्सी and किताब."
+            },
+            {
+              "kind": "speech",
+              "text": "The sentence, with नहीं in its usual place just before है: मेरा पेट ठीक नहीं है — which, said in India, means what it says and rather more."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: पेट",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "पेट goes back to Prakrit पेट्ट (peṭṭa) — and there the clean line ends."
+            },
+            {
+              "kind": "speech",
+              "text": "The mainstream account treats it as a Dravidian word taken into Indo-Aryan; compare reconstructed Dravidian poṭṭ-. Turner's comparative dictionary does not name Dravidian, but neither does he derive peṭṭa from any Sanskrit word: he only remarks that it sits close to Indo-Aryan words for \"basket.\" That resemblance is a note, not a derivation, and it is often quoted as one."
+            },
+            {
+              "kind": "speech",
+              "text": "So: the origin of पेट is unsettled, with Dravidian leading — the honesty रोटी needed, one lesson away from पानी, whose story is exact. A language is made of what people said, and some of that came from neighbours speaking something else."
+            },
+            {
+              "kind": "speech",
+              "text": "There is even a fingerprint: the retroflex consonants, the ट you just curled your tongue for, are the feature of Indian Indo-Aryan most often credited to long contact with Dravidian."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "all six — merā sir, merā hāth, merī āṁkh, merā dāṁt, merā pair, merā peṭ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: all six — *merā sir, merā hāth, merī āṁkh, merā dāṁt, merā pair, merā peṭ*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "merā peṭ ṭhīk nahīṁ hai; then merī āṁkh ṭhīk nahīṁ hai",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *merā peṭ ṭhīk nahīṁ hai*; then *merī āṁkh ṭhīk nahīṁ hai*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "every feminine noun you own — kursī, chāy, kitāb, āṁkh",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: every feminine noun you own — *kursī*, *chāy*, *kitāb*, *āṁkh*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three exact ancestries — āṁkh, dāṁt, pair; then the two unsettled — peṭ, roṭī",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three exact ancestries — *āṁkh*, *dāṁt*, *pair*; then the two unsettled — *peṭ*, *roṭī*]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Where does पेट come from? (Unsettled — Prakrit peṭṭa, most likely a Dravidian loan; the \"basket\" link is a resemblance.) Of your six body words, which takes मेरी? (आँख.) Which earlier word had the same honest dead end? (रोटी, beside पानी.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/hindi/narration/ch38.txt
+++ b/code/learning/human-languages/hindi/narration/ch38.txt
@@ -1,0 +1,170 @@
+Hindi, chapter 38: Six Words for Where It Hurts.
+4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+
+
+Lesson 1 of 4.
+आँख (āṁkh) — the eye, which is the same word in English.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You have a head and a hand. Here is the part of the face — and this one is not merely related to its English translation. It is the same word.
+
+The letters in this word.
+आँ, ख — and the mark on top is an old friend.
+आ is the standalone long ā. Over it sits ँ, the chandrabindu, the moon-dot, which sends the vowel up through the nose — exactly what it does in हाँ. Then ख (kha), breathy, with its inherent a still attached.
+So the word is a nasalised ā followed by kh: āṁkh, humming at the start.
+
+Grammar Lens: feminine, and one you will use daily.
+आँख (āṁkh) = "eye," and it is feminine — मेरी आँख.
+Third feminine noun, third consonant ending: चाय, किताब, आँख. If you were still hoping the spelling would rescue you, let this settle it.
+And it is worth the effort, because these are the words a doctor asks about. मेरी आँख ठीक नहीं है — "my eye is not well."
+
+The word, taken apart: आँख.
+आँख comes from Sanskrit अक्षि (akṣi), "eye" — and akṣi comes from the root h₃ekʷ-, which is one of the securest words in the whole family.
+Its descendants:
+Latin oculus — inside English ocular, monocle, binoculars.
+Old English ēage, which is English eye itself.
+Lithuanian akìs, Armenian akn, and Greek ósse, the old dual form meaning "the two eyes."
+A caution on the Greek, because the obvious candidate is a trap: ophthalmós is usually connected here, but its first part has never been explained, and serious opinion treats it as a pre-Greek word. Cite ósse and stay honest.
+हाथ had to travel a long, battered road from hasta. आँख barely travelled at all — akṣi to āṁkh is a short, clean walk, and at the far end of it an English speaker is saying a version of the same word.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: āṁkh, then merī āṁkh]
+[pause 8 seconds for the answer]
+[your turn — say: the three body words you now have — sir, hāth, āṁkh]
+[pause 8 seconds for the answer]
+[your turn — say: hāṁ and āṁkh — the same moon-dot, the same hum]
+[pause 8 seconds for the answer]
+[your turn — say: akṣi, oculus, eye — one root, three languages]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Is आँख masculine or feminine? (Feminine — merī āṁkh.) Which Greek word is the safe cousin, and which is the trap? (ósse is safe; ophthalmós is unexplained.) What does the ँ over the आ do, and where did you first meet it? (Nasalises the vowel — on हाँ.)
+
+
+Lesson 2 of 4.
+दाँत (dāṁt) — the tooth, and the gender trap of this chapter.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Built like the last word, spelled like the last word, and the opposite gender. This is the pair learners get wrong most often.
+
+The letters in this word.
+दाँ, त — three known parts and no new letter at all.
+द (da) takes ा, and the ँ rides above the head-line for the nasal hum — the same chandrabindu that turns ह into हाँ, "yes." Then त (ta).
+Both द and त are made at the teeth — which is the whole point of Devanagari's mouth-map. The word for tooth is spelled with the two consonants your tongue makes against your teeth. Say dāṁt and feel where it happens.
+
+Grammar Lens: the trap.
+दाँत (dāṁt) = "tooth," and it is masculine — मेरा दाँत.
+Now put the two side by side. आँख and दाँत: same long ā, same chandrabindu, same single final consonant, both parts of the body, both everyday. आँख is feminine. दाँत is masculine.
+There is no rule underneath that. There is no reasoning that gets you from one to the other. This is the pair to hold up whenever you are tempted to guess: मेरी आँख, मेरा दाँत.
+
+The word, taken apart: दाँत.
+दाँत is Sanskrit दन्त (danta), from h₃dónts — and like akṣi this is one of the family's best-attested words.
+Latin dēns, stem dentis — English dentist, dental, trident (a "three-tooth").
+Greek odoús — English odontology.
+Old English tōþ, which is tooth.
+Two body parts in a row, both plain cousins of their English translations. That is not a coincidence about eyes and teeth; it is what a core inherited vocabulary looks like from the inside.
+And the older reading of h₃dónts makes it a participle of h₃ed-, "to bite" — so a tooth is "the biting one," which is what खाना needs it for. Same move as दूध, "the milked one": name the thing after what happens.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: dāṁt, then merā dāṁt]
+[pause 8 seconds for the answer]
+[your turn — say: the trap pair, twice — merī āṁkh, merā dāṁt; again]
+[pause 8 seconds for the answer]
+[your turn — say: hāṁ, then dāṁt — the same moon-dot doing the same job]
+[pause 8 seconds for the answer]
+[your turn — say: danta, dēns, odoús, tooth — one word, four languages]
+[pause 8 seconds for the answer]
+[your turn — say: the two "named for the action" words — dugdha, the milked; the tooth, the biting one]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+आँख and दाँत look alike — do they share a gender? (No — merī āṁkh, merā dāṁt.) Which English words carry the Latin form? (Dentist, dental, trident.) What does the older reading make a tooth? (The biting one — from a root meaning "to bite.")
+
+
+Lesson 3 of 4.
+पैर (pair) — the foot, and the ancestor it does not have.
+
+Warm-up.
+[pause 2 seconds]
+Down from the head, past the hand, to what carries you. And this word's obvious ancestor turns out to belong to a different Hindi word.
+
+Grammar Lens: masculine, and the sentence that uses it.
+पैर (pair) = "foot," and it is masculine — मेरा पैर.
+The ै is a single mātrā for one vowel, ai — not a then i. One sign, one sound, sitting above the head-line on प.
+Now the sentence you would actually say to a doctor, using the नहीं you already have: मेरा पैर ठीक नहीं है — "my foot is not well." Watch the नहीं sit directly before है, which is where Hindi puts its negation.
+
+The word, taken apart: पैर.
+Here is the obvious guess, and it is wrong. Sanskrit has पाद (pāda), "foot" — long ā, famous, the source of English's borrowed pada- words. It looks like it must be the parent of pair. It is not.
+पाँव (pāṁv), Hindi's other everyday word for foot, is the descendant of पाद. पैर comes from the shorter Sanskrit stem पद् (pad-), through Prakrit paya, picking up a Middle Indo-Aryan -ra- ending on the way.
+So Hindi inherited the same body part twice, down two different stems of the same word — and both survive, side by side, meaning the same thing.
+Further back both are ped-, "to walk, to tread":
+Latin pēs, stem pedis — pedal, pedestrian, pedicure.
+Greek poús, stem podós — podium, and the eight of an octopus.
+Old English fōt, which is foot.
+Three body words in three lessons, and every one of them is the same word your own language uses. हाथ had to be argued for through a sound change. These three simply are the cousins.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: pair, then merā pair]
+[pause 8 seconds for the answer]
+[your turn — say: the four body words with their possessives — merā hāth, merī āṁkh, merā dāṁt, merā pair]
+[pause 8 seconds for the answer]
+[your turn — say: merā pair ṭhīk nahīṁ hai — and hear where the nahīṁ sits]
+[pause 8 seconds for the answer]
+[your turn — say: which Hindi word came from pāda, and which from pad- (pāṁv; pair)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Does पैर come from पाद? (No — from पद्; पाँव is the pāda one.) Which English words carry the Latin and Greek forms? (Pedal, pedestrian; podium, octopus.) Say "my foot is not well," and say where नहीं goes. (Merā pair ṭhīk nahīṁ hai — immediately before है.)
+
+
+Lesson 4 of 4.
+पेट (peṭ) — the belly, and a trail that genuinely stops.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Three clean cousins in a row. This one breaks the run — and the break is worth more than another neat answer.
+
+The letters in this word.
+पे, ट — one known letter, one known mātrā, one consonant to feel.
+प takes े, the mātrā that perches on the head-line and turns the built-in a into e — the second of the two vowel signs you practised on नाम and मेरा.
+Then ट: a retroflex ṭ, tongue-tip curled back, not the त of दाँत made flat against the teeth. Say dāṁt, then peṭ.
+
+Grammar Lens: masculine, and the whole set together.
+पेट (peṭ) = "stomach, belly," and it is masculine — मेरा पेट.
+Now you can answer a doctor, and exactly one of the six takes मेरी: merā sir, merā hāth, merī āṁkh, merā dāṁt, merā pair, merā peṭ — feminine company for कुर्सी and किताब.
+The sentence, with नहीं in its usual place just before है: मेरा पेट ठीक नहीं है — which, said in India, means what it says and rather more.
+
+The word, taken apart: पेट.
+पेट goes back to Prakrit पेट्ट (peṭṭa) — and there the clean line ends.
+The mainstream account treats it as a Dravidian word taken into Indo-Aryan; compare reconstructed Dravidian poṭṭ-. Turner's comparative dictionary does not name Dravidian, but neither does he derive peṭṭa from any Sanskrit word: he only remarks that it sits close to Indo-Aryan words for "basket." That resemblance is a note, not a derivation, and it is often quoted as one.
+So: the origin of पेट is unsettled, with Dravidian leading — the honesty रोटी needed, one lesson away from पानी, whose story is exact. A language is made of what people said, and some of that came from neighbours speaking something else.
+There is even a fingerprint: the retroflex consonants, the ट you just curled your tongue for, are the feature of Indian Indo-Aryan most often credited to long contact with Dravidian.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: all six — merā sir, merā hāth, merī āṁkh, merā dāṁt, merā pair, merā peṭ]
+[pause 8 seconds for the answer]
+[your turn — say: merā peṭ ṭhīk nahīṁ hai; then merī āṁkh ṭhīk nahīṁ hai]
+[pause 8 seconds for the answer]
+[your turn — say: every feminine noun you own — kursī, chāy, kitāb, āṁkh]
+[pause 8 seconds for the answer]
+[your turn — say: the three exact ancestries — āṁkh, dāṁt, pair; then the two unsettled — peṭ, roṭī]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Where does पेट come from? (Unsettled — Prakrit peṭṭa, most likely a Dravidian loan; the "basket" link is a resemblance.) Of your six body words, which takes मेरी? (आँख.) Which earlier word had the same honest dead end? (रोटी, beside पानी.)

--- a/code/learning/human-languages/hindi/narration/ch39.json
+++ b/code/learning/human-languages/hindi/narration/ch39.json
@@ -1,0 +1,661 @@
+{
+  "version": 1,
+  "language": "hindi",
+  "chapter": 39,
+  "title": "The People Around You",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:8caddac03ed8c336",
+  "lessons": [
+    {
+      "id": "HI-C39-dost",
+      "sequence": 810,
+      "title": "दोस्त (dost) — the friend, who is \"the one chosen\"",
+      "headword": "दोस्त",
+      "romanization": "",
+      "gloss": "friend — a Persian word for \"the one chosen\", masculine by default but taking either possessive depending on who the friend is",
+      "script": "devanagari",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:245865f8519a8100",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You can name a brother and a sister. Here is the person you picked rather than were given, and the word says exactly that."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "दो, स्त — an ending you have already assembled by hand."
+            },
+            {
+              "kind": "speech",
+              "text": "द with ो gives दो. Then स्त — स stripped of its built-in a by the virāma, fusing with त into one conjunct: the cluster inside नमस्ते, the first conjunct you ever wrote."
+            },
+            {
+              "kind": "speech",
+              "text": "So मेरा दोस्त is built entirely from strokes already yours."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: the noun that leans on who you mean",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "दोस्त (dost) = \"friend,\" and in the dictionary it is masculine — मेरा दोस्त."
+            },
+            {
+              "kind": "speech",
+              "text": "But it bends. When the friend is a woman, ordinary modern Hindi says मेरी दोस्त. The word has not changed shape; the possessive followed the person. Both are current; neither is a mistake."
+            },
+            {
+              "kind": "speech",
+              "text": "That is unlike everything so far. आँख is feminine whatever you mean. दोस्त takes its gender from who the friend is."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart: दोस्त",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "दोस्त is Persian, دوست (dōst); Old Persian had dauštā, an agent noun, \"the one held dear.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Its root is ǵews-, and the old meaning is not \"love\" but \"to taste, to try, to choose.\" Sanskrit inherited it as जुष् (juṣ-). Latin has gustāre — English gusto, disgust — and English choose is the same root."
+            },
+            {
+              "kind": "speech",
+              "text": "So a dōst is one you have tried and chosen; the narrowing to \"beloved\" happened inside the Indo-Iranian branch alone."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "input",
+          "title": "You'll want to know — why it starts with a d",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The consonant at the front of this root came out as z- in Avestan and d- in Old Persian, by a regular sound law across the vocabulary."
+            },
+            {
+              "kind": "speech",
+              "text": "Which is why \"friend\" starts with द in Persian and Hindi while its Sanskrit cousin juṣ- starts with something else. An initial consonant is a passport stamp: it says which road the word came by."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "merā dost for a man, merī dost for a woman",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *merā dost* for a man, *merī dost* for a woman]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the given and the chosen — merā bhāī, merī bahin, merā dost",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the given and the chosen — *merā bhāī, merī bahin, merā dost*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "namaste, then dost — one conjunct",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *namaste*, then *dost* — one conjunct]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "dōst, juṣ-, gustāre, choose",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *dōst*, *juṣ-*, *gustāre*, *choose*]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "How do you say \"my friend\" about a woman? (मेरी दोस्त — the possessive follows the person.) What did the root behind dōst first mean? (To taste, try, choose.) Why does Persian say d- where Avestan says z-? (A regular sound law.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C39-baccha",
+      "sequence": 820,
+      "title": "बच्चा (bacchā) — the child, who is a \"yearling\"",
+      "headword": "बच्चा",
+      "romanization": "",
+      "gloss": "child — masculine, with a feminine बच्ची, and a Persian word that landed on top of an inherited Sanskrit cousin",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:585b746e54384286",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You have पिता and माता. Here is the third person at that table — and this word finally lets the masculine and feminine forms stand side by side."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "grammar",
+          "title": "Grammar Lens: a pair you can see",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "बच्चा (bacchā) = \"child,\" masculine — मेरा बच्चा."
+            },
+            {
+              "kind": "speech",
+              "text": "Here the lean does real work at last. Swap the final -ा for -ी and you get बच्ची (bacchī), a girl child, feminine — मेरी बच्ची."
+            },
+            {
+              "kind": "speech",
+              "text": "This is what दरवाज़ा and कुर्सी only hinted at: for this class of noun -ā/-ī is not a lean but the machinery, and the word changes with the person. Which is exactly what दोस्त would not do."
+            },
+            {
+              "kind": "speech",
+              "text": "You already know how to ask this child's age: कितने साल के हो? — how many years someone is of, rather than how many they have."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: बच्चा",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "बच्चा is Persian, بچه (bacca) — and the obvious story is wrong."
+            },
+            {
+              "kind": "speech",
+              "text": "Persian bacca did not come from Sanskrit वत्स (vatsa), \"calf, young one.\" The two are sisters: one Indo-Iranian word inherited down two separate branches. Centuries later the Persian one was borrowed into Hindi — which had already inherited the Sanskrit one as बछड़ा (bachṛā), \"calf.\""
+            },
+            {
+              "kind": "speech",
+              "text": "So Hindi holds both, the same ancient word by two roads — the pattern दरवाज़ा and द्वार showed you, running again, and the same Persian relay that brought दोस्त."
+            },
+            {
+              "kind": "speech",
+              "text": "Behind both stands wet-, \"year.\" Latin vetus, \"old,\" is from it — English veteran — and so are Latin vitulus, \"calf,\" and English wether, a yearling sheep."
+            },
+            {
+              "kind": "speech",
+              "text": "A child, at the root, is a yearling. पिता and माता are named by relationship; बच्चा is named by age."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "bacchā and bacchī; then merā bacchā, merī bacchī",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *bacchā* and *bacchī*; then *merā bacchā*, *merī bacchī*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the family — merā pitā, merī mātā, merā bacchā",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the family — *merā pitā, merī mātā, merā bacchā*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two roads — bacchā from Persian, bachṛā inherited; one word",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two roads — *bacchā* from Persian, *bachṛā* inherited; one word]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "vetus, vitulus, wether — and the meaning under all of them (year)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *vetus*, *vitulus*, *wether* — and the meaning under all of them (year)]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What is the feminine of बच्चा, and how does the possessive move? (बच्ची — merā bacchā, merī bacchī.) Is Persian bacca descended from Sanskrit vatsa? (No — they are sisters; Hindi's inherited cousin is बछड़ा.) What does the root mean? (Year — a child is a yearling.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C39-aadmi",
+      "sequence": 830,
+      "title": "आदमी (ādmī) — the man, and the lean breaking backwards",
+      "headword": "आदमी",
+      "romanization": "",
+      "gloss": "man, person — masculine despite its -ī ending, and literally \"of Adam\"",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:5b0959e1158d768d",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The child has grown up. And this word does what none so far has — it ends in -ी and is masculine anyway."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "grammar",
+          "title": "Grammar Lens: the lean breaks the other way",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "आदमी (ādmī) = \"man, person,\" and it is masculine. Say एक आदमी — it is also the ordinary word for \"person\" in general, and stays masculine doing that. Ask कितने साल के हो? of him and you are asking how many years he is of, the way Hindi counts age."
+            },
+            {
+              "kind": "speech",
+              "text": "A warning before you reach for the possessive: मेरा आदमी is real Hindi but means what English's my man means. Keep एक आदमी."
+            },
+            {
+              "kind": "speech",
+              "text": "The gender still shows the instant anything agrees with the noun. Put it beside कुर्सी: both end in long -ी, one is feminine, one masculine, and no reasoning takes you from the ending to the answer. Beside बच्चा / बच्ची, where the ending does carry the gender, the contrast is sharper."
+            },
+            {
+              "kind": "speech",
+              "text": "So the lean has failed in both directions: चाय and किताब feminine with no -ी, आदमी masculine with one."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: आदमी",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "आदमी is Arabic, آدمي (ādamī), and it came the Persian way — the road of कुर्सी and किताब."
+            },
+            {
+              "kind": "speech",
+              "text": "Now the ending. That -ī is not Hindi at all. It is the Arabic ending meaning \"belonging to, of the kind of.\" Attach it to آدم (Ādam) and you get \"of Adam.\" A human being, in this word, is one of Adam's."
+            },
+            {
+              "kind": "speech",
+              "text": "آدم is Hebrew ʾādām, and here care is needed. You have probably heard that ʾādām comes from ʾadāmāh, \"ground\" — man made of earth. Genesis sets the two side by side and means you to notice: a deliberate pun, and a famous one."
+            },
+            {
+              "kind": "speech",
+              "text": "It is not the etymology. The prevailing view links the root ʾ-d-m to redness — behind Hebrew ʾādōm, \"red,\" and Edom. Beyond that, unsettled."
+            },
+            {
+              "kind": "speech",
+              "text": "Worth keeping: a wordplay a text makes on purpose is not where a word came from."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ādmī, then ek ādmī",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *ādmī*, then *ek ādmī*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "kursī feminine, ādmī masculine; then merī kursī, and stop",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *kursī* feminine, *ādmī* masculine; then *merī kursī*, and stop]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the lean, and both ways it fails — chāy, kitāb, ādmī",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the lean, and both ways it fails — *chāy*, *kitāb*, *ādmī*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what the -ī on ādamī means",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what the **-ī** on *ādamī* means]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "कुर्सी and आदमी end alike — same gender? (No.) What is the -ī of ādamī doing? (Arabic \"belonging to\" — \"of Adam.\") Is ʾādām from the word for ground? (No — Genesis is making a deliberate pun; the root is usually connected to redness.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "HI-C39-aurat",
+      "sequence": 840,
+      "title": "औरत (aurat) — the word for \"woman,\" and which one to use",
+      "headword": "औरत",
+      "romanization": "",
+      "gloss": "woman — feminine, an Arabic word that only came to mean \"woman\" in Persian, and one of three Hindi words separated by register",
+      "script": "devanagari",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:78acad32b8b61cfe",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The last word of the chapter, and the one where Hindi hands you a choice rather than a word."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "grammar",
+          "title": "Grammar Lens: the pair, and the family complete",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "औरत (aurat) = \"woman,\" and it is feminine. Say एक औरत — and for the reason एक आदमी was the safe phrase, leave मेरी औरत alone: it means my woman, a wife. औ is one vowel letter, au, standing alone."
+            },
+            {
+              "kind": "speech",
+              "text": "Consonant ending, feminine — as चाय, किताब and आँख were. Beside it आदमी: -ी ending, masculine. Neither adult's gender is reachable from spelling. Where you can hear the agreement is on the child: मेरा बच्चा, मेरी बच्ची, the yearling who takes the ending seriously."
+            },
+            {
+              "kind": "speech",
+              "text": "The family: पिता, माता, भाई, बहन, बच्चा, आदमी, औरत — and the chosen one, दोस्त."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart: औरत",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "औरत is Arabic, عورة (ʿawra), on the three-consonant root ʿ-w-r — built the way k-t-b built किताब — whose senses run to a weak point, a gap in a defence, something left uncovered."
+            },
+            {
+              "kind": "speech",
+              "text": "Then the fact that changes what you do with all that: Arabic ʿawra does not mean \"woman.\" That sense is a Persian development. Persian moved the noun to mean a woman or a wife and handed that to Hindi and Urdu, on record from around 1420 — the same Persian relay that carried दोस्त."
+            },
+            {
+              "kind": "speech",
+              "text": "So the harsh root sense is not a claim Arabic makes about women. It is the earlier life of a word another language repurposed."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "input",
+          "title": "You'll want to know — three words, and which to say",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Three words, and the choice is register, exactly as for किताब / पुस्तक / पोथा."
+            },
+            {
+              "kind": "speech",
+              "text": "औरत — Perso-Arabic, plain and everyday. Common in speech; some speakers avoid it formally, partly because of the origin above."
+            },
+            {
+              "kind": "speech",
+              "text": "महिला (mahilā) — a Sanskrit borrowing, the respectful, public word: signs, announcements, official prose. Its Sanskrit origin is uncertain; one serious proposal traces it to Dravidian."
+            },
+            {
+              "kind": "speech",
+              "text": "स्त्री (strī) — Sanskrit, older and literary. Secure back to Indo-Iranian, no further."
+            },
+            {
+              "kind": "speech",
+              "text": "महिला where you would write, औरत where you would talk."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ek aurat, then ek ādmī — neither ending gives its gender away",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *ek aurat*, then *ek ādmī* — neither ending gives its gender away]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "merā pitā, merī mātā, merā bhāī, merī bahin, merā bacchā, merī bacchī",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *merā pitā, merī mātā, merā bhāī, merī bahin, merā bacchā, merī bacchī*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "merā dost, then merī dost",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: *merā dost*, then *merī dost*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "every feminine noun you own — kursī, chāy, kitāb, āṁkh, bacchī",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: every feminine noun you own — *kursī, chāy, kitāb, āṁkh, bacchī*]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Does Arabic عورة mean \"woman\"? (No — that sense is Persian.) Which goes on a public sign, which in conversation? (महिला written; औरत spoken.) Your family, minding every possessive? (Merā pitā, merī mātā, merā bhāī, merī bahin, merā bacchā.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/hindi/narration/ch39.txt
+++ b/code/learning/human-languages/hindi/narration/ch39.txt
@@ -1,0 +1,158 @@
+Hindi, chapter 39: The People Around You.
+4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+
+
+Lesson 1 of 4.
+दोस्त (dost) — the friend, who is "the one chosen".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You can name a brother and a sister. Here is the person you picked rather than were given, and the word says exactly that.
+
+The letters in this word.
+दो, स्त — an ending you have already assembled by hand.
+द with ो gives दो. Then स्त — स stripped of its built-in a by the virāma, fusing with त into one conjunct: the cluster inside नमस्ते, the first conjunct you ever wrote.
+So मेरा दोस्त is built entirely from strokes already yours.
+
+Grammar Lens: the noun that leans on who you mean.
+दोस्त (dost) = "friend," and in the dictionary it is masculine — मेरा दोस्त.
+But it bends. When the friend is a woman, ordinary modern Hindi says मेरी दोस्त. The word has not changed shape; the possessive followed the person. Both are current; neither is a mistake.
+That is unlike everything so far. आँख is feminine whatever you mean. दोस्त takes its gender from who the friend is.
+
+The word, taken apart: दोस्त.
+दोस्त is Persian, دوست (dōst); Old Persian had dauštā, an agent noun, "the one held dear."
+Its root is ǵews-, and the old meaning is not "love" but "to taste, to try, to choose." Sanskrit inherited it as जुष् (juṣ-). Latin has gustāre — English gusto, disgust — and English choose is the same root.
+So a dōst is one you have tried and chosen; the narrowing to "beloved" happened inside the Indo-Iranian branch alone.
+
+You'll want to know — why it starts with a d.
+The consonant at the front of this root came out as z- in Avestan and d- in Old Persian, by a regular sound law across the vocabulary.
+Which is why "friend" starts with द in Persian and Hindi while its Sanskrit cousin juṣ- starts with something else. An initial consonant is a passport stamp: it says which road the word came by.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: merā dost for a man, merī dost for a woman]
+[pause 8 seconds for the answer]
+[your turn — say: the given and the chosen — merā bhāī, merī bahin, merā dost]
+[pause 8 seconds for the answer]
+[your turn — say: namaste, then dost — one conjunct]
+[pause 8 seconds for the answer]
+[your turn — say: dōst, juṣ-, gustāre, choose]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+How do you say "my friend" about a woman? (मेरी दोस्त — the possessive follows the person.) What did the root behind dōst first mean? (To taste, try, choose.) Why does Persian say d- where Avestan says z-? (A regular sound law.)
+
+
+Lesson 2 of 4.
+बच्चा (bacchā) — the child, who is a "yearling".
+
+Warm-up.
+[pause 2 seconds]
+You have पिता and माता. Here is the third person at that table — and this word finally lets the masculine and feminine forms stand side by side.
+
+Grammar Lens: a pair you can see.
+बच्चा (bacchā) = "child," masculine — मेरा बच्चा.
+Here the lean does real work at last. Swap the final -ा for -ी and you get बच्ची (bacchī), a girl child, feminine — मेरी बच्ची.
+This is what दरवाज़ा and कुर्सी only hinted at: for this class of noun -ā/-ī is not a lean but the machinery, and the word changes with the person. Which is exactly what दोस्त would not do.
+You already know how to ask this child's age: कितने साल के हो? — how many years someone is of, rather than how many they have.
+
+The word, taken apart: बच्चा.
+बच्चा is Persian, بچه (bacca) — and the obvious story is wrong.
+Persian bacca did not come from Sanskrit वत्स (vatsa), "calf, young one." The two are sisters: one Indo-Iranian word inherited down two separate branches. Centuries later the Persian one was borrowed into Hindi — which had already inherited the Sanskrit one as बछड़ा (bachṛā), "calf."
+So Hindi holds both, the same ancient word by two roads — the pattern दरवाज़ा and द्वार showed you, running again, and the same Persian relay that brought दोस्त.
+Behind both stands wet-, "year." Latin vetus, "old," is from it — English veteran — and so are Latin vitulus, "calf," and English wether, a yearling sheep.
+A child, at the root, is a yearling. पिता and माता are named by relationship; बच्चा is named by age.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: bacchā and bacchī; then merā bacchā, merī bacchī]
+[pause 8 seconds for the answer]
+[your turn — say: the family — merā pitā, merī mātā, merā bacchā]
+[pause 8 seconds for the answer]
+[your turn — say: the two roads — bacchā from Persian, bachṛā inherited; one word]
+[pause 8 seconds for the answer]
+[your turn — say: vetus, vitulus, wether — and the meaning under all of them (year)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What is the feminine of बच्चा, and how does the possessive move? (बच्ची — merā bacchā, merī bacchī.) Is Persian bacca descended from Sanskrit vatsa? (No — they are sisters; Hindi's inherited cousin is बछड़ा.) What does the root mean? (Year — a child is a yearling.)
+
+
+Lesson 3 of 4.
+आदमी (ādmī) — the man, and the lean breaking backwards.
+
+Warm-up.
+[pause 2 seconds]
+The child has grown up. And this word does what none so far has — it ends in -ी and is masculine anyway.
+
+Grammar Lens: the lean breaks the other way.
+आदमी (ādmī) = "man, person," and it is masculine. Say एक आदमी — it is also the ordinary word for "person" in general, and stays masculine doing that. Ask कितने साल के हो? of him and you are asking how many years he is of, the way Hindi counts age.
+A warning before you reach for the possessive: मेरा आदमी is real Hindi but means what English's my man means. Keep एक आदमी.
+The gender still shows the instant anything agrees with the noun. Put it beside कुर्सी: both end in long -ी, one is feminine, one masculine, and no reasoning takes you from the ending to the answer. Beside बच्चा / बच्ची, where the ending does carry the gender, the contrast is sharper.
+So the lean has failed in both directions: चाय and किताब feminine with no -ी, आदमी masculine with one.
+
+The word, taken apart: आदमी.
+आदमी is Arabic, آدمي (ādamī), and it came the Persian way — the road of कुर्सी and किताब.
+Now the ending. That -ī is not Hindi at all. It is the Arabic ending meaning "belonging to, of the kind of." Attach it to آدم (Ādam) and you get "of Adam." A human being, in this word, is one of Adam's.
+آدم is Hebrew ʾādām, and here care is needed. You have probably heard that ʾādām comes from ʾadāmāh, "ground" — man made of earth. Genesis sets the two side by side and means you to notice: a deliberate pun, and a famous one.
+It is not the etymology. The prevailing view links the root ʾ-d-m to redness — behind Hebrew ʾādōm, "red," and Edom. Beyond that, unsettled.
+Worth keeping: a wordplay a text makes on purpose is not where a word came from.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: ādmī, then ek ādmī]
+[pause 8 seconds for the answer]
+[your turn — say: kursī feminine, ādmī masculine; then merī kursī, and stop]
+[pause 8 seconds for the answer]
+[your turn — say: the lean, and both ways it fails — chāy, kitāb, ādmī]
+[pause 8 seconds for the answer]
+[your turn — say: what the -ī on ādamī means]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+कुर्सी and आदमी end alike — same gender? (No.) What is the -ī of ādamī doing? (Arabic "belonging to" — "of Adam.") Is ʾādām from the word for ground? (No — Genesis is making a deliberate pun; the root is usually connected to redness.)
+
+
+Lesson 4 of 4.
+औरत (aurat) — the word for "woman," and which one to use.
+
+Warm-up.
+[pause 2 seconds]
+The last word of the chapter, and the one where Hindi hands you a choice rather than a word.
+
+Grammar Lens: the pair, and the family complete.
+औरत (aurat) = "woman," and it is feminine. Say एक औरत — and for the reason एक आदमी was the safe phrase, leave मेरी औरत alone: it means my woman, a wife. औ is one vowel letter, au, standing alone.
+Consonant ending, feminine — as चाय, किताब and आँख were. Beside it आदमी: -ी ending, masculine. Neither adult's gender is reachable from spelling. Where you can hear the agreement is on the child: मेरा बच्चा, मेरी बच्ची, the yearling who takes the ending seriously.
+The family: पिता, माता, भाई, बहन, बच्चा, आदमी, औरत — and the chosen one, दोस्त.
+
+The word, taken apart: औरत.
+औरत is Arabic, عورة (ʿawra), on the three-consonant root ʿ-w-r — built the way k-t-b built किताब — whose senses run to a weak point, a gap in a defence, something left uncovered.
+Then the fact that changes what you do with all that: Arabic ʿawra does not mean "woman." That sense is a Persian development. Persian moved the noun to mean a woman or a wife and handed that to Hindi and Urdu, on record from around 1420 — the same Persian relay that carried दोस्त.
+So the harsh root sense is not a claim Arabic makes about women. It is the earlier life of a word another language repurposed.
+
+You'll want to know — three words, and which to say.
+Three words, and the choice is register, exactly as for किताब / पुस्तक / पोथा.
+औरत — Perso-Arabic, plain and everyday. Common in speech; some speakers avoid it formally, partly because of the origin above.
+महिला (mahilā) — a Sanskrit borrowing, the respectful, public word: signs, announcements, official prose. Its Sanskrit origin is uncertain; one serious proposal traces it to Dravidian.
+स्त्री (strī) — Sanskrit, older and literary. Secure back to Indo-Iranian, no further.
+महिला where you would write, औरत where you would talk.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: ek aurat, then ek ādmī — neither ending gives its gender away]
+[pause 8 seconds for the answer]
+[your turn — say: merā pitā, merī mātā, merā bhāī, merī bahin, merā bacchā, merī bacchī]
+[pause 8 seconds for the answer]
+[your turn — say: merā dost, then merī dost]
+[pause 8 seconds for the answer]
+[your turn — say: every feminine noun you own — kursī, chāy, kitāb, āṁkh, bacchī]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Does Arabic عورة mean "woman"? (No — that sense is Persian.) Which goes on a public sign, which in conversation? (महिला written; औरत spoken.) Your family, minding every possessive? (Merā pitā, merī mātā, merā bhāī, merī bahin, merā bacchā.)

--- a/code/learning/human-languages/hindi/roadmap.md
+++ b/code/learning/human-languages/hindi/roadmap.md
@@ -123,6 +123,52 @@ reading course.
   liked as subject — the same inversion Spanish reached in *me gusta* and
   Italian in *mi piace*, in another family, with no borrowing either way.
   **Authored.**
+- **Ch. 36 — One House, Four Languages** (`HI-C36-*`): *ghar* → *darvāzā* →
+  *kamrā* → *kursī*. One room, four sources. **घर** ← Sanskrit *gṛha*, and
+  *gṛha* is **not** from √*grah* "to seize" the way the grammarians' root-lists
+  suggest — it is PIE \**gʰerdʰ-* "**enclosure**," the root of English **yard**
+  and **garden** and the *-grad* of Belgrade, so a house was first a fenced
+  piece of ground. **दरवाज़ा** is Persian, and its *dar* is \**dʰwer-*, the same
+  ancient word as English **door** and Hindi's own learned **द्वार** — one word
+  arriving twice by two roads. **कमरा** is **Portuguese** *câmara*, hence
+  Latin *camera*, hence Hindi's later re-borrowing **कैमरा**. **कुर्सी** is
+  Arabic via Persian, a Wanderwort traceable back through Akkadian *kussû* to
+  Sumerian *guza* — and English *chair* (Greek *kathédra*) is no relation. The
+  payoff is the first **feminine** noun in the track: *merā* becomes *merī*.
+  **Authored.**
+- **Ch. 37 — One Tea, Please** (`HI-C37-*`): *chāy* → *dūdh* → *khānā* →
+  *kitāb*. **चाय** is Sinitic *chá* through Persian, while English *tea* is the
+  same leaf bought at a different Chinese port (Hokkien *tê*, carried by Dutch
+  ships) — not overland-versus-sea, since Portuguese *chá* came by sea.
+  **दूध** ← **दुग्ध** *dugdha*, a past participle: "the **milked**," the same
+  trick **पानी** plays as "the drinkable." **खाना** ← *khādana*, and its nuqta
+  twin **ख़ाना** is Persian *xāna*, "house" — two unrelated words separated on
+  the page by a dot that print routinely drops. **किताब** opens the Arabic
+  three-consonant root **k-t-b**, with *kātib* and *maktab* free. The chapter
+  also corrects **कृपया**: it is signage and announcements, and what carries
+  politeness in speech is the **-िए** of **दीजिए**. **Authored.**
+- **Ch. 38 — Six Words for Where It Hurts** (`HI-C38-*`): *āṁkh* → *dāṁt* →
+  *pair* → *peṭ*. Three flawless Indo-European cousins — **आँख** ← *akṣi* ←
+  \**h₃ekʷ-* (Latin *oculus*, English *eye*; the safe Greek cognate is *ósse*,
+  **not** *ophthalmós*, whose first element is unexplained); **दाँत** ← *danta*
+  ← \**h₃dónts* (*dēns*, *odoús*, *tooth*); **पैर**, which does **not** descend
+  from *pāda* — **पाँव** does — but from the shorter stem *pad-*, both on
+  \**ped-*. Then **पेट**, whose trail genuinely stops: Prakrit *peṭṭa*, most
+  likely a **Dravidian** loan, with the "basket" link a resemblance Turner
+  notes rather than a derivation. आँख and दाँत are the track's sharpest gender
+  trap: identical shape, opposite gender. **Authored.**
+- **Ch. 39 — The People Around You** (`HI-C39-*`): *dost* → *bacchā* → *ādmī* →
+  *aurat*. **दोस्त** is Persian *dōst* ← Old Persian *dauštā* on \**ǵews-* "to
+  **taste, try, choose**" (Sanskrit *juṣ-*, Latin *gustāre*, English
+  **choose**), and it starts with *d-* because Old Persian regularly turned the
+  Indo-Iranian consonant Avestan kept as *z-*. **बच्चा** is a Persian loan that
+  is a **sister**, not a descendant, of Sanskrit *vatsa* — whose own inherited
+  reflex Hindi already had as **बछड़ा** — and the root is \**wet-* "year," so a
+  child is a **yearling**. **आदमी** carries the Arabic *nisba* **-ī**,
+  "of Adam"; the Genesis link between *ʾādām* and *ʾadāmāh* "ground" is a
+  deliberate pun, **not** the etymology. **औरत** is Arabic *ʿawra* — but the
+  sense "woman" is a **Persian** development, not an Arabic one — beside
+  Sanskrit-derived **महिला** and **स्त्री**. **Authored.**
 
 ## Planned
 

--- a/code/learning/human-languages/hindi/session-map.md
+++ b/code/learning/human-languages/hindi/session-map.md
@@ -89,6 +89,38 @@ All thirteen of those earlier atoms had **never** been practised again anywhere
 in the corpus before this tranche. That is the HL09 §7 job these two chapters
 were built to do, alongside teaching the verbs.
 
+## Chapters 36–39 — the pre-A1 noun tranche
+
+Sixteen nouns, four per chapter, every lesson carrying its noun's **gender** as
+part of the atom. Reach-back runs at two cadences, as HL09 §7.2 asks: each
+lesson practises the preceding one to three lessons (which is what closes R1 at
+zero extra lessons), and each chapter's payoff reaches back several chapters to
+atoms nothing had revisited.
+
+| Lesson | Introduces | Reaches back to |
+|---|---|---|
+| ghar | *gṛha* ← \**gʰerdʰ-* "enclosure"; **yard**, **garden**; masculine | the शिरोरेखा (W01), र and स, मेरा नाम (W04) |
+| darvaaza | Persian *dar* ← \**dʰwer-*; the doublet द्वार; the nuqta | the ा mātrā (W03), नमस्ते by hand (W05), शुभ रात्रि (Ch. 27) |
+| kamra | Portuguese *câmara* → Latin *camera* → कैमरा | न and म (W01) |
+| kursi | Arabic via Persian ← Aramaic ← Akkadian ← Sumerian; feminine | the inherent अ (W02), preposed ि (W03), र/स (W04), the virāma and conjuncts (W05), शुभ रात्रि (Ch. 27) |
+| chai | Sinitic *chá* vs Hokkien *tê*; **दीजिए** carries the politeness | कृपया (Ch. 8), माफ़ कीजिए (Ch. 9), पानी (Ch. 15), एक (Ch. 6), कमरा |
+| dudh | *dugdha*, "the milked" — a participle turned noun | पानी, "the drinkable" (Ch. 15) |
+| khaana | *khādana*; the nuqta twin ख़ाना ← Persian *xāna* | न and म (W01), the ा mātrā (W03), रोटी (Ch. 15) |
+| kitaab | the Arabic root **k-t-b**; किताब / पुस्तक / पोथा by register | क and त and the mouth-map (W02), preposed ि (W03), कृपया (Ch. 8), माफ़ कीजिए (Ch. 9) |
+| aankh | *akṣi* ← \**h₃ekʷ-*; *oculus*, *eye*, *ósse* not *ophthalmós* | सिर and हाथ (Ch. 13), the chandrabindu of हाँ (Ch. 7) |
+| daant | *danta* ← \**h₃dónts*; "the biting one" | the head-line (W01), क/त (W02), हाँ (Ch. 7), सिर (Ch. 13), खाना |
+| pair | *pad-*, **not** *pāda* — पाँव is the *pāda* one | हाथ (Ch. 13), नहीं (Ch. 7) |
+| pet | Prakrit *peṭṭa*, probably Dravidian; the trail stops | the े mātrā (W03), सिर and हाथ (Ch. 13), नहीं (Ch. 7), पानी and रोटी (Ch. 15) |
+| dost | Persian *dōst* ← \**ǵews-* "taste, try, choose"; z- vs d- | भाई and बहन (Ch. 12), the virāma and conjuncts (W05), नमस्ते and मेरा नाम by hand (W04, W05) |
+| baccha | Persian *bacca*, sister of *vatsa*; \**wet-* "year" | पिता and माता (Ch. 12), कितने साल के हो (Ch. 19) |
+| aadmi | Arabic *nisba* **-ī**, "of Adam"; the Genesis pun is not etymology | कितने साल के हो (Ch. 19), कुर्सी and किताब |
+| aurat | Arabic *ʿawra*; the "woman" sense is **Persian** | भाई/बहन and पिता/माता (Ch. 12), किताब's register ladder |
+
+**All thirty-nine** pre-A1 atoms the corpus reported as revisited fewer than
+twice before this branch are rescued here. What is left is four atoms, all
+introduced by these chapters' own last lessons, which nothing later exists to
+revisit — a structural tail, not an oversight.
+
 ## Next
 
 Chapter 6 — postpositions (*ko, se, meṁ, par*) and the ergative *ne*.

--- a/code/learning/human-languages/tamil/CHANGELOG.md
+++ b/code/learning/human-languages/tamil/CHANGELOG.md
@@ -1,5 +1,104 @@
 # Changelog
 
+## Chapters 35–38 — fifteen everyday nouns, authored as a level-gate probe
+
+This tranche exists to answer a measurement question as much as a teaching one:
+**does authoring track-local pre-A1 vocabulary actually move
+`levelGate.tracks[tamil]`?** It does, and the size of the move is the finding.
+
+### What the gate did
+
+| figure | before | after |
+|---|---|---|
+| distinct headwords at or below pre-A1 | 33 | **48** |
+| `vocabulary` shortfall against the 300 target | 267 | **252** |
+| pre-A1 atoms revisited fewer than twice | 29 | **0** |
+| track-wide distinct headwords | 67 | **82** |
+| atoms never revisited (of atoms taught) | 48 of 126 | **37 of 156** |
+
+Fifteen new lessons moved the pre-A1 vocabulary count by **exactly fifteen**,
+because `vocabularyOf` counts **distinct headword strings, one per lesson** —
+not the words a lesson teaches. `TA-C12-kudumbam` teaches six kinship terms and
+counts as one; `TA-C15-thanneer-arisi` teaches three and counts as one. Closing
+a 267-headword gap therefore means roughly **267 more lessons at pre-A1**, which
+is the same arithmetic HL09 §3 already published (~150 lessons for the first 300
+words, at ~2 words per lesson) arriving from the other direction.
+
+The **reinforcement** criterion behaved very differently: it went from 29 to
+**zero**, because a payoff can rescue many atoms at once. Reinforcement debt is
+cheap to clear by authoring; vocabulary debt is not.
+
+The `atom-budget` blocker is untouched at 1 — `TA-W01-abugida-va-ka` introduces
+four atoms against a budget of three, and predates this work.
+
+### The chapters
+
+| chapter | node | lessons |
+|---|---|---|
+| 35 — Arriving at a House | `SPINE-MEET-GREET` | வீடு, கதவு, அறை, நாற்காலி |
+| 36 — What You Are Offered | `SPINE-POLITE-REQUEST-REPAIR` | தேநீர், பால், உணவு, தவறு |
+| 37 — Your Town, Your Friend | `SPINE-EXCHANGE-NAMES` | ஊர், நண்பன், இவர், இவர் என் நண்பர் |
+| 38 — Keeping Well, and Leaving | `SPINE-CHECK-WELLBEING`, `SPINE-TAKE-LEAVE` | உடம்பு, சுகம், விடை |
+
+Sequences 750–890, all schema v2, two new atoms each — 8, 8, 8 and 6 per
+chapter, all inside the 12-atom chapter budget. Attached to pre-A1 spine nodes
+through five new `TA-EXT-03*-LANGUAGE-SPECIFIC` extensions on path segments
+`TA-PATH-031`–`035`, which is what makes them count at pre-A1 at all.
+
+### Rescue, at two cadences
+
+Every lesson practises the preceding one to three lessons (R1), and each chapter
+payoff reaches several chapters back. Between them the tranche cleared **all 29**
+pre-A1 atoms that were revisited fewer than twice — the eight Chapter-1 writing
+atoms (**வ**, **க**, **ண**, **ற**, the puḷḷi, the no-conjunct rule, the **ி**
+sign, nasal-triggered voicing), the dative pair from Chapter 6, the register
+atoms from Chapters 8–9 and 19, the kinship atoms from Chapter 12, the body
+parts from Chapter 13, and the water/rice atoms from Chapter 15. Each rescue is
+a real revisit: **நாற்காலி** genuinely uses **நான்கு**, **தவறு** genuinely
+re-reads **மன்னிக்கவும்**, **உடம்பு** genuinely recalls **தலை** and **கை**.
+
+### What the words are, and what they are not
+
+Several of the obvious "first nouns" were **already taught** and are not
+repeated here: தண்ணீர் and சாதம் (Chapter 15), பெயர் (Chapter 2), and அப்பா,
+அம்மா, அண்ணன், தம்பி, அக்கா, தங்கை (Chapter 12 — Tamil's age-graded kinship is
+already in the course). Chapter 37 builds on that rather than restating it:
+**நண்பன் / நண்பி / நண்பர்** splits by sex and respect where the sibling words
+split by age, and the payoff names the contrast.
+
+The etymology was checked against the Dravidian Etymological Dictionary, the
+Madras Tamil Lexicon and Wiktionary before authoring, and four claims changed as
+a result:
+
+- **வீடு** "house" and **வீடு** "release" are **one DEDR entry**, headed by
+  **விடு** "to let go" — and **விடை**, Chapter 38's payoff, is in that entry
+  too. The chapter arc walks in through the house and out through the leave, on
+  one root, because the dictionary says so.
+- **தேநீர்**'s **தே** came through **Malay *teh***, not straight from Chinese;
+  and **Portuguese *chá*** is the *exception* to the maritime-*te* pattern
+  (Macau), not an example of the overland *cha* one.
+- **கதவு** has **no Telugu cognate** in DEDR, and **அறை** has **no Kannada**
+  one. Neither is claimed.
+- **சாப்பிடு** is *not* safely *sāppu* "food" + **இடு**, as this course said in
+  Chapter 32: no Tamil lexicon records a plain *sāppu* meaning "food," and the
+  Dravidian dictionary has **no entry for the verb at all**. `TA-C36-unavu`
+  says so plainly rather than repeating the earlier account.
+
+One genuine English link is claimed and it is a new one: **mulligatawny** is
+**மிளகுத்தண்ணீர்**, "pepper water," carrying the **தண்ணீர்** taught in
+Chapter 15. *Catamaran*, *curry*, *mango* and *pariah* are Tamil's other gifts
+to English and none of them comes from a root in this tranche, so none is
+claimed.
+
+### Book, narration, drivability
+
+Chapters 35–38 are generated to `book/chapters/`, added to `book.tex`, and the
+178-page book compiles with XeLaTeX with **zero** `Missing character` warnings.
+All fifteen lessons derive `coreModality: voice` — every one is drivable once
+the detachable *"The letters in this word"* section is set aside — and every
+table is two or three columns, so the narration exporter linearises all of them
+rather than refusing any.
+
 ## Chapters 33–34 — the eight shared verbs, and a Dravidian seat at the join
 
 Chapter 32 put Tamil on the canonical `VERB-*` concepts with six verbs. Before

--- a/code/learning/human-languages/tamil/README.md
+++ b/code/learning/human-languages/tamil/README.md
@@ -82,6 +82,23 @@ through.
   is **எனக்குப் பிடிக்கும்** — a third dative subject, and the same inversion
   Spanish *gustar*, Italian *piacere* and Hindi *pasand* reach from a completely
   unrelated family. In the book, Chapter 34.
+- **Chapters 35–38 — A visit, in fifteen nouns**
+  ([`lessons/TA-C{35..38}-*`](./lessons/)): the track's first tranche of
+  everyday **nouns**, and the first authored specifically to move the HL09
+  §3.1 level gate. Chapter 35 walks a guest in — வீடு (*vīḍu*), கதவு
+  (*kadavu*), அறை (*aṟai*), நாற்காலி (*nāṟkāli*, "four" plus "leg") — and
+  sets Kannada's *v-* to *b-* shift beside Tamil. Chapter 36 is what you are
+  offered: தேநீர் (*tēnīr*, half a Malay loan welded to the நீர் already
+  inside தண்ணீர்), பால் (*pāl*, the textbook case of Kannada *p-* to
+  *h-*), உணவு (*uṇavu*), and தவறு (*tavaṟu*) to finish an apology.
+  Chapter 37 is the part of a Tamil introduction English does not have —
+  ஊர் (*ūr*, the native place, and the *-ore* in Tanjore), நண்பன் /
+  நண்பி / நண்பர், இவர் and the இ- / அ- / எ- pointing series, closing
+  on **இவர் என் நண்பர்**. Chapter 38 asks after somebody and leaves:
+  உடம்பு (*uḍambu*), சுகம் (*sugam*, the Sanskrit loan Tamil kept beside
+  native நலம்), and விடை (*viḍai*) — which the Dravidian dictionary files
+  in the **same entry as வீடு**, so the arc walks in through the house and out
+  through the leave on one root. In the book, Chapters 35–38.
 - **Writing W01–W04** ([`lessons/TA-W*`](./lessons/)): eight gentle steps teach
   curves, the abugida, retroflexion, the three Tamil n letters, the puḷḷi,
   vowel signs, and whole-word writing for **வணக்கம்** and **நன்றி**.
@@ -124,9 +141,9 @@ than the ability to read the letters.
 
 ## Book / fonts
 
-The 34-chapter book compiles with XeLaTeX using **vendored** Noto fonts
+The 38-chapter book compiles with XeLaTeX using **vendored** Noto fonts
 (`../../_fonts/`) for Tamil and every comparison script, with no system-font
-dependency. Chapters 6–34 are generated from canonical lesson ASTs and checked
+dependency. Chapters 6–38 are generated from canonical lesson ASTs and checked
 against Language Ladder source hashes. `latexmk -xelatex book.tex`.
 
 ## Files

--- a/code/learning/human-languages/tamil/book/book.tex
+++ b/code/learning/human-languages/tamil/book/book.tex
@@ -122,6 +122,10 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \input{chapters/ch32-core-verbs}
 \input{chapters/ch33-verbs-of-the-mind}
 \input{chapters/ch34-verbs-between-people}
+\input{chapters/ch35-arriving-at-a-house}
+\input{chapters/ch36-what-you-are-offered}
+\input{chapters/ch37-your-town-your-friend}
+\input{chapters/ch38-keeping-well-and-leaving}
 
 \backmatter
 

--- a/code/learning/human-languages/tamil/book/chapters/ch35-arriving-at-a-house.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch35-arriving-at-a-house.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:9b721566605c8133
+% canonical-source-hash: fnv1a64:dc38c4fb1b2e3bc9
 % canonical-lessons: TA-C35-veedu, TA-C35-kadavu, TA-C35-arai, TA-C35-naarkaali
 
 \chapter{Arriving at a House}
@@ -102,7 +102,7 @@ Two nouns in a row, the first leaning on the second. Tamil builds a great deal t
 \subsection*{The letters in this word}
 \textbf{\ta{க}} + \textbf{\ta{த}} + \textbf{\ta{வு}}. The first letter is the one that taught you Tamil marks no voicing: \textbf{\ta{க}} spells a hard \emph{k}, a soft \emph{g} and even an \emph{h}, and \textbf{position decides}. Here it opens the word, so it is hard — \emph{ka}, not \emph{ga}.
 
-The same rule then lands on the second letter. \textbf{\ta{த}} is named \emph{ta}, but it sits between two vowels, so it softens. That is why this course writes \emph{ka\textbf{d}avu} and not \emph{katavu}. One rule, two letters, one word.
+The same rule then lands on the second letter. \textbf{\ta{த}} is named \emph{ta}, but it sits between two vowels, so it softens. That is why this book writes \emph{ka\textbf{d}avu} and not \emph{katavu}. One rule, two letters, one word.
 
 \begin{cousinweb}
 \textbf{\ta{கதவு}} is inherited Dravidian. Kannada's \textbf{\ka{ಕದ}} (\emph{kada}) is the same word with less on the end; Malayalam's \textbf{\ml{കതവ്}} (\emph{katavu}) matches Tamil closely.

--- a/code/learning/human-languages/tamil/book/chapters/ch35-arriving-at-a-house.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch35-arriving-at-a-house.tex
@@ -1,0 +1,246 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:9b721566605c8133
+% canonical-lessons: TA-C35-veedu, TA-C35-kadavu, TA-C35-arai, TA-C35-naarkaali
+
+\chapter{Arriving at a House}
+\label{ch:ta-arriving-at-a-house}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can name a Tamil house, its door, a room and a chair, take \ta{நாற்காலி} apart into 'four' and 'leg', place \ta{வீடு} against Kannada \ka{ಬೀಡು} on the v-to-b shift, and say why \ta{கதவு} stayed everyday while Sanskrit-derived \ta{கபாடம்} stayed in books.}
+
+Walk a guest from \ta{வீடு} through \ta{கதவு} into \ta{அறை} and offer a \ta{நாற்காலி}; split the chair into \ta{நால்} and \ta{கால்} and hear \ta{ல்} harden to \ta{ற்} at the join; hold the hard \ta{ற} at the ridge rather than the roof; and name what the puḷḷi does at \ta{ற்கா} and what Tamil refuses to do there.
+\end{chapteropening}
+
+\section[vīḍu]{\ta{வீடு} (vīḍu) — \textquotedblleft{}house,\textquotedblright{} and the place the greeting happens}
+
+\label{lesson:TA-C35-veedu}
+
+
+
+\begin{quote}
+Three verbs from the chapter you have just finished: \emph{pidi}, \textquotedblleft{}to like\textquotedblright{}; \emph{uḍavu}, \textquotedblleft{}to help\textquotedblright{}; \emph{kēḷ}, \textquotedblleft{}to ask.\textquotedblright{} Say them. Now a noun, and the one a conversation usually starts inside.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{வீடு}}
+\begin{quote}
+\textbf{\ta{வீடு}} — \emph{vīḍu} — \textbf{house; home}
+\end{quote}
+
+One word covers both. Tamil does not split the building from the belonging: \textbf{\ta{என்} \ta{வீடு}} (\emph{eṉ vīḍu}) is \textquotedblleft{}my house\textquotedblright{} and \textquotedblleft{}my home\textquotedblright{} at once, and choosing between them is the translator's problem.
+
+With the dative you already own:
+
+\begin{quote}
+\textbf{\ta{வீட்டுக்கு}} — \emph{vīṭṭukku} — \textbf{to the house}
+\end{quote}
+
+The soft \emph{ḍ} hardens and doubles to \emph{ṭṭ} — the \textbf{\ta{படி}} / \textbf{\ta{படித்தேன்}} rule.
+
+\subsection*{The letters in this word}
+\textbf{\ta{வீ}} is \textbf{\ta{வ}}, the first letter you learned, wearing the long \emph{ī} sign \textbf{\ta{ீ}}. Then \textbf{\ta{டு}}: \textbf{\ta{ட}} with the \emph{u} sign.
+
+You are at a door about to say \textbf{\ta{வணக்கம்}}, so read that word while you are here: \textbf{\ta{வ}} + \textbf{\ta{ண}} + \textbf{\ta{க்}} + \textbf{\ta{க}} + \textbf{\ta{ம்}}. The \textbf{\ta{வ}} that opens \emph{vaṇakkam} is the \textbf{\ta{வ}} that opens \emph{vīḍu}.
+
+\begin{cousinweb}
+\textbf{\ta{வீடு}} is inherited, not borrowed:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{the cousin} & \textbf{language and sense} \\
+\midrule
+\textbf{\ml{വീട്}} \emph{vīḍ} & Malayalam, \textquotedblleft{}house\textquotedblright{} \\
+\textbf{\te{వీడు}} \emph{vīḍu} & Telugu, \textquotedblleft{}town, camp\textquotedblright{} \\
+\textbf{\ka{ಬೀಡು}} \emph{bīḍu} & Kannada, \textquotedblleft{}abode, encampment\textquotedblright{} \\
+\bottomrule
+\end{tabularx}
+
+Kannada has changed the front of the word: Tamil says \textbf{v}, Kannada says \textbf{b}. Not a slip — Kannada alone among its neighbours turned inherited word-initial \emph{v-} into \emph{b-}, and the inscriptions show it from about the seventh century. Store the correspondence — it keeps paying.
+
+The \textbf{sense} has drifted where the form has not: Telugu's \emph{vīḍu} is a town, Kannada's \emph{bīḍu} an encampment. Tamil and Malayalam kept it on the dwelling.
+
+One more thing, not a coincidence to explain away. Tamil has a second \textbf{\ta{வீடு}} meaning \textquotedblleft{}\textbf{release, deliverance},\textquotedblright{} as in \textbf{\ta{வீடுபேறு}}. The Dravidian dictionary files house and release under \textbf{one entry}, headed by \textbf{\ta{விடு}} (\emph{viḍu}), \textquotedblleft{}to let go.\textquotedblright{} A house is where you are let go.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}vīḍu\textquotedblright{} — house and home in one word
+  \item \textquotedblleft{}eṉ vīḍu,\textquotedblright{} then the hardening — \textquotedblleft{}vīṭṭukku\textquotedblright{}
+  \item the cousins, ending on the front-swap — \textquotedblleft{}vīḍ … vīḍu … bīḍu\textquotedblright{}
+  \item the root under the house — \textquotedblleft{}viḍu, to let go\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Why does one Tamil word do two English jobs here, and which letter opens both \emph{vīḍu} and \emph{vaṇakkam}? (\textbf{House} and \textbf{home} are not split; and \textbf{\ta{வ}}.) What does Kannada put at the front instead of \emph{v}, and is it a one-off? (\textbf{b} — \emph{bīḍu}; \textbf{regular}, from the seventh century on.) Is the Tamil word for \textquotedblleft{}release\textquotedblright{} the same root as the house? (\textbf{Yes} — both under \textbf{\ta{விடு}}, \textquotedblleft{}to let go.\textquotedblright{})
+\end{tcolorbox}
+\section[kadavu]{\ta{கதவு} (kadavu) — \textquotedblleft{}door,\textquotedblright{} and a word Tamil never gave up}
+
+\label{lesson:TA-C35-kadavu}
+
+
+
+\begin{quote}
+\emph{Vīḍu} — house. Say the cousin that swaps the front letter. (\emph{Bīḍu}, Kannada.) Now the part of the house you actually stand at.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{கதவு}}
+\begin{quote}
+\textbf{\ta{கதவு}} — \emph{kadavu} — \textbf{door}
+\end{quote}
+
+The leaf that swings, and the thing somebody opens when you arrive.
+
+\begin{quote}
+\textbf{\ta{வீட்டுக்} \ta{கதவு}} — \emph{vīṭṭuk kadavu} — \textbf{the house door}
+\end{quote}
+
+Two nouns in a row, the first leaning on the second. Tamil builds a great deal this way, and you have seen it inside a single word: \textbf{\ta{தண்ணீர்}} is \emph{taṇ} plus \emph{nīr}, \textquotedblleft{}cool\textquotedblright{} plus \textquotedblleft{}water.\textquotedblright{}
+
+\subsection*{The letters in this word}
+\textbf{\ta{க}} + \textbf{\ta{த}} + \textbf{\ta{வு}}. The first letter is the one that taught you Tamil marks no voicing: \textbf{\ta{க}} spells a hard \emph{k}, a soft \emph{g} and even an \emph{h}, and \textbf{position decides}. Here it opens the word, so it is hard — \emph{ka}, not \emph{ga}.
+
+The same rule then lands on the second letter. \textbf{\ta{த}} is named \emph{ta}, but it sits between two vowels, so it softens. That is why this course writes \emph{ka\textbf{d}avu} and not \emph{katavu}. One rule, two letters, one word.
+
+\begin{cousinweb}
+\textbf{\ta{கதவு}} is inherited Dravidian. Kannada's \textbf{\ka{ಕದ}} (\emph{kada}) is the same word with less on the end; Malayalam's \textbf{\ml{കതവ്}} (\emph{katavu}) matches Tamil closely.
+
+Tamil also owns a second word for a door-leaf: \textbf{\ta{கபாடம்}} (\emph{kabāḍam}), taken from Sanskrit \textbf{\dv{कपाट}} (\emph{kapāṭa}). It exists, it is correct, and almost nobody says it. It lives in poetry and temple description; \textbf{\ta{கதவு}} lives in the house.
+
+That split is this language's habit. Where a neighbour borrowed a Sanskrit word and let the inherited one fade, Tamil often kept both and gave them different jobs — the inherited word for the everyday thing, the borrowed one for the elevated register. Do not turn that into a rule that Tamil never borrows. It borrows; it rarely evicts.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}kadavu\textquotedblright{} — door
+  \item \textquotedblleft{}vīṭṭuk kadavu\textquotedblright{} — the house door
+  \item the hard one and the soft one in one word — \textquotedblleft{}ka … da\textquotedblright{}
+  \item the everyday word, then the bookish one — \textquotedblleft{}kadavu … kabāḍam\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say \textquotedblleft{}the house door,\textquotedblright{} then explain why the \textbf{\ta{க}} is hard and the \textbf{\ta{த}} soft when neither changed shape. (\emph{Vīṭṭuk kadavu}; \textbf{Tamil marks no voicing} — position decides.) Which of \emph{kadavu} and \emph{kabāḍam} would you hear at somebody's house, and where did the other come from? (\emph{\textbf{Kadavu}}; \emph{kabāḍam} is \textbf{Sanskrit}, and stays literary.) Does keeping both mean Tamil refuses to borrow? (\textbf{No} — it borrows without evicting.)
+\end{tcolorbox}
+\section[aṟai]{\ta{அறை} (aṟai) — \textquotedblleft{}room,\textquotedblright{} and Tamil's second r}
+
+\label{lesson:TA-C35-arai}
+
+
+
+\begin{quote}
+\emph{Vīḍu}, house. \emph{Kadavu}, door — the everyday word Tamil kept while the Sanskrit one stayed in books. Open that door and you are in this word.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{அறை}}
+\begin{quote}
+\textbf{\ta{அறை}} — \emph{aṟai} — \textbf{room}
+\end{quote}
+
+Any room: in a house, in a hotel, a cell. Put it behind \emph{vīḍu} the way you put \emph{kadavu} there:
+
+\begin{quote}
+\textbf{\ta{வீட்டு} \ta{அறை}} — \emph{vīṭṭu aṟai} — \textbf{a room of the house}
+\end{quote}
+
+And with the dative, \textbf{\ta{அறைக்கு}} (\emph{aṟaikku}), \textquotedblleft{}to the room.\textquotedblright{}
+
+\subsection*{The letters in this word}
+\textbf{\ta{அ}} is the standing vowel \emph{a} — a letter in its own right, not a sign hung on a consonant. Then \textbf{\ta{ற}}, then the \emph{ai} sign \textbf{\ta{ை}}, which wraps around the front of its consonant: \textbf{\ta{ற}} + \textbf{\ta{ை}} $\to$ \textbf{\ta{றை}}.
+
+\textbf{\ta{ற}} is the hard \emph{r} you first met inside \textbf{\ta{நன்றி}}. It is not \textbf{\ta{ர}}. Tamil keeps two r-letters and uses both.
+
+\begin{cousinweb}
+\textbf{\ta{அறை}} is inherited. Malayalam's \textbf{\ml{അറ}} (\emph{aṟa}) is the same word, used for a chamber or an inner store-room, and it keeps the same hard r.
+
+So this is \emph{kadavu}'s situation over: an everyday inherited word with a Sanskrit-derived alternative sitting unused in the higher register.
+\end{cousinweb}
+
+\begin{sounds}
+Say the English word \emph{hurry} and stop on the middle sound. That flick of the tongue against the ridge behind your teeth is close to Tamil \textbf{\ta{ர}} (\emph{ra}). Now make it stronger and longer, with real contact: that is \textbf{\ta{ற}} (\emph{ṟa}).
+
+Two cautions. \textbf{Do not curl your tongue back} — retroflex belongs to \textbf{\ta{ண}} and \textbf{\ta{ட}}; \textbf{\ta{ற}} is made at the ridge. And \textbf{do not soften it into the English r of \emph{red}}, which is the wrong shape for both Tamil letters.
+
+Many Tamil speakers merge \textbf{\ta{ர}} and \textbf{\ta{ற}} in casual speech, so you will be understood either way. Learn the difference anyway: the \textbf{spelling} depends on it, and a word written with the wrong r is simply misspelled.
+\end{sounds}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}aṟai\textquotedblright{} — room, on the hard r
+  \item the two r's apart — \textquotedblleft{}ra … ṟa\textquotedblright{}
+  \item \textquotedblleft{}vīṭṭu aṟai\textquotedblright{} — a room of the house
+  \item the three so far — \textquotedblleft{}vīḍu, kadavu, aṟai\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say \textquotedblleft{}a room of the house,\textquotedblright{} and name which of Tamil's two r-letters is in \emph{aṟai} and where else you have read it. (\emph{Vīṭṭu aṟai}; \textbf{\ta{ற}}, the hard one, in \textbf{\ta{நன்றி}}.) Where is \textbf{\ta{ற}} made, and what must your tongue not do? (At the \textbf{ridge} behind the teeth — \textbf{do not curl it back}.) If many speakers merge the two r's, why bother? (Because the \textbf{spelling} does not merge.)
+\end{tcolorbox}
+\section[nāṟkāli]{\ta{நாற்காலி} (nāṟkāli) — \textquotedblleft{}chair,\textquotedblright{} counted out in legs}
+
+\label{lesson:TA-C35-naarkaali}
+
+
+
+\begin{quote}
+Three words in the order you meet them arriving: \emph{vīḍu}, \emph{kadavu}, \emph{aṟai}. Hold the hard r in \emph{aṟai} at the ridge, not the roof. Now the one thing in that room a guest is always pointed at.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{நாற்காலி}}
+\begin{quote}
+\textbf{\ta{நாற்காலி}} — \emph{nāṟkāli} — \textbf{chair}
+\end{quote}
+
+Five syllables for a chair, which sounds extravagant until you find out what it is made of.
+
+\begin{quote}
+\textbf{\ta{நான்} \ta{நாற்காலி} \ta{எடுக்கிறேன்}.} — \emph{nāṉ nāṟkāli eḍukkiṟēṉ} — \textbf{I take a chair.}
+\end{quote}
+
+\subsection*{The letters in this word}
+\textbf{\ta{நா}} + \textbf{\ta{ற்}} + \textbf{\ta{கா}} + \textbf{\ta{லி}}. Every piece is one you have handled.
+
+\textbf{\ta{ந}} is the dental \emph{n}, first of Tamil's three n-letters, wearing the long \emph{ā} sign \textbf{\ta{ா}}. \textbf{\ta{ற்}} is the hard r of \emph{aṟai} under a \textbf{puḷḷi}, the dot that switches off the built-in vowel. \textbf{\ta{கா}} is \textbf{\ta{க}} with that same long \emph{ā}. \textbf{\ta{லி}} is \textbf{\ta{ல}} with the \emph{i} sign \textbf{\ta{ி}}, the first vowel sign you learned, on the way to spelling \textbf{\ta{நன்றி}}.
+
+Now what does \textbf{not} happen at \textbf{\ta{ற்கா}}. Two consonants meet, and Tamil keeps them as two letters with a dot between, rather than fusing them into a stacked shape as the scripts to the north do. That refusal is why a word this long stays readable one piece at a time.
+
+\begin{cousinweb}
+The word is a compound, and both halves are yours:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{the piece} & \textbf{what it is} \\
+\midrule
+\textbf{\ta{நால்}} \emph{nāl} & \textquotedblleft{}four\textquotedblright{} — the form four takes in compounds \\
+\textbf{\ta{கால்}} \emph{kāl} & \textquotedblleft{}leg, foot; a support\textquotedblright{} \\
+\bottomrule
+\end{tabularx}
+
+\textbf{Four} plus \textbf{leg}: a chair is a four-legged thing, said out loud. English cannot do that with \emph{chair}, which travels through French and Latin to a Greek word for \textquotedblleft{}seat\textquotedblright{} without ever showing a leg.
+
+The seam is audible. \textbf{\ta{நான்கு}} (\emph{nāṉku}) is the counting word; in a compound four appears as \textbf{\ta{நால்}}, and before \textbf{\ta{க}} that \textbf{\ta{ல்}} hardens to \textbf{\ta{ற்}}. Hence \textbf{\ta{நாற்காலி}}, and hence \textbf{\ta{நாற்பது}} (\emph{nāṟpadu}), \textquotedblleft{}forty.\textquotedblright{} Malayalam builds the chair from the same two pieces: \textbf{\ml{നാൽക്കാലി}}.
+
+Both halves are inherited Dravidian. Nothing in this chapter was borrowed.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item the seam — \textquotedblleft{}nāṉku … nāl … kāl … nāṟkāli\textquotedblright{}
+  \item \textquotedblleft{}nāṉ nāṟkāli eḍukkiṟēṉ\textquotedblright{} — I take a chair
+  \item the arrival, in order — \textquotedblleft{}vīḍu, kadavu, aṟai, nāṟkāli\textquotedblright{}
+  \item the Kannada front-swap on the first of them — \textquotedblleft{}vīḍu … bīḍu\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Take \emph{nāṟkāli} apart, then walk somebody into your house four nouns deep. (\textbf{\ta{நால்}}, \textquotedblleft{}four,\textquotedblright{} plus \textbf{\ta{கால்}}, \textquotedblleft{}leg\textquotedblright{}; \emph{vīḍu, kadavu, aṟai, nāṟkāli}.) What does the dot in \textbf{\ta{ற்}} do, and what does Tamil refuse to do at that join? (\textbf{Switches off the built-in vowel}; Tamil \textbf{does not stack} the two consonants.) Which of this chapter's words was borrowed? (\textbf{None.})
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch36-what-you-are-offered.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch36-what-you-are-offered.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:71c92947d2d24ca0
+% canonical-source-hash: fnv1a64:231ca7f273eff40e
 % canonical-lessons: TA-C36-teneer, TA-C36-paal, TA-C36-unavu, TA-C36-tavaru
 
 \chapter{What You Are Offered}
@@ -169,7 +169,7 @@ Curl the tip of your tongue \textbf{back} to the roof of your mouth and release 
 
 \textbf{\ta{உண்}} is a bare inherited root, and the Dravidian dictionary lists \emph{uṇavu} inside its entry.
 
-\textbf{\ta{சாப்பிடு}} is where the ground softens, so hold this course's earlier account loosely. You were shown \emph{sāppu}, \textquotedblleft{}food,\textquotedblright{} plus \textbf{\ta{இடு}} (\emph{iḍu}), \textquotedblleft{}to put.\textquotedblright{} The \textbf{\ta{இடு}} is visible in the spelling; the first half is the problem. The great Tamil lexicon records no plain word \emph{sāppu} meaning \textquotedblleft{}food,\textquotedblright{} and the Dravidian etymological dictionary has \textbf{no entry for this verb at all}. It is not Sanskrit — Telugu and Malayalam have their own forms — but its origin is open. The word you would use at a table has the weaker paperwork.
+\textbf{\ta{சாப்பிடு}} is where the ground softens, so hold Chapter 32's earlier account loosely. You were shown \emph{sāppu}, \textquotedblleft{}food,\textquotedblright{} plus \textbf{\ta{இடு}} (\emph{iḍu}), \textquotedblleft{}to put.\textquotedblright{} The \textbf{\ta{இடு}} is visible in the spelling; the first half is the problem. The great Tamil lexicon records no plain word \emph{sāppu} meaning \textquotedblleft{}food,\textquotedblright{} and the Dravidian etymological dictionary has \textbf{no entry for this verb at all}. It is not Sanskrit — Telugu and Malayalam have their own forms — but its origin is open. The word you would use at a table has the weaker paperwork.
 \end{cousinweb}
 
 \subsection*{Your turn}

--- a/code/learning/human-languages/tamil/book/chapters/ch36-what-you-are-offered.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch36-what-you-are-offered.tex
@@ -1,0 +1,250 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:71c92947d2d24ca0
+% canonical-lessons: TA-C36-teneer, TA-C36-paal, TA-C36-unavu, TA-C36-tavaru
+
+\chapter{What You Are Offered}
+\label{ch:ta-what-you-are-offered}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can ask for \ta{தேநீர்}, \ta{பால்} or \ta{உணவு} in Tamil, say \ta{என்} \ta{தவறு} with no verb in it, find \ta{நீர்} inside both \ta{தண்ணீர்} and \ta{தேநீர்}, and state which of this chapter's words was borrowed and which the dictionaries cannot account for.}
+
+Repair a wrong order — \ta{மன்னிக்கவும்}, \ta{என்} \ta{தவறு} — and account for the chapter honestly: \ta{பால்} and \ta{உண்} inherited, \ta{தேநீர்} half a loan through a Malay port, \ta{சாப்பிடு} with no entry in the Dravidian dictionary at all, and \ta{மன்னி} native where the neighbours took Sanskrit kṣamā.
+\end{chapteropening}
+
+\section[tēnīr]{\ta{தேநீர்} (tēnīr) — \textquotedblleft{}tea,\textquotedblright{} half of it already yours}
+
+\label{lesson:TA-C36-teneer}
+
+
+
+\begin{quote}
+\emph{Nāṟkāli}, and what its halves mean. (Four, and leg.) You are in the \emph{aṟai} with the chair, and the next thing in a Tamil house is this.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{தேநீர்}}
+\begin{quote}
+\textbf{\ta{தேநீர்}} — \emph{tēnīr} — \textbf{tea}
+\end{quote}
+
+The second half is yours from the water lesson: \textbf{\ta{நீர்}} (\emph{nīr}), \textquotedblleft{}water,\textquotedblright{} the plain older word inside \textbf{\ta{தண்ணீர்}} (\emph{taṇṇīr}) — \emph{taṇ}, \textquotedblleft{}cool,\textquotedblright{} plus \emph{nīr}. So \textbf{\ta{தேநீர்}} is, literally, \textbf{tea water}.
+
+\begin{quote}
+\textbf{\ta{தேநீர்}, \ta{தயவுசெய்து}.} — \emph{tēnīr, tayavuseytu} — \textbf{Tea, please.}
+\end{quote}
+
+In speech you will also hear plain \textbf{\ta{டீ}} (\emph{ṭī}), straight from English \emph{tea}. \textbf{\ta{தேநீர்}} is the fuller word — a sign, a menu, a formal host.
+
+\subsection*{The letters in this word}
+\textbf{\ta{தே}} is \textbf{\ta{த}} with the \emph{ē} sign \textbf{\ta{ே}}, which stands in front of its consonant. \textbf{\ta{நீ}} is \textbf{\ta{ந}} with the long \emph{ī} sign; \textbf{\ta{ர்}} is \textbf{\ta{ர}} shut by a puḷḷi — the soft r, not the hard \textbf{\ta{ற}}.
+
+Two words beside it are worth reading. \textbf{\ta{நன்றி}} is \textbf{\ta{ந}} + \textbf{\ta{ன்}} + \textbf{\ta{றி}}, what you say when the tea arrives. In \textbf{\ta{தயவுசெய்து}}, \textbf{\ta{செய்}} is \emph{ce} plus \textbf{\ta{ய்}} shut by that same dot before \textbf{\ta{து}}.
+
+\begin{cousinweb}
+\textbf{\ta{நீர்}} is inherited and very old. \textbf{\ta{தே}} is not Tamil at all: it is the combining form of \textbf{\ta{தேய்}} (\emph{tēy}), borrowed from Malay \textbf{teh}, which took it from the Hokkien of the southern Chinese coast, where the leaf is \emph{tê}.
+
+The world's words for tea come in two shapes, decided by \textbf{how the tea reached each language}. The southern Chinese coast carried \emph{te}: Dutch \emph{thee}, and through Dutch, English \emph{tea} and French \emph{thé} — and by the Malay ports, Tamil's \textbf{\ta{தே}}. The overland routes carried \emph{cha}: Persian and Hindi \emph{chāy}, Russian \emph{chay}. Portuguese says \textbf{chá} despite being a sea power, because its traders worked out of Macau. Where the ship docked decided the word.
+
+Tamil then did what the European \emph{te}-languages did not: rather than take the loan whole, it welded it to \textbf{\ta{நீர்}} — a word that has travelled outward as well, since English \textbf{mulligatawny} is Tamil \textbf{\ta{மிளகுத்தண்ணீர்}}, \textquotedblleft{}pepper water.\textquotedblright{}
+
+Weigh that against the rice word. \textbf{\ta{அரிசி}} \emph{may} stand behind English \emph{rice} through Greek, and the dictionaries hedge. The tea routes are documented. \textbf{Different histories, different confidence.}
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item the shared half — \textquotedblleft{}nīr … taṇṇīr … tēnīr\textquotedblright{}
+  \item \textquotedblleft{}tēnīr, tayavuseytu\textquotedblright{} — tea, please
+  \item the two routes — \textquotedblleft{}te … cha\textquotedblright{}
+  \item the pepper water in an English soup — \textquotedblleft{}miḷagut taṇṇīr\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Name the second half of \emph{tēnīr} and the word that shares it, then ask for tea politely. (\textbf{\ta{நீர்}}, inside \textbf{\ta{தண்ணீர்}}; \emph{tēnīr, tayavuseytu}.) Why do some languages say \emph{te} and others \emph{cha}, and which is better established — the tea split or \emph{arisi}-to-\emph{rice}? (\textbf{The route the tea travelled}; and \textbf{the tea split}.)
+\end{tcolorbox}
+\section[pāl]{\ta{பால்} (pāl) — \textquotedblleft{}milk,\textquotedblright{} and a p that becomes an h next door}
+
+\label{lesson:TA-C36-paal}
+
+
+
+\begin{quote}
+\emph{Tēnīr}. Which half is borrowed, and which is the old Tamil word for water? (\emph{Tē} is the traveller; \emph{nīr} is Tamil's own.) Here is what goes into it.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{பால்}}
+\begin{quote}
+\textbf{\ta{பால்}} — \emph{pāl} — \textbf{milk}
+\end{quote}
+
+One syllable, one long \emph{ā}, a final \textbf{\ta{ல்}} with no vowel after it. Say it short and closed: \emph{pāl}, never \emph{pāla}.
+
+\begin{quote}
+\textbf{\ta{பால்} \ta{தேநீர்}} — \emph{pāl tēnīr} — \textbf{milk tea}
+\end{quote}
+
+With \textbf{\ta{தண்ணீர்}} (\emph{taṇṇīr}, cool water) already in hand, you can now name what a Tamil household is likely to put in front of a guest.
+
+\subsection*{The letters in this word}
+\textbf{\ta{பா}} is \textbf{\ta{ப}} with the long \emph{ā} sign \textbf{\ta{ா}}. Then \textbf{\ta{ல்}}: \textbf{\ta{ல}} with the \textbf{puḷḷi}, the dot that removes the built-in \emph{a} and leaves a bare consonant.
+
+That dot is the whole reason the word ends where it does. Without it, \textbf{\ta{பால}} would be \emph{pāla}, two syllables. A single dot carries the difference between a word and a non-word.
+
+\begin{cousinweb}
+\textbf{\ta{பால்}} is inherited Dravidian, and its relatives are close:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{the cousin} & \textbf{language} \\
+\midrule
+\textbf{\ml{പാൽ}} \emph{pāl} & Malayalam \\
+\textbf{\te{పాలు}} \emph{pālu} & Telugu \\
+\textbf{\ka{ಹಾಲು}} \emph{hālu} & Kannada, modern \\
+\bottomrule
+\end{tabularx}
+
+Kannada has changed the front of the word once more, this time \textbf{p} into \textbf{h} — the textbook example of the best-known sound change in the family. \textbf{Old Kannada said \emph{pālu}}, exactly as Tamil does; the \emph{p-} began turning into \emph{h-} around the tenth century and the change had run through the whole vocabulary by the fourteenth.
+
+Put it beside the change you met at the house. Tamil \textbf{v}, Kannada \textbf{b}, in \emph{vīḍu} / \emph{bīḍu}. Tamil \textbf{p}, Kannada \textbf{h}, in \emph{pāl} / \emph{hālu}. Both are regular correspondences at the front of a word, and between them they let you recognise a Kannada word as a relative rather than a stranger. Telugu and Malayalam did neither: they keep the \emph{p}, as Tamil does.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}pāl\textquotedblright{} — stopped by the dot, not \emph{pāla}
+  \item \textquotedblleft{}pāl tēnīr\textquotedblright{} — milk tea
+  \item the two front-swaps together — \textquotedblleft{}vīḍu, bīḍu … pāl, hālu\textquotedblright{}
+  \item what you can be offered — \textquotedblleft{}taṇṇīr, tēnīr, pāl\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Say \textquotedblleft{}milk tea,\textquotedblright{} then say what the dot on \textbf{\ta{ல்}} is doing and what the word would be without it. (\emph{Pāl tēnīr}; it \textbf{removes the built-in vowel}, and without it, \emph{pāla}.) What does Kannada put at the front instead of \emph{p}, and is it a one-off? (\textbf{h} — \emph{hālu}; \textbf{regular}, from the tenth century to the fourteenth.) Name the other Kannada front-swap. (\textbf{v} to \textbf{b} — \emph{vīḍu}, \emph{bīḍu}.)
+\end{tcolorbox}
+\section[uṇavu]{\ta{உணவு} (uṇavu) — \textquotedblleft{}food,\textquotedblright{} from the verb underneath it}
+
+\label{lesson:TA-C36-unavu}
+
+
+
+\begin{quote}
+\emph{Pāl} — milk — and the Kannada shape of it. (\emph{Hālu}.) Drink is settled. Now the word for everything else on the plate.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{உணவு}}
+\begin{quote}
+\textbf{\ta{உணவு}} — \emph{uṇavu} — \textbf{food}
+\end{quote}
+
+The general word: food as a category, not a dish. It covers the rice words you have — \textbf{\ta{அரிசி}} (\emph{arisi}), the raw grain, and \textbf{\ta{சாதம்}} (\emph{sātam}), the cooked meal — and all that is served beside them.
+
+\begin{quote}
+\textbf{\ta{உணவு}, \ta{தயவுசெய்து}.} — \emph{uṇavu, tayavuseytu} — \textbf{Food, please.}
+\end{quote}
+
+Note the register. \textbf{\ta{உணவு}} is the careful, written word — a menu, a sign. Around a family table people say \textbf{\ta{சாப்பாடு}} (\emph{sāppāḍu}).
+
+\subsection*{The letters in this word}
+\textbf{\ta{உ}} is a standing vowel — a full letter, not a sign. Then \textbf{\ta{ண}}, then \textbf{\ta{வு}}, which is \textbf{\ta{வ}} with the \emph{u} sign underneath. \textbf{\ta{ண}} is the retroflex n you first wrote alongside \textbf{\ta{ம}}, and the letter inside \textbf{\ta{தண்ணீர்}}.
+
+\begin{sounds}
+Curl the tip of your tongue \textbf{back} to the roof of your mouth and release into the vowel. That is \textbf{\ta{ண}}, and \emph{uṇavu} gives it a clean run because the letter sits between two vowels. Contrast the \textbf{\ta{ன}} of \textbf{\ta{நன்றி}} and the \textbf{\ta{ந}} of \textbf{\ta{நீர்}}, both made near the teeth.
+\end{sounds}
+
+\begin{cousinweb}
+\textbf{\ta{உணவு}} is \textbf{\ta{உண்}} (\emph{uṇ}), \textquotedblleft{}to eat,\textquotedblright{} with a noun-forming ending. Food is literally \emph{the eating}. Tamil has two eating verbs, of different ages:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{the verb} & \textbf{where it lives} \\
+\midrule
+\textbf{\ta{உண்}} \emph{uṇ} & old, inherited, literary now \\
+\textbf{\ta{சாப்பிடு}} \emph{sāppiḍu} & the everyday spoken verb \\
+\bottomrule
+\end{tabularx}
+
+\textbf{\ta{உண்}} is a bare inherited root, and the Dravidian dictionary lists \emph{uṇavu} inside its entry.
+
+\textbf{\ta{சாப்பிடு}} is where the ground softens, so hold this course's earlier account loosely. You were shown \emph{sāppu}, \textquotedblleft{}food,\textquotedblright{} plus \textbf{\ta{இடு}} (\emph{iḍu}), \textquotedblleft{}to put.\textquotedblright{} The \textbf{\ta{இடு}} is visible in the spelling; the first half is the problem. The great Tamil lexicon records no plain word \emph{sāppu} meaning \textquotedblleft{}food,\textquotedblright{} and the Dravidian etymological dictionary has \textbf{no entry for this verb at all}. It is not Sanskrit — Telugu and Malayalam have their own forms — but its origin is open. The word you would use at a table has the weaker paperwork.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item the root and the noun — \textquotedblleft{}uṇ … uṇavu\textquotedblright{}
+  \item the retroflex, tongue curled back — \textquotedblleft{}uṇavu\textquotedblright{}
+  \item the documented one, then the everyday one — \textquotedblleft{}uṇ … sāppiḍu\textquotedblright{}
+  \item raw grain, then cooked meal — \textquotedblleft{}arisi … sātam\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What verb is \emph{uṇavu} built on, and where does your tongue go for \textbf{\ta{ண}}? (\textbf{\ta{உண்}}; \textbf{curled back}.) Which eating verb would you use at a table, and how sure is anyone where it came from? (\textbf{\ta{சாப்பிடு}} — \textbf{not at all}: the Dravidian dictionary has no entry.) Give the raw grain and the cooked meal. (\emph{Arisi}; \emph{sātam}.)
+\end{tcolorbox}
+\section[tavaṟu]{\ta{தவறு} (tavaṟu) — \textquotedblleft{}a mistake,\textquotedblright{} and the rest of the apology}
+
+\label{lesson:TA-C36-tavaru}
+
+
+
+\begin{quote}
+The chapter back: \emph{tēnīr}, \emph{pāl}, \emph{uṇavu}. Suppose one arrives and it is not what you asked for. You have \textquotedblleft{}sorry,\textquotedblright{} but not the word for what went wrong.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{தவறு}}
+\begin{quote}
+\textbf{\ta{தவறு}} — \emph{tavaṟu} — \textbf{a mistake, an error, a fault}
+\end{quote}
+
+With \textbf{\ta{என்}} (\emph{eṉ}), \textquotedblleft{}my,\textquotedblright{} and no verb — Tamil needs none:
+
+\begin{quote}
+\textbf{\ta{மன்னிக்கவும்}, \ta{என்} \ta{தவறு}. \ta{பால்} \ta{இல்லை}, \ta{தேநீர்}.}
+\end{quote}
+
+>
+
+\begin{quote}
+\emph{maṉṉikkavum, eṉ tavaṟu. pāl illai, tēnīr.}
+\end{quote}
+
+>
+
+\begin{quote}
+\textbf{Sorry, my mistake. Not milk — tea.}
+\end{quote}
+
+\textbf{\ta{மன்னிக்கவும்}} is the careful, written-leaning apology; in speech many Tamil speakers simply say \emph{sorry}, in English. \textbf{\ta{என்} \ta{தவறு}} suits either.
+
+\subsection*{The letters in this word}
+\textbf{\ta{த}} + \textbf{\ta{வ}} + \textbf{\ta{று}}. The last piece is \textbf{\ta{ற}}, the hard r of \emph{aṟai}, with the \emph{u} sign — made at the ridge behind the teeth, tongue flat, not curled.
+
+The apology in front of it does something this word does not. \textbf{\ta{மன்னிக்கவும்}} has \textbf{\ta{ன்னி}}: the alveolar \textbf{\ta{ன}} switched off by a dot, then written a second time with the \emph{i} sign. Tamil doubles a consonant by \textbf{repeating the letter with a dot on the first}, never by inventing a joined shape — the \textbf{\ta{க்க}} of \textbf{\ta{வணக்கம்}} over.
+
+\begin{cousinweb}
+\textbf{\ta{தவறு}} is inherited Dravidian, a verb and a noun in one shape: \textquotedblleft{}to slip, to fail,\textquotedblright{} and \textquotedblleft{}a slip, a mistake.\textquotedblright{} The dictionary files it beside \textbf{\ta{தப்பு}} (\emph{tappu}); its cousins are everywhere.
+
+Now the chapter in a line. \textbf{\ta{மன்னிக்கவும்}} was the showpiece: Tamil kept its own \textbf{\ta{மன்னி}} where Kannada, Telugu and Malayalam reached for Sanskrit \textbf{kṣamā}. \textbf{\ta{தவறு}} is inherited too, and so is \textbf{\ta{உண்}} inside \emph{uṇavu}, and \textbf{\ta{பால்}}. But \textbf{\ta{தேநீர்}} is half a loan from a Malay port, and \textbf{\ta{சாதம்}} was flagged as Sanskrit-influenced when you met it.
+
+So the honest statement is not \textquotedblleft{}Tamil does not borrow.\textquotedblright{} It is that \textbf{Tamil borrows without evicting}: the inherited word stays, and the loan takes a different job or register.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item \textquotedblleft{}eṉ tavaṟu\textquotedblright{} — my mistake, with no verb in it
+  \item the whole repair — \textquotedblleft{}maṉṉikkavum, eṉ tavaṟu\textquotedblright{}
+  \item the two words for a mistake — \textquotedblleft{}tavaṟu … tappu\textquotedblright{}
+  \item the borrowed one among this chapter's words — \textquotedblleft{}tēnīr\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Apologise, name the fault, and say why there is no word for \textquotedblleft{}is\textquotedblright{} in it. (\emph{Maṉṉikkavum, eṉ tavaṟu}; \textbf{Tamil needs none}.) How does Tamil write a doubled consonant, as in \textbf{\ta{ன்னி}} and \textbf{\ta{க்க}}? (\textbf{The letter a second time}, dot on the first.) Which apology verb is native where the neighbours took Sanskrit, and does that make Tamil a language that never borrows? (\textbf{\ta{மன்னி}}, against \textbf{kṣamā}; \textbf{no} — it \textbf{borrows without evicting}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch37-your-town-your-friend.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch37-your-town-your-friend.tex
@@ -1,0 +1,273 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:977ef60cd0294c2e
+% canonical-lessons: TA-C37-uur, TA-C37-nanban, TA-C37-ivar, TA-C37-ivar-en-nanbar
+
+\chapter{Your Town, Your Friend}
+\label{ch:ta-your-town-your-friend}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can ask \ta{உங்கள்} \ta{ஊர்} \ta{என்ன}? and introduce someone with \ta{இவர்} \ta{என்} \ta{நண்பர்}, choose between \ta{நண்பன்}, \ta{நண்பி} and \ta{நண்பர்}, run Tamil's \ta{இ} / \ta{அ} / \ta{எ} pointing series, and hear \ta{ண்} voice the \ta{ப} that follows it.}
+
+Say \ta{இவர்} \ta{என்} \ta{நண்பர்} with no verb in it, pick the ending by respect rather than by habit, name the -ūr inside Tanjore and Bengaḷūru, and state what Tamil forces you to decide for a sibling that it does not force for a friend.
+\end{chapteropening}
+
+\section[ūr]{\ta{ஊர்} (ūr) — \textquotedblleft{}town,\textquotedblright{} and the question Tamil asks early}
+
+\label{lesson:TA-C37-uur}
+
+
+
+\begin{quote}
+\emph{Eṉ tavaṟu} — my mistake, a word that is a verb and a noun at once. Then the general word for food. (\emph{Uṇavu}.) Now back to meeting somebody.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{ஊர்}}
+\begin{quote}
+\textbf{\ta{ஊர்}} — \emph{ūr} — \textbf{town, village; the place you are from}
+\end{quote}
+
+That last sense matters most. \textbf{\ta{உங்கள்} \ta{ஊர்}} is your \textbf{native place}, where your family is from, which may be somewhere you have never lived.
+
+\begin{quote}
+\textbf{\ta{உங்கள்} \ta{ஊர்} \ta{என்ன}} — \emph{uṅgaḷ ūr eṉṉa} — \textbf{What is your town}
+\end{quote}
+
+It lands early in a Tamil conversation and is not nosiness — the slot English fills with "what do you do.
+
+\subsection*{The letters in this word}
+\textbf{\ta{ஊ}} is a standing vowel — long \emph{ū}, partner of the \textbf{\ta{உ}} that opens \emph{uṇavu}. \textbf{\ta{ர்}} is \textbf{\ta{ர}}, the soft r, shut by a puḷḷi. Hold the vowel: \emph{ūr}, not \emph{ur}. Vowel length is part of a word's identity here.
+
+\begin{grammarlens}[title={Grammar Lens: the two registers, side by side}]
+You met this choice on the age question:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{the question} & \textbf{who you say it to} \\
+\midrule
+\textbf{\ta{உன்} \ta{ஊர்} \ta{என்ன}} \emph{uṉ ūr eṉṉa} & a friend, a child, a peer \\
+\textbf{\ta{உங்கள்} \ta{ஊர்} \ta{என்ன}} \emph{uṅgaḷ ūr eṉṉa} & a stranger, an elder, anyone senior \\
+\bottomrule
+\end{tabularx}
+
+Both are possessive plus noun plus question word, with \textbf{no verb} — the shape you learned for \textbf{\ta{உன்} \ta{வயசு} \ta{என்ன}}. Only the possessive changes, and with it the social temperature. When unsure, use \textbf{\ta{உங்கள்}}.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{\ta{ஊர்}} is inherited Dravidian, and welded into city names you know in English:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{the English name} & \textbf{what it is} \\
+\midrule
+\textbf{Tanjore} & Tamil \textbf{\ta{தஞ்சாவூர்}} \emph{Tañjāvūr} \\
+\textbf{Vellore} & Tamil \textbf{\ta{வேலூர்}} \emph{Vēlūr} \\
+\textbf{Bangalore} & Kannada \textbf{\ka{ಬೆಂಗಳೂರು}} \emph{Bengaḷūru} \\
+\bottomrule
+\end{tabularx}
+
+Every one of those \emph{-ore} endings is this word: the British ear turned \emph{-ūr} into \emph{-ore}, and the cities have taken their own names back.
+
+Two exactnesses. Bangalore is a \textbf{Kannada} town, so its \emph{-ūru} is Kannada's form of the inherited word — the family's, not Tamil's alone. And the \emph{first} halves are not all settled; \emph{Vēl-} in Vellore is argued over. The ending is the certain part.
+
+Weigh that against the rice word. \textbf{\ta{அரிசி}} \emph{may} stand behind English \emph{rice} through Greek, and the dictionaries hedge. Nobody hedges about \emph{-ūr}.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item the long vowel — \textquotedblleft{}ūr,\textquotedblright{} not \textquotedblleft{}ur\textquotedblright{}
+  \item to a stranger — \textquotedblleft{}uṅgaḷ ūr eṉṉa\textquotedblright{}
+  \item to a friend — \textquotedblleft{}uṉ ūr eṉṉa\textquotedblright{}
+  \item the ending inside the map — \textquotedblleft{}Tañjāvūr … Vēlūr … Bengaḷūru\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Ask a stranger where they are from, then a friend, and say what \textbf{\ta{ஊர்}} means beyond \textquotedblleft{}town.\textquotedblright{} (\emph{Uṅgaḷ ūr eṉṉa}; \emph{uṉ ūr eṉṉa}; \textbf{your native place}.) Which earlier question has this shape, and is \emph{-ore} in Tanjore really this word? (\textbf{\ta{உன்} \ta{வயசு} \ta{என்ன}}; \textbf{yes}.) How sure are we there, next to \emph{arisi} and \emph{rice}? (\textbf{Much surer.})
+\end{tcolorbox}
+\section[naṇbaṉ]{\ta{நண்பன்} (naṇbaṉ) — \textquotedblleft{}friend,\textquotedblright{} with the ending doing the work}
+
+\label{lesson:TA-C37-nanban}
+
+
+
+\begin{quote}
+A stranger's native place, then the ending inside Tanjore. (\emph{Uṅgaḷ ūr eṉṉa}; \emph{-ūr}.) Now the person you would introduce.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{நண்பன்}}
+\begin{quote}
+\textbf{\ta{நண்பன்}} — \emph{naṇbaṉ} — \textbf{friend} (a man)
+\end{quote}
+
+Tamil will not let you say a bare \textquotedblleft{}friend\textquotedblright{} any more than a bare \textquotedblleft{}brother.\textquotedblright{} The stem is \textbf{\ta{நண்ப}-}; the ending decides.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{the form} & \textbf{who it is} \\
+\midrule
+\textbf{\ta{நண்பன்}} \emph{naṇbaṉ} & a male friend \\
+\textbf{\ta{நண்பி}} \emph{naṇbi} & a female friend \\
+\textbf{\ta{நண்பர்}} \emph{naṇbar} & a friend spoken of with respect \\
+\bottomrule
+\end{tabularx}
+
+The \textbf{-\ta{அர்}} is the respectful plural that turns \textbf{\ta{நீ}} into \textbf{\ta{நீங்கள்}}, applied to a person.
+
+This is a different axis from the family words. \textbf{\ta{அண்ணன்}} and \textbf{\ta{தம்பி}} split brothers by \textbf{age}; the friend words split by \textbf{sex}, \textbf{\ta{நண்பர்}} by \textbf{respect}.
+
+\subsection*{The letters in this word}
+\textbf{\ta{ந}} + \textbf{\ta{ண்}} + \textbf{\ta{ப}} + \textbf{\ta{ன்}} — \textbf{every one of Tamil's n-letters inside one word}. \textbf{\ta{ந}} opens it, dental, at the teeth. \textbf{\ta{ண்}} is retroflex, tongue curled back, closed by a puḷḷi. \textbf{\ta{ன்}} ends it, the alveolar n from \textbf{\ta{நன்றி}}. The writing lesson gave them to you one at a time; here they arrive together.
+
+\begin{sounds}
+The letter after \textbf{\ta{ண்}} is \textbf{\ta{ப}}, named \emph{pa}. The course writes \emph{naṇ\textbf{b}aṉ} because of the \textbf{\ta{நன்றி}} rule: a nasal in front of a stop \textbf{voices it}. A Tamil reader supplies the voicing, as an English reader supplies the \emph{sh} in \emph{sugar}.
+\end{sounds}
+
+\begin{cousinweb}
+Behind \textbf{\ta{நண்பன்}} is \textbf{\ta{நண்பு}} (\emph{naṇbu}), \textquotedblleft{}friendship, closeness,\textquotedblright{} which belongs to the root family of \textbf{\ta{நண்ணு}} (\emph{naṇṇu}), \textquotedblleft{}\textbf{to draw near}.\textquotedblright{} A friend, in Tamil's own accounting, is someone who came close.
+
+Be precise. The Dravidian dictionary files \emph{naṇbu} and \emph{naṇbaṉ} in the same entry as \emph{naṇṇu}; the Tamil lexicon prefers \textbf{\ta{நள்}-}, making them siblings rather than parent and child. They differ on the line of descent, not on the household.
+
+Set it beside \textbf{\ta{அப்பா}} and \textbf{\ta{அம்மா}}, not built out of anything — the repeated-syllable shape children produce for parents worldwide. \textbf{\ta{நண்பன்}} is assembled, from a root you can point at.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item the three endings — \textquotedblleft{}naṇbaṉ, naṇbi, naṇbar\textquotedblright{}
+  \item the voicing after the nasal — \textquotedblleft{}naṉṟi … naṇbaṉ\textquotedblright{}
+  \item the root it came from — \textquotedblleft{}naṇṇu, to draw near\textquotedblright{}
+  \item the family words that split on age instead — \textquotedblleft{}aṇṇaṉ, tambi\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Give the friend-word for a woman, a man, and someone you respect. (\emph{Naṇbi}; \emph{naṇbaṉ}; \emph{naṇbar}.) Which axis do the friend words split on, and which do the brother words? (\textbf{Sex and respect}; \textbf{age}.) Why is \textbf{\ta{ப}} heard as \emph{b}, and are \textbf{\ta{அப்பா}} and \textbf{\ta{அம்மா}} built from a root the way \emph{naṇbaṉ} is? (\textbf{A nasal voices the stop after it}; \textbf{no}.)
+\end{tcolorbox}
+\section[ivar]{\ta{இவர்} (ivar) — \textquotedblleft{}this person,\textquotedblright{} and Tamil's pointing system}
+
+\label{lesson:TA-C37-ivar}
+
+
+
+\begin{quote}
+\emph{Naṇbaṉ}, \emph{naṇbi}, \emph{naṇbar} — and the root behind them. (\emph{Naṇṇu}, to draw near.) You have the word for a friend, but cannot point at one.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{இவர்}}
+\begin{quote}
+\textbf{\ta{இவர்}} — \emph{ivar} — \textbf{this person} (near me, spoken of respectfully)
+\end{quote}
+
+Not \textquotedblleft{}he\textquotedblright{} and not \textquotedblleft{}she\textquotedblright{}: \textbf{\ta{இவர்}} is what you say about a person standing here whom you are treating with respect, and it does not commit you to their sex. It is built on \textbf{\ta{இவன்}} (\emph{ivaṉ}) and \textbf{\ta{இவள்}} (\emph{ivaḷ}), with the same \textbf{-\ta{அர்}} that gave you \textbf{\ta{நண்பர்}}.
+
+One caution about speech: \textbf{\ta{இவர்}} is heard mostly of men, and \textbf{\ta{இவங்க}} (\emph{ivaṅga}) does the same respectful job for a woman.
+
+\subsection*{The letters in this word}
+\textbf{\ta{இ}} + \textbf{\ta{வ}} + \textbf{\ta{ர்}}. \textbf{\ta{இ}} is the standing vowel \emph{i} — the letter, not the \textbf{\ta{ி}} sign that hangs on a consonant. \textbf{\ta{வ}} is the \emph{va} opening \textbf{\ta{வணக்கம்}} and \textbf{\ta{வீடு}}. \textbf{\ta{ர்}} is the soft r with a puḷḷi.
+
+A word this short is almost all arc, which is the moment to recall the usual explanation for that roundness: Tamil was scratched into palm leaf, and a straight stroke along the grain can split the leaf. Hold it as the writing lesson asked — \textbf{the standard account, not a settled fact}, since the earliest Tamil writing was cut into stone and is angular. What survives is the useful part: \textbf{the tool leaves fingerprints on the letters}.
+
+\begin{grammarlens}[title={Grammar Lens: near, far, and which}]
+\textbf{\ta{இவர்}} is one cell of a system, and the system is a single letter at the front:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{the front letter} & \textbf{what it does} \\
+\midrule
+\textbf{\ta{இ}-} & points \textbf{near} — this one, here \\
+\textbf{\ta{அ}-} & points \textbf{away} — that one, there \\
+\textbf{\ta{எ}-} & \textbf{asks} — which one \\
+\bottomrule
+\end{tabularx}
+
+So \textbf{\ta{இவர்}} is \textquotedblleft{}this person,\textquotedblright{} \textbf{\ta{அவர்}} (\emph{avar}) \textquotedblleft{}that person,\textquotedblright{} \textbf{\ta{எவர்}} (\emph{evar}) \textquotedblleft{}which person.\textquotedblright{} You have been using one front already: \textbf{\ta{என்ன}} (\emph{eṉṉa}), \textquotedblleft{}what,\textquotedblright{} is the \textbf{\ta{எ}-} of asking.
+
+Two honest notes. \textbf{\ta{எ}-} is the \textbf{question}, not a third distance. And Old Tamil had a genuine third distance, \textbf{\ta{உ}-}, for something visible but far off; modern Tamil has retired it.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item the three fronts — \textquotedblleft{}i- … a- … e-\textquotedblright{}
+  \item the row they build — \textquotedblleft{}ivar, avar, evar\textquotedblright{}
+  \item the question word you already had — \textquotedblleft{}eṉṉa\textquotedblright{}
+  \item the respectful ending on both — \textquotedblleft{}naṇbar … ivar\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What do \textbf{\ta{இ}-}, \textbf{\ta{அ}-} and \textbf{\ta{எ}-} do at the front of a word, and which question word you already knew is built on \textbf{\ta{எ}-}? (\textbf{Near}; \textbf{away}; \textbf{asks} — and \textbf{\ta{என்ன}}.) Does \textbf{\ta{இவர்}} tell you whether the person is a man or a woman? (\textbf{No} — it marks \textbf{respect}; spoken Tamil leans \textbf{\ta{இவங்க}} for a woman.) How firmly should you hold the palm-leaf explanation for the curves? (As \textbf{the standard account, not a settled fact}.)
+\end{tcolorbox}
+\section[ivar eṉ naṇbar]{\ta{இவர்} \ta{என்} \ta{நண்பர்} — \textquotedblleft{}this is my friend\textquotedblright{}}
+
+\label{lesson:TA-C37-ivar-en-nanbar}
+
+
+
+\begin{quote}
+\emph{Ivar, avar, evar} — near, away, the question. Then \emph{naṇbaṉ, naṇbi, naṇbar}. Everything this lesson needs is in your mouth; what is left is the order.
+\end{quote}
+
+\subsection*{You'll want to know: the introduction}
+\begin{quote}
+\textbf{\ta{இவர்} \ta{என்} \ta{நண்பர்}.} — \emph{ivar eṉ naṇbar} — \textbf{This is my friend.}
+\end{quote}
+
+Three words, and \textbf{not one of them is a verb}. Tamil links two nouns by setting them beside each other, as in \textbf{\ta{என்} \ta{பெயர்} …} and \textbf{\ta{என்} \ta{தவறு}}.
+
+The pieces in order: \textbf{\ta{இவர்}}, the person here; \textbf{\ta{என்}}, my; \textbf{\ta{நண்பர்}}, friend-with-respect. Then stop.
+
+The whole meeting:
+
+\begin{quote}
+— \textbf{\ta{வணக்கம்}. \ta{இவர்} \ta{என்} \ta{நண்பர்}.}
+\end{quote}
+
+>
+
+\begin{quote}
+— \textbf{\ta{வணக்கம்}. \ta{உங்கள்} \ta{ஊர்} \ta{என்ன}.}
+\end{quote}
+
+Every word in it is yours.
+
+\subsection*{The letters in this word}
+\textbf{\ta{என்}} is \textbf{\ta{எ}} with \textbf{\ta{ன்}}, the alveolar n dotted shut. \textbf{\ta{நண்பர்}} opens on dental \textbf{\ta{ந}}, turns on retroflex \textbf{\ta{ண்}}, closes on \textbf{\ta{ர்}}. So one line makes you produce \textbf{\ta{ன்}} and \textbf{\ta{ண்}} within a breath of each other — one at the ridge, the other with the tongue curled back. Hear that difference and the three-way n is no longer theory.
+
+\begin{culture}
+\textbf{\ta{நண்பர்}} rather than \textbf{\ta{நண்பன்}} is a decision, not a default.
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ta{இவர்} \ta{என்} \ta{நண்பன்}.} — a male friend, plainly stated; warm among peers.
+  \item \textbf{\ta{இவர்} \ta{என்} \ta{நண்பி}.} — a female friend, the matching plain form.
+  \item \textbf{\ta{இவர்} \ta{என்} \ta{நண்பர்}.} — the respectful ending; safe with anyone, and right when either party is older or senior.
+\end{itemize}
+
+If unsure, take \textbf{\ta{நண்பர்}}. Over-respect is invisible; under-respect is not.
+
+Notice how differently Tamil makes you think from one word to the next. For a \textbf{sibling} it forces \textbf{age}: there is no bare \textquotedblleft{}brother\textquotedblright{} — you must choose \textbf{\ta{அண்ணன்}} or \textbf{\ta{தம்பி}}, \textbf{\ta{அக்கா}} or \textbf{\ta{தங்கை}}, and say whether they are older or younger than you before you can say anything at all. For a \textbf{friend} it forces \textbf{sex or respect}. For \textbf{parents}, nothing: \textbf{\ta{அப்பா}} and \textbf{\ta{அம்மா}} came into the language whole. Tamil rarely lets you be vague about a relationship.
+\end{culture}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item the introduction — \textquotedblleft{}ivar eṉ naṇbar\textquotedblright{}
+  \item the same line to a peer about a male friend — \textquotedblleft{}ivar eṉ naṇbaṉ\textquotedblright{}
+  \item the greeting and the question around it — \textquotedblleft{}vaṇakkam … uṅgaḷ ūr eṉṉa\textquotedblright{}
+  \item what a sibling word forces you to decide — \textquotedblleft{}aṇṇaṉ, older; tambi, younger\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Introduce a friend respectfully, and say how many verbs the sentence has. (\emph{Ivar eṉ naṇbar}; \textbf{none}.) What does a sibling word force you to decide that a friend word does not? (\textbf{Whether they are older or younger} — \emph{aṇṇaṉ} against \emph{tambi}.) Which friend ending is safe when unsure, and what does \textbf{\ta{இ}-} tell your listener? (\textbf{\ta{நண்பர்}}; that the person is \textbf{near}.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch37-your-town-your-friend.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch37-your-town-your-friend.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:977ef60cd0294c2e
+% canonical-source-hash: fnv1a64:2a3905874c0757ce
 % canonical-lessons: TA-C37-uur, TA-C37-nanban, TA-C37-ivar, TA-C37-ivar-en-nanbar
 
 \chapter{Your Town, Your Friend}
@@ -124,7 +124,7 @@ This is a different axis from the family words. \textbf{\ta{அண்ணன்}}
 \textbf{\ta{ந}} + \textbf{\ta{ண்}} + \textbf{\ta{ப}} + \textbf{\ta{ன்}} — \textbf{every one of Tamil's n-letters inside one word}. \textbf{\ta{ந}} opens it, dental, at the teeth. \textbf{\ta{ண்}} is retroflex, tongue curled back, closed by a puḷḷi. \textbf{\ta{ன்}} ends it, the alveolar n from \textbf{\ta{நன்றி}}. The writing lesson gave them to you one at a time; here they arrive together.
 
 \begin{sounds}
-The letter after \textbf{\ta{ண்}} is \textbf{\ta{ப}}, named \emph{pa}. The course writes \emph{naṇ\textbf{b}aṉ} because of the \textbf{\ta{நன்றி}} rule: a nasal in front of a stop \textbf{voices it}. A Tamil reader supplies the voicing, as an English reader supplies the \emph{sh} in \emph{sugar}.
+The letter after \textbf{\ta{ண்}} is \textbf{\ta{ப}}, named \emph{pa}. This book writes \emph{naṇ\textbf{b}aṉ} because of the \textbf{\ta{நன்றி}} rule: a nasal in front of a stop \textbf{voices it}. A Tamil reader supplies the voicing, as an English reader supplies the \emph{sh} in \emph{sugar}.
 \end{sounds}
 
 \begin{cousinweb}

--- a/code/learning/human-languages/tamil/book/chapters/ch38-keeping-well-and-leaving.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch38-keeping-well-and-leaving.tex
@@ -1,0 +1,203 @@
+% GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
+% canonical-source-hash: fnv1a64:cdf9a751033520e6
+% canonical-lessons: TA-C38-udambu, TA-C38-sugam, TA-C38-vidai
+
+\chapter{Keeping Well, and Leaving}
+\label{ch:ta-keeping-well-and-leaving}
+
+\begin{chapteropening}
+\textbf{By the end of this chapter:} \emph{I can ask \ta{உங்கள்} \ta{உடம்பு} \ta{எப்படி} \ta{இருக்கு}?, recognise \ta{சுகமா}? and place it as the Sanskrit-derived option beside native \ta{நலம்}, say \ta{விடை} \ta{பெறுகிறேன்}, and show that \ta{விடு}, \ta{வீடு} and \ta{விடை} are one root while \ta{ஊர்} and \ta{நண்பன்} are not.}
+
+Close the visit with \ta{நன்றி}. \ta{விடை} \ta{பெறுகிறேன்}., put \ta{விடு}, \ta{வீடு} and \ta{விடை} in one dictionary entry, refuse the second \ta{விடை} that means 'bull' and came from Sanskrit, and refuse to join \ta{ஊர்} and \ta{நண்பன்} to the pattern just because they are nearby.
+\end{chapteropening}
+
+\section[uḍambu]{\ta{உடம்பு} (uḍambu) — \textquotedblleft{}body,\textquotedblright{} and how Tamil asks after your health}
+
+\label{lesson:TA-C38-udambu}
+
+
+
+\begin{quote}
+Introduce a friend respectfully and name the ending. (\emph{Ivar eṉ naṇbar} — the respectful \textbf{-\ta{அர்}}.) Next you would ask how they are.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{உடம்பு}}
+\begin{quote}
+\textbf{\ta{உடம்பு}} — \emph{uḍambu} — \textbf{body}
+\end{quote}
+
+The whole of it, not a part. You have \textbf{\ta{தலை}} (\emph{talai}) and \textbf{\ta{கை}} (\emph{kai}) already; this is what they belong to, and the word inside the question Tamil speakers actually ask:
+
+\begin{quote}
+\textbf{\ta{உங்கள்} \ta{உடம்பு} \ta{எப்படி} \ta{இருக்கு}} — \emph{uṅgaḷ uḍambu eppaḍi irukku} — \textbf{how is your body}, that is, \textbf{how are you keeping}
+\end{quote}
+
+Every piece is yours: \textbf{\ta{உங்கள்}}, \textbf{\ta{எப்படி}}, and \textbf{\ta{இருக்கு}} from \textbf{\ta{இரு}}. What is new is that the health question hangs on a \textbf{noun} rather than on you.
+
+Tamil has a second way to ask it, through \textbf{\ta{உணவு}} — the noun standing on \textbf{\ta{உண்}}, \textquotedblleft{}to eat.\textquotedblright{} Asking whether somebody has eaten is asking whether they are all right.
+
+\subsection*{The letters in this word}
+\textbf{\ta{உ}} + \textbf{\ta{ட}} + \textbf{\ta{ம்}} + \textbf{\ta{பு}}: the standing vowel \emph{u}, \textbf{\ta{ட}}, then \textbf{\ta{ம்}} — \textbf{\ta{ம}} shut by the puḷḷi you have used since \textbf{\ta{வணக்கம்}} — and \textbf{\ta{பு}}. \textbf{\ta{ம}} was one of the first letters you formed with a pen, alongside retroflex \textbf{\ta{ண}}.
+
+\begin{sounds}
+The letters say \emph{u-ṭa-m-pu}; your mouth says \emph{u\textbf{ḍ}a\textbf{mb}u}. \textbf{\ta{ட}} sits between vowels, so it softens — the \emph{paḍi} rule. \textbf{\ta{ப}} follows the nasal \textbf{\ta{ம்}}, so it voices — the \emph{naṉṟi} rule that also made \emph{naṇbaṉ}. Two rules, one short word, neither written down.
+\end{sounds}
+
+\begin{cousinweb}
+Tamil has another word for the body, \textbf{\ta{உடல்}} (\emph{uḍal}), and the Dravidian dictionary does not treat them as rivals: \textbf{\ta{உடல்}}, \textbf{\ta{உடம்பு}} and \textbf{\ta{உடலம்}} sit in the \textbf{same entry}, with Kannada's \textbf{\ka{ಒಡಲು}} beside them. Usage has divided them: \textbf{\ta{உடல்}} leans literary, \textbf{\ta{உடம்பு}} is what you say aloud about someone unwell.
+\end{cousinweb}
+
+\begin{grammarlens}[title={Grammar Lens: where the person goes in a health question}]
+Two shapes Tamil uses to ask about a state:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{the question} & \textbf{where the person sits} \\
+\midrule
+\textbf{\ta{உங்கள்} \ta{உடம்பு} \ta{எப்படி} \ta{இருக்கு}} & as a \textbf{possessor} \\
+\textbf{\ta{உனக்கு} \ta{எத்தனை} \ta{வயது} \ta{ஆகிறது}} & in the \textbf{dative} \\
+\bottomrule
+\end{tabularx}
+
+The formal age question does not make you the subject at all — \textquotedblleft{}\textbf{to you}, how many years are becoming.\textquotedblright{} The body question makes \textbf{\ta{உடம்பு}} the subject.
+\end{grammarlens}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item the two softenings — \textquotedblleft{}uṭampu … uḍambu\textquotedblright{}
+  \item the question — \textquotedblleft{}uṅgaḷ uḍambu eppaḍi irukku\textquotedblright{}
+  \item the parts, the whole, and the two forms of one root — \textquotedblleft{}talai, kai … uḍambu … uḍal\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Ask someone respectfully how they are keeping, through the body, and name the two sound rules inside \emph{uḍambu}. (\emph{Uṅgaḷ uḍambu eppaḍi irukku}; \textbf{\ta{ட}} softens \textbf{between vowels}, \textbf{\ta{ப}} voices \textbf{after a nasal}.) Are \textbf{\ta{உடல்}} and \textbf{\ta{உடம்பு}} different words, and where does the person sit in the formal age question? (\textbf{No}, same entry; \textbf{in the dative}.)
+\end{tcolorbox}
+\section[sugam]{\ta{சுகம்} (sugam) — \textquotedblleft{}ease,\textquotedblright{} the word Tamil did borrow}
+
+\label{lesson:TA-C38-sugam}
+
+
+
+\begin{quote}
+Health through the body, and the other body-word in its entry. (\emph{Uṅgaḷ uḍambu eppaḍi irukku}; \emph{uḍal}.) A second answer came from abroad.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{சுகம்}}
+\begin{quote}
+\textbf{\ta{சுகம்}} — \emph{sugam} — \textbf{wellbeing, ease, comfort}
+\end{quote}
+
+The \textbf{\ta{க}} is doing its old trick: the letter is \emph{ka}, but between vowels it comes out \textbf{g}. \emph{Su-\textbf{g}-am}, not \emph{su-ka-m}.
+
+\begin{quote}
+\textbf{\ta{சுகமா}} — \emph{sugamā} — \textbf{keeping well}
+\end{quote}
+
+It is \textbf{not} the ordinary Tamil \textquotedblleft{}how are you,\textquotedblright{} which is \textbf{\ta{நல்லா} \ta{இருக்கீங்களா}}. \textbf{\ta{சுகமா}} is warmer and more Sanskritic, and which you hear depends on somebody's \textbf{\ta{ஊர்}} — the native place whose name so often ends in \emph{-ūr}.
+
+\subsection*{The letters in this word}
+\textbf{\ta{சு}} + \textbf{\ta{க}} + \textbf{\ta{ம்}}: \textbf{\ta{ச}} with the \emph{u} sign, a bare \textbf{\ta{க}}, \textbf{\ta{ம}} closed by the puḷḷi. Nothing is doubled — hold that against \textbf{\ta{மன்னிக்கவும்}}, where \textbf{\ta{ன்னி}} has \textbf{\ta{ன}} dotted shut and written a second time, and \textbf{\ta{க்க}} does the same to \textbf{\ta{க}}.
+
+\begin{grammarlens}[title={Grammar Lens: where the dative is required}]
+\textbf{\ta{சுகமா}} has no dative in it, and a family of Tamil states demands one: \textbf{\ta{எனக்குத்} \ta{தமிழ்} \ta{தெரியும்}}, \textquotedblleft{}to me, Tamil is known.\textquotedblright{} Put a noun there and the shapes part:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{the phrase} & \textbf{what happened} \\
+\midrule
+\textbf{\ta{நான்}} to \textbf{\ta{எனக்கு}} & the pronoun \textbf{changes its body} \\
+\textbf{\ta{நண்பர்}} to \textbf{\ta{நண்பருக்கு}} & the noun just \textbf{takes -\ta{உக்கு}} \\
+\bottomrule
+\end{tabularx}
+
+So \textbf{\ta{நண்பருக்குத்} \ta{தமிழ்} \ta{தெரியும்}}, and the formal age question does the same: \textbf{\ta{உனக்கு} \ta{எத்தனை} \ta{வயது} \ta{ஆகிறது}}. \textbf{\ta{சுகமா}} does not: knowing and ageing come \emph{to} a person; being well is what a person \textbf{is}.
+\end{grammarlens}
+
+\begin{cousinweb}
+\textbf{\ta{சுகம்}} is Sanskrit \textbf{\dv{सुख}} (\emph{sukha}), \textquotedblleft{}ease\textquotedblright{} — the apology lesson in reverse. There, \textbf{\ta{மன்னிக்கவும்}} stood on Tamil's own \textbf{\ta{மன்னி}} while the neighbours built their \textquotedblleft{}sorry\textquotedblright{} on Sanskrit \textbf{kṣamā}. Here Tamil borrowed \emph{sukha} and \textbf{kept \ta{நலம்}} as the everyday word; Malayalam took the same loan, \textbf{\ml{സുഖം}}, as its ordinary greeting.
+
+The old parse of \emph{sukha} is \emph{su-} \textquotedblleft{}good\textquotedblright{} plus \emph{kha} \textquotedblleft{}aperture\textquotedblright{} — a chariot's axle-hole. \textbf{Treat that as contested}: the standard Sanskrit dictionary hedges it with \textquotedblleft{}said to be,\textquotedblright{} and offers \emph{su-stha}.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item the softened \ta{க} — \textquotedblleft{}sugam,\textquotedblright{} not \textquotedblleft{}sukam\textquotedblright{}
+  \item the state that needs a dative — \textquotedblleft{}naṇbarukkut tamiḻ teriyum\textquotedblright{}
+  \item the state that does not, and the word kept beside it — \textquotedblleft{}sugamā … nalam\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Why is \textbf{\ta{க}} heard as \emph{g}, and what did the noun do that \textbf{\ta{நான்}} does not? (\textbf{Between vowels}; it \textbf{takes -\ta{உக்கு}}, while \textbf{\ta{நான்}} becomes \textbf{\ta{எனக்கு}}.) Which word did Tamil borrow, which did it keep, and how firm is the \textquotedblleft{}good axle-hole\textquotedblright{} story? (\textbf{\ta{சுகம்}}; \textbf{\ta{நலம்}}; \textbf{contested}.)
+\end{tcolorbox}
+\section[viḍai]{\ta{விடை} (viḍai) — \textquotedblleft{}leave,\textquotedblright{} and the root under the house}
+
+\label{lesson:TA-C38-vidai}
+
+
+
+\begin{quote}
+\emph{Sugam} — which language it came from, and which Tamil word stayed beside it. (Sanskrit; \textbf{\ta{நலம்}}.) You came through the door, took the \textbf{\ta{நாற்காலி}} — four legs, counted out — were given tea, said \textbf{\ta{என்} \ta{தவறு}} when the wrong cup arrived, and introduced a friend. One thing is left.
+\end{quote}
+
+\subsection*{You'll want to know: \ta{விடை}}
+\begin{quote}
+\textbf{\ta{விடை}} — \emph{viḍai} — \textbf{leave; permission to depart}
+\end{quote}
+
+Not the act of going — you have \textbf{\ta{போய்} \ta{வருகிறேன்}} for that — but the \textbf{leave itself}, taken with \textbf{\ta{பெறு}} (\emph{peṟu}), \textquotedblleft{}to obtain\textquotedblright{}:
+
+\begin{quote}
+\textbf{\ta{நன்றி}. \ta{விடை} \ta{பெறுகிறேன்}.} — \emph{naṉṟi. viḍai peṟugiṟēṉ.} — \textbf{Thank you. I take my leave.}
+\end{quote}
+
+It is \textbf{formal and slightly literary}; leaving a friend's house you would say \textbf{\ta{போய்} \ta{வருகிறேன்}}.
+
+The \textbf{\ta{தயவுசெய்து}} you learned for asking has a family across the Dravidian languages, all built on the same \emph{daya}, \textquotedblleft{}kindness,\textquotedblright{} plus a light verb. Leaving is not.
+
+\subsection*{The letters in this word}
+\textbf{\ta{வி}} + \textbf{\ta{டை}}. \textbf{\ta{வி}} is \textbf{\ta{வ}} with the \textbf{\ta{ி}} sign — the first vowel sign you learned, which made \textbf{\ta{நன்றி}} possible. \textbf{\ta{டை}} is \textbf{\ta{ட}} with the \emph{ai} sign \textbf{\ta{ை}}, which wraps around the front.
+
+\textbf{\ta{நன்றி}} stands beside it above, so read it once more: \textbf{\ta{ந}} + \textbf{\ta{ன்}} + \textbf{\ta{றி}} — dental n, alveolar n dotted shut, hard \textbf{\ta{ற}} with that same \textbf{\ta{ி}}. And \textbf{\ta{பெறுகிறேன்}} has a \textbf{\ta{க}} between vowels, so it softens.
+
+\begin{cousinweb}
+\textbf{\ta{விடை}} is inherited Dravidian, and belongs to \textbf{\ta{விடு}} (\emph{viḍu}), \textquotedblleft{}to let go.\textquotedblright{} Leave is what you are \emph{let go} with.
+
+Now the first word of these lessons. \textbf{\ta{வீடு}}, \textquotedblleft{}house,\textquotedblright{} is filed by the Dravidian dictionary in the \textbf{same entry as \ta{விடு}} — and \textbf{\ta{விடை}} is in it too:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{the word} & \textbf{what it is} \\
+\midrule
+\textbf{\ta{விடு}} \emph{viḍu} & to let go, to release \\
+\textbf{\ta{வீடு}} \emph{vīḍu} & the house — and, in the old sense, final release \\
+\textbf{\ta{விடை}} \emph{viḍai} & leave to depart \\
+\bottomrule
+\end{tabularx}
+
+You walked in through \textbf{\ta{வீடு}} and walk out through \textbf{\ta{விடை}}, one word in different clothes. Kannada's \textbf{\ka{ಬೀಡು}}, the same house with its \emph{b-}, sits on that root as well.
+
+Two cautions, because a neat pattern is when to slow down. A second \textbf{\ta{விடை}} means \textquotedblleft{}bull,\textquotedblright{} a Sanskrit borrowing from \emph{vṛṣa}; and \textbf{\ta{ஊர்}} — the settlement inside Tanjore — and \textbf{\ta{நண்பன்}} are outside this root entirely.
+\end{cousinweb}
+
+\subsection*{Your turn}
+Say these aloud:
+
+\begin{itemize}
+\raggedright
+  \item the departure — \textquotedblleft{}naṉṟi. viḍai peṟugiṟēṉ.\textquotedblright{}
+  \item the one root, three ways — \textquotedblleft{}viḍu … vīḍu … viḍai\textquotedblright{}
+  \item the two that do not join it — \textquotedblleft{}ūr … naṇbaṉ\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Take your leave formally, thanks in front of it, and name the earlier word that shares this root. (\emph{Naṉṟi. viḍai peṟugiṟēṉ.}; \textbf{\ta{வீடு}}, from \textbf{\ta{விடு}}, \textquotedblleft{}to let go.\textquotedblright{}) Do \textbf{\ta{ஊர்}} and \textbf{\ta{நண்பன்}} belong to that root? (\textbf{No} — a settlement and a closeness; not everything joins up.)
+\end{tcolorbox}

--- a/code/learning/human-languages/tamil/chapters.json
+++ b/code/learning/human-languages/tamil/chapters.json
@@ -598,6 +598,139 @@
           "TA-ETYMON-NUMBERS-6-10-FAMILY-02"
         ]
       }
+    },
+    {
+      "chapter": 35,
+      "title": "Arriving at a House",
+      "label": "ch:ta-arriving-at-a-house",
+      "canDo": "I can name a Tamil house, its door, a room and a chair, take நாற்காலி apart into 'four' and 'leg', place வீடு against Kannada ಬೀಡು on the v-to-b shift, and say why கதவு stayed everyday while Sanskrit-derived கபாடம் stayed in books.",
+      "spineNodes": [
+        "SPINE-MEET-GREET"
+      ],
+      "payoff": {
+        "lesson": "TA-C35-naarkaali",
+        "kind": "production",
+        "summary": "Walk a guest from வீடு through கதவு into அறை and offer a நாற்காலி; split the chair into நால் and கால் and hear ல் harden to ற் at the join; hold the hard ற at the ridge rather than the roof; and name what the puḷḷi does at ற்கா and what Tamil refuses to do there.",
+        "assesses": [
+          "TA-LEX-NAARKAALI-01",
+          "TA-ETYMON-NAARKAALI-02",
+          "TA-LEX-VEEDU-01",
+          "TA-ETYMON-VEEDU-02",
+          "TA-LEX-KADAVU-01",
+          "TA-ETYMON-KADAVU-02",
+          "TA-LEX-ARAI-01",
+          "TA-SOUND-ARAI-02",
+          "TA-LEX-NUMBERS-1-5-01",
+          "TA-SCRIPT-PULLI-VANAKKAM-01",
+          "TA-SCRIPT-PULLI-VANAKKAM-02",
+          "TA-SCRIPT-VOWEL-SIGNS-NANDRI-01",
+          "TA-SCRIPT-I-SIGN-WRITE-NANDRI-01"
+        ]
+      }
+    },
+    {
+      "chapter": 36,
+      "title": "What You Are Offered",
+      "label": "ch:ta-what-you-are-offered",
+      "canDo": "I can ask for தேநீர், பால் or உணவு in Tamil, say என் தவறு with no verb in it, find நீர் inside both தண்ணீர் and தேநீர், and state which of this chapter's words was borrowed and which the dictionaries cannot account for.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "TA-C36-tavaru",
+        "kind": "production",
+        "summary": "Repair a wrong order — மன்னிக்கவும், என் தவறு — and account for the chapter honestly: பால் and உண் inherited, தேநீர் half a loan through a Malay port, சாப்பிடு with no entry in the Dravidian dictionary at all, and மன்னி native where the neighbours took Sanskrit kṣamā.",
+        "assesses": [
+          "TA-LEX-TAVARU-01",
+          "TA-ETYMON-TAVARU-02",
+          "TA-LEX-TENEER-01",
+          "TA-ETYMON-TENEER-02",
+          "TA-LEX-PAAL-01",
+          "TA-ETYMON-PAAL-02",
+          "TA-LEX-UNAVU-01",
+          "TA-ETYMON-UNAVU-02",
+          "TA-ETYMON-MANNIKKAVUM-01",
+          "TA-ETYMON-MANNIKKAVUM-02",
+          "TA-PRAGMATICS-SORRY-REGISTER-01",
+          "TA-SCRIPT-SORRY-REGISTER-02",
+          "TA-SCRIPT-VOWEL-SIGNS-NANDRI-02"
+        ]
+      }
+    },
+    {
+      "chapter": 37,
+      "title": "Your Town, Your Friend",
+      "label": "ch:ta-your-town-your-friend",
+      "canDo": "I can ask உங்கள் ஊர் என்ன? and introduce someone with இவர் என் நண்பர், choose between நண்பன், நண்பி and நண்பர், run Tamil's இ / அ / எ pointing series, and hear ண் voice the ப that follows it.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "TA-C37-ivar-en-nanbar",
+        "kind": "production",
+        "summary": "Say இவர் என் நண்பர் with no verb in it, pick the ending by respect rather than by habit, name the -ūr inside Tanjore and Bengaḷūru, and state what Tamil forces you to decide for a sibling that it does not force for a friend.",
+        "assesses": [
+          "TA-LEX-IVAR-EN-NANBAR-01",
+          "TA-PRAGMATICS-IVAR-EN-NANBAR-02",
+          "TA-LEX-IVAR-01",
+          "TA-GRAMMAR-IVAR-02",
+          "TA-LEX-NANBAN-01",
+          "TA-ETYMON-NANBAN-02",
+          "TA-LEX-UUR-01",
+          "TA-ETYMON-UUR-02",
+          "TA-LEX-KUDUMBAM-02",
+          "TA-ETYMON-KUDUMBAM-01",
+          "TA-SCRIPT-VOWEL-SIGNS-NANDRI-01",
+          "TA-SCRIPT-MA-RETROFLEX-NA-02",
+          "TA-SCRIPT-ABUGIDA-VA-KA-02",
+          "TA-SOUND-I-SIGN-WRITE-NANDRI-03",
+          "TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01",
+          "TA-PRAGMATICS-THANNEER-ARISI-03"
+        ]
+      }
+    },
+    {
+      "chapter": 38,
+      "title": "Keeping Well, and Leaving",
+      "label": "ch:ta-keeping-well-and-leaving",
+      "canDo": "I can ask உங்கள் உடம்பு எப்படி இருக்கு?, recognise சுகமா? and place it as the Sanskrit-derived option beside native நலம், say விடை பெறுகிறேன், and show that விடு, வீடு and விடை are one root while ஊர் and நண்பன் are not.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "TA-C38-vidai",
+        "kind": "production",
+        "summary": "Close the visit with நன்றி. விடை பெறுகிறேன்., put விடு, வீடு and விடை in one dictionary entry, refuse the second விடை that means 'bull' and came from Sanskrit, and refuse to join ஊர் and நண்பன் to the pattern just because they are nearby.",
+        "assesses": [
+          "TA-LEX-VIDAI-01",
+          "TA-ETYMON-VIDAI-02",
+          "TA-LEX-SUGAM-01",
+          "TA-ETYMON-SUGAM-02",
+          "TA-LEX-UDAMBU-01",
+          "TA-ETYMON-UDAMBU-02",
+          "TA-LEX-VEEDU-01",
+          "TA-ETYMON-VEEDU-02",
+          "TA-LEX-UUR-01",
+          "TA-LEX-NANBAN-01",
+          "TA-LEX-TENEER-01",
+          "TA-ETYMON-TAYAVUSEYTU-02",
+          "TA-SCRIPT-I-SIGN-WRITE-NANDRI-01",
+          "TA-SCRIPT-I-SIGN-WRITE-NANDRI-02",
+          "TA-SOUND-I-SIGN-WRITE-NANDRI-03",
+          "TA-SCRIPT-ABUGIDA-VA-KA-03",
+          "TA-LEX-UDAL-URUPPUGAL-01",
+          "TA-GRAMMAR-DATIVE-UKKU-01",
+          "TA-GRAMMAR-DATIVE-STACKING-01",
+          "TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02",
+          "TA-SCRIPT-MA-RETROFLEX-NA-01",
+          "TA-SCRIPT-PULLI-VANAKKAM-01",
+          "TA-SOUND-ABUGIDA-VA-KA-04",
+          "TA-SCRIPT-SORRY-REGISTER-02",
+          "TA-ETYMON-MANNIKKAVUM-02",
+          "TA-LEX-TERI-01"
+        ]
+      }
     }
   ]
 }

--- a/code/learning/human-languages/tamil/curriculum.json
+++ b/code/learning/human-languages/tamil/curriculum.json
@@ -413,13 +413,84 @@
       "before": [],
       "inline": [],
       "after": []
+    },
+    {
+      "id": "TA-PATH-031",
+      "spine_node": "SPINE-MEET-GREET",
+      "lessons": [
+        "TA-C35-veedu",
+        "TA-C35-kadavu",
+        "TA-C35-arai",
+        "TA-C35-naarkaali"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-031-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-032",
+      "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
+      "lessons": [
+        "TA-C36-teneer",
+        "TA-C36-paal",
+        "TA-C36-unavu",
+        "TA-C36-tavaru"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-032-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-033",
+      "spine_node": "SPINE-EXCHANGE-NAMES",
+      "lessons": [
+        "TA-C37-uur",
+        "TA-C37-nanban",
+        "TA-C37-ivar",
+        "TA-C37-ivar-en-nanbar"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-033-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-034",
+      "spine_node": "SPINE-CHECK-WELLBEING",
+      "lessons": [
+        "TA-C38-udambu",
+        "TA-C38-sugam"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-034-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "TA-PATH-035",
+      "spine_node": "SPINE-TAKE-LEAVE",
+      "lessons": [
+        "TA-C38-vidai"
+      ],
+      "before": [],
+      "inline": [
+        "TA-EXT-035-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
     }
   ],
   "spine": {
     "SPINE-MEET-GREET": {
       "segments": [
         "TA-PATH-001",
-        "TA-PATH-003"
+        "TA-PATH-003",
+        "TA-PATH-031"
       ],
       "omits": [
         "GREETING-FORMAL",
@@ -455,7 +526,8 @@
         "TA-PATH-009",
         "TA-PATH-013",
         "TA-PATH-018",
-        "TA-PATH-023"
+        "TA-PATH-023",
+        "TA-PATH-033"
       ],
       "omits": [
         "PRONOUN-ME",
@@ -467,7 +539,8 @@
       "segments": [
         "TA-PATH-008",
         "TA-PATH-010",
-        "TA-PATH-019"
+        "TA-PATH-019",
+        "TA-PATH-034"
       ],
       "omits": [
         "WORD-GOOD",
@@ -478,14 +551,16 @@
     "SPINE-POLITE-REQUEST-REPAIR": {
       "segments": [
         "TA-PATH-015",
-        "TA-PATH-021"
+        "TA-PATH-021",
+        "TA-PATH-032"
       ],
       "omits": [],
       "relocates": {}
     },
     "SPINE-TAKE-LEAVE": {
       "segments": [
-        "TA-PATH-012"
+        "TA-PATH-012",
+        "TA-PATH-035"
       ],
       "omits": [
         "FAREWELL-CASUAL",
@@ -1108,6 +1183,71 @@
       "prerequisites": [],
       "lessons": [
         "TA-C01-vanakkam"
+      ]
+    },
+    {
+      "id": "TA-EXT-031-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can name the house, its door, a room and a chair in Tamil, so a greeting has somewhere to happen.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C35-veedu",
+        "TA-C35-kadavu",
+        "TA-C35-arai",
+        "TA-C35-naarkaali"
+      ]
+    },
+    {
+      "id": "TA-EXT-032-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can ask for tea, milk or food in Tamil, and say whose mistake it was when the wrong thing arrives.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C36-teneer",
+        "TA-C36-paal",
+        "TA-C36-unavu",
+        "TA-C36-tavaru"
+      ]
+    },
+    {
+      "id": "TA-EXT-033-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can ask where somebody is from and introduce a friend in Tamil, choosing the ending that fits.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C37-uur",
+        "TA-C37-nanban",
+        "TA-C37-ivar",
+        "TA-C37-ivar-en-nanbar"
+      ]
+    },
+    {
+      "id": "TA-EXT-034-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can ask after somebody's health in Tamil through the body, and recognise the Sanskrit-derived alternative.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C38-udambu",
+        "TA-C38-sugam"
+      ]
+    },
+    {
+      "id": "TA-EXT-035-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can take my leave in Tamil in the formal register, and place the word on its root.",
+      "prerequisites": [],
+      "lessons": [
+        "TA-C38-vidai"
       ]
     }
   ]

--- a/code/learning/human-languages/tamil/lessons/TA-C35-arai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C35-arai.md
@@ -1,0 +1,102 @@
+---
+schema_version: 2
+id: TA-C35-arai
+spine_node: SPINE-MEET-GREET
+sequence: 770
+chapter: 35
+type: word
+headword: அறை
+gloss: room — and the letter ற, the hard r that is not the r you think it is
+romanization: aṟai
+concept_tag: TA-ROOM
+prerequisites: [TA-C35-kadavu]
+sounds: [tamil-alveolar-rra, tamil-vowel-sign-ai]
+roots: [dravidian-arai-chamber]
+etymology_hook: "அறை is inherited Dravidian — Malayalam അറ aṟa, 'chamber' — and it carries ற, the hard r Tamil keeps separate from ர"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-KADAVU-01, TA-ETYMON-KADAVU-02, TA-LEX-VEEDU-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02]
+introduces:
+  knowledge: [TA-LEX-ARAI-01, TA-SOUND-ARAI-02]
+practises:
+  knowledge: [TA-LEX-KADAVU-01, TA-ETYMON-KADAVU-02, TA-LEX-VEEDU-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-LEX-ARAI-01, TA-SOUND-ARAI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C35-kadavu, TA-C35-veedu, TA-W04-vowel-signs-nandri]
+---
+
+# அறை (aṟai) — "room," and Tamil's second r
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-KADAVU-01, TA-ETYMON-KADAVU-02, TA-LEX-VEEDU-01] -->
+
+[PAUSE 2s] *Vīḍu*, house. *Kadavu*, door — the everyday word Tamil kept while
+the Sanskrit one stayed in books. Open that door and you are in this word.
+
+## You'll want to know: அறை
+<!-- hl-knowledge: introduces=[TA-LEX-ARAI-01]; assesses=[] -->
+
+> **அறை** — *aṟai* — **room**
+
+Any room: in a house, in a hotel, a cell. Put it behind *vīḍu* the way you put
+*kadavu* there:
+
+> **வீட்டு அறை** — *vīṭṭu aṟai* — **a room of the house**
+
+And with the dative, **அறைக்கு** (*aṟaikku*), "to the room."
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-VOWEL-SIGNS-NANDRI-02] -->
+
+**அ** is the standing vowel *a* — a letter in its own right, not a sign hung on
+a consonant. Then **ற**, then the *ai* sign **ை**, which wraps around the front
+of its consonant: **ற** + **ை** → **றை**.
+
+**ற** is the hard *r* you first met inside **நன்றி**. It is not **ர**. Tamil
+keeps two r-letters and uses both.
+
+## The word, taken apart - inherited, like the door
+<!-- hl-knowledge: introduces=[]; assesses=[TA-ETYMON-KADAVU-02] -->
+
+**அறை** is inherited. Malayalam's **അറ** (*aṟa*) is the same word, used for a
+chamber or an inner store-room, and it keeps the same hard r.
+
+So this is *kadavu*'s situation over: an everyday inherited word with a
+Sanskrit-derived alternative sitting unused in the higher register.
+
+## Sounds you'll need: how to make ற
+<!-- hl-knowledge: introduces=[TA-SOUND-ARAI-02]; assesses=[] -->
+
+Say the English word *hurry* and stop on the middle sound. That flick of the
+tongue against the ridge behind your teeth is close to Tamil **ர** (*ra*). Now
+make it stronger and longer, with real contact: that is **ற** (*ṟa*).
+
+Two cautions. **Do not curl your tongue back** — retroflex belongs to **ண** and
+**ட**; **ற** is made at the ridge. And **do not soften it into the English r of
+*red***, which is the wrong shape for both Tamil letters.
+
+Many Tamil speakers merge **ர** and **ற** in casual speech, so you will be
+understood either way. Learn the difference anyway: the **spelling** depends on
+it, and a word written with the wrong r is simply misspelled.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-ARAI-01, TA-SOUND-ARAI-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-LEX-KADAVU-01, TA-ETYMON-KADAVU-02, TA-LEX-VEEDU-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: "aṟai" — room, on the hard r]
+- [YOU SAY: the two r's apart — "ra … ṟa"]
+- [YOU SAY: "vīṭṭu aṟai" — a room of the house]
+- [YOU SAY: the three so far — "vīḍu, kadavu, aṟai"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-ARAI-01, TA-SOUND-ARAI-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-LEX-KADAVU-01, TA-ETYMON-KADAVU-02, TA-LEX-VEEDU-01] -->
+
+[PAUSE 3s] Say "a room of the house," and name which of Tamil's two r-letters is
+in *aṟai* and where else you have read it. (*Vīṭṭu aṟai*; **ற**, the hard one,
+in **நன்றி**.) Where is **ற** made, and what must your tongue not do? (At the
+**ridge** behind the teeth — **do not curl it back**.) If many speakers merge
+the two r's, why bother? (Because the **spelling** does not merge.)

--- a/code/learning/human-languages/tamil/lessons/TA-C35-kadavu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C35-kadavu.md
@@ -58,7 +58,7 @@ no voicing: **க** spells a hard *k*, a soft *g* and even an *h*, and **positio
 decides**. Here it opens the word, so it is hard — *ka*, not *ga*.
 
 The same rule then lands on the second letter. **த** is named *ta*, but it sits
-between two vowels, so it softens. That is why this course writes *ka**d**avu*
+between two vowels, so it softens. That is why this book writes *ka**d**avu*
 and not *katavu*. One rule, two letters, one word.
 
 ## The word, taken apart - the everyday word and the bookish one

--- a/code/learning/human-languages/tamil/lessons/TA-C35-kadavu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C35-kadavu.md
@@ -1,0 +1,97 @@
+---
+schema_version: 2
+id: TA-C35-kadavu
+spine_node: SPINE-MEET-GREET
+sequence: 760
+chapter: 35
+type: word
+headword: கதவு
+gloss: door — Tamil's everyday word is its own, while the Sanskrit one stayed in books
+romanization: kadavu
+concept_tag: TA-DOOR
+prerequisites: [TA-C35-veedu]
+sounds: [tamil-dental-ta, tamil-vowel-sign-u]
+roots: [dravidian-katavu-door]
+etymology_hook: "கதவு is native Dravidian — Kannada ಕದ kada is the same word — while Sanskrit-derived கபாடம் stayed literary"
+duration:
+  max_seconds: 235
+requires:
+  knowledge: [TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02, TA-SCRIPT-ABUGIDA-VA-KA-03, TA-SOUND-ABUGIDA-VA-KA-04]
+introduces:
+  knowledge: [TA-LEX-KADAVU-01, TA-ETYMON-KADAVU-02]
+practises:
+  knowledge: [TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02, TA-SCRIPT-ABUGIDA-VA-KA-03, TA-SOUND-ABUGIDA-VA-KA-04, TA-LEX-KADAVU-01, TA-ETYMON-KADAVU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C35-veedu, TA-W01-abugida-va-ka]
+---
+
+# கதவு (kadavu) — "door," and a word Tamil never gave up
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02] -->
+
+[PAUSE 2s] *Vīḍu* — house. Say the cousin that swaps the front letter. (*Bīḍu*,
+Kannada.) Now the part of the house you actually stand at.
+
+## You'll want to know: கதவு
+<!-- hl-knowledge: introduces=[TA-LEX-KADAVU-01]; assesses=[] -->
+
+> **கதவு** — *kadavu* — **door**
+
+The leaf that swings, and the thing somebody opens when you arrive.
+
+> **வீட்டுக் கதவு** — *vīṭṭuk kadavu* — **the house door**
+
+Two nouns in a row, the first leaning on the second. Tamil builds a great deal
+this way, and you have seen it inside a single word: **தண்ணீர்** is *taṇ* plus
+*nīr*, "cool" plus "water."
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-ABUGIDA-VA-KA-03, TA-SOUND-ABUGIDA-VA-KA-04] -->
+
+**க** + **த** + **வு**. The first letter is the one that taught you Tamil marks
+no voicing: **க** spells a hard *k*, a soft *g* and even an *h*, and **position
+decides**. Here it opens the word, so it is hard — *ka*, not *ga*.
+
+The same rule then lands on the second letter. **த** is named *ta*, but it sits
+between two vowels, so it softens. That is why this course writes *ka**d**avu*
+and not *katavu*. One rule, two letters, one word.
+
+## The word, taken apart - the everyday word and the bookish one
+<!-- hl-knowledge: introduces=[TA-ETYMON-KADAVU-02]; assesses=[] -->
+
+**கதவு** is inherited Dravidian. Kannada's **ಕದ** (*kada*) is the same word with
+less on the end; Malayalam's **കതവ്** (*katavu*) matches Tamil closely.
+
+Tamil also owns a second word for a door-leaf: **கபாடம்** (*kabāḍam*), taken
+from Sanskrit **कपाट** (*kapāṭa*). It exists, it is correct, and almost nobody
+says it. It lives in poetry and temple description; **கதவு** lives in the house.
+
+That split is this language's habit. Where a neighbour borrowed a Sanskrit word
+and let the inherited one fade, Tamil often kept both and gave them different
+jobs — the inherited word for the everyday thing, the borrowed one for the
+elevated register. Do not turn that into a rule that Tamil never borrows. It
+borrows; it rarely evicts.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-KADAVU-01, TA-ETYMON-KADAVU-02, TA-SCRIPT-ABUGIDA-VA-KA-03, TA-SOUND-ABUGIDA-VA-KA-04, TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: "kadavu" — door]
+- [YOU SAY: "vīṭṭuk kadavu" — the house door]
+- [YOU SAY: the hard one and the soft one in one word — "ka … da"]
+- [YOU SAY: the everyday word, then the bookish one — "kadavu … kabāḍam"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-KADAVU-01, TA-ETYMON-KADAVU-02, TA-SCRIPT-ABUGIDA-VA-KA-03, TA-SOUND-ABUGIDA-VA-KA-04, TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02] -->
+
+[PAUSE 3s] Say "the house door," then explain why the **க** is hard and the
+**த** soft when neither changed shape. (*Vīṭṭuk kadavu*; **Tamil marks no
+voicing** — position decides.) Which of *kadavu* and *kabāḍam* would you hear at
+somebody's house, and where did the other come from? (***Kadavu***; *kabāḍam* is
+**Sanskrit**, and stays literary.) Does keeping both mean Tamil refuses to
+borrow? (**No** — it borrows without evicting.)

--- a/code/learning/human-languages/tamil/lessons/TA-C35-naarkaali.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C35-naarkaali.md
@@ -1,0 +1,104 @@
+---
+schema_version: 2
+id: TA-C35-naarkaali
+spine_node: SPINE-MEET-GREET
+sequence: 780
+chapter: 35
+type: word
+headword: நாற்காலி
+gloss: chair — a word you can take apart into "four" and "leg," and the thing a guest is offered
+romanization: nāṟkāli
+concept_tag: TA-CHAIR
+prerequisites: [TA-C35-arai, TA-C07-numbers-1-5, TA-W03-pulli-vanakkam]
+sounds: [tamil-alveolar-rra, pulli-virama, tamil-vowel-sign-aa]
+roots: [dravidian-naanku-four, dravidian-kaal-leg]
+etymology_hook: "நாற்காலி is நால் 'four' plus கால் 'leg' — a chair named by counting its legs, with the seam still visible"
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [TA-LEX-ARAI-01, TA-SOUND-ARAI-02, TA-LEX-KADAVU-01, TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02, TA-ETYMON-KADAVU-02, TA-LEX-NUMBERS-1-5-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-PULLI-VANAKKAM-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01]
+introduces:
+  knowledge: [TA-LEX-NAARKAALI-01, TA-ETYMON-NAARKAALI-02]
+practises:
+  knowledge: [TA-LEX-ARAI-01, TA-SOUND-ARAI-02, TA-LEX-KADAVU-01, TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02, TA-ETYMON-KADAVU-02, TA-LEX-NUMBERS-1-5-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-PULLI-VANAKKAM-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-LEX-NAARKAALI-01, TA-ETYMON-NAARKAALI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C35-arai, TA-C35-kadavu, TA-C35-veedu, TA-C07-numbers-1-5, TA-W03-pulli-vanakkam]
+---
+
+# நாற்காலி (nāṟkāli) — "chair," counted out in legs
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-VEEDU-01, TA-LEX-KADAVU-01, TA-LEX-ARAI-01, TA-SOUND-ARAI-02] -->
+
+[PAUSE 2s] Three words in the order you meet them arriving: *vīḍu*, *kadavu*,
+*aṟai*. Hold the hard r in *aṟai* at the ridge, not the roof. Now the one thing
+in that room a guest is always pointed at.
+
+## You'll want to know: நாற்காலி
+<!-- hl-knowledge: introduces=[TA-LEX-NAARKAALI-01]; assesses=[] -->
+
+> **நாற்காலி** — *nāṟkāli* — **chair**
+
+Five syllables for a chair, which sounds extravagant until you find out what it
+is made of.
+
+> **நான் நாற்காலி எடுக்கிறேன்.** — *nāṉ nāṟkāli eḍukkiṟēṉ* — **I take a chair.**
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-PULLI-VANAKKAM-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01] -->
+
+**நா** + **ற்** + **கா** + **லி**. Every piece is one you have handled.
+
+**ந** is the dental *n*, first of Tamil's three n-letters, wearing the long *ā*
+sign **ா**. **ற்** is the hard r of *aṟai* under a **puḷḷi**, the dot that
+switches off the built-in vowel. **கா** is **க** with that same long *ā*. **லி**
+is **ல** with the *i* sign **ி**, the first vowel sign you learned, on the way
+to spelling **நன்றி**.
+
+Now what does **not** happen at **ற்கா**. Two consonants meet, and Tamil keeps
+them as two letters with a dot between, rather than fusing them into a stacked
+shape as the scripts to the north do. That refusal is why a word this long stays
+readable one piece at a time.
+
+## The word, taken apart - four, and a leg
+<!-- hl-knowledge: introduces=[TA-ETYMON-NAARKAALI-02]; assesses=[TA-LEX-NUMBERS-1-5-01, TA-ETYMON-VEEDU-02, TA-ETYMON-KADAVU-02] -->
+
+The word is a compound, and both halves are yours:
+
+| the piece | what it is |
+|---|---|
+| **நால்** *nāl* | "four" — the form four takes in compounds |
+| **கால்** *kāl* | "leg, foot; a support" |
+
+**Four** plus **leg**: a chair is a four-legged thing, said out loud. English
+cannot do that with *chair*, which travels through French and Latin to a Greek
+word for "seat" without ever showing a leg.
+
+The seam is audible. **நான்கு** (*nāṉku*) is the counting word; in a compound
+four appears as **நால்**, and before **க** that **ல்** hardens to **ற்**. Hence
+**நாற்காலி**, and hence **நாற்பது** (*nāṟpadu*), "forty." Malayalam builds the
+chair from the same two pieces: **നാൽക്കാലി**.
+
+Both halves are inherited Dravidian. Nothing in this chapter was borrowed.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-NAARKAALI-01, TA-ETYMON-NAARKAALI-02, TA-LEX-NUMBERS-1-5-01, TA-LEX-VEEDU-01, TA-LEX-KADAVU-01, TA-LEX-ARAI-01, TA-SOUND-ARAI-02, TA-ETYMON-VEEDU-02, TA-ETYMON-KADAVU-02, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-PULLI-VANAKKAM-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: the seam — "nāṉku … nāl … kāl … nāṟkāli"]
+- [YOU SAY: "nāṉ nāṟkāli eḍukkiṟēṉ" — I take a chair]
+- [YOU SAY: the arrival, in order — "vīḍu, kadavu, aṟai, nāṟkāli"]
+- [YOU SAY: the Kannada front-swap on the first of them — "vīḍu … bīḍu"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-NAARKAALI-01, TA-ETYMON-NAARKAALI-02, TA-LEX-NUMBERS-1-5-01, TA-LEX-VEEDU-01, TA-LEX-KADAVU-01, TA-LEX-ARAI-01, TA-SOUND-ARAI-02, TA-ETYMON-VEEDU-02, TA-ETYMON-KADAVU-02, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-PULLI-VANAKKAM-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01] -->
+
+[PAUSE 3s] Take *nāṟkāli* apart, then walk somebody into your house four nouns
+deep. (**நால்**, "four," plus **கால்**, "leg"; *vīḍu, kadavu, aṟai, nāṟkāli*.)
+What does the dot in **ற்** do, and what does Tamil refuse to do at that join?
+(**Switches off the built-in vowel**; Tamil **does not stack** the two
+consonants.) Which of this chapter's words was borrowed? (**None.**)

--- a/code/learning/human-languages/tamil/lessons/TA-C35-veedu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C35-veedu.md
@@ -1,0 +1,107 @@
+---
+schema_version: 2
+id: TA-C35-veedu
+spine_node: SPINE-MEET-GREET
+sequence: 750
+chapter: 35
+type: word
+headword: வீடு
+gloss: house, home — the word behind the door you say வணக்கம் at, and a v where Kannada says b
+romanization: vīḍu
+concept_tag: TA-HOUSE-DWELLING
+prerequisites: [TA-C34-pidi, TA-W03-write-vanakkam, TA-W04-i-sign-write-nandri, TA-C19-age-register-grammar]
+sounds: [tamil-retroflex-tta, tamil-vowel-sign-ii, tamil-vowel-sign-u]
+roots: [dravidian-viidu-house]
+etymology_hook: "வீடு is inherited Dravidian: Malayalam വീട്, Telugu వీడు, and Kannada ಬೀಡು with b- where Tamil keeps v-"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-PIDI-01, TA-LEX-UTAVU-01, TA-LEX-KEL-01, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-WRITE-VANAKKAM-01]
+introduces:
+  knowledge: [TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02]
+practises:
+  knowledge: [TA-LEX-PIDI-01, TA-LEX-UTAVU-01, TA-LEX-KEL-01, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-WRITE-VANAKKAM-01, TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C34-pidi, TA-C34-utavu, TA-C34-kel, TA-W03-write-vanakkam]
+---
+
+# வீடு (vīḍu) — "house," and the place the greeting happens
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-PIDI-01, TA-LEX-UTAVU-01, TA-LEX-KEL-01] -->
+
+[PAUSE 2s] Three verbs from the chapter you have just finished: *pidi*, "to
+like"; *uḍavu*, "to help"; *kēḷ*, "to ask." Say them. Now a noun, and the one
+a conversation usually starts inside.
+
+## You'll want to know: வீடு
+<!-- hl-knowledge: introduces=[TA-LEX-VEEDU-01]; assesses=[] -->
+
+> **வீடு** — *vīḍu* — **house; home**
+
+One word covers both. Tamil does not split the building from the belonging:
+**என் வீடு** (*eṉ vīḍu*) is "my house" and "my home" at once, and choosing
+between them is the translator's problem.
+
+With the dative you already own:
+
+> **வீட்டுக்கு** — *vīṭṭukku* — **to the house**
+
+The soft *ḍ* hardens and doubles to *ṭṭ* — the **படி** / **படித்தேன்** rule.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-WRITE-VANAKKAM-01] -->
+
+**வீ** is **வ**, the first letter you learned, wearing the long *ī* sign **ீ**.
+Then **டு**: **ட** with the *u* sign.
+
+You are at a door about to say **வணக்கம்**, so read that word while you are
+here: **வ** + **ண** + **க்** + **க** + **ம்**. The **வ** that opens *vaṇakkam*
+is the **வ** that opens *vīḍu*.
+
+## The word, taken apart - the v that turns into a b
+<!-- hl-knowledge: introduces=[TA-ETYMON-VEEDU-02]; assesses=[] -->
+
+**வீடு** is inherited, not borrowed:
+
+| the cousin | language and sense |
+|---|---|
+| **വീട്** *vīḍ* | Malayalam, "house" |
+| **వీడు** *vīḍu* | Telugu, "town, camp" |
+| **ಬೀಡು** *bīḍu* | Kannada, "abode, encampment" |
+
+Kannada has changed the front of the word: Tamil says **v**, Kannada says
+**b**. Not a slip — Kannada alone among its neighbours turned inherited
+word-initial *v-* into *b-*, and the inscriptions show it from about the
+seventh century. Store the correspondence — it keeps paying.
+
+The **sense** has drifted where the form has not: Telugu's *vīḍu* is a town,
+Kannada's *bīḍu* an encampment. Tamil and Malayalam kept it on the dwelling.
+
+One more thing, not a coincidence to explain away. Tamil has a second **வீடு**
+meaning "**release, deliverance**," as in **வீடுபேறு**. The Dravidian
+dictionary files house and release under **one entry**, headed by **விடு**
+(*viḍu*), "to let go." A house is where you are let go.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-WRITE-VANAKKAM-01, TA-LEX-PIDI-01, TA-LEX-UTAVU-01, TA-LEX-KEL-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: "vīḍu" — house and home in one word]
+- [YOU SAY: "eṉ vīḍu," then the hardening — "vīṭṭukku"]
+- [YOU SAY: the cousins, ending on the front-swap — "vīḍ … vīḍu … bīḍu"]
+- [YOU SAY: the root under the house — "viḍu, to let go"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-WRITE-VANAKKAM-01, TA-LEX-PIDI-01, TA-LEX-UTAVU-01, TA-LEX-KEL-01] -->
+
+[PAUSE 3s] Why does one Tamil word do two English jobs here, and which letter
+opens both *vīḍu* and *vaṇakkam*? (**House** and **home** are not split; and
+**வ**.) What does Kannada put at the front instead of *v*, and is it a one-off?
+(**b** — *bīḍu*; **regular**, from the seventh century on.) Is the Tamil word
+for "release" the same root as the house? (**Yes** — both under **விடு**, "to
+let go.")

--- a/code/learning/human-languages/tamil/lessons/TA-C36-paal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C36-paal.md
@@ -1,0 +1,103 @@
+---
+schema_version: 2
+id: TA-C36-paal
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 800
+chapter: 36
+type: word
+headword: பால்
+gloss: milk — one syllable, inherited whole, and the word that shows Kannada turning p into h
+romanization: pāl
+concept_tag: TA-MILK
+prerequisites: [TA-C36-teneer]
+sounds: [pulli-virama, tamil-vowel-sign-aa]
+roots: [dravidian-paal-milk]
+etymology_hook: "பால் is inherited Dravidian — Malayalam പാൽ pāl, Telugu పాలు pālu, and Kannada ಹಾಲು hālu with h for p"
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-LEX-TENEER-01, TA-ETYMON-TENEER-02, TA-LEX-THANNEER-ARISI-01, TA-ETYMON-VEEDU-02, TA-SCRIPT-PULLI-VANAKKAM-01]
+introduces:
+  knowledge: [TA-LEX-PAAL-01, TA-ETYMON-PAAL-02]
+practises:
+  knowledge: [TA-LEX-TENEER-01, TA-ETYMON-TENEER-02, TA-LEX-THANNEER-ARISI-01, TA-ETYMON-VEEDU-02, TA-SCRIPT-PULLI-VANAKKAM-01, TA-LEX-PAAL-01, TA-ETYMON-PAAL-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C36-teneer, TA-C35-veedu, TA-C15-thanneer-arisi]
+---
+
+# பால் (pāl) — "milk," and a p that becomes an h next door
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TENEER-01, TA-ETYMON-TENEER-02] -->
+
+[PAUSE 2s] *Tēnīr*. Which half is borrowed, and which is the old Tamil word for
+water? (*Tē* is the traveller; *nīr* is Tamil's own.) Here is what goes into it.
+
+## You'll want to know: பால்
+<!-- hl-knowledge: introduces=[TA-LEX-PAAL-01]; assesses=[TA-LEX-THANNEER-ARISI-01] -->
+
+> **பால்** — *pāl* — **milk**
+
+One syllable, one long *ā*, a final **ல்** with no vowel after it. Say it short
+and closed: *pāl*, never *pāla*.
+
+> **பால் தேநீர்** — *pāl tēnīr* — **milk tea**
+
+With **தண்ணீர்** (*taṇṇīr*, cool water) already in hand, you can now name what a
+Tamil household is likely to put in front of a guest.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+**பா** is **ப** with the long *ā* sign **ா**. Then **ல்**: **ல** with the
+**puḷḷi**, the dot that removes the built-in *a* and leaves a bare consonant.
+
+That dot is the whole reason the word ends where it does. Without it, **பால**
+would be *pāla*, two syllables. A single dot carries the difference between a
+word and a non-word.
+
+## The word, taken apart - the p that went soft
+<!-- hl-knowledge: introduces=[TA-ETYMON-PAAL-02]; assesses=[TA-ETYMON-VEEDU-02] -->
+
+**பால்** is inherited Dravidian, and its relatives are close:
+
+| the cousin | language |
+|---|---|
+| **പാൽ** *pāl* | Malayalam |
+| **పాలు** *pālu* | Telugu |
+| **ಹಾಲು** *hālu* | Kannada, modern |
+
+Kannada has changed the front of the word once more, this time **p** into
+**h** — the textbook example of the best-known sound change in the family. **Old
+Kannada said *pālu***, exactly as Tamil does; the *p-* began turning into *h-*
+around the tenth century and the change had run through the whole vocabulary by
+the fourteenth.
+
+Put it beside the change you met at the house. Tamil **v**, Kannada **b**, in
+*vīḍu* / *bīḍu*. Tamil **p**, Kannada **h**, in *pāl* / *hālu*. Both are regular
+correspondences at the front of a word, and between them they let you recognise
+a Kannada word as a relative rather than a stranger. Telugu and Malayalam did
+neither: they keep the *p*, as Tamil does.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-PAAL-01, TA-ETYMON-PAAL-02, TA-ETYMON-VEEDU-02, TA-LEX-TENEER-01, TA-ETYMON-TENEER-02, TA-LEX-THANNEER-ARISI-01, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: "pāl" — stopped by the dot, not *pāla*]
+- [YOU SAY: "pāl tēnīr" — milk tea]
+- [YOU SAY: the two front-swaps together — "vīḍu, bīḍu … pāl, hālu"]
+- [YOU SAY: what you can be offered — "taṇṇīr, tēnīr, pāl"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-PAAL-01, TA-ETYMON-PAAL-02, TA-ETYMON-VEEDU-02, TA-LEX-TENEER-01, TA-ETYMON-TENEER-02, TA-LEX-THANNEER-ARISI-01, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+[PAUSE 3s] Say "milk tea," then say what the dot on **ல்** is doing and what the
+word would be without it. (*Pāl tēnīr*; it **removes the built-in vowel**, and
+without it, *pāla*.) What does Kannada put at the front instead of *p*, and is
+it a one-off? (**h** — *hālu*; **regular**, from the tenth century to the
+fourteenth.) Name the other Kannada front-swap. (**v** to **b** — *vīḍu*,
+*bīḍu*.)

--- a/code/learning/human-languages/tamil/lessons/TA-C36-tavaru.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C36-tavaru.md
@@ -1,0 +1,103 @@
+---
+schema_version: 2
+id: TA-C36-tavaru
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 820
+chapter: 36
+type: word
+headword: தவறு
+gloss: a mistake — the noun that lets you finish an apology, and the same word as the verb "to slip"
+romanization: tavaṟu
+concept_tag: TA-MISTAKE
+prerequisites: [TA-C36-unavu, TA-C09-sorry-register]
+sounds: [tamil-alveolar-rra, tamil-vowel-sign-u]
+roots: [dravidian-tavaru-slip-fail]
+etymology_hook: "தவறு is the noun and the verb at once — 'to slip, to fail' and 'a slip' — inherited, and filed beside தப்பு"
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [TA-LEX-UNAVU-01, TA-ETYMON-UNAVU-02, TA-LEX-TENEER-01, TA-ETYMON-TENEER-02, TA-LEX-PAAL-01, TA-ETYMON-PAAL-02, TA-ETYMON-MANNIKKAVUM-01, TA-ETYMON-MANNIKKAVUM-02, TA-PRAGMATICS-SORRY-REGISTER-01, TA-SCRIPT-SORRY-REGISTER-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-SOUND-ARAI-02]
+introduces:
+  knowledge: [TA-LEX-TAVARU-01, TA-ETYMON-TAVARU-02]
+practises:
+  knowledge: [TA-LEX-UNAVU-01, TA-ETYMON-UNAVU-02, TA-LEX-TENEER-01, TA-ETYMON-TENEER-02, TA-LEX-PAAL-01, TA-ETYMON-PAAL-02, TA-ETYMON-MANNIKKAVUM-01, TA-ETYMON-MANNIKKAVUM-02, TA-PRAGMATICS-SORRY-REGISTER-01, TA-SCRIPT-SORRY-REGISTER-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-LEX-TAVARU-01, TA-ETYMON-TAVARU-02, TA-SOUND-ARAI-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C36-unavu, TA-C36-teneer, TA-C36-paal, TA-C09-mannikkavum, TA-C09-sorry-register]
+---
+
+# தவறு (tavaṟu) — "a mistake," and the rest of the apology
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TENEER-01, TA-LEX-PAAL-01, TA-LEX-UNAVU-01] -->
+
+[PAUSE 2s] The chapter back: *tēnīr*, *pāl*, *uṇavu*. Suppose one arrives and it
+is not what you asked for. You have "sorry," but not the word for what went
+wrong.
+
+## You'll want to know: தவறு
+<!-- hl-knowledge: introduces=[TA-LEX-TAVARU-01]; assesses=[TA-PRAGMATICS-SORRY-REGISTER-01, TA-LEX-TENEER-01, TA-LEX-PAAL-01] -->
+
+> **தவறு** — *tavaṟu* — **a mistake, an error, a fault**
+
+With **என்** (*eṉ*), "my," and no verb — Tamil needs none:
+
+> **மன்னிக்கவும், என் தவறு. பால் இல்லை, தேநீர்.**
+>
+> *maṉṉikkavum, eṉ tavaṟu. pāl illai, tēnīr.*
+>
+> **Sorry, my mistake. Not milk — tea.**
+
+**மன்னிக்கவும்** is the careful, written-leaning apology; in speech many Tamil
+speakers simply say *sorry*, in English. **என் தவறு** suits either.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-SCRIPT-SORRY-REGISTER-02, TA-SOUND-ARAI-02] -->
+
+**த** + **வ** + **று**. The last piece is **ற**, the hard r of *aṟai*, with the
+*u* sign — made at the ridge behind the teeth, tongue flat, not curled.
+
+The apology in front of it does something this word does not.
+**மன்னிக்கவும்** has **ன்னி**: the alveolar **ன** switched off by a dot, then
+written a second time with the *i* sign. Tamil doubles a consonant by
+**repeating the letter with a dot on the first**, never by inventing a joined
+shape — the **க்க** of **வணக்கம்** over.
+
+## The word, taken apart - the slip and the noun are one word
+<!-- hl-knowledge: introduces=[TA-ETYMON-TAVARU-02]; assesses=[TA-ETYMON-MANNIKKAVUM-01, TA-ETYMON-MANNIKKAVUM-02, TA-ETYMON-UNAVU-02, TA-ETYMON-TENEER-02, TA-ETYMON-PAAL-02] -->
+
+**தவறு** is inherited Dravidian, a verb and a noun in one shape: "to slip, to
+fail," and "a slip, a mistake." The dictionary files it beside **தப்பு**
+(*tappu*); its cousins are everywhere.
+
+Now the chapter in a line. **மன்னிக்கவும்** was the showpiece: Tamil kept its own
+**மன்னி** where Kannada, Telugu and Malayalam reached for Sanskrit **kṣamā**.
+**தவறு** is inherited too, and so is **உண்** inside *uṇavu*, and **பால்**. But
+**தேநீர்** is half a loan from a Malay port, and **சாதம்** was flagged as
+Sanskrit-influenced when you met it.
+
+So the honest statement is not "Tamil does not borrow." It is that **Tamil
+borrows without evicting**: the inherited word stays, and the loan takes a
+different job or register.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TAVARU-01, TA-ETYMON-TAVARU-02, TA-ETYMON-MANNIKKAVUM-01, TA-ETYMON-MANNIKKAVUM-02, TA-PRAGMATICS-SORRY-REGISTER-01, TA-SCRIPT-SORRY-REGISTER-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-LEX-TENEER-01, TA-ETYMON-TENEER-02, TA-LEX-PAAL-01, TA-ETYMON-PAAL-02, TA-LEX-UNAVU-01, TA-ETYMON-UNAVU-02, TA-SOUND-ARAI-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: "eṉ tavaṟu" — my mistake, with no verb in it]
+- [YOU SAY: the whole repair — "maṉṉikkavum, eṉ tavaṟu"]
+- [YOU SAY: the two words for a mistake — "tavaṟu … tappu"]
+- [YOU SAY: the borrowed one among this chapter's words — "tēnīr"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TAVARU-01, TA-ETYMON-TAVARU-02, TA-ETYMON-MANNIKKAVUM-01, TA-ETYMON-MANNIKKAVUM-02, TA-PRAGMATICS-SORRY-REGISTER-01, TA-SCRIPT-SORRY-REGISTER-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-LEX-TENEER-01, TA-ETYMON-TENEER-02, TA-LEX-PAAL-01, TA-ETYMON-PAAL-02, TA-LEX-UNAVU-01, TA-ETYMON-UNAVU-02, TA-SOUND-ARAI-02] -->
+
+[PAUSE 3s] Apologise, name the fault, and say why there is no word for "is" in
+it. (*Maṉṉikkavum, eṉ tavaṟu*; **Tamil needs none**.) How does Tamil write a
+doubled consonant, as in **ன்னி** and **க்க**? (**The letter a second time**,
+dot on the first.) Which apology verb is native where the neighbours took
+Sanskrit, and does that make Tamil a language that never borrows? (**மன்னி**,
+against **kṣamā**; **no** — it **borrows without evicting**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C36-teneer.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C36-teneer.md
@@ -1,0 +1,104 @@
+---
+schema_version: 2
+id: TA-C36-teneer
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 790
+chapter: 36
+type: word
+headword: தேநீர்
+gloss: tea — a borrowed syllable welded onto the நீர் that is already inside தண்ணீர்
+romanization: tēnīr
+concept_tag: TA-TEA
+prerequisites: [TA-C35-naarkaali, TA-C15-thanneer-arisi, TA-C08-please-register]
+sounds: [tamil-vowel-sign-ee, tamil-vowel-sign-ii]
+roots: [dravidian-niir-water, hokkien-te-tea]
+etymology_hook: "தேநீர் is தே (the travelling word for tea) welded onto native நீர் 'water' — the same நீர் inside தண்ணீர்"
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [TA-LEX-NAARKAALI-01, TA-ETYMON-NAARKAALI-02, TA-LEX-ARAI-01, TA-LEX-THANNEER-ARISI-01, TA-PRAGMATICS-THANNEER-ARISI-03, TA-LEX-TAYAVUSEYTU-01, TA-ETYMON-TAYAVUSEYTU-02, TA-SCRIPT-PLEASE-REGISTER-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-02]
+introduces:
+  knowledge: [TA-LEX-TENEER-01, TA-ETYMON-TENEER-02]
+practises:
+  knowledge: [TA-LEX-NAARKAALI-01, TA-ETYMON-NAARKAALI-02, TA-LEX-ARAI-01, TA-LEX-THANNEER-ARISI-01, TA-PRAGMATICS-THANNEER-ARISI-03, TA-LEX-TAYAVUSEYTU-01, TA-ETYMON-TAYAVUSEYTU-02, TA-SCRIPT-PLEASE-REGISTER-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-02, TA-LEX-TENEER-01, TA-ETYMON-TENEER-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C35-naarkaali, TA-C15-thanneer-arisi, TA-C08-tayavuseytu, TA-C08-please-register]
+---
+
+# தேநீர் (tēnīr) — "tea," half of it already yours
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-NAARKAALI-01, TA-ETYMON-NAARKAALI-02, TA-LEX-ARAI-01] -->
+
+[PAUSE 2s] *Nāṟkāli*, and what its halves mean. (Four, and leg.) You are in the
+*aṟai* with the chair, and the next thing in a Tamil house is this.
+
+## You'll want to know: தேநீர்
+<!-- hl-knowledge: introduces=[TA-LEX-TENEER-01]; assesses=[TA-LEX-THANNEER-ARISI-01, TA-LEX-TAYAVUSEYTU-01] -->
+
+> **தேநீர்** — *tēnīr* — **tea**
+
+The second half is yours from the water lesson: **நீர்** (*nīr*), "water," the
+plain older word inside **தண்ணீர்** (*taṇṇīr*) — *taṇ*, "cool," plus *nīr*. So
+**தேநீர்** is, literally, **tea water**.
+
+> **தேநீர், தயவுசெய்து.** — *tēnīr, tayavuseytu* — **Tea, please.**
+
+In speech you will also hear plain **டீ** (*ṭī*), straight from English *tea*.
+**தேநீர்** is the fuller word — a sign, a menu, a formal host.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-PLEASE-REGISTER-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-02] -->
+
+**தே** is **த** with the *ē* sign **ே**, which stands in front of its consonant.
+**நீ** is **ந** with the long *ī* sign; **ர்** is **ர** shut by a puḷḷi — the
+soft r, not the hard **ற**.
+
+Two words beside it are worth reading. **நன்றி** is **ந** + **ன்** + **றி**,
+what you say when the tea arrives. In **தயவுசெய்து**, **செய்** is *ce* plus
+**ய்** shut by that same dot before **து**.
+
+## The word, taken apart - the syllable that sailed
+<!-- hl-knowledge: introduces=[TA-ETYMON-TENEER-02]; assesses=[TA-PRAGMATICS-THANNEER-ARISI-03, TA-ETYMON-TAYAVUSEYTU-02] -->
+
+**நீர்** is inherited and very old. **தே** is not Tamil at all: it is the
+combining form of **தேய்** (*tēy*), borrowed from Malay **teh**, which took it
+from the Hokkien of the southern Chinese coast, where the leaf is *tê*.
+
+The world's words for tea come in two shapes, decided by **how the tea reached
+each language**. The southern Chinese coast carried *te*: Dutch *thee*, and
+through Dutch, English *tea* and French *thé* — and by the Malay ports, Tamil's
+**தே**. The overland routes carried *cha*: Persian and Hindi *chāy*, Russian
+*chay*. Portuguese says **chá** despite being a sea power, because its traders
+worked out of Macau. Where the ship docked decided the word.
+
+Tamil then did what the European *te*-languages did not: rather than take the
+loan whole, it welded it to **நீர்** — a word that has travelled outward as
+well, since English **mulligatawny** is Tamil **மிளகுத்தண்ணீர்**, "pepper
+water."
+
+Weigh that against the rice word. **அரிசி** *may* stand behind English *rice*
+through Greek, and the dictionaries hedge. The tea routes are documented.
+**Different histories, different confidence.**
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TENEER-01, TA-ETYMON-TENEER-02, TA-LEX-THANNEER-ARISI-01, TA-PRAGMATICS-THANNEER-ARISI-03, TA-LEX-TAYAVUSEYTU-01, TA-ETYMON-TAYAVUSEYTU-02, TA-SCRIPT-PLEASE-REGISTER-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-02, TA-LEX-NAARKAALI-01, TA-ETYMON-NAARKAALI-02, TA-LEX-ARAI-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: the shared half — "nīr … taṇṇīr … tēnīr"]
+- [YOU SAY: "tēnīr, tayavuseytu" — tea, please]
+- [YOU SAY: the two routes — "te … cha"]
+- [YOU SAY: the pepper water in an English soup — "miḷagut taṇṇīr"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TENEER-01, TA-ETYMON-TENEER-02, TA-LEX-THANNEER-ARISI-01, TA-PRAGMATICS-THANNEER-ARISI-03, TA-LEX-TAYAVUSEYTU-01, TA-ETYMON-TAYAVUSEYTU-02, TA-SCRIPT-PLEASE-REGISTER-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-02, TA-LEX-NAARKAALI-01, TA-ETYMON-NAARKAALI-02, TA-LEX-ARAI-01] -->
+
+[PAUSE 3s] Name the second half of *tēnīr* and the word that shares it, then ask
+for tea politely. (**நீர்**, inside **தண்ணீர்**; *tēnīr, tayavuseytu*.) Why do
+some languages say *te* and others *cha*, and which is better established — the
+tea split or *arisi*-to-*rice*? (**The route the tea travelled**; and **the tea
+split**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C36-unavu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C36-unavu.md
@@ -1,0 +1,107 @@
+---
+schema_version: 2
+id: TA-C36-unavu
+spine_node: SPINE-POLITE-REQUEST-REPAIR
+sequence: 810
+chapter: 36
+type: word
+headword: உணவு
+gloss: food — the noun standing on உண், the older eating verb behind சாப்பிடு's everyday one
+romanization: uṇavu
+concept_tag: TA-FOOD
+prerequisites: [TA-C36-paal, TA-C32-saappidu]
+sounds: [tamil-retroflex-nna, tamil-vowel-sign-u]
+roots: [dravidian-un-eat]
+etymology_hook: "உணவு is built on the verb உண் 'to eat' — the older word beside everyday சாப்பிடு, and it carries retroflex ண"
+duration:
+  max_seconds: 245
+requires:
+  knowledge: [TA-LEX-PAAL-01, TA-ETYMON-PAAL-02, TA-LEX-SAAPPIDU-01, TA-ETYMON-SAAPPIDU-02, TA-LEX-THANNEER-ARISI-02, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SOUND-MA-RETROFLEX-NA-03]
+introduces:
+  knowledge: [TA-LEX-UNAVU-01, TA-ETYMON-UNAVU-02]
+practises:
+  knowledge: [TA-LEX-PAAL-01, TA-ETYMON-PAAL-02, TA-LEX-SAAPPIDU-01, TA-ETYMON-SAAPPIDU-02, TA-LEX-THANNEER-ARISI-02, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SOUND-MA-RETROFLEX-NA-03, TA-LEX-UNAVU-01, TA-ETYMON-UNAVU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C36-paal, TA-C32-saappidu, TA-C15-thanneer-arisi, TA-W02-ma-retroflex-na]
+---
+
+# உணவு (uṇavu) — "food," from the verb underneath it
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-PAAL-01, TA-ETYMON-PAAL-02] -->
+
+[PAUSE 2s] *Pāl* — milk — and the Kannada shape of it. (*Hālu*.) Drink is
+settled. Now the word for everything else on the plate.
+
+## You'll want to know: உணவு
+<!-- hl-knowledge: introduces=[TA-LEX-UNAVU-01]; assesses=[TA-LEX-THANNEER-ARISI-02] -->
+
+> **உணவு** — *uṇavu* — **food**
+
+The general word: food as a category, not a dish. It covers the rice words you
+have — **அரிசி** (*arisi*), the raw grain, and **சாதம்** (*sātam*), the cooked
+meal — and all that is served beside them.
+
+> **உணவு, தயவுசெய்து.** — *uṇavu, tayavuseytu* — **Food, please.**
+
+Note the register. **உணவு** is the careful, written word — a menu, a sign.
+Around a family table people say **சாப்பாடு** (*sāppāḍu*).
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-MA-RETROFLEX-NA-02] -->
+
+**உ** is a standing vowel — a full letter, not a sign. Then **ண**, then **வு**,
+which is **வ** with the *u* sign underneath. **ண** is the retroflex n you first
+wrote alongside **ம**, and the letter inside **தண்ணீர்**.
+
+## Sounds you'll need: the tongue in ண
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SOUND-MA-RETROFLEX-NA-03] -->
+
+Curl the tip of your tongue **back** to the roof of your mouth and release into
+the vowel. That is **ண**, and *uṇavu* gives it a clean run because the letter
+sits between two vowels. Contrast the **ன** of **நன்றி** and the **ந** of
+**நீர்**, both made near the teeth.
+
+## The word, taken apart - the verb inside the noun
+<!-- hl-knowledge: introduces=[TA-ETYMON-UNAVU-02]; assesses=[TA-LEX-SAAPPIDU-01, TA-ETYMON-SAAPPIDU-02] -->
+
+**உணவு** is **உண்** (*uṇ*), "to eat," with a noun-forming ending. Food is
+literally *the eating*. Tamil has two eating verbs, of different ages:
+
+| the verb | where it lives |
+|---|---|
+| **உண்** *uṇ* | old, inherited, literary now |
+| **சாப்பிடு** *sāppiḍu* | the everyday spoken verb |
+
+**உண்** is a bare inherited root, and the Dravidian dictionary lists *uṇavu*
+inside its entry.
+
+**சாப்பிடு** is where the ground softens, so hold this course's earlier account
+loosely. You were shown *sāppu*, "food," plus **இடு** (*iḍu*), "to put." The
+**இடு** is visible in the spelling; the first half is the problem. The great
+Tamil lexicon records no plain word *sāppu* meaning "food," and the Dravidian
+etymological dictionary has **no entry for this verb at all**. It is not
+Sanskrit — Telugu and Malayalam have their own forms — but its origin is open.
+The word you would use at a table has the weaker paperwork.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-UNAVU-01, TA-ETYMON-UNAVU-02, TA-LEX-SAAPPIDU-01, TA-ETYMON-SAAPPIDU-02, TA-LEX-THANNEER-ARISI-02, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SOUND-MA-RETROFLEX-NA-03, TA-LEX-PAAL-01, TA-ETYMON-PAAL-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: the root and the noun — "uṇ … uṇavu"]
+- [YOU SAY: the retroflex, tongue curled back — "uṇavu"]
+- [YOU SAY: the documented one, then the everyday one — "uṇ … sāppiḍu"]
+- [YOU SAY: raw grain, then cooked meal — "arisi … sātam"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-UNAVU-01, TA-ETYMON-UNAVU-02, TA-LEX-SAAPPIDU-01, TA-ETYMON-SAAPPIDU-02, TA-LEX-THANNEER-ARISI-02, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SOUND-MA-RETROFLEX-NA-03, TA-LEX-PAAL-01, TA-ETYMON-PAAL-02] -->
+
+[PAUSE 3s] What verb is *uṇavu* built on, and where does your tongue go for
+**ண**? (**உண்**; **curled back**.) Which eating verb would you use at a table,
+and how sure is anyone where it came from? (**சாப்பிடு** — **not at all**: the
+Dravidian dictionary has no entry.) Give the raw grain and the cooked meal.
+(*Arisi*; *sātam*.)

--- a/code/learning/human-languages/tamil/lessons/TA-C36-unavu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C36-unavu.md
@@ -80,7 +80,7 @@ literally *the eating*. Tamil has two eating verbs, of different ages:
 **உண்** is a bare inherited root, and the Dravidian dictionary lists *uṇavu*
 inside its entry.
 
-**சாப்பிடு** is where the ground softens, so hold this course's earlier account
+**சாப்பிடு** is where the ground softens, so hold Chapter 32's earlier account
 loosely. You were shown *sāppu*, "food," plus **இடு** (*iḍu*), "to put." The
 **இடு** is visible in the spelling; the first half is the problem. The great
 Tamil lexicon records no plain word *sāppu* meaning "food," and the Dravidian

--- a/code/learning/human-languages/tamil/lessons/TA-C37-ivar-en-nanbar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C37-ivar-en-nanbar.md
@@ -1,0 +1,105 @@
+---
+schema_version: 2
+id: TA-C37-ivar-en-nanbar
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 860
+chapter: 37
+type: phrase
+headword: இவர் என் நண்பர்
+gloss: "this is my friend" — three words, no verb, and a choice of ending that says how you regard them
+romanization: ivar eṉ naṇbar
+concept_tag: TA-INTRODUCE-A-THIRD-PERSON
+prerequisites: [TA-C37-ivar]
+sounds: [pulli-virama, tamil-retroflex-nna]
+roots: [dravidian-i-proximal-deictic, dravidian-nannu-draw-near]
+etymology_hook: "இவர் என் நண்பர் needs no word for 'is' — Tamil links two nouns by putting them side by side"
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [TA-LEX-IVAR-01, TA-GRAMMAR-IVAR-02, TA-LEX-NANBAN-01, TA-ETYMON-NANBAN-02, TA-LEX-UUR-01, TA-LEX-KUDUMBAM-02, TA-ETYMON-KUDUMBAM-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SCRIPT-ABUGIDA-VA-KA-02]
+introduces:
+  knowledge: [TA-LEX-IVAR-EN-NANBAR-01, TA-PRAGMATICS-IVAR-EN-NANBAR-02]
+practises:
+  knowledge: [TA-LEX-IVAR-01, TA-GRAMMAR-IVAR-02, TA-LEX-NANBAN-01, TA-ETYMON-NANBAN-02, TA-LEX-UUR-01, TA-LEX-KUDUMBAM-02, TA-ETYMON-KUDUMBAM-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-LEX-IVAR-EN-NANBAR-01, TA-PRAGMATICS-IVAR-EN-NANBAR-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C37-ivar, TA-C37-nanban, TA-C37-uur, TA-C12-kudumbam]
+---
+
+# இவர் என் நண்பர் — "this is my friend"
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-IVAR-01, TA-GRAMMAR-IVAR-02, TA-LEX-NANBAN-01] -->
+
+[PAUSE 2s] *Ivar, avar, evar* — near, away, the question. Then *naṇbaṉ, naṇbi,
+naṇbar*. Everything this lesson needs is in your mouth; what is left is the
+order.
+
+## You'll want to know: the introduction
+<!-- hl-knowledge: introduces=[TA-LEX-IVAR-EN-NANBAR-01]; assesses=[TA-LEX-IVAR-01, TA-LEX-NANBAN-01, TA-SCRIPT-ABUGIDA-VA-KA-02] -->
+
+> **இவர் என் நண்பர்.** — *ivar eṉ naṇbar* — **This is my friend.**
+
+Three words, and **not one of them is a verb**. Tamil links two nouns by setting
+them beside each other, as in **என் பெயர் …** and **என் தவறு**.
+
+The pieces in order: **இவர்**, the person here; **என்**, my; **நண்பர்**,
+friend-with-respect. Then stop.
+
+The whole meeting:
+
+> — **வணக்கம். இவர் என் நண்பர்.**
+>
+> — **வணக்கம். உங்கள் ஊர் என்ன.**
+
+Every word in it is yours.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-MA-RETROFLEX-NA-02] -->
+
+**என்** is **எ** with **ன்**, the alveolar n dotted shut. **நண்பர்** opens on
+dental **ந**, turns on retroflex **ண்**, closes on **ர்**. So one line makes you
+produce **ன்** and **ண்** within a breath of each other — one at the ridge, the
+other with the tongue curled back. Hear that difference and the three-way n is
+no longer theory.
+
+## Why it's said this way: which ending you choose
+<!-- hl-knowledge: introduces=[TA-PRAGMATICS-IVAR-EN-NANBAR-02]; assesses=[TA-LEX-KUDUMBAM-02, TA-ETYMON-KUDUMBAM-01, TA-ETYMON-NANBAN-02, TA-LEX-UUR-01, TA-GRAMMAR-IVAR-02] -->
+
+**நண்பர்** rather than **நண்பன்** is a decision, not a default.
+
+- **இவர் என் நண்பன்.** — a male friend, plainly stated; warm among peers.
+- **இவர் என் நண்பி.** — a female friend, the matching plain form.
+- **இவர் என் நண்பர்.** — the respectful ending; safe with anyone, and right when
+  either party is older or senior.
+
+If unsure, take **நண்பர்**. Over-respect is invisible; under-respect is not.
+
+Notice how differently Tamil makes you think from one word to the next. For a
+**sibling** it forces **age**: there is no bare "brother" — you must choose
+**அண்ணன்** or **தம்பி**, **அக்கா** or **தங்கை**, and say whether they are older
+or younger than you before you can say anything at all. For a **friend** it
+forces **sex or respect**. For **parents**, nothing: **அப்பா** and **அம்மா**
+came into the language whole. Tamil rarely lets you be vague about a
+relationship.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-IVAR-EN-NANBAR-01, TA-PRAGMATICS-IVAR-EN-NANBAR-02, TA-LEX-IVAR-01, TA-GRAMMAR-IVAR-02, TA-LEX-NANBAN-01, TA-ETYMON-NANBAN-02, TA-LEX-UUR-01, TA-LEX-KUDUMBAM-02, TA-ETYMON-KUDUMBAM-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SCRIPT-ABUGIDA-VA-KA-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: the introduction — "ivar eṉ naṇbar"]
+- [YOU SAY: the same line to a peer about a male friend — "ivar eṉ naṇbaṉ"]
+- [YOU SAY: the greeting and the question around it — "vaṇakkam … uṅgaḷ ūr eṉṉa"]
+- [YOU SAY: what a sibling word forces you to decide — "aṇṇaṉ, older; tambi, younger"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-IVAR-EN-NANBAR-01, TA-PRAGMATICS-IVAR-EN-NANBAR-02, TA-LEX-IVAR-01, TA-GRAMMAR-IVAR-02, TA-LEX-NANBAN-01, TA-ETYMON-NANBAN-02, TA-LEX-UUR-01, TA-LEX-KUDUMBAM-02, TA-ETYMON-KUDUMBAM-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SCRIPT-ABUGIDA-VA-KA-02] -->
+
+[PAUSE 3s] Introduce a friend respectfully, and say how many verbs the sentence
+has. (*Ivar eṉ naṇbar*; **none**.) What does a sibling word force you to decide
+that a friend word does not? (**Whether they are older or younger** — *aṇṇaṉ*
+against *tambi*.) Which friend ending is safe when unsure, and what does **இ-**
+tell your listener? (**நண்பர்**; that the person is **near**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C37-ivar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C37-ivar.md
@@ -1,0 +1,104 @@
+---
+schema_version: 2
+id: TA-C37-ivar
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 850
+chapter: 37
+type: word
+headword: இவர்
+gloss: this person, spoken of with respect — the near end of Tamil's இ / அ / எ pointing system
+romanization: ivar
+concept_tag: TA-PROXIMAL-PERSON
+prerequisites: [TA-C37-nanban]
+sounds: [tamil-standing-vowel-i, pulli-virama]
+roots: [dravidian-i-proximal-deictic]
+etymology_hook: "இவர் is the இ- 'near' base plus the respectful -அர்; அ- points away and எ- asks which"
+duration:
+  max_seconds: 245
+requires:
+  knowledge: [TA-LEX-NANBAN-01, TA-ETYMON-NANBAN-02, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-CURVES-VA-KA-01, TA-LEX-UUR-01]
+introduces:
+  knowledge: [TA-LEX-IVAR-01, TA-GRAMMAR-IVAR-02]
+practises:
+  knowledge: [TA-LEX-NANBAN-01, TA-ETYMON-NANBAN-02, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-CURVES-VA-KA-01, TA-LEX-UUR-01, TA-LEX-IVAR-01, TA-GRAMMAR-IVAR-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C37-nanban, TA-C37-uur, TA-W01-curves-va-ka, TA-W01-abugida-va-ka]
+---
+
+# இவர் (ivar) — "this person," and Tamil's pointing system
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-NANBAN-01, TA-ETYMON-NANBAN-02] -->
+
+[PAUSE 2s] *Naṇbaṉ*, *naṇbi*, *naṇbar* — and the root behind them. (*Naṇṇu*, to
+draw near.) You have the word for a friend, but cannot point at one.
+
+## You'll want to know: இவர்
+<!-- hl-knowledge: introduces=[TA-LEX-IVAR-01]; assesses=[] -->
+
+> **இவர்** — *ivar* — **this person** (near me, spoken of respectfully)
+
+Not "he" and not "she": **இவர்** is what you say about a person standing here
+whom you are treating with respect, and it does not commit you to their sex. It
+is built on **இவன்** (*ivaṉ*) and **இவள்** (*ivaḷ*), with the same **-அர்** that
+gave you **நண்பர்**.
+
+One caution about speech: **இவர்** is heard mostly of men, and **இவங்க**
+(*ivaṅga*) does the same respectful job for a woman.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-CURVES-VA-KA-01] -->
+
+**இ** + **வ** + **ர்**. **இ** is the standing vowel *i* — the letter, not the
+**ி** sign that hangs on a consonant. **வ** is the *va* opening **வணக்கம்** and
+**வீடு**. **ர்** is the soft r with a puḷḷi.
+
+A word this short is almost all arc, which is the moment to recall the usual
+explanation for that roundness: Tamil was scratched into palm leaf, and a
+straight stroke along the grain can split the leaf. Hold it as the writing
+lesson asked — **the standard account, not a settled fact**, since the earliest
+Tamil writing was cut into stone and is angular. What survives is the useful
+part: **the tool leaves fingerprints on the letters**.
+
+## Grammar Lens: near, far, and which
+<!-- hl-knowledge: introduces=[TA-GRAMMAR-IVAR-02]; assesses=[] -->
+
+**இவர்** is one cell of a system, and the system is a single letter at the
+front:
+
+| the front letter | what it does |
+|---|---|
+| **இ-** | points **near** — this one, here |
+| **அ-** | points **away** — that one, there |
+| **எ-** | **asks** — which one |
+
+So **இவர்** is "this person," **அவர்** (*avar*) "that person," **எவர்** (*evar*)
+"which person." You have been using one front already: **என்ன** (*eṉṉa*),
+"what," is the **எ-** of asking.
+
+Two honest notes. **எ-** is the **question**, not a third distance. And Old
+Tamil had a genuine third distance, **உ-**, for something visible but far off;
+modern Tamil has retired it.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-IVAR-01, TA-GRAMMAR-IVAR-02, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-CURVES-VA-KA-01, TA-LEX-NANBAN-01, TA-ETYMON-NANBAN-02, TA-LEX-UUR-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: the three fronts — "i- … a- … e-"]
+- [YOU SAY: the row they build — "ivar, avar, evar"]
+- [YOU SAY: the question word you already had — "eṉṉa"]
+- [YOU SAY: the respectful ending on both — "naṇbar … ivar"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-IVAR-01, TA-GRAMMAR-IVAR-02, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-CURVES-VA-KA-01, TA-LEX-NANBAN-01, TA-ETYMON-NANBAN-02, TA-LEX-UUR-01] -->
+
+[PAUSE 3s] What do **இ-**, **அ-** and **எ-** do at the front of a word, and which
+question word you already knew is built on **எ-**? (**Near**; **away**;
+**asks** — and **என்ன**.) Does **இவர்** tell you whether the person is a man or a
+woman? (**No** — it marks **respect**; spoken Tamil leans **இவங்க** for a
+woman.) How firmly should you hold the palm-leaf explanation for the curves?
+(As **the standard account, not a settled fact**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C37-nanban.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C37-nanban.md
@@ -1,0 +1,109 @@
+---
+schema_version: 2
+id: TA-C37-nanban
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 840
+chapter: 37
+type: word
+headword: நண்பன்
+gloss: friend — one word with three endings for man, woman and respect, and a root meaning "close"
+romanization: naṇbaṉ
+concept_tag: TA-FRIEND
+prerequisites: [TA-C37-uur, TA-C12-kudumbam]
+sounds: [tamil-retroflex-nna, pulli-virama]
+roots: [dravidian-nannu-draw-near]
+etymology_hook: "நண்பன் sits in the root family of நண்ணு 'to draw near', through the noun நண்பு 'closeness, friendship'"
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [TA-LEX-UUR-01, TA-ETYMON-UUR-02, TA-LEX-KUDUMBAM-02, TA-ETYMON-KUDUMBAM-01, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SOUND-I-SIGN-WRITE-NANDRI-03]
+introduces:
+  knowledge: [TA-LEX-NANBAN-01, TA-ETYMON-NANBAN-02]
+practises:
+  knowledge: [TA-LEX-UUR-01, TA-ETYMON-UUR-02, TA-LEX-KUDUMBAM-02, TA-ETYMON-KUDUMBAM-01, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SOUND-I-SIGN-WRITE-NANDRI-03, TA-LEX-NANBAN-01, TA-ETYMON-NANBAN-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C37-uur, TA-C12-kudumbam, TA-W02-ma-retroflex-na, TA-W04-vowel-signs-nandri]
+---
+
+# நண்பன் (naṇbaṉ) — "friend," with the ending doing the work
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-UUR-01, TA-ETYMON-UUR-02] -->
+
+[PAUSE 2s] A stranger's native place, then the ending inside Tanjore. (*Uṅgaḷ ūr
+eṉṉa*; *-ūr*.) Now the person you would introduce.
+
+## You'll want to know: நண்பன்
+<!-- hl-knowledge: introduces=[TA-LEX-NANBAN-01]; assesses=[TA-LEX-KUDUMBAM-02] -->
+
+> **நண்பன்** — *naṇbaṉ* — **friend** (a man)
+
+Tamil will not let you say a bare "friend" any more than a bare "brother." The
+stem is **நண்ப-**; the ending decides.
+
+| the form | who it is |
+|---|---|
+| **நண்பன்** *naṇbaṉ* | a male friend |
+| **நண்பி** *naṇbi* | a female friend |
+| **நண்பர்** *naṇbar* | a friend spoken of with respect |
+
+The **-அர்** is the respectful plural that turns **நீ** into **நீங்கள்**,
+applied to a person.
+
+This is a different axis from the family words. **அண்ணன்** and **தம்பி** split
+brothers by **age**; the friend words split by **sex**, **நண்பர்** by
+**respect**.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01] -->
+
+**ந** + **ண்** + **ப** + **ன்** — **every one of Tamil's n-letters inside one
+word**. **ந** opens it, dental, at the teeth. **ண்** is retroflex, tongue curled
+back, closed by a puḷḷi. **ன்** ends it, the alveolar n from **நன்றி**. The
+writing lesson gave them to you one at a time; here they arrive together.
+
+## Sounds you'll need: why it is heard as naṇbaṉ
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SOUND-I-SIGN-WRITE-NANDRI-03] -->
+
+The letter after **ண்** is **ப**, named *pa*. The course writes *naṇ**b**aṉ*
+because of the **நன்றி** rule: a nasal in front of a stop **voices it**. A Tamil
+reader supplies the voicing, as an English reader supplies the *sh* in
+*sugar*.
+
+## The word, taken apart - a friend is someone who came close
+<!-- hl-knowledge: introduces=[TA-ETYMON-NANBAN-02]; assesses=[TA-ETYMON-KUDUMBAM-01] -->
+
+Behind **நண்பன்** is **நண்பு** (*naṇbu*), "friendship, closeness," which belongs
+to the root family of **நண்ணு** (*naṇṇu*), "**to draw near**." A friend, in
+Tamil's own accounting, is someone who came close.
+
+Be precise. The Dravidian dictionary files *naṇbu* and *naṇbaṉ* in the same
+entry as *naṇṇu*; the Tamil lexicon prefers **நள்-**, making them siblings
+rather than parent and child. They differ on the line of descent, not on the
+household.
+
+Set it beside **அப்பா** and **அம்மா**, not built out of anything — the
+repeated-syllable shape children produce for parents worldwide. **நண்பன்** is
+assembled, from a root you can point at.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-NANBAN-01, TA-ETYMON-NANBAN-02, TA-LEX-KUDUMBAM-02, TA-ETYMON-KUDUMBAM-01, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SOUND-I-SIGN-WRITE-NANDRI-03, TA-LEX-UUR-01, TA-ETYMON-UUR-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: the three endings — "naṇbaṉ, naṇbi, naṇbar"]
+- [YOU SAY: the voicing after the nasal — "naṉṟi … naṇbaṉ"]
+- [YOU SAY: the root it came from — "naṇṇu, to draw near"]
+- [YOU SAY: the family words that split on age instead — "aṇṇaṉ, tambi"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-NANBAN-01, TA-ETYMON-NANBAN-02, TA-LEX-KUDUMBAM-02, TA-ETYMON-KUDUMBAM-01, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SOUND-I-SIGN-WRITE-NANDRI-03, TA-LEX-UUR-01, TA-ETYMON-UUR-02] -->
+
+[PAUSE 3s] Give the friend-word for a woman, a man, and someone you respect.
+(*Naṇbi*; *naṇbaṉ*; *naṇbar*.) Which axis do the friend words split on, and
+which do the brother words? (**Sex and respect**; **age**.) Why is **ப** heard
+as *b*, and are **அப்பா** and **அம்மா** built from a root the way *naṇbaṉ* is?
+(**A nasal voices the stop after it**; **no**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C37-nanban.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C37-nanban.md
@@ -69,7 +69,7 @@ writing lesson gave them to you one at a time; here they arrive together.
 ## Sounds you'll need: why it is heard as naṇbaṉ
 <!-- hl-knowledge: introduces=[]; assesses=[TA-SOUND-I-SIGN-WRITE-NANDRI-03] -->
 
-The letter after **ண்** is **ப**, named *pa*. The course writes *naṇ**b**aṉ*
+The letter after **ண்** is **ப**, named *pa*. This book writes *naṇ**b**aṉ*
 because of the **நன்றி** rule: a nasal in front of a stop **voices it**. A Tamil
 reader supplies the voicing, as an English reader supplies the *sh* in
 *sugar*.

--- a/code/learning/human-languages/tamil/lessons/TA-C37-uur.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C37-uur.md
@@ -1,0 +1,113 @@
+---
+schema_version: 2
+id: TA-C37-uur
+spine_node: SPINE-EXCHANGE-NAMES
+sequence: 830
+chapter: 37
+type: word
+headword: ஊர்
+gloss: town, village — where you are from, which a Tamil introduction asks for, and the -ore in Bangalore
+romanization: ūr
+concept_tag: TA-HOMETOWN
+prerequisites: [TA-C36-tavaru, TA-C19-vayathu]
+sounds: [tamil-long-vowel-uu, pulli-virama]
+roots: [dravidian-uur-settlement]
+etymology_hook: "ஊர் is inherited Dravidian for a settlement — and it is the -ūru inside Bengalūru, Mysūru and தஞ்சாவூர்"
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [TA-LEX-TAVARU-01, TA-ETYMON-TAVARU-02, TA-LEX-UNAVU-01, TA-LEX-VAYATHU-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01, TA-PRAGMATICS-THANNEER-ARISI-03]
+introduces:
+  knowledge: [TA-LEX-UUR-01, TA-ETYMON-UUR-02]
+practises:
+  knowledge: [TA-LEX-TAVARU-01, TA-ETYMON-TAVARU-02, TA-LEX-UNAVU-01, TA-LEX-VAYATHU-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01, TA-PRAGMATICS-THANNEER-ARISI-03, TA-LEX-UUR-01, TA-ETYMON-UUR-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C36-tavaru, TA-C19-vayathu, TA-C19-age-register-grammar, TA-C15-thanneer-arisi]
+---
+
+# ஊர் (ūr) — "town," and the question Tamil asks early
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-TAVARU-01, TA-ETYMON-TAVARU-02, TA-LEX-UNAVU-01] -->
+
+[PAUSE 2s] *Eṉ tavaṟu* — my mistake, a word that is a verb and a noun at once.
+Then the general word for food. (*Uṇavu*.) Now back to meeting somebody.
+
+## You'll want to know: ஊர்
+<!-- hl-knowledge: introduces=[TA-LEX-UUR-01]; assesses=[TA-LEX-VAYATHU-01] -->
+
+> **ஊர்** — *ūr* — **town, village; the place you are from**
+
+That last sense matters most. **உங்கள் ஊர்** is your **native place**, where
+your family is from, which may be somewhere you have never lived.
+
+> **உங்கள் ஊர் என்ன** — *uṅgaḷ ūr eṉṉa* — **What is your town**
+
+It lands early in a Tamil conversation and is not nosiness — the slot English
+fills with "what do you do.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
+
+**ஊ** is a standing vowel — long *ū*, partner of the **உ** that opens *uṇavu*.
+**ர்** is **ர**, the soft r, shut by a puḷḷi. Hold the vowel: *ūr*, not *ur*.
+Vowel length is part of a word's identity here.
+
+## Grammar Lens: the two registers, side by side
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01] -->
+
+You met this choice on the age question:
+
+| the question | who you say it to |
+|---|---|
+| **உன் ஊர் என்ன** *uṉ ūr eṉṉa* | a friend, a child, a peer |
+| **உங்கள் ஊர் என்ன** *uṅgaḷ ūr eṉṉa* | a stranger, an elder, anyone senior |
+
+Both are possessive plus noun plus question word, with **no verb** — the shape
+you learned for **உன் வயசு என்ன**. Only the possessive changes, and with it the
+social temperature. When unsure, use **உங்கள்**.
+
+## The word, taken apart - the syllable inside the map
+<!-- hl-knowledge: introduces=[TA-ETYMON-UUR-02]; assesses=[TA-PRAGMATICS-THANNEER-ARISI-03] -->
+
+**ஊர்** is inherited Dravidian, and welded into city names you know in
+English:
+
+| the English name | what it is |
+|---|---|
+| **Tanjore** | Tamil **தஞ்சாவூர்** *Tañjāvūr* |
+| **Vellore** | Tamil **வேலூர்** *Vēlūr* |
+| **Bangalore** | Kannada **ಬೆಂಗಳೂರು** *Bengaḷūru* |
+
+Every one of those *-ore* endings is this word: the British ear turned *-ūr*
+into *-ore*, and the cities have taken their own names back.
+
+Two exactnesses. Bangalore is a **Kannada** town, so its *-ūru* is Kannada's
+form of the inherited word — the family's, not Tamil's alone. And the *first*
+halves are not all settled; *Vēl-* in Vellore is argued over. The ending is the
+certain part.
+
+Weigh that against the rice word. **அரிசி** *may* stand behind English *rice*
+through Greek, and the dictionaries hedge. Nobody hedges about *-ūr*.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-UUR-01, TA-ETYMON-UUR-02, TA-LEX-VAYATHU-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01, TA-PRAGMATICS-THANNEER-ARISI-03, TA-LEX-TAVARU-01, TA-ETYMON-TAVARU-02, TA-LEX-UNAVU-01] -->
+
+[PAUSE 1s]
+- [YOU SAY: the long vowel — "ūr," not "ur"]
+- [YOU SAY: to a stranger — "uṅgaḷ ūr eṉṉa"]
+- [YOU SAY: to a friend — "uṉ ūr eṉṉa"]
+- [YOU SAY: the ending inside the map — "Tañjāvūr … Vēlūr … Bengaḷūru"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-UUR-01, TA-ETYMON-UUR-02, TA-LEX-VAYATHU-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-01, TA-PRAGMATICS-THANNEER-ARISI-03, TA-LEX-TAVARU-01, TA-ETYMON-TAVARU-02, TA-LEX-UNAVU-01] -->
+
+[PAUSE 3s] Ask a stranger where they are from, then a friend, and say what
+**ஊர்** means beyond "town." (*Uṅgaḷ ūr eṉṉa*; *uṉ ūr eṉṉa*; **your native
+place**.) Which earlier question has this shape, and is *-ore* in Tanjore really
+this word? (**உன் வயசு என்ன**; **yes**.) How sure are we there, next to *arisi*
+and *rice*? (**Much surer.**)

--- a/code/learning/human-languages/tamil/lessons/TA-C38-sugam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C38-sugam.md
@@ -1,0 +1,106 @@
+---
+schema_version: 2
+id: TA-C38-sugam
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 880
+chapter: 38
+type: word
+headword: சுகம்
+gloss: wellbeing, ease — the Sanskrit word Tamil did take in, sitting beside the native நலம் it never dropped
+romanization: sugam
+concept_tag: TA-WELLBEING-EASE
+prerequisites: [TA-C38-udambu, TA-C09-mannikkavum, TA-C06-dative-stacking]
+sounds: [tamil-vowel-sign-u, final-m]
+roots: [sanskrit-sukha-ease]
+etymology_hook: "சுகம் is Sanskrit सुख sukha — the borrowing Tamil kept beside native நலம், where Malayalam made it the default"
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [TA-LEX-UDAMBU-01, TA-ETYMON-UDAMBU-02, TA-GRAMMAR-DATIVE-UKKU-01, TA-GRAMMAR-DATIVE-STACKING-01, TA-SOUND-ABUGIDA-VA-KA-04, TA-ETYMON-MANNIKKAVUM-02, TA-SCRIPT-SORRY-REGISTER-02, TA-LEX-NANBAN-01, TA-LEX-TERI-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02, TA-LEX-UUR-01, TA-ETYMON-UUR-02]
+introduces:
+  knowledge: [TA-LEX-SUGAM-01, TA-ETYMON-SUGAM-02]
+practises:
+  knowledge: [TA-LEX-UDAMBU-01, TA-ETYMON-UDAMBU-02, TA-GRAMMAR-DATIVE-UKKU-01, TA-GRAMMAR-DATIVE-STACKING-01, TA-SOUND-ABUGIDA-VA-KA-04, TA-ETYMON-MANNIKKAVUM-02, TA-SCRIPT-SORRY-REGISTER-02, TA-LEX-NANBAN-01, TA-LEX-TERI-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02, TA-LEX-SUGAM-01, TA-ETYMON-SUGAM-02, TA-LEX-UUR-01, TA-ETYMON-UUR-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C38-udambu, TA-C09-mannikkavum, TA-C06-dative-ukku, TA-C06-dative-stacking, TA-C32-teri]
+---
+
+# சுகம் (sugam) — "ease," the word Tamil did borrow
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-UDAMBU-01, TA-ETYMON-UDAMBU-02] -->
+
+[PAUSE 2s] Health through the body, and the other body-word in its entry.
+(*Uṅgaḷ uḍambu eppaḍi irukku*; *uḍal*.) A second answer came from abroad.
+
+## You'll want to know: சுகம்
+<!-- hl-knowledge: introduces=[TA-LEX-SUGAM-01]; assesses=[TA-SOUND-ABUGIDA-VA-KA-04, TA-LEX-UUR-01, TA-ETYMON-UUR-02] -->
+
+> **சுகம்** — *sugam* — **wellbeing, ease, comfort**
+
+The **க** is doing its old trick: the letter is *ka*, but between vowels it comes
+out **g**. *Su-**g**-am*, not *su-ka-m*.
+
+> **சுகமா** — *sugamā* — **keeping well**
+
+It is **not** the ordinary Tamil "how are you," which is **நல்லா
+இருக்கீங்களா**. **சுகமா** is warmer and more Sanskritic, and which you hear
+depends on somebody's **ஊர்** — the native place whose name so often ends in
+*-ūr*.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-SORRY-REGISTER-02] -->
+
+**சு** + **க** + **ம்**: **ச** with the *u* sign, a bare **க**, **ம** closed by
+the puḷḷi. Nothing is doubled — hold that against **மன்னிக்கவும்**, where
+**ன்னி** has **ன** dotted shut and written a second time, and **க்க** does the
+same to **க**.
+
+## Grammar Lens: where the dative is required
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-DATIVE-UKKU-01, TA-GRAMMAR-DATIVE-STACKING-01, TA-LEX-NANBAN-01, TA-LEX-TERI-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02] -->
+
+**சுகமா** has no dative in it, and a family of Tamil states demands one:
+**எனக்குத் தமிழ் தெரியும்**, "to me, Tamil is known." Put a noun there and the
+shapes part:
+
+| the phrase | what happened |
+|---|---|
+| **நான்** to **எனக்கு** | the pronoun **changes its body** |
+| **நண்பர்** to **நண்பருக்கு** | the noun just **takes -உக்கு** |
+
+So **நண்பருக்குத் தமிழ் தெரியும்**, and the formal age question does the same:
+**உனக்கு எத்தனை வயது ஆகிறது**. **சுகமா** does not: knowing and ageing come *to*
+a person; being well is what a person **is**.
+
+## The word, taken apart - the borrowing Tamil kept beside its own
+<!-- hl-knowledge: introduces=[TA-ETYMON-SUGAM-02]; assesses=[TA-ETYMON-MANNIKKAVUM-02] -->
+
+**சுகம்** is Sanskrit **सुख** (*sukha*), "ease" — the apology lesson in reverse.
+There, **மன்னிக்கவும்** stood on Tamil's own **மன்னி** while the neighbours
+built their "sorry" on Sanskrit **kṣamā**. Here Tamil borrowed *sukha* and
+**kept நலம்** as the everyday word; Malayalam took the same loan, **സുഖം**, as
+its ordinary greeting.
+
+The old parse of *sukha* is *su-* "good" plus *kha* "aperture" — a chariot's
+axle-hole. **Treat that as contested**: the standard Sanskrit dictionary hedges
+it with "said to be," and offers *su-stha*.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-SUGAM-01, TA-ETYMON-SUGAM-02, TA-ETYMON-MANNIKKAVUM-02, TA-SCRIPT-SORRY-REGISTER-02, TA-SOUND-ABUGIDA-VA-KA-04, TA-GRAMMAR-DATIVE-UKKU-01, TA-GRAMMAR-DATIVE-STACKING-01, TA-LEX-NANBAN-01, TA-LEX-TERI-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02, TA-LEX-UDAMBU-01, TA-ETYMON-UDAMBU-02, TA-LEX-UUR-01, TA-ETYMON-UUR-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: the softened க — "sugam," not "sukam"]
+- [YOU SAY: the state that needs a dative — "naṇbarukkut tamiḻ teriyum"]
+- [YOU SAY: the state that does not, and the word kept beside it — "sugamā … nalam"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-SUGAM-01, TA-ETYMON-SUGAM-02, TA-ETYMON-MANNIKKAVUM-02, TA-SCRIPT-SORRY-REGISTER-02, TA-SOUND-ABUGIDA-VA-KA-04, TA-GRAMMAR-DATIVE-UKKU-01, TA-GRAMMAR-DATIVE-STACKING-01, TA-LEX-NANBAN-01, TA-LEX-TERI-01, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02, TA-LEX-UDAMBU-01, TA-ETYMON-UDAMBU-02, TA-LEX-UUR-01, TA-ETYMON-UUR-02] -->
+
+[PAUSE 3s] Why is **க** heard as *g*, and what did the noun do that **நான்**
+does not? (**Between vowels**; it **takes -உக்கு**, while **நான்** becomes
+**எனக்கு**.) Which word did Tamil borrow, which did it keep, and how firm is the
+"good axle-hole" story? (**சுகம்**; **நலம்**; **contested**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C38-udambu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C38-udambu.md
@@ -1,0 +1,111 @@
+---
+schema_version: 2
+id: TA-C38-udambu
+spine_node: SPINE-CHECK-WELLBEING
+sequence: 870
+chapter: 38
+type: word
+headword: உடம்பு
+gloss: body — the noun in the everyday Tamil way of asking after someone's health
+romanization: uḍambu
+concept_tag: TA-BODY
+prerequisites: [TA-C37-ivar-en-nanbar, TA-C13-udal-uruppugal]
+sounds: [tamil-retroflex-tta, pulli-virama]
+roots: [dravidian-udal-body]
+etymology_hook: "உடம்பு is filed in the same dictionary entry as உடல் — one root, two everyday Tamil words for the body"
+duration:
+  max_seconds: 245
+requires:
+  knowledge: [TA-LEX-IVAR-EN-NANBAR-01, TA-PRAGMATICS-IVAR-EN-NANBAR-02, TA-LEX-IVAR-01, TA-LEX-UDAL-URUPPUGAL-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SOUND-I-SIGN-WRITE-NANDRI-03, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02, TA-LEX-UNAVU-01, TA-ETYMON-UNAVU-02]
+introduces:
+  knowledge: [TA-LEX-UDAMBU-01, TA-ETYMON-UDAMBU-02]
+practises:
+  knowledge: [TA-LEX-IVAR-EN-NANBAR-01, TA-PRAGMATICS-IVAR-EN-NANBAR-02, TA-LEX-IVAR-01, TA-LEX-UDAL-URUPPUGAL-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SOUND-I-SIGN-WRITE-NANDRI-03, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02, TA-LEX-UDAMBU-01, TA-ETYMON-UDAMBU-02, TA-LEX-UNAVU-01, TA-ETYMON-UNAVU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C37-ivar-en-nanbar, TA-C13-udal-uruppugal, TA-C19-age-register-grammar]
+---
+
+# உடம்பு (uḍambu) — "body," and how Tamil asks after your health
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-IVAR-EN-NANBAR-01, TA-PRAGMATICS-IVAR-EN-NANBAR-02, TA-LEX-IVAR-01] -->
+
+[PAUSE 2s] Introduce a friend respectfully and name the ending. (*Ivar eṉ
+naṇbar* — the respectful **-அர்**.) Next you would ask how they are.
+
+## You'll want to know: உடம்பு
+<!-- hl-knowledge: introduces=[TA-LEX-UDAMBU-01]; assesses=[TA-LEX-UDAL-URUPPUGAL-01, TA-LEX-UNAVU-01, TA-ETYMON-UNAVU-02] -->
+
+> **உடம்பு** — *uḍambu* — **body**
+
+The whole of it, not a part. You have **தலை** (*talai*) and **கை** (*kai*)
+already; this is what they belong to, and the word inside the question Tamil
+speakers actually ask:
+
+> **உங்கள் உடம்பு எப்படி இருக்கு** — *uṅgaḷ uḍambu eppaḍi irukku* — **how is
+> your body**, that is, **how are you keeping**
+
+Every piece is yours: **உங்கள்**, **எப்படி**, and **இருக்கு** from **இரு**. What
+is new is that the health question hangs on a **noun** rather than on you.
+
+Tamil has a second way to ask it, through **உணவு** — the noun standing on
+**உண்**, "to eat." Asking whether somebody has eaten is asking whether they are
+all right.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+**உ** + **ட** + **ம்** + **பு**: the standing vowel *u*, **ட**, then **ம்** —
+**ம** shut by the puḷḷi you have used since **வணக்கம்** — and **பு**. **ம** was
+one of the first letters you formed with a pen, alongside retroflex **ண**.
+
+## Sounds you'll need: two softenings in one word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SOUND-I-SIGN-WRITE-NANDRI-03] -->
+
+The letters say *u-ṭa-m-pu*; your mouth says *u**ḍ**a**mb**u*. **ட** sits
+between vowels, so it softens — the *paḍi* rule. **ப** follows the nasal **ம்**,
+so it voices — the *naṉṟi* rule that also made *naṇbaṉ*. Two rules, one short
+word, neither written down.
+
+## The word, taken apart - the same entry as உடல்
+<!-- hl-knowledge: introduces=[TA-ETYMON-UDAMBU-02]; assesses=[] -->
+
+Tamil has another word for the body, **உடல்** (*uḍal*), and the Dravidian
+dictionary does not treat them as rivals: **உடல்**, **உடம்பு** and **உடலம்** sit
+in the **same entry**, with Kannada's **ಒಡಲು** beside them. Usage has divided
+them: **உடல்** leans literary, **உடம்பு** is what you say aloud about someone
+unwell.
+
+## Grammar Lens: where the person goes in a health question
+<!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02] -->
+
+Two shapes Tamil uses to ask about a state:
+
+| the question | where the person sits |
+|---|---|
+| **உங்கள் உடம்பு எப்படி இருக்கு** | as a **possessor** |
+| **உனக்கு எத்தனை வயது ஆகிறது** | in the **dative** |
+
+The formal age question does not make you the subject at all — "**to you**, how
+many years are becoming." The body question makes **உடம்பு** the subject.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-UDAMBU-01, TA-ETYMON-UDAMBU-02, TA-LEX-UDAL-URUPPUGAL-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SOUND-I-SIGN-WRITE-NANDRI-03, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02, TA-LEX-IVAR-EN-NANBAR-01, TA-PRAGMATICS-IVAR-EN-NANBAR-02, TA-LEX-IVAR-01, TA-LEX-UNAVU-01, TA-ETYMON-UNAVU-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: the two softenings — "uṭampu … uḍambu"]
+- [YOU SAY: the question — "uṅgaḷ uḍambu eppaḍi irukku"]
+- [YOU SAY: the parts, the whole, and the two forms of one root — "talai, kai … uḍambu … uḍal"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-UDAMBU-01, TA-ETYMON-UDAMBU-02, TA-LEX-UDAL-URUPPUGAL-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SOUND-I-SIGN-WRITE-NANDRI-03, TA-GRAMMAR-AGE-REGISTER-GRAMMAR-02, TA-LEX-IVAR-EN-NANBAR-01, TA-PRAGMATICS-IVAR-EN-NANBAR-02, TA-LEX-IVAR-01, TA-LEX-UNAVU-01, TA-ETYMON-UNAVU-02] -->
+
+[PAUSE 3s] Ask someone respectfully how they are keeping, through the body, and
+name the two sound rules inside *uḍambu*. (*Uṅgaḷ uḍambu eppaḍi irukku*; **ட**
+softens **between vowels**, **ப** voices **after a nasal**.) Are **உடல்** and
+**உடம்பு** different words, and where does the person sit in the formal age
+question? (**No**, same entry; **in the dative**.)

--- a/code/learning/human-languages/tamil/lessons/TA-C38-vidai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C38-vidai.md
@@ -1,0 +1,109 @@
+---
+schema_version: 2
+id: TA-C38-vidai
+spine_node: SPINE-TAKE-LEAVE
+sequence: 890
+chapter: 38
+type: word
+headword: விடை
+gloss: leave to depart — the noun for taking your leave, from the same root as வீடு
+romanization: viḍai
+concept_tag: TA-LEAVE-TAKING-NOUN
+prerequisites: [TA-C38-sugam, TA-C35-veedu, TA-W04-i-sign-write-nandri]
+sounds: [tamil-retroflex-tta, tamil-vowel-sign-ai]
+roots: [dravidian-vidu-let-go]
+etymology_hook: "விடை sits in the same dictionary entry as விடு 'to let go' and வீடு 'house' — one root, three words"
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [TA-LEX-SUGAM-01, TA-ETYMON-SUGAM-02, TA-LEX-UDAMBU-01, TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02, TA-LEX-UUR-01, TA-LEX-NANBAN-01, TA-LEX-TENEER-01, TA-ETYMON-TAYAVUSEYTU-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-02, TA-SCRIPT-ABUGIDA-VA-KA-03, TA-LEX-NAARKAALI-01, TA-ETYMON-NAARKAALI-02, TA-LEX-TAVARU-01, TA-ETYMON-TAVARU-02]
+introduces:
+  knowledge: [TA-LEX-VIDAI-01, TA-ETYMON-VIDAI-02]
+practises:
+  knowledge: [TA-LEX-SUGAM-01, TA-ETYMON-SUGAM-02, TA-LEX-UDAMBU-01, TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02, TA-LEX-UUR-01, TA-LEX-NANBAN-01, TA-LEX-TENEER-01, TA-ETYMON-TAYAVUSEYTU-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-02, TA-SCRIPT-ABUGIDA-VA-KA-03, TA-LEX-VIDAI-01, TA-ETYMON-VIDAI-02, TA-LEX-NAARKAALI-01, TA-ETYMON-NAARKAALI-02, TA-LEX-TAVARU-01, TA-ETYMON-TAVARU-02]
+skills: [listening, speaking, reading]
+modes: [interpretive, interpersonal, presentational, mediation]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-C38-sugam, TA-C38-udambu, TA-C35-veedu, TA-C37-uur, TA-C36-teneer, TA-C08-tayavuseytu, TA-W04-i-sign-write-nandri]
+---
+
+# விடை (viḍai) — "leave," and the root under the house
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-SUGAM-01, TA-ETYMON-SUGAM-02, TA-LEX-UDAMBU-01, TA-LEX-NAARKAALI-01, TA-ETYMON-NAARKAALI-02, TA-LEX-TAVARU-01, TA-ETYMON-TAVARU-02] -->
+
+[PAUSE 2s] *Sugam* — which language it came from, and which Tamil word stayed
+beside it. (Sanskrit; **நலம்**.) You came through the door, took the
+**நாற்காலி** — four legs, counted out — were given tea, said **என் தவறு** when
+the wrong cup arrived, and introduced a friend. One thing is left.
+
+## You'll want to know: விடை
+<!-- hl-knowledge: introduces=[TA-LEX-VIDAI-01]; assesses=[TA-LEX-TENEER-01, TA-ETYMON-TAYAVUSEYTU-02] -->
+
+> **விடை** — *viḍai* — **leave; permission to depart**
+
+Not the act of going — you have **போய் வருகிறேன்** for that — but the **leave
+itself**, taken with **பெறு** (*peṟu*), "to obtain":
+
+> **நன்றி. விடை பெறுகிறேன்.** — *naṉṟi. viḍai peṟugiṟēṉ.* — **Thank you. I take
+> my leave.**
+
+It is **formal and slightly literary**; leaving a friend's house you would say
+**போய் வருகிறேன்**.
+
+The **தயவுசெய்து** you learned for asking has a family across the Dravidian
+languages, all built on the same *daya*, "kindness," plus a light verb. Leaving
+is not.
+
+## The letters in this word
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-02, TA-SCRIPT-ABUGIDA-VA-KA-03] -->
+
+**வி** + **டை**. **வி** is **வ** with the **ி** sign — the first vowel sign you
+learned, which made **நன்றி** possible. **டை** is **ட** with the *ai*
+sign **ை**, which wraps around the front.
+
+**நன்றி** stands beside it above, so read it once more: **ந** + **ன்** + **றி**
+— dental n, alveolar n dotted shut, hard **ற** with that same **ி**. And
+**பெறுகிறேன்** has a **க** between vowels, so it softens.
+
+## The word, taken apart - one root, three words
+<!-- hl-knowledge: introduces=[TA-ETYMON-VIDAI-02]; assesses=[TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02, TA-LEX-UUR-01, TA-LEX-NANBAN-01] -->
+
+**விடை** is inherited Dravidian, and belongs to **விடு** (*viḍu*), "to let go."
+Leave is what you are *let go* with.
+
+Now the first word of these lessons. **வீடு**, "house," is filed by the
+Dravidian dictionary in the **same entry as விடு** — and **விடை** is in it
+too:
+
+| the word | what it is |
+|---|---|
+| **விடு** *viḍu* | to let go, to release |
+| **வீடு** *vīḍu* | the house — and, in the old sense, final release |
+| **விடை** *viḍai* | leave to depart |
+
+You walked in through **வீடு** and walk out through **விடை**, one word in
+different clothes. Kannada's **ಬೀಡು**, the same house with its *b-*, sits on that
+root as well.
+
+Two cautions, because a neat pattern is when to slow down. A second **விடை**
+means "bull," a Sanskrit borrowing from *vṛṣa*; and **ஊர்** — the settlement
+inside Tanjore — and **நண்பன்** are outside this root entirely.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-VIDAI-01, TA-ETYMON-VIDAI-02, TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02, TA-LEX-UUR-01, TA-LEX-NANBAN-01, TA-LEX-TENEER-01, TA-ETYMON-TAYAVUSEYTU-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-02, TA-SCRIPT-ABUGIDA-VA-KA-03, TA-LEX-SUGAM-01, TA-ETYMON-SUGAM-02, TA-LEX-UDAMBU-01, TA-LEX-NAARKAALI-01, TA-ETYMON-NAARKAALI-02, TA-LEX-TAVARU-01, TA-ETYMON-TAVARU-02] -->
+
+[PAUSE 1s]
+- [YOU SAY: the departure — "naṉṟi. viḍai peṟugiṟēṉ."]
+- [YOU SAY: the one root, three ways — "viḍu … vīḍu … viḍai"]
+- [YOU SAY: the two that do not join it — "ūr … naṇbaṉ"]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-LEX-VIDAI-01, TA-ETYMON-VIDAI-02, TA-LEX-VEEDU-01, TA-ETYMON-VEEDU-02, TA-LEX-UUR-01, TA-LEX-NANBAN-01, TA-LEX-TENEER-01, TA-ETYMON-TAYAVUSEYTU-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-02, TA-SCRIPT-ABUGIDA-VA-KA-03, TA-LEX-SUGAM-01, TA-ETYMON-SUGAM-02, TA-LEX-UDAMBU-01, TA-LEX-NAARKAALI-01, TA-ETYMON-NAARKAALI-02, TA-LEX-TAVARU-01, TA-ETYMON-TAVARU-02] -->
+
+[PAUSE 3s] Take your leave formally, thanks in front of it, and name the earlier
+word that shares this root. (*Naṉṟi. viḍai peṟugiṟēṉ.*; **வீடு**, from **விடு**,
+"to let go.") Do **ஊர்** and **நண்பன்** belong to that root? (**No** — a
+settlement and a closeness; not everything joins up.)

--- a/code/learning/human-languages/tamil/narration/ch35.json
+++ b/code/learning/human-languages/tamil/narration/ch35.json
@@ -4,7 +4,7 @@
   "chapter": 35,
   "title": "Arriving at a House",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:c346ffee5ae76309",
+  "sourceHash": "fnv1a64:2703e3459eee5f3a",
   "lessons": [
     {
       "id": "TA-C35-veedu",
@@ -208,7 +208,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:c1a0f46c867a9c03",
+      "sourceHash": "fnv1a64:563406c98419bdc3",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -271,7 +271,7 @@
             },
             {
               "kind": "speech",
-              "text": "The same rule then lands on the second letter. த is named ta, but it sits between two vowels, so it softens. That is why this course writes kadavu and not katavu. One rule, two letters, one word."
+              "text": "The same rule then lands on the second letter. த is named ta, but it sits between two vowels, so it softens. That is why this book writes kadavu and not katavu. One rule, two letters, one word."
             }
           ]
         },

--- a/code/learning/human-languages/tamil/narration/ch35.json
+++ b/code/learning/human-languages/tamil/narration/ch35.json
@@ -1,0 +1,733 @@
+{
+  "version": 1,
+  "language": "tamil",
+  "chapter": 35,
+  "title": "Arriving at a House",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:c346ffee5ae76309",
+  "lessons": [
+    {
+      "id": "TA-C35-veedu",
+      "sequence": 750,
+      "title": "வீடு (vīḍu) — \"house,\" and the place the greeting happens",
+      "headword": "வீடு",
+      "romanization": "vīḍu",
+      "gloss": "house, home — the word behind the door you say வணக்கம் at, and a v where Kannada says b",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:297479db3d817cd4",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Three verbs from the chapter you have just finished: pidi, \"to like\"; uḍavu, \"to help\"; kēḷ, \"to ask.\" Say them. Now a noun, and the one a conversation usually starts inside."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: வீடு",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "வீடு — vīḍu — house; home."
+            },
+            {
+              "kind": "speech",
+              "text": "One word covers both. Tamil does not split the building from the belonging: என் வீடு (eṉ vīḍu) is \"my house\" and \"my home\" at once, and choosing between them is the translator's problem."
+            },
+            {
+              "kind": "speech",
+              "text": "With the dative you already own:"
+            },
+            {
+              "kind": "speech",
+              "text": "வீட்டுக்கு — vīṭṭukku — to the house."
+            },
+            {
+              "kind": "speech",
+              "text": "The soft ḍ hardens and doubles to ṭṭ — the படி / படித்தேன் rule."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "வீ is வ, the first letter you learned, wearing the long ī sign ீ. Then டு: ட with the u sign."
+            },
+            {
+              "kind": "speech",
+              "text": "You are at a door about to say வணக்கம், so read that word while you are here: வ + ண + க் + க + ம். The வ that opens vaṇakkam is the வ that opens vīḍu."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart - the v that turns into a b",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "வீடு (vīḍu) is inherited, not borrowed:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "the cousin",
+                "language and sense"
+              ],
+              "columns": 2,
+              "rowCount": 3,
+              "utterances": [
+                "the cousin: വീട് vīḍ. language and sense: Malayalam, \"house\".",
+                "the cousin: వీడు vīḍu. language and sense: Telugu, \"town, camp\".",
+                "the cousin: ಬೀಡು bīḍu. language and sense: Kannada, \"abode, encampment\"."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Kannada has changed the front of the word: Tamil says v, Kannada says b. Not a slip — Kannada alone among its neighbours turned inherited word-initial v- into b-, and the inscriptions show it from about the seventh century. Store the correspondence — it keeps paying."
+            },
+            {
+              "kind": "speech",
+              "text": "The sense has drifted where the form has not: Telugu's vīḍu is a town, Kannada's bīḍu an encampment. Tamil and Malayalam kept it on the dwelling."
+            },
+            {
+              "kind": "speech",
+              "text": "One more thing, not a coincidence to explain away. Tamil has a second வீடு (vīḍu) meaning \"release, deliverance,\" as in வீடுபேறு. The Dravidian dictionary files house and release under one entry, headed by விடு (viḍu), \"to let go.\" A house is where you are let go."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"vīḍu\" — house and home in one word",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"vīḍu\" — house and home in one word]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"eṉ vīḍu,\" then the hardening — \"vīṭṭukku\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"eṉ vīḍu,\" then the hardening — \"vīṭṭukku\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the cousins, ending on the front-swap — \"vīḍ … vīḍu … bīḍu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the cousins, ending on the front-swap — \"vīḍ … vīḍu … bīḍu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the root under the house — \"viḍu, to let go\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the root under the house — \"viḍu, to let go\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Why does one Tamil word do two English jobs here, and which letter opens both vīḍu and vaṇakkam? (House and home are not split; and வ.) What does Kannada put at the front instead of v, and is it a one-off? (b — bīḍu; regular, from the seventh century on.) Is the Tamil word for \"release\" the same root as the house? (Yes — both under விடு, \"to let go.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C35-kadavu",
+      "sequence": 760,
+      "title": "கதவு (kadavu) — \"door,\" and a word Tamil never gave up",
+      "headword": "கதவு",
+      "romanization": "kadavu",
+      "gloss": "door — Tamil's everyday word is its own, while the Sanskrit one stayed in books",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:c1a0f46c867a9c03",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Vīḍu — house. Say the cousin that swaps the front letter. (Bīḍu, Kannada.) Now the part of the house you actually stand at."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: கதவு",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "கதவு — kadavu — door."
+            },
+            {
+              "kind": "speech",
+              "text": "The leaf that swings, and the thing somebody opens when you arrive."
+            },
+            {
+              "kind": "speech",
+              "text": "வீட்டுக் கதவு — vīṭṭuk kadavu — the house door."
+            },
+            {
+              "kind": "speech",
+              "text": "Two nouns in a row, the first leaning on the second. Tamil builds a great deal this way, and you have seen it inside a single word: தண்ணீர் is taṇ plus nīr, \"cool\" plus \"water.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "க + த + வு. The first letter is the one that taught you Tamil marks no voicing: க spells a hard k, a soft g and even an h, and position decides. Here it opens the word, so it is hard — ka, not ga."
+            },
+            {
+              "kind": "speech",
+              "text": "The same rule then lands on the second letter. த is named ta, but it sits between two vowels, so it softens. That is why this course writes kadavu and not katavu. One rule, two letters, one word."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart - the everyday word and the bookish one",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "கதவு (kadavu) is inherited Dravidian. Kannada's ಕದ (kada) is the same word with less on the end; Malayalam's കതവ് (katavu) matches Tamil closely."
+            },
+            {
+              "kind": "speech",
+              "text": "Tamil also owns a second word for a door-leaf: கபாடம் (kabāḍam), taken from Sanskrit कपाट (kapāṭa). It exists, it is correct, and almost nobody says it. It lives in poetry and temple description; கதவு (kadavu) lives in the house."
+            },
+            {
+              "kind": "speech",
+              "text": "That split is this language's habit. Where a neighbour borrowed a Sanskrit word and let the inherited one fade, Tamil often kept both and gave them different jobs — the inherited word for the everyday thing, the borrowed one for the elevated register. Do not turn that into a rule that Tamil never borrows. It borrows; it rarely evicts."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"kadavu\" — door",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"kadavu\" — door]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"vīṭṭuk kadavu\" — the house door",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"vīṭṭuk kadavu\" — the house door]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the hard one and the soft one in one word — \"ka … da\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the hard one and the soft one in one word — \"ka … da\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the everyday word, then the bookish one — \"kadavu … kabāḍam\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the everyday word, then the bookish one — \"kadavu … kabāḍam\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say \"the house door,\" then explain why the க is hard and the த soft when neither changed shape. (Vīṭṭuk kadavu; Tamil marks no voicing — position decides.) Which of kadavu and kabāḍam would you hear at somebody's house, and where did the other come from? (Kadavu; kabāḍam is Sanskrit, and stays literary.) Does keeping both mean Tamil refuses to borrow? (No — it borrows without evicting.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C35-arai",
+      "sequence": 770,
+      "title": "அறை (aṟai) — \"room,\" and Tamil's second r",
+      "headword": "அறை",
+      "romanization": "aṟai",
+      "gloss": "room — and the letter ற, the hard r that is not the r you think it is",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:34d173f2cce6d96f",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Vīḍu, house. Kadavu, door — the everyday word Tamil kept while the Sanskrit one stayed in books. Open that door and you are in this word."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: அறை",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "அறை — aṟai — room."
+            },
+            {
+              "kind": "speech",
+              "text": "Any room: in a house, in a hotel, a cell. Put it behind vīḍu the way you put kadavu there:"
+            },
+            {
+              "kind": "speech",
+              "text": "வீட்டு அறை — vīṭṭu aṟai — a room of the house."
+            },
+            {
+              "kind": "speech",
+              "text": "And with the dative, அறைக்கு (aṟaikku), \"to the room.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "அ is the standing vowel a — a letter in its own right, not a sign hung on a consonant. Then ற, then the ai sign ை, which wraps around the front of its consonant: ற + ை becomes றை."
+            },
+            {
+              "kind": "speech",
+              "text": "ற is the hard r you first met inside நன்றி. It is not ர. Tamil keeps two r-letters and uses both."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart - inherited, like the door",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "அறை (aṟai) is inherited. Malayalam's അറ (aṟa) is the same word, used for a chamber or an inner store-room, and it keeps the same hard r."
+            },
+            {
+              "kind": "speech",
+              "text": "So this is kadavu's situation over: an everyday inherited word with a Sanskrit-derived alternative sitting unused in the higher register."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "pronunciation",
+          "title": "Sounds you'll need: how to make ற",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Say the English word hurry and stop on the middle sound. That flick of the tongue against the ridge behind your teeth is close to Tamil ர (ra). Now make it stronger and longer, with real contact: that is ற (ṟa)."
+            },
+            {
+              "kind": "speech",
+              "text": "Two cautions. Do not curl your tongue back — retroflex belongs to ண and ட; ற is made at the ridge. And do not soften it into the English r of red, which is the wrong shape for both Tamil letters."
+            },
+            {
+              "kind": "speech",
+              "text": "Many Tamil speakers merge ர and ற in casual speech, so you will be understood either way. Learn the difference anyway: the spelling depends on it, and a word written with the wrong r is simply misspelled."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"aṟai\" — room, on the hard r",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"aṟai\" — room, on the hard r]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two r's apart — \"ra … ṟa\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two r's apart — \"ra … ṟa\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"vīṭṭu aṟai\" — a room of the house",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"vīṭṭu aṟai\" — a room of the house]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three so far — \"vīḍu, kadavu, aṟai\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three so far — \"vīḍu, kadavu, aṟai\"]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say \"a room of the house,\" and name which of Tamil's two r-letters is in aṟai and where else you have read it. (Vīṭṭu aṟai; ற, the hard one, in நன்றி.) Where is ற made, and what must your tongue not do? (At the ridge behind the teeth — do not curl it back.) If many speakers merge the two r's, why bother? (Because the spelling does not merge.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C35-naarkaali",
+      "sequence": 780,
+      "title": "நாற்காலி (nāṟkāli) — \"chair,\" counted out in legs",
+      "headword": "நாற்காலி",
+      "romanization": "nāṟkāli",
+      "gloss": "chair — a word you can take apart into \"four\" and \"leg,\" and the thing a guest is offered",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:f68ff6aa061a196c",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Three words in the order you meet them arriving: vīḍu, kadavu, aṟai. Hold the hard r in aṟai at the ridge, not the roof. Now the one thing in that room a guest is always pointed at."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: நாற்காலி",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "நாற்காலி — nāṟkāli — chair."
+            },
+            {
+              "kind": "speech",
+              "text": "Five syllables for a chair, which sounds extravagant until you find out what it is made of."
+            },
+            {
+              "kind": "speech",
+              "text": "நான் நாற்காலி எடுக்கிறேன். — nāṉ nāṟkāli eḍukkiṟēṉ — I take a chair."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "நா + ற் + கா + லி. Every piece is one you have handled."
+            },
+            {
+              "kind": "speech",
+              "text": "ந is the dental n, first of Tamil's three n-letters, wearing the long ā sign ா. ற் is the hard r of aṟai under a puḷḷi, the dot that switches off the built-in vowel. கா is க with that same long ā. லி is ல with the i sign ி, the first vowel sign you learned, on the way to spelling நன்றி."
+            },
+            {
+              "kind": "speech",
+              "text": "Now what does not happen at ற்கா. Two consonants meet, and Tamil keeps them as two letters with a dot between, rather than fusing them into a stacked shape as the scripts to the north do. That refusal is why a word this long stays readable one piece at a time."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart - four, and a leg",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The word is a compound, and both halves are yours:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "the piece",
+                "what it is"
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "the piece: நால் nāl. what it is: \"four\" — the form four takes in compounds.",
+                "the piece: கால் kāl. what it is: \"leg, foot; a support\"."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Four plus leg: a chair is a four-legged thing, said out loud. English cannot do that with chair, which travels through French and Latin to a Greek word for \"seat\" without ever showing a leg."
+            },
+            {
+              "kind": "speech",
+              "text": "The seam is audible. நான்கு (nāṉku) is the counting word; in a compound four appears as நால், and before க that ல் hardens to ற். Hence நாற்காலி (nāṟkāli), and hence நாற்பது (nāṟpadu), \"forty.\" Malayalam builds the chair from the same two pieces: നാൽക്കാലി."
+            },
+            {
+              "kind": "speech",
+              "text": "Both halves are inherited Dravidian. Nothing in this chapter was borrowed."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the seam — \"nāṉku … nāl … kāl … nāṟkāli\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the seam — \"nāṉku … nāl … kāl … nāṟkāli\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"nāṉ nāṟkāli eḍukkiṟēṉ\" — I take a chair",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"nāṉ nāṟkāli eḍukkiṟēṉ\" — I take a chair]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the arrival, in order — \"vīḍu, kadavu, aṟai, nāṟkāli\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the arrival, in order — \"vīḍu, kadavu, aṟai, nāṟkāli\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the Kannada front-swap on the first of them — \"vīḍu … bīḍu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the Kannada front-swap on the first of them — \"vīḍu … bīḍu\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Take nāṟkāli apart, then walk somebody into your house four nouns deep. (நால், \"four,\" plus கால், \"leg\"; vīḍu, kadavu, aṟai, nāṟkāli.) What does the dot in ற் do, and what does Tamil refuse to do at that join? (Switches off the built-in vowel; Tamil does not stack the two consonants.) Which of this chapter's words was borrowed? (None.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/tamil/narration/ch35.txt
+++ b/code/learning/human-languages/tamil/narration/ch35.txt
@@ -1,0 +1,176 @@
+Tamil, chapter 35: Arriving at a House.
+4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+
+
+Lesson 1 of 4.
+வீடு (vīḍu) — "house," and the place the greeting happens.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Three verbs from the chapter you have just finished: pidi, "to like"; uḍavu, "to help"; kēḷ, "to ask." Say them. Now a noun, and the one a conversation usually starts inside.
+
+You'll want to know: வீடு.
+வீடு — vīḍu — house; home.
+One word covers both. Tamil does not split the building from the belonging: என் வீடு (eṉ vīḍu) is "my house" and "my home" at once, and choosing between them is the translator's problem.
+With the dative you already own:
+வீட்டுக்கு — vīṭṭukku — to the house.
+The soft ḍ hardens and doubles to ṭṭ — the படி / படித்தேன் rule.
+
+The letters in this word.
+வீ is வ, the first letter you learned, wearing the long ī sign ீ. Then டு: ட with the u sign.
+You are at a door about to say வணக்கம், so read that word while you are here: வ + ண + க் + க + ம். The வ that opens vaṇakkam is the வ that opens vīḍu.
+
+The word, taken apart - the v that turns into a b.
+வீடு (vīḍu) is inherited, not borrowed:
+[a table of 3 rows, read aloud]
+the cousin: വീട് vīḍ. language and sense: Malayalam, "house".
+the cousin: వీడు vīḍu. language and sense: Telugu, "town, camp".
+the cousin: ಬೀಡು bīḍu. language and sense: Kannada, "abode, encampment".
+Kannada has changed the front of the word: Tamil says v, Kannada says b. Not a slip — Kannada alone among its neighbours turned inherited word-initial v- into b-, and the inscriptions show it from about the seventh century. Store the correspondence — it keeps paying.
+The sense has drifted where the form has not: Telugu's vīḍu is a town, Kannada's bīḍu an encampment. Tamil and Malayalam kept it on the dwelling.
+One more thing, not a coincidence to explain away. Tamil has a second வீடு (vīḍu) meaning "release, deliverance," as in வீடுபேறு. The Dravidian dictionary files house and release under one entry, headed by விடு (viḍu), "to let go." A house is where you are let go.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "vīḍu" — house and home in one word]
+[pause 8 seconds for the answer]
+[your turn — say: "eṉ vīḍu," then the hardening — "vīṭṭukku"]
+[pause 8 seconds for the answer]
+[your turn — say: the cousins, ending on the front-swap — "vīḍ … vīḍu … bīḍu"]
+[pause 8 seconds for the answer]
+[your turn — say: the root under the house — "viḍu, to let go"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Why does one Tamil word do two English jobs here, and which letter opens both vīḍu and vaṇakkam? (House and home are not split; and வ.) What does Kannada put at the front instead of v, and is it a one-off? (b — bīḍu; regular, from the seventh century on.) Is the Tamil word for "release" the same root as the house? (Yes — both under விடு, "to let go.")
+
+
+Lesson 2 of 4.
+கதவு (kadavu) — "door," and a word Tamil never gave up.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Vīḍu — house. Say the cousin that swaps the front letter. (Bīḍu, Kannada.) Now the part of the house you actually stand at.
+
+You'll want to know: கதவு.
+கதவு — kadavu — door.
+The leaf that swings, and the thing somebody opens when you arrive.
+வீட்டுக் கதவு — vīṭṭuk kadavu — the house door.
+Two nouns in a row, the first leaning on the second. Tamil builds a great deal this way, and you have seen it inside a single word: தண்ணீர் is taṇ plus nīr, "cool" plus "water."
+
+The letters in this word.
+க + த + வு. The first letter is the one that taught you Tamil marks no voicing: க spells a hard k, a soft g and even an h, and position decides. Here it opens the word, so it is hard — ka, not ga.
+The same rule then lands on the second letter. த is named ta, but it sits between two vowels, so it softens. That is why this course writes kadavu and not katavu. One rule, two letters, one word.
+
+The word, taken apart - the everyday word and the bookish one.
+கதவு (kadavu) is inherited Dravidian. Kannada's ಕದ (kada) is the same word with less on the end; Malayalam's കതവ് (katavu) matches Tamil closely.
+Tamil also owns a second word for a door-leaf: கபாடம் (kabāḍam), taken from Sanskrit कपाट (kapāṭa). It exists, it is correct, and almost nobody says it. It lives in poetry and temple description; கதவு (kadavu) lives in the house.
+That split is this language's habit. Where a neighbour borrowed a Sanskrit word and let the inherited one fade, Tamil often kept both and gave them different jobs — the inherited word for the everyday thing, the borrowed one for the elevated register. Do not turn that into a rule that Tamil never borrows. It borrows; it rarely evicts.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "kadavu" — door]
+[pause 8 seconds for the answer]
+[your turn — say: "vīṭṭuk kadavu" — the house door]
+[pause 8 seconds for the answer]
+[your turn — say: the hard one and the soft one in one word — "ka … da"]
+[pause 8 seconds for the answer]
+[your turn — say: the everyday word, then the bookish one — "kadavu … kabāḍam"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say "the house door," then explain why the க is hard and the த soft when neither changed shape. (Vīṭṭuk kadavu; Tamil marks no voicing — position decides.) Which of kadavu and kabāḍam would you hear at somebody's house, and where did the other come from? (Kadavu; kabāḍam is Sanskrit, and stays literary.) Does keeping both mean Tamil refuses to borrow? (No — it borrows without evicting.)
+
+
+Lesson 3 of 4.
+அறை (aṟai) — "room," and Tamil's second r.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Vīḍu, house. Kadavu, door — the everyday word Tamil kept while the Sanskrit one stayed in books. Open that door and you are in this word.
+
+You'll want to know: அறை.
+அறை — aṟai — room.
+Any room: in a house, in a hotel, a cell. Put it behind vīḍu the way you put kadavu there:
+வீட்டு அறை — vīṭṭu aṟai — a room of the house.
+And with the dative, அறைக்கு (aṟaikku), "to the room."
+
+The letters in this word.
+அ is the standing vowel a — a letter in its own right, not a sign hung on a consonant. Then ற, then the ai sign ை, which wraps around the front of its consonant: ற + ை becomes றை.
+ற is the hard r you first met inside நன்றி. It is not ர. Tamil keeps two r-letters and uses both.
+
+The word, taken apart - inherited, like the door.
+அறை (aṟai) is inherited. Malayalam's അറ (aṟa) is the same word, used for a chamber or an inner store-room, and it keeps the same hard r.
+So this is kadavu's situation over: an everyday inherited word with a Sanskrit-derived alternative sitting unused in the higher register.
+
+Sounds you'll need: how to make ற.
+Say the English word hurry and stop on the middle sound. That flick of the tongue against the ridge behind your teeth is close to Tamil ர (ra). Now make it stronger and longer, with real contact: that is ற (ṟa).
+Two cautions. Do not curl your tongue back — retroflex belongs to ண and ட; ற is made at the ridge. And do not soften it into the English r of red, which is the wrong shape for both Tamil letters.
+Many Tamil speakers merge ர and ற in casual speech, so you will be understood either way. Learn the difference anyway: the spelling depends on it, and a word written with the wrong r is simply misspelled.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "aṟai" — room, on the hard r]
+[pause 8 seconds for the answer]
+[your turn — say: the two r's apart — "ra … ṟa"]
+[pause 8 seconds for the answer]
+[your turn — say: "vīṭṭu aṟai" — a room of the house]
+[pause 8 seconds for the answer]
+[your turn — say: the three so far — "vīḍu, kadavu, aṟai"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say "a room of the house," and name which of Tamil's two r-letters is in aṟai and where else you have read it. (Vīṭṭu aṟai; ற, the hard one, in நன்றி.) Where is ற made, and what must your tongue not do? (At the ridge behind the teeth — do not curl it back.) If many speakers merge the two r's, why bother? (Because the spelling does not merge.)
+
+
+Lesson 4 of 4.
+நாற்காலி (nāṟkāli) — "chair," counted out in legs.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Three words in the order you meet them arriving: vīḍu, kadavu, aṟai. Hold the hard r in aṟai at the ridge, not the roof. Now the one thing in that room a guest is always pointed at.
+
+You'll want to know: நாற்காலி.
+நாற்காலி — nāṟkāli — chair.
+Five syllables for a chair, which sounds extravagant until you find out what it is made of.
+நான் நாற்காலி எடுக்கிறேன். — nāṉ nāṟkāli eḍukkiṟēṉ — I take a chair.
+
+The letters in this word.
+நா + ற் + கா + லி. Every piece is one you have handled.
+ந is the dental n, first of Tamil's three n-letters, wearing the long ā sign ா. ற் is the hard r of aṟai under a puḷḷi, the dot that switches off the built-in vowel. கா is க with that same long ā. லி is ல with the i sign ி, the first vowel sign you learned, on the way to spelling நன்றி.
+Now what does not happen at ற்கா. Two consonants meet, and Tamil keeps them as two letters with a dot between, rather than fusing them into a stacked shape as the scripts to the north do. That refusal is why a word this long stays readable one piece at a time.
+
+The word, taken apart - four, and a leg.
+The word is a compound, and both halves are yours:
+[a table of 2 rows, read aloud]
+the piece: நால் nāl. what it is: "four" — the form four takes in compounds.
+the piece: கால் kāl. what it is: "leg, foot; a support".
+Four plus leg: a chair is a four-legged thing, said out loud. English cannot do that with chair, which travels through French and Latin to a Greek word for "seat" without ever showing a leg.
+The seam is audible. நான்கு (nāṉku) is the counting word; in a compound four appears as நால், and before க that ல் hardens to ற். Hence நாற்காலி (nāṟkāli), and hence நாற்பது (nāṟpadu), "forty." Malayalam builds the chair from the same two pieces: നാൽക്കാലി.
+Both halves are inherited Dravidian. Nothing in this chapter was borrowed.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the seam — "nāṉku … nāl … kāl … nāṟkāli"]
+[pause 8 seconds for the answer]
+[your turn — say: "nāṉ nāṟkāli eḍukkiṟēṉ" — I take a chair]
+[pause 8 seconds for the answer]
+[your turn — say: the arrival, in order — "vīḍu, kadavu, aṟai, nāṟkāli"]
+[pause 8 seconds for the answer]
+[your turn — say: the Kannada front-swap on the first of them — "vīḍu … bīḍu"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Take nāṟkāli apart, then walk somebody into your house four nouns deep. (நால், "four," plus கால், "leg"; vīḍu, kadavu, aṟai, nāṟkāli.) What does the dot in ற் do, and what does Tamil refuse to do at that join? (Switches off the built-in vowel; Tamil does not stack the two consonants.) Which of this chapter's words was borrowed? (None.)

--- a/code/learning/human-languages/tamil/narration/ch35.txt
+++ b/code/learning/human-languages/tamil/narration/ch35.txt
@@ -65,7 +65,7 @@ Two nouns in a row, the first leaning on the second. Tamil builds a great deal t
 
 The letters in this word.
 க + த + வு. The first letter is the one that taught you Tamil marks no voicing: க spells a hard k, a soft g and even an h, and position decides. Here it opens the word, so it is hard — ka, not ga.
-The same rule then lands on the second letter. த is named ta, but it sits between two vowels, so it softens. That is why this course writes kadavu and not katavu. One rule, two letters, one word.
+The same rule then lands on the second letter. த is named ta, but it sits between two vowels, so it softens. That is why this book writes kadavu and not katavu. One rule, two letters, one word.
 
 The word, taken apart - the everyday word and the bookish one.
 கதவு (kadavu) is inherited Dravidian. Kannada's ಕದ (kada) is the same word with less on the end; Malayalam's കതവ് (katavu) matches Tamil closely.

--- a/code/learning/human-languages/tamil/narration/ch36.json
+++ b/code/learning/human-languages/tamil/narration/ch36.json
@@ -1,0 +1,717 @@
+{
+  "version": 1,
+  "language": "tamil",
+  "chapter": 36,
+  "title": "What You Are Offered",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:670535ac9b63a59a",
+  "lessons": [
+    {
+      "id": "TA-C36-teneer",
+      "sequence": 790,
+      "title": "தேநீர் (tēnīr) — \"tea,\" half of it already yours",
+      "headword": "தேநீர்",
+      "romanization": "tēnīr",
+      "gloss": "tea — a borrowed syllable welded onto the நீர் that is already inside தண்ணீர்",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:fbaac7d8134225e1",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Nāṟkāli, and what its halves mean. (Four, and leg.) You are in the aṟai with the chair, and the next thing in a Tamil house is this."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: தேநீர்",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "தேநீர் — tēnīr — tea."
+            },
+            {
+              "kind": "speech",
+              "text": "The second half is yours from the water lesson: நீர் (nīr), \"water,\" the plain older word inside தண்ணீர் (taṇṇīr) — taṇ, \"cool,\" plus nīr. So தேநீர் (tēnīr) is, literally, tea water."
+            },
+            {
+              "kind": "speech",
+              "text": "தேநீர், தயவுசெய்து. — tēnīr, tayavuseytu — Tea, please."
+            },
+            {
+              "kind": "speech",
+              "text": "In speech you will also hear plain டீ (ṭī), straight from English tea. தேநீர் (tēnīr) is the fuller word — a sign, a menu, a formal host."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "தே is த with the ē sign ே, which stands in front of its consonant. நீ is ந with the long ī sign; ர் is ர shut by a puḷḷi — the soft r, not the hard ற."
+            },
+            {
+              "kind": "speech",
+              "text": "Two words beside it are worth reading. நன்றி is ந + ன் + றி, what you say when the tea arrives. In தயவுசெய்து, செய் is ce plus ய் shut by that same dot before து."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart - the syllable that sailed",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "நீர் is inherited and very old. தே is not Tamil at all: it is the combining form of தேய் (tēy), borrowed from Malay teh, which took it from the Hokkien of the southern Chinese coast, where the leaf is tê."
+            },
+            {
+              "kind": "speech",
+              "text": "The world's words for tea come in two shapes, decided by how the tea reached each language. The southern Chinese coast carried te: Dutch thee, and through Dutch, English tea and French thé — and by the Malay ports, Tamil's தே. The overland routes carried cha: Persian and Hindi chāy, Russian chay. Portuguese says chá despite being a sea power, because its traders worked out of Macau. Where the ship docked decided the word."
+            },
+            {
+              "kind": "speech",
+              "text": "Tamil then did what the European te-languages did not: rather than take the loan whole, it welded it to நீர் — a word that has travelled outward as well, since English mulligatawny is Tamil மிளகுத்தண்ணீர், \"pepper water.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Weigh that against the rice word. அரிசி may stand behind English rice through Greek, and the dictionaries hedge. The tea routes are documented. Different histories, different confidence."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the shared half — \"nīr … taṇṇīr … tēnīr\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the shared half — \"nīr … taṇṇīr … tēnīr\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"tēnīr, tayavuseytu\" — tea, please",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"tēnīr, tayavuseytu\" — tea, please]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two routes — \"te … cha\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two routes — \"te … cha\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the pepper water in an English soup — \"miḷagut taṇṇīr\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the pepper water in an English soup — \"miḷagut taṇṇīr\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Name the second half of tēnīr and the word that shares it, then ask for tea politely. (நீர், inside தண்ணீர்; tēnīr, tayavuseytu.) Why do some languages say te and others cha, and which is better established — the tea split or arisi-to-rice? (The route the tea travelled; and the tea split.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C36-paal",
+      "sequence": 800,
+      "title": "பால் (pāl) — \"milk,\" and a p that becomes an h next door",
+      "headword": "பால்",
+      "romanization": "pāl",
+      "gloss": "milk — one syllable, inherited whole, and the word that shows Kannada turning p into h",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:6a72f2af11ebc2dc",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Tēnīr. Which half is borrowed, and which is the old Tamil word for water? (Tē is the traveller; nīr is Tamil's own.) Here is what goes into it."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: பால்",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "பால் — pāl — milk."
+            },
+            {
+              "kind": "speech",
+              "text": "One syllable, one long ā, a final ல் with no vowel after it. Say it short and closed: pāl, never pāla."
+            },
+            {
+              "kind": "speech",
+              "text": "பால் தேநீர் — pāl tēnīr — milk tea."
+            },
+            {
+              "kind": "speech",
+              "text": "With தண்ணீர் (taṇṇīr, cool water) already in hand, you can now name what a Tamil household is likely to put in front of a guest."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "பா is ப with the long ā sign ா. Then ல்: ல with the puḷḷi, the dot that removes the built-in a and leaves a bare consonant."
+            },
+            {
+              "kind": "speech",
+              "text": "That dot is the whole reason the word ends where it does. Without it, பால would be pāla, two syllables. A single dot carries the difference between a word and a non-word."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart - the p that went soft",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "பால் (pāl) is inherited Dravidian, and its relatives are close:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "the cousin",
+                "language"
+              ],
+              "columns": 2,
+              "rowCount": 3,
+              "utterances": [
+                "the cousin: പാൽ pāl. language: Malayalam.",
+                "the cousin: పాలు pālu. language: Telugu.",
+                "the cousin: ಹಾಲು hālu. language: Kannada, modern."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Kannada has changed the front of the word once more, this time p into h — the textbook example of the best-known sound change in the family. Old Kannada said pālu, exactly as Tamil does; the p- began turning into h- around the tenth century and the change had run through the whole vocabulary by the fourteenth."
+            },
+            {
+              "kind": "speech",
+              "text": "Put it beside the change you met at the house. Tamil v, Kannada b, in vīḍu / bīḍu. Tamil p, Kannada h, in pāl / hālu. Both are regular correspondences at the front of a word, and between them they let you recognise a Kannada word as a relative rather than a stranger. Telugu and Malayalam did neither: they keep the p, as Tamil does."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"pāl\" — stopped by the dot, not pāla",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"pāl\" — stopped by the dot, not *pāla*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"pāl tēnīr\" — milk tea",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"pāl tēnīr\" — milk tea]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two front-swaps together — \"vīḍu, bīḍu … pāl, hālu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two front-swaps together — \"vīḍu, bīḍu … pāl, hālu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what you can be offered — \"taṇṇīr, tēnīr, pāl\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what you can be offered — \"taṇṇīr, tēnīr, pāl\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say \"milk tea,\" then say what the dot on ல் is doing and what the word would be without it. (Pāl tēnīr; it removes the built-in vowel, and without it, pāla.) What does Kannada put at the front instead of p, and is it a one-off? (h — hālu; regular, from the tenth century to the fourteenth.) Name the other Kannada front-swap. (v to b — vīḍu, bīḍu.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C36-unavu",
+      "sequence": 810,
+      "title": "உணவு (uṇavu) — \"food,\" from the verb underneath it",
+      "headword": "உணவு",
+      "romanization": "uṇavu",
+      "gloss": "food — the noun standing on உண், the older eating verb behind சாப்பிடு's everyday one",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:79a09af6b5c1e1fd",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Pāl — milk — and the Kannada shape of it. (Hālu.) Drink is settled. Now the word for everything else on the plate."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: உணவு",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "உணவு — uṇavu — food."
+            },
+            {
+              "kind": "speech",
+              "text": "The general word: food as a category, not a dish. It covers the rice words you have — அரிசி (arisi), the raw grain, and சாதம் (sātam), the cooked meal — and all that is served beside them."
+            },
+            {
+              "kind": "speech",
+              "text": "உணவு, தயவுசெய்து. — uṇavu, tayavuseytu — Food, please."
+            },
+            {
+              "kind": "speech",
+              "text": "Note the register. உணவு (uṇavu) is the careful, written word — a menu, a sign. Around a family table people say சாப்பாடு (sāppāḍu)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "உ is a standing vowel — a full letter, not a sign. Then ண, then வு, which is வ with the u sign underneath. ண is the retroflex n you first wrote alongside ம, and the letter inside தண்ணீர்."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "pronunciation",
+          "title": "Sounds you'll need: the tongue in ண",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Curl the tip of your tongue back to the roof of your mouth and release into the vowel. That is ண, and uṇavu gives it a clean run because the letter sits between two vowels. Contrast the ன of நன்றி and the ந of நீர், both made near the teeth."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "etymology",
+          "title": "The word, taken apart - the verb inside the noun",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "உணவு (uṇavu) is உண் (uṇ), \"to eat,\" with a noun-forming ending. Food is literally the eating. Tamil has two eating verbs, of different ages:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "the verb",
+                "where it lives"
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "the verb: உண் uṇ. where it lives: old, inherited, literary now.",
+                "the verb: சாப்பிடு sāppiḍu. where it lives: the everyday spoken verb."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "உண் is a bare inherited root, and the Dravidian dictionary lists uṇavu inside its entry."
+            },
+            {
+              "kind": "speech",
+              "text": "சாப்பிடு is where the ground softens, so hold this course's earlier account loosely. You were shown sāppu, \"food,\" plus இடு (iḍu), \"to put.\" The இடு is visible in the spelling; the first half is the problem. The great Tamil lexicon records no plain word sāppu meaning \"food,\" and the Dravidian etymological dictionary has no entry for this verb at all. It is not Sanskrit — Telugu and Malayalam have their own forms — but its origin is open. The word you would use at a table has the weaker paperwork."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the root and the noun — \"uṇ … uṇavu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the root and the noun — \"uṇ … uṇavu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the retroflex, tongue curled back — \"uṇavu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the retroflex, tongue curled back — \"uṇavu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the documented one, then the everyday one — \"uṇ … sāppiḍu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the documented one, then the everyday one — \"uṇ … sāppiḍu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "raw grain, then cooked meal — \"arisi … sātam\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: raw grain, then cooked meal — \"arisi … sātam\"]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What verb is uṇavu built on, and where does your tongue go for ண? (உண்; curled back.) Which eating verb would you use at a table, and how sure is anyone where it came from? (சாப்பிடு — not at all: the Dravidian dictionary has no entry.) Give the raw grain and the cooked meal. (Arisi; sātam.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C36-tavaru",
+      "sequence": 820,
+      "title": "தவறு (tavaṟu) — \"a mistake,\" and the rest of the apology",
+      "headword": "தவறு",
+      "romanization": "tavaṟu",
+      "gloss": "a mistake — the noun that lets you finish an apology, and the same word as the verb \"to slip\"",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:46edc651e85b20f4",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The chapter back: tēnīr, pāl, uṇavu. Suppose one arrives and it is not what you asked for. You have \"sorry,\" but not the word for what went wrong."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: தவறு",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "தவறு — tavaṟu — a mistake, an error, a fault."
+            },
+            {
+              "kind": "speech",
+              "text": "With என் (eṉ), \"my,\" and no verb — Tamil needs none:"
+            },
+            {
+              "kind": "speech",
+              "text": "மன்னிக்கவும், என் தவறு. பால் இல்லை, தேநீர். maṉṉikkavum, eṉ tavaṟu. pāl illai, tēnīr. Sorry, my mistake. Not milk — tea."
+            },
+            {
+              "kind": "speech",
+              "text": "மன்னிக்கவும் is the careful, written-leaning apology; in speech many Tamil speakers simply say sorry, in English. என் தவறு (tavaṟu) suits either."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "த + வ + று. The last piece is ற, the hard r of aṟai, with the u sign — made at the ridge behind the teeth, tongue flat, not curled."
+            },
+            {
+              "kind": "speech",
+              "text": "The apology in front of it does something this word does not. மன்னிக்கவும் has ன்னி: the alveolar ன switched off by a dot, then written a second time with the i sign. Tamil doubles a consonant by repeating the letter with a dot on the first, never by inventing a joined shape — the க்க of வணக்கம் over."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart - the slip and the noun are one word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "தவறு (tavaṟu) is inherited Dravidian, a verb and a noun in one shape: \"to slip, to fail,\" and \"a slip, a mistake.\" The dictionary files it beside தப்பு (tappu); its cousins are everywhere."
+            },
+            {
+              "kind": "speech",
+              "text": "Now the chapter in a line. மன்னிக்கவும் was the showpiece: Tamil kept its own மன்னி where Kannada, Telugu and Malayalam reached for Sanskrit kṣamā. தவறு (tavaṟu) is inherited too, and so is உண் inside uṇavu, and பால் (pāl). But தேநீர் (tēnīr) is half a loan from a Malay port, and சாதம் was flagged as Sanskrit-influenced when you met it."
+            },
+            {
+              "kind": "speech",
+              "text": "So the honest statement is not \"Tamil does not borrow.\" It is that Tamil borrows without evicting: the inherited word stays, and the loan takes a different job or register."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"eṉ tavaṟu\" — my mistake, with no verb in it",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"eṉ tavaṟu\" — my mistake, with no verb in it]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the whole repair — \"maṉṉikkavum, eṉ tavaṟu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the whole repair — \"maṉṉikkavum, eṉ tavaṟu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two words for a mistake — \"tavaṟu … tappu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two words for a mistake — \"tavaṟu … tappu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the borrowed one among this chapter's words — \"tēnīr\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the borrowed one among this chapter's words — \"tēnīr\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Apologise, name the fault, and say why there is no word for \"is\" in it. (Maṉṉikkavum, eṉ tavaṟu; Tamil needs none.) How does Tamil write a doubled consonant, as in ன்னி and க்க? (The letter a second time, dot on the first.) Which apology verb is native where the neighbours took Sanskrit, and does that make Tamil a language that never borrows? (மன்னி, against kṣamā; no — it borrows without evicting.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/tamil/narration/ch36.json
+++ b/code/learning/human-languages/tamil/narration/ch36.json
@@ -4,7 +4,7 @@
   "chapter": 36,
   "title": "What You Are Offered",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:670535ac9b63a59a",
+  "sourceHash": "fnv1a64:f2d3d5c13c0737fe",
   "lessons": [
     {
       "id": "TA-C36-teneer",
@@ -371,7 +371,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:79a09af6b5c1e1fd",
+      "sourceHash": "fnv1a64:044f1ad4f016e2c5",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -473,7 +473,7 @@
             },
             {
               "kind": "speech",
-              "text": "சாப்பிடு is where the ground softens, so hold this course's earlier account loosely. You were shown sāppu, \"food,\" plus இடு (iḍu), \"to put.\" The இடு is visible in the spelling; the first half is the problem. The great Tamil lexicon records no plain word sāppu meaning \"food,\" and the Dravidian etymological dictionary has no entry for this verb at all. It is not Sanskrit — Telugu and Malayalam have their own forms — but its origin is open. The word you would use at a table has the weaker paperwork."
+              "text": "சாப்பிடு is where the ground softens, so hold Chapter 32's earlier account loosely. You were shown sāppu, \"food,\" plus இடு (iḍu), \"to put.\" The இடு is visible in the spelling; the first half is the problem. The great Tamil lexicon records no plain word sāppu meaning \"food,\" and the Dravidian etymological dictionary has no entry for this verb at all. It is not Sanskrit — Telugu and Malayalam have their own forms — but its origin is open. The word you would use at a table has the weaker paperwork."
             }
           ]
         },

--- a/code/learning/human-languages/tamil/narration/ch36.txt
+++ b/code/learning/human-languages/tamil/narration/ch36.txt
@@ -1,0 +1,172 @@
+Tamil, chapter 36: What You Are Offered.
+4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+
+
+Lesson 1 of 4.
+தேநீர் (tēnīr) — "tea," half of it already yours.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Nāṟkāli, and what its halves mean. (Four, and leg.) You are in the aṟai with the chair, and the next thing in a Tamil house is this.
+
+You'll want to know: தேநீர்.
+தேநீர் — tēnīr — tea.
+The second half is yours from the water lesson: நீர் (nīr), "water," the plain older word inside தண்ணீர் (taṇṇīr) — taṇ, "cool," plus nīr. So தேநீர் (tēnīr) is, literally, tea water.
+தேநீர், தயவுசெய்து. — tēnīr, tayavuseytu — Tea, please.
+In speech you will also hear plain டீ (ṭī), straight from English tea. தேநீர் (tēnīr) is the fuller word — a sign, a menu, a formal host.
+
+The letters in this word.
+தே is த with the ē sign ே, which stands in front of its consonant. நீ is ந with the long ī sign; ர் is ர shut by a puḷḷi — the soft r, not the hard ற.
+Two words beside it are worth reading. நன்றி is ந + ன் + றி, what you say when the tea arrives. In தயவுசெய்து, செய் is ce plus ய் shut by that same dot before து.
+
+The word, taken apart - the syllable that sailed.
+நீர் is inherited and very old. தே is not Tamil at all: it is the combining form of தேய் (tēy), borrowed from Malay teh, which took it from the Hokkien of the southern Chinese coast, where the leaf is tê.
+The world's words for tea come in two shapes, decided by how the tea reached each language. The southern Chinese coast carried te: Dutch thee, and through Dutch, English tea and French thé — and by the Malay ports, Tamil's தே. The overland routes carried cha: Persian and Hindi chāy, Russian chay. Portuguese says chá despite being a sea power, because its traders worked out of Macau. Where the ship docked decided the word.
+Tamil then did what the European te-languages did not: rather than take the loan whole, it welded it to நீர் — a word that has travelled outward as well, since English mulligatawny is Tamil மிளகுத்தண்ணீர், "pepper water."
+Weigh that against the rice word. அரிசி may stand behind English rice through Greek, and the dictionaries hedge. The tea routes are documented. Different histories, different confidence.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the shared half — "nīr … taṇṇīr … tēnīr"]
+[pause 8 seconds for the answer]
+[your turn — say: "tēnīr, tayavuseytu" — tea, please]
+[pause 8 seconds for the answer]
+[your turn — say: the two routes — "te … cha"]
+[pause 8 seconds for the answer]
+[your turn — say: the pepper water in an English soup — "miḷagut taṇṇīr"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Name the second half of tēnīr and the word that shares it, then ask for tea politely. (நீர், inside தண்ணீர்; tēnīr, tayavuseytu.) Why do some languages say te and others cha, and which is better established — the tea split or arisi-to-rice? (The route the tea travelled; and the tea split.)
+
+
+Lesson 2 of 4.
+பால் (pāl) — "milk," and a p that becomes an h next door.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Tēnīr. Which half is borrowed, and which is the old Tamil word for water? (Tē is the traveller; nīr is Tamil's own.) Here is what goes into it.
+
+You'll want to know: பால்.
+பால் — pāl — milk.
+One syllable, one long ā, a final ல் with no vowel after it. Say it short and closed: pāl, never pāla.
+பால் தேநீர் — pāl tēnīr — milk tea.
+With தண்ணீர் (taṇṇīr, cool water) already in hand, you can now name what a Tamil household is likely to put in front of a guest.
+
+The letters in this word.
+பா is ப with the long ā sign ா. Then ல்: ல with the puḷḷi, the dot that removes the built-in a and leaves a bare consonant.
+That dot is the whole reason the word ends where it does. Without it, பால would be pāla, two syllables. A single dot carries the difference between a word and a non-word.
+
+The word, taken apart - the p that went soft.
+பால் (pāl) is inherited Dravidian, and its relatives are close:
+[a table of 3 rows, read aloud]
+the cousin: പാൽ pāl. language: Malayalam.
+the cousin: పాలు pālu. language: Telugu.
+the cousin: ಹಾಲು hālu. language: Kannada, modern.
+Kannada has changed the front of the word once more, this time p into h — the textbook example of the best-known sound change in the family. Old Kannada said pālu, exactly as Tamil does; the p- began turning into h- around the tenth century and the change had run through the whole vocabulary by the fourteenth.
+Put it beside the change you met at the house. Tamil v, Kannada b, in vīḍu / bīḍu. Tamil p, Kannada h, in pāl / hālu. Both are regular correspondences at the front of a word, and between them they let you recognise a Kannada word as a relative rather than a stranger. Telugu and Malayalam did neither: they keep the p, as Tamil does.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "pāl" — stopped by the dot, not pāla]
+[pause 8 seconds for the answer]
+[your turn — say: "pāl tēnīr" — milk tea]
+[pause 8 seconds for the answer]
+[your turn — say: the two front-swaps together — "vīḍu, bīḍu … pāl, hālu"]
+[pause 8 seconds for the answer]
+[your turn — say: what you can be offered — "taṇṇīr, tēnīr, pāl"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say "milk tea," then say what the dot on ல் is doing and what the word would be without it. (Pāl tēnīr; it removes the built-in vowel, and without it, pāla.) What does Kannada put at the front instead of p, and is it a one-off? (h — hālu; regular, from the tenth century to the fourteenth.) Name the other Kannada front-swap. (v to b — vīḍu, bīḍu.)
+
+
+Lesson 3 of 4.
+உணவு (uṇavu) — "food," from the verb underneath it.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Pāl — milk — and the Kannada shape of it. (Hālu.) Drink is settled. Now the word for everything else on the plate.
+
+You'll want to know: உணவு.
+உணவு — uṇavu — food.
+The general word: food as a category, not a dish. It covers the rice words you have — அரிசி (arisi), the raw grain, and சாதம் (sātam), the cooked meal — and all that is served beside them.
+உணவு, தயவுசெய்து. — uṇavu, tayavuseytu — Food, please.
+Note the register. உணவு (uṇavu) is the careful, written word — a menu, a sign. Around a family table people say சாப்பாடு (sāppāḍu).
+
+The letters in this word.
+உ is a standing vowel — a full letter, not a sign. Then ண, then வு, which is வ with the u sign underneath. ண is the retroflex n you first wrote alongside ம, and the letter inside தண்ணீர்.
+
+Sounds you'll need: the tongue in ண.
+Curl the tip of your tongue back to the roof of your mouth and release into the vowel. That is ண, and uṇavu gives it a clean run because the letter sits between two vowels. Contrast the ன of நன்றி and the ந of நீர், both made near the teeth.
+
+The word, taken apart - the verb inside the noun.
+உணவு (uṇavu) is உண் (uṇ), "to eat," with a noun-forming ending. Food is literally the eating. Tamil has two eating verbs, of different ages:
+[a table of 2 rows, read aloud]
+the verb: உண் uṇ. where it lives: old, inherited, literary now.
+the verb: சாப்பிடு sāppiḍu. where it lives: the everyday spoken verb.
+உண் is a bare inherited root, and the Dravidian dictionary lists uṇavu inside its entry.
+சாப்பிடு is where the ground softens, so hold this course's earlier account loosely. You were shown sāppu, "food," plus இடு (iḍu), "to put." The இடு is visible in the spelling; the first half is the problem. The great Tamil lexicon records no plain word sāppu meaning "food," and the Dravidian etymological dictionary has no entry for this verb at all. It is not Sanskrit — Telugu and Malayalam have their own forms — but its origin is open. The word you would use at a table has the weaker paperwork.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the root and the noun — "uṇ … uṇavu"]
+[pause 8 seconds for the answer]
+[your turn — say: the retroflex, tongue curled back — "uṇavu"]
+[pause 8 seconds for the answer]
+[your turn — say: the documented one, then the everyday one — "uṇ … sāppiḍu"]
+[pause 8 seconds for the answer]
+[your turn — say: raw grain, then cooked meal — "arisi … sātam"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What verb is uṇavu built on, and where does your tongue go for ண? (உண்; curled back.) Which eating verb would you use at a table, and how sure is anyone where it came from? (சாப்பிடு — not at all: the Dravidian dictionary has no entry.) Give the raw grain and the cooked meal. (Arisi; sātam.)
+
+
+Lesson 4 of 4.
+தவறு (tavaṟu) — "a mistake," and the rest of the apology.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The chapter back: tēnīr, pāl, uṇavu. Suppose one arrives and it is not what you asked for. You have "sorry," but not the word for what went wrong.
+
+You'll want to know: தவறு.
+தவறு — tavaṟu — a mistake, an error, a fault.
+With என் (eṉ), "my," and no verb — Tamil needs none:
+மன்னிக்கவும், என் தவறு. பால் இல்லை, தேநீர். maṉṉikkavum, eṉ tavaṟu. pāl illai, tēnīr. Sorry, my mistake. Not milk — tea.
+மன்னிக்கவும் is the careful, written-leaning apology; in speech many Tamil speakers simply say sorry, in English. என் தவறு (tavaṟu) suits either.
+
+The letters in this word.
+த + வ + று. The last piece is ற, the hard r of aṟai, with the u sign — made at the ridge behind the teeth, tongue flat, not curled.
+The apology in front of it does something this word does not. மன்னிக்கவும் has ன்னி: the alveolar ன switched off by a dot, then written a second time with the i sign. Tamil doubles a consonant by repeating the letter with a dot on the first, never by inventing a joined shape — the க்க of வணக்கம் over.
+
+The word, taken apart - the slip and the noun are one word.
+தவறு (tavaṟu) is inherited Dravidian, a verb and a noun in one shape: "to slip, to fail," and "a slip, a mistake." The dictionary files it beside தப்பு (tappu); its cousins are everywhere.
+Now the chapter in a line. மன்னிக்கவும் was the showpiece: Tamil kept its own மன்னி where Kannada, Telugu and Malayalam reached for Sanskrit kṣamā. தவறு (tavaṟu) is inherited too, and so is உண் inside uṇavu, and பால் (pāl). But தேநீர் (tēnīr) is half a loan from a Malay port, and சாதம் was flagged as Sanskrit-influenced when you met it.
+So the honest statement is not "Tamil does not borrow." It is that Tamil borrows without evicting: the inherited word stays, and the loan takes a different job or register.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "eṉ tavaṟu" — my mistake, with no verb in it]
+[pause 8 seconds for the answer]
+[your turn — say: the whole repair — "maṉṉikkavum, eṉ tavaṟu"]
+[pause 8 seconds for the answer]
+[your turn — say: the two words for a mistake — "tavaṟu … tappu"]
+[pause 8 seconds for the answer]
+[your turn — say: the borrowed one among this chapter's words — "tēnīr"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Apologise, name the fault, and say why there is no word for "is" in it. (Maṉṉikkavum, eṉ tavaṟu; Tamil needs none.) How does Tamil write a doubled consonant, as in ன்னி and க்க? (The letter a second time, dot on the first.) Which apology verb is native where the neighbours took Sanskrit, and does that make Tamil a language that never borrows? (மன்னி, against kṣamā; no — it borrows without evicting.)

--- a/code/learning/human-languages/tamil/narration/ch36.txt
+++ b/code/learning/human-languages/tamil/narration/ch36.txt
@@ -114,7 +114,7 @@ The word, taken apart - the verb inside the noun.
 the verb: உண் uṇ. where it lives: old, inherited, literary now.
 the verb: சாப்பிடு sāppiḍu. where it lives: the everyday spoken verb.
 உண் is a bare inherited root, and the Dravidian dictionary lists uṇavu inside its entry.
-சாப்பிடு is where the ground softens, so hold this course's earlier account loosely. You were shown sāppu, "food," plus இடு (iḍu), "to put." The இடு is visible in the spelling; the first half is the problem. The great Tamil lexicon records no plain word sāppu meaning "food," and the Dravidian etymological dictionary has no entry for this verb at all. It is not Sanskrit — Telugu and Malayalam have their own forms — but its origin is open. The word you would use at a table has the weaker paperwork.
+சாப்பிடு is where the ground softens, so hold Chapter 32's earlier account loosely. You were shown sāppu, "food," plus இடு (iḍu), "to put." The இடு is visible in the spelling; the first half is the problem. The great Tamil lexicon records no plain word sāppu meaning "food," and the Dravidian etymological dictionary has no entry for this verb at all. It is not Sanskrit — Telugu and Malayalam have their own forms — but its origin is open. The word you would use at a table has the weaker paperwork.
 
 Guided Practice.
 [pause 1 second]

--- a/code/learning/human-languages/tamil/narration/ch37.json
+++ b/code/learning/human-languages/tamil/narration/ch37.json
@@ -1,0 +1,768 @@
+{
+  "version": 1,
+  "language": "tamil",
+  "chapter": 37,
+  "title": "Your Town, Your Friend",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:7d37f287632fb94f",
+  "lessons": [
+    {
+      "id": "TA-C37-uur",
+      "sequence": 830,
+      "title": "ஊர் (ūr) — \"town,\" and the question Tamil asks early",
+      "headword": "ஊர்",
+      "romanization": "ūr",
+      "gloss": "town, village — where you are from, which a Tamil introduction asks for, and the -ore in Bangalore",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:3393a38bd4aca7f7",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Eṉ tavaṟu — my mistake, a word that is a verb and a noun at once. Then the general word for food. (Uṇavu.) Now back to meeting somebody."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: ஊர்",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ஊர் — ūr — town, village; the place you are from."
+            },
+            {
+              "kind": "speech",
+              "text": "That last sense matters most. உங்கள் ஊர் (ūr) is your native place, where your family is from, which may be somewhere you have never lived."
+            },
+            {
+              "kind": "speech",
+              "text": "உங்கள் ஊர் என்ன — uṅgaḷ ūr eṉṉa — What is your town."
+            },
+            {
+              "kind": "speech",
+              "text": "It lands early in a Tamil conversation and is not nosiness — the slot English fills with \"what do you do."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ஊ is a standing vowel — long ū, partner of the உ that opens uṇavu. ர் is ர, the soft r, shut by a puḷḷi. Hold the vowel: ūr, not ur. Vowel length is part of a word's identity here."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: the two registers, side by side",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "You met this choice on the age question:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "the question",
+                "who you say it to"
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "the question: உன் ஊர் என்ன uṉ ūr eṉṉa. who you say it to: a friend, a child, a peer.",
+                "the question: உங்கள் ஊர் என்ன uṅgaḷ ūr eṉṉa. who you say it to: a stranger, an elder, anyone senior."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Both are possessive plus noun plus question word, with no verb — the shape you learned for உன் வயசு என்ன. Only the possessive changes, and with it the social temperature. When unsure, use உங்கள்."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "etymology",
+          "title": "The word, taken apart - the syllable inside the map",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ஊர் (ūr) is inherited Dravidian, and welded into city names you know in English:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "the English name",
+                "what it is"
+              ],
+              "columns": 2,
+              "rowCount": 3,
+              "utterances": [
+                "the English name: Tanjore. what it is: Tamil தஞ்சாவூர் Tañjāvūr.",
+                "the English name: Vellore. what it is: Tamil வேலூர் Vēlūr.",
+                "the English name: Bangalore. what it is: Kannada ಬೆಂಗಳೂರು Bengaḷūru."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Every one of those -ore endings is this word: the British ear turned -ūr into -ore, and the cities have taken their own names back."
+            },
+            {
+              "kind": "speech",
+              "text": "Two exactnesses. Bangalore is a Kannada town, so its -ūru is Kannada's form of the inherited word — the family's, not Tamil's alone. And the first halves are not all settled; Vēl- in Vellore is argued over. The ending is the certain part."
+            },
+            {
+              "kind": "speech",
+              "text": "Weigh that against the rice word. அரிசி may stand behind English rice through Greek, and the dictionaries hedge. Nobody hedges about -ūr."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the long vowel — \"ūr,\" not \"ur\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the long vowel — \"ūr,\" not \"ur\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "to a stranger — \"uṅgaḷ ūr eṉṉa\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: to a stranger — \"uṅgaḷ ūr eṉṉa\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "to a friend — \"uṉ ūr eṉṉa\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: to a friend — \"uṉ ūr eṉṉa\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the ending inside the map — \"Tañjāvūr … Vēlūr … Bengaḷūru\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the ending inside the map — \"Tañjāvūr … Vēlūr … Bengaḷūru\"]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Ask a stranger where they are from, then a friend, and say what ஊர் means beyond \"town.\" (Uṅgaḷ ūr eṉṉa; uṉ ūr eṉṉa; your native place.) Which earlier question has this shape, and is -ore in Tanjore really this word? (உன் வயசு என்ன; yes.) How sure are we there, next to arisi and rice? (Much surer.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C37-nanban",
+      "sequence": 840,
+      "title": "நண்பன் (naṇbaṉ) — \"friend,\" with the ending doing the work",
+      "headword": "நண்பன்",
+      "romanization": "naṇbaṉ",
+      "gloss": "friend — one word with three endings for man, woman and respect, and a root meaning \"close\"",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:5b1b5f724e390f6b",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A stranger's native place, then the ending inside Tanjore. (Uṅgaḷ ūr eṉṉa; -ūr.) Now the person you would introduce."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: நண்பன்",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "நண்பன் — naṇbaṉ — friend (a man)."
+            },
+            {
+              "kind": "speech",
+              "text": "Tamil will not let you say a bare \"friend\" any more than a bare \"brother.\" The stem is நண்ப-; the ending decides."
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "the form",
+                "who it is"
+              ],
+              "columns": 2,
+              "rowCount": 3,
+              "utterances": [
+                "the form: நண்பன் naṇbaṉ. who it is: a male friend.",
+                "the form: நண்பி naṇbi. who it is: a female friend.",
+                "the form: நண்பர் naṇbar. who it is: a friend spoken of with respect."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "The -அர் is the respectful plural that turns நீ into நீங்கள், applied to a person."
+            },
+            {
+              "kind": "speech",
+              "text": "This is a different axis from the family words. அண்ணன் and தம்பி split brothers by age; the friend words split by sex, நண்பர் by respect."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ந + ண் + ப + ன் — every one of Tamil's n-letters inside one word. ந opens it, dental, at the teeth. ண் is retroflex, tongue curled back, closed by a puḷḷi. ன் ends it, the alveolar n from நன்றி. The writing lesson gave them to you one at a time; here they arrive together."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "pronunciation",
+          "title": "Sounds you'll need: why it is heard as naṇbaṉ",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The letter after ண் is ப, named pa. The course writes naṇbaṉ because of the நன்றி rule: a nasal in front of a stop voices it. A Tamil reader supplies the voicing, as an English reader supplies the sh in sugar."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "etymology",
+          "title": "The word, taken apart - a friend is someone who came close",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Behind நண்பன் (naṇbaṉ) is நண்பு (naṇbu), \"friendship, closeness,\" which belongs to the root family of நண்ணு (naṇṇu), \"to draw near.\" A friend, in Tamil's own accounting, is someone who came close."
+            },
+            {
+              "kind": "speech",
+              "text": "Be precise. The Dravidian dictionary files naṇbu and naṇbaṉ in the same entry as naṇṇu; the Tamil lexicon prefers நள்-, making them siblings rather than parent and child. They differ on the line of descent, not on the household."
+            },
+            {
+              "kind": "speech",
+              "text": "Set it beside அப்பா and அம்மா, not built out of anything — the repeated-syllable shape children produce for parents worldwide. நண்பன் (naṇbaṉ) is assembled, from a root you can point at."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three endings — \"naṇbaṉ, naṇbi, naṇbar\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three endings — \"naṇbaṉ, naṇbi, naṇbar\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the voicing after the nasal — \"naṉṟi … naṇbaṉ\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the voicing after the nasal — \"naṉṟi … naṇbaṉ\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the root it came from — \"naṇṇu, to draw near\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the root it came from — \"naṇṇu, to draw near\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the family words that split on age instead — \"aṇṇaṉ, tambi\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the family words that split on age instead — \"aṇṇaṉ, tambi\"]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give the friend-word for a woman, a man, and someone you respect. (Naṇbi; naṇbaṉ; naṇbar.) Which axis do the friend words split on, and which do the brother words? (Sex and respect; age.) Why is ப heard as b, and are அப்பா and அம்மா built from a root the way naṇbaṉ is? (A nasal voices the stop after it; no.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C37-ivar",
+      "sequence": 850,
+      "title": "இவர் (ivar) — \"this person,\" and Tamil's pointing system",
+      "headword": "இவர்",
+      "romanization": "ivar",
+      "gloss": "this person, spoken of with respect — the near end of Tamil's இ / அ / எ pointing system",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:9ca3f8708b12b192",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Naṇbaṉ, naṇbi, naṇbar — and the root behind them. (Naṇṇu, to draw near.) You have the word for a friend, but cannot point at one."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: இவர்",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "இவர் — ivar — this person (near me, spoken of respectfully)."
+            },
+            {
+              "kind": "speech",
+              "text": "Not \"he\" and not \"she\": இவர் (ivar) is what you say about a person standing here whom you are treating with respect, and it does not commit you to their sex. It is built on இவன் (ivaṉ) and இவள் (ivaḷ), with the same -அர் that gave you நண்பர்."
+            },
+            {
+              "kind": "speech",
+              "text": "One caution about speech: இவர் (ivar) is heard mostly of men, and இவங்க (ivaṅga) does the same respectful job for a woman."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "இ + வ + ர். இ is the standing vowel i — the letter, not the ி sign that hangs on a consonant. வ is the va opening வணக்கம் and வீடு. ர் is the soft r with a puḷḷi."
+            },
+            {
+              "kind": "speech",
+              "text": "A word this short is almost all arc, which is the moment to recall the usual explanation for that roundness: Tamil was scratched into palm leaf, and a straight stroke along the grain can split the leaf. Hold it as the writing lesson asked — the standard account, not a settled fact, since the earliest Tamil writing was cut into stone and is angular. What survives is the useful part: the tool leaves fingerprints on the letters."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: near, far, and which",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "இவர் (ivar) is one cell of a system, and the system is a single letter at the front:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "the front letter",
+                "what it does"
+              ],
+              "columns": 2,
+              "rowCount": 3,
+              "utterances": [
+                "the front letter: இ-. what it does: points near — this one, here.",
+                "the front letter: அ-. what it does: points away — that one, there.",
+                "the front letter: எ-. what it does: asks — which one."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "So இவர் (ivar) is \"this person,\" அவர் (avar) \"that person,\" எவர் (evar) \"which person.\" You have been using one front already: என்ன (eṉṉa), \"what,\" is the எ- of asking."
+            },
+            {
+              "kind": "speech",
+              "text": "Two honest notes. எ- is the question, not a third distance. And Old Tamil had a genuine third distance, உ-, for something visible but far off; modern Tamil has retired it."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the three fronts — \"i- … a- … e-\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the three fronts — \"i- … a- … e-\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the row they build — \"ivar, avar, evar\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the row they build — \"ivar, avar, evar\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the question word you already had — \"eṉṉa\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the question word you already had — \"eṉṉa\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the respectful ending on both — \"naṇbar … ivar\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the respectful ending on both — \"naṇbar … ivar\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What do இ-, அ- and எ- do at the front of a word, and which question word you already knew is built on எ-? (Near; away; asks — and என்ன.) Does இவர் (ivar) tell you whether the person is a man or a woman? (No — it marks respect; spoken Tamil leans இவங்க for a woman.) How firmly should you hold the palm-leaf explanation for the curves? (As the standard account, not a settled fact.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C37-ivar-en-nanbar",
+      "sequence": 860,
+      "title": "இவர் என் நண்பர் (ivar eṉ naṇbar) — \"this is my friend\"",
+      "headword": "இவர் என் நண்பர்",
+      "romanization": "ivar eṉ naṇbar",
+      "gloss": "\"this is my friend\" — three words, no verb, and a choice of ending that says how you regard them",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:a2e2284ae61b8a8e",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Ivar, avar, evar — near, away, the question. Then naṇbaṉ, naṇbi, naṇbar. Everything this lesson needs is in your mouth; what is left is the order."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: the introduction",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "இவர் என் நண்பர். — ivar eṉ naṇbar — This is my friend."
+            },
+            {
+              "kind": "speech",
+              "text": "Three words, and not one of them is a verb. Tamil links two nouns by setting them beside each other, as in என் பெயர் … and என் தவறு."
+            },
+            {
+              "kind": "speech",
+              "text": "The pieces in order: இவர் (ivar), the person here; என், my; நண்பர், friend-with-respect. Then stop."
+            },
+            {
+              "kind": "speech",
+              "text": "The whole meeting:"
+            },
+            {
+              "kind": "speech",
+              "text": "— வணக்கம். இவர் என் நண்பர் (ivar eṉ naṇbar). — வணக்கம். உங்கள் ஊர் (ūr) என்ன."
+            },
+            {
+              "kind": "speech",
+              "text": "Every word in it is yours."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "என் is எ with ன், the alveolar n dotted shut. நண்பர் opens on dental ந, turns on retroflex ண், closes on ர். So one line makes you produce ன் and ண் within a breath of each other — one at the ridge, the other with the tongue curled back. Hear that difference and the three-way n is no longer theory."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "culture-pragmatics",
+          "title": "Why it's said this way: which ending you choose",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "நண்பர் rather than நண்பன் (naṇbaṉ) is a decision, not a default."
+            },
+            {
+              "kind": "speech",
+              "text": "இவர் (ivar) என் நண்பன் (naṇbaṉ). — a male friend, plainly stated; warm among peers."
+            },
+            {
+              "kind": "speech",
+              "text": "இவர் (ivar) என் நண்பி. — a female friend, the matching plain form."
+            },
+            {
+              "kind": "speech",
+              "text": "இவர் என் நண்பர் (ivar eṉ naṇbar). — the respectful ending; safe with anyone, and right when either party is older or senior."
+            },
+            {
+              "kind": "speech",
+              "text": "If unsure, take நண்பர். Over-respect is invisible; under-respect is not."
+            },
+            {
+              "kind": "speech",
+              "text": "Notice how differently Tamil makes you think from one word to the next. For a sibling it forces age: there is no bare \"brother\" — you must choose அண்ணன் or தம்பி, அக்கா or தங்கை, and say whether they are older or younger than you before you can say anything at all. For a friend it forces sex or respect. For parents, nothing: அப்பா and அம்மா came into the language whole. Tamil rarely lets you be vague about a relationship."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the introduction — \"ivar eṉ naṇbar\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the introduction — \"ivar eṉ naṇbar\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the same line to a peer about a male friend — \"ivar eṉ naṇbaṉ\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the same line to a peer about a male friend — \"ivar eṉ naṇbaṉ\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the greeting and the question around it — \"vaṇakkam … uṅgaḷ ūr eṉṉa\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the greeting and the question around it — \"vaṇakkam … uṅgaḷ ūr eṉṉa\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "what a sibling word forces you to decide — \"aṇṇaṉ, older; tambi, younger\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: what a sibling word forces you to decide — \"aṇṇaṉ, older; tambi, younger\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Introduce a friend respectfully, and say how many verbs the sentence has. (Ivar eṉ naṇbar; none.) What does a sibling word force you to decide that a friend word does not? (Whether they are older or younger — aṇṇaṉ against tambi.) Which friend ending is safe when unsure, and what does இ- tell your listener? (நண்பர்; that the person is near.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/tamil/narration/ch37.json
+++ b/code/learning/human-languages/tamil/narration/ch37.json
@@ -4,7 +4,7 @@
   "chapter": 37,
   "title": "Your Town, Your Friend",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:7d37f287632fb94f",
+  "sourceHash": "fnv1a64:956feb3bb64ab0cb",
   "lessons": [
     {
       "id": "TA-C37-uur",
@@ -228,7 +228,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5b1b5f724e390f6b",
+      "sourceHash": "fnv1a64:e3f3e23276e44561",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -312,7 +312,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "The letter after ண் is ப, named pa. The course writes naṇbaṉ because of the நன்றி rule: a nasal in front of a stop voices it. A Tamil reader supplies the voicing, as an English reader supplies the sh in sugar."
+              "text": "The letter after ண் is ப, named pa. This book writes naṇbaṉ because of the நன்றி rule: a nasal in front of a stop voices it. A Tamil reader supplies the voicing, as an English reader supplies the sh in sugar."
             }
           ]
         },

--- a/code/learning/human-languages/tamil/narration/ch37.txt
+++ b/code/learning/human-languages/tamil/narration/ch37.txt
@@ -1,0 +1,186 @@
+Tamil, chapter 37: Your Town, Your Friend.
+4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+
+
+Lesson 1 of 4.
+ஊர் (ūr) — "town," and the question Tamil asks early.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Eṉ tavaṟu — my mistake, a word that is a verb and a noun at once. Then the general word for food. (Uṇavu.) Now back to meeting somebody.
+
+You'll want to know: ஊர்.
+ஊர் — ūr — town, village; the place you are from.
+That last sense matters most. உங்கள் ஊர் (ūr) is your native place, where your family is from, which may be somewhere you have never lived.
+உங்கள் ஊர் என்ன — uṅgaḷ ūr eṉṉa — What is your town.
+It lands early in a Tamil conversation and is not nosiness — the slot English fills with "what do you do.
+
+The letters in this word.
+ஊ is a standing vowel — long ū, partner of the உ that opens uṇavu. ர் is ர, the soft r, shut by a puḷḷi. Hold the vowel: ūr, not ur. Vowel length is part of a word's identity here.
+
+Grammar Lens: the two registers, side by side.
+You met this choice on the age question:
+[a table of 2 rows, read aloud]
+the question: உன் ஊர் என்ன uṉ ūr eṉṉa. who you say it to: a friend, a child, a peer.
+the question: உங்கள் ஊர் என்ன uṅgaḷ ūr eṉṉa. who you say it to: a stranger, an elder, anyone senior.
+Both are possessive plus noun plus question word, with no verb — the shape you learned for உன் வயசு என்ன. Only the possessive changes, and with it the social temperature. When unsure, use உங்கள்.
+
+The word, taken apart - the syllable inside the map.
+ஊர் (ūr) is inherited Dravidian, and welded into city names you know in English:
+[a table of 3 rows, read aloud]
+the English name: Tanjore. what it is: Tamil தஞ்சாவூர் Tañjāvūr.
+the English name: Vellore. what it is: Tamil வேலூர் Vēlūr.
+the English name: Bangalore. what it is: Kannada ಬೆಂಗಳೂರು Bengaḷūru.
+Every one of those -ore endings is this word: the British ear turned -ūr into -ore, and the cities have taken their own names back.
+Two exactnesses. Bangalore is a Kannada town, so its -ūru is Kannada's form of the inherited word — the family's, not Tamil's alone. And the first halves are not all settled; Vēl- in Vellore is argued over. The ending is the certain part.
+Weigh that against the rice word. அரிசி may stand behind English rice through Greek, and the dictionaries hedge. Nobody hedges about -ūr.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the long vowel — "ūr," not "ur"]
+[pause 8 seconds for the answer]
+[your turn — say: to a stranger — "uṅgaḷ ūr eṉṉa"]
+[pause 8 seconds for the answer]
+[your turn — say: to a friend — "uṉ ūr eṉṉa"]
+[pause 8 seconds for the answer]
+[your turn — say: the ending inside the map — "Tañjāvūr … Vēlūr … Bengaḷūru"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Ask a stranger where they are from, then a friend, and say what ஊர் means beyond "town." (Uṅgaḷ ūr eṉṉa; uṉ ūr eṉṉa; your native place.) Which earlier question has this shape, and is -ore in Tanjore really this word? (உன் வயசு என்ன; yes.) How sure are we there, next to arisi and rice? (Much surer.)
+
+
+Lesson 2 of 4.
+நண்பன் (naṇbaṉ) — "friend," with the ending doing the work.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+A stranger's native place, then the ending inside Tanjore. (Uṅgaḷ ūr eṉṉa; -ūr.) Now the person you would introduce.
+
+You'll want to know: நண்பன்.
+நண்பன் — naṇbaṉ — friend (a man).
+Tamil will not let you say a bare "friend" any more than a bare "brother." The stem is நண்ப-; the ending decides.
+[a table of 3 rows, read aloud]
+the form: நண்பன் naṇbaṉ. who it is: a male friend.
+the form: நண்பி naṇbi. who it is: a female friend.
+the form: நண்பர் naṇbar. who it is: a friend spoken of with respect.
+The -அர் is the respectful plural that turns நீ into நீங்கள், applied to a person.
+This is a different axis from the family words. அண்ணன் and தம்பி split brothers by age; the friend words split by sex, நண்பர் by respect.
+
+The letters in this word.
+ந + ண் + ப + ன் — every one of Tamil's n-letters inside one word. ந opens it, dental, at the teeth. ண் is retroflex, tongue curled back, closed by a puḷḷi. ன் ends it, the alveolar n from நன்றி. The writing lesson gave them to you one at a time; here they arrive together.
+
+Sounds you'll need: why it is heard as naṇbaṉ.
+The letter after ண் is ப, named pa. The course writes naṇbaṉ because of the நன்றி rule: a nasal in front of a stop voices it. A Tamil reader supplies the voicing, as an English reader supplies the sh in sugar.
+
+The word, taken apart - a friend is someone who came close.
+Behind நண்பன் (naṇbaṉ) is நண்பு (naṇbu), "friendship, closeness," which belongs to the root family of நண்ணு (naṇṇu), "to draw near." A friend, in Tamil's own accounting, is someone who came close.
+Be precise. The Dravidian dictionary files naṇbu and naṇbaṉ in the same entry as naṇṇu; the Tamil lexicon prefers நள்-, making them siblings rather than parent and child. They differ on the line of descent, not on the household.
+Set it beside அப்பா and அம்மா, not built out of anything — the repeated-syllable shape children produce for parents worldwide. நண்பன் (naṇbaṉ) is assembled, from a root you can point at.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the three endings — "naṇbaṉ, naṇbi, naṇbar"]
+[pause 8 seconds for the answer]
+[your turn — say: the voicing after the nasal — "naṉṟi … naṇbaṉ"]
+[pause 8 seconds for the answer]
+[your turn — say: the root it came from — "naṇṇu, to draw near"]
+[pause 8 seconds for the answer]
+[your turn — say: the family words that split on age instead — "aṇṇaṉ, tambi"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give the friend-word for a woman, a man, and someone you respect. (Naṇbi; naṇbaṉ; naṇbar.) Which axis do the friend words split on, and which do the brother words? (Sex and respect; age.) Why is ப heard as b, and are அப்பா and அம்மா built from a root the way naṇbaṉ is? (A nasal voices the stop after it; no.)
+
+
+Lesson 3 of 4.
+இவர் (ivar) — "this person," and Tamil's pointing system.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Naṇbaṉ, naṇbi, naṇbar — and the root behind them. (Naṇṇu, to draw near.) You have the word for a friend, but cannot point at one.
+
+You'll want to know: இவர்.
+இவர் — ivar — this person (near me, spoken of respectfully).
+Not "he" and not "she": இவர் (ivar) is what you say about a person standing here whom you are treating with respect, and it does not commit you to their sex. It is built on இவன் (ivaṉ) and இவள் (ivaḷ), with the same -அர் that gave you நண்பர்.
+One caution about speech: இவர் (ivar) is heard mostly of men, and இவங்க (ivaṅga) does the same respectful job for a woman.
+
+The letters in this word.
+இ + வ + ர். இ is the standing vowel i — the letter, not the ி sign that hangs on a consonant. வ is the va opening வணக்கம் and வீடு. ர் is the soft r with a puḷḷi.
+A word this short is almost all arc, which is the moment to recall the usual explanation for that roundness: Tamil was scratched into palm leaf, and a straight stroke along the grain can split the leaf. Hold it as the writing lesson asked — the standard account, not a settled fact, since the earliest Tamil writing was cut into stone and is angular. What survives is the useful part: the tool leaves fingerprints on the letters.
+
+Grammar Lens: near, far, and which.
+இவர் (ivar) is one cell of a system, and the system is a single letter at the front:
+[a table of 3 rows, read aloud]
+the front letter: இ-. what it does: points near — this one, here.
+the front letter: அ-. what it does: points away — that one, there.
+the front letter: எ-. what it does: asks — which one.
+So இவர் (ivar) is "this person," அவர் (avar) "that person," எவர் (evar) "which person." You have been using one front already: என்ன (eṉṉa), "what," is the எ- of asking.
+Two honest notes. எ- is the question, not a third distance. And Old Tamil had a genuine third distance, உ-, for something visible but far off; modern Tamil has retired it.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the three fronts — "i- … a- … e-"]
+[pause 8 seconds for the answer]
+[your turn — say: the row they build — "ivar, avar, evar"]
+[pause 8 seconds for the answer]
+[your turn — say: the question word you already had — "eṉṉa"]
+[pause 8 seconds for the answer]
+[your turn — say: the respectful ending on both — "naṇbar … ivar"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What do இ-, அ- and எ- do at the front of a word, and which question word you already knew is built on எ-? (Near; away; asks — and என்ன.) Does இவர் (ivar) tell you whether the person is a man or a woman? (No — it marks respect; spoken Tamil leans இவங்க for a woman.) How firmly should you hold the palm-leaf explanation for the curves? (As the standard account, not a settled fact.)
+
+
+Lesson 4 of 4.
+இவர் என் நண்பர் (ivar eṉ naṇbar) — "this is my friend".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Ivar, avar, evar — near, away, the question. Then naṇbaṉ, naṇbi, naṇbar. Everything this lesson needs is in your mouth; what is left is the order.
+
+You'll want to know: the introduction.
+இவர் என் நண்பர். — ivar eṉ naṇbar — This is my friend.
+Three words, and not one of them is a verb. Tamil links two nouns by setting them beside each other, as in என் பெயர் … and என் தவறு.
+The pieces in order: இவர் (ivar), the person here; என், my; நண்பர், friend-with-respect. Then stop.
+The whole meeting:
+— வணக்கம். இவர் என் நண்பர் (ivar eṉ naṇbar). — வணக்கம். உங்கள் ஊர் (ūr) என்ன.
+Every word in it is yours.
+
+The letters in this word.
+என் is எ with ன், the alveolar n dotted shut. நண்பர் opens on dental ந, turns on retroflex ண், closes on ர். So one line makes you produce ன் and ண் within a breath of each other — one at the ridge, the other with the tongue curled back. Hear that difference and the three-way n is no longer theory.
+
+Why it's said this way: which ending you choose.
+நண்பர் rather than நண்பன் (naṇbaṉ) is a decision, not a default.
+இவர் (ivar) என் நண்பன் (naṇbaṉ). — a male friend, plainly stated; warm among peers.
+இவர் (ivar) என் நண்பி. — a female friend, the matching plain form.
+இவர் என் நண்பர் (ivar eṉ naṇbar). — the respectful ending; safe with anyone, and right when either party is older or senior.
+If unsure, take நண்பர். Over-respect is invisible; under-respect is not.
+Notice how differently Tamil makes you think from one word to the next. For a sibling it forces age: there is no bare "brother" — you must choose அண்ணன் or தம்பி, அக்கா or தங்கை, and say whether they are older or younger than you before you can say anything at all. For a friend it forces sex or respect. For parents, nothing: அப்பா and அம்மா came into the language whole. Tamil rarely lets you be vague about a relationship.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the introduction — "ivar eṉ naṇbar"]
+[pause 8 seconds for the answer]
+[your turn — say: the same line to a peer about a male friend — "ivar eṉ naṇbaṉ"]
+[pause 8 seconds for the answer]
+[your turn — say: the greeting and the question around it — "vaṇakkam … uṅgaḷ ūr eṉṉa"]
+[pause 8 seconds for the answer]
+[your turn — say: what a sibling word forces you to decide — "aṇṇaṉ, older; tambi, younger"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Introduce a friend respectfully, and say how many verbs the sentence has. (Ivar eṉ naṇbar; none.) What does a sibling word force you to decide that a friend word does not? (Whether they are older or younger — aṇṇaṉ against tambi.) Which friend ending is safe when unsure, and what does இ- tell your listener? (நண்பர்; that the person is near.)

--- a/code/learning/human-languages/tamil/narration/ch37.txt
+++ b/code/learning/human-languages/tamil/narration/ch37.txt
@@ -76,7 +76,7 @@ The letters in this word.
 ந + ண் + ப + ன் — every one of Tamil's n-letters inside one word. ந opens it, dental, at the teeth. ண் is retroflex, tongue curled back, closed by a puḷḷi. ன் ends it, the alveolar n from நன்றி. The writing lesson gave them to you one at a time; here they arrive together.
 
 Sounds you'll need: why it is heard as naṇbaṉ.
-The letter after ண் is ப, named pa. The course writes naṇbaṉ because of the நன்றி rule: a nasal in front of a stop voices it. A Tamil reader supplies the voicing, as an English reader supplies the sh in sugar.
+The letter after ண் is ப, named pa. This book writes naṇbaṉ because of the நன்றி rule: a nasal in front of a stop voices it. A Tamil reader supplies the voicing, as an English reader supplies the sh in sugar.
 
 The word, taken apart - a friend is someone who came close.
 Behind நண்பன் (naṇbaṉ) is நண்பு (naṇbu), "friendship, closeness," which belongs to the root family of நண்ணு (naṇṇu), "to draw near." A friend, in Tamil's own accounting, is someone who came close.

--- a/code/learning/human-languages/tamil/narration/ch38.json
+++ b/code/learning/human-languages/tamil/narration/ch38.json
@@ -1,0 +1,558 @@
+{
+  "version": 1,
+  "language": "tamil",
+  "chapter": 38,
+  "title": "Keeping Well, and Leaving",
+  "drivablePrefix": 0,
+  "sourceHash": "fnv1a64:d9d5146731ccd6eb",
+  "lessons": [
+    {
+      "id": "TA-C38-udambu",
+      "sequence": 870,
+      "title": "உடம்பு (uḍambu) — \"body,\" and how Tamil asks after your health",
+      "headword": "உடம்பு",
+      "romanization": "uḍambu",
+      "gloss": "body — the noun in the everyday Tamil way of asking after someone's health",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:4c3a8be338bc60b3",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Introduce a friend respectfully and name the ending. (Ivar eṉ naṇbar — the respectful -அர்.) Next you would ask how they are."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: உடம்பு",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "உடம்பு — uḍambu — body."
+            },
+            {
+              "kind": "speech",
+              "text": "The whole of it, not a part. You have தலை (talai) and கை (kai) already; this is what they belong to, and the word inside the question Tamil speakers actually ask:"
+            },
+            {
+              "kind": "speech",
+              "text": "உங்கள் உடம்பு எப்படி இருக்கு — uṅgaḷ uḍambu eppaḍi irukku — how is your body, that is, how are you keeping."
+            },
+            {
+              "kind": "speech",
+              "text": "Every piece is yours: உங்கள், எப்படி, and இருக்கு from இரு. What is new is that the health question hangs on a noun rather than on you."
+            },
+            {
+              "kind": "speech",
+              "text": "Tamil has a second way to ask it, through உணவு — the noun standing on உண், \"to eat.\" Asking whether somebody has eaten is asking whether they are all right."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "உ + ட + ம் + பு: the standing vowel u, ட, then ம் — ம shut by the puḷḷi you have used since வணக்கம் — and பு. ம was one of the first letters you formed with a pen, alongside retroflex ண."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "pronunciation",
+          "title": "Sounds you'll need: two softenings in one word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The letters say u-ṭa-m-pu; your mouth says uḍambu. ட sits between vowels, so it softens — the paḍi rule. ப follows the nasal ம், so it voices — the naṉṟi rule that also made naṇbaṉ. Two rules, one short word, neither written down."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "etymology",
+          "title": "The word, taken apart - the same entry as உடல்",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Tamil has another word for the body, உடல் (uḍal), and the Dravidian dictionary does not treat them as rivals: உடல், உடம்பு (uḍambu) and உடலம் sit in the same entry, with Kannada's ಒಡಲು beside them. Usage has divided them: உடல் leans literary, உடம்பு (uḍambu) is what you say aloud about someone unwell."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "grammar",
+          "title": "Grammar Lens: where the person goes in a health question",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Two shapes Tamil uses to ask about a state:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "the question",
+                "where the person sits"
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "the question: உங்கள் உடம்பு (uḍambu) எப்படி இருக்கு. where the person sits: as a possessor.",
+                "the question: உனக்கு எத்தனை வயது ஆகிறது. where the person sits: in the dative."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "The formal age question does not make you the subject at all — \"to you, how many years are becoming.\" The body question makes உடம்பு (uḍambu) the subject."
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two softenings — \"uṭampu … uḍambu\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two softenings — \"uṭampu … uḍambu\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the question — \"uṅgaḷ uḍambu eppaḍi irukku\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the question — \"uṅgaḷ uḍambu eppaḍi irukku\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the parts, the whole, and the two forms of one root — \"talai, kai … uḍambu … uḍal\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the parts, the whole, and the two forms of one root — \"talai, kai … uḍambu … uḍal\"]"
+            }
+          ]
+        },
+        {
+          "index": 7,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Ask someone respectfully how they are keeping, through the body, and name the two sound rules inside uḍambu. (Uṅgaḷ uḍambu eppaḍi irukku; ட softens between vowels, ப voices after a nasal.) Are உடல் and உடம்பு different words, and where does the person sit in the formal age question? (No, same entry; in the dative.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C38-sugam",
+      "sequence": 880,
+      "title": "சுகம் (sugam) — \"ease,\" the word Tamil did borrow",
+      "headword": "சுகம்",
+      "romanization": "sugam",
+      "gloss": "wellbeing, ease — the Sanskrit word Tamil did take in, sitting beside the native நலம் it never dropped",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:e334b1613ee920fd",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Health through the body, and the other body-word in its entry. (Uṅgaḷ uḍambu eppaḍi irukku; uḍal.) A second answer came from abroad."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: சுகம்",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "சுகம் — sugam — wellbeing, ease, comfort."
+            },
+            {
+              "kind": "speech",
+              "text": "The க is doing its old trick: the letter is ka, but between vowels it comes out g. Su-g-am, not su-ka-m."
+            },
+            {
+              "kind": "speech",
+              "text": "சுகமா — sugamā — keeping well."
+            },
+            {
+              "kind": "speech",
+              "text": "It is not the ordinary Tamil \"how are you,\" which is நல்லா இருக்கீங்களா. சுகமா is warmer and more Sanskritic, and which you hear depends on somebody's ஊர் — the native place whose name so often ends in -ūr."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "சு + க + ம்: ச with the u sign, a bare க, ம closed by the puḷḷi. Nothing is doubled — hold that against மன்னிக்கவும், where ன்னி has ன dotted shut and written a second time, and க்க does the same to க."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: where the dative is required",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "சுகமா has no dative in it, and a family of Tamil states demands one: எனக்குத் தமிழ் தெரியும், \"to me, Tamil is known.\" Put a noun there and the shapes part:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "the phrase",
+                "what happened"
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "the phrase: நான் to எனக்கு. what happened: the pronoun changes its body.",
+                "the phrase: நண்பர் to நண்பருக்கு. what happened: the noun just takes -உக்கு."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "So நண்பருக்குத் தமிழ் தெரியும், and the formal age question does the same: உனக்கு எத்தனை வயது ஆகிறது. சுகமா does not: knowing and ageing come to a person; being well is what a person is."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "etymology",
+          "title": "The word, taken apart - the borrowing Tamil kept beside its own",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "சுகம் (sugam) is Sanskrit सुख (sukha), \"ease\" — the apology lesson in reverse. There, மன்னிக்கவும் stood on Tamil's own மன்னி while the neighbours built their \"sorry\" on Sanskrit kṣamā. Here Tamil borrowed sukha and kept நலம் as the everyday word; Malayalam took the same loan, സുഖം, as its ordinary greeting."
+            },
+            {
+              "kind": "speech",
+              "text": "The old parse of sukha is su- \"good\" plus kha \"aperture\" — a chariot's axle-hole. Treat that as contested: the standard Sanskrit dictionary hedges it with \"said to be,\" and offers su-stha."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the softened க — \"sugam,\" not \"sukam\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the softened க — \"sugam,\" not \"sukam\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the state that needs a dative — \"naṇbarukkut tamiḻ teriyum\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the state that needs a dative — \"naṇbarukkut tamiḻ teriyum\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the state that does not, and the word kept beside it — \"sugamā … nalam\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the state that does not, and the word kept beside it — \"sugamā … nalam\"]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Why is க heard as g, and what did the noun do that நான் does not? (Between vowels; it takes -உக்கு, while நான் becomes எனக்கு.) Which word did Tamil borrow, which did it keep, and how firm is the \"good axle-hole\" story? (சுகம் (sugam); நலம்; contested.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C38-vidai",
+      "sequence": 890,
+      "title": "விடை (viḍai) — \"leave,\" and the root under the house",
+      "headword": "விடை",
+      "romanization": "viḍai",
+      "gloss": "leave to depart — the noun for taking your leave, from the same root as வீடு",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:f9300ce323ff2a68",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Sugam — which language it came from, and which Tamil word stayed beside it. (Sanskrit; நலம்.) You came through the door, took the நாற்காலி — four legs, counted out — were given tea, said என் தவறு when the wrong cup arrived, and introduced a friend. One thing is left."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "input",
+          "title": "You'll want to know: விடை",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "விடை — viḍai — leave; permission to depart."
+            },
+            {
+              "kind": "speech",
+              "text": "Not the act of going — you have போய் வருகிறேன் for that — but the leave itself, taken with பெறு (peṟu), \"to obtain\":"
+            },
+            {
+              "kind": "speech",
+              "text": "நன்றி. விடை பெறுகிறேன். — naṉṟi. viḍai peṟugiṟēṉ. — Thank you. I take my leave."
+            },
+            {
+              "kind": "speech",
+              "text": "It is formal and slightly literary; leaving a friend's house you would say போய் வருகிறேன்."
+            },
+            {
+              "kind": "speech",
+              "text": "The தயவுசெய்து you learned for asking has a family across the Dravidian languages, all built on the same daya, \"kindness,\" plus a light verb. Leaving is not."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "வி + டை. வி is வ with the ி sign — the first vowel sign you learned, which made நன்றி possible. டை is ட with the ai sign ை, which wraps around the front."
+            },
+            {
+              "kind": "speech",
+              "text": "நன்றி stands beside it above, so read it once more: ந + ன் + றி — dental n, alveolar n dotted shut, hard ற with that same ி. And பெறுகிறேன் has a க between vowels, so it softens."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "etymology",
+          "title": "The word, taken apart - one root, three words",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "விடை (viḍai) is inherited Dravidian, and belongs to விடு (viḍu), \"to let go.\" Leave is what you are let go with."
+            },
+            {
+              "kind": "speech",
+              "text": "Now the first word of these lessons. வீடு, \"house,\" is filed by the Dravidian dictionary in the same entry as விடு — and விடை (viḍai) is in it too:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "the word",
+                "what it is"
+              ],
+              "columns": 2,
+              "rowCount": 3,
+              "utterances": [
+                "the word: விடு viḍu. what it is: to let go, to release.",
+                "the word: வீடு vīḍu. what it is: the house — and, in the old sense, final release.",
+                "the word: விடை viḍai. what it is: leave to depart."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "You walked in through வீடு and walk out through விடை (viḍai), one word in different clothes. Kannada's ಬೀಡು, the same house with its b-, sits on that root as well."
+            },
+            {
+              "kind": "speech",
+              "text": "Two cautions, because a neat pattern is when to slow down. A second விடை (viḍai) means \"bull,\" a Sanskrit borrowing from vṛṣa; and ஊர் — the settlement inside Tanjore — and நண்பன் are outside this root entirely."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the departure — \"naṉṟi. viḍai peṟugiṟēṉ.\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the departure — \"naṉṟi. viḍai peṟugiṟēṉ.\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the one root, three ways — \"viḍu … vīḍu … viḍai\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the one root, three ways — \"viḍu … vīḍu … viḍai\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the two that do not join it — \"ūr … naṇbaṉ\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the two that do not join it — \"ūr … naṇbaṉ\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Take your leave formally, thanks in front of it, and name the earlier word that shares this root. (Naṉṟi. viḍai peṟugiṟēṉ.; வீடு, from விடு, \"to let go.\") Do ஊர் and நண்பன் belong to that root? (No — a settlement and a closeness; not everything joins up.)"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "findings": []
+}

--- a/code/learning/human-languages/tamil/narration/ch38.txt
+++ b/code/learning/human-languages/tamil/narration/ch38.txt
@@ -1,0 +1,135 @@
+Tamil, chapter 38: Keeping Well, and Leaving.
+3 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+
+
+Lesson 1 of 3.
+உடம்பு (uḍambu) — "body," and how Tamil asks after your health.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Introduce a friend respectfully and name the ending. (Ivar eṉ naṇbar — the respectful -அர்.) Next you would ask how they are.
+
+You'll want to know: உடம்பு.
+உடம்பு — uḍambu — body.
+The whole of it, not a part. You have தலை (talai) and கை (kai) already; this is what they belong to, and the word inside the question Tamil speakers actually ask:
+உங்கள் உடம்பு எப்படி இருக்கு — uṅgaḷ uḍambu eppaḍi irukku — how is your body, that is, how are you keeping.
+Every piece is yours: உங்கள், எப்படி, and இருக்கு from இரு. What is new is that the health question hangs on a noun rather than on you.
+Tamil has a second way to ask it, through உணவு — the noun standing on உண், "to eat." Asking whether somebody has eaten is asking whether they are all right.
+
+The letters in this word.
+உ + ட + ம் + பு: the standing vowel u, ட, then ம் — ம shut by the puḷḷi you have used since வணக்கம் — and பு. ம was one of the first letters you formed with a pen, alongside retroflex ண.
+
+Sounds you'll need: two softenings in one word.
+The letters say u-ṭa-m-pu; your mouth says uḍambu. ட sits between vowels, so it softens — the paḍi rule. ப follows the nasal ம், so it voices — the naṉṟi rule that also made naṇbaṉ. Two rules, one short word, neither written down.
+
+The word, taken apart - the same entry as உடல்.
+Tamil has another word for the body, உடல் (uḍal), and the Dravidian dictionary does not treat them as rivals: உடல், உடம்பு (uḍambu) and உடலம் sit in the same entry, with Kannada's ಒಡಲು beside them. Usage has divided them: உடல் leans literary, உடம்பு (uḍambu) is what you say aloud about someone unwell.
+
+Grammar Lens: where the person goes in a health question.
+Two shapes Tamil uses to ask about a state:
+[a table of 2 rows, read aloud]
+the question: உங்கள் உடம்பு (uḍambu) எப்படி இருக்கு. where the person sits: as a possessor.
+the question: உனக்கு எத்தனை வயது ஆகிறது. where the person sits: in the dative.
+The formal age question does not make you the subject at all — "to you, how many years are becoming." The body question makes உடம்பு (uḍambu) the subject.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the two softenings — "uṭampu … uḍambu"]
+[pause 8 seconds for the answer]
+[your turn — say: the question — "uṅgaḷ uḍambu eppaḍi irukku"]
+[pause 8 seconds for the answer]
+[your turn — say: the parts, the whole, and the two forms of one root — "talai, kai … uḍambu … uḍal"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Ask someone respectfully how they are keeping, through the body, and name the two sound rules inside uḍambu. (Uṅgaḷ uḍambu eppaḍi irukku; ட softens between vowels, ப voices after a nasal.) Are உடல் and உடம்பு different words, and where does the person sit in the formal age question? (No, same entry; in the dative.)
+
+
+Lesson 2 of 3.
+சுகம் (sugam) — "ease," the word Tamil did borrow.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Health through the body, and the other body-word in its entry. (Uṅgaḷ uḍambu eppaḍi irukku; uḍal.) A second answer came from abroad.
+
+You'll want to know: சுகம்.
+சுகம் — sugam — wellbeing, ease, comfort.
+The க is doing its old trick: the letter is ka, but between vowels it comes out g. Su-g-am, not su-ka-m.
+சுகமா — sugamā — keeping well.
+It is not the ordinary Tamil "how are you," which is நல்லா இருக்கீங்களா. சுகமா is warmer and more Sanskritic, and which you hear depends on somebody's ஊர் — the native place whose name so often ends in -ūr.
+
+The letters in this word.
+சு + க + ம்: ச with the u sign, a bare க, ம closed by the puḷḷi. Nothing is doubled — hold that against மன்னிக்கவும், where ன்னி has ன dotted shut and written a second time, and க்க does the same to க.
+
+Grammar Lens: where the dative is required.
+சுகமா has no dative in it, and a family of Tamil states demands one: எனக்குத் தமிழ் தெரியும், "to me, Tamil is known." Put a noun there and the shapes part:
+[a table of 2 rows, read aloud]
+the phrase: நான் to எனக்கு. what happened: the pronoun changes its body.
+the phrase: நண்பர் to நண்பருக்கு. what happened: the noun just takes -உக்கு.
+So நண்பருக்குத் தமிழ் தெரியும், and the formal age question does the same: உனக்கு எத்தனை வயது ஆகிறது. சுகமா does not: knowing and ageing come to a person; being well is what a person is.
+
+The word, taken apart - the borrowing Tamil kept beside its own.
+சுகம் (sugam) is Sanskrit सुख (sukha), "ease" — the apology lesson in reverse. There, மன்னிக்கவும் stood on Tamil's own மன்னி while the neighbours built their "sorry" on Sanskrit kṣamā. Here Tamil borrowed sukha and kept நலம் as the everyday word; Malayalam took the same loan, സുഖം, as its ordinary greeting.
+The old parse of sukha is su- "good" plus kha "aperture" — a chariot's axle-hole. Treat that as contested: the standard Sanskrit dictionary hedges it with "said to be," and offers su-stha.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the softened க — "sugam," not "sukam"]
+[pause 8 seconds for the answer]
+[your turn — say: the state that needs a dative — "naṇbarukkut tamiḻ teriyum"]
+[pause 8 seconds for the answer]
+[your turn — say: the state that does not, and the word kept beside it — "sugamā … nalam"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Why is க heard as g, and what did the noun do that நான் does not? (Between vowels; it takes -உக்கு, while நான் becomes எனக்கு.) Which word did Tamil borrow, which did it keep, and how firm is the "good axle-hole" story? (சுகம் (sugam); நலம்; contested.)
+
+
+Lesson 3 of 3.
+விடை (viḍai) — "leave," and the root under the house.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Sugam — which language it came from, and which Tamil word stayed beside it. (Sanskrit; நலம்.) You came through the door, took the நாற்காலி — four legs, counted out — were given tea, said என் தவறு when the wrong cup arrived, and introduced a friend. One thing is left.
+
+You'll want to know: விடை.
+விடை — viḍai — leave; permission to depart.
+Not the act of going — you have போய் வருகிறேன் for that — but the leave itself, taken with பெறு (peṟu), "to obtain":
+நன்றி. விடை பெறுகிறேன். — naṉṟi. viḍai peṟugiṟēṉ. — Thank you. I take my leave.
+It is formal and slightly literary; leaving a friend's house you would say போய் வருகிறேன்.
+The தயவுசெய்து you learned for asking has a family across the Dravidian languages, all built on the same daya, "kindness," plus a light verb. Leaving is not.
+
+The letters in this word.
+வி + டை. வி is வ with the ி sign — the first vowel sign you learned, which made நன்றி possible. டை is ட with the ai sign ை, which wraps around the front.
+நன்றி stands beside it above, so read it once more: ந + ன் + றி — dental n, alveolar n dotted shut, hard ற with that same ி. And பெறுகிறேன் has a க between vowels, so it softens.
+
+The word, taken apart - one root, three words.
+விடை (viḍai) is inherited Dravidian, and belongs to விடு (viḍu), "to let go." Leave is what you are let go with.
+Now the first word of these lessons. வீடு, "house," is filed by the Dravidian dictionary in the same entry as விடு — and விடை (viḍai) is in it too:
+[a table of 3 rows, read aloud]
+the word: விடு viḍu. what it is: to let go, to release.
+the word: வீடு vīḍu. what it is: the house — and, in the old sense, final release.
+the word: விடை viḍai. what it is: leave to depart.
+You walked in through வீடு and walk out through விடை (viḍai), one word in different clothes. Kannada's ಬೀಡು, the same house with its b-, sits on that root as well.
+Two cautions, because a neat pattern is when to slow down. A second விடை (viḍai) means "bull," a Sanskrit borrowing from vṛṣa; and ஊர் — the settlement inside Tanjore — and நண்பன் are outside this root entirely.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the departure — "naṉṟi. viḍai peṟugiṟēṉ."]
+[pause 8 seconds for the answer]
+[your turn — say: the one root, three ways — "viḍu … vīḍu … viḍai"]
+[pause 8 seconds for the answer]
+[your turn — say: the two that do not join it — "ūr … naṇbaṉ"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Take your leave formally, thanks in front of it, and name the earlier word that shares this root. (Naṉṟi. viḍai peṟugiṟēṉ.; வீடு, from விடு, "to let go.") Do ஊர் and நண்பன் belong to that root? (No — a settlement and a closeness; not everything joins up.)

--- a/code/learning/human-languages/tamil/roadmap.md
+++ b/code/learning/human-languages/tamil/roadmap.md
@@ -130,6 +130,26 @@ records as omitted. `VERB-HEAR` also stays omitted even though கேள் cove
 hearing, because one lesson realises one concept — a separate hearing lesson
 would have to earn its own place.
 
+## Chapters 35–38 — the first nouns, and a level-gate probe (authored)
+
+Fifteen everyday nouns in four chapters, attached to **pre-A1** spine nodes
+through five new `TA-EXT-03*-LANGUAGE-SPECIFIC` extensions so that they count
+where the gate measures. Chapter 35 (`SPINE-MEET-GREET`) is arriving at a house;
+36 (`SPINE-POLITE-REQUEST-REPAIR`) is what you are offered and how you say the
+mistake was yours; 37 (`SPINE-EXCHANGE-NAMES`) is the native place and the
+friend, ending on **இவர் என் நண்பர்**; 38 (`SPINE-CHECK-WELLBEING` and
+`SPINE-TAKE-LEAVE`) asks after a body and takes leave.
+
+The measurement it was written to take: pre-A1 headwords **33 → 48**, the
+vocabulary shortfall **267 → 252**, and pre-A1 atoms revisited fewer than twice
+**29 → 0**. Fifteen lessons bought fifteen headwords, because the gate counts
+one headword per lesson; the remaining 252 are therefore roughly 252 more
+lessons at pre-A1, which is HL09 §3's own arithmetic seen from the other side.
+
+Still open at pre-A1 for this track: the vocabulary gap above, and
+`TA-W01-abugida-va-ka`, which introduces four atoms against a budget of three
+and is the last `atom-budget` blocker.
+
 ## Planned
 
 | Chapter | Theme |

--- a/code/packages/typescript/human-language-data/tests/chapters.test.ts
+++ b/code/packages/typescript/human-language-data/tests/chapters.test.ts
@@ -225,11 +225,11 @@ describe("corpus snapshot", () => {
     // bookChapters 377 -> 378, declaredChapters 279 -> 280, chaptersWithoutCapability
     // holds at 98. A new chapter that shipped without a `canDo`/`payoff` would have
     // pushed the debt to 99, which is exactly what this trio is here to catch.
-    expect(report.summary.bookChapters).toBe(452); // +1: Spanish ch41, the second B1 chapter
+    expect(report.summary.bookChapters).toBe(464); // +1: Spanish ch41, the second B1 chapter
     // 317 -> 318 when russian chapter 3 gained a capability. It was the only
     // generated chapter with no HL05 entry, so it was also the only generated chapter
     // the book could not give an opening to.
-    expect(report.summary.declaredChapters).toBe(354); // +1: Spanish ch41, the second B1 chapter
+    expect(report.summary.declaredChapters).toBe(366); // +1: Spanish ch41, the second B1 chapter
     expect(report.summary.chaptersWithoutCapability).toBe(98);
     expect(report.summary.payoffsNotClosed).toBe(0);
     expect(report.summary.unknownPayoffLessons).toBe(0);

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -325,9 +325,13 @@ describe("the real corpus", () => {
     // lesson's own, structurally unreachable), Bengali 12 of 18 -> 4 of 35, Tamil 53% ->
     // 38%, Arabic four ch28-30 atoms off zero. Adding vocabulary and reducing orphans at
     // the same time is the whole point; a corpus that only grows is not a course.
-    expect(report.summary.atomsTaught).toBe(2023); // +9: Spanish ch41's nine atoms // +9: the four Spanish B1 lessons
-    expect(report.summary.atomsNeverRevisited).toBe(516);
-    expect(report.summary.neverRevisitedPercent).toBe(26);
+    // The pre-A1 vocabulary probe (hindi/arabic/tamil, 45 lessons across three
+    // unrelated families) confirmed the reach-back discipline scales past verbs:
+    // atomsTaught +98 while atomsNeverRevisited FELL by 53. 22% is the lowest this
+    // figure has read since it was first measured at 51%.
+    expect(report.summary.atomsTaught).toBe(2121);
+    expect(report.summary.atomsNeverRevisited).toBe(463);
+    expect(report.summary.neverRevisitedPercent).toBe(22);
 
     // 509 -> 517, and the eight split into TWO DIFFERENT PHENOMENA this number conflates.
     //
@@ -393,8 +397,8 @@ describe("the real corpus", () => {
     // So this is not a cost the new chapter incurred; it is a debt the old chapters
     // already had, which only became measurable once something followed them. Any
     // chapter appended to any track will do this, and the number is honest either way.
-    expect(report.summary.missedByWindow.R1).toBe(788);
-    expect(report.summary.missedByWindow.R2).toBe(1305);
+    expect(report.summary.missedByWindow.R1).toBe(797);
+    expect(report.summary.missedByWindow.R2).toBe(1376);
   });
 
   it("shows what a declared reading order was worth", () => {

--- a/code/packages/typescript/human-language-data/tests/levels.test.ts
+++ b/code/packages/typescript/human-language-data/tests/levels.test.ts
@@ -217,7 +217,7 @@ describe("corpus snapshot", () => {
     const { lessons, curricula: paths, spine } = loadEverything();
     const summary = summarizeLevels(lessons, paths, spine);
 
-    expect(summary.byLevel["pre-A1"]).toBe(650);
+    expect(summary.byLevel["pre-A1"]).toBe(696);
     expect(summary.byLevel.A1).toBe(297);
     expect(summary.byLevel.A2).toBe(350);
     // 8, not 0: Spanish chapters 38 and 41 realize SPINE-NARRATE-EVENTS and
@@ -279,7 +279,7 @@ describe("corpus snapshot", () => {
     const { lessons, curricula: paths, spine } = loadEverything();
     const ramp = lessonsUpToLevel(lessons, paths, spine, "A1");
     // The whole point: this is a FILTER over the one corpus, not a second corpus.
-    expect(ramp).toHaveLength(947);
+    expect(ramp).toHaveLength(993);
     expect(ramp.length).toBeLessThan(lessons.length);
   });
 });

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -793,15 +793,19 @@ describe("corpus regression", () => {
     // figure to rise whenever a non-Latin track authors honestly.
     expect(manifest.summary).toEqual({
       // Both Spanish B1 chapters, 38 and 41, are entirely ear-only, so each is fully
-      // drivable. They are what moved the whole-corpus figure from 66% to 67%.
-      totalLessons: 1453,
-      voice: 977,
-      sight: 423,
+      // drivable. They moved the whole-corpus figure from 66% to 67% — then the
+      // pre-A1 vocabulary probe (hindi/arabic/tamil) added honest script sections
+      // under the canonical heading, and the whole-lesson figure fell back to 66%.
+      // `coreDrivable` is unaffected: those blocks are detachable, so the driving
+      // edition itself lost nothing. This is the sight-share seam, not a regression.
+      totalLessons: 1499,
+      voice: 983,
+      sight: 463,
       pen: 53,
-      drivableLessons: 977,
-      drivablePercent: 67,
+      drivableLessons: 983,
+      drivablePercent: 66,
       trackCount: 22,
-      chapterCount: 452,
+      chapterCount: 464,
       // Prerequisite order still costs a commuter 132 of the 965 ear-only lessons:
       // they sit behind a blocker in their own chapter and stay unreachable in the car
       // until HL-C17 reshapes the remaining wide tables.
@@ -810,9 +814,9 @@ describe("corpus regression", () => {
       // and the alphabetical fallback it replaced had been flattering this number by
       // putting eyes-needed lessons later than they really come. The real order is
       // worse, which is the measurement becoming honest, not the corpus regressing.
-      drivablePrefixTotal: 794,
+      drivablePrefixTotal: 796,
       fullyDrivableChapters: 307,
-      unstartableChapters: 108,
+      unstartableChapters: 119,
       overriddenLessons: 0,
       lessonsWithoutChapter: 0,
     });

--- a/code/packages/typescript/human-language-data/tests/narration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/narration.test.ts
@@ -608,7 +608,7 @@ describe("the whole corpus", () => {
     // 378, not the 375 this was authored against: HL-C39 and HL-C40 each added a
     // Chapter 1 (Mandarin Chinese and Japanese) while this branch waited to merge, and
     // the Latin core-verb chapter (chapter 37, eight verb lessons) added one more.
-    expect(chapters).toHaveLength(452);
+    expect(chapters).toHaveLength(464);
   });
 
   it("leaves no Markdown typography in the spoken script", () => {

--- a/code/packages/typescript/human-language-data/tests/ramp.test.ts
+++ b/code/packages/typescript/human-language-data/tests/ramp.test.ts
@@ -106,7 +106,7 @@ describe("corpus snapshot", () => {
     // schema-v2 migration lands; the violation count will rise as it does, and that is
     // the measurement improving rather than the corpus worsening.
     expect(report.summary.unmeasurableLessons).toBe(572);
-    expect(report.summary.measurablePercent).toBe(61);
+    expect(report.summary.measurablePercent).toBe(62);
   });
 
   it("names the steepest lesson, which is where a burn-down starts", () => {
@@ -257,7 +257,7 @@ describe("the script ramp against the real corpus", () => {
 
     // The cousin layer's footprint. Not a violation — a reason to keep that layer
     // visually skippable, so a reader who knows no sister language can pass it by.
-    expect(report.summary.lessonsWithForeignScript).toBe(152);
+    expect(report.summary.lessonsWithForeignScript).toBe(165);
     expect(report.summary.maxForeignGlyphsInALesson).toBe(26);
   });
 


### PR DESCRIPTION
Hindi, Arabic and Tamil each author 15 everyday nouns attached to pre-A1 spine nodes via language-specific extensions, to answer one question: **does track-local vocabulary actually move `levelGate.vocabulary` and shrink its `shortfall`?**

Every one of the 22 tracks is blocked on vocabulary (shortfalls 256–297 against a 300 target), and the shared spine declares only 7 pre-A1 nodes / 34 concepts — so extension-attached lessons are the only path that could work.

## The answer, confirmed three times independently

```
hindi   34 → 50 headwords   shortfall 266 → 250
arabic  33 → 48 headwords   shortfall 267 → 252
tamil   33 → 48 headwords   shortfall 267 → 252
```

**Yes, it moves — at exactly one headword per lesson, no matter how many words a lesson actually teaches.** `vocabularyOf()` counts distinct `headword:` strings; `AR-C34-taam` hands the learner four words off one root and counts as one. Fifteen lessons bought fifteen headwords, in every track.

**Closing pre-A1 costs ~250 more lessons per track — roughly 5,500 lessons corpus-wide.** That's the honest scale of this program, from measurement rather than estimate.

## A second finding, also confirmed independently by all three

**The seven pre-A1 spine nodes are all social speech acts and own no concept for naming a concrete object.** *mesa/mez/mezai*, *ghar/bayt/veedu* — none has an honest pre-A1 home. All three agents dropped the household words rather than force them onto a node that doesn't fit, and said so plainly. Either pre-A1 needs concrete-object nodes, or a 300-headword target is wrong for a spine this socially scoped. **Not resolved here** — surfaced for whoever owns the spine.

## Reinforcement is cheap where vocabulary is not

```
atomsTaught 2023 → 2121    atomsNeverRevisited 511 → 463
            neverRevisitedPercent  26 → 22
```

The lowest this figure has read since it was first measured at 51%. **Tamil's reinforcement blocker went from 29 to zero in one tranche** — a payoff rescues a dozen atoms at once, where vocabulary buys exactly one headword per lesson with no bulk discount. Two axes of the level gate, two very different costs.

## Self-corrected errors, all caught before shipping

Hindi's गृह is not from √grah "to seize" (a grammarians' root-list; the real PIE cousin is \*gʰerdʰ- → yard/garden) · Tamil's விடு "house" and "release" are **one DEDR entry**, which became the chapter's actual spine rather than a footnote · Arabic's *kitāb* premise held (`AR-C31-kataba` already derives it).

Tamil also flagged **pre-existing debt that is not this PR's**: chapter 32's claim that *sāppiḍu* = *sāppu* "food" + *iḍu* has no lexicon support — no source records a plain *sāppu*, and DEDR has no entry for the verb. It declined to repeat the unsupported claim in its own lesson.

Cross-volume phrases banned mid-flight by another session's HL-C50 series ("this course", "The course", "course's") slipped into three lessons across two tracks — caught by the `standalone-book` guard and rewritten to book-scoped phrasing.

## Verification

- **928 tests pass** at default timeouts, no CLI flags (405 + 523).
- Three drift gates clean; artifacts regenerated, never hand-merged.
- Books: hindi 164pp, arabic 164pp, tamil 178pp — **zero `Missing character`**.

No `src/`, script or workflow changes — content, data, generated artifacts and test pins only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)