### PR TITLE
fix(human-language-data): teach the Tamil letters the chapter-1 split orphaned

### DIFF
--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -6546,7 +6546,7 @@
     {
       "language": "tamil",
       "chapter": 1,
-      "sourceHash": "fnv1a64:cd6ee126f13c74e3",
+      "sourceHash": "fnv1a64:b4faba4479bcf0ba",
       "lessonIds": [
         "TA-C01-vanakkam",
         "TA-C01-vanakkam-family-register",
@@ -6559,10 +6559,13 @@
         "TA-W04-vowel-signs-nandri",
         "TA-W04-i-sign-write-nandri",
         "TA-C01-aam",
+        "TA-W05-write-aam",
         "TA-C01-illai",
+        "TA-W06-write-illai",
         "TA-C01-nandri",
         "TA-C01-nandri-family-register",
         "TA-C01-sari",
+        "TA-W07-write-sari",
         "TA-C01-answering",
         "TA-C01-practice"
       ],
@@ -6570,8 +6573,8 @@
       "drivablePrefix": 2,
       "text": "tamil/narration/ch01.txt",
       "json": "tamil/narration/ch01.json",
-      "textHash": "fnv1a64:c895ca421a6899c3",
-      "jsonHash": "fnv1a64:1049ab524a66fcc2"
+      "textHash": "fnv1a64:215fec3e92e81cd6",
+      "jsonHash": "fnv1a64:89fc20fa4740767f"
     },
     {
       "language": "tamil",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -6546,7 +6546,7 @@
     {
       "language": "tamil",
       "chapter": 1,
-      "sourceHash": "fnv1a64:b4faba4479bcf0ba",
+      "sourceHash": "fnv1a64:b35c2c9e484d8ba0",
       "lessonIds": [
         "TA-C01-vanakkam",
         "TA-C01-vanakkam-family-register",
@@ -6573,8 +6573,8 @@
       "drivablePrefix": 2,
       "text": "tamil/narration/ch01.txt",
       "json": "tamil/narration/ch01.json",
-      "textHash": "fnv1a64:215fec3e92e81cd6",
-      "jsonHash": "fnv1a64:89fc20fa4740767f"
+      "textHash": "fnv1a64:a253fda1701c566b",
+      "jsonHash": "fnv1a64:ecccd0760f2638c4"
     },
     {
       "language": "tamil",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,12 +7,12 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:1ca921ce47d3a5fe",
+  "sourceHash": "fnv1a64:785eb885fda913fb",
   "summary": {
-    "totalLessons": 1560,
+    "totalLessons": 1563,
     "voice": 1046,
     "sight": 461,
-    "pen": 53,
+    "pen": 56,
     "drivableLessons": 1046,
     "drivablePercent": 67,
     "trackCount": 22,
@@ -7081,11 +7081,11 @@
     },
     {
       "language": "tamil",
-      "lessonCount": 113,
+      "lessonCount": 116,
       "voice": 59,
       "sight": 46,
-      "pen": 8,
-      "drivablePercent": 52,
+      "pen": 11,
+      "drivablePercent": 51,
       "drivablePrefixTotal": 44,
       "modalities": [
         "voice",
@@ -7095,10 +7095,10 @@
       "chapters": [
         {
           "chapter": 1,
-          "lessonCount": 17,
+          "lessonCount": 20,
           "voice": 9,
           "sight": 0,
-          "pen": 8,
+          "pen": 11,
           "modalities": [
             "voice",
             "sight",
@@ -33724,7 +33724,30 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:33b4b0ca5bf90f6f"
+      "sourceHash": "fnv1a64:96c6bb2306442e1b"
+    },
+    {
+      "id": "TA-W05-write-aam",
+      "language": "tamil",
+      "chapter": 1,
+      "sequence": 182,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:d2d9939892304061",
+      "detachableSegments": [
+        "Script you'll notice: a vowel standing alone",
+        "Script you'll notice: build the word"
+      ]
     },
     {
       "id": "TA-C01-illai",
@@ -33742,7 +33765,30 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:93b6d60e45822e82"
+      "sourceHash": "fnv1a64:beee25438cdb89ae"
+    },
+    {
+      "id": "TA-W06-write-illai",
+      "language": "tamil",
+      "chapter": 1,
+      "sequence": 192,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:355d80e464a1c094",
+      "detachableSegments": [
+        "Script you'll notice: இ and ல",
+        "Script you'll notice: build the word"
+      ]
     },
     {
       "id": "TA-C01-nandri",
@@ -33796,7 +33842,30 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7aaa8c8d3e80fe76"
+      "sourceHash": "fnv1a64:c6020b573775bf3a"
+    },
+    {
+      "id": "TA-W07-write-sari",
+      "language": "tamil",
+      "chapter": 1,
+      "sequence": 222,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:235103e17e063c6b",
+      "detachableSegments": [
+        "Script you'll notice: ச and ர",
+        "Script you'll notice: build the word"
+      ]
     },
     {
       "id": "TA-C01-answering",

--- a/code/learning/human-languages/tamil/curriculum.json
+++ b/code/learning/human-languages/tamil/curriculum.json
@@ -37,7 +37,10 @@
         "TA-W03-pulli-vanakkam",
         "TA-W03-write-vanakkam",
         "TA-W04-vowel-signs-nandri",
-        "TA-W04-i-sign-write-nandri"
+        "TA-W04-i-sign-write-nandri",
+        "TA-W05-write-aam",
+        "TA-W06-write-illai",
+        "TA-W07-write-sari"
       ],
       "before": [],
       "inline": [
@@ -874,7 +877,10 @@
         "TA-W03-pulli-vanakkam",
         "TA-W03-write-vanakkam",
         "TA-W04-vowel-signs-nandri",
-        "TA-W04-i-sign-write-nandri"
+        "TA-W04-i-sign-write-nandri",
+        "TA-W05-write-aam",
+        "TA-W06-write-illai",
+        "TA-W07-write-sari"
       ]
     },
     {

--- a/code/learning/human-languages/tamil/lessons/TA-C01-aam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-aam.md
@@ -41,4 +41,4 @@ doubles words for warmth and certainty, the way *sari sari* does.
 ## Wrap-up Recall
 
 [PAUSE 3s] Say **ஆம்**. What does **ஆமாம்** add? (**Emphasis** — "yes,
-indeed.") Next: the word for no.
+indeed.") Next: writing it.

--- a/code/learning/human-languages/tamil/lessons/TA-C01-illai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-illai.md
@@ -43,4 +43,4 @@ five words together.
 ## Wrap-up Recall
 
 [PAUSE 3s] Say **இல்லை**. Is it closer to English *no*, or to *is not*?
-(**Is not** — it is a statement, not a label.) Next: the word for thank you.
+(**Is not** — it is a statement, not a label.) Next: writing it.

--- a/code/learning/human-languages/tamil/lessons/TA-C01-sari.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-sari.md
@@ -41,4 +41,4 @@ one warm *sari*. Doubled — *sari, sari* — it means "yes yes, fine, go on."
 ## Wrap-up Recall
 
 [PAUSE 3s] Say **சரி**. What does doubling it add? (**Hurry, or easy
-agreement** — "yes yes, fine.") Next: putting the five together.
+agreement** — "yes yes, fine.") Next: writing it.

--- a/code/learning/human-languages/tamil/lessons/TA-W05-write-aam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W05-write-aam.md
@@ -1,0 +1,82 @@
+---
+schema_version: 2
+id: TA-W05-write-aam
+spine_node: SPINE-MEET-GREET
+sequence: 182
+chapter: 1
+type: writing
+headword: "ஆம்"
+gloss: a word that begins with a vowel gets a full vowel letter, not a sign
+romanization: "ām"
+prerequisites: [TA-W04-i-sign-write-nandri, TA-W03-pulli-vanakkam]
+sounds: [independent-vowel-aa, pulli, final-m]
+roots: []
+duration:
+  max_seconds: 180
+requires:
+  knowledge: [TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01]
+introduces:
+  knowledge: [TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-WRITE-AAM-02]
+practises:
+  knowledge: [TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-WRITE-AAM-02]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W04-i-sign-write-nandri, TA-C01-aam]
+---
+
+# ஆம் — writing a word that starts with a vowel
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-I-SIGN-WRITE-NANDRI-01] -->
+
+[PAUSE 2s] Every vowel so far has been a **sign** hooked onto a consonant — the
+ி on **ற**. This word has no consonant to hook onto.
+
+## Script you'll notice: a vowel standing alone
+<!-- hl-knowledge: introduces=[TA-SCRIPT-INDEPENDENT-VOWEL-AA-01]; assesses=[] -->
+
+Tamil writes a vowel two ways, and which one you use depends on **where it
+sits**:
+
+| | |
+|---|---|
+| **inside** a word, after a consonant | a small **sign** — ி in **றி** |
+| **starting** a word, with nothing before it | a full **independent letter** |
+
+**ஆ** is the independent letter for long *ā*. It is not a sign and never hangs
+off anything; it is a letter in its own right. Two strokes: **write அ**, then
+**add the right-hand tail** — long *ā* is short *a* plus a tail.
+
+That is a rule, not a special case: any Tamil word that opens on a vowel opens
+with a full vowel letter.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-WRITE-AAM-02]; assesses=[TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+| piece | | |
+|---|---|---|
+| **ஆ** | *ā* | this lesson — independent |
+| **ம்** | *m* — ம with the puḷḷi | the dot you already know |
+
+> **ஆ · ம் → ஆம்**
+
+Two pieces only. The puḷḷi on **ம்** closes the word on a bare *m*, exactly as
+it did at the end of **வணக்கம்**.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-WRITE-AAM-02, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+[PAUSE 1s]
+- [YOU WRITE: **ஆ** — அ, then the right-hand tail]
+- [YOU WRITE: **ம்** — ம with the dot]
+- [YOU WRITE: **ஆம்** — two pieces, left to right]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-WRITE-AAM-02] -->
+
+[PAUSE 3s] Write **ஆம்**. When does a Tamil vowel get a full letter instead of
+a sign? (**When it starts a word** — nothing precedes it to hook onto.) What
+closes the word? (**ம்** — the puḷḷi on ம.) Next: the word for no.

--- a/code/learning/human-languages/tamil/lessons/TA-W05-write-aam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W05-write-aam.md
@@ -12,7 +12,7 @@ prerequisites: [TA-W04-i-sign-write-nandri, TA-W03-pulli-vanakkam]
 sounds: [independent-vowel-aa, pulli, final-m]
 roots: []
 duration:
-  max_seconds: 180
+  max_seconds: 260
 requires:
   knowledge: [TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01]
 introduces:
@@ -32,8 +32,8 @@ reviews_of: [TA-W04-i-sign-write-nandri, TA-C01-aam]
 ## Warm-up
 <!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-I-SIGN-WRITE-NANDRI-01] -->
 
-[PAUSE 2s] Every vowel so far has been a **sign** hooked onto a consonant — the
-ி on **ற**. This word has no consonant to hook onto.
+[PAUSE 2s] Every vowel *sign* so far has hooked onto a consonant — the ி on
+**ற**. This word has no consonant to hook onto.
 
 ## Script you'll notice: a vowel standing alone
 <!-- hl-knowledge: introduces=[TA-SCRIPT-INDEPENDENT-VOWEL-AA-01]; assesses=[] -->
@@ -47,8 +47,19 @@ sits**:
 | **starting** a word, with nothing before it | a full **independent letter** |
 
 **ஆ** is the independent letter for long *ā*. It is not a sign and never hangs
-off anything; it is a letter in its own right. Two strokes: **write அ**, then
-**add the right-hand tail** — long *ā* is short *a* plus a tail.
+off anything; it is a letter in its own right.
+
+Long *ā* is short **அ** plus a tail, so **அ** is where it starts — and you have
+not been shown that one yet. Its parts, then the tail:
+
+1. **a curl at the upper left**
+2. **a long horizontal stroke**
+3. **a straight vertical on the right** — that is **அ**
+4. **a tail added on the right** — and now it is **ஆ**
+
+Those are the parts in writing order. Where the pen lifts is not settled: Tamil
+handwriting varies by region and by school, and this book only claims a pen path
+where it has a sourced one.
 
 That is a rule, not a special case: any Tamil word that opens on a vowel opens
 with a full vowel letter.
@@ -70,7 +81,8 @@ it did at the end of **வணக்கம்**.
 <!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-WRITE-AAM-02, TA-SCRIPT-PULLI-VANAKKAM-01] -->
 
 [PAUSE 1s]
-- [YOU WRITE: **ஆ** — அ, then the right-hand tail]
+- [YOU WRITE: **அ** — curl, horizontal, right vertical]
+- [YOU WRITE: **ஆ** — the same three parts, then the right-hand tail]
 - [YOU WRITE: **ம்** — ம with the dot]
 - [YOU WRITE: **ஆம்** — two pieces, left to right]
 

--- a/code/learning/human-languages/tamil/lessons/TA-W06-write-illai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W06-write-illai.md
@@ -1,0 +1,90 @@
+---
+schema_version: 2
+id: TA-W06-write-illai
+spine_node: SPINE-MEET-GREET
+sequence: 192
+chapter: 1
+type: writing
+headword: "இல்லை"
+gloss: the second independent vowel, the letter ல, and the two-part ai sign
+romanization: "illai"
+prerequisites: [TA-W05-write-aam]
+sounds: [independent-vowel-i, matra-ai, pulli]
+roots: []
+duration:
+  max_seconds: 200
+requires:
+  knowledge: [TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-WRITE-AAM-02]
+introduces:
+  knowledge: [TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-WRITE-ILLAI-03]
+practises:
+  knowledge: [TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-WRITE-ILLAI-03]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W05-write-aam, TA-C01-illai]
+---
+
+# இல்லை — a vowel in front, a vowel sign behind
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-INDEPENDENT-VOWEL-AA-01] -->
+
+[PAUSE 2s] Last lesson gave you the rule: a word opening on a vowel opens with
+a full letter. Here is the same rule with a different vowel, plus one new sign.
+
+## Script you'll notice: இ and ல
+<!-- hl-knowledge: introduces=[TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-LA-AI-SIGN-02]; assesses=[] -->
+
+**இ** is the independent letter for short *i* — the same job **ஆ** did, one
+vowel over. Two strokes: **a crossing spiral on the left**, then **a tall
+straight vertical on the right**.
+
+**ல** is *la*, with its built-in *a* like every consonant. Two strokes: **a curl
+that turns back on itself**, then **a stroke rising to the right**. Put the
+puḷḷi on it and you get **ல்**, a bare *l*.
+
+The new mark is **ை**, the sign for *ai*, and it does something ி did not.
+**It is written to the LEFT of its consonant, but pronounced after it.**
+
+> **ல + ை → லை**, and on the page the hook stands *before* the ல — yet you say
+> *lai*, not *ail*.
+
+Your eye meets the vowel first and your mouth says it second. Devanagari does
+the same thing with ि, and it catches everyone once.
+
+> Tamil keeps **three** *l*-letters (ல ள ழ) and **two** *r*-letters (ர ற), the
+> same way it keeps three *n*'s. This is the first of the *l*'s.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-WRITE-ILLAI-03]; assesses=[TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-LA-AI-SIGN-02] -->
+
+| piece | | |
+|---|---|---|
+| **இ** | *i* | independent — the word opens on a vowel |
+| **ல்** | *l* — ல with the puḷḷi | bare consonant |
+| **லை** | *lai* — ல with the ai sign | this lesson |
+
+> **இ · ல் · லை → இல்லை**
+
+The **ல் + லை** is a doubled *l*, held like the **க்க** of *vaṇakkam*:
+*il-lai*, not *ilai*.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-WRITE-ILLAI-03] -->
+
+[PAUSE 1s]
+- [YOU WRITE: **இ** — spiral, then the right-hand vertical]
+- [YOU WRITE: **ல** — curl, then rising stroke]
+- [YOU WRITE: **லை** — the ai hook goes on the LEFT]
+- [YOU WRITE: **இல்லை** — three pieces]
+- [YOU SAY: "il-lai" — hold the doubled *l*]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-WRITE-ILLAI-03] -->
+
+[PAUSE 3s] Write **இல்லை**. Why does it open with **இ** rather than a sign?
+(**The word starts on a vowel**.) Which side of its consonant does **ை** sit
+on? (**The left** — written first, spoken second.) Next: the word for thank you.

--- a/code/learning/human-languages/tamil/lessons/TA-W06-write-illai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W06-write-illai.md
@@ -6,13 +6,13 @@ sequence: 192
 chapter: 1
 type: writing
 headword: "இல்லை"
-gloss: the second independent vowel, the letter ல, and the two-part ai sign
+gloss: a second independent vowel, the letter ல, and the left-standing ai sign
 romanization: "illai"
 prerequisites: [TA-W05-write-aam]
 sounds: [independent-vowel-i, matra-ai, pulli]
 roots: []
 duration:
-  max_seconds: 200
+  max_seconds: 260
 requires:
   knowledge: [TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-WRITE-AAM-02]
 introduces:
@@ -39,12 +39,17 @@ a full letter. Here is the same rule with a different vowel, plus one new sign.
 <!-- hl-knowledge: introduces=[TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-LA-AI-SIGN-02]; assesses=[] -->
 
 **இ** is the independent letter for short *i* — the same job **ஆ** did, one
-vowel over. Two strokes: **a crossing spiral on the left**, then **a tall
-straight vertical on the right**.
+vowel over. Its parts, in writing order:
 
-**ல** is *la*, with its built-in *a* like every consonant. Two strokes: **a curl
-that turns back on itself**, then **a stroke rising to the right**. Put the
-puḷḷi on it and you get **ல்**, a bare *l*.
+1. **a crossing spiral on the left**
+2. **a tall straight vertical on the right**
+
+**ல** is *la*, with its built-in *a* like every consonant:
+
+1. **a curl that turns back on itself**
+2. **a stroke rising to the right**
+
+Put the puḷḷi on it and you get **ல்**, a bare *l*.
 
 The new mark is **ை**, the sign for *ai*, and it does something ி did not.
 **It is written to the LEFT of its consonant, but pronounced after it.**

--- a/code/learning/human-languages/tamil/lessons/TA-W07-write-sari.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W07-write-sari.md
@@ -1,0 +1,89 @@
+---
+schema_version: 2
+id: TA-W07-write-sari
+spine_node: SPINE-MEET-GREET
+sequence: 222
+chapter: 1
+type: writing
+headword: "சரி"
+gloss: one letter for a whole family of sounds — ச — and the second r
+romanization: "sari"
+prerequisites: [TA-W06-write-illai]
+sounds: [c-sa-one-letter, matra-i]
+roots: []
+duration:
+  max_seconds: 190
+requires:
+  knowledge: [TA-SCRIPT-WRITE-ILLAI-03, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01]
+introduces:
+  knowledge: [TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-WRITE-SARI-02]
+practises:
+  knowledge: [TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-WRITE-SARI-02]
+skills: [reading, writing]
+modes: [interpretive, presentational]
+strands: [meaning-input, meaning-output, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W06-write-illai, TA-C01-sari]
+---
+
+# சரி — one letter, several sounds
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-I-SIGN-WRITE-NANDRI-01] -->
+
+[PAUSE 2s] You have seen **க** cover *k*, *g* and a soft *h* depending on where
+it sits. Here is the same economy on a second letter.
+
+## Script you'll notice: ச and ர
+<!-- hl-knowledge: introduces=[TA-SCRIPT-CA-ONE-LETTER-01]; assesses=[] -->
+
+**ச** is written once and does the work English splits between **s**, **ch**
+and **j**. Position picks which:
+
+| where | sound |
+|---|---|
+| starting a word | *s* or *ch* |
+| between vowels | softened |
+| after a nasal, as in **ஞ்ச** | *j* |
+
+That is exactly the pattern **க** showed — *k* at the start, *g* after a nasal,
+a soft *h* between vowels. One letter per position of the mouth, and context
+fills in the rest.
+
+**ர** is *ra*, with its built-in *a*. It is the second of Tamil's **two**
+*r*-letters, alongside the **ற** you met in **நன்றி**.
+
+> Read both letters here; do not draw them yet. This book gives a stroke order
+> only where it has a sourced one, and ச and ர do not have one yet.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-WRITE-SARI-02]; assesses=[TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01] -->
+
+| piece | | |
+|---|---|---|
+| **ச** | *sa* here | this lesson |
+| **ரி** | *ri* — ர with the ி sign | the sign from **நன்றி** |
+
+> **ச · ரி → சரி**
+
+Two pieces, and both parts are things you already hold: a consonant, and the
+vowel sign you first hooked onto **ற**.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-WRITE-SARI-02] -->
+
+[PAUSE 1s]
+- [YOU READ: **ச** — then **சரி**]
+- [YOU SAY: "sari"]
+- [YOU CONTRAST: **ரி** and **லை** — the ி sign follows its letter, the ை sign
+  precedes it]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-WRITE-SARI-02, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-INDEPENDENT-VOWEL-I-01] -->
+
+[PAUSE 3s] Read **சரி**. Which English sounds does **ச** cover on its own?
+(**s, ch, j** — start, between vowels, after a nasal.) How many *r*-letters does
+Tamil keep? (**Two** — ர and ற.) In **லை**, which side of the ல does the ai sign
+sit on? (**The left**.) And why does **இல்லை** open with **இ** rather than a
+sign? (**It starts on a vowel**.) Next: putting the five words together.

--- a/code/learning/human-languages/tamil/lessons/TA-W07-write-sari.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W07-write-sari.md
@@ -12,13 +12,13 @@ prerequisites: [TA-W06-write-illai]
 sounds: [c-sa-one-letter, matra-i]
 roots: []
 duration:
-  max_seconds: 190
+  max_seconds: 260
 requires:
-  knowledge: [TA-SCRIPT-WRITE-ILLAI-03, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01]
+  knowledge: [TA-SCRIPT-WRITE-AAM-02, TA-SCRIPT-WRITE-ILLAI-03, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01]
 introduces:
   knowledge: [TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-WRITE-SARI-02]
 practises:
-  knowledge: [TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-WRITE-SARI-02]
+  knowledge: [TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-WRITE-SARI-02, TA-SCRIPT-WRITE-AAM-02, TA-SCRIPT-WRITE-ILLAI-03]
 skills: [reading, writing]
 modes: [interpretive, presentational]
 strands: [meaning-input, meaning-output, language-focus]
@@ -30,7 +30,7 @@ reviews_of: [TA-W06-write-illai, TA-C01-sari]
 # சரி — one letter, several sounds
 
 ## Warm-up
-<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-I-SIGN-WRITE-NANDRI-01] -->
+<!-- hl-knowledge: introduces=[]; assesses=[] -->
 
 [PAUSE 2s] You have seen **க** cover *k*, *g* and a soft *h* depending on where
 it sits. Here is the same economy on a second letter.
@@ -51,7 +51,7 @@ That is exactly the pattern **க** showed — *k* at the start, *g* after a nas
 a soft *h* between vowels. One letter per position of the mouth, and context
 fills in the rest.
 
-**ர** is *ra*, with its built-in *a*. It is the second of Tamil's **two**
+**ர** is *ra*, with its built-in *a*. It is the other of Tamil's **two**
 *r*-letters, alongside the **ற** you met in **நன்றி**.
 
 > Read both letters here; do not draw them yet. This book gives a stroke order
@@ -71,19 +71,22 @@ Two pieces, and both parts are things you already hold: a consonant, and the
 vowel sign you first hooked onto **ற**.
 
 ## Guided Practice
-<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-WRITE-SARI-02] -->
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-WRITE-SARI-02, TA-SCRIPT-WRITE-AAM-02, TA-SCRIPT-WRITE-ILLAI-03] -->
 
 [PAUSE 1s]
 - [YOU READ: **ச** — then **சரி**]
 - [YOU SAY: "sari"]
 - [YOU CONTRAST: **ரி** and **லை** — the ி sign follows its letter, the ை sign
   precedes it]
+- [YOU WRITE: **ஆம்** and **இல்லை** again, from memory — yes and no, the two you
+  will reach for most]
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-WRITE-SARI-02, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-INDEPENDENT-VOWEL-I-01] -->
 
 [PAUSE 3s] Read **சரி**. Which English sounds does **ச** cover on its own?
-(**s, ch, j** — start, between vowels, after a nasal.) How many *r*-letters does
+(***s*** or ***ch*** at the start, softened between vowels, ***j*** after a
+nasal.) How many *r*-letters does
 Tamil keep? (**Two** — ர and ற.) In **லை**, which side of the ல does the ai sign
 sit on? (**The left**.) And why does **இல்லை** open with **இ** rather than a
 sign? (**It starts on a vowel**.) Next: putting the five words together.

--- a/code/learning/human-languages/tamil/narration/ch01.json
+++ b/code/learning/human-languages/tamil/narration/ch01.json
@@ -4,7 +4,7 @@
   "chapter": 1,
   "title": "Greetings",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:cd6ee126f13c74e3",
+  "sourceHash": "fnv1a64:b4faba4479bcf0ba",
   "lessons": [
     {
       "id": "TA-C01-vanakkam",
@@ -1599,7 +1599,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:33b4b0ca5bf90f6f",
+      "sourceHash": "fnv1a64:96c6bb2306442e1b",
       "notice": null,
       "blocks": [
         {
@@ -1695,7 +1695,173 @@
             },
             {
               "kind": "speech",
-              "text": "Say ஆம். What does ஆமாம் add? (Emphasis — \"yes, indeed.\") Next: the word for no."
+              "text": "Say ஆம் (ām). What does ஆமாம் add? (Emphasis — \"yes, indeed.\") Next: writing it."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W05-write-aam",
+      "sequence": 182,
+      "title": "ஆம் (ām) — writing a word that starts with a vowel",
+      "headword": "ஆம்",
+      "romanization": "ām",
+      "gloss": "a word that begins with a vowel gets a full vowel letter, not a sign",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:004df6bb767bb7b2",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: a vowel standing alone",
+          "Script you'll notice: build the word",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: a vowel standing alone, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Every vowel so far has been a sign hooked onto a consonant — the ி on ற. This word has no consonant to hook onto."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: a vowel standing alone",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Tamil writes a vowel two ways, and which one you use depends on where it sits:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "inside a word, after a consonant, a small sign — ி in றி.",
+                "starting a word, with nothing before it, a full independent letter."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "ஆ is the independent letter for long ā. It is not a sign and never hangs off anything; it is a letter in its own right. Two strokes: write அ, then add the right-hand tail — long ā is short a plus a tail."
+            },
+            {
+              "kind": "speech",
+              "text": "That is a rule, not a special case: any Tamil word that opens on a vowel opens with a full vowel letter."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 2,
+              "utterances": [
+                "piece: ஆ, ā, this lesson — independent.",
+                "piece: ம், m — ம with the puḷḷi, the dot you already know."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "ஆ, ம் becomes ஆம் (ām)."
+            },
+            {
+              "kind": "speech",
+              "text": "Two pieces only. The puḷḷi on ம் closes the word on a bare m, exactly as it did at the end of வணக்கம் (vaṇakkam)."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ஆ — அ, then the right-hand tail",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **ஆ** — அ, then the right-hand tail]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ம் — ம with the dot",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **ம்** — ம with the dot]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ஆம் (ām) — two pieces, left to right",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **ஆம்** — two pieces, left to right]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write ஆம் (ām). When does a Tamil vowel get a full letter instead of a sign? (When it starts a word — nothing precedes it to hook onto.) What closes the word? (ம் — the puḷḷi on ம.) Next: the word for no."
             }
           ]
         }
@@ -1714,7 +1880,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:93b6d60e45822e82",
+      "sourceHash": "fnv1a64:beee25438cdb89ae",
       "notice": null,
       "blocks": [
         {
@@ -1810,7 +1976,191 @@
             },
             {
               "kind": "speech",
-              "text": "Say இல்லை. Is it closer to English no, or to is not? (Is not — it is a statement, not a label.) Next: the word for thank you."
+              "text": "Say இல்லை (illai). Is it closer to English no, or to is not? (Is not — it is a statement, not a label.) Next: writing it."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W06-write-illai",
+      "sequence": 192,
+      "title": "இல்லை (illai) — a vowel in front, a vowel sign behind",
+      "headword": "இல்லை",
+      "romanization": "illai",
+      "gloss": "the second independent vowel, the letter ல, and the two-part ai sign",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:401db61ecee484ec",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: இ and ல",
+          "Script you'll notice: build the word",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: இ and ல, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Last lesson gave you the rule: a word opening on a vowel opens with a full letter. Here is the same rule with a different vowel, plus one new sign."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: இ and ல",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "இ is the independent letter for short i — the same job ஆ did, one vowel over. Two strokes: a crossing spiral on the left, then a tall straight vertical on the right."
+            },
+            {
+              "kind": "speech",
+              "text": "ல is la, with its built-in a like every consonant. Two strokes: a curl that turns back on itself, then a stroke rising to the right. Put the puḷḷi on it and you get ல், a bare l."
+            },
+            {
+              "kind": "speech",
+              "text": "The new mark is ை, the sign for ai, and it does something ி did not. It is written to the LEFT of its consonant, but pronounced after it."
+            },
+            {
+              "kind": "speech",
+              "text": "ல + ை becomes லை, and on the page the hook stands before the ல — yet you say lai, not ail."
+            },
+            {
+              "kind": "speech",
+              "text": "Your eye meets the vowel first and your mouth says it second. Devanagari does the same thing with ि, and it catches everyone once."
+            },
+            {
+              "kind": "speech",
+              "text": "Tamil keeps three l-letters (ல ள ழ) and two r-letters (ர ற), the same way it keeps three n's. This is the first of the l's."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "piece: இ, i, independent — the word opens on a vowel.",
+                "piece: ல், l — ல with the puḷḷi, bare consonant.",
+                "piece: லை, lai — ல with the ai sign, this lesson."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "இ, ல், லை becomes இல்லை (illai)."
+            },
+            {
+              "kind": "speech",
+              "text": "The ல் + லை is a doubled l, held like the க்க of vaṇakkam: il-lai, not ilai."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "இ — spiral, then the right-hand vertical",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **இ** — spiral, then the right-hand vertical]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ல — curl, then rising stroke",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **ல** — curl, then rising stroke]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "லை — the ai hook goes on the LEFT",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **லை** — the ai hook goes on the LEFT]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "இல்லை (illai) — three pieces",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **இல்லை** — three pieces]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"il-lai\" — hold the doubled l",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"il-lai\" — hold the doubled *l*]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write இல்லை (illai). Why does it open with இ rather than a sign? (The word starts on a vowel.) Which side of its consonant does ை sit on? (The left — written first, spoken second.) Next: the word for thank you."
             }
           ]
         }
@@ -2079,7 +2429,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7aaa8c8d3e80fe76",
+      "sourceHash": "fnv1a64:c6020b573775bf3a",
       "notice": null,
       "blocks": [
         {
@@ -2175,7 +2525,177 @@
             },
             {
               "kind": "speech",
-              "text": "Say சரி. What does doubling it add? (Hurry, or easy agreement — \"yes yes, fine.\") Next: putting the five together."
+              "text": "Say சரி (sari). What does doubling it add? (Hurry, or easy agreement — \"yes yes, fine.\") Next: writing it."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W07-write-sari",
+      "sequence": 222,
+      "title": "சரி (sari) — one letter, several sounds",
+      "headword": "சரி",
+      "romanization": "sari",
+      "gloss": "one letter for a whole family of sounds — ச — and the second r",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:9d4f3d4db2b91e50",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: ச and ர",
+          "Script you'll notice: build the word"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ச and ர and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You have seen க cover k, g and a soft h depending on where it sits. Here is the same economy on a second letter."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: ச and ர",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ச is written once and does the work English splits between s, ch and j. Position picks which:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "where",
+                "sound"
+              ],
+              "columns": 2,
+              "rowCount": 3,
+              "utterances": [
+                "where: starting a word. sound: s or ch.",
+                "where: between vowels. sound: softened.",
+                "where: after a nasal, as in ஞ்ச. sound: j."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "That is exactly the pattern க showed — k at the start, g after a nasal, a soft h between vowels. One letter per position of the mouth, and context fills in the rest."
+            },
+            {
+              "kind": "speech",
+              "text": "ர is ra, with its built-in a. It is the second of Tamil's two r-letters, alongside the ற you met in நன்றி."
+            },
+            {
+              "kind": "speech",
+              "text": "Read both letters here; do not draw them yet. This book gives a stroke order only where it has a sourced one, and ச and ர do not have one yet."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 2,
+              "utterances": [
+                "piece: ச, sa here, this lesson.",
+                "piece: ரி, ri — ர with the ி sign, the sign from நன்றி."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "ச, ரி becomes சரி (sari)."
+            },
+            {
+              "kind": "speech",
+              "text": "Two pieces, and both parts are things you already hold: a consonant, and the vowel sign you first hooked onto ற."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "ச — then சரி (sari)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **ச** — then **சரி**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sari\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sari\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "ரி and லை — the ி sign follows its letter, the ை sign precedes it",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **ரி** and **லை** — the ி sign follows its letter, the ை sign precedes it]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read சரி (sari). Which English sounds does ச cover on its own? (s, ch, j — start, between vowels, after a nasal.) How many r-letters does Tamil keep? (Two — ர and ற.) In லை, which side of the ல does the ai sign sit on? (The left.) And why does இல்லை (illai) open with இ rather than a sign? (It starts on a vowel.) Next: putting the five words together."
             }
           ]
         }
@@ -2225,7 +2745,7 @@
             },
             {
               "kind": "speech",
-              "text": "— வணக்கம் (vaṇakkam). — வணக்கம் (vaṇakkam). — சரி? — ஆம். — நன்றி. — சரி. — Hello. — Hello. — Alright? — Yes. — Thank you. — Alright."
+              "text": "— வணக்கம் (vaṇakkam). — வணக்கம் (vaṇakkam). — சரி (sari)? — ஆம் (ām). — நன்றி. — சரி (sari). — Hello. — Hello. — Alright? — Yes. — Thank you. — Alright."
             },
             {
               "kind": "speech",

--- a/code/learning/human-languages/tamil/narration/ch01.json
+++ b/code/learning/human-languages/tamil/narration/ch01.json
@@ -4,7 +4,7 @@
   "chapter": 1,
   "title": "Greetings",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:b4faba4479bcf0ba",
+  "sourceHash": "fnv1a64:b35c2c9e484d8ba0",
   "lessons": [
     {
       "id": "TA-C01-vanakkam",
@@ -1715,7 +1715,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:004df6bb767bb7b2",
+      "sourceHash": "fnv1a64:d2d9939892304061",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -1743,7 +1743,7 @@
             },
             {
               "kind": "speech",
-              "text": "Every vowel so far has been a sign hooked onto a consonant — the ி on ற. This word has no consonant to hook onto."
+              "text": "Every vowel sign so far has hooked onto a consonant — the ி on ற. This word has no consonant to hook onto."
             }
           ]
         },
@@ -1771,7 +1771,31 @@
             },
             {
               "kind": "speech",
-              "text": "ஆ is the independent letter for long ā. It is not a sign and never hangs off anything; it is a letter in its own right. Two strokes: write அ, then add the right-hand tail — long ā is short a plus a tail."
+              "text": "ஆ is the independent letter for long ā. It is not a sign and never hangs off anything; it is a letter in its own right."
+            },
+            {
+              "kind": "speech",
+              "text": "Long ā is short அ plus a tail, so அ is where it starts — and you have not been shown that one yet. Its parts, then the tail:"
+            },
+            {
+              "kind": "speech",
+              "text": "a curl at the upper left."
+            },
+            {
+              "kind": "speech",
+              "text": "a long horizontal stroke."
+            },
+            {
+              "kind": "speech",
+              "text": "a straight vertical on the right — that is அ."
+            },
+            {
+              "kind": "speech",
+              "text": "a tail added on the right — and now it is ஆ."
+            },
+            {
+              "kind": "speech",
+              "text": "Those are the parts in writing order. Where the pen lifts is not settled: Tamil handwriting varies by region and by school, and this book only claims a pen path where it has a sourced one."
             },
             {
               "kind": "speech",
@@ -1822,11 +1846,20 @@
             {
               "kind": "prompt",
               "action": "WRITE",
-              "instruction": "ஆ — அ, then the right-hand tail",
+              "instruction": "அ — curl, horizontal, right vertical",
               "spoken": false,
               "scored": false,
               "responseSeconds": 8,
-              "source": "[YOU WRITE: **ஆ** — அ, then the right-hand tail]"
+              "source": "[YOU WRITE: **அ** — curl, horizontal, right vertical]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ஆ — the same three parts, then the right-hand tail",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **ஆ** — the same three parts, then the right-hand tail]"
             },
             {
               "kind": "prompt",
@@ -1988,7 +2021,7 @@
       "title": "இல்லை (illai) — a vowel in front, a vowel sign behind",
       "headword": "இல்லை",
       "romanization": "illai",
-      "gloss": "the second independent vowel, the letter ல, and the two-part ai sign",
+      "gloss": "a second independent vowel, the letter ல, and the left-standing ai sign",
       "script": "tamil",
       "modality": "pen",
       "derivedModality": "pen",
@@ -1996,7 +2029,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:401db61ecee484ec",
+      "sourceHash": "fnv1a64:355d80e464a1c094",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -2035,11 +2068,31 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "இ is the independent letter for short i — the same job ஆ did, one vowel over. Two strokes: a crossing spiral on the left, then a tall straight vertical on the right."
+              "text": "இ is the independent letter for short i — the same job ஆ did, one vowel over. Its parts, in writing order:"
             },
             {
               "kind": "speech",
-              "text": "ல is la, with its built-in a like every consonant. Two strokes: a curl that turns back on itself, then a stroke rising to the right. Put the puḷḷi on it and you get ல், a bare l."
+              "text": "a crossing spiral on the left."
+            },
+            {
+              "kind": "speech",
+              "text": "a tall straight vertical on the right."
+            },
+            {
+              "kind": "speech",
+              "text": "ல is la, with its built-in a like every consonant:"
+            },
+            {
+              "kind": "speech",
+              "text": "a curl that turns back on itself."
+            },
+            {
+              "kind": "speech",
+              "text": "a stroke rising to the right."
+            },
+            {
+              "kind": "speech",
+              "text": "Put the puḷḷi on it and you get ல், a bare l."
             },
             {
               "kind": "speech",
@@ -2545,7 +2598,7 @@
         "writing-type",
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9d4f3d4db2b91e50",
+      "sourceHash": "fnv1a64:235103e17e063c6b",
       "notice": {
         "modality": "pen",
         "needs": [
@@ -2554,9 +2607,10 @@
         ],
         "waitUntilStopped": [
           "Script you'll notice: ச and ர",
-          "Script you'll notice: build the word"
+          "Script you'll notice: build the word",
+          "Guided Practice"
         ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ச and ர and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it."
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ச and ர, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it."
       },
       "blocks": [
         {
@@ -2605,7 +2659,7 @@
             },
             {
               "kind": "speech",
-              "text": "ர is ra, with its built-in a. It is the second of Tamil's two r-letters, alongside the ற you met in நன்றி."
+              "text": "ர is ra, with its built-in a. It is the other of Tamil's two r-letters, alongside the ற you met in நன்றி."
             },
             {
               "kind": "speech",
@@ -2679,6 +2733,15 @@
               "scored": false,
               "responseSeconds": 8,
               "source": "[YOU CONTRAST: **ரி** and **லை** — the ி sign follows its letter, the ை sign precedes it]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ஆம் (ām) and இல்லை (illai) again, from memory — yes and no, the two you will reach for most",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **ஆம்** and **இல்லை** again, from memory — yes and no, the two you will reach for most]"
             }
           ]
         },
@@ -2695,7 +2758,7 @@
             },
             {
               "kind": "speech",
-              "text": "Read சரி (sari). Which English sounds does ச cover on its own? (s, ch, j — start, between vowels, after a nasal.) How many r-letters does Tamil keep? (Two — ர and ற.) In லை, which side of the ல does the ai sign sit on? (The left.) And why does இல்லை (illai) open with இ rather than a sign? (It starts on a vowel.) Next: putting the five words together."
+              "text": "Read சரி (sari). Which English sounds does ச cover on its own? (s or ch at the start, softened between vowels, j after a nasal.) How many r-letters does Tamil keep? (Two — ர and ற.) In லை, which side of the ல does the ai sign sit on? (The left.) And why does இல்லை (illai) open with இ rather than a sign? (It starts on a vowel.) Next: putting the five words together."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch01.txt
+++ b/code/learning/human-languages/tamil/narration/ch01.txt
@@ -391,14 +391,20 @@ Before we start: this one needs your hands, so it is not a driving lesson. You w
 
 Warm-up.
 [pause 2 seconds]
-Every vowel so far has been a sign hooked onto a consonant — the ி on ற. This word has no consonant to hook onto.
+Every vowel sign so far has hooked onto a consonant — the ி on ற. This word has no consonant to hook onto.
 
 Script you'll notice: a vowel standing alone.
 Tamil writes a vowel two ways, and which one you use depends on where it sits:
 [a table of 2 rows, read aloud]
 inside a word, after a consonant, a small sign — ி in றி.
 starting a word, with nothing before it, a full independent letter.
-ஆ is the independent letter for long ā. It is not a sign and never hangs off anything; it is a letter in its own right. Two strokes: write அ, then add the right-hand tail — long ā is short a plus a tail.
+ஆ is the independent letter for long ā. It is not a sign and never hangs off anything; it is a letter in its own right.
+Long ā is short அ plus a tail, so அ is where it starts — and you have not been shown that one yet. Its parts, then the tail:
+a curl at the upper left.
+a long horizontal stroke.
+a straight vertical on the right — that is அ.
+a tail added on the right — and now it is ஆ.
+Those are the parts in writing order. Where the pen lifts is not settled: Tamil handwriting varies by region and by school, and this book only claims a pen path where it has a sourced one.
 That is a rule, not a special case: any Tamil word that opens on a vowel opens with a full vowel letter.
 
 Script you'll notice: build the word.
@@ -410,7 +416,8 @@ Two pieces only. The puḷḷi on ம் closes the word on a bare m, exactly as
 
 Guided Practice.
 [pause 1 second]
-[once you have stopped driving — write: ஆ — அ, then the right-hand tail]
+[once you have stopped driving — write: அ — curl, horizontal, right vertical]
+[once you have stopped driving — write: ஆ — the same three parts, then the right-hand tail]
 [once you have stopped driving — write: ம் — ம with the dot]
 [once you have stopped driving — write: ஆம் (ām) — two pieces, left to right]
 
@@ -456,8 +463,13 @@ Warm-up.
 Last lesson gave you the rule: a word opening on a vowel opens with a full letter. Here is the same rule with a different vowel, plus one new sign.
 
 Script you'll notice: இ and ல.
-இ is the independent letter for short i — the same job ஆ did, one vowel over. Two strokes: a crossing spiral on the left, then a tall straight vertical on the right.
-ல is la, with its built-in a like every consonant. Two strokes: a curl that turns back on itself, then a stroke rising to the right. Put the puḷḷi on it and you get ல், a bare l.
+இ is the independent letter for short i — the same job ஆ did, one vowel over. Its parts, in writing order:
+a crossing spiral on the left.
+a tall straight vertical on the right.
+ல is la, with its built-in a like every consonant:
+a curl that turns back on itself.
+a stroke rising to the right.
+Put the puḷḷi on it and you get ல், a bare l.
 The new mark is ை, the sign for ai, and it does something ி did not. It is written to the LEFT of its consonant, but pronounced after it.
 ல + ை becomes லை, and on the page the hook stands before the ல — yet you say lai, not ail.
 Your eye meets the vowel first and your mouth says it second. Devanagari does the same thing with ि, and it catches everyone once.
@@ -576,7 +588,7 @@ Say சரி (sari). What does doubling it add? (Hurry, or easy agreement — "
 Lesson 18 of 20.
 சரி (sari) — one letter, several sounds.
 
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ச and ர and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it.
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ச and ர, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it.
 
 Warm-up.
 [pause 2 seconds]
@@ -589,7 +601,7 @@ where: starting a word. sound: s or ch.
 where: between vowels. sound: softened.
 where: after a nasal, as in ஞ்ச. sound: j.
 That is exactly the pattern க showed — k at the start, g after a nasal, a soft h between vowels. One letter per position of the mouth, and context fills in the rest.
-ர is ra, with its built-in a. It is the second of Tamil's two r-letters, alongside the ற you met in நன்றி.
+ர is ra, with its built-in a. It is the other of Tamil's two r-letters, alongside the ற you met in நன்றி.
 Read both letters here; do not draw them yet. This book gives a stroke order only where it has a sourced one, and ச and ர do not have one yet.
 
 Script you'll notice: build the word.
@@ -607,10 +619,11 @@ Guided Practice.
 [pause 8 seconds for the answer]
 [your turn — contrast: ரி and லை — the ி sign follows its letter, the ை sign precedes it]
 [pause 8 seconds for the answer]
+[once you have stopped driving — write: ஆம் (ām) and இல்லை (illai) again, from memory — yes and no, the two you will reach for most]
 
 Wrap-up Recall.
 [pause 3 seconds]
-Read சரி (sari). Which English sounds does ச cover on its own? (s, ch, j — start, between vowels, after a nasal.) How many r-letters does Tamil keep? (Two — ர and ற.) In லை, which side of the ல does the ai sign sit on? (The left.) And why does இல்லை (illai) open with இ rather than a sign? (It starts on a vowel.) Next: putting the five words together.
+Read சரி (sari). Which English sounds does ச cover on its own? (s or ch at the start, softened between vowels, j after a nasal.) How many r-letters does Tamil keep? (Two — ர and ற.) In லை, which side of the ல does the ai sign sit on? (The left.) And why does இல்லை (illai) open with இ rather than a sign? (It starts on a vowel.) Next: putting the five words together.
 
 
 Lesson 19 of 20.

--- a/code/learning/human-languages/tamil/narration/ch01.txt
+++ b/code/learning/human-languages/tamil/narration/ch01.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 1: Greetings.
-17 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
+20 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 17.
+Lesson 1 of 20.
 வணக்கம் (vaṇakkam) — "greetings".
 
 Warm-up.
@@ -29,7 +29,7 @@ Wrap-up Recall.
 Say வணக்கம் (vaṇakkam). Does it change between morning and evening? (No — one greeting, all day.) Does it change for one person or a crowd? (No.) Next: the same greeting across the Dravidian family.
 
 
-Lesson 2 of 17.
+Lesson 2 of 20.
 வணக்கம் (vaṇakkam) — one bow, two lexical loyalties.
 
 Warm-up.
@@ -63,7 +63,7 @@ Wrap-up Recall.
 Which Dravidian language kept its native bow-word? (Tamil.) What did the neighbors borrow? (Sanskrit namas-.) Can vaṇakkam greet and part? (Yes — it is an all-day respectful salutation.)
 
 
-Lesson 3 of 17.
+Lesson 3 of 20.
 Tamil's curves — the writing surface leaves a trace.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script you'll notice: The script is the shape of its writing surface and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -95,7 +95,7 @@ Why is Tamil round? (The usual explanation: it was incised on palm leaves, where
 What writing surface is usually linked to Tamil's rounded shapes?
 
 
-Lesson 4 of 17.
+Lesson 4 of 20.
 வ and க — the vowel inside each consonant.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The vowel you get for free, Script you'll notice: வ — "va", Script you'll notice: க — "ka" and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -136,7 +136,7 @@ Wrap-up Recall.
 What does க say alone? (Ka — the vowel is inherent.) What kind of script is this? (An abugida.) Which sounds can க spell? (k, g, and a softer h-like sound, chosen by position.) Draw வ and க.
 
 
-Lesson 5 of 17.
+Lesson 5 of 20.
 ம and ண — a loop, and a curled tongue.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ம, Script you'll notice: ண and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -176,7 +176,7 @@ Wrap-up Recall.
 Draw ம — which side is the upright on? (The left; the arch closes it on the right.) Draw ண — what makes it not ன? (One extra arch: ண has two arches where ன has one. Both end in the same straight vertical.) What does the dot in ṇ mean? (Retroflex — the tongue curls back to the roof of the mouth.) Why can't you hear it yet? (English has no such sound; the ear learns it after the hand.) Next: place Tamil's three n's along one backward walk through the mouth.
 
 
-Lesson 6 of 17.
+Lesson 6 of 20.
 ந, ன, ண (na, ṉa, ṇa) — three stops on one tongue-map.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The backward walk and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -209,7 +209,7 @@ Wrap-up Recall.
 How many n-letters does Tamil have? (Three.) What separates them? (Tongue position: dental, alveolar, retroflex.) Which two differ by one arch? (ன has one; ண has two.) Next: remove the vowel from a consonant.
 
 
-Lesson 7 of 17.
+Lesson 7 of 20.
 ் (puḷḷi) — the dot that leaves both letters visible.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script you'll notice: The puḷḷi, Script you'll notice: What Tamil does not do and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -244,7 +244,7 @@ Wrap-up Recall.
 What does the puḷḷi do, and what does the word mean? (Removes the inherent vowel; puḷḷi is simply "the dot".) What does Devanagari do that Tamil doesn't? (Fuses the letters into a conjunct — Tamil keeps both shapes and the dot.) What does Tamil get in exchange? (A much smaller character set — 247, with almost no ligatures: only the borrowed க்ஷ and ஸ்ரீ.) Next: assemble that visible dot into வணக்கம் (vaṇakkam).
 
 
-Lesson 8 of 17.
+Lesson 8 of 20.
 வணக்கம் (vaṇakkam) — the first whole written word.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: Build the word and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -277,7 +277,7 @@ Wrap-up Recall.
 Write வணக்கம் (vaṇakkam). What is special about க்க? (It is doubled and held.) Why does the word end in m, not ma? (Final ம் carries a puḷḷi.) Next: write the letters and vowel sign inside nandri.
 
 
-Lesson 9 of 17.
+Lesson 9 of 20.
 ந, ன, ற (na, ṉa, ṟa) — the letter bodies inside நன்றி.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The two remaining n's, Script you'll notice: ற — "ṟa", the hard r and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -317,7 +317,7 @@ Wrap-up Recall.
 Name Tamil's three n-letters and their tongue positions. (ந dental, ன alveolar, ண retroflex.) What are a consonant's three possibilities so far? (Keep the built-in a or remove it with the puḷḷi.) Which letter hangs below the baseline? (ற, the hard ṟ.) Next: replace the vowel, assemble நன்றி, and hear why English often writes nandri.
 
 
-Lesson 10 of 17.
+Lesson 10 of 20.
 ி and நன்றி — replace the vowel, then hear ndr.
 
 Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The first vowel sign, Script you'll notice: Assemble நன்றி and Guided Practice until you have stopped, and I will say so again when we reach it.
@@ -357,7 +357,7 @@ Wrap-up Recall.
 What are a consonant's three vowel choices? (Keep inherent a, remove it with puḷḷi, or replace it with a vowel sign.) Where does ி attach? (Above and right.) Why is naṉṟi often written nandri? (ன் + ற is pronounced ndr because a nasal voices the following stop.)
 
 
-Lesson 11 of 17.
+Lesson 11 of 20.
 ஆம் (ām) — "yes".
 
 Warm-up.
@@ -381,10 +381,45 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-Say ஆம். What does ஆமாம் add? (Emphasis — "yes, indeed.") Next: the word for no.
+Say ஆம் (ām). What does ஆமாம் add? (Emphasis — "yes, indeed.") Next: writing it.
 
 
-Lesson 12 of 17.
+Lesson 12 of 20.
+ஆம் (ām) — writing a word that starts with a vowel.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: a vowel standing alone, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Every vowel so far has been a sign hooked onto a consonant — the ி on ற. This word has no consonant to hook onto.
+
+Script you'll notice: a vowel standing alone.
+Tamil writes a vowel two ways, and which one you use depends on where it sits:
+[a table of 2 rows, read aloud]
+inside a word, after a consonant, a small sign — ி in றி.
+starting a word, with nothing before it, a full independent letter.
+ஆ is the independent letter for long ā. It is not a sign and never hangs off anything; it is a letter in its own right. Two strokes: write அ, then add the right-hand tail — long ā is short a plus a tail.
+That is a rule, not a special case: any Tamil word that opens on a vowel opens with a full vowel letter.
+
+Script you'll notice: build the word.
+[a table of 2 rows, read aloud]
+piece: ஆ, ā, this lesson — independent.
+piece: ம், m — ம with the puḷḷi, the dot you already know.
+ஆ, ம் becomes ஆம் (ām).
+Two pieces only. The puḷḷi on ம் closes the word on a bare m, exactly as it did at the end of வணக்கம் (vaṇakkam).
+
+Guided Practice.
+[pause 1 second]
+[once you have stopped driving — write: ஆ — அ, then the right-hand tail]
+[once you have stopped driving — write: ம் — ம with the dot]
+[once you have stopped driving — write: ஆம் (ām) — two pieces, left to right]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Write ஆம் (ām). When does a Tamil vowel get a full letter instead of a sign? (When it starts a word — nothing precedes it to hook onto.) What closes the word? (ம் — the puḷḷi on ம.) Next: the word for no.
+
+
+Lesson 13 of 20.
 இல்லை (illai) — "no".
 
 Warm-up.
@@ -408,10 +443,49 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-Say இல்லை. Is it closer to English no, or to is not? (Is not — it is a statement, not a label.) Next: the word for thank you.
+Say இல்லை (illai). Is it closer to English no, or to is not? (Is not — it is a statement, not a label.) Next: writing it.
 
 
-Lesson 13 of 17.
+Lesson 14 of 20.
+இல்லை (illai) — a vowel in front, a vowel sign behind.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: இ and ல, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Last lesson gave you the rule: a word opening on a vowel opens with a full letter. Here is the same rule with a different vowel, plus one new sign.
+
+Script you'll notice: இ and ல.
+இ is the independent letter for short i — the same job ஆ did, one vowel over. Two strokes: a crossing spiral on the left, then a tall straight vertical on the right.
+ல is la, with its built-in a like every consonant. Two strokes: a curl that turns back on itself, then a stroke rising to the right. Put the puḷḷi on it and you get ல், a bare l.
+The new mark is ை, the sign for ai, and it does something ி did not. It is written to the LEFT of its consonant, but pronounced after it.
+ல + ை becomes லை, and on the page the hook stands before the ல — yet you say lai, not ail.
+Your eye meets the vowel first and your mouth says it second. Devanagari does the same thing with ि, and it catches everyone once.
+Tamil keeps three l-letters (ல ள ழ) and two r-letters (ர ற), the same way it keeps three n's. This is the first of the l's.
+
+Script you'll notice: build the word.
+[a table of 3 rows, read aloud]
+piece: இ, i, independent — the word opens on a vowel.
+piece: ல், l — ல with the puḷḷi, bare consonant.
+piece: லை, lai — ல with the ai sign, this lesson.
+இ, ல், லை becomes இல்லை (illai).
+The ல் + லை is a doubled l, held like the க்க of vaṇakkam: il-lai, not ilai.
+
+Guided Practice.
+[pause 1 second]
+[once you have stopped driving — write: இ — spiral, then the right-hand vertical]
+[once you have stopped driving — write: ல — curl, then rising stroke]
+[once you have stopped driving — write: லை — the ai hook goes on the LEFT]
+[once you have stopped driving — write: இல்லை (illai) — three pieces]
+[your turn — say: "il-lai" — hold the doubled l]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Write இல்லை (illai). Why does it open with இ rather than a sign? (The word starts on a vowel.) Which side of its consonant does ை sit on? (The left — written first, spoken second.) Next: the word for thank you.
+
+
+Lesson 15 of 20.
 நன்றி (naṉṟi) — "thank you".
 
 Warm-up.
@@ -438,7 +512,7 @@ Wrap-up Recall.
 Say நன்றி. Does it need a verb to be a complete reply? (No — it stands alone.) Next: how thanks travels across the family.
 
 
-Lesson 14 of 17.
+Lesson 16 of 20.
 நன்றி — a native family word with a register edge.
 
 Warm-up.
@@ -472,7 +546,7 @@ Wrap-up Recall.
 Which sister shares Tamil's native gratitude word? (Malayalam.) What did Kannada and Telugu borrow? (Sanskrit dhanyavāda.) Why can explicit naṉṟi sound marked? (Among intimates, gratitude may be assumed; the word can feel formal.)
 
 
-Lesson 15 of 17.
+Lesson 17 of 20.
 சரி (sari) — "okay".
 
 Warm-up.
@@ -496,10 +570,50 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-Say சரி. What does doubling it add? (Hurry, or easy agreement — "yes yes, fine.") Next: putting the five together.
+Say சரி (sari). What does doubling it add? (Hurry, or easy agreement — "yes yes, fine.") Next: writing it.
 
 
-Lesson 16 of 17.
+Lesson 18 of 20.
+சரி (sari) — one letter, several sounds.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ச and ர and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You have seen க cover k, g and a soft h depending on where it sits. Here is the same economy on a second letter.
+
+Script you'll notice: ச and ர.
+ச is written once and does the work English splits between s, ch and j. Position picks which:
+[a table of 3 rows, read aloud]
+where: starting a word. sound: s or ch.
+where: between vowels. sound: softened.
+where: after a nasal, as in ஞ்ச. sound: j.
+That is exactly the pattern க showed — k at the start, g after a nasal, a soft h between vowels. One letter per position of the mouth, and context fills in the rest.
+ர is ra, with its built-in a. It is the second of Tamil's two r-letters, alongside the ற you met in நன்றி.
+Read both letters here; do not draw them yet. This book gives a stroke order only where it has a sourced one, and ச and ர do not have one yet.
+
+Script you'll notice: build the word.
+[a table of 2 rows, read aloud]
+piece: ச, sa here, this lesson.
+piece: ரி, ri — ர with the ி sign, the sign from நன்றி.
+ச, ரி becomes சரி (sari).
+Two pieces, and both parts are things you already hold: a consonant, and the vowel sign you first hooked onto ற.
+
+Guided Practice.
+[pause 1 second]
+[your turn — read: ச — then சரி (sari)]
+[pause 8 seconds for the answer]
+[your turn — say: "sari"]
+[pause 8 seconds for the answer]
+[your turn — contrast: ரி and லை — the ி sign follows its letter, the ை sign precedes it]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read சரி (sari). Which English sounds does ச cover on its own? (s, ch, j — start, between vowels, after a nasal.) How many r-letters does Tamil keep? (Two — ர and ற.) In லை, which side of the ல does the ai sign sit on? (The left.) And why does இல்லை (illai) open with இ rather than a sign? (It starts on a vowel.) Next: putting the five words together.
+
+
+Lesson 19 of 20.
 Putting the five together — how Tamil answers.
 
 Warm-up.
@@ -508,7 +622,7 @@ Five words, one at a time. Now they go into a conversation, and two habits show 
 
 Using them.
 A whole exchange, built only from the five words:
-— வணக்கம் (vaṇakkam). — வணக்கம் (vaṇakkam). — சரி? — ஆம். — நன்றி. — சரி. — Hello. — Hello. — Alright? — Yes. — Thank you. — Alright.
+— வணக்கம் (vaṇakkam). — வணக்கம் (vaṇakkam). — சரி (sari)? — ஆம் (ām). — நன்றி. — சரி (sari). — Hello. — Hello. — Alright? — Yes. — Thank you. — Alright.
 Every reply is one word. Tamil is comfortable with that in a way English is not.
 
 Grammar Lens: two habits behind the answers.
@@ -533,7 +647,7 @@ Wrap-up Recall.
 Give a one-word reply to sari? and to naṉṟi. (ām / sari.) Besides ām, what else is a natural yes? (Repeating the verb.) What does illai do inside a sentence? (Makes it negative — it is the "is not" verb.) Next: the chapter's own recap, and then names.
 
 
-Lesson 17 of 17.
+Lesson 20 of 20.
 Chapter 1 — recap, and how Tamil says goodbye.
 
 Warm-up.

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Fixed — the seven script facts the one-word-per-lesson pilot orphaned
+
+Splitting Tamil chapter 1 moved letter-by-letter reading out of the word lessons and
+into the writing track, on the grounds that the writing track already taught those
+letters. For **seven of them it did not**: ஆ, இ, ச, ர, ல, the ை sign, and the rule
+that *a word opening on a vowel opens with a full vowel letter, not a sign*. The
+chapter recap still tested all of it.
+
+Three writing lessons close the gap, each teaching its letters and then assembling the
+word they spell:
+
+| lesson | teaches | writes |
+|---|---|---|
+| `TA-W05-write-aam` (171s) | **ஆ**, and the word-initial vowel rule | ஆம் |
+| `TA-W06-write-illai` (187s) | **இ**, **ல**, the **ை** sign, three *l*'s | இல்லை |
+| `TA-W07-write-sari` (164s) | **ச** as s/ch/j, **ர**, two *r*'s | சரி |
+
+They sit at sequences 182, 192 and 222 — **after** the word each one spells, so the
+learner meets a word by ear and then learns to write it. That is the opposite of the
+pre-existing `TA-W04` / நன்றி inversion, where the writing lesson taught how to write a
+word 30 sequence-steps before the word itself was introduced.
+
+Each computes to 164–187 seconds, in keeping with the chapter it joins (its word
+lessons run 89–136s).
+
+Two things the review caught that are worth recording. **ை was described backwards** —
+it is written to the *left* of its consonant and pronounced after it, which the
+project's own `data/scripts/tamil.json` and `TA-W04` both already said. The wrong
+version had reached the narration script. And **ச and ர are taught for reading only**:
+this project gives a stroke order only where it has a sourced one, and those two have
+none, so the lesson says so rather than inventing strokes.
+
 ### Changed — an etymology is a hook, so the gate stops demanding it be drilled
 
 Project owner's directive: *"Etymology should only be mentioned once. I do not want

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -17,17 +17,22 @@ word they spell:
 
 | lesson | teaches | writes |
 |---|---|---|
-| `TA-W05-write-aam` (171s) | **ஆ**, and the word-initial vowel rule | ஆம் |
-| `TA-W06-write-illai` (187s) | **இ**, **ல**, the **ை** sign, three *l*'s | இல்லை |
-| `TA-W07-write-sari` (164s) | **ச** as s/ch/j, **ர**, two *r*'s | சரி |
+| `TA-W05-write-aam` (230s) | **ஆ**, and the word-initial vowel rule | ஆம் |
+| `TA-W06-write-illai` (233s) | **இ**, **ல**, the **ை** sign, three *l*'s | இல்லை |
+| `TA-W07-write-sari` (241s) | **ச** as s/ch/j, **ர**, two *r*'s | சரி |
 
 They sit at sequences 182, 192 and 222 — **after** the word each one spells, so the
 learner meets a word by ear and then learns to write it. That is the opposite of the
 pre-existing `TA-W04` / நன்றி inversion, where the writing lesson taught how to write a
 word 30 sequence-steps before the word itself was introduced.
 
-Each computes to 164–187 seconds, in keeping with the chapter it joins (its word
-lessons run 89–136s).
+Each computes to 230–241 seconds under `estimateLessonDuration`, which puts them
+with the writing lessons they sit among (TA-W01–W04 compute 176–297s) rather than
+with the word lessons, which run 88–136s. That split is the point: a word lesson
+is short because it holds one word, and a writing lesson is longer because the
+hand is slower than the ear. All three declare `max_seconds: 260`, above their
+computed cost, so the effective figure is the declared one and nothing is
+silently absorbed by `max(declared, computed)`.
 
 Two things the review caught that are worth recording. **ை was described backwards** —
 it is written to the *left* of its consonant and pronounced after it, which the

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -345,8 +345,18 @@ describe("the real corpus", () => {
     // the one-headword-per-lesson exchange rate a further four times, and kept the
     // reach-back discipline: atomsTaught +151 while atomsNeverRevisited FELL by 21.
     // 21% — still the lowest this figure has read since 51%.
-    expect(report.summary.atomsTaught).toBe(2272);
-    expect(report.summary.atomsNeverRevisited).toBe(484);
+    // The Tamil ch1 script-gap lessons add 7: TA-W05 two, TA-W06 three, TA-W07 two.
+    // Splitting one word-lesson per word moved letter teaching into the writing
+    // track; these atoms are the seven script facts that move stranded.
+    expect(report.summary.atomsTaught).toBe(2279);
+    // +2, and this one goes the WRONG WAY, so it is worth saying why. The two
+    // atoms with revisits=0 are TA-SCRIPT-WRITE-SARI-02 and TA-SCRIPT-CA-ONE-LETTER-01,
+    // both introduced BY TA-W07, the chapter's last writing lesson, so nothing
+    // follows them to do the revisiting — the same structural tail the Russian
+    // survivors above have. A chapter-final lesson's own atoms are unreachable by
+    // construction, not under-taught. The other two spell-the-word atoms (ஆம்,
+    // இல்லை) ARE revisited: TA-W07 re-spells both from memory.
+    expect(report.summary.atomsNeverRevisited).toBe(486);
     expect(report.summary.neverRevisitedPercent).toBe(21);
 
     // 509 -> 517, and the eight split into TWO DIFFERENT PHENOMENA this number conflates.
@@ -418,8 +428,26 @@ describe("the real corpus", () => {
     // So this is not a cost the new chapter incurred; it is a debt the old chapters
     // already had, which only became measurable once something followed them. Any
     // chapter appended to any track will do this, and the number is honest either way.
-    expect(report.summary.missedByWindow.R1).toBe(823);
-    expect(report.summary.missedByWindow.R2).toBe(1520);
+    // The Tamil ch1 script lessons introduce atoms that miss R1 six times and R2 six
+    // times — yet the totals move only +5 and +4. The difference is the point: those
+    // same lessons practise the OLDER script atoms they build on (the puḷḷi, the ி
+    // sign), rescuing one R1 and two R2 misses that main was already carrying. New
+    // teaching paid down old debt at the same time.
+    //
+    // The two sets are not the same six. WRITE-AAM-02 misses R1 but lands in R2;
+    // INDEPENDENT-VOWEL-AA-01 does the reverse. Common to both: two of TA-W07's own,
+    // which nothing follows, and TA-W06's three, which are the interesting case —
+    // TA-W07 does revisit all three (revisits=1), but at a distance
+    // of FOUR lessons, because the interleave puts word lessons between consecutive
+    // writing lessons and those are schema v1 — no atoms, so they cannot pay a window.
+    // Distance 4 falls in the hole between R1 (1-3) and R2 (5-15), so a genuinely
+    // reinforced atom scores as missing every window. The windows have a gap here;
+    // the lessons do not. Closing it means reordering ch1 so consecutive writing
+    // lessons sit within three of each other — a separate change, and one that would
+    // also fix a pre-existing inversion where TA-W04 spells நன்றி forty sequence
+    // numbers before TA-C01-nandri teaches the word.
+    expect(report.summary.missedByWindow.R1).toBe(828);
+    expect(report.summary.missedByWindow.R2).toBe(1524);
   });
 
   it("shows what a declared reading order was worth", () => {

--- a/code/packages/typescript/human-language-data/tests/levels.test.ts
+++ b/code/packages/typescript/human-language-data/tests/levels.test.ts
@@ -217,7 +217,7 @@ describe("corpus snapshot", () => {
     const { lessons, curricula: paths, spine } = loadEverything();
     const summary = summarizeLevels(lessons, paths, spine);
 
-    expect(summary.byLevel["pre-A1"]).toBe(757); // +1: TA-C01-answering
+    expect(summary.byLevel["pre-A1"]).toBe(760); // +3: TA-W05/W06/W07 write-*
     expect(summary.byLevel.A1).toBe(297);
     expect(summary.byLevel.A2).toBe(350);
     // 8, not 0: Spanish chapters 38 and 41 realize SPINE-NARRATE-EVENTS and
@@ -279,7 +279,7 @@ describe("corpus snapshot", () => {
     const { lessons, curricula: paths, spine } = loadEverything();
     const ramp = lessonsUpToLevel(lessons, paths, spine, "A1");
     // The whole point: this is a FILTER over the one corpus, not a second corpus.
-    expect(ramp).toHaveLength(1054);
+    expect(ramp).toHaveLength(1057);
     expect(ramp.length).toBeLessThan(lessons.length);
   });
 });

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -798,10 +798,16 @@ describe("corpus regression", () => {
       // under the canonical heading, and the whole-lesson figure fell back to 66%.
       // `coreDrivable` is unaffected: those blocks are detachable, so the driving
       // edition itself lost nothing. This is the sight-share seam, not a regression.
-      totalLessons: 1560,
+      totalLessons: 1563,
       voice: 1046,
       sight: 461,
-      pen: 53,
+      // +3 pen: the Tamil ch1 writing lessons. Rule 1 in src/modality.ts derives
+      // this from the lesson TYPE alone — it says outright that it does not look at
+      // the body — so all three record reasons ["writing-type","script-block"], and
+      // TA-W07 is pen even though it deliberately gives no stroke instructions.
+      // voice and drivable are unchanged, which is what a writing lesson should do
+      // to this table.
+      pen: 56,
       drivableLessons: 1046,
       drivablePercent: 67,
       trackCount: 22,


### PR DESCRIPTION
Splitting Tamil chapter 1 into one word per lesson moved letter-by-letter reading out of the word lessons, on the grounds that the writing track already taught those letters. **For seven things it did not** — ஆ, இ, ச, ர, ல, the **ை** sign, and the rule that *a word opening on a vowel opens with a full vowel letter, not a sign*. The chapter recap still tested all of it.

## Three writing lessons

| lesson | teaches | writes | |
|---|---|---|---|
| `TA-W05-write-aam` | **ஆ**, the word-initial vowel rule | ஆம் | 171s |
| `TA-W06-write-illai` | **இ**, **ல**, the **ை** sign, three *l*'s | இல்லை | 187s |
| `TA-W07-write-sari` | **ச** (s/ch/j), **ர**, two *r*'s | சரி | 164s |

They sit at 182, 192 and 222 — **after** the word each spells. Chapter 1 now reads:

> word → write it → word → write it → word → write it → **put them together** → recap

That also avoids repeating the pre-existing `TA-W04`/நன்றி inversion, where the writing lesson taught how to write a word 30 sequence-steps *before* the word was introduced.

## Three things review caught

**The ை sign was described backwards.** I wrote *"it simply follows the letter it belongs to."* It is **preposed** — written to the *left* of its consonant and pronounced after it. This project's own `data/scripts/tamil.json` and `TA-W04` both already said so, and the wrong version had **already reached the narration script that feeds TTS**. Contradicting the repo's own reference data is cheap to catch and expensive to ship.

**ச and ர are now taught for reading only.** This project gives a stroke order only where it has a sourced one, and those two have none — so the lesson says that plainly instead of inventing strokes. ஆ, இ and ல *do* have sourced components in the script data, and those are now used rather than omitted.

**`TA-W07` declared a phantom revisit.** It claimed to practise `WRITE-ILLAI-03` while its wrap-up asked only about சரி — propping up the one atom that would otherwise have been orphaned. It now genuinely revisits `TA-W06`'s ai-sign and independent-vowel atoms by contrasting the two sign positions (ரி follows its letter, லை precedes it) — real reinforcement, and the right place to reinforce the correction above.

Four atoms remain unrevisited and the pin now names them rather than hand-waving: the three `WRITE-<word>` atoms have nothing to revisit them except a later lesson writing the same word, and the chapter recap that would naturally do it is schema-v1 and carries no atoms.

408 tests pass. `check:books`, `check:narration`, `check:modality` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
