### PR TITLE
feat(human-language-data): Tamil chapter 1, one word per lesson (pilot)

### DIFF
--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -6278,8 +6278,10 @@
     {
       "language": "tamil",
       "chapter": 1,
-      "sourceHash": "fnv1a64:fe3d3298ecc5bc3a",
+      "sourceHash": "fnv1a64:cd6ee126f13c74e3",
       "lessonIds": [
+        "TA-C01-vanakkam",
+        "TA-C01-vanakkam-family-register",
         "TA-W01-curves-va-ka",
         "TA-W01-abugida-va-ka",
         "TA-W02-ma-retroflex-na",
@@ -6292,17 +6294,16 @@
         "TA-C01-illai",
         "TA-C01-nandri",
         "TA-C01-nandri-family-register",
-        "TA-C01-practice",
         "TA-C01-sari",
-        "TA-C01-vanakkam",
-        "TA-C01-vanakkam-family-register"
+        "TA-C01-answering",
+        "TA-C01-practice"
       ],
-      "voiceLessons": 3,
-      "drivablePrefix": 0,
+      "voiceLessons": 9,
+      "drivablePrefix": 2,
       "text": "tamil/narration/ch01.txt",
       "json": "tamil/narration/ch01.json",
-      "textHash": "fnv1a64:54d93220c6e15269",
-      "jsonHash": "fnv1a64:04ce359d6dc1e3c8"
+      "textHash": "fnv1a64:c895ca421a6899c3",
+      "jsonHash": "fnv1a64:1049ab524a66fcc2"
     },
     {
       "language": "tamil",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,19 +7,19 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:16968fe4391d74bc",
+  "sourceHash": "fnv1a64:4b847a00f72383f6",
   "summary": {
-    "totalLessons": 1499,
-    "voice": 983,
-    "sight": 463,
+    "totalLessons": 1500,
+    "voice": 989,
+    "sight": 458,
     "pen": 53,
-    "drivableLessons": 983,
+    "drivableLessons": 989,
     "drivablePercent": 66,
     "trackCount": 22,
     "chapterCount": 464,
-    "drivablePrefixTotal": 796,
+    "drivablePrefixTotal": 798,
     "fullyDrivableChapters": 307,
-    "unstartableChapters": 119,
+    "unstartableChapters": 118,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
   },
@@ -6789,12 +6789,12 @@
     },
     {
       "language": "tamil",
-      "lessonCount": 112,
-      "voice": 53,
-      "sight": 51,
+      "lessonCount": 113,
+      "voice": 59,
+      "sight": 46,
       "pen": 8,
-      "drivablePercent": 47,
-      "drivablePrefixTotal": 42,
+      "drivablePercent": 52,
+      "drivablePrefixTotal": 44,
       "modalities": [
         "voice",
         "sight",
@@ -6803,19 +6803,22 @@
       "chapters": [
         {
           "chapter": 1,
-          "lessonCount": 16,
-          "voice": 3,
-          "sight": 5,
+          "lessonCount": 17,
+          "voice": 9,
+          "sight": 0,
           "pen": 8,
           "modalities": [
             "voice",
             "sight",
             "pen"
           ],
-          "drivablePrefix": 0,
+          "drivablePrefix": 2,
           "firstNonVoiceLesson": "TA-W01-curves-va-ka",
           "drivable": false,
-          "drivableLessonIds": []
+          "drivableLessonIds": [
+            "TA-C01-vanakkam",
+            "TA-C01-vanakkam-family-register"
+          ]
         },
         {
           "chapter": 2,
@@ -32113,6 +32116,42 @@
       "sourceHash": "fnv1a64:46ebaea1981bf7f9"
     },
     {
+      "id": "TA-C01-vanakkam",
+      "language": "tamil",
+      "chapter": 1,
+      "sequence": 10,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:017a3556c7283313"
+    },
+    {
+      "id": "TA-C01-vanakkam-family-register",
+      "language": "tamil",
+      "chapter": 1,
+      "sequence": 20,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ad7b57e45071d385"
+    },
+    {
       "id": "TA-W01-curves-va-ka",
       "language": "tamil",
       "chapter": 1,
@@ -32301,71 +32340,61 @@
       "id": "TA-C01-aam",
       "language": "tamil",
       "chapter": 1,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "sequence": 180,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block",
-        "sight-cue"
+        "no-visual-dependency"
       ],
-      "coreModality": "sight",
+      "coreModality": "voice",
       "coreReasons": [
-        "sight-cue"
+        "no-visual-dependency"
       ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:5971b60f9445ebba",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:33b4b0ca5bf90f6f"
     },
     {
       "id": "TA-C01-illai",
       "language": "tamil",
       "chapter": 1,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "sequence": 190,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:eb7d4be5afd2b4a8",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:93b6d60e45822e82"
     },
     {
       "id": "TA-C01-nandri",
       "language": "tamil",
       "chapter": 1,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "sequence": 200,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e3b598578abbeee7",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:d08803bcdd6448e5"
     },
     {
       "id": "TA-C01-nandri-family-register",
       "language": "tamil",
       "chapter": 1,
-      "sequence": null,
+      "sequence": 210,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -32377,73 +32406,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:1b71da01982a1c62"
-    },
-    {
-      "id": "TA-C01-practice",
-      "language": "tamil",
-      "chapter": 1,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:9fc5ad0e85df4288"
+      "sourceHash": "fnv1a64:df441fa9eb2d1a4a"
     },
     {
       "id": "TA-C01-sari",
       "language": "tamil",
       "chapter": 1,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:8abff912866c6ae0",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "TA-C01-vanakkam",
-      "language": "tamil",
-      "chapter": 1,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:4c4fa4af1fcb85dd",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "TA-C01-vanakkam-family-register",
-      "language": "tamil",
-      "chapter": 1,
-      "sequence": null,
+      "sequence": 220,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -32455,7 +32424,43 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:22c3d53d824d6cd4"
+      "sourceHash": "fnv1a64:7aaa8c8d3e80fe76"
+    },
+    {
+      "id": "TA-C01-answering",
+      "language": "tamil",
+      "chapter": 1,
+      "sequence": 230,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a0ce2d20f0c139e8"
+    },
+    {
+      "id": "TA-C01-practice",
+      "language": "tamil",
+      "chapter": 1,
+      "sequence": 240,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:de8fee8d6b42c1e3"
     },
     {
       "id": "TA-C02-en",

--- a/code/learning/human-languages/tamil/curriculum.json
+++ b/code/learning/human-languages/tamil/curriculum.json
@@ -73,7 +73,8 @@
       "id": "TA-PATH-006",
       "spine_node": "SPINE-RESPOND-BASIC",
       "lessons": [
-        "TA-C01-sari"
+        "TA-C01-sari",
+        "TA-C01-answering"
       ],
       "before": [],
       "inline": [],
@@ -515,9 +516,7 @@
         "TA-PATH-004",
         "TA-PATH-006"
       ],
-      "omits": [
-        "RESPONSE-YESNO"
-      ],
+      "omits": [],
       "relocates": {}
     },
     "SPINE-EXCHANGE-NAMES": {

--- a/code/learning/human-languages/tamil/lessons/TA-C01-aam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-aam.md
@@ -1,62 +1,44 @@
 ---
 id: TA-C01-aam
+sequence: 180
 chapter: 1
 type: word
 headword: ஆம்
 gloss: yes (ām)
 concept_tag: RESPONSE-YES
-prerequisites: [TA-C01-vanakkam-family-register]
+prerequisites: [TA-C01-vanakkam]
 sounds: [independent-vowel-aa, matra-vs-independent]
 roots: [ām]
-est_minutes: 3
-reviews_of: [TA-C01-vanakkam-family-register, TA-C01-vanakkam, TA-C01-nandri]
+est_minutes: 1
+reviews_of: [TA-C01-vanakkam]
 ---
 
 # ஆம் (ām) — "yes"
 
 ## Warm-up
 
-[PAUSE 2s] A two-letter word, and your first look at how Tamil writes a vowel
-that stands on its own.
+[PAUSE 2s] The plain yes. One word, and then we will put these together.
 
-## The letters in this word
+## The word
 
-*(Skim if you read Tamil.)*
+**ஆம்** — *ām* — **"yes."**
 
-- **ஆ** = **"ā"** (a long "aa"). When a word **starts** with a vowel, Tamil
-  uses a full **independent vowel letter** like this — not the little vowel
-  *sign* you hook onto a consonant. (Compare: the "i" hooked onto **ற** to make
-  **றி** last lesson; here the vowel leads, so it gets its own full letter.)
-- **ம்** = "m," with the **puḷḷi** dot removing its built-in *a* — the same
-  bare *m* that ended *vaṇakkam*.
+One beat, with a long opening *aa*.
 
-Left to right: **ஆ · ம்** = *ā-m* →
+Stretch it and you get **ஆமாம்** (*āmām*) — "yes, indeed; that's right." Tamil
+doubles words for warmth and certainty, the way *sari sari* does.
 
-> **ஆம்** = **ām** = "yes."
-
-## The word, taken apart
-
-**ஆம்** (*ām*) is the plain "yes." Stretch it for emphasis and you get
-**ஆமாம்** (*āmām*) — "yes, indeed / that's right," a doubling-up that Tamil
-loves for warmth and certainty.
-
-## Grammar Lens: Tamil often answers by echoing the verb
-
-*ām* exists, but Tamil speakers frequently say "yes" by **repeating the verb**
-of the question instead. Asked *"vandāyā?"* ("did you come?"), a natural yes is
-*"vandēn"* ("I came"). English leans on a single all-purpose *yes*; Tamil often
-answers with the action itself. Bank *ām* as the simple word, and don't be
-surprised when a "yes" comes back as a whole verb.
+> *Ām* is a worn-down form of *āgum*, "it becomes, it will be" — a yes that
+> started life as a verb, which is a very Tamil way to agree.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: ā · m → "ām"]
-- [YOU SAY: the emphatic "āmām" — "yes, indeed"]
-- [YOU SAY: why ஆ is a *full* letter here (the word starts with the vowel)]
+- [YOU SAY: "ām" — one long *aa*, closed on the *m*]
+- [YOU SAY: "āmām" — the emphatic double]
+- [YOU SAY: "ām" then "sari" — yes, and alright]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Read **ஆம்**. Why is **ஆ** a full vowel letter rather than a vowel
-sign? (The word begins with the vowel — nothing to hook onto.) What's the
-emphatic "yes"? (*āmām*.)
+[PAUSE 3s] Say **ஆம்**. What does **ஆமாம்** add? (**Emphasis** — "yes,
+indeed.") Next: the word for no.

--- a/code/learning/human-languages/tamil/lessons/TA-C01-answering.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-answering.md
@@ -1,0 +1,71 @@
+---
+id: TA-C01-answering
+sequence: 230
+chapter: 1
+type: phrase
+headword: ஆம் / இல்லை / சரி
+gloss: answering in Tamil — the five words in use, and the two habits behind them
+concept_tag: RESPONSE-YESNO
+prerequisites: [TA-C01-sari, TA-C01-nandri, TA-C01-illai, TA-C01-aam, TA-C01-vanakkam]
+sounds: []
+roots: []
+est_minutes: 2
+reviews_of: [TA-C01-sari, TA-C01-nandri, TA-C01-illai, TA-C01-aam, TA-C01-vanakkam]
+---
+
+# Putting the five together — how Tamil answers
+
+## Warm-up
+
+[PAUSE 2s] Five words, one at a time. Now they go into a conversation, and two
+habits show up that English does not have.
+
+## Using them
+
+A whole exchange, built only from the five words:
+
+> — **வணக்கம்.** — **வணக்கம்.**
+> — **சரி?** — **ஆம்.**
+> — **நன்றி.** — **சரி.**
+>
+> *— Hello. — Hello.*
+> *— Alright? — Yes.*
+> *— Thank you. — Alright.*
+
+Every reply is one word. Tamil is comfortable with that in a way English is not.
+
+## Grammar Lens: two habits behind the answers
+
+**One — Tamil often answers by echoing the verb.**
+
+*Ām* is correct, but a speaker will often say yes by **repeating the verb of the
+question**. Asked "did you come?", a natural yes is *vandēṉ* — "I came." Keep
+*ām* as your word, and expect a yes to come back as a whole verb.
+
+**Two — Tamil negates by *being*, not with a "not"-word.**
+
+English makes a sentence negative by inserting *not*. Tamil swaps in the
+negative verb of existence:
+
+| | |
+|---|---|
+| *puttakam **uṇḍu*** | "there **is** a book" |
+| *puttakam **illai*** | "there **is not** a book" |
+
+So *illai* does double duty: alone it is the everyday **no**; inside a sentence
+it is what makes the whole thing negative. Learn it as *is not* and both uses
+fall out.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the exchange above, both parts]
+- [YOU HEAR: "puttakam uṇḍu" … "puttakam illai" — only the last word changed]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Give a one-word reply to *sari?* and to *naṉṟi*. (**ām** / **sari**.)
+Besides *ām*, what else is a natural yes? (**Repeating the verb**.) What does
+*illai* do inside a sentence? (**Makes it negative** — it is the "is not"
+verb.) Next: the chapter's own
+recap, and then names.

--- a/code/learning/human-languages/tamil/lessons/TA-C01-illai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-illai.md
@@ -1,5 +1,6 @@
 ---
 id: TA-C01-illai
+sequence: 190
 chapter: 1
 type: word
 headword: இல்லை
@@ -8,66 +9,38 @@ concept_tag: RESPONSE-NO
 prerequisites: [TA-C01-aam]
 sounds: [independent-vowel-i, matra-ai, pulli-virama]
 roots: [il]
-est_minutes: 4
-reviews_of: [TA-C01-aam, TA-C01-vanakkam]
+est_minutes: 1
+reviews_of: [TA-C01-aam]
 ---
 
-# இல்லை (illai) — "no," and how Tamil says a thing is *not*
+# இல்லை (illai) — "no"
 
 ## Warm-up
 
-[PAUSE 2s] The partner of *ām*. But where English "no" is a small flat word,
-Tamil's *illai* is really a tiny verb meaning **"it is not / there is not"** —
-and that's a window into how the language thinks.
+[PAUSE 2s] The other half of the pair. One word, and then the lesson that puts
+all five together.
 
-## The letters in this word
+## The word
 
-*(Skim if you read Tamil.)*
+**இல்லை** — *illai* — **"no."**
 
-- **இ** = **"i"** — an **independent vowel** (the word starts with it, so it
-  gets a full letter, exactly like **ஆ** in *ām*).
-- **ல்** = "l," with the **puḷḷi** dot removing its vowel → bare *l*.
-- **லை** = "lai" — the consonant **ல** (la) carrying the **vowel sign ை**,
-  which makes **"ai."**
+Two beats: *il-lai*, with the *l* held across the join.
 
-Left to right: **இ · ல் · லை** = *i-l-lai* →
+On its own it is the everyday **no**. But it is not really the adjective "no" —
+it is a small statement meaning **"is not."** That will matter when we put the
+five words together.
 
-> **இல்லை** = **illai**
-
-(Notice **ல் + லை** — a bare *l* leaning into *lai*, giving the doubled "ll.")
-
-## The word, taken apart
-
-**இல்லை** (*illai*) is built on the root **இல்** (*il*), the idea of
-**"not-being, absence."** So *illai* is not really the adjective "no" — it is
-the statement **"[it] is not," "[there] is not."** Its positive twin is
-**உண்டு** (*uṇḍu*), "there is."
-
-## Grammar Lens: Tamil negates by *being*, not by a "not"-word
-
-English changes a sentence to negative by inserting *not* / *no*: "there **is**
-a book" → "there is **no** book." Tamil instead swaps in the **negative verb of
-existence**:
-
-- *puttakam **uṇḍu*** — "there **is** a book."
-- *puttakam **illai*** — "there **is not** a book."
-
-So *illai* does double duty: on its own it's the everyday **"no,"** and inside
-a sentence it's the word that makes the whole thing negative. Learn it as "is
-not," and both uses fall out naturally. (This — negation carried by a special
-verb rather than a particle — is a deeply Dravidian habit, quite unlike
-English or Hindi.)
+> Its root is *il*, the idea of *not-being*. Its positive twin is *uṇḍu*,
+> "there is."
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: i · l · lai → "illai"]
-- [YOU SAY: the pair — *ām* ("yes") / *illai* ("no")]
-- [YOU SAY: "puttakam illai" — "there is no book"]
+- [YOU SAY: "illai" — two beats, the *l* held across the join]
+- [YOU SAY: the pair — "ām" … "illai"]
+- [YOU SAY: it alone, as a complete answer]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Read **இல்லை**. Literally, is it closer to "no" or to "is not"?
-("Is not / there is not.") What is its positive twin? (*uṇḍu*, "there is.") How
-does Tamil make a sentence negative — with a particle like English *not*, or by
-swapping in a negative verb? (A negative verb.)
+[PAUSE 3s] Say **இல்லை**. Is it closer to English *no*, or to *is not*?
+(**Is not** — it is a statement, not a label.) Next: the word for thank you.

--- a/code/learning/human-languages/tamil/lessons/TA-C01-nandri-family-register.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-nandri-family-register.md
@@ -1,5 +1,6 @@
 ---
 id: TA-C01-nandri-family-register
+sequence: 210
 chapter: 1
 type: etymology
 headword: நன்றி / നന്ദി

--- a/code/learning/human-languages/tamil/lessons/TA-C01-nandri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-nandri.md
@@ -1,76 +1,46 @@
 ---
 id: TA-C01-nandri
+sequence: 200
 chapter: 1
 type: word
 headword: நன்றி
 gloss: thank you (naṉṟi — "goodness, gratitude")
 concept_tag: COURTESY-THANKS
-prerequisites: [TA-C01-vanakkam-family-register]
+prerequisites: [TA-C01-illai]
 sounds: [dental-vs-alveolar-vs-retroflex-n, matra-i]
 roots: [nal]
-est_minutes: 4
-reviews_of: [TA-C01-vanakkam-family-register, TA-C01-vanakkam]
+est_minutes: 1
+reviews_of: [TA-C01-illai]
 ---
 
-# நன்றி (naṉṟi) — "thank you," literally "goodness"
+# நன்றி (naṉṟi) — "thank you"
 
 ## Warm-up
 
-[PAUSE 2s] The word for gratitude — and the doorway to one of Tamil's most
-famous features: it hears differences between sounds English throws into one
-bin.
+[PAUSE 2s] One word again. This is the one you will reach for second-most, and
+Tamil says it with a noun rather than a verb.
 
-## The letters in this word
+## The word
 
-*(Skim if you read Tamil.)* Three consonants and a vowel sign:
+**நன்றி** — *naṉṟi* — **"thank you."**
 
-- **ந** = "na" — a **dental** *n* (tongue on the teeth, like the *n* in
-  Spanish *nada*).
-- **ன்** = "ṉ" — a **different** *n*, **alveolar** (tongue on the ridge just
-  behind the teeth), with a **puḷḷi** dot killing its vowel.
-- **ற** = "ṟa" — a hard *r*/*ṟ* sound made with a tap further back.
-- **ி** is a **vowel sign** that changes the built-in *a* to **"i"**:
-  **ற + ி → றி** = "ṟi."
+Two beats: *naṉ-ṟi*. The *ṉ* and the *ṟ* are both made further back than English
+*n* and *r*; copy the sound rather than the spelling.
 
-Left to right: **ந · ன் · றி** = *na-ṉ-ṟi* →
+It works on its own, with no verb around it. Someone hands you something; you
+say *naṉṟi*, and that is a whole sentence.
 
-> **நன்றி** = **naṉṟi**
-
-## The word, taken apart
-
-**நன்றி** (*naṉṟi*) grows from the root **நல் / நன்** (*nal / naṉ*), "good,
-goodness" — the same root inside *nanmai* ("good deed"), *nallavan* ("a good
-man"). So *naṉṟi* is literally **"goodness"**, and to say it is to name the
-good someone has done you. Gratitude, in Tamil, is just "the good [you did]."
-
-## Grammar Lens: Tamil hears three of every *n*, *l*, and *r*
-
-You met **ந** (dental na), **ன** (alveolar ṉa), and last lesson **ண**
-(retroflex ṇa) — **three** *n*-letters, for three tongue positions:
-
-| Letter | Sound | Tongue |
-|---|---|---|
-| **ந** | dental *n* | on the teeth |
-| **ன** | alveolar *ṉ* | on the ridge behind the teeth |
-| **ண** | retroflex *ṇ* | curled back to the roof |
-
-Tamil does the same for *l* (**ல ள ழ**) and *r* (**ர ற**). English fuses all
-these into single letters and never notices; Tamil keeps them distinct, and
-they **change meaning** — so learning to hear them is learning to read. Don't
-drill the whole set now; just know the differences are real and will return
-word by word.
+> Its root is *nal*, "good" — the same *nal-* inside *nalla* ("good") and
+> *nanmai* ("a good deed"). Saying *naṉṟi* names the good someone did you.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: na · ṉ · ṟi → "naṉṟi"]
-- [YOU SAY: the three *n*'s — ந (teeth), ன (ridge), ண (curled back)]
-- [YOU SAY: "nal — good; naṉṟi — the good you did"]
+- [YOU SAY: "naṉṟi" — two beats, both consonants far back]
+- [YOU SAY: "vaṇakkam" then "naṉṟi" — greeting, then thanks]
+- [YOU SAY: it on its own, with nothing around it]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Read **நன்றி**. What does it literally mean, and from what root?
-("Goodness," from *nal* "good.") How many distinct *n*-sounds does Tamil write,
-and what tells them apart? (Three — dental, alveolar, retroflex — by tongue
-position.) Next: compare the gratitude word across the family and choose its
-register.
+[PAUSE 3s] Say **நன்றி**. Does it need a verb to be a complete reply? (**No** —
+it stands alone.) Next: how thanks travels across the family.

--- a/code/learning/human-languages/tamil/lessons/TA-C01-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-practice.md
@@ -1,15 +1,16 @@
 ---
 id: TA-C01-practice
+sequence: 240
 chapter: 1
 type: practice
 headword: (recap)
 gloss: Chapter 1 recap + the Tamil farewell
 concept_tag: REVIEW
-prerequisites: [TA-C01-vanakkam-family-register, TA-C01-nandri-family-register, TA-C01-aam, TA-C01-illai, TA-C01-sari]
+prerequisites: [TA-C01-answering, TA-C01-vanakkam-family-register, TA-C01-nandri-family-register, TA-C01-aam, TA-C01-illai, TA-C01-sari]
 sounds: []
 roots: []
 est_minutes: 4
-reviews_of: [TA-C01-vanakkam-family-register, TA-C01-nandri-family-register, TA-C01-vanakkam, TA-C01-nandri, TA-C01-aam, TA-C01-illai, TA-C01-sari]
+reviews_of: [TA-C01-answering, TA-C01-vanakkam-family-register, TA-C01-nandri-family-register, TA-C01-vanakkam, TA-C01-nandri, TA-C01-aam, TA-C01-illai, TA-C01-sari]
 ---
 
 # Chapter 1 — recap, and how Tamil says goodbye

--- a/code/learning/human-languages/tamil/lessons/TA-C01-sari.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-sari.md
@@ -1,67 +1,44 @@
 ---
 id: TA-C01-sari
+sequence: 220
 chapter: 1
 type: word
 headword: சரி
 gloss: okay / alright / correct (sari)
 concept_tag: RESPONSE-OKAY
-prerequisites: [TA-C01-aam]
+prerequisites: [TA-C01-nandri]
 sounds: [c-sa-one-letter, matra-i]
 roots: [sari]
-est_minutes: 3
-reviews_of: [TA-C01-aam, TA-C01-illai]
+est_minutes: 1
+reviews_of: [TA-C01-nandri]
 ---
 
-# சரி (sari) — "okay," the word that oils every conversation
+# சரி (sari) — "okay"
 
 ## Warm-up
 
-[PAUSE 2s] If *ām* is "yes" and *illai* is "no," *sari* is the easy middle:
-"okay, alright, fine, agreed." You'll hear it constantly — and it hides a neat
-fact about the Tamil alphabet.
+[PAUSE 2s] The most useful small word in the language, and the easiest to say.
 
-## The letters in this word
+## The word
 
-*(Skim if you read Tamil.)*
+**சரி** — *sari* — **"okay, alright, correct."**
 
-- **ச** = "sa" (here) — but this **one letter** also does the job of English
-  *s*, *ch*, and *j*: at the start of a word it's often "sa," between vowels it
-  softens. Tamil simply doesn't give voiced/unvoiced or *s*/*ch* their own
-  separate letters — **context** decides the sound. (You saw the same economy
-  with **க**, which can be *k*, *g*, or *h* depending on where it sits.)
-- **ரி** = "ri" — the consonant **ர** (ra) carrying the **vowel sign ி** for
-  "i."
+Two beats: *sa-ri*.
 
-Left to right: **ச · ரி** = *sa-ri* →
+It is the verbal nod of Tamil. Someone proposes a plan and the whole reply is
+one warm *sari*. Doubled — *sari, sari* — it means "yes yes, fine, go on."
 
-> **சரி** = **sari** = "okay / correct."
-
-## The word, taken apart
-
-**சரி** (*sari*) is the native Tamil word for **"correct, even, level,"** and
-by an easy hop, **"okay, agreed."** It is the verbal nod of the language:
-propose a plan and the reply is a single warm *"sari."* Repeat it — *"sari,
-sari"* — and it means "yes yes, alright, enough said."
-
-## Grammar Lens: one letter, several sounds
-
-English mostly gives each sound its own letter; Tamil does the opposite for its
-stop-consonants — **one** letter per position of the mouth, and the voicing
-(*k* vs *g*, *s* vs *ch*) is filled in by rules of position. That's why a
-learner can't always *predict* the exact sound from the letter alone at first —
-but it also means Tamil has a strikingly **small** alphabet for the sounds it
-covers. You'll pick up the position-rules by ear, word by word.
+> It began as "correct, even, level," and slid from *that is right* to *alright*
+> the way English *right* did.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: sa · ri → "sari"]
-- [YOU SAY: the everyday triple — *ām* (yes) · *illai* (no) · *sari* (okay)]
-- [YOU SAY: "sari, sari" — "alright, alright"]
+- [YOU SAY: "sari"]
+- [YOU SAY: "sari, sari" — the doubled, hurry-along version]
+- [YOU SAY: agree to something with nothing but this word]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Read **சரி**. What does it literally mean, and what does it do in
-conversation? ("Correct/even" → "okay, agreed.") Why can't you always predict
-whether **ச** is "sa" or "cha"? (Tamil uses one letter per mouth-position; the
-exact sound depends on where it sits in the word.)
+[PAUSE 3s] Say **சரி**. What does doubling it add? (**Hurry, or easy
+agreement** — "yes yes, fine.") Next: putting the five together.

--- a/code/learning/human-languages/tamil/lessons/TA-C01-vanakkam-family-register.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-vanakkam-family-register.md
@@ -1,5 +1,6 @@
 ---
 id: TA-C01-vanakkam-family-register
+sequence: 20
 chapter: 1
 type: etymology
 headword: வணக்கம் / நமஸ்காரம்

--- a/code/learning/human-languages/tamil/lessons/TA-C01-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-vanakkam.md
@@ -1,5 +1,6 @@
 ---
 id: TA-C01-vanakkam
+sequence: 10
 chapter: 1
 type: word
 headword: வணக்கம்
@@ -8,63 +9,39 @@ concept_tag: GREETING-HELLO
 prerequisites: []
 sounds: [tamil-inherent-a, pulli-virama, retroflex-n]
 roots: [vaṇaṅku]
-est_minutes: 4
+est_minutes: 1
 reviews_of: []
 ---
 
-# வணக்கம் (vaṇakkam) — "greetings," a small act of respect
+# வணக்கம் (vaṇakkam) — "greetings"
 
 ## Warm-up
 
-[PAUSE 2s] The first Tamil word, and the one you'll use most. Like *namaste*,
-it is literally a gesture of respect turned into a word. You'll learn to
-*read* it and to understand it in the same breath.
+[PAUSE 2s] The first Tamil word, and the one you will use most. One word, one
+lesson. Say it, and you have greeted someone.
 
-## The letters in this word
+## The word
 
-*(If you already read Tamil, skim this — it's here so the book needs no prior
-knowledge.)* Tamil is written **left to right**, and — like the Indian scripts
-generally — every consonant carries a **built-in "a"** unless something removes
-it.
+**வணக்கம்** — *vaṇakkam* — **"greetings."**
 
-- **வ** = "va" · **க** = "ka" · **ம** = "ma" — each consonant with its built-in
-  *a*.
-- **ண** = "ṇa" — a **retroflex** *n*, made with the tongue curled back to the
-  roof of the mouth. Tamil keeps several *n*-sounds and several *l*-sounds
-  apart; this is the curled-back one. (More on that next lesson.)
-- **க்** — the dot on top (called a **puḷḷi**) **kills the built-in vowel**,
-  leaving a bare "k." So the double **க்க** is "k-ka" = a held "kk."
+Say it *va-ṇak-kam*, with the *kk* held a beat longer than a single *k*.
 
-Put them in order, left to right: **வ · ண · க் · க · ம்** = *va-ṇa-k-ka-m* →
+It is what you say walking into a room, answering a phone, or meeting anyone at
+all. It does not change for morning or evening, and it does not change for one
+person or many.
 
-> **வணக்கம்** = **vaṇakkam**
-
-You just read Tamil. Two facts did most of it: consonants carry *a*, and a
-**puḷḷi** dot removes it.
-
-## The word, taken apart
-
-**வணக்கம்** (*vaṇakkam*) comes from the verb **வணங்கு** (*vaṇaṅku*), "to bow,
-to bend, to pay homage." Add the ending that turns a verb into a noun of the
-action, and you get *vaṇakkam* = **"a bowing, an act of reverence"** — the
-same idea as Sanskrit *namaste* ("I bow to you"), but built from a **native
-Tamil** root, not a borrowed one.
-
-That last point is the whole personality of Tamil: it is an old language proud
-of its own word-stock, and it often keeps a home-grown word where its
-neighbours reached for Sanskrit.
+> Its root is the verb *vaṇaṅku*, "to bow." *Vaṇakkam* is the act of bowing,
+> turned into a word — and it is native Tamil, not borrowed from Sanskrit.
 
 ## Guided Practice
 
 [PAUSE 1s]
-- [YOU SAY: read it left to right — va · ṇa · k · ka · m → "vaṇakkam"]
-- [YOU SAY: what the *puḷḷi* dot on க் does (kills its vowel: ka → k)]
-- [YOU SAY: "vaṇaṅku — to bow; vaṇakkam — an act of reverence"]
+- [YOU SAY: "vaṇakkam" — hold the *kk*]
+- [YOU SAY: it to someone arriving]
+- [YOU SAY: it to someone leaving — the same word does both]
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Read **வணக்கம்**. What verb is it built from, and what does that
-verb mean? (*vaṇaṅku*, "to bow / pay homage.") What does a **puḷḷi** do to a
-consonant? (Removes its built-in *a*.) Is the root borrowed from Sanskrit?
-(**No** — it is native Tamil.) Next: compare that native greeting across the
-family and learn where it fits.
+[PAUSE 3s] Say **வணக்கம்**. Does it change between morning and evening?
+(**No** — one greeting, all day.) Does it change for one person or a crowd?
+(**No**.) Next: the same greeting across the Dravidian family.

--- a/code/learning/human-languages/tamil/narration/ch01.json
+++ b/code/learning/human-languages/tamil/narration/ch01.json
@@ -3,9 +3,256 @@
   "language": "tamil",
   "chapter": 1,
   "title": "Greetings",
-  "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:fe3d3298ecc5bc3a",
+  "drivablePrefix": 2,
+  "sourceHash": "fnv1a64:cd6ee126f13c74e3",
   "lessons": [
+    {
+      "id": "TA-C01-vanakkam",
+      "sequence": 10,
+      "title": "வணக்கம் (vaṇakkam) — \"greetings\"",
+      "headword": "வணக்கம்",
+      "romanization": "",
+      "gloss": "hello / greetings (vaṇakkam — \"reverence, homage\")",
+      "script": "tamil",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:017a3556c7283313",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The first Tamil word, and the one you will use most. One word, one lesson. Say it, and you have greeted someone."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "வணக்கம் — vaṇakkam — \"greetings.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Say it va-ṇak-kam, with the kk held a beat longer than a single k."
+            },
+            {
+              "kind": "speech",
+              "text": "It is what you say walking into a room, answering a phone, or meeting anyone at all. It does not change for morning or evening, and it does not change for one person or many."
+            },
+            {
+              "kind": "speech",
+              "text": "Its root is the verb vaṇaṅku, \"to bow.\" Vaṇakkam is the act of bowing, turned into a word — and it is native Tamil, not borrowed from Sanskrit."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"vaṇakkam\" — hold the kk",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"vaṇakkam\" — hold the *kk*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "it to someone arriving",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: it to someone arriving]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "it to someone leaving — the same word does both",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: it to someone leaving — the same word does both]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say வணக்கம் (vaṇakkam). Does it change between morning and evening? (No — one greeting, all day.) Does it change for one person or a crowd? (No.) Next: the same greeting across the Dravidian family."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C01-vanakkam-family-register",
+      "sequence": 20,
+      "title": "வணக்கம் (vaṇakkam) — one bow, two lexical loyalties",
+      "headword": "வணக்கம் / நமஸ்காரம்",
+      "romanization": "",
+      "gloss": "Tamil kept a native bow-word where its neighbors borrowed Sanskrit, and uses it across settings",
+      "script": "tamil",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:ad7b57e45071d385",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Vaṇakkam names a bow. Neighboring languages name the same gesture with a different inherited or borrowed root."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "Across the family",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "Language",
+                "\"Hello\"",
+                "Source"
+              ],
+              "columns": 3,
+              "rowCount": 6,
+              "utterances": [
+                "Language: Tamil. \"Hello\": vaṇakkam. Source: native Dravidian vaṇaṅku.",
+                "Language: Kannada. \"Hello\": namaskāra. Source: Sanskrit.",
+                "Language: Telugu. \"Hello\": namaskāram. Source: Sanskrit.",
+                "Language: Malayalam. \"Hello\": namaskāram. Source: Sanskrit.",
+                "Language: Hindi. \"Hello\": namaste. Source: Sanskrit.",
+                "Language: English. \"Hello\": hello. Source: Germanic hailing-call."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Four tracks use Sanskrit namas-, \"bow.\" Tamil kept its own verb. The gesture and social meaning match; the lexical loyalty differs."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "unknown",
+          "title": "Where the word fits",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Say vaṇakkam with pressed palms or a small head-bow: the gesture is the word. It works as hello and goodbye, at any time, to almost anyone. It is respectful without being stiff; cinema and formal speech can also use it as a ringing one-word salutation to a whole room."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"vaṇakkam\" with a small bow",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"vaṇakkam\" with a small bow]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "Tamil vaṇaṅku, neighbors Sanskrit namas-",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: Tamil *vaṇaṅku* · neighbors Sanskrit *namas-*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CHOOSE",
+              "instruction": "greeting or parting becomes வணக்கம் (vaṇakkam) works",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CHOOSE: greeting or parting → **வணக்கம்** works]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Which Dravidian language kept its native bow-word? (Tamil.) What did the neighbors borrow? (Sanskrit namas-.) Can vaṇakkam greet and part? (Yes — it is an all-day respectful salutation.)"
+            }
+          ]
+        }
+      ]
+    },
     {
       "id": "TA-W01-curves-va-ka",
       "sequence": 100,
@@ -1341,30 +1588,19 @@
     },
     {
       "id": "TA-C01-aam",
-      "sequence": null,
+      "sequence": 180,
       "title": "ஆம் (ām) — \"yes\"",
       "headword": "ஆம்",
       "romanization": "",
       "gloss": "yes (ām)",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block",
-        "sight-cue"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5971b60f9445ebba",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page",
-          "your eyes, because the lesson points at something written down"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:33b4b0ca5bf90f6f",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -1379,61 +1615,35 @@
             },
             {
               "kind": "speech",
-              "text": "A two-letter word, and your first look at how Tamil writes a vowel that stands on its own."
+              "text": "The plain yes. One word, and then we will put these together."
             }
           ]
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
+          "type": "unknown",
+          "title": "The word",
           "segments": [
             {
               "kind": "speech",
-              "text": "(Skim if you read Tamil.)"
+              "text": "ஆம் — ām — \"yes.\""
             },
             {
               "kind": "speech",
-              "text": "ஆ = \"ā\" (a long \"aa\"). When a word starts with a vowel, Tamil uses a full independent vowel letter like this — not the little vowel sign you hook onto a consonant. (Compare: the \"i\" hooked onto ற to make றி last lesson; here the vowel leads, so it gets its own full letter.)"
+              "text": "One beat, with a long opening aa."
             },
             {
               "kind": "speech",
-              "text": "ம் = \"m,\" with the puḷḷi dot removing its built-in a — the same bare m that ended vaṇakkam."
+              "text": "Stretch it and you get ஆமாம் (āmām) — \"yes, indeed; that's right.\" Tamil doubles words for warmth and certainty, the way sari sari does."
             },
             {
               "kind": "speech",
-              "text": "Left to right: ஆ, ம் = ā-m, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "ஆம் = ām = \"yes.\""
+              "text": "Ām is a worn-down form of āgum, \"it becomes, it will be\" — a yes that started life as a verb, which is a very Tamil way to agree."
             }
           ]
         },
         {
           "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ஆம் (ām) is the plain \"yes.\" Stretch it for emphasis and you get ஆமாம் (āmām) — \"yes, indeed / that's right,\" a doubling-up that Tamil loves for warmth and certainty."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: Tamil often answers by echoing the verb",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ām exists, but Tamil speakers frequently say \"yes\" by repeating the verb of the question instead. Asked \"vandāyā?\" (\"did you come?\"), a natural yes is \"vandēn\" (\"I came\"). English leans on a single all-purpose yes; Tamil often answers with the action itself. Bank ām as the simple word, and don't be surprised when a \"yes\" comes back as a whole verb."
-            }
-          ]
-        },
-        {
-          "index": 4,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -1446,34 +1656,34 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "ā, m becomes \"ām\"",
+              "instruction": "\"ām\" — one long aa, closed on the m",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: ā · m → \"ām\"]"
+              "source": "[YOU SAY: \"ām\" — one long *aa*, closed on the *m*]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the emphatic \"āmām\" — \"yes, indeed\"",
+              "instruction": "\"āmām\" — the emphatic double",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the emphatic \"āmām\" — \"yes, indeed\"]"
+              "source": "[YOU SAY: \"āmām\" — the emphatic double]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "why ஆ is a full letter here (the word starts with the vowel)",
+              "instruction": "\"ām\" then \"sari\" — yes, and alright",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: why ஆ is a *full* letter here (the word starts with the vowel)]"
+              "source": "[YOU SAY: \"ām\" then \"sari\" — yes, and alright]"
             }
           ]
         },
         {
-          "index": 5,
+          "index": 3,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -1485,7 +1695,7 @@
             },
             {
               "kind": "speech",
-              "text": "Read ஆம். Why is ஆ a full vowel letter rather than a vowel sign? (The word begins with the vowel — nothing to hook onto.) What's the emphatic \"yes\"? (āmām.)"
+              "text": "Say ஆம். What does ஆமாம் add? (Emphasis — \"yes, indeed.\") Next: the word for no."
             }
           ]
         }
@@ -1493,28 +1703,19 @@
     },
     {
       "id": "TA-C01-illai",
-      "sequence": null,
-      "title": "இல்லை (illai) — \"no,\" and how Tamil says a thing is not",
+      "sequence": 190,
+      "title": "இல்லை (illai) — \"no\"",
       "headword": "இல்லை",
       "romanization": "",
       "gloss": "no / there isn't (illai — the negative)",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:eb7d4be5afd2b4a8",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:93b6d60e45822e82",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -1529,81 +1730,35 @@
             },
             {
               "kind": "speech",
-              "text": "The partner of ām. But where English \"no\" is a small flat word, Tamil's illai is really a tiny verb meaning \"it is not / there is not\" — and that's a window into how the language thinks."
+              "text": "The other half of the pair. One word, and then the lesson that puts all five together."
             }
           ]
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
+          "type": "unknown",
+          "title": "The word",
           "segments": [
             {
               "kind": "speech",
-              "text": "(Skim if you read Tamil.)"
+              "text": "இல்லை — illai — \"no.\""
             },
             {
               "kind": "speech",
-              "text": "இ = \"i\" — an independent vowel (the word starts with it, so it gets a full letter, exactly like ஆ in ām)."
+              "text": "Two beats: il-lai, with the l held across the join."
             },
             {
               "kind": "speech",
-              "text": "ல் = \"l,\" with the puḷḷi dot removing its vowel becomes bare l."
+              "text": "On its own it is the everyday no. But it is not really the adjective \"no\" — it is a small statement meaning \"is not.\" That will matter when we put the five words together."
             },
             {
               "kind": "speech",
-              "text": "லை = \"lai\" — the consonant ல (la) carrying the vowel sign ை, which makes \"ai.\""
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: இ, ல், லை = i-l-lai, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "இல்லை = illai."
-            },
-            {
-              "kind": "speech",
-              "text": "(Notice ல் + லை — a bare l leaning into lai, giving the doubled \"ll.\")"
+              "text": "Its root is il, the idea of not-being. Its positive twin is uṇḍu, \"there is.\""
             }
           ]
         },
         {
           "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "இல்லை (illai) is built on the root இல் (il), the idea of \"not-being, absence.\" So illai is not really the adjective \"no\" — it is the statement \"[it] is not,\" \"[there] is not.\" Its positive twin is உண்டு (uṇḍu), \"there is.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: Tamil negates by being, not by a \"not\"-word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "English changes a sentence to negative by inserting not / no: \"there is a book\" becomes \"there is no book.\" Tamil instead swaps in the negative verb of existence:"
-            },
-            {
-              "kind": "speech",
-              "text": "puttakam uṇḍu — \"there is a book.\""
-            },
-            {
-              "kind": "speech",
-              "text": "puttakam illai — \"there is not a book.\""
-            },
-            {
-              "kind": "speech",
-              "text": "So illai does double duty: on its own it's the everyday \"no,\" and inside a sentence it's the word that makes the whole thing negative. Learn it as \"is not,\" and both uses fall out naturally. (This — negation carried by a special verb rather than a particle — is a deeply Dravidian habit, quite unlike English or Hindi.)"
-            }
-          ]
-        },
-        {
-          "index": 4,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -1616,34 +1771,34 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "i, l, lai becomes \"illai\"",
+              "instruction": "\"illai\" — two beats, the l held across the join",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: i · l · lai → \"illai\"]"
+              "source": "[YOU SAY: \"illai\" — two beats, the *l* held across the join]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the pair — ām (\"yes\") / illai (\"no\")",
+              "instruction": "the pair — \"ām\" … \"illai\"",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the pair — *ām* (\"yes\") / *illai* (\"no\")]"
+              "source": "[YOU SAY: the pair — \"ām\" … \"illai\"]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"puttakam illai\" — \"there is no book\"",
+              "instruction": "it alone, as a complete answer",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"puttakam illai\" — \"there is no book\"]"
+              "source": "[YOU SAY: it alone, as a complete answer]"
             }
           ]
         },
         {
-          "index": 5,
+          "index": 3,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -1655,7 +1810,7 @@
             },
             {
               "kind": "speech",
-              "text": "Read இல்லை. Literally, is it closer to \"no\" or to \"is not\"? (\"Is not / there is not.\") What is its positive twin? (uṇḍu, \"there is.\") How does Tamil make a sentence negative — with a particle like English not, or by swapping in a negative verb? (A negative verb.)"
+              "text": "Say இல்லை. Is it closer to English no, or to is not? (Is not — it is a statement, not a label.) Next: the word for thank you."
             }
           ]
         }
@@ -1663,28 +1818,19 @@
     },
     {
       "id": "TA-C01-nandri",
-      "sequence": null,
-      "title": "நன்றி (naṉṟi) — \"thank you,\" literally \"goodness\"",
+      "sequence": 200,
+      "title": "நன்றி (naṉṟi) — \"thank you\"",
       "headword": "நன்றி",
       "romanization": "",
       "gloss": "thank you (naṉṟi — \"goodness, gratitude\")",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e3b598578abbeee7",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:d08803bcdd6448e5",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -1699,88 +1845,35 @@
             },
             {
               "kind": "speech",
-              "text": "The word for gratitude — and the doorway to one of Tamil's most famous features: it hears differences between sounds English throws into one bin."
+              "text": "One word again. This is the one you will reach for second-most, and Tamil says it with a noun rather than a verb."
             }
           ]
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
+          "type": "unknown",
+          "title": "The word",
           "segments": [
             {
               "kind": "speech",
-              "text": "(Skim if you read Tamil.) Three consonants and a vowel sign:"
+              "text": "நன்றி — naṉṟi — \"thank you.\""
             },
             {
               "kind": "speech",
-              "text": "ந = \"na\" — a dental n (tongue on the teeth, like the n in Spanish nada)."
+              "text": "Two beats: naṉ-ṟi. The ṉ and the ṟ are both made further back than English n and r; copy the sound rather than the spelling."
             },
             {
               "kind": "speech",
-              "text": "ன் = \"ṉ\" — a different n, alveolar (tongue on the ridge just behind the teeth), with a puḷḷi dot killing its vowel."
+              "text": "It works on its own, with no verb around it. Someone hands you something; you say naṉṟi, and that is a whole sentence."
             },
             {
               "kind": "speech",
-              "text": "ற = \"ṟa\" — a hard r/ṟ sound made with a tap further back."
-            },
-            {
-              "kind": "speech",
-              "text": "ி is a vowel sign that changes the built-in a to \"i\": ற + ி becomes றி = \"ṟi.\""
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: ந, ன், றி = na-ṉ-ṟi, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "நன்றி = naṉṟi."
+              "text": "Its root is nal, \"good\" — the same nal- inside nalla (\"good\") and nanmai (\"a good deed\"). Saying naṉṟi names the good someone did you."
             }
           ]
         },
         {
           "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "நன்றி (naṉṟi) grows from the root நல் / நன் (nal / naṉ), \"good, goodness\" — the same root inside nanmai (\"good deed\"), nallavan (\"a good man\"). So naṉṟi is literally \"goodness\", and to say it is to name the good someone has done you. Gratitude, in Tamil, is just \"the good [you did].\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: Tamil hears three of every n, l, and r",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "You met ந (dental na), ன (alveolar ṉa), and last lesson ண (retroflex ṇa) — three n-letters, for three tongue positions:"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "Letter",
-                "Sound",
-                "Tongue"
-              ],
-              "columns": 3,
-              "rowCount": 3,
-              "utterances": [
-                "Letter: ந. Sound: dental n. Tongue: on the teeth.",
-                "Letter: ன. Sound: alveolar ṉ. Tongue: on the ridge behind the teeth.",
-                "Letter: ண. Sound: retroflex ṇ. Tongue: curled back to the roof."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Tamil does the same for l (ல ள ழ) and r (ர ற). English fuses all these into single letters and never notices; Tamil keeps them distinct, and they change meaning — so learning to hear them is learning to read. Don't drill the whole set now; just know the differences are real and will return word by word."
-            }
-          ]
-        },
-        {
-          "index": 4,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -1793,34 +1886,34 @@
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "na, ṉ, ṟi becomes \"naṉṟi\"",
+              "instruction": "\"naṉṟi\" — two beats, both consonants far back",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: na · ṉ · ṟi → \"naṉṟi\"]"
+              "source": "[YOU SAY: \"naṉṟi\" — two beats, both consonants far back]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "the three n's — ந (teeth), ன (ridge), ண (curled back)",
+              "instruction": "\"vaṇakkam\" then \"naṉṟi\" — greeting, then thanks",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: the three *n*'s — ந (teeth), ன (ridge), ண (curled back)]"
+              "source": "[YOU SAY: \"vaṇakkam\" then \"naṉṟi\" — greeting, then thanks]"
             },
             {
               "kind": "prompt",
               "action": "SAY",
-              "instruction": "\"nal — good; naṉṟi — the good you did\"",
+              "instruction": "it on its own, with nothing around it",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU SAY: \"nal — good; naṉṟi — the good you did\"]"
+              "source": "[YOU SAY: it on its own, with nothing around it]"
             }
           ]
         },
         {
-          "index": 5,
+          "index": 3,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -1832,7 +1925,7 @@
             },
             {
               "kind": "speech",
-              "text": "Read நன்றி. What does it literally mean, and from what root? (\"Goodness,\" from nal \"good.\") How many distinct n-sounds does Tamil write, and what tells them apart? (Three — dental, alveolar, retroflex — by tongue position.) Next: compare the gratitude word across the family and choose its register."
+              "text": "Say நன்றி. Does it need a verb to be a complete reply? (No — it stands alone.) Next: how thanks travels across the family."
             }
           ]
         }
@@ -1840,7 +1933,7 @@
     },
     {
       "id": "TA-C01-nandri-family-register",
-      "sequence": null,
+      "sequence": 210,
       "title": "நன்றி — a native family word with a register edge",
       "headword": "நன்றி / നന്ദി",
       "romanization": "",
@@ -1851,7 +1944,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:1b71da01982a1c62",
+      "sourceHash": "fnv1a64:df441fa9eb2d1a4a",
       "notice": null,
       "blocks": [
         {
@@ -1974,8 +2067,265 @@
       ]
     },
     {
+      "id": "TA-C01-sari",
+      "sequence": 220,
+      "title": "சரி (sari) — \"okay\"",
+      "headword": "சரி",
+      "romanization": "",
+      "gloss": "okay / alright / correct (sari)",
+      "script": "tamil",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:7aaa8c8d3e80fe76",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The most useful small word in the language, and the easiest to say."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "சரி — sari — \"okay, alright, correct.\""
+            },
+            {
+              "kind": "speech",
+              "text": "Two beats: sa-ri."
+            },
+            {
+              "kind": "speech",
+              "text": "It is the verbal nod of Tamil. Someone proposes a plan and the whole reply is one warm sari. Doubled — sari, sari — it means \"yes yes, fine, go on.\""
+            },
+            {
+              "kind": "speech",
+              "text": "It began as \"correct, even, level,\" and slid from that is right to alright the way English right did."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sari\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sari\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sari, sari\" — the doubled, hurry-along version",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sari, sari\" — the doubled, hurry-along version]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "agree to something with nothing but this word",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: agree to something with nothing but this word]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say சரி. What does doubling it add? (Hurry, or easy agreement — \"yes yes, fine.\") Next: putting the five together."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C01-answering",
+      "sequence": 230,
+      "title": "Putting the five together — how Tamil answers",
+      "headword": "ஆம் / இல்லை / சரி",
+      "romanization": "",
+      "gloss": "answering in Tamil — the five words in use, and the two habits behind them",
+      "script": "tamil",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:a0ce2d20f0c139e8",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Five words, one at a time. Now they go into a conversation, and two habits show up that English does not have."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "Using them",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "A whole exchange, built only from the five words:"
+            },
+            {
+              "kind": "speech",
+              "text": "— வணக்கம் (vaṇakkam). — வணக்கம் (vaṇakkam). — சரி? — ஆம். — நன்றி. — சரி. — Hello. — Hello. — Alright? — Yes. — Thank you. — Alright."
+            },
+            {
+              "kind": "speech",
+              "text": "Every reply is one word. Tamil is comfortable with that in a way English is not."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: two habits behind the answers",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "One — Tamil often answers by echoing the verb."
+            },
+            {
+              "kind": "speech",
+              "text": "Ām is correct, but a speaker will often say yes by repeating the verb of the question. Asked \"did you come?\", a natural yes is vandēṉ — \"I came.\" Keep ām as your word, and expect a yes to come back as a whole verb."
+            },
+            {
+              "kind": "speech",
+              "text": "Two — Tamil negates by being, not with a \"not\"-word."
+            },
+            {
+              "kind": "speech",
+              "text": "English makes a sentence negative by inserting not. Tamil swaps in the negative verb of existence:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "puttakam uṇḍu, \"there is a book\".",
+                "puttakam illai, \"there is not a book\"."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "So illai does double duty: alone it is the everyday no; inside a sentence it is what makes the whole thing negative. Learn it as is not and both uses fall out."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the exchange above, both parts",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the exchange above, both parts]"
+            },
+            {
+              "kind": "prompt",
+              "action": "HEAR",
+              "instruction": "\"puttakam uṇḍu\" … \"puttakam illai\" — only the last word changed",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU HEAR: \"puttakam uṇḍu\" … \"puttakam illai\" — only the last word changed]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give a one-word reply to sari? and to naṉṟi. (ām / sari.) Besides ām, what else is a natural yes? (Repeating the verb.) What does illai do inside a sentence? (Makes it negative — it is the \"is not\" verb.) Next: the chapter's own recap, and then names."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "TA-C01-practice",
-      "sequence": null,
+      "sequence": 240,
       "title": "Chapter 1 — recap, and how Tamil says goodbye",
       "headword": "(recap)",
       "romanization": "",
@@ -1986,7 +2336,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9fc5ad0e85df4288",
+      "sourceHash": "fnv1a64:de8fee8d6b42c1e3",
       "notice": null,
       "blocks": [
         {
@@ -2115,439 +2465,6 @@
             {
               "kind": "speech",
               "text": "Next chapter: introducing yourself — en peyar… (\"my name…\"), and Tamil's nī / nīṅgaḷ (familiar / respectful \"you\")."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-C01-sari",
-      "sequence": null,
-      "title": "சரி (sari) — \"okay,\" the word that oils every conversation",
-      "headword": "சரி",
-      "romanization": "",
-      "gloss": "okay / alright / correct (sari)",
-      "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:8abff912866c6ae0",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "If ām is \"yes\" and illai is \"no,\" sari is the easy middle: \"okay, alright, fine, agreed.\" You'll hear it constantly — and it hides a neat fact about the Tamil alphabet."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Tamil.)"
-            },
-            {
-              "kind": "speech",
-              "text": "ச = \"sa\" (here) — but this one letter also does the job of English s, ch, and j: at the start of a word it's often \"sa,\" between vowels it softens. Tamil simply doesn't give voiced/unvoiced or s/ch their own separate letters — context decides the sound. (You saw the same economy with க, which can be k, g, or h depending on where it sits.)"
-            },
-            {
-              "kind": "speech",
-              "text": "ரி = \"ri\" — the consonant ர (ra) carrying the vowel sign ி for \"i.\""
-            },
-            {
-              "kind": "speech",
-              "text": "Left to right: ச, ரி = sa-ri, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "சரி = sari = \"okay / correct.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "சரி (sari) is the native Tamil word for \"correct, even, level,\" and by an easy hop, \"okay, agreed.\" It is the verbal nod of the language: propose a plan and the reply is a single warm \"sari.\" Repeat it — \"sari, sari\" — and it means \"yes yes, alright, enough said.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: one letter, several sounds",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "English mostly gives each sound its own letter; Tamil does the opposite for its stop-consonants — one letter per position of the mouth, and the voicing (k vs g, s vs ch) is filled in by rules of position. That's why a learner can't always predict the exact sound from the letter alone at first — but it also means Tamil has a strikingly small alphabet for the sounds it covers. You'll pick up the position-rules by ear, word by word."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "sa, ri becomes \"sari\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: sa · ri → \"sari\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the everyday triple — ām (yes), illai (no), sari (okay)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the everyday triple — *ām* (yes) · *illai* (no) · *sari* (okay)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"sari, sari\" — \"alright, alright\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"sari, sari\" — \"alright, alright\"]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read சரி. What does it literally mean, and what does it do in conversation? (\"Correct/even\" becomes \"okay, agreed.\") Why can't you always predict whether ச is \"sa\" or \"cha\"? (Tamil uses one letter per mouth-position; the exact sound depends on where it sits in the word.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-C01-vanakkam",
-      "sequence": null,
-      "title": "வணக்கம் (vaṇakkam) — \"greetings,\" a small act of respect",
-      "headword": "வணக்கம்",
-      "romanization": "",
-      "gloss": "hello / greetings (vaṇakkam — \"reverence, homage\")",
-      "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:4c4fa4af1fcb85dd",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The first Tamil word, and the one you'll use most. Like namaste, it is literally a gesture of respect turned into a word. You'll learn to read it and to understand it in the same breath."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(If you already read Tamil, skim this — it's here so the book needs no prior knowledge.) Tamil is written left to right, and — like the Indian scripts generally — every consonant carries a built-in \"a\" unless something removes it."
-            },
-            {
-              "kind": "speech",
-              "text": "வ = \"va\", க = \"ka\", ம = \"ma\" — each consonant with its built-in a."
-            },
-            {
-              "kind": "speech",
-              "text": "ண = \"ṇa\" — a retroflex n, made with the tongue curled back to the roof of the mouth. Tamil keeps several n-sounds and several l-sounds apart; this is the curled-back one. (More on that next lesson.)"
-            },
-            {
-              "kind": "speech",
-              "text": "க் — the dot on top (called a puḷḷi) kills the built-in vowel, leaving a bare \"k.\" So the double க்க is \"k-ka\" = a held \"kk.\""
-            },
-            {
-              "kind": "speech",
-              "text": "Put them in order, left to right: வ, ண, க், க, ம் = va-ṇa-k-ka-m, which gives:"
-            },
-            {
-              "kind": "speech",
-              "text": "வணக்கம் = vaṇakkam."
-            },
-            {
-              "kind": "speech",
-              "text": "You just read Tamil. Two facts did most of it: consonants carry a, and a puḷḷi dot removes it."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "வணக்கம் (vaṇakkam) comes from the verb வணங்கு (vaṇaṅku), \"to bow, to bend, to pay homage.\" Add the ending that turns a verb into a noun of the action, and you get vaṇakkam = \"a bowing, an act of reverence\" — the same idea as Sanskrit namaste (\"I bow to you\"), but built from a native Tamil root, not a borrowed one."
-            },
-            {
-              "kind": "speech",
-              "text": "That last point is the whole personality of Tamil: it is an old language proud of its own word-stock, and it often keeps a home-grown word where its neighbours reached for Sanskrit."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "read it left to right — va, ṇa, k, ka, m becomes \"vaṇakkam\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: read it left to right — va · ṇa · k · ka · m → \"vaṇakkam\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "what the puḷḷi dot on க் does (kills its vowel: ka becomes k)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: what the *puḷḷi* dot on க் does (kills its vowel: ka → k)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"vaṇaṅku — to bow; vaṇakkam — an act of reverence\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"vaṇaṅku — to bow; vaṇakkam — an act of reverence\"]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read வணக்கம் (vaṇakkam). What verb is it built from, and what does that verb mean? (vaṇaṅku, \"to bow / pay homage.\") What does a puḷḷi do to a consonant? (Removes its built-in a.) Is the root borrowed from Sanskrit? (No — it is native Tamil.) Next: compare that native greeting across the family and learn where it fits."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-C01-vanakkam-family-register",
-      "sequence": null,
-      "title": "வணக்கம் (vaṇakkam) — one bow, two lexical loyalties",
-      "headword": "வணக்கம் / நமஸ்காரம்",
-      "romanization": "",
-      "gloss": "Tamil kept a native bow-word where its neighbors borrowed Sanskrit, and uses it across settings",
-      "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:22c3d53d824d6cd4",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Vaṇakkam names a bow. Neighboring languages name the same gesture with a different inherited or borrowed root."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "Across the family",
-          "segments": [
-            {
-              "kind": "table",
-              "headers": [
-                "Language",
-                "\"Hello\"",
-                "Source"
-              ],
-              "columns": 3,
-              "rowCount": 6,
-              "utterances": [
-                "Language: Tamil. \"Hello\": vaṇakkam. Source: native Dravidian vaṇaṅku.",
-                "Language: Kannada. \"Hello\": namaskāra. Source: Sanskrit.",
-                "Language: Telugu. \"Hello\": namaskāram. Source: Sanskrit.",
-                "Language: Malayalam. \"Hello\": namaskāram. Source: Sanskrit.",
-                "Language: Hindi. \"Hello\": namaste. Source: Sanskrit.",
-                "Language: English. \"Hello\": hello. Source: Germanic hailing-call."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Four tracks use Sanskrit namas-, \"bow.\" Tamil kept its own verb. The gesture and social meaning match; the lexical loyalty differs."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "unknown",
-          "title": "Where the word fits",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Say vaṇakkam with pressed palms or a small head-bow: the gesture is the word. It works as hello and goodbye, at any time, to almost anyone. It is respectful without being stiff; cinema and formal speech can also use it as a ringing one-word salutation to a whole room."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"vaṇakkam\" with a small bow",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"vaṇakkam\" with a small bow]"
-            },
-            {
-              "kind": "prompt",
-              "action": "CONTRAST",
-              "instruction": "Tamil vaṇaṅku, neighbors Sanskrit namas-",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU CONTRAST: Tamil *vaṇaṅku* · neighbors Sanskrit *namas-*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "CHOOSE",
-              "instruction": "greeting or parting becomes வணக்கம் (vaṇakkam) works",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU CHOOSE: greeting or parting → **வணக்கம்** works]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Which Dravidian language kept its native bow-word? (Tamil.) What did the neighbors borrow? (Sanskrit namas-.) Can vaṇakkam greet and part? (Yes — it is an all-day respectful salutation.)"
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch01.txt
+++ b/code/learning/human-languages/tamil/narration/ch01.txt
@@ -1,8 +1,69 @@
 Tamil, chapter 1: Greetings.
-16 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+17 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 16.
+Lesson 1 of 17.
+வணக்கம் (vaṇakkam) — "greetings".
+
+Warm-up.
+[pause 2 seconds]
+The first Tamil word, and the one you will use most. One word, one lesson. Say it, and you have greeted someone.
+
+The word.
+வணக்கம் — vaṇakkam — "greetings."
+Say it va-ṇak-kam, with the kk held a beat longer than a single k.
+It is what you say walking into a room, answering a phone, or meeting anyone at all. It does not change for morning or evening, and it does not change for one person or many.
+Its root is the verb vaṇaṅku, "to bow." Vaṇakkam is the act of bowing, turned into a word — and it is native Tamil, not borrowed from Sanskrit.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "vaṇakkam" — hold the kk]
+[pause 8 seconds for the answer]
+[your turn — say: it to someone arriving]
+[pause 8 seconds for the answer]
+[your turn — say: it to someone leaving — the same word does both]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say வணக்கம் (vaṇakkam). Does it change between morning and evening? (No — one greeting, all day.) Does it change for one person or a crowd? (No.) Next: the same greeting across the Dravidian family.
+
+
+Lesson 2 of 17.
+வணக்கம் (vaṇakkam) — one bow, two lexical loyalties.
+
+Warm-up.
+[pause 2 seconds]
+Vaṇakkam names a bow. Neighboring languages name the same gesture with a different inherited or borrowed root.
+
+Across the family.
+[a table of 6 rows, read aloud]
+Language: Tamil. "Hello": vaṇakkam. Source: native Dravidian vaṇaṅku.
+Language: Kannada. "Hello": namaskāra. Source: Sanskrit.
+Language: Telugu. "Hello": namaskāram. Source: Sanskrit.
+Language: Malayalam. "Hello": namaskāram. Source: Sanskrit.
+Language: Hindi. "Hello": namaste. Source: Sanskrit.
+Language: English. "Hello": hello. Source: Germanic hailing-call.
+Four tracks use Sanskrit namas-, "bow." Tamil kept its own verb. The gesture and social meaning match; the lexical loyalty differs.
+
+Where the word fits.
+Say vaṇakkam with pressed palms or a small head-bow: the gesture is the word. It works as hello and goodbye, at any time, to almost anyone. It is respectful without being stiff; cinema and formal speech can also use it as a ringing one-word salutation to a whole room.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "vaṇakkam" with a small bow]
+[pause 8 seconds for the answer]
+[your turn — contrast: Tamil vaṇaṅku, neighbors Sanskrit namas-]
+[pause 8 seconds for the answer]
+[your turn — choose: greeting or parting becomes வணக்கம் (vaṇakkam) works]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Which Dravidian language kept its native bow-word? (Tamil.) What did the neighbors borrow? (Sanskrit namas-.) Can vaṇakkam greet and part? (Yes — it is an all-day respectful salutation.)
+
+
+Lesson 3 of 17.
 Tamil's curves — the writing surface leaves a trace.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script you'll notice: The script is the shape of its writing surface and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -34,7 +95,7 @@ Why is Tamil round? (The usual explanation: it was incised on palm leaves, where
 What writing surface is usually linked to Tamil's rounded shapes?
 
 
-Lesson 2 of 16.
+Lesson 4 of 17.
 வ and க — the vowel inside each consonant.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The vowel you get for free, Script you'll notice: வ — "va", Script you'll notice: க — "ka" and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -75,7 +136,7 @@ Wrap-up Recall.
 What does க say alone? (Ka — the vowel is inherent.) What kind of script is this? (An abugida.) Which sounds can க spell? (k, g, and a softer h-like sound, chosen by position.) Draw வ and க.
 
 
-Lesson 3 of 16.
+Lesson 5 of 17.
 ம and ண — a loop, and a curled tongue.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ம, Script you'll notice: ண and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -115,7 +176,7 @@ Wrap-up Recall.
 Draw ம — which side is the upright on? (The left; the arch closes it on the right.) Draw ண — what makes it not ன? (One extra arch: ண has two arches where ன has one. Both end in the same straight vertical.) What does the dot in ṇ mean? (Retroflex — the tongue curls back to the roof of the mouth.) Why can't you hear it yet? (English has no such sound; the ear learns it after the hand.) Next: place Tamil's three n's along one backward walk through the mouth.
 
 
-Lesson 4 of 16.
+Lesson 6 of 17.
 ந, ன, ண (na, ṉa, ṇa) — three stops on one tongue-map.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The backward walk and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -148,7 +209,7 @@ Wrap-up Recall.
 How many n-letters does Tamil have? (Three.) What separates them? (Tongue position: dental, alveolar, retroflex.) Which two differ by one arch? (ன has one; ண has two.) Next: remove the vowel from a consonant.
 
 
-Lesson 5 of 16.
+Lesson 7 of 17.
 ் (puḷḷi) — the dot that leaves both letters visible.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script you'll notice: The puḷḷi, Script you'll notice: What Tamil does not do and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -183,7 +244,7 @@ Wrap-up Recall.
 What does the puḷḷi do, and what does the word mean? (Removes the inherent vowel; puḷḷi is simply "the dot".) What does Devanagari do that Tamil doesn't? (Fuses the letters into a conjunct — Tamil keeps both shapes and the dot.) What does Tamil get in exchange? (A much smaller character set — 247, with almost no ligatures: only the borrowed க்ஷ and ஸ்ரீ.) Next: assemble that visible dot into வணக்கம் (vaṇakkam).
 
 
-Lesson 6 of 16.
+Lesson 8 of 17.
 வணக்கம் (vaṇakkam) — the first whole written word.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: Build the word and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -216,7 +277,7 @@ Wrap-up Recall.
 Write வணக்கம் (vaṇakkam). What is special about க்க? (It is doubled and held.) Why does the word end in m, not ma? (Final ம் carries a puḷḷi.) Next: write the letters and vowel sign inside nandri.
 
 
-Lesson 7 of 16.
+Lesson 9 of 17.
 ந, ன, ற (na, ṉa, ṟa) — the letter bodies inside நன்றி.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The two remaining n's, Script you'll notice: ற — "ṟa", the hard r and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -256,7 +317,7 @@ Wrap-up Recall.
 Name Tamil's three n-letters and their tongue positions. (ந dental, ன alveolar, ண retroflex.) What are a consonant's three possibilities so far? (Keep the built-in a or remove it with the puḷḷi.) Which letter hangs below the baseline? (ற, the hard ṟ.) Next: replace the vowel, assemble நன்றி, and hear why English often writes nandri.
 
 
-Lesson 8 of 16.
+Lesson 10 of 17.
 ி and நன்றி — replace the vowel, then hear ndr.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The first vowel sign, Script you'll notice: Assemble நன்றி and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -296,127 +357,88 @@ Wrap-up Recall.
 What are a consonant's three vowel choices? (Keep inherent a, remove it with puḷḷi, or replace it with a vowel sign.) Where does ி attach? (Above and right.) Why is naṉṟi often written nandri? (ன் + ற is pronounced ndr because a nasal voices the following stop.)
 
 
-Lesson 9 of 16.
+Lesson 11 of 17.
 ஆம் (ām) — "yes".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
-A two-letter word, and your first look at how Tamil writes a vowel that stands on its own.
+The plain yes. One word, and then we will put these together.
 
-The letters in this word.
-(Skim if you read Tamil.)
-ஆ = "ā" (a long "aa"). When a word starts with a vowel, Tamil uses a full independent vowel letter like this — not the little vowel sign you hook onto a consonant. (Compare: the "i" hooked onto ற to make றி last lesson; here the vowel leads, so it gets its own full letter.)
-ம் = "m," with the puḷḷi dot removing its built-in a — the same bare m that ended vaṇakkam.
-Left to right: ஆ, ம் = ā-m, which gives:
-ஆம் = ām = "yes."
-
-The word, taken apart.
-ஆம் (ām) is the plain "yes." Stretch it for emphasis and you get ஆமாம் (āmām) — "yes, indeed / that's right," a doubling-up that Tamil loves for warmth and certainty.
-
-Grammar Lens: Tamil often answers by echoing the verb.
-ām exists, but Tamil speakers frequently say "yes" by repeating the verb of the question instead. Asked "vandāyā?" ("did you come?"), a natural yes is "vandēn" ("I came"). English leans on a single all-purpose yes; Tamil often answers with the action itself. Bank ām as the simple word, and don't be surprised when a "yes" comes back as a whole verb.
+The word.
+ஆம் — ām — "yes."
+One beat, with a long opening aa.
+Stretch it and you get ஆமாம் (āmām) — "yes, indeed; that's right." Tamil doubles words for warmth and certainty, the way sari sari does.
+Ām is a worn-down form of āgum, "it becomes, it will be" — a yes that started life as a verb, which is a very Tamil way to agree.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: ā, m becomes "ām"]
+[your turn — say: "ām" — one long aa, closed on the m]
 [pause 8 seconds for the answer]
-[your turn — say: the emphatic "āmām" — "yes, indeed"]
+[your turn — say: "āmām" — the emphatic double]
 [pause 8 seconds for the answer]
-[your turn — say: why ஆ is a full letter here (the word starts with the vowel)]
+[your turn — say: "ām" then "sari" — yes, and alright]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Read ஆம். Why is ஆ a full vowel letter rather than a vowel sign? (The word begins with the vowel — nothing to hook onto.) What's the emphatic "yes"? (āmām.)
+Say ஆம். What does ஆமாம் add? (Emphasis — "yes, indeed.") Next: the word for no.
 
 
-Lesson 10 of 16.
-இல்லை (illai) — "no," and how Tamil says a thing is not.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+Lesson 12 of 17.
+இல்லை (illai) — "no".
 
 Warm-up.
 [pause 2 seconds]
-The partner of ām. But where English "no" is a small flat word, Tamil's illai is really a tiny verb meaning "it is not / there is not" — and that's a window into how the language thinks.
+The other half of the pair. One word, and then the lesson that puts all five together.
 
-The letters in this word.
-(Skim if you read Tamil.)
-இ = "i" — an independent vowel (the word starts with it, so it gets a full letter, exactly like ஆ in ām).
-ல் = "l," with the puḷḷi dot removing its vowel becomes bare l.
-லை = "lai" — the consonant ல (la) carrying the vowel sign ை, which makes "ai."
-Left to right: இ, ல், லை = i-l-lai, which gives:
-இல்லை = illai.
-(Notice ல் + லை — a bare l leaning into lai, giving the doubled "ll.")
-
-The word, taken apart.
-இல்லை (illai) is built on the root இல் (il), the idea of "not-being, absence." So illai is not really the adjective "no" — it is the statement "[it] is not," "[there] is not." Its positive twin is உண்டு (uṇḍu), "there is."
-
-Grammar Lens: Tamil negates by being, not by a "not"-word.
-English changes a sentence to negative by inserting not / no: "there is a book" becomes "there is no book." Tamil instead swaps in the negative verb of existence:
-puttakam uṇḍu — "there is a book."
-puttakam illai — "there is not a book."
-So illai does double duty: on its own it's the everyday "no," and inside a sentence it's the word that makes the whole thing negative. Learn it as "is not," and both uses fall out naturally. (This — negation carried by a special verb rather than a particle — is a deeply Dravidian habit, quite unlike English or Hindi.)
+The word.
+இல்லை — illai — "no."
+Two beats: il-lai, with the l held across the join.
+On its own it is the everyday no. But it is not really the adjective "no" — it is a small statement meaning "is not." That will matter when we put the five words together.
+Its root is il, the idea of not-being. Its positive twin is uṇḍu, "there is."
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: i, l, lai becomes "illai"]
+[your turn — say: "illai" — two beats, the l held across the join]
 [pause 8 seconds for the answer]
-[your turn — say: the pair — ām ("yes") / illai ("no")]
+[your turn — say: the pair — "ām" … "illai"]
 [pause 8 seconds for the answer]
-[your turn — say: "puttakam illai" — "there is no book"]
+[your turn — say: it alone, as a complete answer]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Read இல்லை. Literally, is it closer to "no" or to "is not"? ("Is not / there is not.") What is its positive twin? (uṇḍu, "there is.") How does Tamil make a sentence negative — with a particle like English not, or by swapping in a negative verb? (A negative verb.)
+Say இல்லை. Is it closer to English no, or to is not? (Is not — it is a statement, not a label.) Next: the word for thank you.
 
 
-Lesson 11 of 16.
-நன்றி (naṉṟi) — "thank you," literally "goodness".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+Lesson 13 of 17.
+நன்றி (naṉṟi) — "thank you".
 
 Warm-up.
 [pause 2 seconds]
-The word for gratitude — and the doorway to one of Tamil's most famous features: it hears differences between sounds English throws into one bin.
+One word again. This is the one you will reach for second-most, and Tamil says it with a noun rather than a verb.
 
-The letters in this word.
-(Skim if you read Tamil.) Three consonants and a vowel sign:
-ந = "na" — a dental n (tongue on the teeth, like the n in Spanish nada).
-ன் = "ṉ" — a different n, alveolar (tongue on the ridge just behind the teeth), with a puḷḷi dot killing its vowel.
-ற = "ṟa" — a hard r/ṟ sound made with a tap further back.
-ி is a vowel sign that changes the built-in a to "i": ற + ி becomes றி = "ṟi."
-Left to right: ந, ன், றி = na-ṉ-ṟi, which gives:
-நன்றி = naṉṟi.
-
-The word, taken apart.
-நன்றி (naṉṟi) grows from the root நல் / நன் (nal / naṉ), "good, goodness" — the same root inside nanmai ("good deed"), nallavan ("a good man"). So naṉṟi is literally "goodness", and to say it is to name the good someone has done you. Gratitude, in Tamil, is just "the good [you did]."
-
-Grammar Lens: Tamil hears three of every n, l, and r.
-You met ந (dental na), ன (alveolar ṉa), and last lesson ண (retroflex ṇa) — three n-letters, for three tongue positions:
-[a table of 3 rows, read aloud]
-Letter: ந. Sound: dental n. Tongue: on the teeth.
-Letter: ன. Sound: alveolar ṉ. Tongue: on the ridge behind the teeth.
-Letter: ண. Sound: retroflex ṇ. Tongue: curled back to the roof.
-Tamil does the same for l (ல ள ழ) and r (ர ற). English fuses all these into single letters and never notices; Tamil keeps them distinct, and they change meaning — so learning to hear them is learning to read. Don't drill the whole set now; just know the differences are real and will return word by word.
+The word.
+நன்றி — naṉṟi — "thank you."
+Two beats: naṉ-ṟi. The ṉ and the ṟ are both made further back than English n and r; copy the sound rather than the spelling.
+It works on its own, with no verb around it. Someone hands you something; you say naṉṟi, and that is a whole sentence.
+Its root is nal, "good" — the same nal- inside nalla ("good") and nanmai ("a good deed"). Saying naṉṟi names the good someone did you.
 
 Guided Practice.
 [pause 1 second]
-[your turn — say: na, ṉ, ṟi becomes "naṉṟi"]
+[your turn — say: "naṉṟi" — two beats, both consonants far back]
 [pause 8 seconds for the answer]
-[your turn — say: the three n's — ந (teeth), ன (ridge), ண (curled back)]
+[your turn — say: "vaṇakkam" then "naṉṟi" — greeting, then thanks]
 [pause 8 seconds for the answer]
-[your turn — say: "nal — good; naṉṟi — the good you did"]
+[your turn — say: it on its own, with nothing around it]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Read நன்றி. What does it literally mean, and from what root? ("Goodness," from nal "good.") How many distinct n-sounds does Tamil write, and what tells them apart? (Three — dental, alveolar, retroflex — by tongue position.) Next: compare the gratitude word across the family and choose its register.
+Say நன்றி. Does it need a verb to be a complete reply? (No — it stands alone.) Next: how thanks travels across the family.
 
 
-Lesson 12 of 16.
+Lesson 14 of 17.
 நன்றி — a native family word with a register edge.
 
 Warm-up.
@@ -450,7 +472,68 @@ Wrap-up Recall.
 Which sister shares Tamil's native gratitude word? (Malayalam.) What did Kannada and Telugu borrow? (Sanskrit dhanyavāda.) Why can explicit naṉṟi sound marked? (Among intimates, gratitude may be assumed; the word can feel formal.)
 
 
-Lesson 13 of 16.
+Lesson 15 of 17.
+சரி (sari) — "okay".
+
+Warm-up.
+[pause 2 seconds]
+The most useful small word in the language, and the easiest to say.
+
+The word.
+சரி — sari — "okay, alright, correct."
+Two beats: sa-ri.
+It is the verbal nod of Tamil. Someone proposes a plan and the whole reply is one warm sari. Doubled — sari, sari — it means "yes yes, fine, go on."
+It began as "correct, even, level," and slid from that is right to alright the way English right did.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "sari"]
+[pause 8 seconds for the answer]
+[your turn — say: "sari, sari" — the doubled, hurry-along version]
+[pause 8 seconds for the answer]
+[your turn — say: agree to something with nothing but this word]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say சரி. What does doubling it add? (Hurry, or easy agreement — "yes yes, fine.") Next: putting the five together.
+
+
+Lesson 16 of 17.
+Putting the five together — how Tamil answers.
+
+Warm-up.
+[pause 2 seconds]
+Five words, one at a time. Now they go into a conversation, and two habits show up that English does not have.
+
+Using them.
+A whole exchange, built only from the five words:
+— வணக்கம் (vaṇakkam). — வணக்கம் (vaṇakkam). — சரி? — ஆம். — நன்றி. — சரி. — Hello. — Hello. — Alright? — Yes. — Thank you. — Alright.
+Every reply is one word. Tamil is comfortable with that in a way English is not.
+
+Grammar Lens: two habits behind the answers.
+One — Tamil often answers by echoing the verb.
+Ām is correct, but a speaker will often say yes by repeating the verb of the question. Asked "did you come?", a natural yes is vandēṉ — "I came." Keep ām as your word, and expect a yes to come back as a whole verb.
+Two — Tamil negates by being, not with a "not"-word.
+English makes a sentence negative by inserting not. Tamil swaps in the negative verb of existence:
+[a table of 2 rows, read aloud]
+puttakam uṇḍu, "there is a book".
+puttakam illai, "there is not a book".
+So illai does double duty: alone it is the everyday no; inside a sentence it is what makes the whole thing negative. Learn it as is not and both uses fall out.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: the exchange above, both parts]
+[pause 8 seconds for the answer]
+[your turn — hear: "puttakam uṇḍu" … "puttakam illai" — only the last word changed]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give a one-word reply to sari? and to naṉṟi. (ām / sari.) Besides ām, what else is a natural yes? (Repeating the verb.) What does illai do inside a sentence? (Makes it negative — it is the "is not" verb.) Next: the chapter's own recap, and then names.
+
+
+Lesson 17 of 17.
 Chapter 1 — recap, and how Tamil says goodbye.
 
 Warm-up.
@@ -485,109 +568,3 @@ Wrap-up Recall.
 [pause 3 seconds]
 Read all five words aloud. What does the everyday Tamil goodbye literally mean, and why isn't it just "I'm leaving"? ("I'll go and come back" — a bare "I go" sounds like a final parting, so you promise a return.) What does a puḷḷi do? (Removes a consonant's built-in a.)
 Next chapter: introducing yourself — en peyar… ("my name…"), and Tamil's nī / nīṅgaḷ (familiar / respectful "you").
-
-
-Lesson 14 of 16.
-சரி (sari) — "okay," the word that oils every conversation.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-If ām is "yes" and illai is "no," sari is the easy middle: "okay, alright, fine, agreed." You'll hear it constantly — and it hides a neat fact about the Tamil alphabet.
-
-The letters in this word.
-(Skim if you read Tamil.)
-ச = "sa" (here) — but this one letter also does the job of English s, ch, and j: at the start of a word it's often "sa," between vowels it softens. Tamil simply doesn't give voiced/unvoiced or s/ch their own separate letters — context decides the sound. (You saw the same economy with க, which can be k, g, or h depending on where it sits.)
-ரி = "ri" — the consonant ர (ra) carrying the vowel sign ி for "i."
-Left to right: ச, ரி = sa-ri, which gives:
-சரி = sari = "okay / correct."
-
-The word, taken apart.
-சரி (sari) is the native Tamil word for "correct, even, level," and by an easy hop, "okay, agreed." It is the verbal nod of the language: propose a plan and the reply is a single warm "sari." Repeat it — "sari, sari" — and it means "yes yes, alright, enough said."
-
-Grammar Lens: one letter, several sounds.
-English mostly gives each sound its own letter; Tamil does the opposite for its stop-consonants — one letter per position of the mouth, and the voicing (k vs g, s vs ch) is filled in by rules of position. That's why a learner can't always predict the exact sound from the letter alone at first — but it also means Tamil has a strikingly small alphabet for the sounds it covers. You'll pick up the position-rules by ear, word by word.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: sa, ri becomes "sari"]
-[pause 8 seconds for the answer]
-[your turn — say: the everyday triple — ām (yes), illai (no), sari (okay)]
-[pause 8 seconds for the answer]
-[your turn — say: "sari, sari" — "alright, alright"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Read சரி. What does it literally mean, and what does it do in conversation? ("Correct/even" becomes "okay, agreed.") Why can't you always predict whether ச is "sa" or "cha"? (Tamil uses one letter per mouth-position; the exact sound depends on where it sits in the word.)
-
-
-Lesson 15 of 16.
-வணக்கம் (vaṇakkam) — "greetings," a small act of respect.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The first Tamil word, and the one you'll use most. Like namaste, it is literally a gesture of respect turned into a word. You'll learn to read it and to understand it in the same breath.
-
-The letters in this word.
-(If you already read Tamil, skim this — it's here so the book needs no prior knowledge.) Tamil is written left to right, and — like the Indian scripts generally — every consonant carries a built-in "a" unless something removes it.
-வ = "va", க = "ka", ம = "ma" — each consonant with its built-in a.
-ண = "ṇa" — a retroflex n, made with the tongue curled back to the roof of the mouth. Tamil keeps several n-sounds and several l-sounds apart; this is the curled-back one. (More on that next lesson.)
-க் — the dot on top (called a puḷḷi) kills the built-in vowel, leaving a bare "k." So the double க்க is "k-ka" = a held "kk."
-Put them in order, left to right: வ, ண, க், க, ம் = va-ṇa-k-ka-m, which gives:
-வணக்கம் = vaṇakkam.
-You just read Tamil. Two facts did most of it: consonants carry a, and a puḷḷi dot removes it.
-
-The word, taken apart.
-வணக்கம் (vaṇakkam) comes from the verb வணங்கு (vaṇaṅku), "to bow, to bend, to pay homage." Add the ending that turns a verb into a noun of the action, and you get vaṇakkam = "a bowing, an act of reverence" — the same idea as Sanskrit namaste ("I bow to you"), but built from a native Tamil root, not a borrowed one.
-That last point is the whole personality of Tamil: it is an old language proud of its own word-stock, and it often keeps a home-grown word where its neighbours reached for Sanskrit.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: read it left to right — va, ṇa, k, ka, m becomes "vaṇakkam"]
-[pause 8 seconds for the answer]
-[your turn — say: what the puḷḷi dot on க் does (kills its vowel: ka becomes k)]
-[pause 8 seconds for the answer]
-[your turn — say: "vaṇaṅku — to bow; vaṇakkam — an act of reverence"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Read வணக்கம் (vaṇakkam). What verb is it built from, and what does that verb mean? (vaṇaṅku, "to bow / pay homage.") What does a puḷḷi do to a consonant? (Removes its built-in a.) Is the root borrowed from Sanskrit? (No — it is native Tamil.) Next: compare that native greeting across the family and learn where it fits.
-
-
-Lesson 16 of 16.
-வணக்கம் (vaṇakkam) — one bow, two lexical loyalties.
-
-Warm-up.
-[pause 2 seconds]
-Vaṇakkam names a bow. Neighboring languages name the same gesture with a different inherited or borrowed root.
-
-Across the family.
-[a table of 6 rows, read aloud]
-Language: Tamil. "Hello": vaṇakkam. Source: native Dravidian vaṇaṅku.
-Language: Kannada. "Hello": namaskāra. Source: Sanskrit.
-Language: Telugu. "Hello": namaskāram. Source: Sanskrit.
-Language: Malayalam. "Hello": namaskāram. Source: Sanskrit.
-Language: Hindi. "Hello": namaste. Source: Sanskrit.
-Language: English. "Hello": hello. Source: Germanic hailing-call.
-Four tracks use Sanskrit namas-, "bow." Tamil kept its own verb. The gesture and social meaning match; the lexical loyalty differs.
-
-Where the word fits.
-Say vaṇakkam with pressed palms or a small head-bow: the gesture is the word. It works as hello and goodbye, at any time, to almost anyone. It is respectful without being stiff; cinema and formal speech can also use it as a ringing one-word salutation to a whole room.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "vaṇakkam" with a small bow]
-[pause 8 seconds for the answer]
-[your turn — contrast: Tamil vaṇaṅku, neighbors Sanskrit namas-]
-[pause 8 seconds for the answer]
-[your turn — choose: greeting or parting becomes வணக்கம் (vaṇakkam) works]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Which Dravidian language kept its native bow-word? (Tamil.) What did the neighbors borrow? (Sanskrit namas-.) Can vaṇakkam greet and part? (Yes — it is an all-day respectful salutation.)

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -301,12 +301,24 @@ describe("the real corpus", () => {
 
     // ORDER. Until this reaches zero every other number here is provisional: a ramp
     // whose reading order is unknown cannot be verified at all.
-    expect(report.summary.lessonsWithoutSequence).toBe(515);
+        // 515 -> 507. Eight Tamil chapter-1 lessons that had no `sequence` were given one
+    // from the order the curriculum path already declared, so the continuity walk can
+    // finally see it. The corpus GREW by a lesson over the same change, and that lesson
+    // was born sequenced, so it never entered this count.
+    expect(report.summary.lessonsWithoutSequence).toBe(507);
     expect(report.summary.tracksWithUnorderedLessons).toBe(19);
-    expect(report.summary.forwardPrerequisites).toBe(245);
+        // 245 -> 240. Not five prerequisites fixed — five that were never real. Without a
+    // `sequence` the walk falls back to alphabetical, so "TA-C01-aam requires
+    // TA-C01-vanakkam-family-register" read as a forward prerequisite purely because
+    // `aam` sorts first. Declaring chapter 1's order removed the artifact.
+    expect(report.summary.forwardPrerequisites).toBe(240);
 
     // Lessons claiming to review material the learner has not reached yet.
-    expect(report.summary.forwardReviews).toBe(300);
+    // 300 -> 285. Fourteen are the same alphabetical-fallback artifact as
+    // forwardPrerequisites above, four of them in the writing track rather than the
+    // word lessons; the fifteenth is a `reviews_of` list that genuinely shrank when its
+    // lesson was rewritten.
+    expect(report.summary.forwardReviews).toBe(285);
 
     // REINFORCEMENT. The founding promise is that the course "constantly
     // re-emphasizes what was learnt previously". It shipped with HALF taught once.
@@ -380,7 +392,12 @@ describe("the real corpus", () => {
     // now does it deliberately, and completely: the accident only ever covered the
     // tail after the first word, so 45 self-references it had never caught are gone
     // too. Every one was verified to be a token of the reporting lesson's own headword.
-    expect(report.summary.forwardReferences).toBe(443);
+    //
+    // 443 -> 439, and NOT because of the prose rewrite — a sequence-only corpus reads
+    // 439 too. All four dropped references sit in TA-W01-curves-va-ka,
+    // TA-W03-pulli-vanakkam and TA-C01-practice, none of which had prose edited. They
+    // stopped counting because chapter 1 now declares its order.
+    expect(report.summary.forwardReferences).toBe(439);
 
     // HL09 step 3 closed 17 R1 windows in chapters 3-6, measured on the corpus of the
     // day as 766 -> 749. The absolute figures drift as main lands lessons; what the

--- a/code/packages/typescript/human-language-data/tests/levels.test.ts
+++ b/code/packages/typescript/human-language-data/tests/levels.test.ts
@@ -217,7 +217,7 @@ describe("corpus snapshot", () => {
     const { lessons, curricula: paths, spine } = loadEverything();
     const summary = summarizeLevels(lessons, paths, spine);
 
-    expect(summary.byLevel["pre-A1"]).toBe(696);
+    expect(summary.byLevel["pre-A1"]).toBe(697); // +1: TA-C01-answering
     expect(summary.byLevel.A1).toBe(297);
     expect(summary.byLevel.A2).toBe(350);
     // 8, not 0: Spanish chapters 38 and 41 realize SPINE-NARRATE-EVENTS and
@@ -279,7 +279,7 @@ describe("corpus snapshot", () => {
     const { lessons, curricula: paths, spine } = loadEverything();
     const ramp = lessonsUpToLevel(lessons, paths, spine, "A1");
     // The whole point: this is a FILTER over the one corpus, not a second corpus.
-    expect(ramp).toHaveLength(993);
+    expect(ramp).toHaveLength(994);
     expect(ramp.length).toBeLessThan(lessons.length);
   });
 });

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -798,11 +798,11 @@ describe("corpus regression", () => {
       // under the canonical heading, and the whole-lesson figure fell back to 66%.
       // `coreDrivable` is unaffected: those blocks are detachable, so the driving
       // edition itself lost nothing. This is the sight-share seam, not a regression.
-      totalLessons: 1499,
-      voice: 983,
-      sight: 463,
+      totalLessons: 1500,
+      voice: 989,
+      sight: 458,
       pen: 53,
-      drivableLessons: 983,
+      drivableLessons: 989,
       drivablePercent: 66,
       trackCount: 22,
       chapterCount: 464,
@@ -814,9 +814,9 @@ describe("corpus regression", () => {
       // and the alphabetical fallback it replaced had been flattering this number by
       // putting eyes-needed lessons later than they really come. The real order is
       // worse, which is the measurement becoming honest, not the corpus regressing.
-      drivablePrefixTotal: 796,
+      drivablePrefixTotal: 798,
       fullyDrivableChapters: 307,
-      unstartableChapters: 119,
+      unstartableChapters: 118,
       overriddenLessons: 0,
       lessonsWithoutChapter: 0,
     });

--- a/code/packages/typescript/human-language-data/tests/ramp.test.ts
+++ b/code/packages/typescript/human-language-data/tests/ramp.test.ts
@@ -105,7 +105,7 @@ describe("corpus snapshot", () => {
     // and many unmeasurable lessons has not proved it is gentle. Ratchet this DOWN as
     // schema-v2 migration lands; the violation count will rise as it does, and that is
     // the measurement improving rather than the corpus worsening.
-    expect(report.summary.unmeasurableLessons).toBe(572);
+    expect(report.summary.unmeasurableLessons).toBe(573); // +1: TA-C01-answering, schema-v1 like its chapter
     expect(report.summary.measurablePercent).toBe(62);
   });
 
@@ -248,7 +248,13 @@ describe("the script ramp against the real corpus", () => {
     // 61 lessons put more than three new shapes on the page at once. This is the
     // HL-C18C burn-down list. It is REPORT-ONLY: the debt predates the measurement,
     // so it is made visible rather than turned into a build failure.
-    expect(report.summary.lessonViolations).toBe(61);
+    // 61 -> 60, and the net hides two moves in opposite directions. Two Tamil ch1
+    // lessons left the list when chapter 1 gained a declared reading order. One
+    // JOINED it: TA-C01-vanakkam. Removing its script block stopped it counting as a
+    // script lesson, so the five glyphs of வணக்கம் itself now register against the
+    // three-glyph budget — which is honest. A five-letter word IS five new shapes on
+    // page one; the old structure hid that behind a "letters in this word" heading.
+    expect(report.summary.lessonViolations).toBe(60);
 
     // All five are Japanese Chapter 1, which opens kanji beside hiragana in its very
     // first lesson and adds katakana in its fifth.


### PR DESCRIPTION
> *"one lesson one word. Then one lesson where put the words together and explain the grammar. Then we go back to keep learning more words. And then combine them."*

A pilot on **one chapter of one track**, so you can read it before 21 others inherit the pattern.

## What each word lesson lost

- **The letter-by-letter decomposition.** Reading Tamil is the writing track's job, and `TA-W01`–`TA-W04` already do it.
- **The Grammar Lens.** Two duplicated the writing track; the other two moved into a new put-it-together lesson.

**New `TA-C01-answering`** — a short exchange built from the five words, then the two habits behind them: yes by echoing the verb, and negation carried by a verb rather than a particle.

| | before | after |
|---|---|---|
| வணக்கம் | 256s | **136s** |
| ஆம் | 196s | **91s** |
| இல்லை | 243s | **103s** |
| நன்றி | 243s | **128s** |
| சரி | 235s | **89s** |
| *put-it-together* | — | 222s |

## Chapter 1 also gained a declared reading order

Its eight lessons had no `sequence`, so the continuity walk sorted them alphabetically. Writing down the order the curriculum path already declared removed **five forward prerequisites and fourteen forward reviews that were never real** — artifacts of sorting *aam* before *vanakkam*.

## A heading rename defeated the modality classifier

Worth reading, because it nearly shipped. The first version renamed `## The letters in this word` → `## The word` while **keeping** the decomposition. `parse.ts` detects script blocks by heading name and never inspects content — so all five lessons flipped to `voice`, `drivable: true`, while the generated narration still said:

> *Read it left to right: வ · ண · க் · க · ம்*

Five lessons advertised as safe to do while driving, telling the driver to read Tamil. Fixed by removing the decomposition rather than relabelling it.

One consequence kept deliberately: `TA-C01-vanakkam` now **joins** the script-ramp violator list, because the five glyphs of வணக்கம் itself count against the three-glyph budget. A five-letter word on page one *is* five new shapes — the old structure hid that behind a heading.

## Three gaps, recorded rather than papered over

- **Six letters lost their only home** — ஆ, இ, ச, ர, ல் and the ை sign appear in no writing lesson, and the chapter recap still tests them. The writing track needs those before this pattern spreads.
- **The book is unaffected** — Tamil chapters 1–5 are hand-written `.tex`. You've since said those can be rewritten; that's next.
- **Etymology-once isn't fully met** — the two `-family-register` lessons still restate roots the word lessons give.

405 tests pass. `check:books`, `check:narration`, `check:modality` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
