### PR TITLE
feat(human-language-data): Tamil teaches speaking first, script arrives gently

### DIFF
--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -3465,23 +3465,26 @@
     {
       "language": "tamil",
       "chapter": 6,
-      "sourceHash": "fnv1a64:8cb1982f517a21f4",
+      "sourceHash": "fnv1a64:506251379b3d7dec",
       "lessonIds": [
         "TA-C06-dative-ukku",
+        "TA-W02-ma-retroflex-na",
         "TA-C06-dative-stacking",
         "TA-C06-dative-subject",
-        "TA-C06-dative-subject-family"
+        "TA-C06-dative-subject-family",
+        "TA-W02-three-ns"
       ],
       "tex": "tamil/book/chapters/ch06-dative-case.tex"
     },
     {
       "language": "tamil",
       "chapter": 7,
-      "sourceHash": "fnv1a64:eccac2217fcc1cce",
+      "sourceHash": "fnv1a64:05cb6ac8a2d2d6a1",
       "lessonIds": [
         "TA-C07-numbers-1-5",
         "TA-C07-numbers-1-5-family",
         "TA-C07-numbers-6-10",
+        "TA-W03-pulli-vanakkam",
         "TA-C07-numbers-6-10-family"
       ],
       "tex": "tamil/book/chapters/ch07-numbers-1-10.tex"
@@ -3489,17 +3492,18 @@
     {
       "language": "tamil",
       "chapter": 8,
-      "sourceHash": "fnv1a64:ff8de4c167bb1241",
+      "sourceHash": "fnv1a64:c562ead22324f223",
       "lessonIds": [
         "TA-C08-tayavuseytu",
-        "TA-C08-please-register"
+        "TA-C08-please-register",
+        "TA-W03-write-vanakkam"
       ],
       "tex": "tamil/book/chapters/ch08-please.tex"
     },
     {
       "language": "tamil",
       "chapter": 9,
-      "sourceHash": "fnv1a64:7fa83cac8c8e39bf",
+      "sourceHash": "fnv1a64:85cf044551d1062b",
       "lessonIds": [
         "TA-C09-mannikkavum",
         "TA-C09-sorry-register"
@@ -3509,16 +3513,17 @@
     {
       "language": "tamil",
       "chapter": 10,
-      "sourceHash": "fnv1a64:285ec93ffe2143af",
+      "sourceHash": "fnv1a64:1623b23a579366eb",
       "lessonIds": [
-        "TA-C10-vaara-kizhamai"
+        "TA-C10-vaara-kizhamai",
+        "TA-W04-vowel-signs-nandri"
       ],
       "tex": "tamil/book/chapters/ch10-days.tex"
     },
     {
       "language": "tamil",
       "chapter": 11,
-      "sourceHash": "fnv1a64:816c584dec2fa772",
+      "sourceHash": "fnv1a64:05e39dd3fc34184b",
       "lessonIds": [
         "TA-C11-nirangal"
       ],
@@ -3527,7 +3532,7 @@
     {
       "language": "tamil",
       "chapter": 12,
-      "sourceHash": "fnv1a64:30be3d82f65307ff",
+      "sourceHash": "fnv1a64:af93b4956465c997",
       "lessonIds": [
         "TA-C12-kudumbam"
       ],
@@ -3536,16 +3541,17 @@
     {
       "language": "tamil",
       "chapter": 13,
-      "sourceHash": "fnv1a64:7e71618cae516fbc",
+      "sourceHash": "fnv1a64:40a7007a7a869a42",
       "lessonIds": [
-        "TA-C13-udal-uruppugal"
+        "TA-C13-udal-uruppugal",
+        "TA-W04-i-sign-write-nandri"
       ],
       "tex": "tamil/book/chapters/ch13-body-parts.tex"
     },
     {
       "language": "tamil",
       "chapter": 14,
-      "sourceHash": "fnv1a64:872e2a100049b519",
+      "sourceHash": "fnv1a64:9279d58ba913f0fa",
       "lessonIds": [
         "TA-C14-kaalangal"
       ],
@@ -3554,7 +3560,7 @@
     {
       "language": "tamil",
       "chapter": 15,
-      "sourceHash": "fnv1a64:6eb8ad3ee9295566",
+      "sourceHash": "fnv1a64:2cc2b6dc5c14ee0d",
       "lessonIds": [
         "TA-C15-thanneer-arisi"
       ],
@@ -3563,16 +3569,17 @@
     {
       "language": "tamil",
       "chapter": 16,
-      "sourceHash": "fnv1a64:5f41ac5048e292df",
+      "sourceHash": "fnv1a64:65fedf852d45ae79",
       "lessonIds": [
-        "TA-C16-thamizh-maadangal"
+        "TA-C16-thamizh-maadangal",
+        "TA-W05-write-aam"
       ],
       "tex": "tamil/book/chapters/ch16-months.tex"
     },
     {
       "language": "tamil",
       "chapter": 17,
-      "sourceHash": "fnv1a64:e57f7bea45ffc8ab",
+      "sourceHash": "fnv1a64:90be6cdf7f59a425",
       "lessonIds": [
         "TA-C17-nanpakal-nalliravu",
         "TA-C17-transparent-middle-synonyms"
@@ -3582,9 +3589,10 @@
     {
       "language": "tamil",
       "chapter": 18,
-      "sourceHash": "fnv1a64:c9ee2c591af90a48",
+      "sourceHash": "fnv1a64:46d568fe65afb671",
       "lessonIds": [
         "TA-C18-mani",
+        "TA-W06-write-illai",
         "TA-C18-mani-homophone-time"
       ],
       "tex": "tamil/book/chapters/ch18-telling-time.tex"
@@ -3592,17 +3600,18 @@
     {
       "language": "tamil",
       "chapter": 19,
-      "sourceHash": "fnv1a64:158e1e4de8950e2a",
+      "sourceHash": "fnv1a64:d7293b885b36096e",
       "lessonIds": [
         "TA-C19-vayathu",
-        "TA-C19-age-register-grammar"
+        "TA-C19-age-register-grammar",
+        "TA-W07-write-sari"
       ],
       "tex": "tamil/book/chapters/ch19-age.tex"
     },
     {
       "language": "tamil",
       "chapter": 20,
-      "sourceHash": "fnv1a64:17a98f1177a6f798",
+      "sourceHash": "fnv1a64:ea74641a7aeaa215",
       "lessonIds": [
         "TA-C20-pathinondru-irupathu",
         "TA-C20-vaanilai"
@@ -3612,7 +3621,7 @@
     {
       "language": "tamil",
       "chapter": 21,
-      "sourceHash": "fnv1a64:311e0fc1921788a6",
+      "sourceHash": "fnv1a64:4e1e9c8c1a0e2f1d",
       "lessonIds": [
         "TA-C21-naay-poonai"
       ],
@@ -3621,7 +3630,7 @@
     {
       "language": "tamil",
       "chapter": 22,
-      "sourceHash": "fnv1a64:dcbc62f4f6ad78a7",
+      "sourceHash": "fnv1a64:ae71142a83f6bbb1",
       "lessonIds": [
         "TA-C22-paccai-manjal"
       ],
@@ -3630,7 +3639,7 @@
     {
       "language": "tamil",
       "chapter": 23,
-      "sourceHash": "fnv1a64:df614acc750a66b3",
+      "sourceHash": "fnv1a64:a2ce180ed0981b94",
       "lessonIds": [
         "TA-C23-naal",
         "TA-C23-day-family-register"
@@ -3640,7 +3649,7 @@
     {
       "language": "tamil",
       "chapter": 24,
-      "sourceHash": "fnv1a64:d6206fbb0b4a40bb",
+      "sourceHash": "fnv1a64:a49f29933aebc915",
       "lessonIds": [
         "TA-C24-iravu",
         "TA-C24-night-register-darkness"
@@ -3650,7 +3659,7 @@
     {
       "language": "tamil",
       "chapter": 25,
-      "sourceHash": "fnv1a64:9c4269766dbc36bd",
+      "sourceHash": "fnv1a64:f2aab1ca9b0d3ff1",
       "lessonIds": [
         "TA-C25-iniya-iravu",
         "TA-C25-goodnight-alternatives"
@@ -3660,7 +3669,7 @@
     {
       "language": "tamil",
       "chapter": 26,
-      "sourceHash": "fnv1a64:8a01a19aed95768e",
+      "sourceHash": "fnv1a64:21264f934ed1f572",
       "lessonIds": [
         "TA-C26-kaalai"
       ],
@@ -3669,7 +3678,7 @@
     {
       "language": "tamil",
       "chapter": 27,
-      "sourceHash": "fnv1a64:f05a977714a428f1",
+      "sourceHash": "fnv1a64:aa7e34235182f0bf",
       "lessonIds": [
         "TA-C27-maalai"
       ],
@@ -3678,7 +3687,7 @@
     {
       "language": "tamil",
       "chapter": 28,
-      "sourceHash": "fnv1a64:3f1781336d4dbbb5",
+      "sourceHash": "fnv1a64:ec92e87b3b4283ca",
       "lessonIds": [
         "TA-C28-pirpakal",
         "TA-C28-afternoon-boundary"
@@ -3688,7 +3697,7 @@
     {
       "language": "tamil",
       "chapter": 29,
-      "sourceHash": "fnv1a64:20cadfca8eec724a",
+      "sourceHash": "fnv1a64:3462cdc973cb1a18",
       "lessonIds": [
         "TA-C29-kaalai-vanakkam"
       ],
@@ -3697,7 +3706,7 @@
     {
       "language": "tamil",
       "chapter": 30,
-      "sourceHash": "fnv1a64:0f9658a0088c0b7d",
+      "sourceHash": "fnv1a64:859a3c0278df7426",
       "lessonIds": [
         "TA-C30-maalai-vanakkam"
       ],
@@ -3706,7 +3715,7 @@
     {
       "language": "tamil",
       "chapter": 31,
-      "sourceHash": "fnv1a64:10ad0e46ce192b01",
+      "sourceHash": "fnv1a64:3f7bcb598113beed",
       "lessonIds": [
         "TA-C31-matiya-vanakkam",
         "TA-C31-afternoon-greeting-root"
@@ -3716,7 +3725,7 @@
     {
       "language": "tamil",
       "chapter": 32,
-      "sourceHash": "fnv1a64:910c91b3fe4d342c",
+      "sourceHash": "fnv1a64:babedd13feadc02b",
       "lessonIds": [
         "TA-C32-iru",
         "TA-C32-po",
@@ -3730,7 +3739,7 @@
     {
       "language": "tamil",
       "chapter": 33,
-      "sourceHash": "fnv1a64:9e974c94abcf0cec",
+      "sourceHash": "fnv1a64:508c27ca16a3cf45",
       "lessonIds": [
         "TA-C33-ninai",
         "TA-C33-puri",
@@ -3742,7 +3751,7 @@
     {
       "language": "tamil",
       "chapter": 34,
-      "sourceHash": "fnv1a64:a7767e667ee93f24",
+      "sourceHash": "fnv1a64:9156ad6e37c5a81d",
       "lessonIds": [
         "TA-C34-edu",
         "TA-C34-kel",
@@ -3754,7 +3763,7 @@
     {
       "language": "tamil",
       "chapter": 35,
-      "sourceHash": "fnv1a64:dc38c4fb1b2e3bc9",
+      "sourceHash": "fnv1a64:2236d8055ff46015",
       "lessonIds": [
         "TA-C35-veedu",
         "TA-C35-kadavu",
@@ -3766,7 +3775,7 @@
     {
       "language": "tamil",
       "chapter": 36,
-      "sourceHash": "fnv1a64:231ca7f273eff40e",
+      "sourceHash": "fnv1a64:723f22137faa2040",
       "lessonIds": [
         "TA-C36-teneer",
         "TA-C36-paal",
@@ -3778,7 +3787,7 @@
     {
       "language": "tamil",
       "chapter": 37,
-      "sourceHash": "fnv1a64:2a3905874c0757ce",
+      "sourceHash": "fnv1a64:34cbfdd3aecc18be",
       "lessonIds": [
         "TA-C37-uur",
         "TA-C37-nanban",
@@ -3790,7 +3799,7 @@
     {
       "language": "tamil",
       "chapter": 38,
-      "sourceHash": "fnv1a64:cdf9a751033520e6",
+      "sourceHash": "fnv1a64:d80f92dc2be328ee",
       "lessonIds": [
         "TA-C38-udambu",
         "TA-C38-sugam",

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -6819,61 +6819,50 @@
     {
       "language": "tamil",
       "chapter": 1,
-      "sourceHash": "fnv1a64:b35c2c9e484d8ba0",
+      "sourceHash": "fnv1a64:4ba983e1f562762e",
       "lessonIds": [
         "TA-C01-vanakkam",
         "TA-C01-vanakkam-family-register",
-        "TA-W01-curves-va-ka",
-        "TA-W01-abugida-va-ka",
-        "TA-W02-ma-retroflex-na",
-        "TA-W02-three-ns",
-        "TA-W03-pulli-vanakkam",
-        "TA-W03-write-vanakkam",
-        "TA-W04-vowel-signs-nandri",
-        "TA-W04-i-sign-write-nandri",
         "TA-C01-aam",
-        "TA-W05-write-aam",
         "TA-C01-illai",
-        "TA-W06-write-illai",
         "TA-C01-nandri",
         "TA-C01-nandri-family-register",
         "TA-C01-sari",
-        "TA-W07-write-sari",
         "TA-C01-answering",
         "TA-C01-practice"
       ],
       "voiceLessons": 9,
-      "drivablePrefix": 2,
+      "drivablePrefix": 9,
       "text": "tamil/narration/ch01.txt",
       "json": "tamil/narration/ch01.json",
-      "textHash": "fnv1a64:a253fda1701c566b",
-      "jsonHash": "fnv1a64:ecccd0760f2638c4"
+      "textHash": "fnv1a64:aaa99ff4ee4d4ab4",
+      "jsonHash": "fnv1a64:8dde1002440168e8"
     },
     {
       "language": "tamil",
       "chapter": 2,
-      "sourceHash": "fnv1a64:4a88253cf308c812",
+      "sourceHash": "fnv1a64:5ddf50ce83788a95",
       "lessonIds": [
+        "TA-C02-peyar",
         "TA-C02-en",
         "TA-C02-en-peyar",
-        "TA-C02-enna",
-        "TA-C02-magizhcci",
         "TA-C02-nii-niingal",
-        "TA-C02-peyar",
-        "TA-C02-practice",
-        "TA-C02-ungal-peyar-enna"
+        "TA-C02-enna",
+        "TA-C02-ungal-peyar-enna",
+        "TA-C02-magizhcci",
+        "TA-C02-practice"
       ],
       "voiceLessons": 3,
       "drivablePrefix": 0,
       "text": "tamil/narration/ch02.txt",
       "json": "tamil/narration/ch02.json",
-      "textHash": "fnv1a64:0093e1e0a5686f58",
-      "jsonHash": "fnv1a64:98647cd4b9623dac"
+      "textHash": "fnv1a64:16569d2844b716ae",
+      "jsonHash": "fnv1a64:d630085af5e8a783"
     },
     {
       "language": "tamil",
       "chapter": 3,
-      "sourceHash": "fnv1a64:8ccf2dad23d346e7",
+      "sourceHash": "fnv1a64:1c736a85ee572d92",
       "lessonIds": [
         "TA-C03-eppadi",
         "TA-C03-eppadi-irukkirirgal",
@@ -6887,97 +6876,103 @@
       "text": "tamil/narration/ch03.txt",
       "json": "tamil/narration/ch03.json",
       "textHash": "fnv1a64:ea7853c6d4277b9a",
-      "jsonHash": "fnv1a64:4f015ef82391247e"
+      "jsonHash": "fnv1a64:5da5d3c37a951d6d"
     },
     {
       "language": "tamil",
       "chapter": 4,
-      "sourceHash": "fnv1a64:e6cc92ef0275935e",
+      "sourceHash": "fnv1a64:ac8d1a3a89c18c13",
       "lessonIds": [
-        "TA-C04-mindum-sandippom",
-        "TA-C04-naalai",
         "TA-C04-po",
         "TA-C04-poy-varugiren",
+        "TA-C04-naalai",
+        "TA-C04-mindum-sandippom",
+        "TA-W01-curves-va-ka",
         "TA-C04-practice"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "tamil/narration/ch04.txt",
       "json": "tamil/narration/ch04.json",
-      "textHash": "fnv1a64:ae9e25d9c47018af",
-      "jsonHash": "fnv1a64:3f9ef050ea8e704f"
+      "textHash": "fnv1a64:1b171aacaedb487f",
+      "jsonHash": "fnv1a64:48f48916a78ef3be"
     },
     {
       "language": "tamil",
       "chapter": 5,
-      "sourceHash": "fnv1a64:6e46aaef34f9ba78",
+      "sourceHash": "fnv1a64:0718a395630b7532",
       "lessonIds": [
-        "TA-C05-naan-tamizh-pesugiren",
         "TA-C05-pesu",
-        "TA-C05-practice",
+        "TA-C05-naan-tamizh-pesugiren",
+        "TA-W01-abugida-va-ka",
         "TA-C05-vaazh",
-        "TA-C05-velai-sey"
+        "TA-C05-velai-sey",
+        "TA-C05-practice"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "tamil/narration/ch05.txt",
       "json": "tamil/narration/ch05.json",
-      "textHash": "fnv1a64:2dd4162f93a7fc45",
-      "jsonHash": "fnv1a64:4027d382a2e05e1f"
+      "textHash": "fnv1a64:2ead7f41ba4f39f3",
+      "jsonHash": "fnv1a64:b1f272e50a261bd1"
     },
     {
       "language": "tamil",
       "chapter": 6,
-      "sourceHash": "fnv1a64:f39b57f3b08140c4",
+      "sourceHash": "fnv1a64:46861411f2d2c948",
       "lessonIds": [
         "TA-C06-dative-ukku",
+        "TA-W02-ma-retroflex-na",
         "TA-C06-dative-stacking",
         "TA-C06-dative-subject",
-        "TA-C06-dative-subject-family"
+        "TA-C06-dative-subject-family",
+        "TA-W02-three-ns"
       ],
       "voiceLessons": 4,
-      "drivablePrefix": 4,
+      "drivablePrefix": 1,
       "text": "tamil/narration/ch06.txt",
       "json": "tamil/narration/ch06.json",
-      "textHash": "fnv1a64:ae1483790f06771f",
-      "jsonHash": "fnv1a64:e8493bb83cfc3677"
+      "textHash": "fnv1a64:ad5b508bb9ecc3e8",
+      "jsonHash": "fnv1a64:76c82a3f5a3abb4e"
     },
     {
       "language": "tamil",
       "chapter": 7,
-      "sourceHash": "fnv1a64:1c193954d5aaadb3",
+      "sourceHash": "fnv1a64:3a0207b0f2cb9ddd",
       "lessonIds": [
         "TA-C07-numbers-1-5",
         "TA-C07-numbers-1-5-family",
         "TA-C07-numbers-6-10",
+        "TA-W03-pulli-vanakkam",
         "TA-C07-numbers-6-10-family"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 0,
       "text": "tamil/narration/ch07.txt",
       "json": "tamil/narration/ch07.json",
-      "textHash": "fnv1a64:8e825487bcf9d0db",
-      "jsonHash": "fnv1a64:e71a4942dc2dcc55"
+      "textHash": "fnv1a64:c7dc6f20d202db4b",
+      "jsonHash": "fnv1a64:d953b140ddace97a"
     },
     {
       "language": "tamil",
       "chapter": 8,
-      "sourceHash": "fnv1a64:f6321c5249da200d",
+      "sourceHash": "fnv1a64:17e6eaaffab36d7e",
       "lessonIds": [
         "TA-C08-tayavuseytu",
-        "TA-C08-please-register"
+        "TA-C08-please-register",
+        "TA-W03-write-vanakkam"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 1,
       "text": "tamil/narration/ch08.txt",
       "json": "tamil/narration/ch08.json",
-      "textHash": "fnv1a64:d04fe181d7b5441b",
-      "jsonHash": "fnv1a64:c35b2dfee666a0cd"
+      "textHash": "fnv1a64:cd156cf073852c28",
+      "jsonHash": "fnv1a64:f3db2754e9e1db24"
     },
     {
       "language": "tamil",
       "chapter": 9,
-      "sourceHash": "fnv1a64:262d769ef6d9dc12",
+      "sourceHash": "fnv1a64:da456f87ee652d26",
       "lessonIds": [
         "TA-C09-mannikkavum",
         "TA-C09-sorry-register"
@@ -6987,26 +6982,27 @@
       "text": "tamil/narration/ch09.txt",
       "json": "tamil/narration/ch09.json",
       "textHash": "fnv1a64:b55fd3eb089a952f",
-      "jsonHash": "fnv1a64:a05916195a405428"
+      "jsonHash": "fnv1a64:e9418df28bb4321c"
     },
     {
       "language": "tamil",
       "chapter": 10,
-      "sourceHash": "fnv1a64:9bc3e175ebf3b9fd",
+      "sourceHash": "fnv1a64:e70145e0b10eb0f9",
       "lessonIds": [
-        "TA-C10-vaara-kizhamai"
+        "TA-C10-vaara-kizhamai",
+        "TA-W04-vowel-signs-nandri"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 1,
       "text": "tamil/narration/ch10.txt",
       "json": "tamil/narration/ch10.json",
-      "textHash": "fnv1a64:8a3a185957d47b1d",
-      "jsonHash": "fnv1a64:ba37efa90c0292f5"
+      "textHash": "fnv1a64:4e839a2dee4d13c9",
+      "jsonHash": "fnv1a64:6e3f5ac4aaabcae5"
     },
     {
       "language": "tamil",
       "chapter": 11,
-      "sourceHash": "fnv1a64:690810fd97646553",
+      "sourceHash": "fnv1a64:479e39edeecc0c29",
       "lessonIds": [
         "TA-C11-nirangal"
       ],
@@ -7015,12 +7011,12 @@
       "text": "tamil/narration/ch11.txt",
       "json": "tamil/narration/ch11.json",
       "textHash": "fnv1a64:4ed8ecddf6838cae",
-      "jsonHash": "fnv1a64:1dcc8e30ee8b1831"
+      "jsonHash": "fnv1a64:a26ac478785212b2"
     },
     {
       "language": "tamil",
       "chapter": 12,
-      "sourceHash": "fnv1a64:37498296b121ed1e",
+      "sourceHash": "fnv1a64:643afe30d635fb6e",
       "lessonIds": [
         "TA-C12-kudumbam"
       ],
@@ -7029,26 +7025,27 @@
       "text": "tamil/narration/ch12.txt",
       "json": "tamil/narration/ch12.json",
       "textHash": "fnv1a64:0296fadea74dd331",
-      "jsonHash": "fnv1a64:00466f3aa9861a74"
+      "jsonHash": "fnv1a64:9448b5641865926a"
     },
     {
       "language": "tamil",
       "chapter": 13,
-      "sourceHash": "fnv1a64:1dbbb29d47b23eee",
+      "sourceHash": "fnv1a64:93438d9d63e80927",
       "lessonIds": [
-        "TA-C13-udal-uruppugal"
+        "TA-C13-udal-uruppugal",
+        "TA-W04-i-sign-write-nandri"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 1,
       "text": "tamil/narration/ch13.txt",
       "json": "tamil/narration/ch13.json",
-      "textHash": "fnv1a64:8d6f6e4aebc72052",
-      "jsonHash": "fnv1a64:7887611f7828cd4e"
+      "textHash": "fnv1a64:391d26a127ad9dd5",
+      "jsonHash": "fnv1a64:57e69d0d98ebd5ba"
     },
     {
       "language": "tamil",
       "chapter": 14,
-      "sourceHash": "fnv1a64:efef50f495c96454",
+      "sourceHash": "fnv1a64:88494c15360167e5",
       "lessonIds": [
         "TA-C14-kaalangal"
       ],
@@ -7057,12 +7054,12 @@
       "text": "tamil/narration/ch14.txt",
       "json": "tamil/narration/ch14.json",
       "textHash": "fnv1a64:a5d77cff80c3b50c",
-      "jsonHash": "fnv1a64:836b28a32691c628"
+      "jsonHash": "fnv1a64:e97966f4d05a3d36"
     },
     {
       "language": "tamil",
       "chapter": 15,
-      "sourceHash": "fnv1a64:591fbb252f2da03b",
+      "sourceHash": "fnv1a64:bbff81bbd706c3c6",
       "lessonIds": [
         "TA-C15-thanneer-arisi"
       ],
@@ -7071,26 +7068,27 @@
       "text": "tamil/narration/ch15.txt",
       "json": "tamil/narration/ch15.json",
       "textHash": "fnv1a64:4db6b99411b1b54c",
-      "jsonHash": "fnv1a64:3784e6dc57da9a42"
+      "jsonHash": "fnv1a64:1462b7c53e561294"
     },
     {
       "language": "tamil",
       "chapter": 16,
-      "sourceHash": "fnv1a64:3e3463dfa65338df",
+      "sourceHash": "fnv1a64:9aa25237c1a7fa85",
       "lessonIds": [
-        "TA-C16-thamizh-maadangal"
+        "TA-C16-thamizh-maadangal",
+        "TA-W05-write-aam"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 1,
       "text": "tamil/narration/ch16.txt",
       "json": "tamil/narration/ch16.json",
-      "textHash": "fnv1a64:0ec3ef6c0f7a3137",
-      "jsonHash": "fnv1a64:fd0982ab3307da87"
+      "textHash": "fnv1a64:075cfa3a5ba428af",
+      "jsonHash": "fnv1a64:0311023be8f42382"
     },
     {
       "language": "tamil",
       "chapter": 17,
-      "sourceHash": "fnv1a64:06273003bfe95d72",
+      "sourceHash": "fnv1a64:6ffa0438a52caeaa",
       "lessonIds": [
         "TA-C17-nanpakal-nalliravu",
         "TA-C17-transparent-middle-synonyms"
@@ -7100,42 +7098,44 @@
       "text": "tamil/narration/ch17.txt",
       "json": "tamil/narration/ch17.json",
       "textHash": "fnv1a64:f6a024984996821d",
-      "jsonHash": "fnv1a64:214aafcf2bbbacfe"
+      "jsonHash": "fnv1a64:910a8fbc88140428"
     },
     {
       "language": "tamil",
       "chapter": 18,
-      "sourceHash": "fnv1a64:b273f5380b760010",
+      "sourceHash": "fnv1a64:6b1369c681d37000",
       "lessonIds": [
         "TA-C18-mani",
+        "TA-W06-write-illai",
         "TA-C18-mani-homophone-time"
       ],
       "voiceLessons": 2,
-      "drivablePrefix": 2,
+      "drivablePrefix": 1,
       "text": "tamil/narration/ch18.txt",
       "json": "tamil/narration/ch18.json",
-      "textHash": "fnv1a64:4fd3228d0cb2360c",
-      "jsonHash": "fnv1a64:52521b39eb78d0b3"
+      "textHash": "fnv1a64:75e012b7acfd4a2e",
+      "jsonHash": "fnv1a64:d659a67a1f034fd1"
     },
     {
       "language": "tamil",
       "chapter": 19,
-      "sourceHash": "fnv1a64:1c8de13134073142",
+      "sourceHash": "fnv1a64:491071c339bc2838",
       "lessonIds": [
         "TA-C19-vayathu",
-        "TA-C19-age-register-grammar"
+        "TA-C19-age-register-grammar",
+        "TA-W07-write-sari"
       ],
       "voiceLessons": 2,
       "drivablePrefix": 2,
       "text": "tamil/narration/ch19.txt",
       "json": "tamil/narration/ch19.json",
-      "textHash": "fnv1a64:f488fb0280c7fb77",
-      "jsonHash": "fnv1a64:1cd5375417f2e11b"
+      "textHash": "fnv1a64:77cb15e97560ce35",
+      "jsonHash": "fnv1a64:3e68a72d9c6f2949"
     },
     {
       "language": "tamil",
       "chapter": 20,
-      "sourceHash": "fnv1a64:fdf0cc4db10b69be",
+      "sourceHash": "fnv1a64:2cf7f0e2e424d5a4",
       "lessonIds": [
         "TA-C20-pathinondru-irupathu",
         "TA-C20-vaanilai"
@@ -7145,12 +7145,12 @@
       "text": "tamil/narration/ch20.txt",
       "json": "tamil/narration/ch20.json",
       "textHash": "fnv1a64:0090ff714c4601ea",
-      "jsonHash": "fnv1a64:aa53077e1724be08"
+      "jsonHash": "fnv1a64:cac2df28d5d827cf"
     },
     {
       "language": "tamil",
       "chapter": 21,
-      "sourceHash": "fnv1a64:9723f9dcd572ac08",
+      "sourceHash": "fnv1a64:4c3e69eb6f237751",
       "lessonIds": [
         "TA-C21-naay-poonai"
       ],
@@ -7159,12 +7159,12 @@
       "text": "tamil/narration/ch21.txt",
       "json": "tamil/narration/ch21.json",
       "textHash": "fnv1a64:48902886989d2146",
-      "jsonHash": "fnv1a64:a27115e3d2f883d3"
+      "jsonHash": "fnv1a64:6d432a2b71c2488d"
     },
     {
       "language": "tamil",
       "chapter": 22,
-      "sourceHash": "fnv1a64:b8ec45b437f75500",
+      "sourceHash": "fnv1a64:093d888489413d50",
       "lessonIds": [
         "TA-C22-paccai-manjal"
       ],
@@ -7173,12 +7173,12 @@
       "text": "tamil/narration/ch22.txt",
       "json": "tamil/narration/ch22.json",
       "textHash": "fnv1a64:a2a51ab8ff59542b",
-      "jsonHash": "fnv1a64:a24c66fe3db0e0e1"
+      "jsonHash": "fnv1a64:b1877cf3518ae7f3"
     },
     {
       "language": "tamil",
       "chapter": 23,
-      "sourceHash": "fnv1a64:5c6398928a9c2ba4",
+      "sourceHash": "fnv1a64:e101514a5078173a",
       "lessonIds": [
         "TA-C23-naal",
         "TA-C23-day-family-register"
@@ -7188,12 +7188,12 @@
       "text": "tamil/narration/ch23.txt",
       "json": "tamil/narration/ch23.json",
       "textHash": "fnv1a64:d94067274a15b0dd",
-      "jsonHash": "fnv1a64:204247f0ec05d5a9"
+      "jsonHash": "fnv1a64:bea80eb6ba8ae396"
     },
     {
       "language": "tamil",
       "chapter": 24,
-      "sourceHash": "fnv1a64:44ef396f3945a420",
+      "sourceHash": "fnv1a64:bcea2d1a3a4809af",
       "lessonIds": [
         "TA-C24-iravu",
         "TA-C24-night-register-darkness"
@@ -7203,12 +7203,12 @@
       "text": "tamil/narration/ch24.txt",
       "json": "tamil/narration/ch24.json",
       "textHash": "fnv1a64:b29c79354713db6c",
-      "jsonHash": "fnv1a64:0e3a1cfddd61b59c"
+      "jsonHash": "fnv1a64:53e81b763e7d4e43"
     },
     {
       "language": "tamil",
       "chapter": 25,
-      "sourceHash": "fnv1a64:da98a42e0008636f",
+      "sourceHash": "fnv1a64:a476bb11b5f796c3",
       "lessonIds": [
         "TA-C25-iniya-iravu",
         "TA-C25-goodnight-alternatives"
@@ -7218,12 +7218,12 @@
       "text": "tamil/narration/ch25.txt",
       "json": "tamil/narration/ch25.json",
       "textHash": "fnv1a64:4b85de6a52f99aa7",
-      "jsonHash": "fnv1a64:3f7e5538754cabd6"
+      "jsonHash": "fnv1a64:526c1b5e091769aa"
     },
     {
       "language": "tamil",
       "chapter": 26,
-      "sourceHash": "fnv1a64:a491a14d123de4c1",
+      "sourceHash": "fnv1a64:4487b829f729ae28",
       "lessonIds": [
         "TA-C26-kaalai"
       ],
@@ -7232,12 +7232,12 @@
       "text": "tamil/narration/ch26.txt",
       "json": "tamil/narration/ch26.json",
       "textHash": "fnv1a64:e8400ef09352fbc1",
-      "jsonHash": "fnv1a64:9889da1ecd1c6b35"
+      "jsonHash": "fnv1a64:9d3b2484eb4cf726"
     },
     {
       "language": "tamil",
       "chapter": 27,
-      "sourceHash": "fnv1a64:771849e1943269f5",
+      "sourceHash": "fnv1a64:8a3ee365c271485b",
       "lessonIds": [
         "TA-C27-maalai"
       ],
@@ -7246,12 +7246,12 @@
       "text": "tamil/narration/ch27.txt",
       "json": "tamil/narration/ch27.json",
       "textHash": "fnv1a64:eee1bcc33fc7e65c",
-      "jsonHash": "fnv1a64:a69901fd37b9d33d"
+      "jsonHash": "fnv1a64:02e3f70c92b52d45"
     },
     {
       "language": "tamil",
       "chapter": 28,
-      "sourceHash": "fnv1a64:6419f9af0cbb8148",
+      "sourceHash": "fnv1a64:e2e6fd53c38b59e0",
       "lessonIds": [
         "TA-C28-pirpakal",
         "TA-C28-afternoon-boundary"
@@ -7261,12 +7261,12 @@
       "text": "tamil/narration/ch28.txt",
       "json": "tamil/narration/ch28.json",
       "textHash": "fnv1a64:d3ea8f5f95ce316a",
-      "jsonHash": "fnv1a64:60e1847f59e8dca9"
+      "jsonHash": "fnv1a64:1b8fa6cc947c3c16"
     },
     {
       "language": "tamil",
       "chapter": 29,
-      "sourceHash": "fnv1a64:0ee1e256b5928da8",
+      "sourceHash": "fnv1a64:c5303420ac3aa1b6",
       "lessonIds": [
         "TA-C29-kaalai-vanakkam"
       ],
@@ -7275,12 +7275,12 @@
       "text": "tamil/narration/ch29.txt",
       "json": "tamil/narration/ch29.json",
       "textHash": "fnv1a64:411d70e89e1e9e3b",
-      "jsonHash": "fnv1a64:e13d2adc3a96a449"
+      "jsonHash": "fnv1a64:819aefebf24cf2bd"
     },
     {
       "language": "tamil",
       "chapter": 30,
-      "sourceHash": "fnv1a64:f5c2a578b5b6df4d",
+      "sourceHash": "fnv1a64:543b13b5f49981c2",
       "lessonIds": [
         "TA-C30-maalai-vanakkam"
       ],
@@ -7289,12 +7289,12 @@
       "text": "tamil/narration/ch30.txt",
       "json": "tamil/narration/ch30.json",
       "textHash": "fnv1a64:e3908935f85900d2",
-      "jsonHash": "fnv1a64:2b977eca7cdaeab7"
+      "jsonHash": "fnv1a64:f3b27f973d306e03"
     },
     {
       "language": "tamil",
       "chapter": 31,
-      "sourceHash": "fnv1a64:f8ee12008eeeb646",
+      "sourceHash": "fnv1a64:9da02aa156c2f34f",
       "lessonIds": [
         "TA-C31-matiya-vanakkam",
         "TA-C31-afternoon-greeting-root"
@@ -7304,12 +7304,12 @@
       "text": "tamil/narration/ch31.txt",
       "json": "tamil/narration/ch31.json",
       "textHash": "fnv1a64:9dd889090730b2ee",
-      "jsonHash": "fnv1a64:5c5de448dada4d4e"
+      "jsonHash": "fnv1a64:e701fc6b90667a99"
     },
     {
       "language": "tamil",
       "chapter": 32,
-      "sourceHash": "fnv1a64:4dd37565979d56c1",
+      "sourceHash": "fnv1a64:35b9dc9110e4130e",
       "lessonIds": [
         "TA-C32-iru",
         "TA-C32-po",
@@ -7323,12 +7323,12 @@
       "text": "tamil/narration/ch32.txt",
       "json": "tamil/narration/ch32.json",
       "textHash": "fnv1a64:38557cf06f796458",
-      "jsonHash": "fnv1a64:abadf3ea1b02b4e9"
+      "jsonHash": "fnv1a64:112f898956e47fc7"
     },
     {
       "language": "tamil",
       "chapter": 33,
-      "sourceHash": "fnv1a64:0434296a320b16ff",
+      "sourceHash": "fnv1a64:87330318c12938c6",
       "lessonIds": [
         "TA-C33-ninai",
         "TA-C33-puri",
@@ -7340,12 +7340,12 @@
       "text": "tamil/narration/ch33.txt",
       "json": "tamil/narration/ch33.json",
       "textHash": "fnv1a64:d5d28e2aea496fd2",
-      "jsonHash": "fnv1a64:c750386fad7726a9"
+      "jsonHash": "fnv1a64:a7856dd949e95471"
     },
     {
       "language": "tamil",
       "chapter": 34,
-      "sourceHash": "fnv1a64:b09af3aa1df4854a",
+      "sourceHash": "fnv1a64:0afe185a93c0169e",
       "lessonIds": [
         "TA-C34-edu",
         "TA-C34-kel",
@@ -7357,12 +7357,12 @@
       "text": "tamil/narration/ch34.txt",
       "json": "tamil/narration/ch34.json",
       "textHash": "fnv1a64:3b698d59bb660735",
-      "jsonHash": "fnv1a64:46adf7fdfc05b3c6"
+      "jsonHash": "fnv1a64:157d4fcd23ee1fbb"
     },
     {
       "language": "tamil",
       "chapter": 35,
-      "sourceHash": "fnv1a64:2703e3459eee5f3a",
+      "sourceHash": "fnv1a64:c26956daee7bf61d",
       "lessonIds": [
         "TA-C35-veedu",
         "TA-C35-kadavu",
@@ -7374,12 +7374,12 @@
       "text": "tamil/narration/ch35.txt",
       "json": "tamil/narration/ch35.json",
       "textHash": "fnv1a64:73c0cbf33267d147",
-      "jsonHash": "fnv1a64:7316a8120132566d"
+      "jsonHash": "fnv1a64:c720257d941123fc"
     },
     {
       "language": "tamil",
       "chapter": 36,
-      "sourceHash": "fnv1a64:f2d3d5c13c0737fe",
+      "sourceHash": "fnv1a64:402bf0320fcdb2c7",
       "lessonIds": [
         "TA-C36-teneer",
         "TA-C36-paal",
@@ -7391,12 +7391,12 @@
       "text": "tamil/narration/ch36.txt",
       "json": "tamil/narration/ch36.json",
       "textHash": "fnv1a64:0939422c53d55470",
-      "jsonHash": "fnv1a64:eaecb9427be3c9af"
+      "jsonHash": "fnv1a64:6923acb60ff29cd2"
     },
     {
       "language": "tamil",
       "chapter": 37,
-      "sourceHash": "fnv1a64:956feb3bb64ab0cb",
+      "sourceHash": "fnv1a64:f9fc24867a2d77c3",
       "lessonIds": [
         "TA-C37-uur",
         "TA-C37-nanban",
@@ -7408,12 +7408,12 @@
       "text": "tamil/narration/ch37.txt",
       "json": "tamil/narration/ch37.json",
       "textHash": "fnv1a64:ac8790b0e34fcd44",
-      "jsonHash": "fnv1a64:9935f52d6ca83937"
+      "jsonHash": "fnv1a64:971f62277de17d49"
     },
     {
       "language": "tamil",
       "chapter": 38,
-      "sourceHash": "fnv1a64:d9d5146731ccd6eb",
+      "sourceHash": "fnv1a64:02d8bcf3e16a7add",
       "lessonIds": [
         "TA-C38-udambu",
         "TA-C38-sugam",
@@ -7424,7 +7424,7 @@
       "text": "tamil/narration/ch38.txt",
       "json": "tamil/narration/ch38.json",
       "textHash": "fnv1a64:a5992018dceb6f58",
-      "jsonHash": "fnv1a64:b69a57e66c22ac5f"
+      "jsonHash": "fnv1a64:bc1f7c59145681fd"
     },
     {
       "language": "telugu",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:4c2bd817f66e7bbd",
+  "sourceHash": "fnv1a64:7e11d3eca3b425bc",
   "summary": {
     "totalLessons": 1615,
     "voice": 1068,
@@ -17,8 +17,8 @@
     "drivablePercent": 66,
     "trackCount": 22,
     "chapterCount": 497,
-    "drivablePrefixTotal": 870,
-    "fullyDrivableChapters": 327,
+    "drivablePrefixTotal": 873,
+    "fullyDrivableChapters": 322,
     "unstartableChapters": 129,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
@@ -7354,7 +7354,7 @@
       "sight": 46,
       "pen": 11,
       "drivablePercent": 51,
-      "drivablePrefixTotal": 44,
+      "drivablePrefixTotal": 47,
       "modalities": [
         "voice",
         "sight",
@@ -7363,21 +7363,26 @@
       "chapters": [
         {
           "chapter": 1,
-          "lessonCount": 20,
+          "lessonCount": 9,
           "voice": 9,
           "sight": 0,
-          "pen": 11,
+          "pen": 0,
           "modalities": [
-            "voice",
-            "sight",
-            "pen"
+            "voice"
           ],
-          "drivablePrefix": 2,
-          "firstNonVoiceLesson": "TA-W01-curves-va-ka",
-          "drivable": false,
+          "drivablePrefix": 9,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
           "drivableLessonIds": [
             "TA-C01-vanakkam",
-            "TA-C01-vanakkam-family-register"
+            "TA-C01-vanakkam-family-register",
+            "TA-C01-aam",
+            "TA-C01-illai",
+            "TA-C01-nandri",
+            "TA-C01-nandri-family-register",
+            "TA-C01-sari",
+            "TA-C01-answering",
+            "TA-C01-practice"
           ]
         },
         {
@@ -7391,7 +7396,7 @@
             "sight"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "TA-C02-en",
+          "firstNonVoiceLesson": "TA-C02-peyar",
           "drivable": false,
           "drivableLessonIds": []
         },
@@ -7412,62 +7417,64 @@
         },
         {
           "chapter": 4,
-          "lessonCount": 5,
+          "lessonCount": 6,
           "voice": 1,
           "sight": 4,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
             "voice",
-            "sight"
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "TA-C04-mindum-sandippom",
+          "firstNonVoiceLesson": "TA-C04-po",
           "drivable": false,
           "drivableLessonIds": []
         },
         {
           "chapter": 5,
-          "lessonCount": 5,
+          "lessonCount": 6,
           "voice": 1,
           "sight": 4,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
             "voice",
-            "sight"
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 0,
-          "firstNonVoiceLesson": "TA-C05-naan-tamizh-pesugiren",
+          "firstNonVoiceLesson": "TA-C05-pesu",
           "drivable": false,
           "drivableLessonIds": []
         },
         {
           "chapter": 6,
-          "lessonCount": 4,
+          "lessonCount": 6,
           "voice": 4,
           "sight": 0,
-          "pen": 0,
+          "pen": 2,
           "modalities": [
-            "voice"
+            "voice",
+            "sight",
+            "pen"
           ],
-          "drivablePrefix": 4,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
+          "drivablePrefix": 1,
+          "firstNonVoiceLesson": "TA-W02-ma-retroflex-na",
+          "drivable": false,
           "drivableLessonIds": [
-            "TA-C06-dative-ukku",
-            "TA-C06-dative-stacking",
-            "TA-C06-dative-subject",
-            "TA-C06-dative-subject-family"
+            "TA-C06-dative-ukku"
           ]
         },
         {
           "chapter": 7,
-          "lessonCount": 4,
+          "lessonCount": 5,
           "voice": 1,
           "sight": 3,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
             "voice",
-            "sight"
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 0,
           "firstNonVoiceLesson": "TA-C07-numbers-1-5",
@@ -7476,13 +7483,14 @@
         },
         {
           "chapter": 8,
-          "lessonCount": 2,
+          "lessonCount": 3,
           "voice": 1,
           "sight": 1,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
             "voice",
-            "sight"
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 1,
           "firstNonVoiceLesson": "TA-C08-please-register",
@@ -7510,16 +7518,18 @@
         },
         {
           "chapter": 10,
-          "lessonCount": 1,
+          "lessonCount": 2,
           "voice": 1,
           "sight": 0,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "voice"
+            "voice",
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 1,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
+          "firstNonVoiceLesson": "TA-W04-vowel-signs-nandri",
+          "drivable": false,
           "drivableLessonIds": [
             "TA-C10-vaara-kizhamai"
           ]
@@ -7556,16 +7566,18 @@
         },
         {
           "chapter": 13,
-          "lessonCount": 1,
+          "lessonCount": 2,
           "voice": 1,
           "sight": 0,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "voice"
+            "voice",
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 1,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
+          "firstNonVoiceLesson": "TA-W04-i-sign-write-nandri",
+          "drivable": false,
           "drivableLessonIds": [
             "TA-C13-udal-uruppugal"
           ]
@@ -7604,16 +7616,18 @@
         },
         {
           "chapter": 16,
-          "lessonCount": 1,
+          "lessonCount": 2,
           "voice": 1,
           "sight": 0,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "voice"
+            "voice",
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 1,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
+          "firstNonVoiceLesson": "TA-W05-write-aam",
+          "drivable": false,
           "drivableLessonIds": [
             "TA-C16-thamizh-maadangal"
           ]
@@ -7637,33 +7651,36 @@
         },
         {
           "chapter": 18,
-          "lessonCount": 2,
+          "lessonCount": 3,
           "voice": 2,
           "sight": 0,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "voice"
+            "voice",
+            "sight",
+            "pen"
           ],
-          "drivablePrefix": 2,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
+          "drivablePrefix": 1,
+          "firstNonVoiceLesson": "TA-W06-write-illai",
+          "drivable": false,
           "drivableLessonIds": [
-            "TA-C18-mani",
-            "TA-C18-mani-homophone-time"
+            "TA-C18-mani"
           ]
         },
         {
           "chapter": 19,
-          "lessonCount": 2,
+          "lessonCount": 3,
           "voice": 2,
           "sight": 0,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "voice"
+            "voice",
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 2,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
+          "firstNonVoiceLesson": "TA-W07-write-sari",
+          "drivable": false,
           "drivableLessonIds": [
             "TA-C19-vayathu",
             "TA-C19-age-register-grammar"
@@ -34818,195 +34835,10 @@
       "sourceHash": "fnv1a64:ad7b57e45071d385"
     },
     {
-      "id": "TA-W01-curves-va-ka",
-      "language": "tamil",
-      "chapter": 1,
-      "sequence": 100,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type",
-        "script-block",
-        "sight-cue"
-      ],
-      "coreModality": "pen",
-      "coreReasons": [
-        "writing-type",
-        "sight-cue"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:52e873e570e7a21e",
-      "detachableSegments": [
-        "Script you'll notice: The script is the shape of its writing surface"
-      ]
-    },
-    {
-      "id": "TA-W01-abugida-va-ka",
-      "language": "tamil",
-      "chapter": 1,
-      "sequence": 110,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "coreModality": "pen",
-      "coreReasons": [
-        "writing-type"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:a2fe0a66292e2a3b",
-      "detachableSegments": [
-        "Script you'll notice: The vowel you get for free",
-        "Script you'll notice: வ — \"va\"",
-        "Script you'll notice: க — \"ka\""
-      ]
-    },
-    {
-      "id": "TA-W02-ma-retroflex-na",
-      "language": "tamil",
-      "chapter": 1,
-      "sequence": 120,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "coreModality": "pen",
-      "coreReasons": [
-        "writing-type"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:207da9661587565a",
-      "detachableSegments": [
-        "Script you'll notice: ம",
-        "Script you'll notice: ண"
-      ]
-    },
-    {
-      "id": "TA-W02-three-ns",
-      "language": "tamil",
-      "chapter": 1,
-      "sequence": 130,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "coreModality": "pen",
-      "coreReasons": [
-        "writing-type"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:0a6a4e9cd2c74425",
-      "detachableSegments": [
-        "Script you'll notice: The backward walk"
-      ]
-    },
-    {
-      "id": "TA-W03-pulli-vanakkam",
-      "language": "tamil",
-      "chapter": 1,
-      "sequence": 140,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type",
-        "script-block",
-        "sight-cue"
-      ],
-      "coreModality": "pen",
-      "coreReasons": [
-        "writing-type"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:9d8862d16c87f51c",
-      "detachableSegments": [
-        "Script you'll notice: The puḷḷi",
-        "Script you'll notice: What Tamil does *not* do"
-      ]
-    },
-    {
-      "id": "TA-W03-write-vanakkam",
-      "language": "tamil",
-      "chapter": 1,
-      "sequence": 150,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "coreModality": "pen",
-      "coreReasons": [
-        "writing-type"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:fe21150d048b0f05",
-      "detachableSegments": [
-        "Script you'll notice: Build the word"
-      ]
-    },
-    {
-      "id": "TA-W04-vowel-signs-nandri",
-      "language": "tamil",
-      "chapter": 1,
-      "sequence": 160,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "coreModality": "pen",
-      "coreReasons": [
-        "writing-type"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:0396b3f438d3d484",
-      "detachableSegments": [
-        "Script you'll notice: The two remaining n's",
-        "Script you'll notice: ற — \"ṟa\", the hard r"
-      ]
-    },
-    {
-      "id": "TA-W04-i-sign-write-nandri",
-      "language": "tamil",
-      "chapter": 1,
-      "sequence": 170,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "coreModality": "pen",
-      "coreReasons": [
-        "writing-type"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:fc6618acb28f2b17",
-      "detachableSegments": [
-        "Script you'll notice: The first vowel sign",
-        "Script you'll notice: Assemble நன்றி"
-      ]
-    },
-    {
       "id": "TA-C01-aam",
       "language": "tamil",
       "chapter": 1,
-      "sequence": 180,
+      "sequence": 30,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -35018,36 +34850,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:96c6bb2306442e1b"
-    },
-    {
-      "id": "TA-W05-write-aam",
-      "language": "tamil",
-      "chapter": 1,
-      "sequence": 182,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "coreModality": "pen",
-      "coreReasons": [
-        "writing-type"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:d2d9939892304061",
-      "detachableSegments": [
-        "Script you'll notice: a vowel standing alone",
-        "Script you'll notice: build the word"
-      ]
+      "sourceHash": "fnv1a64:ce84e297bd916c0f"
     },
     {
       "id": "TA-C01-illai",
       "language": "tamil",
       "chapter": 1,
-      "sequence": 190,
+      "sequence": 40,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -35059,36 +34868,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:beee25438cdb89ae"
-    },
-    {
-      "id": "TA-W06-write-illai",
-      "language": "tamil",
-      "chapter": 1,
-      "sequence": 192,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "coreModality": "pen",
-      "coreReasons": [
-        "writing-type"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:355d80e464a1c094",
-      "detachableSegments": [
-        "Script you'll notice: இ and ல",
-        "Script you'll notice: build the word"
-      ]
+      "sourceHash": "fnv1a64:fab96586503e281c"
     },
     {
       "id": "TA-C01-nandri",
       "language": "tamil",
       "chapter": 1,
-      "sequence": 200,
+      "sequence": 50,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -35100,13 +34886,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:d08803bcdd6448e5"
+      "sourceHash": "fnv1a64:eabaf0f0e3333bf6"
     },
     {
       "id": "TA-C01-nandri-family-register",
       "language": "tamil",
       "chapter": 1,
-      "sequence": 210,
+      "sequence": 60,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -35118,13 +34904,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:df441fa9eb2d1a4a"
+      "sourceHash": "fnv1a64:60338f1932bc98d3"
     },
     {
       "id": "TA-C01-sari",
       "language": "tamil",
       "chapter": 1,
-      "sequence": 220,
+      "sequence": 70,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -35136,36 +34922,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c6020b573775bf3a"
-    },
-    {
-      "id": "TA-W07-write-sari",
-      "language": "tamil",
-      "chapter": 1,
-      "sequence": 222,
-      "modality": "pen",
-      "derived": "pen",
-      "drivable": false,
-      "reasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "coreModality": "pen",
-      "coreReasons": [
-        "writing-type"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:235103e17e063c6b",
-      "detachableSegments": [
-        "Script you'll notice: ச and ர",
-        "Script you'll notice: build the word"
-      ]
+      "sourceHash": "fnv1a64:17d7a2c78ef6c9c9"
     },
     {
       "id": "TA-C01-answering",
       "language": "tamil",
       "chapter": 1,
-      "sequence": 230,
+      "sequence": 80,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -35177,13 +34940,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a0ce2d20f0c139e8"
+      "sourceHash": "fnv1a64:e3574d76d640bfad"
     },
     {
       "id": "TA-C01-practice",
       "language": "tamil",
       "chapter": 1,
-      "sequence": 240,
+      "sequence": 90,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -35195,13 +34958,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:de8fee8d6b42c1e3"
+      "sourceHash": "fnv1a64:c81d31ec864320b8"
     },
     {
-      "id": "TA-C02-en",
+      "id": "TA-C02-peyar",
       "language": "tamil",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 100,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -35213,7 +34976,28 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a21db6ae59748a32",
+      "sourceHash": "fnv1a64:a332e99363610b9e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C02-en",
+      "language": "tamil",
+      "chapter": 2,
+      "sequence": 110,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5d5a9c62328bb6c9",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -35222,7 +35006,7 @@
       "id": "TA-C02-en-peyar",
       "language": "tamil",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 120,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -35234,52 +35018,13 @@
         "sight-cue"
       ],
       "coreDrivable": false,
-      "sourceHash": "fnv1a64:0fa6e13aeee02146"
-    },
-    {
-      "id": "TA-C02-enna",
-      "language": "tamil",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:25fcc38dc3c7e5ad",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "TA-C02-magizhcci",
-      "language": "tamil",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:c3bc57954e56329f"
+      "sourceHash": "fnv1a64:1170a1a64a27cac8"
     },
     {
       "id": "TA-C02-nii-niingal",
       "language": "tamil",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 140,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -35291,16 +35036,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:777a927ff6b68192",
+      "sourceHash": "fnv1a64:88ed443a4d4d2cbc",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "TA-C02-peyar",
+      "id": "TA-C02-enna",
       "language": "tamil",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 150,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -35312,34 +35057,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:f21262c05a8174ac",
+      "sourceHash": "fnv1a64:9d41a8ac0f94efe6",
       "detachableSegments": [
         "The letters in this word"
       ]
-    },
-    {
-      "id": "TA-C02-practice",
-      "language": "tamil",
-      "chapter": 2,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:460dd2935bc8810b"
     },
     {
       "id": "TA-C02-ungal-peyar-enna",
       "language": "tamil",
       "chapter": 2,
-      "sequence": null,
+      "sequence": 160,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -35351,13 +35078,49 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:fd46f23f443298d1"
+      "sourceHash": "fnv1a64:f8ac64f1e7a0c725"
+    },
+    {
+      "id": "TA-C02-magizhcci",
+      "language": "tamil",
+      "chapter": 2,
+      "sequence": 165,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5519f38ad4330a86"
+    },
+    {
+      "id": "TA-C02-practice",
+      "language": "tamil",
+      "chapter": 2,
+      "sequence": 170,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:10c4d0f86990f82a"
     },
     {
       "id": "TA-C03-eppadi",
       "language": "tamil",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 180,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -35369,7 +35132,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:115a665d0b5ae3db",
+      "sourceHash": "fnv1a64:1d3bf7b5cc442f13",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -35378,7 +35141,7 @@
       "id": "TA-C03-eppadi-irukkirirgal",
       "language": "tamil",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 190,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -35390,7 +35153,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:54b96e84af48f100",
+      "sourceHash": "fnv1a64:0a99d5e4478d95d7",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -35399,7 +35162,7 @@
       "id": "TA-C03-naan",
       "language": "tamil",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 200,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -35411,7 +35174,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:bf125d1e56b58ba0",
+      "sourceHash": "fnv1a64:aaef6470e27b2b3d",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -35420,7 +35183,7 @@
       "id": "TA-C03-nalam",
       "language": "tamil",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 210,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -35432,7 +35195,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7085a36204532448",
+      "sourceHash": "fnv1a64:9e274834464afc76",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -35441,7 +35204,7 @@
       "id": "TA-C03-paravayillai",
       "language": "tamil",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 220,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -35453,7 +35216,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:706b526524e2e1ab",
+      "sourceHash": "fnv1a64:a7e6694023ebed70",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -35462,7 +35225,7 @@
       "id": "TA-C03-practice",
       "language": "tamil",
       "chapter": 3,
-      "sequence": null,
+      "sequence": 230,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -35474,55 +35237,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:38559b2a97d4823f"
-    },
-    {
-      "id": "TA-C04-mindum-sandippom",
-      "language": "tamil",
-      "chapter": 4,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:2bd30145a8a3485b",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
-    },
-    {
-      "id": "TA-C04-naalai",
-      "language": "tamil",
-      "chapter": 4,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:46d7d64986982553",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:61cfedde655dc9d7"
     },
     {
       "id": "TA-C04-po",
       "language": "tamil",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 240,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -35534,7 +35255,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:99257b30e11fb454",
+      "sourceHash": "fnv1a64:a137cdf96f4af1dd",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -35543,7 +35264,7 @@
       "id": "TA-C04-poy-varugiren",
       "language": "tamil",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 250,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -35555,16 +35276,83 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:f14e5eedd7053032",
+      "sourceHash": "fnv1a64:b827e77978feac54",
       "detachableSegments": [
         "The letters in this word"
       ]
+    },
+    {
+      "id": "TA-C04-naalai",
+      "language": "tamil",
+      "chapter": 4,
+      "sequence": 255,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:93385c7a8e7ee524",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C04-mindum-sandippom",
+      "language": "tamil",
+      "chapter": 4,
+      "sequence": 260,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:8dd1d2b81b09c384",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-W01-curves-va-ka",
+      "language": "tamil",
+      "chapter": 4,
+      "sequence": 270,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block",
+        "sight-cue"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type",
+        "sight-cue"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:2c2e171ca2be012a",
+      "detachableSegments": [
+        "Script you'll notice: The script is the shape of its writing surface"
+      ],
+      "delivery": "script"
     },
     {
       "id": "TA-C04-practice",
       "language": "tamil",
       "chapter": 4,
-      "sequence": null,
+      "sequence": 290,
       "modality": "voice",
       "derived": "voice",
       "drivable": true,
@@ -35576,34 +35364,13 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:65bb3e5878370184"
-    },
-    {
-      "id": "TA-C05-naan-tamizh-pesugiren",
-      "language": "tamil",
-      "chapter": 5,
-      "sequence": null,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:42a739df1441cc91",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:849cf4a2e960db6a"
     },
     {
       "id": "TA-C05-pesu",
       "language": "tamil",
       "chapter": 5,
-      "sequence": null,
+      "sequence": 300,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -35615,34 +35382,16 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:5667a5594c84050d",
+      "sourceHash": "fnv1a64:d3ef5e5538b5a60d",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "TA-C05-practice",
+      "id": "TA-C05-naan-tamizh-pesugiren",
       "language": "tamil",
       "chapter": 5,
-      "sequence": null,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:13bb1c850f393572"
-    },
-    {
-      "id": "TA-C05-vaazh",
-      "language": "tamil",
-      "chapter": 5,
-      "sequence": null,
+      "sequence": 310,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -35654,7 +35403,53 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9853bbbff15ebc67",
+      "sourceHash": "fnv1a64:ea295f6dbc121380",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-W01-abugida-va-ka",
+      "language": "tamil",
+      "chapter": 5,
+      "sequence": 320,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:e60a2cf8db255147",
+      "detachableSegments": [
+        "Script you'll notice: The vowel you get for free",
+        "Script you'll notice: வ — \"va\"",
+        "Script you'll notice: க — \"ka\""
+      ],
+      "delivery": "script"
+    },
+    {
+      "id": "TA-C05-vaazh",
+      "language": "tamil",
+      "chapter": 5,
+      "sequence": 330,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:c25a4a6426c60568",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -35663,7 +35458,7 @@
       "id": "TA-C05-velai-sey",
       "language": "tamil",
       "chapter": 5,
-      "sequence": null,
+      "sequence": 340,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -35675,329 +35470,15 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ca5c5c9223f2aab4",
+      "sourceHash": "fnv1a64:64528b6911be0db6",
       "detachableSegments": [
         "The letters in this word"
       ]
     },
     {
-      "id": "TA-C06-dative-ukku",
+      "id": "TA-C05-practice",
       "language": "tamil",
-      "chapter": 6,
-      "sequence": 180,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:80d96e6884624d7c"
-    },
-    {
-      "id": "TA-C06-dative-stacking",
-      "language": "tamil",
-      "chapter": 6,
-      "sequence": 190,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:4284bfb529666b68"
-    },
-    {
-      "id": "TA-C06-dative-subject",
-      "language": "tamil",
-      "chapter": 6,
-      "sequence": 200,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:5ac4c3bda06796be"
-    },
-    {
-      "id": "TA-C06-dative-subject-family",
-      "language": "tamil",
-      "chapter": 6,
-      "sequence": 210,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:2918677f2a6352d0"
-    },
-    {
-      "id": "TA-C07-numbers-1-5",
-      "language": "tamil",
-      "chapter": 7,
-      "sequence": 220,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "wide-table"
-      ],
-      "coreModality": "sight",
-      "coreReasons": [
-        "wide-table"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:abb924eead9ea4ef"
-    },
-    {
-      "id": "TA-C07-numbers-1-5-family",
-      "language": "tamil",
-      "chapter": 7,
-      "sequence": 230,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "wide-table"
-      ],
-      "coreModality": "sight",
-      "coreReasons": [
-        "wide-table"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:43c348a1c52641ce"
-    },
-    {
-      "id": "TA-C07-numbers-6-10",
-      "language": "tamil",
-      "chapter": 7,
-      "sequence": 240,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "sight-cue",
-        "wide-table"
-      ],
-      "coreModality": "sight",
-      "coreReasons": [
-        "sight-cue",
-        "wide-table"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:4ddc2af168d07ed1"
-    },
-    {
-      "id": "TA-C07-numbers-6-10-family",
-      "language": "tamil",
-      "chapter": 7,
-      "sequence": 250,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:74ab19978e0308e0"
-    },
-    {
-      "id": "TA-C08-tayavuseytu",
-      "language": "tamil",
-      "chapter": 8,
-      "sequence": 260,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:b64c5bd7dd10f8eb"
-    },
-    {
-      "id": "TA-C08-please-register",
-      "language": "tamil",
-      "chapter": 8,
-      "sequence": 270,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:11ca8536d913b3ec",
-      "detachableSegments": [
-        "Script you'll notice: Read the join in செய்து"
-      ]
-    },
-    {
-      "id": "TA-C09-mannikkavum",
-      "language": "tamil",
-      "chapter": 9,
-      "sequence": 280,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:b6af60ab308e7049"
-    },
-    {
-      "id": "TA-C09-sorry-register",
-      "language": "tamil",
-      "chapter": 9,
-      "sequence": 290,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "script-block"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:63705a2b1437e7b4",
-      "detachableSegments": [
-        "Script you'll notice: Read ன்னி"
-      ]
-    },
-    {
-      "id": "TA-C10-vaara-kizhamai",
-      "language": "tamil",
-      "chapter": 10,
-      "sequence": 300,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:7d4d6526c887f8d7"
-    },
-    {
-      "id": "TA-C11-nirangal",
-      "language": "tamil",
-      "chapter": 11,
-      "sequence": 310,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
-      "reasons": [
-        "sight-cue"
-      ],
-      "coreModality": "sight",
-      "coreReasons": [
-        "sight-cue"
-      ],
-      "coreDrivable": false,
-      "sourceHash": "fnv1a64:442d28ae6ba4719a"
-    },
-    {
-      "id": "TA-C12-kudumbam",
-      "language": "tamil",
-      "chapter": 12,
-      "sequence": 320,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:d83e9a64372df884"
-    },
-    {
-      "id": "TA-C13-udal-uruppugal",
-      "language": "tamil",
-      "chapter": 13,
-      "sequence": 330,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:29bbeb31bbfd6439"
-    },
-    {
-      "id": "TA-C14-kaalangal",
-      "language": "tamil",
-      "chapter": 14,
-      "sequence": 340,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
-      "reasons": [
-        "no-visual-dependency"
-      ],
-      "coreModality": "voice",
-      "coreReasons": [
-        "no-visual-dependency"
-      ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:555129c6b521a26a"
-    },
-    {
-      "id": "TA-C15-thanneer-arisi",
-      "language": "tamil",
-      "chapter": 15,
+      "chapter": 5,
       "sequence": 350,
       "modality": "voice",
       "derived": "voice",
@@ -36010,12 +35491,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:69c3cb0567033e1e"
+      "sourceHash": "fnv1a64:7672680a71915ae9"
     },
     {
-      "id": "TA-C16-thamizh-maadangal",
+      "id": "TA-C06-dative-ukku",
       "language": "tamil",
-      "chapter": 16,
+      "chapter": 6,
       "sequence": 360,
       "modality": "voice",
       "derived": "voice",
@@ -36028,30 +35509,36 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:bc0905b8d3ab5ecc"
+      "sourceHash": "fnv1a64:fefd6585b85ebcb8"
     },
     {
-      "id": "TA-C17-nanpakal-nalliravu",
+      "id": "TA-W02-ma-retroflex-na",
       "language": "tamil",
-      "chapter": 17,
+      "chapter": 6,
       "sequence": 370,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "writing-type",
+        "script-block"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:49f6e1ca6f73b6d4"
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:3dac8aa75e4a6c93",
+      "detachableSegments": [
+        "Script you'll notice: ம",
+        "Script you'll notice: ண"
+      ],
+      "delivery": "script"
     },
     {
-      "id": "TA-C17-transparent-middle-synonyms",
+      "id": "TA-C06-dative-stacking",
       "language": "tamil",
-      "chapter": 17,
+      "chapter": 6,
       "sequence": 380,
       "modality": "voice",
       "derived": "voice",
@@ -36064,12 +35551,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c43444f3c116f991"
+      "sourceHash": "fnv1a64:b6735982d308a9b7"
     },
     {
-      "id": "TA-C18-mani",
+      "id": "TA-C06-dative-subject",
       "language": "tamil",
-      "chapter": 18,
+      "chapter": 6,
       "sequence": 390,
       "modality": "voice",
       "derived": "voice",
@@ -36082,12 +35569,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7edef22adf32f80f"
+      "sourceHash": "fnv1a64:f2af170cba5d5680"
     },
     {
-      "id": "TA-C18-mani-homophone-time",
+      "id": "TA-C06-dative-subject-family",
       "language": "tamil",
-      "chapter": 18,
+      "chapter": 6,
       "sequence": 400,
       "modality": "voice",
       "derived": "voice",
@@ -36100,102 +35587,116 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:f5c848b349d8fe58"
+      "sourceHash": "fnv1a64:15d841e1d8f9bd2f"
     },
     {
-      "id": "TA-C19-vayathu",
+      "id": "TA-W02-three-ns",
       "language": "tamil",
-      "chapter": 19,
+      "chapter": 6,
       "sequence": 410,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "writing-type",
+        "script-block"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:707e217350c30e75"
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:ab29843a61b3d47c",
+      "detachableSegments": [
+        "Script you'll notice: The backward walk"
+      ],
+      "delivery": "script"
     },
     {
-      "id": "TA-C19-age-register-grammar",
+      "id": "TA-C07-numbers-1-5",
       "language": "tamil",
-      "chapter": 19,
+      "chapter": 7,
       "sequence": 420,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "wide-table"
       ],
-      "coreModality": "voice",
+      "coreModality": "sight",
       "coreReasons": [
-        "no-visual-dependency"
+        "wide-table"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:15d09bbc0d429868"
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:7f1fe2cf223f2795"
     },
     {
-      "id": "TA-C20-pathinondru-irupathu",
+      "id": "TA-C07-numbers-1-5-family",
       "language": "tamil",
-      "chapter": 20,
+      "chapter": 7,
       "sequence": 430,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "wide-table"
       ],
-      "coreModality": "voice",
+      "coreModality": "sight",
       "coreReasons": [
-        "no-visual-dependency"
+        "wide-table"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:83599a85f76e0d2c"
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:1348a3cd6d2254dc"
     },
     {
-      "id": "TA-C20-vaanilai",
+      "id": "TA-C07-numbers-6-10",
       "language": "tamil",
-      "chapter": 20,
+      "chapter": 7,
       "sequence": 440,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "sight-cue",
+        "wide-table"
       ],
-      "coreModality": "voice",
+      "coreModality": "sight",
       "coreReasons": [
-        "no-visual-dependency"
+        "sight-cue",
+        "wide-table"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:e976c1dcd9de69f6"
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:401209a5981f3533"
     },
     {
-      "id": "TA-C21-naay-poonai",
+      "id": "TA-W03-pulli-vanakkam",
       "language": "tamil",
-      "chapter": 21,
+      "chapter": 7,
       "sequence": 450,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "writing-type",
+        "script-block",
+        "sight-cue"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:de5497918953d746"
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:64efe447e0048de5",
+      "detachableSegments": [
+        "Script you'll notice: The puḷḷi",
+        "Script you'll notice: What Tamil does *not* do"
+      ],
+      "delivery": "script"
     },
     {
-      "id": "TA-C22-paccai-manjal",
+      "id": "TA-C07-numbers-6-10-family",
       "language": "tamil",
-      "chapter": 22,
+      "chapter": 7,
       "sequence": 460,
       "modality": "voice",
       "derived": "voice",
@@ -36208,12 +35709,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7c72b7c8044cb6de"
+      "sourceHash": "fnv1a64:cee9f967507bdf77"
     },
     {
-      "id": "TA-C23-naal",
+      "id": "TA-C08-tayavuseytu",
       "language": "tamil",
-      "chapter": 23,
+      "chapter": 8,
       "sequence": 470,
       "modality": "voice",
       "derived": "voice",
@@ -36226,48 +35727,56 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ad1a9f6edfca5d2b"
+      "sourceHash": "fnv1a64:b971e0b2bb303f4a"
     },
     {
-      "id": "TA-C23-day-family-register",
+      "id": "TA-C08-please-register",
       "language": "tamil",
-      "chapter": 23,
+      "chapter": 8,
       "sequence": 480,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:be8dbaeab3323246"
+      "sourceHash": "fnv1a64:623569769d69e6a3",
+      "detachableSegments": [
+        "Script you'll notice: Read the join in செய்து"
+      ]
     },
     {
-      "id": "TA-C24-iravu",
+      "id": "TA-W03-write-vanakkam",
       "language": "tamil",
-      "chapter": 24,
+      "chapter": 8,
       "sequence": 490,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "writing-type",
+        "script-block"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:32036d5e65c5aec1"
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:fda8442069111930",
+      "detachableSegments": [
+        "Script you'll notice: Build the word"
+      ],
+      "delivery": "script"
     },
     {
-      "id": "TA-C24-night-register-darkness",
+      "id": "TA-C09-mannikkavum",
       "language": "tamil",
-      "chapter": 24,
+      "chapter": 9,
       "sequence": 500,
       "modality": "voice",
       "derived": "voice",
@@ -36280,30 +35789,33 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b660a38234786f74"
+      "sourceHash": "fnv1a64:2ca552bc0eb5b07e"
     },
     {
-      "id": "TA-C25-iniya-iravu",
+      "id": "TA-C09-sorry-register",
       "language": "tamil",
-      "chapter": 25,
+      "chapter": 9,
       "sequence": 510,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "script-block"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c412c2fd55012e40"
+      "sourceHash": "fnv1a64:0b10828379b8e21d",
+      "detachableSegments": [
+        "Script you'll notice: Read ன்னி"
+      ]
     },
     {
-      "id": "TA-C25-goodnight-alternatives",
+      "id": "TA-C10-vaara-kizhamai",
       "language": "tamil",
-      "chapter": 25,
+      "chapter": 10,
       "sequence": 520,
       "modality": "voice",
       "derived": "voice",
@@ -36316,48 +35828,54 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:bcf8703e4fee1dda"
+      "sourceHash": "fnv1a64:ff31b17db43deacb"
     },
     {
-      "id": "TA-C26-kaalai",
+      "id": "TA-W04-vowel-signs-nandri",
       "language": "tamil",
-      "chapter": 26,
+      "chapter": 10,
       "sequence": 530,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "writing-type",
+        "script-block"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:f31e62ada32eba46"
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:b1f78acfb57601f8",
+      "detachableSegments": [
+        "Script you'll notice: The two remaining n's",
+        "Script you'll notice: ற — \"ṟa\", the hard r"
+      ],
+      "delivery": "script"
     },
     {
-      "id": "TA-C27-maalai",
+      "id": "TA-C11-nirangal",
       "language": "tamil",
-      "chapter": 27,
+      "chapter": 11,
       "sequence": 540,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "sight-cue"
       ],
-      "coreModality": "voice",
+      "coreModality": "sight",
       "coreReasons": [
-        "no-visual-dependency"
+        "sight-cue"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:c8b7ae0842bacb6d"
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:4b1ab1ec3abd07dd"
     },
     {
-      "id": "TA-C28-pirpakal",
+      "id": "TA-C12-kudumbam",
       "language": "tamil",
-      "chapter": 28,
+      "chapter": 12,
       "sequence": 550,
       "modality": "voice",
       "derived": "voice",
@@ -36370,12 +35888,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:0568dee970d8dc36"
+      "sourceHash": "fnv1a64:418d1b0b702acbe3"
     },
     {
-      "id": "TA-C28-afternoon-boundary",
+      "id": "TA-C13-udal-uruppugal",
       "language": "tamil",
-      "chapter": 28,
+      "chapter": 13,
       "sequence": 560,
       "modality": "voice",
       "derived": "voice",
@@ -36388,30 +35906,36 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:2e0fef18cdf187fb"
+      "sourceHash": "fnv1a64:a126d778478d4902"
     },
     {
-      "id": "TA-C29-kaalai-vanakkam",
+      "id": "TA-W04-i-sign-write-nandri",
       "language": "tamil",
-      "chapter": 29,
+      "chapter": 13,
       "sequence": 570,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "writing-type",
+        "script-block"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:0903cbd5df40e04f"
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:3418015b917f2833",
+      "detachableSegments": [
+        "Script you'll notice: The first vowel sign",
+        "Script you'll notice: Assemble நன்றி"
+      ],
+      "delivery": "script"
     },
     {
-      "id": "TA-C30-maalai-vanakkam",
+      "id": "TA-C14-kaalangal",
       "language": "tamil",
-      "chapter": 30,
+      "chapter": 14,
       "sequence": 580,
       "modality": "voice",
       "derived": "voice",
@@ -36424,12 +35948,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e605d22d0c8038e0"
+      "sourceHash": "fnv1a64:3c8ce6fb6a613930"
     },
     {
-      "id": "TA-C31-matiya-vanakkam",
+      "id": "TA-C15-thanneer-arisi",
       "language": "tamil",
-      "chapter": 31,
+      "chapter": 15,
       "sequence": 590,
       "modality": "voice",
       "derived": "voice",
@@ -36442,12 +35966,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:40bdf24325c6deef"
+      "sourceHash": "fnv1a64:1a1b674fcef23d70"
     },
     {
-      "id": "TA-C31-afternoon-greeting-root",
+      "id": "TA-C16-thamizh-maadangal",
       "language": "tamil",
-      "chapter": 31,
+      "chapter": 16,
       "sequence": 600,
       "modality": "voice",
       "derived": "voice",
@@ -36460,30 +35984,36 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:0f94f0e85cdff5f4"
+      "sourceHash": "fnv1a64:14dab8c9cd8fec07"
     },
     {
-      "id": "TA-C32-iru",
+      "id": "TA-W05-write-aam",
       "language": "tamil",
-      "chapter": 32,
+      "chapter": 16,
       "sequence": 610,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "writing-type",
+        "script-block"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:d66cfc3bade90237"
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:2806a117ad48f726",
+      "detachableSegments": [
+        "Script you'll notice: a vowel standing alone",
+        "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
     },
     {
-      "id": "TA-C32-po",
+      "id": "TA-C17-nanpakal-nalliravu",
       "language": "tamil",
-      "chapter": 32,
+      "chapter": 17,
       "sequence": 620,
       "modality": "voice",
       "derived": "voice",
@@ -36496,12 +36026,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:19f2c25a59f0f982"
+      "sourceHash": "fnv1a64:f54b98fb24a35ebe"
     },
     {
-      "id": "TA-C32-vaa",
+      "id": "TA-C17-transparent-middle-synonyms",
       "language": "tamil",
-      "chapter": 32,
+      "chapter": 17,
       "sequence": 630,
       "modality": "voice",
       "derived": "voice",
@@ -36514,12 +36044,12 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:6d11abac17fa8c52"
+      "sourceHash": "fnv1a64:1a6961f763d05fc1"
     },
     {
-      "id": "TA-C32-saappidu",
+      "id": "TA-C18-mani",
       "language": "tamil",
-      "chapter": 32,
+      "chapter": 18,
       "sequence": 640,
       "modality": "voice",
       "derived": "voice",
@@ -36532,30 +36062,36 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:bb3c1c1696795fe0"
+      "sourceHash": "fnv1a64:f0c21e500c9a13b9"
     },
     {
-      "id": "TA-C32-paar",
+      "id": "TA-W06-write-illai",
       "language": "tamil",
-      "chapter": 32,
+      "chapter": 18,
       "sequence": 650,
-      "modality": "voice",
-      "derived": "voice",
-      "drivable": true,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
       "reasons": [
-        "no-visual-dependency"
+        "writing-type",
+        "script-block"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:39ea79380f0de2f5"
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:8ac490a17d82b53a",
+      "detachableSegments": [
+        "Script you'll notice: இ and ல",
+        "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
     },
     {
-      "id": "TA-C32-teri",
+      "id": "TA-C18-mani-homophone-time",
       "language": "tamil",
-      "chapter": 32,
+      "chapter": 18,
       "sequence": 660,
       "modality": "voice",
       "derived": "voice",
@@ -36568,159 +36104,144 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:43e3caa79eab7344"
+      "sourceHash": "fnv1a64:e021e7775002900c"
     },
     {
-      "id": "TA-C33-ninai",
+      "id": "TA-C19-vayathu",
       "language": "tamil",
-      "chapter": 33,
+      "chapter": 19,
       "sequence": 670,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:bec4abda60466215",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:e7a729c0a3693e61"
     },
     {
-      "id": "TA-C33-puri",
+      "id": "TA-C19-age-register-grammar",
       "language": "tamil",
-      "chapter": 33,
+      "chapter": 19,
       "sequence": 680,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:33fe6b5286b65e12",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:e56e7a5816e08838"
     },
     {
-      "id": "TA-C33-padi",
+      "id": "TA-W07-write-sari",
       "language": "tamil",
-      "chapter": 33,
+      "chapter": 19,
       "sequence": 690,
-      "modality": "sight",
-      "derived": "sight",
+      "modality": "pen",
+      "derived": "pen",
       "drivable": false,
       "reasons": [
+        "writing-type",
         "script-block"
       ],
-      "coreModality": "voice",
+      "coreModality": "pen",
       "coreReasons": [
-        "no-visual-dependency"
+        "writing-type"
       ],
-      "coreDrivable": true,
-      "sourceHash": "fnv1a64:58ad67ba9a906ea4",
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:e901b4d9eeba8fde",
       "detachableSegments": [
-        "The letters in this word"
-      ]
+        "Script you'll notice: ச and ர",
+        "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
     },
     {
-      "id": "TA-C33-ezhutu",
+      "id": "TA-C20-pathinondru-irupathu",
       "language": "tamil",
-      "chapter": 33,
+      "chapter": 20,
       "sequence": 700,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:3a36a9291ceaaf55",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:31182bc6d2e785e6"
     },
     {
-      "id": "TA-C34-edu",
+      "id": "TA-C20-vaanilai",
       "language": "tamil",
-      "chapter": 34,
+      "chapter": 20,
       "sequence": 710,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:3247ff041aada7e8",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:661e8c72b79c3d22"
     },
     {
-      "id": "TA-C34-kel",
+      "id": "TA-C21-naay-poonai",
       "language": "tamil",
-      "chapter": 34,
+      "chapter": 21,
       "sequence": 720,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:5a4741225dff9092",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:a2f119fd5362a2d8"
     },
     {
-      "id": "TA-C34-utavu",
+      "id": "TA-C22-paccai-manjal",
       "language": "tamil",
-      "chapter": 34,
+      "chapter": 22,
       "sequence": 730,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:cbacf37334d54ef5",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:3114da16b86a47ea"
     },
     {
-      "id": "TA-C34-pidi",
+      "id": "TA-C23-naal",
       "language": "tamil",
-      "chapter": 34,
+      "chapter": 23,
       "sequence": 740,
       "modality": "voice",
       "derived": "voice",
@@ -36733,13 +36254,355 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:1480cdf0e8dbdd75"
+      "sourceHash": "fnv1a64:01ed309a4046ac0d"
     },
     {
-      "id": "TA-C35-veedu",
+      "id": "TA-C23-day-family-register",
       "language": "tamil",
-      "chapter": 35,
+      "chapter": 23,
       "sequence": 750,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:43a47e46c1189b5e"
+    },
+    {
+      "id": "TA-C24-iravu",
+      "language": "tamil",
+      "chapter": 24,
+      "sequence": 760,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7838990e6a1e86ab"
+    },
+    {
+      "id": "TA-C24-night-register-darkness",
+      "language": "tamil",
+      "chapter": 24,
+      "sequence": 770,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b3a2d9a756bc31c9"
+    },
+    {
+      "id": "TA-C25-iniya-iravu",
+      "language": "tamil",
+      "chapter": 25,
+      "sequence": 780,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3874dc4fc0a7afb5"
+    },
+    {
+      "id": "TA-C25-goodnight-alternatives",
+      "language": "tamil",
+      "chapter": 25,
+      "sequence": 790,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:614ee145f16a1bf3"
+    },
+    {
+      "id": "TA-C26-kaalai",
+      "language": "tamil",
+      "chapter": 26,
+      "sequence": 800,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:be68ac32ac9c4962"
+    },
+    {
+      "id": "TA-C27-maalai",
+      "language": "tamil",
+      "chapter": 27,
+      "sequence": 810,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9b58ae9e7d826a6f"
+    },
+    {
+      "id": "TA-C28-pirpakal",
+      "language": "tamil",
+      "chapter": 28,
+      "sequence": 820,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f0692fb16627812a"
+    },
+    {
+      "id": "TA-C28-afternoon-boundary",
+      "language": "tamil",
+      "chapter": 28,
+      "sequence": 830,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:52837d88f23a53f5"
+    },
+    {
+      "id": "TA-C29-kaalai-vanakkam",
+      "language": "tamil",
+      "chapter": 29,
+      "sequence": 840,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:824054e5b5c328eb"
+    },
+    {
+      "id": "TA-C30-maalai-vanakkam",
+      "language": "tamil",
+      "chapter": 30,
+      "sequence": 850,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:a569e6a16620cd0e"
+    },
+    {
+      "id": "TA-C31-matiya-vanakkam",
+      "language": "tamil",
+      "chapter": 31,
+      "sequence": 860,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:ed3341669544458b"
+    },
+    {
+      "id": "TA-C31-afternoon-greeting-root",
+      "language": "tamil",
+      "chapter": 31,
+      "sequence": 870,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:aebc39e8e3bbc929"
+    },
+    {
+      "id": "TA-C32-iru",
+      "language": "tamil",
+      "chapter": 32,
+      "sequence": 880,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:23936f7a7029f5e4"
+    },
+    {
+      "id": "TA-C32-po",
+      "language": "tamil",
+      "chapter": 32,
+      "sequence": 890,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:9895466949df9e89"
+    },
+    {
+      "id": "TA-C32-vaa",
+      "language": "tamil",
+      "chapter": 32,
+      "sequence": 900,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:b8b7f1f6cbee9bd4"
+    },
+    {
+      "id": "TA-C32-saappidu",
+      "language": "tamil",
+      "chapter": 32,
+      "sequence": 910,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:484b58557e1ab908"
+    },
+    {
+      "id": "TA-C32-paar",
+      "language": "tamil",
+      "chapter": 32,
+      "sequence": 920,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7c0c7b2534e55fb3"
+    },
+    {
+      "id": "TA-C32-teri",
+      "language": "tamil",
+      "chapter": 32,
+      "sequence": 930,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5c10a4213db12268"
+    },
+    {
+      "id": "TA-C33-ninai",
+      "language": "tamil",
+      "chapter": 33,
+      "sequence": 940,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36751,7 +36614,172 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:297479db3d817cd4",
+      "sourceHash": "fnv1a64:3da01ee3c6063b7b",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C33-puri",
+      "language": "tamil",
+      "chapter": 33,
+      "sequence": 950,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f02f6b37ae1e15ce",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C33-padi",
+      "language": "tamil",
+      "chapter": 33,
+      "sequence": 960,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:7eae469fe811e74e",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C33-ezhutu",
+      "language": "tamil",
+      "chapter": 33,
+      "sequence": 970,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:3cbfae9f73f99b68",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C34-edu",
+      "language": "tamil",
+      "chapter": 34,
+      "sequence": 980,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:5d6ea6f315808c33",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C34-kel",
+      "language": "tamil",
+      "chapter": 34,
+      "sequence": 990,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:f5e3b74b5b3bf025",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C34-utavu",
+      "language": "tamil",
+      "chapter": 34,
+      "sequence": 1000,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:39f1276ff0515dcc",
+      "detachableSegments": [
+        "The letters in this word"
+      ]
+    },
+    {
+      "id": "TA-C34-pidi",
+      "language": "tamil",
+      "chapter": 34,
+      "sequence": 1010,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
+      "reasons": [
+        "no-visual-dependency"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:d9826b5358141478"
+    },
+    {
+      "id": "TA-C35-veedu",
+      "language": "tamil",
+      "chapter": 35,
+      "sequence": 1020,
+      "modality": "sight",
+      "derived": "sight",
+      "drivable": false,
+      "reasons": [
+        "script-block"
+      ],
+      "coreModality": "voice",
+      "coreReasons": [
+        "no-visual-dependency"
+      ],
+      "coreDrivable": true,
+      "sourceHash": "fnv1a64:02cdeb414fe5f151",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36760,7 +36788,7 @@
       "id": "TA-C35-kadavu",
       "language": "tamil",
       "chapter": 35,
-      "sequence": 760,
+      "sequence": 1030,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36772,7 +36800,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:563406c98419bdc3",
+      "sourceHash": "fnv1a64:939efbe63d9682c4",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36781,7 +36809,7 @@
       "id": "TA-C35-arai",
       "language": "tamil",
       "chapter": 35,
-      "sequence": 770,
+      "sequence": 1040,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36793,7 +36821,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:34d173f2cce6d96f",
+      "sourceHash": "fnv1a64:52db51b4d7161024",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36802,7 +36830,7 @@
       "id": "TA-C35-naarkaali",
       "language": "tamil",
       "chapter": 35,
-      "sequence": 780,
+      "sequence": 1050,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36814,7 +36842,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:f68ff6aa061a196c",
+      "sourceHash": "fnv1a64:cd96726728bb3047",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36823,7 +36851,7 @@
       "id": "TA-C36-teneer",
       "language": "tamil",
       "chapter": 36,
-      "sequence": 790,
+      "sequence": 1060,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36835,7 +36863,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:fbaac7d8134225e1",
+      "sourceHash": "fnv1a64:a16ff2a5db8e0872",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36844,7 +36872,7 @@
       "id": "TA-C36-paal",
       "language": "tamil",
       "chapter": 36,
-      "sequence": 800,
+      "sequence": 1070,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36856,7 +36884,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:6a72f2af11ebc2dc",
+      "sourceHash": "fnv1a64:fdcb199d987a2bd6",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36865,7 +36893,7 @@
       "id": "TA-C36-unavu",
       "language": "tamil",
       "chapter": 36,
-      "sequence": 810,
+      "sequence": 1080,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36877,7 +36905,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:044f1ad4f016e2c5",
+      "sourceHash": "fnv1a64:e042fc7d55223d2d",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36886,7 +36914,7 @@
       "id": "TA-C36-tavaru",
       "language": "tamil",
       "chapter": 36,
-      "sequence": 820,
+      "sequence": 1090,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36898,7 +36926,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:46edc651e85b20f4",
+      "sourceHash": "fnv1a64:28d405c93048afda",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36907,7 +36935,7 @@
       "id": "TA-C37-uur",
       "language": "tamil",
       "chapter": 37,
-      "sequence": 830,
+      "sequence": 1100,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36919,7 +36947,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:3393a38bd4aca7f7",
+      "sourceHash": "fnv1a64:e9126594107cd522",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36928,7 +36956,7 @@
       "id": "TA-C37-nanban",
       "language": "tamil",
       "chapter": 37,
-      "sequence": 840,
+      "sequence": 1110,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36940,7 +36968,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e3f3e23276e44561",
+      "sourceHash": "fnv1a64:3b1e135aa5ebe420",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36949,7 +36977,7 @@
       "id": "TA-C37-ivar",
       "language": "tamil",
       "chapter": 37,
-      "sequence": 850,
+      "sequence": 1120,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36961,7 +36989,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9ca3f8708b12b192",
+      "sourceHash": "fnv1a64:86cddb2e115cba53",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36970,7 +36998,7 @@
       "id": "TA-C37-ivar-en-nanbar",
       "language": "tamil",
       "chapter": 37,
-      "sequence": 860,
+      "sequence": 1130,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -36982,7 +37010,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a2e2284ae61b8a8e",
+      "sourceHash": "fnv1a64:30fc8c871f6986df",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -36991,7 +37019,7 @@
       "id": "TA-C38-udambu",
       "language": "tamil",
       "chapter": 38,
-      "sequence": 870,
+      "sequence": 1140,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -37003,7 +37031,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:4c3a8be338bc60b3",
+      "sourceHash": "fnv1a64:fb6e418ebdb8be6c",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -37012,7 +37040,7 @@
       "id": "TA-C38-sugam",
       "language": "tamil",
       "chapter": 38,
-      "sequence": 880,
+      "sequence": 1150,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -37024,7 +37052,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:e334b1613ee920fd",
+      "sourceHash": "fnv1a64:00918ca7669305da",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -37033,7 +37061,7 @@
       "id": "TA-C38-vidai",
       "language": "tamil",
       "chapter": 38,
-      "sequence": 890,
+      "sequence": 1160,
       "modality": "sight",
       "derived": "sight",
       "drivable": false,
@@ -37045,7 +37073,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:f9300ce323ff2a68",
+      "sourceHash": "fnv1a64:9e168048336c9617",
       "detachableSegments": [
         "The letters in this word"
       ]

--- a/code/learning/human-languages/tamil/book/chapters/ch01-greetings.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch01-greetings.tex
@@ -1,20 +1,21 @@
 \chapter{Greetings}
 \label{ch:greetings}
 
-The Tamil greetings and the words that oil a first conversation --- and,
-taught through them, how to read the Tamil script and how Tamil sits inside
-the Dravidian family. Each lesson introduces the letters its word needs, so
-you learn to read the word and understand it at once.
+The Tamil greetings and the words that oil a first conversation, and how Tamil
+sits inside the Dravidian family. This chapter is \textbf{spoken}: you can say
+everything in it without reading a letter. The Tamil is printed alongside so the
+shapes grow familiar, but nothing here asks you to read or write them. The
+writing strand starts in Chapter~4 and adds one lesson at a time, and every
+letter it teaches spells a word you already know by ear.
 
 \section{\ta{வணக்கம்} \emph{(vaṇakkam)} --- ``greetings,'' a small act of respect}
 \label{lesson:vanakkam}
 
 \begin{sounds}
-Tamil reads \textbf{left to right}, and every consonant carries a built-in
-``a.'' \ta{வ} va, \ta{க} ka, \ta{ம} ma. \ta{ண} is a \textbf{retroflex} \emph{ṇ}
-(tongue curled back). The dot on top --- a \textbf{puḷḷi} --- \emph{kills} the
-built-in vowel: \ta{க்} is a bare \emph{k}, so \ta{க்க} is a held ``kk.'' Read
-\ta{வ·ண·க்·க·ம்} $\to$ \emph{vaṇakkam}.
+Say it \emph{va-\d{n}ak-kam}. The \d{n} is a \textbf{retroflex} \emph{n} ---
+curl the tongue back to the roof of the mouth, further back than an English
+\emph{n}. The \emph{kk} is \textbf{held}, a beat longer than a single \emph{k},
+and that length is doing real work: Tamil distinguishes words by it.
 \end{sounds}
 
 \begin{cousinweb}
@@ -55,10 +56,11 @@ anyone, respectful without being stiff.
 \label{lesson:nandri}
 
 \begin{sounds}
-New: \ta{ந} \emph{na} (\textbf{dental}, tongue on the teeth), \ta{ன்} \emph{ṉ}
-(\textbf{alveolar}, on the ridge behind the teeth, with a puḷḷi), and \ta{ற}
-\emph{ṟa}. The vowel sign \ta{ி} makes ``i'' (\ta{றி} = ṟi). Read
-\ta{ந·ன்·றி} $\to$ \emph{naṉṟi}.
+Say it \emph{na\d{n}-\d{r}i}. Tamil hears \textbf{three} different \emph{n}
+sounds and this word uses two of them: a \textbf{dental} \emph{n} (tongue on the
+teeth) to open, then an \textbf{alveolar} one (on the ridge just behind them).
+The \d{r} is its own sound again, not the English \emph{r}. English ears
+flatten all of this to ``nandri,'' which is close enough to be understood.
 \end{sounds}
 
 \begin{cousinweb}
@@ -99,9 +101,9 @@ took the Sanskrit one --- the family splits as it did over ``hello.''
 \label{lesson:aam}
 
 \begin{sounds}
-\ta{ஆ} is the \textbf{independent vowel} ``ā'': when a word \emph{starts} with
-a vowel, Tamil uses a full vowel letter, not the little sign it hooks onto a
-consonant. \ta{ம்} is a bare \emph{m} (puḷḷi). Read \ta{ஆ·ம்} $\to$ \emph{ām}.
+Say it \emph{\=am} --- a \textbf{long} \emph{a}, held about twice as long as
+the short one, closing on a plain \emph{m}. Vowel length is meaningful in Tamil,
+so the length is not decoration.
 \end{sounds}
 
 \begin{cousinweb}
@@ -119,9 +121,9 @@ as the simple word, but expect a ``yes'' to come back as a whole verb.
 \label{lesson:illai}
 
 \begin{sounds}
-\ta{இ} is the independent vowel ``i'' (word-initial, like \ta{ஆ}). \ta{ல்} is a
-bare \emph{l} (puḷḷi); \ta{லை} is \emph{lai} (the consonant \ta{ல} with the
-vowel sign \ta{ை} for ``ai''). Read \ta{இ·ல்·லை} $\to$ \emph{illai}.
+Say it \emph{il-lai}, with the \emph{l} \textbf{held} across the join --- the
+same doubling you met in \emph{va\d{n}ak-kam}. The ending is the diphthong
+\emph{ai}, as in English ``eye,'' not two separate vowels.
 \end{sounds}
 
 \begin{cousinweb}
@@ -144,10 +146,11 @@ Dravidian habit, unlike English or Hindi.
 \label{lesson:sari}
 
 \begin{sounds}
-\ta{ச} is one letter doing the work of English \emph{s}, \emph{ch}, and
-\emph{j} --- Tamil gives voicing no separate letters, so \textbf{position}
-decides the sound (just as \ta{க} can be \emph{k}, \emph{g}, or \emph{h}).
-\ta{ரி} is \emph{ri}. Read \ta{ச·ரி} $\to$ \emph{sari}.
+Say it \emph{sari}, two light syllables, stress even. The opening sound sits
+between English \emph{s} and \emph{ch}, and Tamil treats that whole range as one
+sound chosen by \textbf{position} in the word rather than by a separate spelling
+--- the same economy that lets one \emph{k}-sound also be heard as \emph{g} or a
+soft \emph{h}.
 \end{sounds}
 
 \begin{cousinweb}
@@ -170,7 +173,7 @@ predictable from the letter alone --- you pick it up by ear, word by word.
 \begin{center}
 \begin{tabular}{@{}lll@{}}
 \toprule
-Read & & Meaning \\
+& & Meaning \\
 \midrule
 \ta{வணக்கம்} & \emph{vaṇakkam} & hello / greetings \\
 \ta{நன்றி} & \emph{naṉṟi} & thank you \\

--- a/code/learning/human-languages/tamil/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch04-farewells.tex
@@ -87,6 +87,36 @@ Sanskrit grammar uses for how sounds join at a boundary. A Dravidian core beside
 a Sanskrit borrowing --- the recurring thread of this track.
 \end{cousinweb}
 
+\section[Tamil's curves]{Tamil's curves --- the writing surface leaves a trace}
+\label{lesson:TA-W01-curves-va-ka}
+
+The first lesson of the writing strand teaches no letter at all. Before the
+first shape, look at a line of Tamil and notice what is \emph{not} there:
+
+\begin{center}\ta{வணக்கம்}\end{center}
+
+\textbf{Nothing joins the letters together}, and there are far fewer corners
+than in Devanagari --- no hanging head-line, and a great deal of curve.
+(Straight strokes do exist: most of these letters have a flat bar across the
+top.)
+
+Tamil was written for centuries on \textbf{palm leaves}, scratched with a metal
+stylus and rubbed with soot to make the scratches show. A palm leaf has a
+\textbf{grain}, like wood: draw a long straight line along it and the stylus can
+\textbf{split the leaf}. The usual account is that scribes bent their strokes in
+response --- a curve crosses the fibres at an angle instead of running with them.
+
+Treat that as \textbf{the standard explanation rather than a settled fact}. The
+earliest Tamil writing --- Tamil-Brahmi, cut into stone and pottery --- is
+noticeably \emph{angular}; the rounding came later, through the
+Va\d{t}\d{t}eḻuttu (``round script'') stage. And Devanagari was written on
+the same leaves without going round. So the leaf is one pressure among several,
+not a complete answer.
+
+It is still worth carrying, because it makes the right general point:
+\textbf{the tool leaves fingerprints on the letters.} Latin's straight strokes
+suit a wax tablet and a chisel; Tamil's curves suit a stylus and a leaf.
+
 \section{The farewells}
 \label{lesson:ta-farewells-practice}
 

--- a/code/learning/human-languages/tamil/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch05-first-verbs.tex
@@ -54,6 +54,36 @@ unlike Hindi, where even ``I speak'' changes for the speaker's gender
 (\emph{bolt\=a}/\emph{bolt\=\i}). Tamil saves gender for ``he/she/it.''
 \end{grammarlens}
 
+\section[\ta{வ} and \ta{க}]{\ta{வ} and \ta{க} --- the vowel inside each consonant}
+\label{lesson:TA-W01-abugida-va-ka}
+
+\subsection*{Script you'll notice: the vowel you get for free}
+
+Tamil is an \textbf{abugida}, like Devanagari: a consonant already contains a
+vowel. \textbf{\ta{க} is not ``k.'' \ta{க} is ``ka.''} Every consonant carries a
+built-in \emph{a} until a later mark removes or replaces it.
+
+\subsection*{Script you'll notice: \ta{வ} and \ta{க}}
+
+\ta{வ} --- \emph{va}. Its parts, in the conventional order: 1.~\textbf{a
+near-closed loop on the left} 2.~\textbf{a full-height arm across the top,
+ending in a descender on the right}.
+
+\ta{க} --- \emph{ka}. 1.~\textbf{a straight horizontal top bar} 2.~\textbf{a
+bowl hanging from its left end} 3.~\textbf{a short right stroke that hooks left
+below}.
+
+\begin{grammarlens}
+\textbf{One letter, three sounds --- now on the page.} Chapter~1 said Tamil
+picks this sound by position rather than by spelling; here is the letter that
+does it. Devanagari spells \emph{ka}, \emph{kha}, \emph{ga} and \emph{gha} with
+four separate letters. Tamil writes \ta{க} for all of them: \emph{k} at the
+start of a word and when doubled (\ta{க்க}), \emph{g} after a nasal
+(\ta{ங்க}), and a softer \emph{h}-like sound between vowels. That is why Tamil
+needs only 18 consonant letters where Devanagari needs 33 --- its native words
+do not depend on those written distinctions.
+\end{grammarlens}
+
 \section{\ta{வாழ்} \emph{(v\=a\d{l})} --- ``to live, to flourish''}
 \label{lesson:vaazh}
 

--- a/code/learning/human-languages/tamil/book/chapters/ch06-dative-case.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch06-dative-case.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:8cb1982f517a21f4
-% canonical-lessons: TA-C06-dative-ukku, TA-C06-dative-stacking, TA-C06-dative-subject, TA-C06-dative-subject-family
+% canonical-source-hash: fnv1a64:506251379b3d7dec
+% canonical-lessons: TA-C06-dative-ukku, TA-W02-ma-retroflex-na, TA-C06-dative-stacking, TA-C06-dative-subject, TA-C06-dative-subject-family, TA-W02-three-ns
 
 \chapter{Dative Case and Dative Subjects}
 \label{ch:ta-dative-case}
@@ -56,7 +56,48 @@ Say these aloud:
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-What does \textbf{-\ta{உக்கு}} mean? (\textquotedblleft{}\textbf{To}\textquotedblright{} or \textquotedblleft{}\textbf{for}.\textquotedblright{}) Where does it go? (\textbf{On the end} of the noun — Tamil adds, it doesn't put a word in front.) What is \textquotedblleft{}to me\textquotedblright{}? (\textbf{\ta{எனக்கு}} \emph{enakku} — the pronoun's body changes to \emph{en-} first.) Why does the suffix show up as \emph{-ukku} and \emph{-kku}? (\textbf{One case, two shapes}, chosen by the noun's ending.) Next: compare that visible one-purpose suffix with a fused Latin ending.
+What does \textbf{-\ta{உக்கு}} mean? (\textquotedblleft{}\textbf{To}\textquotedblright{} or \textquotedblleft{}\textbf{for}.\textquotedblright{}) Where does it go? (\textbf{On the end} of the noun — Tamil adds, it doesn't put a word in front.) What is \textquotedblleft{}to me\textquotedblright{}? (\textbf{\ta{எனக்கு}} \emph{enakku} — the pronoun's body changes to \emph{en-} first.) Why does the suffix show up as \emph{-ukku} and \emph{-kku}? (\textbf{One case, two shapes}, chosen by the noun's ending.) Next: two more letters — \ta{ம} and retroflex \ta{ண}.
+\end{tcolorbox}
+\section[ma, ṇa]{\ta{ம} and \ta{ண} — a loop, and a curled tongue}
+
+\label{lesson:TA-W02-ma-retroflex-na}
+
+
+
+\begin{quote}
+Two more letters, and with them you'll have every letter of this book's first word. One is easy. The other is a sound you may not be able to hear yet.
+\end{quote}
+
+\subsection*{Script you'll notice: \ta{ம}}
+1. \textbf{a straight vertical stroke on the LEFT} 2. \textbf{a horizontal along the bottom} 3. \textbf{a rounded arch closing it on the RIGHT}
+
+Get the sides the right way round. The \textbf{upright is on the left} and the \textbf{curve on the right} — which is the reverse of what most people guess, and the reverse of the Devanagari habit of hanging a shape off a right-hand spine.
+
+\subsection*{Script you'll notice: \ta{ண}}
+1. \textbf{a straight top bar} 2. \textbf{a loop on the left} 3. \textbf{two arches} 4. \textbf{a straight vertical on the right, down to the baseline}
+
+The dot under the romanization — \textbf{ṇ}, not plain \emph{n} — is doing real work.
+
+\begin{sounds}
+Say English \textbf{n}. Your tongue touches just behind your teeth.
+
+Now curl the tip of your tongue \textbf{up and back} toward the roof of your mouth, and say it again. That is \textbf{ṇ}, and it is a different letter in Tamil.
+
+English has no such sound and no way to write one, which is why an English speaker typically \textbf{cannot hear the difference at first}. That is expected. The ear learns it after the hand does, which is one good argument for writing the letters rather than only reading them.
+
+Retroflex sounds are a signature of the languages of India — they show up across Tamil, Telugu, Kannada, Malayalam, Hindi and Sanskrit alike, in families that are otherwise unrelated to each other. It's one of the features that makes South Asia a \emph{linguistic area}: neighbouring languages that borrowed a sound from each other rather than inheriting it.
+\end{sounds}
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Write it:} \ta{ம} — \textquotedblleft{}left upright, bottom, \textbf{right} arch\textquotedblright{}
+  \item \emph{Write it:} \ta{ண} — \textquotedblleft{}top bar, left loop, \textbf{two} arches, straight vertical\textquotedblright{}
+  \item \emph{Say it:} plain \emph{n}, then curl the tongue back — \textbf{ṇ}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Draw \textbf{\ta{ம}} — which side is the upright on? (\textbf{The left}; the arch closes it on the right.) Draw \textbf{\ta{ண}} — what makes it \emph{not} \ta{ன}? (\textbf{One extra arch}: \ta{ண} has \textbf{two} arches where \ta{ன} has one. Both end in the same straight vertical.) What does the dot in \textbf{ṇ} mean? (\textbf{Retroflex} — the tongue curls \textbf{back} to the roof of the mouth.) Why can't you hear it yet? (\textbf{English has no such sound}; the ear learns it after the hand.) Next: stacking that dative suffix where Latin would fuse several meanings.
 \end{tcolorbox}
 \section[peyar + ukku]{-\ta{உக்கு} — one carriage in a suffix train}
 
@@ -199,4 +240,44 @@ The comparison also makes cross-language practice useful: once you recognize \te
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Do the four sisters agree on dative experiencers? (\textbf{Yes}.) Which four suffix shapes reveal the relationship? (\emph{\textbf{-ukku, -ku, -ge, -ikku}}.) What stays plain in the sentence? (The thing \textbf{known or experienced}.)
+\end{tcolorbox}
+\section[na, ṉa, ṇa]{\ta{ந}, \ta{ன}, \ta{ண} — three stops on one tongue-map}
+
+\label{lesson:TA-W02-three-ns}
+
+
+
+\begin{quote}
+English writes one \emph{n}. Tamil keeps three tongue positions apart.
+\end{quote}
+
+\subsection*{Script you'll notice: The backward walk}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{letter} & \textbf{sound} & \textbf{tongue} \\
+\midrule
+\textbf{\ta{ந}} & \emph{na} & against the \textbf{teeth} (dental) \\
+\textbf{\ta{ன}} & \emph{ṉa} & on the \textbf{ridge} behind the teeth (alveolar) \\
+\textbf{\ta{ண}} & \emph{ṇa} & \textbf{curled back} to the roof (retroflex) \\
+\bottomrule
+\end{tabularx}
+
+Move backward: teeth $\to$ ridge $\to$ curled roof. English spells all three with one letter and initially hears them as the same sound; Tamil uses separate letters because its words depend on the contrast.
+
+You will draw \ta{ந} and \ta{ன} when \emph{nandri} needs them. For now compare the last pair: \textbf{\ta{ண} is \ta{ன} with one extra arch}. Both open with a top bar and loop and finish with the same vertical. \ta{ன} has one middle arch; \ta{ண} has two.
+
+Retroflex sounds occur across unrelated South Asian language families. That shared geography makes the region a \textbf{linguistic area}: neighbors can borrow a sound pattern without inheriting it from one ancestor.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Say it:} dental \ta{ந} at the teeth
+  \item \emph{Say it:} alveolar \ta{ன} at the ridge
+  \item \emph{Say it:} retroflex \ta{ண} with the tongue curled back
+  \item \emph{Trace it:} one arch in \ta{ன} · two arches in \ta{ண}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+How many n-letters does Tamil have? (\textbf{Three}.) What separates them? (Tongue position: \textbf{dental, alveolar, retroflex}.) Which two differ by one arch? (\textbf{\ta{ன}} has one; \textbf{\ta{ண}} has two.) Next: the numbers one to five.
 \end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch07-numbers-1-10.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch07-numbers-1-10.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:eccac2217fcc1cce
-% canonical-lessons: TA-C07-numbers-1-5, TA-C07-numbers-1-5-family, TA-C07-numbers-6-10, TA-C07-numbers-6-10-family
+% canonical-source-hash: fnv1a64:05cb6ac8a2d2d6a1
+% canonical-lessons: TA-C07-numbers-1-5, TA-C07-numbers-1-5-family, TA-C07-numbers-6-10, TA-W03-pulli-vanakkam, TA-C07-numbers-6-10-family
 
 \chapter{Numbers One to Ten}
 \label{ch:ta-numbers-one-to-ten}
@@ -145,7 +145,61 @@ Say these aloud:
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Count six to ten in Tamil. (\emph{Āṟu, ēḻu, eṭṭu, oṉpatu, pattu}.) Which number is written with \textbf{\ta{ழ}}, and where else does that letter appear? (\textbf{Seven}, \emph{ēḻu} — the same letter that ends \emph{Tamiḻ}.) How is \textbf{nine} built? (\emph{Oṉ} \textquotedblleft{}one\textquotedblright{} + \emph{patu} \textquotedblleft{}ten\textquotedblright{} $\to$ \emph{oṉpatu}, one short of ten.) Next: follow these forms across the family and hear Kannada \emph{p} soften to \emph{h}.
+Count six to ten in Tamil. (\emph{Āṟu, ēḻu, eṭṭu, oṉpatu, pattu}.) Which number is written with \textbf{\ta{ழ}}, and where else does that letter appear? (\textbf{Seven}, \emph{ēḻu} — the same letter that ends \emph{Tamiḻ}.) How is \textbf{nine} built? (\emph{Oṉ} \textquotedblleft{}one\textquotedblright{} + \emph{patu} \textquotedblleft{}ten\textquotedblright{} $\to$ \emph{oṉpatu}, one short of ten.) Next: the puḷḷi — the dot that takes a consonant's built-in vowel away.
+\end{tcolorbox}
+\section[puḷḷi]{\ta{்} — the dot that leaves both letters visible}
+
+\label{lesson:TA-W03-pulli-vanakkam}
+
+
+
+\begin{quote}
+Every consonant carries a built-in \textbf{a}. So how do you write a consonant with \textbf{no} vowel — the \emph{k} in \emph{vaṇakkam}, or the \emph{m} at the end?
+
+One dot.
+\end{quote}
+
+\subsection*{Script you'll notice: The puḷḷi}
+\begin{quote}
+\textbf{\ta{க}} = \emph{ka}  $\to$  \textbf{\ta{க்}} = \emph{k}
+\end{quote}
+
+\textbf{\ta{புள்ளி}} (\emph{puḷḷi}) means simply \textbf{\textquotedblleft{}the dot.\textquotedblright{}} Written above a letter, it removes the inherent vowel. That's the whole rule.
+
+\textbf{A standing note for this whole track.} These lessons quote real Tamil words and examples, and most of them contain letters the track has not taught you to draw yet — \emph{puḷḷi}'s own name uses \textbf{\ta{ப}}, \textbf{\ta{ள}} and the \textbf{\ta{ு}} sign, and the comparisons below reach for others again. \textbf{Read anything printed here; only draw the letters a lesson has actually broken into strokes.} The data file behind this track covers 11 letters so far and says so (\texttt{complete: false}) — it grows as the chapters need it.
+
+\subsection*{Script you'll notice: What Tamil does \emph{not} do}
+If you have done the Devanagari track, this is the moment to notice a real divergence.
+
+In Devanagari, killing the vowel makes the bare consonant \textbf{fuse} with the next one into a squeezed \textbf{conjunct} — \dv{स्} + \dv{त} becomes \dv{स्त}, and the first letter loses its spine. The virama usually disappears into the ligature.
+
+\textbf{Tamil doesn't do that.} The dot stays visible, and both letters keep their full shape:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+Devanagari & \dv{स्} + \dv{त} $\to$ \textbf{\dv{स्त}} — a new fused shape \\
+\textbf{Tamil} & \ta{க்} + \ta{க} $\to$ \textbf{\ta{க்க}} — two letters, dot intact \\
+\bottomrule
+\end{tabularx}
+
+The consequence is arithmetic. Tamil's whole set is \textbf{247 characters}: 12 vowels + 18 consonants + the 216 consonant-vowel combinations + the \textbf{āytam \ta{ஃ}}. That is genuinely all of them. Devanagari's conjuncts run to many hundreds of ligature shapes on top of its letters, each to be learned or at least recognised.
+
+(One honest exception: Tamil does have a few \textbf{ligatures borrowed with Sanskrit words} — \textbf{\ta{க்ஷ}} \emph{kṣa} and \textbf{\ta{ஸ்ரீ}} \emph{śrī}. They sit outside the 18 native consonants and outside the 247.)
+
+\subsection*{Your turn}
+Write these out:
+
+\begin{itemize}
+\raggedright
+  \item \ta{க்} — \textquotedblleft{}\ta{க}, then the dot above\textquotedblright{}
+  \item \ta{க்க} — two full letters, dot intact, \textbf{no fusing}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What does the \textbf{puḷḷi} do, and what does the word mean? (Removes the \textbf{inherent vowel}; \emph{puḷḷi} is simply \textquotedblleft{}\textbf{the dot}\textquotedblright{}.) What does Devanagari do that Tamil doesn't? (\textbf{Fuses} the letters into a \textbf{conjunct} — Tamil keeps both shapes and the dot.) What does Tamil get in exchange? (A \textbf{much smaller character set} — 247, with \textbf{almost} no ligatures: only the borrowed \ta{க்ஷ} and \ta{ஸ்ரீ}.) Next: six, seven and ten across the family.
 \end{tcolorbox}
 \section[\ta{ஆறு} \ta{ஏழு} \ta{பத்து}]{Six to ten — family resemblances and one Kannada shift}
 

--- a/code/learning/human-languages/tamil/book/chapters/ch08-please.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch08-please.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:ff8de4c167bb1241
-% canonical-lessons: TA-C08-tayavuseytu, TA-C08-please-register
+% canonical-source-hash: fnv1a64:c562ead22324f223
+% canonical-lessons: TA-C08-tayavuseytu, TA-C08-please-register, TA-W03-write-vanakkam
 
 \chapter{Please}
 \label{ch:ta-please}
@@ -95,4 +95,48 @@ Use \emph{tayavu seytu} to mark \textquotedblleft{}please, do me the kindness\te
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 What carries everyday \textquotedblleft{}please\textquotedblright{}? (The respectful verb ending \emph{\textbf{-uṅgaḷ}}.) When is \emph{tayavu seytu} especially useful? (A \textbf{markedly polite or emphatic} request.) What silences \emph{y} in \textbf{\ta{ய்}}? (The \textbf{puḷḷi}.)
+\end{tcolorbox}
+\section[vaṇakkam]{\ta{வணக்கம்} — the first whole written word}
+
+\label{lesson:TA-W03-write-vanakkam}
+
+
+
+\begin{quote}
+You know the four letter bodies and the vowel-killing dot. Assemble them left to right.
+\end{quote}
+
+\subsection*{Script you'll notice: Build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{வ}} & \emph{va} & Lesson 1 \\
+\textbf{\ta{ண}} & \emph{ṇa} & Lesson 2 \\
+\textbf{\ta{க்}} & \emph{k} — \ta{க} with the dot & last lesson \\
+\textbf{\ta{க}} & \emph{ka} & Lesson 1 \\
+\textbf{\ta{ம்}} & \emph{m} — \ta{ம} with the dot & this lesson \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{வ} · \ta{ண} · \ta{க்} · \ta{க} · \ta{ம்} $\to$ \ta{வணக்கம்}}
+\end{quote}
+
+Hear two details. \textbf{\ta{க்க}} is a \textbf{doubled} consonant: hold it, \emph{vaṇak-kam}, not \emph{vaṇakam}. Tamil distinguishes single from double consonants. Final \textbf{\ta{ம்}} is a bare \emph{m}, so the word closes instead of trailing into \emph{ma}.
+
+That is the first word of this book, written by hand.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Write it:} \ta{க்} — \ta{க} with the dot
+  \item \emph{Write it:} \ta{க்க} — two full letters, dot intact
+  \item \emph{Write it:} \textbf{\ta{வணக்கம்}} — five pieces, left to right
+  \item \emph{Say it:} \textquotedblleft{}vaṇa\textbf{k-k}am\textquotedblright{} — hold the middle
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Write \textbf{\ta{வணக்கம்}}. What is special about \textbf{\ta{க்க}}? (It is \textbf{doubled} and held.) Why does the word end in \emph{m}, not \emph{ma}? (Final \textbf{\ta{ம்}} carries a \textbf{puḷḷi}.) Next: the formal way to say \emph{please forgive me}.
 \end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch09-sorry.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch09-sorry.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:7fa83cac8c8e39bf
+% canonical-source-hash: fnv1a64:85cf044551d1062b
 % canonical-lessons: TA-C09-mannikkavum, TA-C09-sorry-register
 
 \chapter{Sorry}

--- a/code/learning/human-languages/tamil/book/chapters/ch10-days.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch10-days.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:285ec93ffe2143af
-% canonical-lessons: TA-C10-vaara-kizhamai
+% canonical-source-hash: fnv1a64:1623b23a579366eb
+% canonical-lessons: TA-C10-vaara-kizhamai, TA-W04-vowel-signs-nandri
 
 \chapter{Days of the Week}
 \label{ch:ta-days-of-the-week}
@@ -56,4 +56,47 @@ Say these aloud:
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 What does every Tamil weekday end in, and where does that word come from? (\textbf{\ta{கிழமை}} \emph{kizhamai}, \textquotedblleft{}day\textquotedblright{} — Tamil's \textbf{own} word, not Sanskrit \emph{vāra}.) Which four planet-names are Tamil's own, and which three are Sanskrit borrowings? (\textbf{Moon, Mars, Venus, Sun are native}; \textbf{Mercury, Jupiter, Saturn are Sanskrit} — \emph{Budha, Bṛhaspati, Śani}.)
+\end{tcolorbox}
+\section[na, ṉa, ṟa]{\ta{ந}, \ta{ன}, \ta{ற} — the letter bodies inside \ta{நன்றி}}
+
+\label{lesson:TA-W04-vowel-signs-nandri}
+
+
+
+\begin{quote}
+Lesson 2 showed you that Tamil has \textbf{three} n-letters and promised you'd draw the other two when a word needed them. Chapter 1's \emph{thank you} needs both.
+\end{quote}
+
+\subsection*{Script you'll notice: The two remaining n's}
+\textbf{\ta{ந}} — \emph{na}, the \textbf{dental} n, tongue against the teeth:
+
+1. \textbf{a straight top bar} 2. \textbf{a vertical on the left} 3. \textbf{a second vertical in the middle} 4. \textbf{a right stroke that curls below the baseline} and sweeps left into a descender
+
+\textbf{\ta{ன}} — \emph{ṉa}, the \textbf{alveolar} n, tongue on the ridge behind the teeth:
+
+1. \textbf{a straight top bar} 2. \textbf{a loop on the left} 3. \textbf{one arch} 4. \textbf{a straight vertical on the right, down to the baseline}
+
+Compare it with Lesson 2's \textbf{\ta{ண}}: same top bar, same loop, same closing vertical. \textbf{\ta{ண} simply has a second arch inserted before that vertical.} So \textbf{\ta{ன} is \ta{ண} minus one arch} — one arch for \ta{ன}, two for \ta{ண}. That is the whole contrast, and it is the cheapest way to keep them apart.
+
+With Lesson 2's \textbf{\ta{ண}} (retroflex), that completes the set. Same consonant to an English ear; three letters, three tongue positions, in Tamil.
+
+\subsection*{Script you'll notice: \ta{ற} — \textquotedblleft{}ṟa\textquotedblright{}, the hard r}
+1. \textbf{two arches side by side} — giving it three legs down to the baseline 2. \textbf{the right leg keeps going below the baseline}, sweeps \textbf{left}, and drops into a long descender
+
+It is the tallest thing you have drawn: most Tamil letters sit on the baseline, and \ta{ற} hangs well beneath it.
+
+The dot under \textbf{ṟ} marks it as the \emph{hard} or trilled r, distinct from Tamil's other r. You'll meet the contrast properly later; for now, learn the shape.
+
+\subsection*{Your turn}
+Write these out:
+
+\begin{itemize}
+\raggedright
+  \item \ta{ந} — \textquotedblleft{}top bar, \textbf{two} verticals, then the curl that sweeps left\textquotedblright{}
+  \item \ta{ன} — \textquotedblleft{}top bar, left loop, \textbf{one} arch, straight vertical\textquotedblright{}
+  \item \ta{ற} — \textquotedblleft{}two arches, then the leg that sweeps left and drops\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Name Tamil's three n-letters and their tongue positions. (\textbf{\ta{ந}} dental, \textbf{\ta{ன}} alveolar, \textbf{\ta{ண}} retroflex.) What are a consonant's three possibilities so far? (Keep the built-in \textbf{a} or \textbf{remove} it with the puḷḷi.) Which letter hangs below the baseline? (\textbf{\ta{ற}}, the hard \emph{ṟ}.) Next: the colours — black, white, red and blue.
 \end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch11-colours.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch11-colours.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:816c584dec2fa772
+% canonical-source-hash: fnv1a64:05e39dd3fc34184b
 % canonical-lessons: TA-C11-nirangal
 
 \chapter{Colours}

--- a/code/learning/human-languages/tamil/book/chapters/ch12-family.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch12-family.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:30be3d82f65307ff
+% canonical-source-hash: fnv1a64:af93b4956465c997
 % canonical-lessons: TA-C12-kudumbam
 
 \chapter{Family}

--- a/code/learning/human-languages/tamil/book/chapters/ch13-body-parts.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch13-body-parts.tex
@@ -1,12 +1,12 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:7e71618cae516fbc
-% canonical-lessons: TA-C13-udal-uruppugal
+% canonical-source-hash: fnv1a64:40a7007a7a869a42
+% canonical-lessons: TA-C13-udal-uruppugal, TA-W04-i-sign-write-nandri
 
 \chapter{Body Parts}
 \label{ch:ta-body-parts}
 
 \begin{chapteropening}
-\textbf{By the end of this chapter:} \emph{I can say head and hand in Tamil and account for why both stayed native here where Hindi's pair came from Sanskrit.}
+\textbf{By the end of this chapter:} \emph{I can say head and hand in Tamil, account for why both stayed native here where Hindi's pair came from Sanskrit, and write \ta{நன்றி} from its pieces.}
 
 Say talai and kai, then state the contrast with Hindi's Sanskrit-descended pair.
 \end{chapteropening}
@@ -42,4 +42,65 @@ Say these aloud:
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 What are Tamil's words for head and hand? (\textbf{\ta{தலை}} \emph{talai}, \textbf{\ta{கை}} \emph{kai}.) Are either of these Sanskrit loans? (\textbf{No} — both native Dravidian, unlike Hindi's Sanskrit-descended \emph{sir} and \emph{hāth}.)
+\end{tcolorbox}
+\section[i, naṉṟi / nandri]{\ta{ி} and \ta{நன்றி} — replace the vowel, then hear \emph{ndr}}
+
+\label{lesson:TA-W04-i-sign-write-nandri}
+
+
+
+\begin{quote}
+A consonant can keep \emph{a} or lose it under a puḷḷi. The third option is to replace it with a vowel sign.
+\end{quote}
+
+\subsection*{Script you'll notice: The first vowel sign}
+\begin{quote}
+\textbf{\ta{ற}} = \emph{ṟa} $\to$ \textbf{\ta{றி}} = \emph{ṟi}
+\end{quote}
+
+\textbf{\ta{ி}} is a hook above and to the right. The consonant keeps its shape; the sign hangs from it. Later, \textbf{\ta{ை}} (\emph{ai}) will appear before its consonant on the page but after it in speech, the same eye/ear trap as Devanagari \dv{ि}.
+
+\subsection*{Script you'll notice: Assemble \ta{நன்றி}}
+\begin{quote}
+\textbf{\ta{ந} · \ta{ன்} · \ta{றி} $\to$ \ta{நன்றி}}
+\end{quote}
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{ந}} & \emph{na} — dental & last lesson \\
+\textbf{\ta{ன்}} & \emph{ṉ} — alveolar, with puḷḷi & Lessons 3–4 \\
+\textbf{\ta{றி}} & \emph{ṟi} — \ta{ற} plus the i-sign & this lesson \\
+\bottomrule
+\end{tabularx}
+
+\begin{sounds}
+\textbf{\ta{ன்} + \ta{ற}} is pronounced close to \textbf{ndr}. This follows a broader Tamil rule: a \textbf{nasal voices the stop after it}.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} & \textbf{} \\
+\midrule
+\ta{ந்} + \ta{த} & \emph{nd} & \textbf{\ta{வந்து}} \emph{vandu} \\
+\ta{ண்} + \ta{ட} & \emph{ṇḍ} & retroflex pair \\
+\ta{ன்} + \ta{ற} & \emph{ndr} & \textbf{\ta{நன்றி}} \\
+\bottomrule
+\end{tabularx}
+
+Each n-letter creates its own cluster. That payoff explains both the three spellings and the common English romanization \textbf{nandri}, whose \emph{d} is heard but not separately written.
+\end{sounds}
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Write it:} \ta{றி} — \ta{ற} plus the hook above right
+  \item \emph{Write it:} \textbf{\ta{நன்றி}} — three pieces
+  \item \emph{Say it:} \textquotedblleft{}\ta{ன்} + \ta{ற} = \textbf{ndr}\textquotedblright{}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+What are a consonant's three vowel choices? (Keep inherent \textbf{a}, \textbf{remove} it with puḷḷi, or \textbf{replace} it with a vowel sign.) Where does \textbf{\ta{ி}} attach? (\textbf{Above and right}.) Why is \emph{naṉṟi} often written \emph{nandri}? (\textbf{\ta{ன்} + \ta{ற}} is pronounced \emph{ndr} because a nasal voices the following stop.)
 \end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch14-seasons.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch14-seasons.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:872e2a100049b519
+% canonical-source-hash: fnv1a64:9279d58ba913f0fa
 % canonical-lessons: TA-C14-kaalangal
 
 \chapter{Seasons}

--- a/code/learning/human-languages/tamil/book/chapters/ch15-water-and-rice.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch15-water-and-rice.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:6eb8ad3ee9295566
+% canonical-source-hash: fnv1a64:2cc2b6dc5c14ee0d
 % canonical-lessons: TA-C15-thanneer-arisi
 
 \chapter{Water and Rice}

--- a/code/learning/human-languages/tamil/book/chapters/ch16-months.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch16-months.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:5f41ac5048e292df
-% canonical-lessons: TA-C16-thamizh-maadangal
+% canonical-source-hash: fnv1a64:65fedf852d45ae79
+% canonical-lessons: TA-C16-thamizh-maadangal, TA-W05-write-aam
 
 \chapter{Tamil Months}
 \label{ch:ta-tamil-months}
@@ -42,4 +42,68 @@ Say these aloud:
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 What kind of calendar is the Tamil month system — solar, lunar, or lunisolar? (\textbf{Solar} — a genuinely separate calendar from both Gregorian and Hindu lunisolar.) What are the twelve months traditionally named for? (\textbf{Nakshatras}, lunar-mansion star groups.) What two important occasions are dated by this calendar? (\textbf{Tamil New Year} (Chithirai 1) and \textbf{Pongal} (Thai 1).)
+\end{tcolorbox}
+\section[ām]{\ta{ஆம்} — writing a word that starts with a vowel}
+
+\label{lesson:TA-W05-write-aam}
+
+
+
+\begin{quote}
+Every vowel \emph{sign} so far has hooked onto a consonant — the \ta{ி} on \textbf{\ta{ற}}. This word has no consonant to hook onto.
+\end{quote}
+
+\subsection*{Script you'll notice: a vowel standing alone}
+Tamil writes a vowel two ways, and which one you use depends on \textbf{where it sits}:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+\textbf{inside} a word, after a consonant & a small \textbf{sign} — \ta{ி} in \textbf{\ta{றி}} \\
+\textbf{starting} a word, with nothing before it & a full \textbf{independent letter} \\
+\bottomrule
+\end{tabularx}
+
+\textbf{\ta{ஆ}} is the independent letter for long \emph{ā}. It is not a sign and never hangs off anything; it is a letter in its own right.
+
+Long \emph{ā} is short \textbf{\ta{அ}} plus a tail, so \textbf{\ta{அ}} is where it starts — and you have not been shown that one yet. Its parts, then the tail:
+
+1. \textbf{a curl at the upper left} 2. \textbf{a long horizontal stroke} 3. \textbf{a straight vertical on the right} — that is \textbf{\ta{அ}} 4. \textbf{a tail added on the right} — and now it is \textbf{\ta{ஆ}}
+
+Those are the parts in writing order. Where the pen lifts is not settled: Tamil handwriting varies by region and by school, and this book only claims a pen path where it has a sourced one.
+
+That is a rule, not a special case: any Tamil word that opens on a vowel opens with a full vowel letter.
+
+\subsection*{Script you'll notice: build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{ஆ}} & \emph{ā} & this lesson — independent \\
+\textbf{\ta{ம்}} & \emph{m} — \ta{ம} with the puḷḷi & the dot you already know \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{ஆ} · \ta{ம்} $\to$ \ta{ஆம்}}
+\end{quote}
+
+Two pieces only. The puḷḷi on \textbf{\ta{ம்}} closes the word on a bare \emph{m}, exactly as it did at the end of \textbf{\ta{வணக்கம்}}.
+
+\subsection*{Your turn}
+Write these out:
+
+\begin{itemize}
+\raggedright
+  \item \textbf{\ta{அ}} — curl, horizontal, right vertical
+  \item \textbf{\ta{ஆ}} — the same three parts, then the right-hand tail
+  \item \textbf{\ta{ம்}} — \ta{ம} with the dot
+  \item \textbf{\ta{ஆம்}} — two pieces, left to right
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Write \textbf{\ta{ஆம்}}. When does a Tamil vowel get a full letter instead of a sign? (\textbf{When it starts a word} — nothing precedes it to hook onto.) What closes the word? (\textbf{\ta{ம்}} — the puḷḷi on \ta{ம}.) Next: noon and midnight.
 \end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch17-noon-and-midnight.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch17-noon-and-midnight.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:e57f7bea45ffc8ab
+% canonical-source-hash: fnv1a64:90be6cdf7f59a425
 % canonical-lessons: TA-C17-nanpakal-nalliravu, TA-C17-transparent-middle-synonyms
 
 \chapter{Noon and Midnight}

--- a/code/learning/human-languages/tamil/book/chapters/ch18-telling-time.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch18-telling-time.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:c9ee2c591af90a48
-% canonical-lessons: TA-C18-mani, TA-C18-mani-homophone-time
+% canonical-source-hash: fnv1a64:46d568fe65afb671
+% canonical-lessons: TA-C18-mani, TA-W06-write-illai, TA-C18-mani-homophone-time
 
 \chapter{Telling Time}
 \label{ch:ta-telling-time}
@@ -32,7 +32,71 @@ You've just watched Kannada and Telugu both borrow Sanskrit's \textquotedblleft{
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-Is Tamil's \textbf{\ta{மணி}} (\textquotedblleft{}hour\textquotedblright{}) from the same Sanskrit root as Kannada/Telugu/Hindi's hour-words? (\textbf{Most likely no} — it's treated as a native Dravidian \textquotedblleft{}bell\textquotedblright{} word that independently reached \textquotedblleft{}hour\textquotedblright{} the same way, though even DEDR flags this as not fully settled.) What semantic path links the meanings? (A \textbf{bell announces the hour}.) Next: distinguish the likely Sanskrit gem homophone and tell the time.
+Is Tamil's \textbf{\ta{மணி}} (\textquotedblleft{}hour\textquotedblright{}) from the same Sanskrit root as Kannada/Telugu/Hindi's hour-words? (\textbf{Most likely no} — it's treated as a native Dravidian \textquotedblleft{}bell\textquotedblright{} word that independently reached \textquotedblleft{}hour\textquotedblright{} the same way, though even DEDR flags this as not fully settled.) What semantic path links the meanings? (A \textbf{bell announces the hour}.) Next: writing \ta{இல்லை} — a second independent vowel, \ta{ல}, and the ai sign.
+\end{tcolorbox}
+\section[illai]{\ta{இல்லை} — a vowel in front, a vowel sign behind}
+
+\label{lesson:TA-W06-write-illai}
+
+
+
+\begin{quote}
+Last lesson gave you the rule: a word opening on a vowel opens with a full letter. Here is the same rule with a different vowel, plus one new sign.
+\end{quote}
+
+\subsection*{Script you'll notice: \ta{இ} and \ta{ல}}
+\textbf{\ta{இ}} is the independent letter for short \emph{i} — the same job \textbf{\ta{ஆ}} did, one vowel over. Its parts, in writing order:
+
+1. \textbf{a crossing spiral on the left} 2. \textbf{a tall straight vertical on the right}
+
+\textbf{\ta{ல}} is \emph{la}, with its built-in \emph{a} like every consonant:
+
+1. \textbf{a curl that turns back on itself} 2. \textbf{a stroke rising to the right}
+
+Put the puḷḷi on it and you get \textbf{\ta{ல்}}, a bare \emph{l}.
+
+The new mark is \textbf{\ta{ை}}, the sign for \emph{ai}, and it does something \ta{ி} did not. \textbf{It is written to the LEFT of its consonant, but pronounced after it.}
+
+\begin{quote}
+\textbf{\ta{ல} + \ta{ை} $\to$ \ta{லை}}, and on the page the hook stands \emph{before} the \ta{ல} — yet you say \emph{lai}, not \emph{ail}.
+\end{quote}
+
+Your eye meets the vowel first and your mouth says it second. Devanagari does the same thing with \dv{ि}, and it catches everyone once.
+
+\begin{quote}
+Tamil keeps \textbf{three} \emph{l}-letters (\ta{ல} \ta{ள} \ta{ழ}) and \textbf{two} \emph{r}-letters (\ta{ர} \ta{ற}), the same way it keeps three \emph{n}'s. This is the first of the \emph{l}'s.
+\end{quote}
+
+\subsection*{Script you'll notice: build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{இ}} & \emph{i} & independent — the word opens on a vowel \\
+\textbf{\ta{ல்}} & \emph{l} — \ta{ல} with the puḷḷi & bare consonant \\
+\textbf{\ta{லை}} & \emph{lai} — \ta{ல} with the ai sign & this lesson \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{இ} · \ta{ல்} · \ta{லை} $\to$ \ta{இல்லை}}
+\end{quote}
+
+The \textbf{\ta{ல்} + \ta{லை}} is a doubled \emph{l}, held like the \textbf{\ta{க்க}} of \emph{vaṇakkam}: \emph{il-lai}, not \emph{ilai}.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Write it:} \textbf{\ta{இ}} — spiral, then the right-hand vertical
+  \item \emph{Write it:} \textbf{\ta{ல}} — curl, then rising stroke
+  \item \emph{Write it:} \textbf{\ta{லை}} — the ai hook goes on the LEFT
+  \item \emph{Write it:} \textbf{\ta{இல்லை}} — three pieces
+  \item \emph{Say it:} \textquotedblleft{}il-lai\textquotedblright{} — hold the doubled \emph{l}
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Write \textbf{\ta{இல்லை}}. Why does it open with \textbf{\ta{இ}} rather than a sign? (\textbf{The word starts on a vowel}.) Which side of its consonant does \textbf{\ta{ை}} sit on? (\textbf{The left} — written first, spoken second.) Next: the gem-word homophone, and telling clock time.
 \end{tcolorbox}
 \section[\ta{மணி} / \ta{மணி}]{\ta{மணி} — hour or jewel? Context decides}
 

--- a/code/learning/human-languages/tamil/book/chapters/ch19-age.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch19-age.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:158e1e4de8950e2a
-% canonical-lessons: TA-C19-vayathu, TA-C19-age-register-grammar
+% canonical-source-hash: fnv1a64:d7293b885b36096e
+% canonical-lessons: TA-C19-vayathu, TA-C19-age-register-grammar, TA-W07-write-sari
 
 \chapter{Asking Someone's Age}
 \label{ch:ta-asking-age}
@@ -78,4 +78,65 @@ Do not compress these into \textquotedblleft{}Tamil's one grammar.\textquotedblr
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Which shape is casual? (\textbf{Possessive}: \textquotedblleft{}your age what?\textquotedblright{}) Which is formal? (\textbf{Dative + aakirathu}, \textquotedblleft{}become.\textquotedblright{}) Does Malayalam use the same verb? (\textbf{No} — it uses \textquotedblleft{}exists.\textquotedblright{})
+\end{tcolorbox}
+\section[sari]{\ta{சரி} — one letter, several sounds}
+
+\label{lesson:TA-W07-write-sari}
+
+
+
+\begin{quote}
+You have seen \textbf{\ta{க}} cover \emph{k}, \emph{g} and a soft \emph{h} depending on where it sits. Here is the same economy on a second letter.
+\end{quote}
+
+\subsection*{Script you'll notice: \ta{ச} and \ta{ர}}
+\textbf{\ta{ச}} is written once and does the work English splits between \textbf{s}, \textbf{ch} and \textbf{j}. Position picks which:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{where} & \textbf{sound} \\
+\midrule
+starting a word & \emph{s} or \emph{ch} \\
+between vowels & softened \\
+after a nasal, as in \textbf{\ta{ஞ்ச}} & \emph{j} \\
+\bottomrule
+\end{tabularx}
+
+That is exactly the pattern \textbf{\ta{க}} showed — \emph{k} at the start, \emph{g} after a nasal, a soft \emph{h} between vowels. One letter per position of the mouth, and context fills in the rest.
+
+\textbf{\ta{ர}} is \emph{ra}, with its built-in \emph{a}. It is the other of Tamil's \textbf{two} \emph{r}-letters, alongside the \textbf{\ta{ற}} you met in \textbf{\ta{நன்றி}}.
+
+\begin{quote}
+Read both letters here; do not draw them yet. This book gives a stroke order only where it has a sourced one, and \ta{ச} and \ta{ர} do not have one yet.
+\end{quote}
+
+\subsection*{Script you'll notice: build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{ச}} & \emph{sa} here & this lesson \\
+\textbf{\ta{ரி}} & \emph{ri} — \ta{ர} with the \ta{ி} sign & the sign from \textbf{\ta{நன்றி}} \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{ச} · \ta{ரி} $\to$ \ta{சரி}}
+\end{quote}
+
+Two pieces, and both parts are things you already hold: a consonant, and the vowel sign you first hooked onto \textbf{\ta{ற}}.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \textbf{\ta{ச}} — then \textbf{\ta{சரி}}
+  \item \emph{Say it:} \textquotedblleft{}sari\textquotedblright{}
+  \item \emph{Contrast:} \textbf{\ta{ரி}} and \textbf{\ta{லை}} — the \ta{ி} sign follows its letter, the \ta{ை} sign precedes it
+  \item \emph{Write it:} \textbf{\ta{ஆம்}} and \textbf{\ta{இல்லை}} again, from memory — yes and no, the two you will reach for most
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read \textbf{\ta{சரி}}. Which English sounds does \textbf{\ta{ச}} cover on its own? (\emph{\textbf{s}} or \emph{\textbf{ch}} at the start, softened between vowels, \emph{\textbf{j}} after a nasal.) How many \emph{r}-letters does Tamil keep? (\textbf{Two} — \ta{ர} and \ta{ற}.) In \textbf{\ta{லை}}, which side of the \ta{ல} does the ai sign sit on? (\textbf{The left}.) And why does \textbf{\ta{இல்லை}} open with \textbf{\ta{இ}} rather than a sign? (\textbf{It starts on a vowel}.) Next: the numbers eleven to twenty.
 \end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch20-numbers-and-weather.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch20-numbers-and-weather.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:17a98f1177a6f798
+% canonical-source-hash: fnv1a64:ea74641a7aeaa215
 % canonical-lessons: TA-C20-pathinondru-irupathu, TA-C20-vaanilai
 
 \chapter{Numbers Eleven to Twenty and Weather}

--- a/code/learning/human-languages/tamil/book/chapters/ch21-dog-and-cat.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch21-dog-and-cat.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:311e0fc1921788a6
+% canonical-source-hash: fnv1a64:4e1e9c8c1a0e2f1d
 % canonical-lessons: TA-C21-naay-poonai
 
 \chapter{Dog and Cat}

--- a/code/learning/human-languages/tamil/book/chapters/ch22-green-and-yellow.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch22-green-and-yellow.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:dcbc62f4f6ad78a7
+% canonical-source-hash: fnv1a64:ae71142a83f6bbb1
 % canonical-lessons: TA-C22-paccai-manjal
 
 \chapter{Green and Yellow}

--- a/code/learning/human-languages/tamil/book/chapters/ch23-day.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch23-day.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:df614acc750a66b3
+% canonical-source-hash: fnv1a64:a2ce180ed0981b94
 % canonical-lessons: TA-C23-naal, TA-C23-day-family-register
 
 \chapter{Day}

--- a/code/learning/human-languages/tamil/book/chapters/ch24-night.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch24-night.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:d6206fbb0b4a40bb
+% canonical-source-hash: fnv1a64:a49f29933aebc915
 % canonical-lessons: TA-C24-iravu, TA-C24-night-register-darkness
 
 \chapter{Night}

--- a/code/learning/human-languages/tamil/book/chapters/ch25-good-night.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch25-good-night.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:9c4269766dbc36bd
+% canonical-source-hash: fnv1a64:f2aab1ca9b0d3ff1
 % canonical-lessons: TA-C25-iniya-iravu, TA-C25-goodnight-alternatives
 
 \chapter{Good Night}

--- a/code/learning/human-languages/tamil/book/chapters/ch26-morning.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch26-morning.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:8a01a19aed95768e
+% canonical-source-hash: fnv1a64:21264f934ed1f572
 % canonical-lessons: TA-C26-kaalai
 
 \chapter{Morning}

--- a/code/learning/human-languages/tamil/book/chapters/ch27-evening.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch27-evening.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:f05a977714a428f1
+% canonical-source-hash: fnv1a64:aa7e34235182f0bf
 % canonical-lessons: TA-C27-maalai
 
 \chapter{Evening}

--- a/code/learning/human-languages/tamil/book/chapters/ch28-afternoon.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch28-afternoon.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:3f1781336d4dbbb5
+% canonical-source-hash: fnv1a64:ec92e87b3b4283ca
 % canonical-lessons: TA-C28-pirpakal, TA-C28-afternoon-boundary
 
 \chapter{Afternoon}

--- a/code/learning/human-languages/tamil/book/chapters/ch29-good-morning.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch29-good-morning.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:20cadfca8eec724a
+% canonical-source-hash: fnv1a64:3462cdc973cb1a18
 % canonical-lessons: TA-C29-kaalai-vanakkam
 
 \chapter{Good Morning}

--- a/code/learning/human-languages/tamil/book/chapters/ch30-good-evening.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch30-good-evening.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:0f9658a0088c0b7d
+% canonical-source-hash: fnv1a64:859a3c0278df7426
 % canonical-lessons: TA-C30-maalai-vanakkam
 
 \chapter{Good Evening}

--- a/code/learning/human-languages/tamil/book/chapters/ch31-good-afternoon.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch31-good-afternoon.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:10ad0e46ce192b01
+% canonical-source-hash: fnv1a64:3f7bcb598113beed
 % canonical-lessons: TA-C31-matiya-vanakkam, TA-C31-afternoon-greeting-root
 
 \chapter{Good Afternoon}

--- a/code/learning/human-languages/tamil/book/chapters/ch32-core-verbs.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch32-core-verbs.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:910c91b3fe4d342c
+% canonical-source-hash: fnv1a64:babedd13feadc02b
 % canonical-lessons: TA-C32-iru, TA-C32-po, TA-C32-vaa, TA-C32-saappidu, TA-C32-paar, TA-C32-teri
 
 \chapter{The Core Verbs}

--- a/code/learning/human-languages/tamil/book/chapters/ch33-verbs-of-the-mind.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch33-verbs-of-the-mind.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:9e974c94abcf0cec
+% canonical-source-hash: fnv1a64:508c27ca16a3cf45
 % canonical-lessons: TA-C33-ninai, TA-C33-puri, TA-C33-padi, TA-C33-ezhutu
 
 \chapter{Four Verbs of the Mind}

--- a/code/learning/human-languages/tamil/book/chapters/ch34-verbs-between-people.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch34-verbs-between-people.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:a7767e667ee93f24
+% canonical-source-hash: fnv1a64:9156ad6e37c5a81d
 % canonical-lessons: TA-C34-edu, TA-C34-kel, TA-C34-utavu, TA-C34-pidi
 
 \chapter{Four Verbs Between People}

--- a/code/learning/human-languages/tamil/book/chapters/ch35-arriving-at-a-house.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch35-arriving-at-a-house.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:dc38c4fb1b2e3bc9
+% canonical-source-hash: fnv1a64:2236d8055ff46015
 % canonical-lessons: TA-C35-veedu, TA-C35-kadavu, TA-C35-arai, TA-C35-naarkaali
 
 \chapter{Arriving at a House}

--- a/code/learning/human-languages/tamil/book/chapters/ch36-what-you-are-offered.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch36-what-you-are-offered.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:231ca7f273eff40e
+% canonical-source-hash: fnv1a64:723f22137faa2040
 % canonical-lessons: TA-C36-teneer, TA-C36-paal, TA-C36-unavu, TA-C36-tavaru
 
 \chapter{What You Are Offered}

--- a/code/learning/human-languages/tamil/book/chapters/ch37-your-town-your-friend.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch37-your-town-your-friend.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:2a3905874c0757ce
+% canonical-source-hash: fnv1a64:34cbfdd3aecc18be
 % canonical-lessons: TA-C37-uur, TA-C37-nanban, TA-C37-ivar, TA-C37-ivar-en-nanbar
 
 \chapter{Your Town, Your Friend}

--- a/code/learning/human-languages/tamil/book/chapters/ch38-keeping-well-and-leaving.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch38-keeping-well-and-leaving.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:cdf9a751033520e6
+% canonical-source-hash: fnv1a64:d80f92dc2be328ee
 % canonical-lessons: TA-C38-udambu, TA-C38-sugam, TA-C38-vidai
 
 \chapter{Keeping Well, and Leaving}

--- a/code/learning/human-languages/tamil/chapters.json
+++ b/code/learning/human-languages/tamil/chapters.json
@@ -7,23 +7,18 @@
       "chapter": 1,
       "title": "Greetings",
       "label": "ch:greetings",
-      "canDo": "I can write வணக்கம் and நன்றி by hand, put the puḷḷi and the ி sign in the right places, and tell Tamil's three n-letters apart by name.",
+      "canDo": "I can greet someone, say yes, no and thank you, agree with sari, and hold a short exchange out loud — entirely by ear.",
       "spineNodes": [
         "SPINE-MEET-GREET",
         "SPINE-RESPOND-BASIC",
         "SPINE-COURTESY-THANK"
       ],
       "payoff": {
-        "lesson": "TA-W04-i-sign-write-nandri",
+        "lesson": "TA-C01-answering",
         "kind": "task",
-        "summary": "Write நன்றி from its three pieces — ன் under a puḷḷi, ற with the ி hook — and say why the seam sounds ndr.",
-        "assesses": [
-          "TA-SCRIPT-VOWEL-SIGNS-NANDRI-01",
-          "TA-SCRIPT-PULLI-VANAKKAM-01",
-          "TA-SCRIPT-I-SIGN-WRITE-NANDRI-01",
-          "TA-SCRIPT-I-SIGN-WRITE-NANDRI-02",
-          "TA-SOUND-I-SIGN-WRITE-NANDRI-03"
-        ]
+        "summary": "Hold the whole exchange out loud — greet, answer ஆம் or இல்லை, thank, and close with சரி — using only the ear.",
+        "assesses": [],
+        "note": "Chapter 1 holds no writing lesson and introduces no knowledge atoms at all, because its nine lessons are schema v1 and declare none. `assesses` is therefore empty as a matter of fact, and `payoffsNotClosed` is unaffected by it. Be clear about what that costs: chapters.ts guards the representativeness check with `introduced.size > 0`, so this payoff is not measured rather than passing — the gate that used to report tamil:1 at 5/24 now says nothing about it, and the corpus total holds at 25 only because tamil:13 took its place when TA-W04-i-sign-write-nandri moved there. Modelling spoken atoms is HL-C25 work. The writing strand starts in chapter 4."
       }
     },
     {
@@ -163,7 +158,7 @@
       "chapter": 13,
       "title": "Body Parts",
       "label": "ch:ta-body-parts",
-      "canDo": "I can say head and hand in Tamil and account for why both stayed native here where Hindi's pair came from Sanskrit.",
+      "canDo": "I can say head and hand in Tamil, account for why both stayed native here where Hindi's pair came from Sanskrit, and write நன்றி from its pieces.",
       "spineNodes": [
         "SPINE-CHECK-WELLBEING"
       ],
@@ -171,10 +166,11 @@
         "lesson": "TA-C13-udal-uruppugal",
         "kind": "production",
         "summary": "Say talai and kai, then state the contrast with Hindi's Sanskrit-descended pair.",
-        "assesses": [
-          "TA-ETYMON-KUDUMBAM-01",
-          "TA-LEX-UDAL-URUPPUGAL-01"
-        ]
+   "assesses": [
+    "TA-ETYMON-KUDUMBAM-01",
+    "TA-LEX-UDAL-URUPPUGAL-01"
+   ],
+   "note": "This chapter gained TA-W04-i-sign-write-nandri when the writing strand was spread out, and the payoff was not widened to match, so representativeness fell from 2/2 to 1/4 and this chapter is now the tamil entry in payoffsNotRepresentative — the slot chapter 1 used to hold. Widening it means authoring a payoff that assesses both the body-part vocabulary and the நன்றி spelling, which is HL-C25 work."
       }
     },
     {

--- a/code/learning/human-languages/tamil/lessons/TA-C01-aam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-aam.md
@@ -1,6 +1,6 @@
 ---
 id: TA-C01-aam
-sequence: 180
+sequence: 30
 chapter: 1
 type: word
 headword: ஆம்
@@ -41,4 +41,4 @@ doubles words for warmth and certainty, the way *sari sari* does.
 ## Wrap-up Recall
 
 [PAUSE 3s] Say **ஆம்**. What does **ஆமாம்** add? (**Emphasis** — "yes,
-indeed.") Next: writing it.
+indeed.") Next: the word for no.

--- a/code/learning/human-languages/tamil/lessons/TA-C01-answering.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-answering.md
@@ -1,6 +1,6 @@
 ---
 id: TA-C01-answering
-sequence: 230
+sequence: 80
 chapter: 1
 type: phrase
 headword: ஆம் / இல்லை / சரி

--- a/code/learning/human-languages/tamil/lessons/TA-C01-illai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-illai.md
@@ -1,6 +1,6 @@
 ---
 id: TA-C01-illai
-sequence: 190
+sequence: 40
 chapter: 1
 type: word
 headword: இல்லை
@@ -43,4 +43,4 @@ five words together.
 ## Wrap-up Recall
 
 [PAUSE 3s] Say **இல்லை**. Is it closer to English *no*, or to *is not*?
-(**Is not** — it is a statement, not a label.) Next: writing it.
+(**Is not** — it is a statement, not a label.) Next: the word for thank you.

--- a/code/learning/human-languages/tamil/lessons/TA-C01-nandri-family-register.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-nandri-family-register.md
@@ -1,6 +1,6 @@
 ---
 id: TA-C01-nandri-family-register
-sequence: 210
+sequence: 60
 chapter: 1
 type: etymology
 headword: நன்றி / നന്ദി

--- a/code/learning/human-languages/tamil/lessons/TA-C01-nandri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-nandri.md
@@ -1,6 +1,6 @@
 ---
 id: TA-C01-nandri
-sequence: 200
+sequence: 50
 chapter: 1
 type: word
 headword: நன்றி

--- a/code/learning/human-languages/tamil/lessons/TA-C01-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-practice.md
@@ -1,6 +1,6 @@
 ---
 id: TA-C01-practice
-sequence: 240
+sequence: 90
 chapter: 1
 type: practice
 headword: (recap)
@@ -17,15 +17,14 @@ reviews_of: [TA-C01-answering, TA-C01-vanakkam-family-register, TA-C01-nandri-fa
 
 ## Warm-up
 
-[PAUSE 2s] Five words, and with them a first handful of Tamil letters read
-straight off the page. Let's gather them — and add the farewell, which carries
-a small piece of Tamil culture.
+[PAUSE 2s] Five words, all of them said and none of them written. Let's gather
+them — and add the farewell, which carries a small piece of Tamil culture.
 
-## Read them back
+## Say them back
 
-Sound each out, left to right, before checking:
+Say each one before you check the meaning:
 
-| Read | | Meaning |
+| | | Meaning |
 |---|---|---|
 | **வணக்கம்** | *vaṇakkam* | hello / greetings |
 | **நன்றி** | *naṉṟi* | thank you |
@@ -33,11 +32,10 @@ Sound each out, left to right, before checking:
 | **இல்லை** | *illai* | no / there isn't |
 | **சரி** | *sari* | okay / correct |
 
-The letters that did it: consonants carry a built-in **"a"**; a **puḷḷi** dot
-removes it; a **vowel sign** (like ி for "i," ை for "ai") swaps the built-in
-vowel; and a word-initial vowel gets a **full letter** (ஆ, இ). Plus the big
-idea — Tamil hears **three** *n*'s, three *l*'s, two *r*'s, and lets **one**
-letter stand for several stop-sounds.
+The Tamil is printed beside each word on purpose. You are not expected to read
+it yet and nothing here will ask you to — but five words is a good number of
+shapes to start getting used to. Writing begins in chapter 4, and by then every
+letter you meet will spell a word you already say.
 
 ## The farewell — why Tamil won't just say "I'm leaving"
 
@@ -60,10 +58,10 @@ time. It's a whole worldview folded into a goodbye. (You can also simply repeat
 
 ## Wrap-up Recall
 
-[PAUSE 3s] Read all five words aloud. What does the everyday Tamil goodbye
+[PAUSE 3s] Say all five words aloud. What does the everyday Tamil goodbye
 literally mean, and why isn't it just "I'm leaving"? ("I'll go and come back" —
-a bare "I go" sounds like a final parting, so you promise a return.) What does
-a **puḷḷi** do? (Removes a consonant's built-in *a*.)
+a bare "I go" sounds like a final parting, so you promise a return.) Which of
+the five works both to meet someone and to part from them? (**வணக்கம்**.)
 
 Next chapter: introducing yourself — *en peyar…* ("my name…"), and Tamil's
 **nī / nīṅgaḷ** (familiar / respectful "you").

--- a/code/learning/human-languages/tamil/lessons/TA-C01-sari.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C01-sari.md
@@ -1,6 +1,6 @@
 ---
 id: TA-C01-sari
-sequence: 220
+sequence: 70
 chapter: 1
 type: word
 headword: சரி
@@ -41,4 +41,4 @@ one warm *sari*. Doubled — *sari, sari* — it means "yes yes, fine, go on."
 ## Wrap-up Recall
 
 [PAUSE 3s] Say **சரி**. What does doubling it add? (**Hurry, or easy
-agreement** — "yes yes, fine.") Next: writing it.
+agreement** — "yes yes, fine.") Next: putting the five words together.

--- a/code/learning/human-languages/tamil/lessons/TA-C02-en-peyar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-en-peyar.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C02-en-peyar
 chapter: 2
+sequence: 120
 type: phrase
 headword: என் பெயர் …
 gloss: my name is… (with no "is")

--- a/code/learning/human-languages/tamil/lessons/TA-C02-en.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-en.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C02-en
 chapter: 2
+sequence: 110
 type: word
 headword: என்
 gloss: my

--- a/code/learning/human-languages/tamil/lessons/TA-C02-enna.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-enna.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C02-enna
 chapter: 2
+sequence: 150
 type: word
 headword: என்ன
 gloss: what

--- a/code/learning/human-languages/tamil/lessons/TA-C02-magizhcci.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-magizhcci.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C02-magizhcci
 chapter: 2
+sequence: 165
 type: phrase
 headword: மகிழ்ச்சி
 gloss: joy / pleased to meet you

--- a/code/learning/human-languages/tamil/lessons/TA-C02-nii-niingal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-nii-niingal.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C02-nii-niingal
 chapter: 2
+sequence: 140
 type: word
 headword: நீ / நீங்கள்
 gloss: you (familiar / respectful)

--- a/code/learning/human-languages/tamil/lessons/TA-C02-peyar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-peyar.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C02-peyar
 chapter: 2
+sequence: 100
 type: word
 headword: பெயர்
 gloss: name

--- a/code/learning/human-languages/tamil/lessons/TA-C02-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-practice.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C02-practice
 chapter: 2
+sequence: 170
 type: practice
 headword: (dialogue)
 gloss: Chapter 2 recap — the introduction exchange

--- a/code/learning/human-languages/tamil/lessons/TA-C02-ungal-peyar-enna.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-ungal-peyar-enna.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C02-ungal-peyar-enna
 chapter: 2
+sequence: 160
 type: phrase
 headword: உங்கள் பெயர் என்ன?
 gloss: what's your name?

--- a/code/learning/human-languages/tamil/lessons/TA-C03-eppadi-irukkirirgal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-eppadi-irukkirirgal.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C03-eppadi-irukkirirgal
 chapter: 3
+sequence: 190
 type: phrase
 headword: நீங்கள் எப்படி இருக்கிறீர்கள்?
 gloss: how are you? (respectful)

--- a/code/learning/human-languages/tamil/lessons/TA-C03-eppadi.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-eppadi.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C03-eppadi
 chapter: 3
+sequence: 180
 type: word
 headword: எப்படி
 gloss: how

--- a/code/learning/human-languages/tamil/lessons/TA-C03-naan.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-naan.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C03-naan
 chapter: 3
+sequence: 200
 type: word
 headword: நான்
 gloss: I

--- a/code/learning/human-languages/tamil/lessons/TA-C03-nalam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-nalam.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C03-nalam
 chapter: 3
+sequence: 210
 type: word
 headword: நலம்
 gloss: well, wellness, good — and the reply "நான் நலமாக இருக்கிறேன்"

--- a/code/learning/human-languages/tamil/lessons/TA-C03-paravayillai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-paravayillai.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C03-paravayillai
 chapter: 3
+sequence: 220
 type: phrase
 headword: பரவாயில்லை
 gloss: it's okay / no problem / you're welcome

--- a/code/learning/human-languages/tamil/lessons/TA-C03-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-practice.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C03-practice
 chapter: 3
+sequence: 230
 type: practice
 headword: (dialogue)
 gloss: Chapter 3 recap — the how-are-you exchange

--- a/code/learning/human-languages/tamil/lessons/TA-C04-mindum-sandippom.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C04-mindum-sandippom.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C04-mindum-sandippom
 chapter: 4
+sequence: 260
 type: phrase
 headword: மீண்டும் சந்திப்போம்
 gloss: we'll meet again

--- a/code/learning/human-languages/tamil/lessons/TA-C04-naalai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C04-naalai.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C04-naalai
 chapter: 4
+sequence: 255
 type: phrase
 headword: நாளை பார்க்கலாம்
 gloss: see you tomorrow

--- a/code/learning/human-languages/tamil/lessons/TA-C04-po.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C04-po.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C04-po
 chapter: 4
+sequence: 240
 type: word
 headword: போ
 gloss: to go (and வா, to come)

--- a/code/learning/human-languages/tamil/lessons/TA-C04-poy-varugiren.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C04-poy-varugiren.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C04-poy-varugiren
 chapter: 4
+sequence: 250
 type: phrase
 headword: போய் வருகிறேன்
 gloss: goodbye (lit. "I'll go and come back")

--- a/code/learning/human-languages/tamil/lessons/TA-C04-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C04-practice.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C04-practice
 chapter: 4
+sequence: 290
 type: practice
 headword: (dialogue)
 gloss: Chapter 4 recap — the farewells

--- a/code/learning/human-languages/tamil/lessons/TA-C05-naan-tamizh-pesugiren.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-naan-tamizh-pesugiren.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C05-naan-tamizh-pesugiren
 chapter: 5
+sequence: 310
 type: phrase
 headword: நான் தமிழ் பேசுகிறேன்
 gloss: I speak Tamil

--- a/code/learning/human-languages/tamil/lessons/TA-C05-pesu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-pesu.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C05-pesu
 chapter: 5
+sequence: 300
 type: word
 headword: பேசு
 gloss: to speak

--- a/code/learning/human-languages/tamil/lessons/TA-C05-practice.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-practice.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C05-practice
 chapter: 5
+sequence: 350
 type: practice
 headword: (dialogue)
 gloss: Chapter 5 recap — the first verbs

--- a/code/learning/human-languages/tamil/lessons/TA-C05-vaazh.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-vaazh.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C05-vaazh
 chapter: 5
+sequence: 330
 type: word
 headword: வாழ்
 gloss: to live, to flourish

--- a/code/learning/human-languages/tamil/lessons/TA-C05-velai-sey.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-velai-sey.md
@@ -1,6 +1,7 @@
 ---
 id: TA-C05-velai-sey
 chapter: 5
+sequence: 340
 type: word
 headword: வேலை செய்
 gloss: to work (lit. "work-do")

--- a/code/learning/human-languages/tamil/lessons/TA-C06-dative-stacking.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C06-dative-stacking.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C06-dative-stacking
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 190
+sequence: 380
 chapter: 6
 type: grammar
 headword: பெயர் + உக்கு

--- a/code/learning/human-languages/tamil/lessons/TA-C06-dative-subject-family.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C06-dative-subject-family.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C06-dative-subject-family
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 210
+sequence: 400
 chapter: 6
 type: grammar
 headword: எனக்கு / నాకు / ನನಗೆ / എനിക്ക്

--- a/code/learning/human-languages/tamil/lessons/TA-C06-dative-subject.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C06-dative-subject.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C06-dative-subject
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 200
+sequence: 390
 chapter: 6
 type: phrase
 headword: எனக்குத் தமிழ் தெரியும்

--- a/code/learning/human-languages/tamil/lessons/TA-C06-dative-ukku.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C06-dative-ukku.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C06-dative-ukku
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 180
+sequence: 360
 chapter: 6
 type: word
 headword: -உக்கு
@@ -74,5 +74,4 @@ The pronoun changes its body (*nāṉ* → *en-*) before the suffix lands. Nouns
 (**On the end** of the noun — Tamil adds, it doesn't put a word in front.) What is
 "to me"? (**எனக்கு** *enakku* — the pronoun's body changes to *en-* first.) Why does
 the suffix show up as *-ukku* and *-kku*? (**One case, two shapes**, chosen by the
-noun's ending.) Next: compare that visible one-purpose suffix with a fused Latin
-ending.
+noun's ending.) Next: two more letters — ம and retroflex ண.

--- a/code/learning/human-languages/tamil/lessons/TA-C07-numbers-1-5-family.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C07-numbers-1-5-family.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C07-numbers-1-5-family
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 230
+sequence: 430
 chapter: 7
 type: etymology
 headword: இரண்டு மூன்று நான்கு ஐந்து

--- a/code/learning/human-languages/tamil/lessons/TA-C07-numbers-1-5.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C07-numbers-1-5.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C07-numbers-1-5
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 220
+sequence: 420
 chapter: 7
 type: word
 headword: ஒன்று இரண்டு மூன்று நான்கு ஐந்து

--- a/code/learning/human-languages/tamil/lessons/TA-C07-numbers-6-10-family.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C07-numbers-6-10-family.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C07-numbers-6-10-family
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 250
+sequence: 460
 chapter: 7
 type: etymology
 headword: ஆறு ஏழு பத்து

--- a/code/learning/human-languages/tamil/lessons/TA-C07-numbers-6-10.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C07-numbers-6-10.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C07-numbers-6-10
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 240
+sequence: 440
 chapter: 7
 type: word
 headword: ஆறு ஏழு எட்டு ஒன்பது பத்து
@@ -89,5 +89,4 @@ one-away-from-ten rather than named outright.
 [PAUSE 3s] Count six to ten in Tamil. (*Āṟu, ēḻu, eṭṭu, oṉpatu, pattu*.) Which
 number is written with **ழ**, and where else does that letter appear? (**Seven**,
 *ēḻu* — the same letter that ends *Tamiḻ*.) How is **nine** built? (*Oṉ* "one" +
-*patu* "ten" → *oṉpatu*, one short of ten.) Next: follow these forms across the
-family and hear Kannada *p* soften to *h*.
+*patu* "ten" → *oṉpatu*, one short of ten.) Next: the puḷḷi — the dot that takes a consonant's built-in vowel away.

--- a/code/learning/human-languages/tamil/lessons/TA-C08-please-register.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C08-please-register.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C08-please-register
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 270
+sequence: 480
 chapter: 8
 type: grammar
 headword: தயவுசெய்து / -உங்கள்

--- a/code/learning/human-languages/tamil/lessons/TA-C08-tayavuseytu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C08-tayavuseytu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C08-tayavuseytu
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 260
+sequence: 470
 chapter: 8
 type: phrase
 headword: தயவுசெய்து

--- a/code/learning/human-languages/tamil/lessons/TA-C09-mannikkavum.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C09-mannikkavum.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C09-mannikkavum
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 280
+sequence: 500
 chapter: 9
 type: phrase
 headword: மன்னிக்கவும்

--- a/code/learning/human-languages/tamil/lessons/TA-C09-sorry-register.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C09-sorry-register.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C09-sorry-register
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 290
+sequence: 510
 chapter: 9
 type: grammar
 headword: மன்னிக்கவும் / sorry

--- a/code/learning/human-languages/tamil/lessons/TA-C10-vaara-kizhamai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C10-vaara-kizhamai.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C10-vaara-kizhamai
 spine_node: SPINE-TIME-OF-DAY
-sequence: 300
+sequence: 520
 chapter: 10
 type: word
 headword: திங்கள்–ஞாயிறு

--- a/code/learning/human-languages/tamil/lessons/TA-C11-nirangal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C11-nirangal.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C11-nirangal
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 310
+sequence: 540
 chapter: 11
 type: word
 headword: கருப்பு வெள்ளை சிவப்பு நீலம்

--- a/code/learning/human-languages/tamil/lessons/TA-C12-kudumbam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C12-kudumbam.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C12-kudumbam
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 320
+sequence: 550
 chapter: 12
 type: word
 headword: அப்பா அம்மா அண்ணன் தம்பி அக்கா தங்கை

--- a/code/learning/human-languages/tamil/lessons/TA-C13-udal-uruppugal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C13-udal-uruppugal.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C13-udal-uruppugal
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 330
+sequence: 560
 chapter: 13
 type: word
 headword: தலை கை

--- a/code/learning/human-languages/tamil/lessons/TA-C14-kaalangal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C14-kaalangal.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C14-kaalangal
 spine_node: SPINE-TIME-OF-DAY
-sequence: 340
+sequence: 580
 chapter: 14
 type: word
 headword: வசந்த காலம் கோடைக் காலம் மழைக் காலம் குளிர் காலம்

--- a/code/learning/human-languages/tamil/lessons/TA-C15-thanneer-arisi.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C15-thanneer-arisi.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C15-thanneer-arisi
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 350
+sequence: 590
 chapter: 15
 type: word
 headword: தண்ணீர் அரிசி சாதம்

--- a/code/learning/human-languages/tamil/lessons/TA-C16-thamizh-maadangal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C16-thamizh-maadangal.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C16-thamizh-maadangal
 spine_node: SPINE-TIME-OF-DAY
-sequence: 360
+sequence: 600
 chapter: 16
 type: word
 headword: சித்திரை வைகாசி ஆனி ஆடி ஆவணி புரட்டாசி ஐப்பசி கார்த்திகை மார்கழி தை மாசி பங்குனி

--- a/code/learning/human-languages/tamil/lessons/TA-C17-nanpakal-nalliravu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C17-nanpakal-nalliravu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C17-nanpakal-nalliravu
 spine_node: SPINE-TIME-OF-DAY
-sequence: 370
+sequence: 620
 chapter: 17
 type: word
 headword: நண்பகல் நள்ளிரவு

--- a/code/learning/human-languages/tamil/lessons/TA-C17-transparent-middle-synonyms.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C17-transparent-middle-synonyms.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C17-transparent-middle-synonyms
 spine_node: SPINE-TIME-OF-DAY
-sequence: 380
+sequence: 630
 chapter: 17
 type: etymology
 headword: நடுப்பகல், நடு இரவு

--- a/code/learning/human-languages/tamil/lessons/TA-C18-mani-homophone-time.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C18-mani-homophone-time.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C18-mani-homophone-time
 spine_node: SPINE-TIME-OF-DAY
-sequence: 400
+sequence: 660
 chapter: 18
 type: etymology
 headword: மணி / மணி

--- a/code/learning/human-languages/tamil/lessons/TA-C18-mani.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C18-mani.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C18-mani
 spine_node: SPINE-TIME-OF-DAY
-sequence: 390
+sequence: 640
 chapter: 18
 type: word
 headword: மணி
@@ -64,5 +64,4 @@ possible Sanskrit connection for this whole word-family as unresolved, so hold
 Kannada/Telugu/Hindi's hour-words? (**Most likely no** — it's treated as a native
 Dravidian "bell" word that independently reached "hour" the same way, though even
 DEDR flags this as not fully settled.) What semantic path links the meanings?
-(A **bell announces the hour**.) Next: distinguish the likely Sanskrit gem
-homophone and tell the time.
+(A **bell announces the hour**.) Next: writing இல்லை — a second independent vowel, ல, and the ai sign.

--- a/code/learning/human-languages/tamil/lessons/TA-C19-age-register-grammar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C19-age-register-grammar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C19-age-register-grammar
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 420
+sequence: 680
 chapter: 19
 type: grammar
 headword: உன் வயசு என்ன? / உனக்கு எத்தனை வயது ஆகிறது?

--- a/code/learning/human-languages/tamil/lessons/TA-C19-vayathu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C19-vayathu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C19-vayathu
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 410
+sequence: 670
 chapter: 19
 type: phrase
 headword: உனக்கு எத்தனை வயது ஆகிறது?

--- a/code/learning/human-languages/tamil/lessons/TA-C20-pathinondru-irupathu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C20-pathinondru-irupathu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C20-pathinondru-irupathu
 spine_node: SPINE-COUNT-ONE-TO-FIVE
-sequence: 430
+sequence: 700
 chapter: 20
 type: word
 headword: பதினொன்று — இருபது

--- a/code/learning/human-languages/tamil/lessons/TA-C20-vaanilai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C20-vaanilai.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C20-vaanilai
 spine_node: SPINE-TIME-OF-DAY
-sequence: 440
+sequence: 710
 chapter: 20
 type: word
 headword: வானிலை

--- a/code/learning/human-languages/tamil/lessons/TA-C21-naay-poonai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C21-naay-poonai.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C21-naay-poonai
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 450
+sequence: 720
 chapter: 21
 type: word
 headword: நாய், பூனை

--- a/code/learning/human-languages/tamil/lessons/TA-C22-paccai-manjal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C22-paccai-manjal.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C22-paccai-manjal
 spine_node: SPINE-DEFINITE-REFERENCE
-sequence: 460
+sequence: 730
 chapter: 22
 type: word
 headword: பச்சை, மஞ்சள்

--- a/code/learning/human-languages/tamil/lessons/TA-C23-day-family-register.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C23-day-family-register.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C23-day-family-register
 spine_node: SPINE-TIME-OF-DAY
-sequence: 480
+sequence: 750
 chapter: 23
 type: etymology
 headword: நாள் / தினம்

--- a/code/learning/human-languages/tamil/lessons/TA-C23-naal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C23-naal.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C23-naal
 spine_node: SPINE-TIME-OF-DAY
-sequence: 470
+sequence: 740
 chapter: 23
 type: word
 headword: நாள்

--- a/code/learning/human-languages/tamil/lessons/TA-C24-iravu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C24-iravu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C24-iravu
 spine_node: SPINE-TIME-OF-DAY
-sequence: 490
+sequence: 760
 chapter: 24
 type: word
 headword: இரவு

--- a/code/learning/human-languages/tamil/lessons/TA-C24-night-register-darkness.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C24-night-register-darkness.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C24-night-register-darkness
 spine_node: SPINE-TIME-OF-DAY
-sequence: 500
+sequence: 770
 chapter: 24
 type: grammar
 headword: இரவு / ராத்திரி / இருள்

--- a/code/learning/human-languages/tamil/lessons/TA-C25-goodnight-alternatives.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C25-goodnight-alternatives.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C25-goodnight-alternatives
 spine_node: SPINE-TIME-OF-DAY
-sequence: 520
+sequence: 790
 chapter: 25
 type: etymology
 headword: நல்ல இரவு / இரவு வணக்கம்

--- a/code/learning/human-languages/tamil/lessons/TA-C25-iniya-iravu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C25-iniya-iravu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C25-iniya-iravu
 spine_node: SPINE-TIME-OF-DAY
-sequence: 510
+sequence: 780
 chapter: 25
 type: phrase
 headword: இனிய இரவு

--- a/code/learning/human-languages/tamil/lessons/TA-C26-kaalai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C26-kaalai.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C26-kaalai
 spine_node: SPINE-TIME-OF-DAY
-sequence: 530
+sequence: 800
 chapter: 26
 type: word
 headword: காலை

--- a/code/learning/human-languages/tamil/lessons/TA-C27-maalai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C27-maalai.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C27-maalai
 spine_node: SPINE-TIME-OF-DAY
-sequence: 540
+sequence: 810
 chapter: 27
 type: word
 headword: மாலை

--- a/code/learning/human-languages/tamil/lessons/TA-C28-afternoon-boundary.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C28-afternoon-boundary.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C28-afternoon-boundary
 spine_node: SPINE-TIME-OF-DAY
-sequence: 560
+sequence: 830
 chapter: 28
 type: etymology
 headword: நடுப்பகல் / மதியம்

--- a/code/learning/human-languages/tamil/lessons/TA-C28-pirpakal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C28-pirpakal.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C28-pirpakal
 spine_node: SPINE-TIME-OF-DAY
-sequence: 550
+sequence: 820
 chapter: 28
 type: word
 headword: பிற்பகல்

--- a/code/learning/human-languages/tamil/lessons/TA-C29-kaalai-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C29-kaalai-vanakkam.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C29-kaalai-vanakkam
 spine_node: SPINE-TIME-OF-DAY
-sequence: 570
+sequence: 840
 chapter: 29
 type: phrase
 headword: காலை வணக்கம்

--- a/code/learning/human-languages/tamil/lessons/TA-C30-maalai-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C30-maalai-vanakkam.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C30-maalai-vanakkam
 spine_node: SPINE-TIME-OF-DAY
-sequence: 580
+sequence: 850
 chapter: 30
 type: phrase
 headword: மாலை வணக்கம்

--- a/code/learning/human-languages/tamil/lessons/TA-C31-afternoon-greeting-root.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C31-afternoon-greeting-root.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C31-afternoon-greeting-root
 spine_node: SPINE-TIME-OF-DAY
-sequence: 600
+sequence: 870
 chapter: 31
 type: etymology
 headword: மதிய

--- a/code/learning/human-languages/tamil/lessons/TA-C31-matiya-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C31-matiya-vanakkam.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C31-matiya-vanakkam
 spine_node: SPINE-TIME-OF-DAY
-sequence: 590
+sequence: 860
 chapter: 31
 type: phrase
 headword: மதிய வணக்கம்

--- a/code/learning/human-languages/tamil/lessons/TA-C32-iru.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C32-iru.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C32-iru
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 610
+sequence: 880
 chapter: 32
 type: word
 headword: இரு

--- a/code/learning/human-languages/tamil/lessons/TA-C32-paar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C32-paar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C32-paar
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 650
+sequence: 920
 chapter: 32
 type: word
 headword: பார்

--- a/code/learning/human-languages/tamil/lessons/TA-C32-po.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C32-po.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C32-po
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 620
+sequence: 890
 chapter: 32
 type: word
 headword: போ

--- a/code/learning/human-languages/tamil/lessons/TA-C32-saappidu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C32-saappidu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C32-saappidu
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 640
+sequence: 910
 chapter: 32
 type: word
 headword: சாப்பிடு

--- a/code/learning/human-languages/tamil/lessons/TA-C32-teri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C32-teri.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C32-teri
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 660
+sequence: 930
 chapter: 32
 type: word
 headword: தெரி

--- a/code/learning/human-languages/tamil/lessons/TA-C32-vaa.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C32-vaa.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C32-vaa
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 630
+sequence: 900
 chapter: 32
 type: word
 headword: வா

--- a/code/learning/human-languages/tamil/lessons/TA-C33-ezhutu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C33-ezhutu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C33-ezhutu
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 700
+sequence: 970
 chapter: 33
 type: word
 headword: எழுது

--- a/code/learning/human-languages/tamil/lessons/TA-C33-ninai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C33-ninai.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C33-ninai
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 670
+sequence: 940
 chapter: 33
 type: word
 headword: நினை

--- a/code/learning/human-languages/tamil/lessons/TA-C33-padi.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C33-padi.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C33-padi
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 690
+sequence: 960
 chapter: 33
 type: word
 headword: படி

--- a/code/learning/human-languages/tamil/lessons/TA-C33-puri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C33-puri.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C33-puri
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 680
+sequence: 950
 chapter: 33
 type: word
 headword: புரி

--- a/code/learning/human-languages/tamil/lessons/TA-C34-edu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C34-edu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C34-edu
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 710
+sequence: 980
 chapter: 34
 type: word
 headword: எடு

--- a/code/learning/human-languages/tamil/lessons/TA-C34-kel.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C34-kel.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C34-kel
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 720
+sequence: 990
 chapter: 34
 type: word
 headword: கேள்

--- a/code/learning/human-languages/tamil/lessons/TA-C34-pidi.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C34-pidi.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C34-pidi
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 740
+sequence: 1010
 chapter: 34
 type: word
 headword: பிடி

--- a/code/learning/human-languages/tamil/lessons/TA-C34-utavu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C34-utavu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C34-utavu
 spine_node: SPINE-SAY-WHAT-I-DO
-sequence: 730
+sequence: 1000
 chapter: 34
 type: word
 headword: உதவு

--- a/code/learning/human-languages/tamil/lessons/TA-C35-arai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C35-arai.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C35-arai
 spine_node: SPINE-MEET-GREET
-sequence: 770
+sequence: 1040
 chapter: 35
 type: word
 headword: அறை

--- a/code/learning/human-languages/tamil/lessons/TA-C35-kadavu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C35-kadavu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C35-kadavu
 spine_node: SPINE-MEET-GREET
-sequence: 760
+sequence: 1030
 chapter: 35
 type: word
 headword: கதவு

--- a/code/learning/human-languages/tamil/lessons/TA-C35-naarkaali.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C35-naarkaali.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C35-naarkaali
 spine_node: SPINE-MEET-GREET
-sequence: 780
+sequence: 1050
 chapter: 35
 type: word
 headword: நாற்காலி

--- a/code/learning/human-languages/tamil/lessons/TA-C35-veedu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C35-veedu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C35-veedu
 spine_node: SPINE-MEET-GREET
-sequence: 750
+sequence: 1020
 chapter: 35
 type: word
 headword: வீடு

--- a/code/learning/human-languages/tamil/lessons/TA-C36-paal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C36-paal.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C36-paal
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 800
+sequence: 1070
 chapter: 36
 type: word
 headword: பால்

--- a/code/learning/human-languages/tamil/lessons/TA-C36-tavaru.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C36-tavaru.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C36-tavaru
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 820
+sequence: 1090
 chapter: 36
 type: word
 headword: தவறு

--- a/code/learning/human-languages/tamil/lessons/TA-C36-teneer.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C36-teneer.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C36-teneer
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 790
+sequence: 1060
 chapter: 36
 type: word
 headword: தேநீர்

--- a/code/learning/human-languages/tamil/lessons/TA-C36-unavu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C36-unavu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C36-unavu
 spine_node: SPINE-POLITE-REQUEST-REPAIR
-sequence: 810
+sequence: 1080
 chapter: 36
 type: word
 headword: உணவு

--- a/code/learning/human-languages/tamil/lessons/TA-C37-ivar-en-nanbar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C37-ivar-en-nanbar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C37-ivar-en-nanbar
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 860
+sequence: 1130
 chapter: 37
 type: phrase
 headword: இவர் என் நண்பர்

--- a/code/learning/human-languages/tamil/lessons/TA-C37-ivar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C37-ivar.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C37-ivar
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 850
+sequence: 1120
 chapter: 37
 type: word
 headword: இவர்

--- a/code/learning/human-languages/tamil/lessons/TA-C37-nanban.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C37-nanban.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C37-nanban
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 840
+sequence: 1110
 chapter: 37
 type: word
 headword: நண்பன்

--- a/code/learning/human-languages/tamil/lessons/TA-C37-uur.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C37-uur.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C37-uur
 spine_node: SPINE-EXCHANGE-NAMES
-sequence: 830
+sequence: 1100
 chapter: 37
 type: word
 headword: ஊர்

--- a/code/learning/human-languages/tamil/lessons/TA-C38-sugam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C38-sugam.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C38-sugam
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 880
+sequence: 1150
 chapter: 38
 type: word
 headword: சுகம்

--- a/code/learning/human-languages/tamil/lessons/TA-C38-udambu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C38-udambu.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C38-udambu
 spine_node: SPINE-CHECK-WELLBEING
-sequence: 870
+sequence: 1140
 chapter: 38
 type: word
 headword: உடம்பு

--- a/code/learning/human-languages/tamil/lessons/TA-C38-vidai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C38-vidai.md
@@ -2,7 +2,7 @@
 schema_version: 2
 id: TA-C38-vidai
 spine_node: SPINE-TAKE-LEAVE
-sequence: 890
+sequence: 1160
 chapter: 38
 type: word
 headword: விடை

--- a/code/learning/human-languages/tamil/lessons/TA-W01-abugida-va-ka.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W01-abugida-va-ka.md
@@ -2,8 +2,9 @@
 schema_version: 2
 id: TA-W01-abugida-va-ka
 spine_node: SPINE-MEET-GREET
-sequence: 110
-chapter: 1
+sequence: 320
+delivery: script
+chapter: 5
 type: writing
 headword: "வ, க"
 gloss: the inherent vowel and the first two Tamil letters, including க's position-driven sounds

--- a/code/learning/human-languages/tamil/lessons/TA-W01-curves-va-ka.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W01-curves-va-ka.md
@@ -2,8 +2,9 @@
 schema_version: 2
 id: TA-W01-curves-va-ka
 spine_node: SPINE-MEET-GREET
-sequence: 100
-chapter: 1
+sequence: 270
+delivery: script
+chapter: 4
 type: writing
 headword: "தமிழ் எழுத்து"
 gloss: why Tamil writing is so round, with the palm-leaf account presented as a qualified explanation
@@ -80,4 +81,4 @@ and a chisel; Tamil's curves suit a stylus and a leaf.
 leaves**, where a straight stroke along the grain can **split** them — though
 early Tamil-Brahmi was angular, so it is not the whole story.) What broader point
 does the account teach? (**Tools and surfaces leave fingerprints on scripts.**)
-Next: the vowel hidden inside a consonant, then வ and க.
+Next: the chapter's own recap of the farewells.

--- a/code/learning/human-languages/tamil/lessons/TA-W02-ma-retroflex-na.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W02-ma-retroflex-na.md
@@ -2,8 +2,9 @@
 schema_version: 2
 id: TA-W02-ma-retroflex-na
 spine_node: SPINE-MEET-GREET
-sequence: 120
-chapter: 1
+sequence: 370
+delivery: script
+chapter: 6
 type: writing
 headword: "ம, ண"
 gloss: write ம and retroflex ண while training the tongue to curl back
@@ -91,5 +92,4 @@ rather than inheriting it.
 [PAUSE 3s] Draw **ம** — which side is the upright on? (**The left**; the
 arch closes it on the right.) Draw **ண** — what makes it *not* ன? (**One extra arch**: ண has **two** arches where ன has one. Both end in the same straight vertical.) What does the dot in **ṇ** mean? (**Retroflex** — the tongue curls
 **back** to the roof of the mouth.) Why can't you hear it yet? (**English has no
-such sound**; the ear learns it after the hand.) Next: place Tamil's three n's
-along one backward walk through the mouth.
+such sound**; the ear learns it after the hand.) Next: stacking that dative suffix where Latin would fuse several meanings.

--- a/code/learning/human-languages/tamil/lessons/TA-W02-three-ns.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W02-three-ns.md
@@ -2,8 +2,9 @@
 schema_version: 2
 id: TA-W02-three-ns
 spine_node: SPINE-MEET-GREET
-sequence: 130
-chapter: 1
+sequence: 410
+delivery: script
+chapter: 6
 type: writing
 headword: "ந, ன, ண"
 gloss: Tamil writes dental, alveolar, and retroflex n with three separate letters
@@ -69,4 +70,4 @@ sound pattern without inheriting it from one ancestor.
 
 [PAUSE 3s] How many n-letters does Tamil have? (**Three**.) What separates them?
 (Tongue position: **dental, alveolar, retroflex**.) Which two differ by one
-arch? (**ன** has one; **ண** has two.) Next: remove the vowel from a consonant.
+arch? (**ன** has one; **ண** has two.) Next: the numbers one to five.

--- a/code/learning/human-languages/tamil/lessons/TA-W03-pulli-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W03-pulli-vanakkam.md
@@ -2,8 +2,9 @@
 schema_version: 2
 id: TA-W03-pulli-vanakkam
 spine_node: SPINE-MEET-GREET
-sequence: 140
-chapter: 1
+sequence: 450
+delivery: script
+chapter: 7
 type: writing
 headword: "்"
 gloss: "the puḷḷi — a visible dot that removes the inherent vowel without creating a conjunct"
@@ -96,4 +97,4 @@ consonants and outside the 247.)
 that Tamil doesn't? (**Fuses** the letters into a **conjunct** — Tamil keeps both
 shapes and the dot.) What does Tamil get in exchange? (A **much smaller
 character set** — 247, with **almost** no ligatures: only the borrowed க்ஷ and
-ஸ்ரீ.) Next: assemble that visible dot into **வணக்கம்**.
+ஸ்ரீ.) Next: six, seven and ten across the family.

--- a/code/learning/human-languages/tamil/lessons/TA-W03-write-vanakkam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W03-write-vanakkam.md
@@ -2,8 +2,9 @@
 schema_version: 2
 id: TA-W03-write-vanakkam
 spine_node: SPINE-MEET-GREET
-sequence: 150
-chapter: 1
+sequence: 490
+delivery: script
+chapter: 8
 type: writing
 headword: "வணக்கம்"
 gloss: assemble the first greeting and hold its doubled consonant
@@ -69,4 +70,4 @@ this book, written by hand.
 
 [PAUSE 3s] Write **வணக்கம்**. What is special about **க்க**? (It is **doubled**
 and held.) Why does the word end in *m*, not *ma*? (Final **ம்** carries a
-**puḷḷi**.) Next: write the letters and vowel sign inside *nandri*.
+**puḷḷi**.) Next: the formal way to say *please forgive me*.

--- a/code/learning/human-languages/tamil/lessons/TA-W04-i-sign-write-nandri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W04-i-sign-write-nandri.md
@@ -2,8 +2,9 @@
 schema_version: 2
 id: TA-W04-i-sign-write-nandri
 spine_node: SPINE-MEET-GREET
-sequence: 170
-chapter: 1
+sequence: 570
+delivery: script
+chapter: 13
 type: writing
 headword: "ி, நன்றி"
 gloss: replace the inherent vowel with i, assemble நன்றி, and hear nasal-triggered voicing

--- a/code/learning/human-languages/tamil/lessons/TA-W04-vowel-signs-nandri.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W04-vowel-signs-nandri.md
@@ -2,8 +2,9 @@
 schema_version: 2
 id: TA-W04-vowel-signs-nandri
 spine_node: SPINE-MEET-GREET
-sequence: 160
-chapter: 1
+sequence: 530
+delivery: script
+chapter: 10
 type: writing
 headword: "ந, ன, ற"
 gloss: "write the remaining two n-letters and the hard r needed for நன்றி"
@@ -90,5 +91,4 @@ other r. You'll meet the contrast properly later; for now, learn the shape.
 [PAUSE 3s] Name Tamil's three n-letters and their tongue positions. (**ந**
 dental, **ன** alveolar, **ண** retroflex.) What are a consonant's three
 possibilities so far? (Keep the built-in **a** or **remove** it with the puḷḷi.)
-Which letter hangs below the baseline? (**ற**, the hard *ṟ*.) Next: replace the
-vowel, assemble **நன்றி**, and hear why English often writes *nandri*.
+Which letter hangs below the baseline? (**ற**, the hard *ṟ*.) Next: the colours — black, white, red and blue.

--- a/code/learning/human-languages/tamil/lessons/TA-W05-write-aam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W05-write-aam.md
@@ -2,8 +2,9 @@
 schema_version: 2
 id: TA-W05-write-aam
 spine_node: SPINE-MEET-GREET
-sequence: 182
-chapter: 1
+sequence: 610
+delivery: script
+chapter: 16
 type: writing
 headword: "ஆம்"
 gloss: a word that begins with a vowel gets a full vowel letter, not a sign
@@ -91,4 +92,4 @@ it did at the end of **வணக்கம்**.
 
 [PAUSE 3s] Write **ஆம்**. When does a Tamil vowel get a full letter instead of
 a sign? (**When it starts a word** — nothing precedes it to hook onto.) What
-closes the word? (**ம்** — the puḷḷi on ம.) Next: the word for no.
+closes the word? (**ம்** — the puḷḷi on ம.) Next: noon and midnight.

--- a/code/learning/human-languages/tamil/lessons/TA-W06-write-illai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W06-write-illai.md
@@ -2,8 +2,9 @@
 schema_version: 2
 id: TA-W06-write-illai
 spine_node: SPINE-MEET-GREET
-sequence: 192
-chapter: 1
+sequence: 650
+delivery: script
+chapter: 18
 type: writing
 headword: "இல்லை"
 gloss: a second independent vowel, the letter ல, and the left-standing ai sign
@@ -92,4 +93,4 @@ The **ல் + லை** is a doubled *l*, held like the **க்க** of *vaṇa
 
 [PAUSE 3s] Write **இல்லை**. Why does it open with **இ** rather than a sign?
 (**The word starts on a vowel**.) Which side of its consonant does **ை** sit
-on? (**The left** — written first, spoken second.) Next: the word for thank you.
+on? (**The left** — written first, spoken second.) Next: the gem-word homophone, and telling clock time.

--- a/code/learning/human-languages/tamil/lessons/TA-W07-write-sari.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W07-write-sari.md
@@ -2,8 +2,9 @@
 schema_version: 2
 id: TA-W07-write-sari
 spine_node: SPINE-MEET-GREET
-sequence: 222
-chapter: 1
+sequence: 690
+delivery: script
+chapter: 19
 type: writing
 headword: "சரி"
 gloss: one letter for a whole family of sounds — ச — and the second r
@@ -89,4 +90,4 @@ vowel sign you first hooked onto **ற**.
 nasal.) How many *r*-letters does
 Tamil keep? (**Two** — ர and ற.) In **லை**, which side of the ல does the ai sign
 sit on? (**The left**.) And why does **இல்லை** open with **இ** rather than a
-sign? (**It starts on a vowel**.) Next: putting the five words together.
+sign? (**It starts on a vowel**.) Next: the numbers eleven to twenty.

--- a/code/learning/human-languages/tamil/narration/ch01.json
+++ b/code/learning/human-languages/tamil/narration/ch01.json
@@ -3,8 +3,8 @@
   "language": "tamil",
   "chapter": 1,
   "title": "Greetings",
-  "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:b35c2c9e484d8ba0",
+  "drivablePrefix": 9,
+  "sourceHash": "fnv1a64:4ba983e1f562762e",
   "lessons": [
     {
       "id": "TA-C01-vanakkam",
@@ -115,7 +115,7 @@
             },
             {
               "kind": "speech",
-              "text": "Say வணக்கம் (vaṇakkam). Does it change between morning and evening? (No — one greeting, all day.) Does it change for one person or a crowd? (No.) Next: the same greeting across the Dravidian family."
+              "text": "Say வணக்கம். Does it change between morning and evening? (No — one greeting, all day.) Does it change for one person or a crowd? (No.) Next: the same greeting across the Dravidian family."
             }
           ]
         }
@@ -124,7 +124,7 @@
     {
       "id": "TA-C01-vanakkam-family-register",
       "sequence": 20,
-      "title": "வணக்கம் (vaṇakkam) — one bow, two lexical loyalties",
+      "title": "வணக்கம் — one bow, two lexical loyalties",
       "headword": "வணக்கம் / நமஸ்காரம்",
       "romanization": "",
       "gloss": "Tamil kept a native bow-word where its neighbors borrowed Sanskrit, and uses it across settings",
@@ -226,7 +226,7 @@
             {
               "kind": "prompt",
               "action": "CHOOSE",
-              "instruction": "greeting or parting becomes வணக்கம் (vaṇakkam) works",
+              "instruction": "greeting or parting becomes வணக்கம் works",
               "spoken": true,
               "scored": false,
               "responseSeconds": 8,
@@ -254,1341 +254,8 @@
       ]
     },
     {
-      "id": "TA-W01-curves-va-ka",
-      "sequence": 100,
-      "title": "Tamil's curves — the writing surface leaves a trace",
-      "headword": "தமிழ் எழுத்து",
-      "romanization": "tamiḻ eḻuttu",
-      "gloss": "why Tamil writing is so round, with the palm-leaf account presented as a qualified explanation",
-      "script": "tamil",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block",
-        "sight-cue"
-      ],
-      "sourceHash": "fnv1a64:52e873e570e7a21e",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page",
-          "your eyes, because the lesson points at something written down"
-        ],
-        "waitUntilStopped": [
-          "Script you'll notice: The script is the shape of its writing surface",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script you'll notice: The script is the shape of its writing surface and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Before the first letter, look at a line of Tamil and notice what isn't there:"
-            },
-            {
-              "kind": "speech",
-              "text": "வணக்கம் (vaṇakkam)."
-            },
-            {
-              "kind": "speech",
-              "text": "Nothing joins the letters together, and there are far fewer corners than in Devanagari — no hanging head-line, and a great deal of curve. (Straight strokes do exist: most of these letters have a flat bar across the top.) The roundness has a usual explanation, and it is the best story in this chapter."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script you'll notice: The script is the shape of its writing surface",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Tamil was written for centuries on palm leaves, scratched with a metal stylus and then rubbed with soot to make the scratches show."
-            },
-            {
-              "kind": "speech",
-              "text": "A palm leaf has a grain, like wood. Draw a long straight line along that grain and the stylus can split the leaf. The usual account is that scribes bent their strokes in response: a curve crosses the fibres at an angle instead of running with them."
-            },
-            {
-              "kind": "speech",
-              "text": "Treat that as the standard explanation rather than a settled fact. The earliest Tamil writing — Tamil-Brahmi, cut into stone and pottery — is noticeably angular; the rounding came later, through the Vaṭṭeḻuttu (\"round script\") stage. And Devanagari was written on the same leaves without going round. So the leaf is one pressure among several, not a complete answer."
-            },
-            {
-              "kind": "speech",
-              "text": "It is still worth carrying, because it makes the right general point: the tool leaves fingerprints on the letters. Latin's straight strokes suit a wax tablet and a chisel; Tamil's curves suit a stylus and a leaf."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "TRACE",
-              "instruction": "a curve crossing the imagined grain of a palm leaf",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU TRACE: a curve crossing the imagined grain of a palm leaf]"
-            },
-            {
-              "kind": "prompt",
-              "action": "CONTRAST",
-              "instruction": "angular Tamil-Brahmi, later rounded Vaṭṭeḻuttu",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU CONTRAST: angular Tamil-Brahmi · later rounded Vaṭṭeḻuttu]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the usual reason for the curves — \"a straight line can split the leaf\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the usual reason for the curves — \"a straight line can **split the leaf**\"]"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Why is Tamil round? (The usual explanation: it was incised on palm leaves, where a straight stroke along the grain can split them — though early Tamil-Brahmi was angular, so it is not the whole story.) What broader point does the account teach? (Tools and surfaces leave fingerprints on scripts.) Next: the vowel hidden inside a consonant, then வ and க."
-            },
-            {
-              "kind": "activity",
-              "scored": true,
-              "id": "TA-W01-curves-va-ka-writing-surface",
-              "prompt": "What writing surface is usually linked to Tamil's rounded shapes?",
-              "assesses": [
-                "TA-SCRIPT-CURVES-VA-KA-01"
-              ],
-              "responseSeconds": 8,
-              "acceptedResponses": [
-                "palm leaves",
-                "palm leaf",
-                "leaves of palm"
-              ],
-              "feedback": {
-                "correct": "Correct: the usual account links Tamil's curves to writing on palm leaves.",
-                "incorrect": "The usual explanation points to palm leaves, which straight strokes along the grain could split."
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-W01-abugida-va-ka",
-      "sequence": 110,
-      "title": "வ and க — the vowel inside each consonant",
-      "headword": "வ, க",
-      "romanization": "va, ka",
-      "gloss": "the inherent vowel and the first two Tamil letters, including க's position-driven sounds",
-      "script": "tamil",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:a2fe0a66292e2a3b",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script you'll notice: The vowel you get for free",
-          "Script you'll notice: வ — \"va\"",
-          "Script you'll notice: க — \"ka\"",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The vowel you get for free, Script you'll notice: வ — \"va\", Script you'll notice: க — \"ka\" and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Tamil's letters do not join and they carry many curves. Now learn the sound that arrives for free inside every consonant."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script you'll notice: The vowel you get for free",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Tamil is an abugida, like Devanagari: a consonant already contains a vowel."
-            },
-            {
-              "kind": "speech",
-              "text": "க is not \"k\". க is \"ka\"."
-            },
-            {
-              "kind": "speech",
-              "text": "Every consonant carries a built-in a until a later mark removes or replaces it."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "script",
-          "title": "Script you'll notice: வ — \"va\"",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "a near-closed loop on the left."
-            },
-            {
-              "kind": "speech",
-              "text": "a full-height arm across the top, ending in a descender on the right."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "script",
-          "title": "Script you'll notice: க — \"ka\"",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "a straight horizontal top bar."
-            },
-            {
-              "kind": "speech",
-              "text": "a bowl hanging from its left end."
-            },
-            {
-              "kind": "speech",
-              "text": "a short right stroke that hooks left below."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "pronunciation",
-          "title": "Sounds you'll need: One letter, three sounds",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Devanagari separates क, ख, ग, घ. Tamil uses க across that space: k at the start of a word and when doubled (க்க), g after a nasal (ங்க), and a softer h-like sound between vowels. Position, not a new spelling, selects the sound."
-            },
-            {
-              "kind": "speech",
-              "text": "Tamil therefore needs only 18 consonant letters where Devanagari needs 33; its native words do not depend on those written distinctions."
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "வ — \"left loop, top arm, descender\"",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: வ — \"left loop, top arm, descender\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "க — \"top bar, left bowl, hooking right stroke\"",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: க — \"top bar, left bowl, hooking right stroke\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"க is ka, not k\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"க is **ka**, not k\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "CONTRAST",
-              "instruction": "initial k, after a nasal g, between vowels soft h",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU CONTRAST: initial *k* · after a nasal *g* · between vowels soft *h*]"
-            }
-          ]
-        },
-        {
-          "index": 6,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does க say alone? (Ka — the vowel is inherent.) What kind of script is this? (An abugida.) Which sounds can க spell? (k, g, and a softer h-like sound, chosen by position.) Draw வ and க."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-W02-ma-retroflex-na",
-      "sequence": 120,
-      "title": "ம and ண — a loop, and a curled tongue",
-      "headword": "ம, ண",
-      "romanization": "ma, ṇa",
-      "gloss": "write ம and retroflex ண while training the tongue to curl back",
-      "script": "tamil",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:207da9661587565a",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script you'll notice: ம",
-          "Script you'll notice: ண",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ம, Script you'll notice: ண and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Two more letters, and with them you'll have every letter of this book's first word. One is easy. The other is a sound you may not be able to hear yet."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script you'll notice: ம",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "a straight vertical stroke on the LEFT."
-            },
-            {
-              "kind": "speech",
-              "text": "a horizontal along the bottom."
-            },
-            {
-              "kind": "speech",
-              "text": "a rounded arch closing it on the RIGHT."
-            },
-            {
-              "kind": "speech",
-              "text": "Get the sides the right way round. The upright is on the left and the curve on the right — which is the reverse of what most people guess, and the reverse of the Devanagari habit of hanging a shape off a right-hand spine."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "script",
-          "title": "Script you'll notice: ண",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "a straight top bar."
-            },
-            {
-              "kind": "speech",
-              "text": "a loop on the left."
-            },
-            {
-              "kind": "speech",
-              "text": "two arches."
-            },
-            {
-              "kind": "speech",
-              "text": "a straight vertical on the right, down to the baseline."
-            },
-            {
-              "kind": "speech",
-              "text": "The dot under the romanization — ṇ, not plain n — is doing real work."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "pronunciation",
-          "title": "Sounds you'll need: Retroflex",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Say English n. Your tongue touches just behind your teeth."
-            },
-            {
-              "kind": "speech",
-              "text": "Now curl the tip of your tongue up and back toward the roof of your mouth, and say it again. That is ṇ, and it is a different letter in Tamil."
-            },
-            {
-              "kind": "speech",
-              "text": "English has no such sound and no way to write one, which is why an English speaker typically cannot hear the difference at first. That is expected. The ear learns it after the hand does, which is one good argument for writing the letters rather than only reading them."
-            },
-            {
-              "kind": "speech",
-              "text": "Retroflex sounds are a signature of the languages of India — they show up across Tamil, Telugu, Kannada, Malayalam, Hindi and Sanskrit alike, in families that are otherwise unrelated to each other. It's one of the features that makes South Asia a linguistic area: neighbouring languages that borrowed a sound from each other rather than inheriting it."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "ம — \"left upright, bottom, right arch\"",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: ம — \"left upright, bottom, **right** arch\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "ண — \"top bar, left loop, two arches, straight vertical\"",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: ண — \"top bar, left loop, **two** arches, straight vertical\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "plain n, then curl the tongue back — ṇ",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: plain *n*, then curl the tongue back — **ṇ**]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Draw ம — which side is the upright on? (The left; the arch closes it on the right.) Draw ண — what makes it not ன? (One extra arch: ண has two arches where ன has one. Both end in the same straight vertical.) What does the dot in ṇ mean? (Retroflex — the tongue curls back to the roof of the mouth.) Why can't you hear it yet? (English has no such sound; the ear learns it after the hand.) Next: place Tamil's three n's along one backward walk through the mouth."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-W02-three-ns",
-      "sequence": 130,
-      "title": "ந, ன, ண (na, ṉa, ṇa) — three stops on one tongue-map",
-      "headword": "ந, ன, ண",
-      "romanization": "na, ṉa, ṇa",
-      "gloss": "Tamil writes dental, alveolar, and retroflex n with three separate letters",
-      "script": "tamil",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:0a6a4e9cd2c74425",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script you'll notice: The backward walk",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The backward walk and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "English writes one n. Tamil keeps three tongue positions apart."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script you'll notice: The backward walk",
-          "segments": [
-            {
-              "kind": "table",
-              "headers": [
-                "letter",
-                "sound",
-                "tongue"
-              ],
-              "columns": 3,
-              "rowCount": 3,
-              "utterances": [
-                "letter: ந. sound: na. tongue: against the teeth (dental).",
-                "letter: ன. sound: ṉa. tongue: on the ridge behind the teeth (alveolar).",
-                "letter: ண. sound: ṇa. tongue: curled back to the roof (retroflex)."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Move backward: teeth becomes ridge becomes curled roof. English spells all three with one letter and initially hears them as the same sound; Tamil uses separate letters because its words depend on the contrast."
-            },
-            {
-              "kind": "speech",
-              "text": "You will draw ந and ன when nandri needs them. For now compare the last pair: ண is ன with one extra arch. Both open with a top bar and loop and finish with the same vertical. ன has one middle arch; ண has two."
-            },
-            {
-              "kind": "speech",
-              "text": "Retroflex sounds occur across unrelated South Asian language families. That shared geography makes the region a linguistic area: neighbors can borrow a sound pattern without inheriting it from one ancestor."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "dental ந at the teeth",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: dental ந at the teeth]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "alveolar ன at the ridge",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: alveolar ன at the ridge]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "retroflex ண with the tongue curled back",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: retroflex ண with the tongue curled back]"
-            },
-            {
-              "kind": "prompt",
-              "action": "TRACE",
-              "instruction": "one arch in ன, two arches in ண",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU TRACE: one arch in ன · two arches in ண]"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "How many n-letters does Tamil have? (Three.) What separates them? (Tongue position: dental, alveolar, retroflex.) Which two differ by one arch? (ன has one; ண has two.) Next: remove the vowel from a consonant."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-W03-pulli-vanakkam",
-      "sequence": 140,
-      "title": "் (puḷḷi) — the dot that leaves both letters visible",
-      "headword": "்",
-      "romanization": "puḷḷi",
-      "gloss": "the puḷḷi — a visible dot that removes the inherent vowel without creating a conjunct",
-      "script": "tamil",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block",
-        "sight-cue"
-      ],
-      "sourceHash": "fnv1a64:9d8862d16c87f51c",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page",
-          "your eyes, because the lesson points at something written down"
-        ],
-        "waitUntilStopped": [
-          "Script you'll notice: The puḷḷi",
-          "Script you'll notice: What Tamil does not do",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script you'll notice: The puḷḷi, Script you'll notice: What Tamil does not do and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Every consonant carries a built-in a. So how do you write a consonant with no vowel — the k in vaṇakkam, or the m at the end?"
-            },
-            {
-              "kind": "speech",
-              "text": "One dot."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script you'll notice: The puḷḷi",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "க = ka becomes க் = k."
-            },
-            {
-              "kind": "speech",
-              "text": "புள்ளி (puḷḷi) means simply \"the dot.\" Written above a letter, it removes the inherent vowel. That's the whole rule."
-            },
-            {
-              "kind": "speech",
-              "text": "A standing note for this whole track. These lessons quote real Tamil words and examples, and most of them contain letters the track has not taught you to draw yet — puḷḷi's own name uses ப, ள and the ு sign, and the comparisons below reach for others again. Read anything printed here; only draw the letters a lesson has actually broken into strokes. The data file behind this track covers 11 letters so far and says so (complete: false) — it grows as the chapters need it."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "script",
-          "title": "Script you'll notice: What Tamil does not do",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "If you have done the Devanagari track, this is the moment to notice a real divergence."
-            },
-            {
-              "kind": "speech",
-              "text": "In Devanagari, killing the vowel makes the bare consonant fuse with the next one into a squeezed conjunct — स् + त becomes स्त, and the first letter loses its spine. The virama usually disappears into the ligature."
-            },
-            {
-              "kind": "speech",
-              "text": "Tamil doesn't do that. The dot stays visible, and both letters keep their full shape:"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "",
-                ""
-              ],
-              "columns": 2,
-              "rowCount": 2,
-              "utterances": [
-                "Devanagari, स् + त becomes स्त — a new fused shape.",
-                "Tamil, க் + க becomes க்க — two letters, dot intact."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "The consequence is arithmetic. Tamil's whole set is 247 characters: 12 vowels + 18 consonants + the 216 consonant-vowel combinations + the āytam ஃ. That is genuinely all of them. Devanagari's conjuncts run to many hundreds of ligature shapes on top of its letters, each to be learned or at least recognised."
-            },
-            {
-              "kind": "speech",
-              "text": "(One honest exception: Tamil does have a few ligatures borrowed with Sanskrit words — க்ஷ kṣa and ஸ்ரீ śrī. They sit outside the 18 native consonants and outside the 247.)"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "க் — \"க, then the dot above\"",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: க் — \"க, then the dot above\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "க்க — two full letters, dot intact, no fusing",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: க்க — two full letters, dot intact, **no fusing**]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does the puḷḷi do, and what does the word mean? (Removes the inherent vowel; puḷḷi is simply \"the dot\".) What does Devanagari do that Tamil doesn't? (Fuses the letters into a conjunct — Tamil keeps both shapes and the dot.) What does Tamil get in exchange? (A much smaller character set — 247, with almost no ligatures: only the borrowed க்ஷ and ஸ்ரீ.) Next: assemble that visible dot into வணக்கம் (vaṇakkam)."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-W03-write-vanakkam",
-      "sequence": 150,
-      "title": "வணக்கம் (vaṇakkam) — the first whole written word",
-      "headword": "வணக்கம்",
-      "romanization": "vaṇakkam",
-      "gloss": "assemble the first greeting and hold its doubled consonant",
-      "script": "tamil",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:fe21150d048b0f05",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script you'll notice: Build the word",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: Build the word and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "You know the four letter bodies and the vowel-killing dot. Assemble them left to right."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script you'll notice: Build the word",
-          "segments": [
-            {
-              "kind": "table",
-              "headers": [
-                "piece",
-                "",
-                ""
-              ],
-              "columns": 3,
-              "rowCount": 5,
-              "utterances": [
-                "piece: வ, va, Lesson 1.",
-                "piece: ண, ṇa, Lesson 2.",
-                "piece: க், k — க with the dot, last lesson.",
-                "piece: க, ka, Lesson 1.",
-                "piece: ம், m — ம with the dot, this lesson."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "வ, ண, க், க, ம் becomes வணக்கம் (vaṇakkam)."
-            },
-            {
-              "kind": "speech",
-              "text": "Hear two details. க்க is a doubled consonant: hold it, vaṇak-kam, not vaṇakam. Tamil distinguishes single from double consonants. Final ம் is a bare m, so the word closes instead of trailing into ma."
-            },
-            {
-              "kind": "speech",
-              "text": "That is the first word of this book, written by hand."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "க் — க with the dot",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: க் — க with the dot]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "க்க — two full letters, dot intact",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: க்க — two full letters, dot intact]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "வணக்கம் (vaṇakkam) — five pieces, left to right",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: **வணக்கம்** — five pieces, left to right]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"vaṇak-kam\" — hold the middle",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"vaṇa**k-k**am\" — hold the middle]"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Write வணக்கம் (vaṇakkam). What is special about க்க? (It is doubled and held.) Why does the word end in m, not ma? (Final ம் carries a puḷḷi.) Next: write the letters and vowel sign inside nandri."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-W04-vowel-signs-nandri",
-      "sequence": 160,
-      "title": "ந, ன, ற (na, ṉa, ṟa) — the letter bodies inside நன்றி",
-      "headword": "ந, ன, ற",
-      "romanization": "na, ṉa, ṟa",
-      "gloss": "write the remaining two n-letters and the hard r needed for நன்றி",
-      "script": "tamil",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:0396b3f438d3d484",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script you'll notice: The two remaining n's",
-          "Script you'll notice: ற — \"ṟa\", the hard r",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The two remaining n's, Script you'll notice: ற — \"ṟa\", the hard r and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Lesson 2 showed you that Tamil has three n-letters and promised you'd draw the other two when a word needed them. Chapter 1's thank you needs both."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script you'll notice: The two remaining n's",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ந — na, the dental n, tongue against the teeth:"
-            },
-            {
-              "kind": "speech",
-              "text": "a straight top bar."
-            },
-            {
-              "kind": "speech",
-              "text": "a vertical on the left."
-            },
-            {
-              "kind": "speech",
-              "text": "a second vertical in the middle."
-            },
-            {
-              "kind": "speech",
-              "text": "a right stroke that curls below the baseline and sweeps left into a descender."
-            },
-            {
-              "kind": "speech",
-              "text": "ன — ṉa, the alveolar n, tongue on the ridge behind the teeth:"
-            },
-            {
-              "kind": "speech",
-              "text": "a straight top bar."
-            },
-            {
-              "kind": "speech",
-              "text": "a loop on the left."
-            },
-            {
-              "kind": "speech",
-              "text": "one arch."
-            },
-            {
-              "kind": "speech",
-              "text": "a straight vertical on the right, down to the baseline."
-            },
-            {
-              "kind": "speech",
-              "text": "Compare it with Lesson 2's ண: same top bar, same loop, same closing vertical. ண simply has a second arch inserted before that vertical. So ன is ண minus one arch — one arch for ன, two for ண. That is the whole contrast, and it is the cheapest way to keep them apart."
-            },
-            {
-              "kind": "speech",
-              "text": "With Lesson 2's ண (retroflex), that completes the set. Same consonant to an English ear; three letters, three tongue positions, in Tamil."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "script",
-          "title": "Script you'll notice: ற — \"ṟa\", the hard r",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "two arches side by side — giving it three legs down to the baseline."
-            },
-            {
-              "kind": "speech",
-              "text": "the right leg keeps going below the baseline, sweeps left, and drops into a long descender."
-            },
-            {
-              "kind": "speech",
-              "text": "It is the tallest thing you have drawn: most Tamil letters sit on the baseline, and ற hangs well beneath it."
-            },
-            {
-              "kind": "speech",
-              "text": "The dot under ṟ marks it as the hard or trilled r, distinct from Tamil's other r. You'll meet the contrast properly later; for now, learn the shape."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "ந — \"top bar, two verticals, then the curl that sweeps left\"",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: ந — \"top bar, **two** verticals, then the curl that sweeps left\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "ன — \"top bar, left loop, one arch, straight vertical\"",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: ன — \"top bar, left loop, **one** arch, straight vertical\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "ற — \"two arches, then the leg that sweeps left and drops\"",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: ற — \"two arches, then the leg that sweeps left and drops\"]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Name Tamil's three n-letters and their tongue positions. (ந dental, ன alveolar, ண retroflex.) What are a consonant's three possibilities so far? (Keep the built-in a or remove it with the puḷḷi.) Which letter hangs below the baseline? (ற, the hard ṟ.) Next: replace the vowel, assemble நன்றி, and hear why English often writes nandri."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-W04-i-sign-write-nandri",
-      "sequence": 170,
-      "title": "ி and நன்றி — replace the vowel, then hear ndr",
-      "headword": "ி, நன்றி",
-      "romanization": "i, naṉṟi / nandri",
-      "gloss": "replace the inherent vowel with i, assemble நன்றி, and hear nasal-triggered voicing",
-      "script": "tamil",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:fc6618acb28f2b17",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script you'll notice: The first vowel sign",
-          "Script you'll notice: Assemble நன்றி",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The first vowel sign, Script you'll notice: Assemble நன்றி and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "A consonant can keep a or lose it under a puḷḷi. The third option is to replace it with a vowel sign."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script you'll notice: The first vowel sign",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ற = ṟa becomes றி = ṟi."
-            },
-            {
-              "kind": "speech",
-              "text": "ி is a hook above and to the right. The consonant keeps its shape; the sign hangs from it. Later, ை (ai) will appear before its consonant on the page but after it in speech, the same eye/ear trap as Devanagari ि."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "script",
-          "title": "Script you'll notice: Assemble நன்றி",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ந, ன், றி becomes நன்றி."
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "piece",
-                "",
-                ""
-              ],
-              "columns": 3,
-              "rowCount": 3,
-              "utterances": [
-                "piece: ந, na — dental, last lesson.",
-                "piece: ன், ṉ — alveolar, with puḷḷi, Lessons 3–4.",
-                "piece: றி, ṟi — ற plus the i-sign, this lesson."
-              ]
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "pronunciation",
-          "title": "Sounds you'll need: Why nandri has a d-sound",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ன் + ற is pronounced close to ndr. This follows a broader Tamil rule: a nasal voices the stop after it."
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "",
-                "",
-                ""
-              ],
-              "columns": 3,
-              "rowCount": 3,
-              "utterances": [
-                "ந் + த, nd, வந்து vandu.",
-                "ண் + ட, ṇḍ, retroflex pair.",
-                "ன் + ற, ndr, நன்றி."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "Each n-letter creates its own cluster. That payoff explains both the three spellings and the common English romanization nandri, whose d is heard but not separately written."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "றி — ற plus the hook above right",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: றி — ற plus the hook above right]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "நன்றி — three pieces",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: **நன்றி** — three pieces]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"ன் + ற = ndr\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"ன் + ற = **ndr**\"]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What are a consonant's three vowel choices? (Keep inherent a, remove it with puḷḷi, or replace it with a vowel sign.) Where does ி attach? (Above and right.) Why is naṉṟi often written nandri? (ன் + ற is pronounced ndr because a nasal voices the following stop.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "TA-C01-aam",
-      "sequence": 180,
+      "sequence": 30,
       "title": "ஆம் (ām) — \"yes\"",
       "headword": "ஆம்",
       "romanization": "",
@@ -1599,7 +266,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:96c6bb2306442e1b",
+      "sourceHash": "fnv1a64:ce84e297bd916c0f",
       "notice": null,
       "blocks": [
         {
@@ -1695,206 +362,7 @@
             },
             {
               "kind": "speech",
-              "text": "Say ஆம் (ām). What does ஆமாம் add? (Emphasis — \"yes, indeed.\") Next: writing it."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-W05-write-aam",
-      "sequence": 182,
-      "title": "ஆம் (ām) — writing a word that starts with a vowel",
-      "headword": "ஆம்",
-      "romanization": "ām",
-      "gloss": "a word that begins with a vowel gets a full vowel letter, not a sign",
-      "script": "tamil",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:d2d9939892304061",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script you'll notice: a vowel standing alone",
-          "Script you'll notice: build the word",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: a vowel standing alone, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Every vowel sign so far has hooked onto a consonant — the ி on ற. This word has no consonant to hook onto."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script you'll notice: a vowel standing alone",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Tamil writes a vowel two ways, and which one you use depends on where it sits:"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "",
-                ""
-              ],
-              "columns": 2,
-              "rowCount": 2,
-              "utterances": [
-                "inside a word, after a consonant, a small sign — ி in றி.",
-                "starting a word, with nothing before it, a full independent letter."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "ஆ is the independent letter for long ā. It is not a sign and never hangs off anything; it is a letter in its own right."
-            },
-            {
-              "kind": "speech",
-              "text": "Long ā is short அ plus a tail, so அ is where it starts — and you have not been shown that one yet. Its parts, then the tail:"
-            },
-            {
-              "kind": "speech",
-              "text": "a curl at the upper left."
-            },
-            {
-              "kind": "speech",
-              "text": "a long horizontal stroke."
-            },
-            {
-              "kind": "speech",
-              "text": "a straight vertical on the right — that is அ."
-            },
-            {
-              "kind": "speech",
-              "text": "a tail added on the right — and now it is ஆ."
-            },
-            {
-              "kind": "speech",
-              "text": "Those are the parts in writing order. Where the pen lifts is not settled: Tamil handwriting varies by region and by school, and this book only claims a pen path where it has a sourced one."
-            },
-            {
-              "kind": "speech",
-              "text": "That is a rule, not a special case: any Tamil word that opens on a vowel opens with a full vowel letter."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "script",
-          "title": "Script you'll notice: build the word",
-          "segments": [
-            {
-              "kind": "table",
-              "headers": [
-                "piece",
-                "",
-                ""
-              ],
-              "columns": 3,
-              "rowCount": 2,
-              "utterances": [
-                "piece: ஆ, ā, this lesson — independent.",
-                "piece: ம், m — ம with the puḷḷi, the dot you already know."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "ஆ, ம் becomes ஆம் (ām)."
-            },
-            {
-              "kind": "speech",
-              "text": "Two pieces only. The puḷḷi on ம் closes the word on a bare m, exactly as it did at the end of வணக்கம் (vaṇakkam)."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "அ — curl, horizontal, right vertical",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: **அ** — curl, horizontal, right vertical]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "ஆ — the same three parts, then the right-hand tail",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: **ஆ** — the same three parts, then the right-hand tail]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "ம் — ம with the dot",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: **ம்** — ம with the dot]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "ஆம் (ām) — two pieces, left to right",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: **ஆம்** — two pieces, left to right]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Write ஆம் (ām). When does a Tamil vowel get a full letter instead of a sign? (When it starts a word — nothing precedes it to hook onto.) What closes the word? (ம் — the puḷḷi on ம.) Next: the word for no."
+              "text": "Say ஆம். What does ஆமாம் add? (Emphasis — \"yes, indeed.\") Next: the word for no."
             }
           ]
         }
@@ -1902,7 +370,7 @@
     },
     {
       "id": "TA-C01-illai",
-      "sequence": 190,
+      "sequence": 40,
       "title": "இல்லை (illai) — \"no\"",
       "headword": "இல்லை",
       "romanization": "",
@@ -1913,7 +381,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:beee25438cdb89ae",
+      "sourceHash": "fnv1a64:fab96586503e281c",
       "notice": null,
       "blocks": [
         {
@@ -2009,211 +477,7 @@
             },
             {
               "kind": "speech",
-              "text": "Say இல்லை (illai). Is it closer to English no, or to is not? (Is not — it is a statement, not a label.) Next: writing it."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-W06-write-illai",
-      "sequence": 192,
-      "title": "இல்லை (illai) — a vowel in front, a vowel sign behind",
-      "headword": "இல்லை",
-      "romanization": "illai",
-      "gloss": "a second independent vowel, the letter ல, and the left-standing ai sign",
-      "script": "tamil",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:355d80e464a1c094",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script you'll notice: இ and ல",
-          "Script you'll notice: build the word",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: இ and ல, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Last lesson gave you the rule: a word opening on a vowel opens with a full letter. Here is the same rule with a different vowel, plus one new sign."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script you'll notice: இ and ல",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "இ is the independent letter for short i — the same job ஆ did, one vowel over. Its parts, in writing order:"
-            },
-            {
-              "kind": "speech",
-              "text": "a crossing spiral on the left."
-            },
-            {
-              "kind": "speech",
-              "text": "a tall straight vertical on the right."
-            },
-            {
-              "kind": "speech",
-              "text": "ல is la, with its built-in a like every consonant:"
-            },
-            {
-              "kind": "speech",
-              "text": "a curl that turns back on itself."
-            },
-            {
-              "kind": "speech",
-              "text": "a stroke rising to the right."
-            },
-            {
-              "kind": "speech",
-              "text": "Put the puḷḷi on it and you get ல், a bare l."
-            },
-            {
-              "kind": "speech",
-              "text": "The new mark is ை, the sign for ai, and it does something ி did not. It is written to the LEFT of its consonant, but pronounced after it."
-            },
-            {
-              "kind": "speech",
-              "text": "ல + ை becomes லை, and on the page the hook stands before the ல — yet you say lai, not ail."
-            },
-            {
-              "kind": "speech",
-              "text": "Your eye meets the vowel first and your mouth says it second. Devanagari does the same thing with ि, and it catches everyone once."
-            },
-            {
-              "kind": "speech",
-              "text": "Tamil keeps three l-letters (ல ள ழ) and two r-letters (ர ற), the same way it keeps three n's. This is the first of the l's."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "script",
-          "title": "Script you'll notice: build the word",
-          "segments": [
-            {
-              "kind": "table",
-              "headers": [
-                "piece",
-                "",
-                ""
-              ],
-              "columns": 3,
-              "rowCount": 3,
-              "utterances": [
-                "piece: இ, i, independent — the word opens on a vowel.",
-                "piece: ல், l — ல with the puḷḷi, bare consonant.",
-                "piece: லை, lai — ல with the ai sign, this lesson."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "இ, ல், லை becomes இல்லை (illai)."
-            },
-            {
-              "kind": "speech",
-              "text": "The ல் + லை is a doubled l, held like the க்க of vaṇakkam: il-lai, not ilai."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "இ — spiral, then the right-hand vertical",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: **இ** — spiral, then the right-hand vertical]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "ல — curl, then rising stroke",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: **ல** — curl, then rising stroke]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "லை — the ai hook goes on the LEFT",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: **லை** — the ai hook goes on the LEFT]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "இல்லை (illai) — three pieces",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: **இல்லை** — three pieces]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"il-lai\" — hold the doubled l",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"il-lai\" — hold the doubled *l*]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Write இல்லை (illai). Why does it open with இ rather than a sign? (The word starts on a vowel.) Which side of its consonant does ை sit on? (The left — written first, spoken second.) Next: the word for thank you."
+              "text": "Say இல்லை. Is it closer to English no, or to is not? (Is not — it is a statement, not a label.) Next: the word for thank you."
             }
           ]
         }
@@ -2221,7 +485,7 @@
     },
     {
       "id": "TA-C01-nandri",
-      "sequence": 200,
+      "sequence": 50,
       "title": "நன்றி (naṉṟi) — \"thank you\"",
       "headword": "நன்றி",
       "romanization": "",
@@ -2232,7 +496,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d08803bcdd6448e5",
+      "sourceHash": "fnv1a64:eabaf0f0e3333bf6",
       "notice": null,
       "blocks": [
         {
@@ -2336,7 +600,7 @@
     },
     {
       "id": "TA-C01-nandri-family-register",
-      "sequence": 210,
+      "sequence": 60,
       "title": "நன்றி — a native family word with a register edge",
       "headword": "நன்றி / നന്ദി",
       "romanization": "",
@@ -2347,7 +611,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:df441fa9eb2d1a4a",
+      "sourceHash": "fnv1a64:60338f1932bc98d3",
       "notice": null,
       "blocks": [
         {
@@ -2471,7 +735,7 @@
     },
     {
       "id": "TA-C01-sari",
-      "sequence": 220,
+      "sequence": 70,
       "title": "சரி (sari) — \"okay\"",
       "headword": "சரி",
       "romanization": "",
@@ -2482,7 +746,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c6020b573775bf3a",
+      "sourceHash": "fnv1a64:17d7a2c78ef6c9c9",
       "notice": null,
       "blocks": [
         {
@@ -2578,187 +842,7 @@
             },
             {
               "kind": "speech",
-              "text": "Say சரி (sari). What does doubling it add? (Hurry, or easy agreement — \"yes yes, fine.\") Next: writing it."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-W07-write-sari",
-      "sequence": 222,
-      "title": "சரி (sari) — one letter, several sounds",
-      "headword": "சரி",
-      "romanization": "sari",
-      "gloss": "one letter for a whole family of sounds — ச — and the second r",
-      "script": "tamil",
-      "modality": "pen",
-      "derivedModality": "pen",
-      "modalityReasons": [
-        "writing-type",
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:235103e17e063c6b",
-      "notice": {
-        "modality": "pen",
-        "needs": [
-          "a pen and something to write on",
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "Script you'll notice: ச and ர",
-          "Script you'll notice: build the word",
-          "Guided Practice"
-        ],
-        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ச and ர, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "You have seen க cover k, g and a soft h depending on where it sits. Here is the same economy on a second letter."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "Script you'll notice: ச and ர",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ச is written once and does the work English splits between s, ch and j. Position picks which:"
-            },
-            {
-              "kind": "table",
-              "headers": [
-                "where",
-                "sound"
-              ],
-              "columns": 2,
-              "rowCount": 3,
-              "utterances": [
-                "where: starting a word. sound: s or ch.",
-                "where: between vowels. sound: softened.",
-                "where: after a nasal, as in ஞ்ச. sound: j."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "That is exactly the pattern க showed — k at the start, g after a nasal, a soft h between vowels. One letter per position of the mouth, and context fills in the rest."
-            },
-            {
-              "kind": "speech",
-              "text": "ர is ra, with its built-in a. It is the other of Tamil's two r-letters, alongside the ற you met in நன்றி."
-            },
-            {
-              "kind": "speech",
-              "text": "Read both letters here; do not draw them yet. This book gives a stroke order only where it has a sourced one, and ச and ர do not have one yet."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "script",
-          "title": "Script you'll notice: build the word",
-          "segments": [
-            {
-              "kind": "table",
-              "headers": [
-                "piece",
-                "",
-                ""
-              ],
-              "columns": 3,
-              "rowCount": 2,
-              "utterances": [
-                "piece: ச, sa here, this lesson.",
-                "piece: ரி, ri — ர with the ி sign, the sign from நன்றி."
-              ]
-            },
-            {
-              "kind": "speech",
-              "text": "ச, ரி becomes சரி (sari)."
-            },
-            {
-              "kind": "speech",
-              "text": "Two pieces, and both parts are things you already hold: a consonant, and the vowel sign you first hooked onto ற."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "READ",
-              "instruction": "ச — then சரி (sari)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU READ: **ச** — then **சரி**]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"sari\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"sari\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "CONTRAST",
-              "instruction": "ரி and லை — the ி sign follows its letter, the ை sign precedes it",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU CONTRAST: **ரி** and **லை** — the ி sign follows its letter, the ை sign precedes it]"
-            },
-            {
-              "kind": "prompt",
-              "action": "WRITE",
-              "instruction": "ஆம் (ām) and இல்லை (illai) again, from memory — yes and no, the two you will reach for most",
-              "spoken": false,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU WRITE: **ஆம்** and **இல்லை** again, from memory — yes and no, the two you will reach for most]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Read சரி (sari). Which English sounds does ச cover on its own? (s or ch at the start, softened between vowels, j after a nasal.) How many r-letters does Tamil keep? (Two — ர and ற.) In லை, which side of the ல does the ai sign sit on? (The left.) And why does இல்லை (illai) open with இ rather than a sign? (It starts on a vowel.) Next: putting the five words together."
+              "text": "Say சரி. What does doubling it add? (Hurry, or easy agreement — \"yes yes, fine.\") Next: putting the five words together."
             }
           ]
         }
@@ -2766,7 +850,7 @@
     },
     {
       "id": "TA-C01-answering",
-      "sequence": 230,
+      "sequence": 80,
       "title": "Putting the five together — how Tamil answers",
       "headword": "ஆம் / இல்லை / சரி",
       "romanization": "",
@@ -2777,7 +861,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a0ce2d20f0c139e8",
+      "sourceHash": "fnv1a64:e3574d76d640bfad",
       "notice": null,
       "blocks": [
         {
@@ -2808,7 +892,7 @@
             },
             {
               "kind": "speech",
-              "text": "— வணக்கம் (vaṇakkam). — வணக்கம் (vaṇakkam). — சரி (sari)? — ஆம் (ām). — நன்றி. — சரி (sari). — Hello. — Hello. — Alright? — Yes. — Thank you. — Alright."
+              "text": "— வணக்கம். — வணக்கம். — சரி? — ஆம். — நன்றி. — சரி. — Hello. — Hello. — Alright? — Yes. — Thank you. — Alright."
             },
             {
               "kind": "speech",
@@ -2908,7 +992,7 @@
     },
     {
       "id": "TA-C01-practice",
-      "sequence": 240,
+      "sequence": 90,
       "title": "Chapter 1 — recap, and how Tamil says goodbye",
       "headword": "(recap)",
       "romanization": "",
@@ -2919,7 +1003,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:de8fee8d6b42c1e3",
+      "sourceHash": "fnv1a64:c81d31ec864320b8",
       "notice": null,
       "blocks": [
         {
@@ -2935,39 +1019,39 @@
             },
             {
               "kind": "speech",
-              "text": "Five words, and with them a first handful of Tamil letters read straight off the page. Let's gather them — and add the farewell, which carries a small piece of Tamil culture."
+              "text": "Five words, all of them said and none of them written. Let's gather them — and add the farewell, which carries a small piece of Tamil culture."
             }
           ]
         },
         {
           "index": 1,
           "type": "unknown",
-          "title": "Read them back",
+          "title": "Say them back",
           "segments": [
             {
               "kind": "speech",
-              "text": "Sound each out, left to right, before checking:"
+              "text": "Say each one before you check the meaning:"
             },
             {
               "kind": "table",
               "headers": [
-                "Read",
+                "",
                 "",
                 "Meaning"
               ],
               "columns": 3,
               "rowCount": 5,
               "utterances": [
-                "Read: வணக்கம், vaṇakkam. Meaning: hello / greetings.",
-                "Read: நன்றி, naṉṟi. Meaning: thank you.",
-                "Read: ஆம், ām. Meaning: yes.",
-                "Read: இல்லை, illai. Meaning: no / there isn't.",
-                "Read: சரி, sari. Meaning: okay / correct."
+                "வணக்கம், vaṇakkam. Meaning: hello / greetings.",
+                "நன்றி, naṉṟi. Meaning: thank you.",
+                "ஆம், ām. Meaning: yes.",
+                "இல்லை, illai. Meaning: no / there isn't.",
+                "சரி, sari. Meaning: okay / correct."
               ]
             },
             {
               "kind": "speech",
-              "text": "The letters that did it: consonants carry a built-in \"a\"; a puḷḷi dot removes it; a vowel sign (like ி for \"i,\" ை for \"ai\") swaps the built-in vowel; and a word-initial vowel gets a full letter (ஆ, இ). Plus the big idea — Tamil hears three n's, three l's, two r's, and lets one letter stand for several stop-sounds."
+              "text": "The Tamil is printed beside each word on purpose. You are not expected to read it yet and nothing here will ask you to — but five words is a good number of shapes to start getting used to. Writing begins in chapter 4, and by then every letter you meet will spell a word you already say."
             }
           ]
         },
@@ -2986,7 +1070,7 @@
             },
             {
               "kind": "speech",
-              "text": "And the reply is போய் வா (pōy vā) — \"go, and come [back].\" You never sign off with a bare \"I am going\": saying only \"I go\" sounds ominous, like a final departure. So you promise a return — go and come back — every single time. It's a whole worldview folded into a goodbye. (You can also simply repeat வணக்கம் (vaṇakkam), which works to part as well as to meet.)"
+              "text": "And the reply is போய் வா (pōy vā) — \"go, and come [back].\" You never sign off with a bare \"I am going\": saying only \"I go\" sounds ominous, like a final departure. So you promise a return — go and come back — every single time. It's a whole worldview folded into a goodbye. (You can also simply repeat வணக்கம், which works to part as well as to meet.)"
             }
           ]
         },
@@ -3043,7 +1127,7 @@
             },
             {
               "kind": "speech",
-              "text": "Read all five words aloud. What does the everyday Tamil goodbye literally mean, and why isn't it just \"I'm leaving\"? (\"I'll go and come back\" — a bare \"I go\" sounds like a final parting, so you promise a return.) What does a puḷḷi do? (Removes a consonant's built-in a.)"
+              "text": "Say all five words aloud. What does the everyday Tamil goodbye literally mean, and why isn't it just \"I'm leaving\"? (\"I'll go and come back\" — a bare \"I go\" sounds like a final parting, so you promise a return.) Which of the five works both to meet someone and to part from them? (வணக்கம்.)"
             },
             {
               "kind": "speech",

--- a/code/learning/human-languages/tamil/narration/ch01.txt
+++ b/code/learning/human-languages/tamil/narration/ch01.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 1: Greetings.
-20 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
+9 lessons. All 9 can be done entirely by ear.
 
 
-Lesson 1 of 20.
+Lesson 1 of 9.
 வணக்கம் (vaṇakkam) — "greetings".
 
 Warm-up.
@@ -26,11 +26,11 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-Say வணக்கம் (vaṇakkam). Does it change between morning and evening? (No — one greeting, all day.) Does it change for one person or a crowd? (No.) Next: the same greeting across the Dravidian family.
+Say வணக்கம். Does it change between morning and evening? (No — one greeting, all day.) Does it change for one person or a crowd? (No.) Next: the same greeting across the Dravidian family.
 
 
-Lesson 2 of 20.
-வணக்கம் (vaṇakkam) — one bow, two lexical loyalties.
+Lesson 2 of 9.
+வணக்கம் — one bow, two lexical loyalties.
 
 Warm-up.
 [pause 2 seconds]
@@ -55,7 +55,7 @@ Guided Practice.
 [pause 8 seconds for the answer]
 [your turn — contrast: Tamil vaṇaṅku, neighbors Sanskrit namas-]
 [pause 8 seconds for the answer]
-[your turn — choose: greeting or parting becomes வணக்கம் (vaṇakkam) works]
+[your turn — choose: greeting or parting becomes வணக்கம் works]
 [pause 8 seconds for the answer]
 
 Wrap-up Recall.
@@ -63,301 +63,7 @@ Wrap-up Recall.
 Which Dravidian language kept its native bow-word? (Tamil.) What did the neighbors borrow? (Sanskrit namas-.) Can vaṇakkam greet and part? (Yes — it is an all-day respectful salutation.)
 
 
-Lesson 3 of 20.
-Tamil's curves — the writing surface leaves a trace.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script you'll notice: The script is the shape of its writing surface and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Before the first letter, look at a line of Tamil and notice what isn't there:
-வணக்கம் (vaṇakkam).
-Nothing joins the letters together, and there are far fewer corners than in Devanagari — no hanging head-line, and a great deal of curve. (Straight strokes do exist: most of these letters have a flat bar across the top.) The roundness has a usual explanation, and it is the best story in this chapter.
-
-Script you'll notice: The script is the shape of its writing surface.
-Tamil was written for centuries on palm leaves, scratched with a metal stylus and then rubbed with soot to make the scratches show.
-A palm leaf has a grain, like wood. Draw a long straight line along that grain and the stylus can split the leaf. The usual account is that scribes bent their strokes in response: a curve crosses the fibres at an angle instead of running with them.
-Treat that as the standard explanation rather than a settled fact. The earliest Tamil writing — Tamil-Brahmi, cut into stone and pottery — is noticeably angular; the rounding came later, through the Vaṭṭeḻuttu ("round script") stage. And Devanagari was written on the same leaves without going round. So the leaf is one pressure among several, not a complete answer.
-It is still worth carrying, because it makes the right general point: the tool leaves fingerprints on the letters. Latin's straight strokes suit a wax tablet and a chisel; Tamil's curves suit a stylus and a leaf.
-
-Guided Practice.
-[pause 1 second]
-[once you have stopped driving — trace: a curve crossing the imagined grain of a palm leaf]
-[your turn — contrast: angular Tamil-Brahmi, later rounded Vaṭṭeḻuttu]
-[pause 8 seconds for the answer]
-[your turn — say: the usual reason for the curves — "a straight line can split the leaf"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Why is Tamil round? (The usual explanation: it was incised on palm leaves, where a straight stroke along the grain can split them — though early Tamil-Brahmi was angular, so it is not the whole story.) What broader point does the account teach? (Tools and surfaces leave fingerprints on scripts.) Next: the vowel hidden inside a consonant, then வ and க.
-[question — say your answer, then pause 8 seconds]
-What writing surface is usually linked to Tamil's rounded shapes?
-
-
-Lesson 4 of 20.
-வ and க — the vowel inside each consonant.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The vowel you get for free, Script you'll notice: வ — "va", Script you'll notice: க — "ka" and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Tamil's letters do not join and they carry many curves. Now learn the sound that arrives for free inside every consonant.
-
-Script you'll notice: The vowel you get for free.
-Tamil is an abugida, like Devanagari: a consonant already contains a vowel.
-க is not "k". க is "ka".
-Every consonant carries a built-in a until a later mark removes or replaces it.
-
-Script you'll notice: வ — "va".
-a near-closed loop on the left.
-a full-height arm across the top, ending in a descender on the right.
-
-Script you'll notice: க — "ka".
-a straight horizontal top bar.
-a bowl hanging from its left end.
-a short right stroke that hooks left below.
-
-Sounds you'll need: One letter, three sounds.
-Devanagari separates क, ख, ग, घ. Tamil uses க across that space: k at the start of a word and when doubled (க்க), g after a nasal (ங்க), and a softer h-like sound between vowels. Position, not a new spelling, selects the sound.
-Tamil therefore needs only 18 consonant letters where Devanagari needs 33; its native words do not depend on those written distinctions.
-
-Guided Practice.
-[pause 1 second]
-[once you have stopped driving — write: வ — "left loop, top arm, descender"]
-[once you have stopped driving — write: க — "top bar, left bowl, hooking right stroke"]
-[your turn — say: "க is ka, not k"]
-[pause 8 seconds for the answer]
-[your turn — contrast: initial k, after a nasal g, between vowels soft h]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does க say alone? (Ka — the vowel is inherent.) What kind of script is this? (An abugida.) Which sounds can க spell? (k, g, and a softer h-like sound, chosen by position.) Draw வ and க.
-
-
-Lesson 5 of 20.
-ம and ண — a loop, and a curled tongue.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ம, Script you'll notice: ண and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Two more letters, and with them you'll have every letter of this book's first word. One is easy. The other is a sound you may not be able to hear yet.
-
-Script you'll notice: ம.
-a straight vertical stroke on the LEFT.
-a horizontal along the bottom.
-a rounded arch closing it on the RIGHT.
-Get the sides the right way round. The upright is on the left and the curve on the right — which is the reverse of what most people guess, and the reverse of the Devanagari habit of hanging a shape off a right-hand spine.
-
-Script you'll notice: ண.
-a straight top bar.
-a loop on the left.
-two arches.
-a straight vertical on the right, down to the baseline.
-The dot under the romanization — ṇ, not plain n — is doing real work.
-
-Sounds you'll need: Retroflex.
-Say English n. Your tongue touches just behind your teeth.
-Now curl the tip of your tongue up and back toward the roof of your mouth, and say it again. That is ṇ, and it is a different letter in Tamil.
-English has no such sound and no way to write one, which is why an English speaker typically cannot hear the difference at first. That is expected. The ear learns it after the hand does, which is one good argument for writing the letters rather than only reading them.
-Retroflex sounds are a signature of the languages of India — they show up across Tamil, Telugu, Kannada, Malayalam, Hindi and Sanskrit alike, in families that are otherwise unrelated to each other. It's one of the features that makes South Asia a linguistic area: neighbouring languages that borrowed a sound from each other rather than inheriting it.
-
-Guided Practice.
-[pause 1 second]
-[once you have stopped driving — write: ம — "left upright, bottom, right arch"]
-[once you have stopped driving — write: ண — "top bar, left loop, two arches, straight vertical"]
-[your turn — say: plain n, then curl the tongue back — ṇ]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Draw ம — which side is the upright on? (The left; the arch closes it on the right.) Draw ண — what makes it not ன? (One extra arch: ண has two arches where ன has one. Both end in the same straight vertical.) What does the dot in ṇ mean? (Retroflex — the tongue curls back to the roof of the mouth.) Why can't you hear it yet? (English has no such sound; the ear learns it after the hand.) Next: place Tamil's three n's along one backward walk through the mouth.
-
-
-Lesson 6 of 20.
-ந, ன, ண (na, ṉa, ṇa) — three stops on one tongue-map.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The backward walk and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-English writes one n. Tamil keeps three tongue positions apart.
-
-Script you'll notice: The backward walk.
-[a table of 3 rows, read aloud]
-letter: ந. sound: na. tongue: against the teeth (dental).
-letter: ன. sound: ṉa. tongue: on the ridge behind the teeth (alveolar).
-letter: ண. sound: ṇa. tongue: curled back to the roof (retroflex).
-Move backward: teeth becomes ridge becomes curled roof. English spells all three with one letter and initially hears them as the same sound; Tamil uses separate letters because its words depend on the contrast.
-You will draw ந and ன when nandri needs them. For now compare the last pair: ண is ன with one extra arch. Both open with a top bar and loop and finish with the same vertical. ன has one middle arch; ண has two.
-Retroflex sounds occur across unrelated South Asian language families. That shared geography makes the region a linguistic area: neighbors can borrow a sound pattern without inheriting it from one ancestor.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: dental ந at the teeth]
-[pause 8 seconds for the answer]
-[your turn — say: alveolar ன at the ridge]
-[pause 8 seconds for the answer]
-[your turn — say: retroflex ண with the tongue curled back]
-[pause 8 seconds for the answer]
-[once you have stopped driving — trace: one arch in ன, two arches in ண]
-
-Wrap-up Recall.
-[pause 3 seconds]
-How many n-letters does Tamil have? (Three.) What separates them? (Tongue position: dental, alveolar, retroflex.) Which two differ by one arch? (ன has one; ண has two.) Next: remove the vowel from a consonant.
-
-
-Lesson 7 of 20.
-் (puḷḷi) — the dot that leaves both letters visible.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script you'll notice: The puḷḷi, Script you'll notice: What Tamil does not do and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Every consonant carries a built-in a. So how do you write a consonant with no vowel — the k in vaṇakkam, or the m at the end?
-One dot.
-
-Script you'll notice: The puḷḷi.
-க = ka becomes க் = k.
-புள்ளி (puḷḷi) means simply "the dot." Written above a letter, it removes the inherent vowel. That's the whole rule.
-A standing note for this whole track. These lessons quote real Tamil words and examples, and most of them contain letters the track has not taught you to draw yet — puḷḷi's own name uses ப, ள and the ு sign, and the comparisons below reach for others again. Read anything printed here; only draw the letters a lesson has actually broken into strokes. The data file behind this track covers 11 letters so far and says so (complete: false) — it grows as the chapters need it.
-
-Script you'll notice: What Tamil does not do.
-If you have done the Devanagari track, this is the moment to notice a real divergence.
-In Devanagari, killing the vowel makes the bare consonant fuse with the next one into a squeezed conjunct — स् + त becomes स्त, and the first letter loses its spine. The virama usually disappears into the ligature.
-Tamil doesn't do that. The dot stays visible, and both letters keep their full shape:
-[a table of 2 rows, read aloud]
-Devanagari, स् + त becomes स्त — a new fused shape.
-Tamil, க் + க becomes க்க — two letters, dot intact.
-The consequence is arithmetic. Tamil's whole set is 247 characters: 12 vowels + 18 consonants + the 216 consonant-vowel combinations + the āytam ஃ. That is genuinely all of them. Devanagari's conjuncts run to many hundreds of ligature shapes on top of its letters, each to be learned or at least recognised.
-(One honest exception: Tamil does have a few ligatures borrowed with Sanskrit words — க்ஷ kṣa and ஸ்ரீ śrī. They sit outside the 18 native consonants and outside the 247.)
-
-Guided Practice.
-[pause 1 second]
-[once you have stopped driving — write: க் — "க, then the dot above"]
-[once you have stopped driving — write: க்க — two full letters, dot intact, no fusing]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does the puḷḷi do, and what does the word mean? (Removes the inherent vowel; puḷḷi is simply "the dot".) What does Devanagari do that Tamil doesn't? (Fuses the letters into a conjunct — Tamil keeps both shapes and the dot.) What does Tamil get in exchange? (A much smaller character set — 247, with almost no ligatures: only the borrowed க்ஷ and ஸ்ரீ.) Next: assemble that visible dot into வணக்கம் (vaṇakkam).
-
-
-Lesson 8 of 20.
-வணக்கம் (vaṇakkam) — the first whole written word.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: Build the word and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-You know the four letter bodies and the vowel-killing dot. Assemble them left to right.
-
-Script you'll notice: Build the word.
-[a table of 5 rows, read aloud]
-piece: வ, va, Lesson 1.
-piece: ண, ṇa, Lesson 2.
-piece: க், k — க with the dot, last lesson.
-piece: க, ka, Lesson 1.
-piece: ம், m — ம with the dot, this lesson.
-வ, ண, க், க, ம் becomes வணக்கம் (vaṇakkam).
-Hear two details. க்க is a doubled consonant: hold it, vaṇak-kam, not vaṇakam. Tamil distinguishes single from double consonants. Final ம் is a bare m, so the word closes instead of trailing into ma.
-That is the first word of this book, written by hand.
-
-Guided Practice.
-[pause 1 second]
-[once you have stopped driving — write: க் — க with the dot]
-[once you have stopped driving — write: க்க — two full letters, dot intact]
-[once you have stopped driving — write: வணக்கம் (vaṇakkam) — five pieces, left to right]
-[your turn — say: "vaṇak-kam" — hold the middle]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Write வணக்கம் (vaṇakkam). What is special about க்க? (It is doubled and held.) Why does the word end in m, not ma? (Final ம் carries a puḷḷi.) Next: write the letters and vowel sign inside nandri.
-
-
-Lesson 9 of 20.
-ந, ன, ற (na, ṉa, ṟa) — the letter bodies inside நன்றி.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The two remaining n's, Script you'll notice: ற — "ṟa", the hard r and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Lesson 2 showed you that Tamil has three n-letters and promised you'd draw the other two when a word needed them. Chapter 1's thank you needs both.
-
-Script you'll notice: The two remaining n's.
-ந — na, the dental n, tongue against the teeth:
-a straight top bar.
-a vertical on the left.
-a second vertical in the middle.
-a right stroke that curls below the baseline and sweeps left into a descender.
-ன — ṉa, the alveolar n, tongue on the ridge behind the teeth:
-a straight top bar.
-a loop on the left.
-one arch.
-a straight vertical on the right, down to the baseline.
-Compare it with Lesson 2's ண: same top bar, same loop, same closing vertical. ண simply has a second arch inserted before that vertical. So ன is ண minus one arch — one arch for ன, two for ண. That is the whole contrast, and it is the cheapest way to keep them apart.
-With Lesson 2's ண (retroflex), that completes the set. Same consonant to an English ear; three letters, three tongue positions, in Tamil.
-
-Script you'll notice: ற — "ṟa", the hard r.
-two arches side by side — giving it three legs down to the baseline.
-the right leg keeps going below the baseline, sweeps left, and drops into a long descender.
-It is the tallest thing you have drawn: most Tamil letters sit on the baseline, and ற hangs well beneath it.
-The dot under ṟ marks it as the hard or trilled r, distinct from Tamil's other r. You'll meet the contrast properly later; for now, learn the shape.
-
-Guided Practice.
-[pause 1 second]
-[once you have stopped driving — write: ந — "top bar, two verticals, then the curl that sweeps left"]
-[once you have stopped driving — write: ன — "top bar, left loop, one arch, straight vertical"]
-[once you have stopped driving — write: ற — "two arches, then the leg that sweeps left and drops"]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Name Tamil's three n-letters and their tongue positions. (ந dental, ன alveolar, ண retroflex.) What are a consonant's three possibilities so far? (Keep the built-in a or remove it with the puḷḷi.) Which letter hangs below the baseline? (ற, the hard ṟ.) Next: replace the vowel, assemble நன்றி, and hear why English often writes nandri.
-
-
-Lesson 10 of 20.
-ி and நன்றி — replace the vowel, then hear ndr.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The first vowel sign, Script you'll notice: Assemble நன்றி and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-A consonant can keep a or lose it under a puḷḷi. The third option is to replace it with a vowel sign.
-
-Script you'll notice: The first vowel sign.
-ற = ṟa becomes றி = ṟi.
-ி is a hook above and to the right. The consonant keeps its shape; the sign hangs from it. Later, ை (ai) will appear before its consonant on the page but after it in speech, the same eye/ear trap as Devanagari ि.
-
-Script you'll notice: Assemble நன்றி.
-ந, ன், றி becomes நன்றி.
-[a table of 3 rows, read aloud]
-piece: ந, na — dental, last lesson.
-piece: ன், ṉ — alveolar, with puḷḷi, Lessons 3–4.
-piece: றி, ṟi — ற plus the i-sign, this lesson.
-
-Sounds you'll need: Why nandri has a d-sound.
-ன் + ற is pronounced close to ndr. This follows a broader Tamil rule: a nasal voices the stop after it.
-[a table of 3 rows, read aloud]
-ந் + த, nd, வந்து vandu.
-ண் + ட, ṇḍ, retroflex pair.
-ன் + ற, ndr, நன்றி.
-Each n-letter creates its own cluster. That payoff explains both the three spellings and the common English romanization nandri, whose d is heard but not separately written.
-
-Guided Practice.
-[pause 1 second]
-[once you have stopped driving — write: றி — ற plus the hook above right]
-[once you have stopped driving — write: நன்றி — three pieces]
-[your turn — say: "ன் + ற = ndr"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What are a consonant's three vowel choices? (Keep inherent a, remove it with puḷḷi, or replace it with a vowel sign.) Where does ி attach? (Above and right.) Why is naṉṟi often written nandri? (ன் + ற is pronounced ndr because a nasal voices the following stop.)
-
-
-Lesson 11 of 20.
+Lesson 3 of 9.
 ஆம் (ām) — "yes".
 
 Warm-up.
@@ -381,52 +87,10 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-Say ஆம் (ām). What does ஆமாம் add? (Emphasis — "yes, indeed.") Next: writing it.
+Say ஆம். What does ஆமாம் add? (Emphasis — "yes, indeed.") Next: the word for no.
 
 
-Lesson 12 of 20.
-ஆம் (ām) — writing a word that starts with a vowel.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: a vowel standing alone, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Every vowel sign so far has hooked onto a consonant — the ி on ற. This word has no consonant to hook onto.
-
-Script you'll notice: a vowel standing alone.
-Tamil writes a vowel two ways, and which one you use depends on where it sits:
-[a table of 2 rows, read aloud]
-inside a word, after a consonant, a small sign — ி in றி.
-starting a word, with nothing before it, a full independent letter.
-ஆ is the independent letter for long ā. It is not a sign and never hangs off anything; it is a letter in its own right.
-Long ā is short அ plus a tail, so அ is where it starts — and you have not been shown that one yet. Its parts, then the tail:
-a curl at the upper left.
-a long horizontal stroke.
-a straight vertical on the right — that is அ.
-a tail added on the right — and now it is ஆ.
-Those are the parts in writing order. Where the pen lifts is not settled: Tamil handwriting varies by region and by school, and this book only claims a pen path where it has a sourced one.
-That is a rule, not a special case: any Tamil word that opens on a vowel opens with a full vowel letter.
-
-Script you'll notice: build the word.
-[a table of 2 rows, read aloud]
-piece: ஆ, ā, this lesson — independent.
-piece: ம், m — ம with the puḷḷi, the dot you already know.
-ஆ, ம் becomes ஆம் (ām).
-Two pieces only. The puḷḷi on ம் closes the word on a bare m, exactly as it did at the end of வணக்கம் (vaṇakkam).
-
-Guided Practice.
-[pause 1 second]
-[once you have stopped driving — write: அ — curl, horizontal, right vertical]
-[once you have stopped driving — write: ஆ — the same three parts, then the right-hand tail]
-[once you have stopped driving — write: ம் — ம with the dot]
-[once you have stopped driving — write: ஆம் (ām) — two pieces, left to right]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Write ஆம் (ām). When does a Tamil vowel get a full letter instead of a sign? (When it starts a word — nothing precedes it to hook onto.) What closes the word? (ம் — the puḷḷi on ம.) Next: the word for no.
-
-
-Lesson 13 of 20.
+Lesson 4 of 9.
 இல்லை (illai) — "no".
 
 Warm-up.
@@ -450,54 +114,10 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-Say இல்லை (illai). Is it closer to English no, or to is not? (Is not — it is a statement, not a label.) Next: writing it.
+Say இல்லை. Is it closer to English no, or to is not? (Is not — it is a statement, not a label.) Next: the word for thank you.
 
 
-Lesson 14 of 20.
-இல்லை (illai) — a vowel in front, a vowel sign behind.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: இ and ல, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Last lesson gave you the rule: a word opening on a vowel opens with a full letter. Here is the same rule with a different vowel, plus one new sign.
-
-Script you'll notice: இ and ல.
-இ is the independent letter for short i — the same job ஆ did, one vowel over. Its parts, in writing order:
-a crossing spiral on the left.
-a tall straight vertical on the right.
-ல is la, with its built-in a like every consonant:
-a curl that turns back on itself.
-a stroke rising to the right.
-Put the puḷḷi on it and you get ல், a bare l.
-The new mark is ை, the sign for ai, and it does something ி did not. It is written to the LEFT of its consonant, but pronounced after it.
-ல + ை becomes லை, and on the page the hook stands before the ல — yet you say lai, not ail.
-Your eye meets the vowel first and your mouth says it second. Devanagari does the same thing with ि, and it catches everyone once.
-Tamil keeps three l-letters (ல ள ழ) and two r-letters (ர ற), the same way it keeps three n's. This is the first of the l's.
-
-Script you'll notice: build the word.
-[a table of 3 rows, read aloud]
-piece: இ, i, independent — the word opens on a vowel.
-piece: ல், l — ல with the puḷḷi, bare consonant.
-piece: லை, lai — ல with the ai sign, this lesson.
-இ, ல், லை becomes இல்லை (illai).
-The ல் + லை is a doubled l, held like the க்க of vaṇakkam: il-lai, not ilai.
-
-Guided Practice.
-[pause 1 second]
-[once you have stopped driving — write: இ — spiral, then the right-hand vertical]
-[once you have stopped driving — write: ல — curl, then rising stroke]
-[once you have stopped driving — write: லை — the ai hook goes on the LEFT]
-[once you have stopped driving — write: இல்லை (illai) — three pieces]
-[your turn — say: "il-lai" — hold the doubled l]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Write இல்லை (illai). Why does it open with இ rather than a sign? (The word starts on a vowel.) Which side of its consonant does ை sit on? (The left — written first, spoken second.) Next: the word for thank you.
-
-
-Lesson 15 of 20.
+Lesson 5 of 9.
 நன்றி (naṉṟi) — "thank you".
 
 Warm-up.
@@ -524,7 +144,7 @@ Wrap-up Recall.
 Say நன்றி. Does it need a verb to be a complete reply? (No — it stands alone.) Next: how thanks travels across the family.
 
 
-Lesson 16 of 20.
+Lesson 6 of 9.
 நன்றி — a native family word with a register edge.
 
 Warm-up.
@@ -558,7 +178,7 @@ Wrap-up Recall.
 Which sister shares Tamil's native gratitude word? (Malayalam.) What did Kannada and Telugu borrow? (Sanskrit dhanyavāda.) Why can explicit naṉṟi sound marked? (Among intimates, gratitude may be assumed; the word can feel formal.)
 
 
-Lesson 17 of 20.
+Lesson 7 of 9.
 சரி (sari) — "okay".
 
 Warm-up.
@@ -582,51 +202,10 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-Say சரி (sari). What does doubling it add? (Hurry, or easy agreement — "yes yes, fine.") Next: writing it.
+Say சரி. What does doubling it add? (Hurry, or easy agreement — "yes yes, fine.") Next: putting the five words together.
 
 
-Lesson 18 of 20.
-சரி (sari) — one letter, several sounds.
-
-Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ச and ர, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-You have seen க cover k, g and a soft h depending on where it sits. Here is the same economy on a second letter.
-
-Script you'll notice: ச and ர.
-ச is written once and does the work English splits between s, ch and j. Position picks which:
-[a table of 3 rows, read aloud]
-where: starting a word. sound: s or ch.
-where: between vowels. sound: softened.
-where: after a nasal, as in ஞ்ச. sound: j.
-That is exactly the pattern க showed — k at the start, g after a nasal, a soft h between vowels. One letter per position of the mouth, and context fills in the rest.
-ர is ra, with its built-in a. It is the other of Tamil's two r-letters, alongside the ற you met in நன்றி.
-Read both letters here; do not draw them yet. This book gives a stroke order only where it has a sourced one, and ச and ர do not have one yet.
-
-Script you'll notice: build the word.
-[a table of 2 rows, read aloud]
-piece: ச, sa here, this lesson.
-piece: ரி, ri — ர with the ி sign, the sign from நன்றி.
-ச, ரி becomes சரி (sari).
-Two pieces, and both parts are things you already hold: a consonant, and the vowel sign you first hooked onto ற.
-
-Guided Practice.
-[pause 1 second]
-[your turn — read: ச — then சரி (sari)]
-[pause 8 seconds for the answer]
-[your turn — say: "sari"]
-[pause 8 seconds for the answer]
-[your turn — contrast: ரி and லை — the ி sign follows its letter, the ை sign precedes it]
-[pause 8 seconds for the answer]
-[once you have stopped driving — write: ஆம் (ām) and இல்லை (illai) again, from memory — yes and no, the two you will reach for most]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Read சரி (sari). Which English sounds does ச cover on its own? (s or ch at the start, softened between vowels, j after a nasal.) How many r-letters does Tamil keep? (Two — ர and ற.) In லை, which side of the ல does the ai sign sit on? (The left.) And why does இல்லை (illai) open with இ rather than a sign? (It starts on a vowel.) Next: putting the five words together.
-
-
-Lesson 19 of 20.
+Lesson 8 of 9.
 Putting the five together — how Tamil answers.
 
 Warm-up.
@@ -635,7 +214,7 @@ Five words, one at a time. Now they go into a conversation, and two habits show 
 
 Using them.
 A whole exchange, built only from the five words:
-— வணக்கம் (vaṇakkam). — வணக்கம் (vaṇakkam). — சரி (sari)? — ஆம் (ām). — நன்றி. — சரி (sari). — Hello. — Hello. — Alright? — Yes. — Thank you. — Alright.
+— வணக்கம். — வணக்கம். — சரி? — ஆம். — நன்றி. — சரி. — Hello. — Hello. — Alright? — Yes. — Thank you. — Alright.
 Every reply is one word. Tamil is comfortable with that in a way English is not.
 
 Grammar Lens: two habits behind the answers.
@@ -660,27 +239,27 @@ Wrap-up Recall.
 Give a one-word reply to sari? and to naṉṟi. (ām / sari.) Besides ām, what else is a natural yes? (Repeating the verb.) What does illai do inside a sentence? (Makes it negative — it is the "is not" verb.) Next: the chapter's own recap, and then names.
 
 
-Lesson 20 of 20.
+Lesson 9 of 9.
 Chapter 1 — recap, and how Tamil says goodbye.
 
 Warm-up.
 [pause 2 seconds]
-Five words, and with them a first handful of Tamil letters read straight off the page. Let's gather them — and add the farewell, which carries a small piece of Tamil culture.
+Five words, all of them said and none of them written. Let's gather them — and add the farewell, which carries a small piece of Tamil culture.
 
-Read them back.
-Sound each out, left to right, before checking:
+Say them back.
+Say each one before you check the meaning:
 [a table of 5 rows, read aloud]
-Read: வணக்கம், vaṇakkam. Meaning: hello / greetings.
-Read: நன்றி, naṉṟi. Meaning: thank you.
-Read: ஆம், ām. Meaning: yes.
-Read: இல்லை, illai. Meaning: no / there isn't.
-Read: சரி, sari. Meaning: okay / correct.
-The letters that did it: consonants carry a built-in "a"; a puḷḷi dot removes it; a vowel sign (like ி for "i," ை for "ai") swaps the built-in vowel; and a word-initial vowel gets a full letter (ஆ, இ). Plus the big idea — Tamil hears three n's, three l's, two r's, and lets one letter stand for several stop-sounds.
+வணக்கம், vaṇakkam. Meaning: hello / greetings.
+நன்றி, naṉṟi. Meaning: thank you.
+ஆம், ām. Meaning: yes.
+இல்லை, illai. Meaning: no / there isn't.
+சரி, sari. Meaning: okay / correct.
+The Tamil is printed beside each word on purpose. You are not expected to read it yet and nothing here will ask you to — but five words is a good number of shapes to start getting used to. Writing begins in chapter 4, and by then every letter you meet will spell a word you already say.
 
 The farewell — why Tamil won't just say "I'm leaving".
 Tamil has no casual "bye." The everyday goodbye is:
 போய் வருகிறேன் (pōy varugiṟēṉ) — literally "I'll go and come [back]."
-And the reply is போய் வா (pōy vā) — "go, and come [back]." You never sign off with a bare "I am going": saying only "I go" sounds ominous, like a final departure. So you promise a return — go and come back — every single time. It's a whole worldview folded into a goodbye. (You can also simply repeat வணக்கம் (vaṇakkam), which works to part as well as to meet.)
+And the reply is போய் வா (pōy vā) — "go, and come [back]." You never sign off with a bare "I am going": saying only "I go" sounds ominous, like a final departure. So you promise a return — go and come back — every single time. It's a whole worldview folded into a goodbye. (You can also simply repeat வணக்கம், which works to part as well as to meet.)
 
 Guided Practice.
 [pause 1 second]
@@ -693,5 +272,5 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-Read all five words aloud. What does the everyday Tamil goodbye literally mean, and why isn't it just "I'm leaving"? ("I'll go and come back" — a bare "I go" sounds like a final parting, so you promise a return.) What does a puḷḷi do? (Removes a consonant's built-in a.)
+Say all five words aloud. What does the everyday Tamil goodbye literally mean, and why isn't it just "I'm leaving"? ("I'll go and come back" — a bare "I go" sounds like a final parting, so you promise a return.) Which of the five works both to meet someone and to part from them? (வணக்கம்.)
 Next chapter: introducing yourself — en peyar… ("my name…"), and Tamil's nī / nīṅgaḷ (familiar / respectful "you").

--- a/code/learning/human-languages/tamil/narration/ch02.json
+++ b/code/learning/human-languages/tamil/narration/ch02.json
@@ -4,589 +4,11 @@
   "chapter": 2,
   "title": "Chapter 2",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:4a88253cf308c812",
+  "sourceHash": "fnv1a64:5ddf50ce83788a95",
   "lessons": [
     {
-      "id": "TA-C02-en",
-      "sequence": null,
-      "title": "என் (eṉ) — \"my\"",
-      "headword": "என்",
-      "romanization": "",
-      "gloss": "my",
-      "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:a21db6ae59748a32",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "\"My\" — and, like peyar, a word with no European cousin at all."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Tamil.) எ (independent vowel e, word-initial) + ன் (bare alveolar ṉ, puḷḷi) becomes eṉ."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "என் (eṉ, \"my\") is the possessive of நான் (nāṉ, \"I\") — native Dravidian, from the pronoun stem yān / nān. It has no Indo-European cousin: the Tamil \"I/my\" is built on a different root from English I/my (which go back to eǵ and me-). Two families, two entirely separate words for the self."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"eṉ\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"eṉ\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "its source — nāṉ (\"I\") becomes eṉ (\"my\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: its source — *nāṉ* (\"I\") → *eṉ* (\"my\")]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What word is என் the possessive of, and does it share a root with English my? (nāṉ, \"I\"; no — different family entirely.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-C02-en-peyar",
-      "sequence": null,
-      "title": "என் பெயர் … (eṉ peyar …) — \"my name is…,\" with no \"is\"",
-      "headword": "என் பெயர் …",
-      "romanization": "",
-      "gloss": "my name is… (with no \"is\")",
-      "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "sight-cue"
-      ],
-      "sourceHash": "fnv1a64:0fa6e13aeee02146",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, because the lesson points at something written down"
-        ],
-        "waitUntilStopped": [],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Assemble the two atoms — eṉ and peyar — and notice a whole word English needs that Tamil doesn't."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The phrase, assembled",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "eṉ (my) + peyar (name) + your name."
-            },
-            {
-              "kind": "speech",
-              "text": "என் பெயர் … = \"my name …\" becomes \"my name is…\""
-            },
-            {
-              "kind": "speech",
-              "text": "Eṉ peyar Arun. becomes \"My name is Arun.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "grammar",
-          "title": "Grammar Lens: Tamil has no word for \"is\" here",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Look at what's missing: there is no verb. Tamil sets \"my name\" beside \"Arun\" — eṉ peyar Arun — and the \"is\" is simply understood. This is the zero copula: for equational sentences (X is Y), Dravidian needs no \"to be\" at all — where English needs is, Hindi needs hai, Arabic (you'll see) also drops it. Tamil says only \"my name Arun.\""
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"eṉ peyar …\" with your name",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"eṉ peyar …\" with your name]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "notice — no word for \"is\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: notice — no word for \"is\"]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Give your name in Tamil. (Eṉ peyar ….) What does Tamil leave out that English requires? (The verb \"is\" — the zero copula.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-C02-enna",
-      "sequence": null,
-      "title": "என்ன (eṉṉa) — \"what\"",
-      "headword": "என்ன",
-      "romanization": "",
-      "gloss": "what",
-      "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:25fcc38dc3c7e5ad",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The last piece of the question: \"what.\""
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Tamil.) எ (e) + ன் (bare ṉ) + ன (ṉa) becomes eṉṉa — a doubled, held ṉṉ."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "என்ன (eṉṉa, \"what\") is native Dravidian, on the interrogative stem yā- / e- that heads Tamil's whole question family: eṉṉa (what), yār (who), eppo (when), enge (where), ēṉ (why). Like Hindi's k- words and English's wh- words — but from a different, Dravidian root."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"eṉṉa\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"eṉṉa\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the Tamil question family — eṉṉa, yār, enge",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the Tamil question family — eṉṉa, yār, enge]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What stem heads Tamil's question-words, and is it the same as English's wh-? (yā-/e-; same idea, different — Dravidian — root.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-C02-magizhcci",
-      "sequence": null,
-      "title": "மகிழ்ச்சி (magiḻcci) — \"joy,\" and \"pleased to meet you\"",
-      "headword": "மகிழ்ச்சி",
-      "romanization": "",
-      "gloss": "joy / pleased to meet you",
-      "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:c3bc57954e56329f",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The warm close — and a sound almost unique to Tamil."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The phrase",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The full form is உங்களை சந்தித்ததில் மகிழ்ச்சி (uṅgaḷai sandittatil magiḻcci) — \"in having met you, joy.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "மகிழ்ச்சி (magiḻcci, \"joy, gladness\") is native Dravidian, from magiḻ (\"to rejoice\"). It carries the letter ழ (ḻ) — a retroflex glide almost unique to Tamil, with no English equivalent (the same sound in the name Tamiḻ itself). In casual speech, a smile or the English \"nice to meet you\" also does the job."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"magiḻcci\" — feel the ழ (ḻ) glide",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"magiḻcci\" — feel the ழ (*ḻ*) glide]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the fuller form — \"uṅgaḷai sandittatil magiḻcci\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the fuller form — \"uṅgaḷai sandittatil magiḻcci\"]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does மகிழ்ச்சி mean and from what verb? (\"Joy,\" from magiḻ, \"to rejoice.\") What rare Tamil sound does it contain? (ழ, ḻ — also in Tamiḻ.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-C02-nii-niingal",
-      "sequence": null,
-      "title": "நீ / நீங்கள் (nī / nīṅgaḷ) — \"you,\" familiar and respectful",
-      "headword": "நீ / நீங்கள்",
-      "romanization": "",
-      "gloss": "you (familiar / respectful)",
-      "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:777a927ff6b68192",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "To ask a name you need \"you\" — and Tamil makes respect the same way French does."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Tamil.) நீ: ந (dental na) + ீ (the long-ī sign) becomes nī. நீங்கள் adds ங்கள் (ṅgaḷ)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "நீ (nī, familiar \"you\") from Proto-Dravidian nīn — native, unrelated to the European \"you\" words (from tū). நீங்கள் (nīṅgaḷ) is nī + the plural ending -kaḷ."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: respect by the plural — again",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Tamil grades \"you\" in two: nī (familiar — friends, children) and nīṅgaḷ (respectful — and literally the plural, \"you-all\"). This is the same politeness-by-plural as French vous: address one respected person as \"you all.\" For a first meeting, always nīṅgaḷ."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"nī\" (familiar), \"nīṅgaḷ\" (respectful)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"nī\" (familiar), \"nīṅgaḷ\" (respectful)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "nīṅgaḷ = nī + plural -kaḷ",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: nīṅgaḷ = nī + plural -kaḷ]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "How does Tamil make \"you\" respectful, and which European language uses the same trick? (By the plural — nīṅgaḷ; French vous.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "TA-C02-peyar",
-      "sequence": null,
+      "sequence": 100,
       "title": "பெயர் (peyar) — \"name,\" where the family is not Indo-European",
       "headword": "பெயர்",
       "romanization": "",
@@ -597,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f21262c05a8174ac",
+      "sourceHash": "fnv1a64:a332e99363610b9e",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -712,8 +134,699 @@
       ]
     },
     {
+      "id": "TA-C02-en",
+      "sequence": 110,
+      "title": "என் (eṉ) — \"my\"",
+      "headword": "என்",
+      "romanization": "",
+      "gloss": "my",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:5d5a9c62328bb6c9",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "\"My\" — and, like peyar, a word with no European cousin at all."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Tamil.) எ (independent vowel e, word-initial) + ன் (bare alveolar ṉ, puḷḷi) becomes eṉ."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "என் (eṉ, \"my\") is the possessive of நான் (nāṉ, \"I\") — native Dravidian, from the pronoun stem yān / nān. It has no Indo-European cousin: the Tamil \"I/my\" is built on a different root from English I/my (which go back to eǵ and me-). Two families, two entirely separate words for the self."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"eṉ\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"eṉ\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "its source — nāṉ (\"I\") becomes eṉ (\"my\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: its source — *nāṉ* (\"I\") → *eṉ* (\"my\")]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What word is என் the possessive of, and does it share a root with English my? (nāṉ, \"I\"; no — different family entirely.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C02-en-peyar",
+      "sequence": 120,
+      "title": "என் பெயர் … (eṉ peyar …) — \"my name is…,\" with no \"is\"",
+      "headword": "என் பெயர் …",
+      "romanization": "",
+      "gloss": "my name is… (with no \"is\")",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:1170a1a64a27cac8",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Assemble the two atoms — eṉ and peyar — and notice a whole word English needs that Tamil doesn't."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The phrase, assembled",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "eṉ (my) + peyar (name) + your name."
+            },
+            {
+              "kind": "speech",
+              "text": "என் பெயர் … = \"my name …\" becomes \"my name is…\""
+            },
+            {
+              "kind": "speech",
+              "text": "Eṉ peyar Arun. becomes \"My name is Arun.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: Tamil has no word for \"is\" here",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Look at what's missing: there is no verb. Tamil sets \"my name\" beside \"Arun\" — eṉ peyar Arun — and the \"is\" is simply understood. This is the zero copula: for equational sentences (X is Y), Dravidian needs no \"to be\" at all — where English needs is, Hindi needs hai, Arabic (you'll see) also drops it. Tamil says only \"my name Arun.\""
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"eṉ peyar …\" with your name",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"eṉ peyar …\" with your name]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "notice — no word for \"is\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: notice — no word for \"is\"]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Give your name in Tamil. (Eṉ peyar ….) What does Tamil leave out that English requires? (The verb \"is\" — the zero copula.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C02-nii-niingal",
+      "sequence": 140,
+      "title": "நீ / நீங்கள் (nī / nīṅgaḷ) — \"you,\" familiar and respectful",
+      "headword": "நீ / நீங்கள்",
+      "romanization": "",
+      "gloss": "you (familiar / respectful)",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:88ed443a4d4d2cbc",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "To ask a name you need \"you\" — and Tamil makes respect the same way French does."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Tamil.) நீ: ந (dental na) + ீ (the long-ī sign) becomes nī. நீங்கள் adds ங்கள் (ṅgaḷ)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "நீ (nī, familiar \"you\") from Proto-Dravidian nīn — native, unrelated to the European \"you\" words (from tū). நீங்கள் (nīṅgaḷ) is nī + the plural ending -kaḷ."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: respect by the plural — again",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Tamil grades \"you\" in two: nī (familiar — friends, children) and nīṅgaḷ (respectful — and literally the plural, \"you-all\"). This is the same politeness-by-plural as French vous: address one respected person as \"you all.\" For a first meeting, always nīṅgaḷ."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"nī\" (familiar), \"nīṅgaḷ\" (respectful)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"nī\" (familiar), \"nīṅgaḷ\" (respectful)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "nīṅgaḷ = nī + plural -kaḷ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: nīṅgaḷ = nī + plural -kaḷ]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "How does Tamil make \"you\" respectful, and which European language uses the same trick? (By the plural — nīṅgaḷ; French vous.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C02-enna",
+      "sequence": 150,
+      "title": "என்ன (eṉṉa) — \"what\"",
+      "headword": "என்ன",
+      "romanization": "",
+      "gloss": "what",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:9d41a8ac0f94efe6",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The last piece of the question: \"what.\""
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "(Skim if you read Tamil.) எ (e) + ன் (bare ṉ) + ன (ṉa) becomes eṉṉa — a doubled, held ṉṉ."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "என்ன (eṉṉa, \"what\") is native Dravidian, on the interrogative stem yā- / e- that heads Tamil's whole question family: eṉṉa (what), yār (who), eppo (when), enge (where), ēṉ (why). Like Hindi's k- words and English's wh- words — but from a different, Dravidian root."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"eṉṉa\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"eṉṉa\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the Tamil question family — eṉṉa, yār, enge",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the Tamil question family — eṉṉa, yār, enge]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What stem heads Tamil's question-words, and is it the same as English's wh-? (yā-/e-; same idea, different — Dravidian — root.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C02-ungal-peyar-enna",
+      "sequence": 160,
+      "title": "உங்கள் பெயர் என்ன? (uṅgaḷ peyar eṉṉa?) — \"what's your name?\"",
+      "headword": "உங்கள் பெயர் என்ன?",
+      "romanization": "",
+      "gloss": "what's your name?",
+      "script": "tamil",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:f8ac64f1e7a0c725",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Assemble the question — your + name + what — and note, again, no \"is.\""
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The phrase, assembled",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "உங்கள் (uṅgaḷ, \"your\") = the possessive of nīṅgaḷ (\"you,\" respectful)."
+            },
+            {
+              "kind": "speech",
+              "text": "உங்கள் பெயர் என்ன? = literally \"your name what?\" = \"what's your name?\""
+            },
+            {
+              "kind": "speech",
+              "text": "Three words, no verb — the zero copula holds for questions too. Tamil never adds an \"is.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "grammar",
+          "title": "Grammar Lens: answer, and the familiar version",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Answer with the sentence you built: Eṉ peyar Arun. The familiar \"your\" swaps uṅgaḷ for uṉ (from nī): uṉ peyar eṉṉa?"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"uṅgaḷ peyar eṉṉa?\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"uṅgaḷ peyar eṉṉa?\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "ask, then answer — \"uṅgaḷ peyar eṉṉa?\" / \"eṉ peyar …\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: ask, then answer — \"uṅgaḷ peyar eṉṉa?\" / \"eṉ peyar …\"]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does உங்கள் பெயர் என்ன? literally say, and what's missing versus English? (\"Your name what?\"; no \"is\" — zero copula.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C02-magizhcci",
+      "sequence": 165,
+      "title": "மகிழ்ச்சி (magiḻcci) — \"joy,\" and \"pleased to meet you\"",
+      "headword": "மகிழ்ச்சி",
+      "romanization": "",
+      "gloss": "joy / pleased to meet you",
+      "script": "tamil",
+      "modality": "voice",
+      "derivedModality": "voice",
+      "modalityReasons": [
+        "no-visual-dependency"
+      ],
+      "sourceHash": "fnv1a64:5519f38ad4330a86",
+      "notice": null,
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The warm close — and a sound almost unique to Tamil."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "unknown",
+          "title": "The phrase",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "The full form is உங்களை சந்தித்ததில் மகிழ்ச்சி (uṅgaḷai sandittatil magiḻcci) — \"in having met you, joy.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "மகிழ்ச்சி (magiḻcci, \"joy, gladness\") is native Dravidian, from magiḻ (\"to rejoice\"). It carries the letter ழ (ḻ) — a retroflex glide almost unique to Tamil, with no English equivalent (the same sound in the name Tamiḻ itself). In casual speech, a smile or the English \"nice to meet you\" also does the job."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"magiḻcci\" — feel the ழ (ḻ) glide",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"magiḻcci\" — feel the ழ (*ḻ*) glide]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the fuller form — \"uṅgaḷai sandittatil magiḻcci\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the fuller form — \"uṅgaḷai sandittatil magiḻcci\"]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does மகிழ்ச்சி mean and from what verb? (\"Joy,\" from magiḻ, \"to rejoice.\") What rare Tamil sound does it contain? (ழ, ḻ — also in Tamiḻ.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "TA-C02-practice",
-      "sequence": null,
+      "sequence": 170,
       "title": "Chapter 2 — the introduction, whole",
       "headword": "(dialogue)",
       "romanization": "",
@@ -724,7 +837,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:460dd2935bc8810b",
+      "sourceHash": "fnv1a64:10c4d0f86990f82a",
       "notice": null,
       "blocks": [
         {
@@ -848,119 +961,6 @@
             {
               "kind": "speech",
               "text": "Next chapter: eppaḍi irukkīṅgaḷ? (\"how are you?\") and answering with nallā — the responding cycle."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-C02-ungal-peyar-enna",
-      "sequence": null,
-      "title": "உங்கள் பெயர் என்ன? (uṅgaḷ peyar eṉṉa?) — \"what's your name?\"",
-      "headword": "உங்கள் பெயர் என்ன?",
-      "romanization": "",
-      "gloss": "what's your name?",
-      "script": "tamil",
-      "modality": "voice",
-      "derivedModality": "voice",
-      "modalityReasons": [
-        "no-visual-dependency"
-      ],
-      "sourceHash": "fnv1a64:fd46f23f443298d1",
-      "notice": null,
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Assemble the question — your + name + what — and note, again, no \"is.\""
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "unknown",
-          "title": "The phrase, assembled",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "உங்கள் (uṅgaḷ, \"your\") = the possessive of nīṅgaḷ (\"you,\" respectful)."
-            },
-            {
-              "kind": "speech",
-              "text": "உங்கள் பெயர் என்ன? = literally \"your name what?\" = \"what's your name?\""
-            },
-            {
-              "kind": "speech",
-              "text": "Three words, no verb — the zero copula holds for questions too. Tamil never adds an \"is.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "grammar",
-          "title": "Grammar Lens: answer, and the familiar version",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Answer with the sentence you built: Eṉ peyar Arun. The familiar \"your\" swaps uṅgaḷ for uṉ (from nī): uṉ peyar eṉṉa?"
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"uṅgaḷ peyar eṉṉa?\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"uṅgaḷ peyar eṉṉa?\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "ask, then answer — \"uṅgaḷ peyar eṉṉa?\" / \"eṉ peyar …\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: ask, then answer — \"uṅgaḷ peyar eṉṉa?\" / \"eṉ peyar …\"]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does உங்கள் பெயர் என்ன? literally say, and what's missing versus English? (\"Your name what?\"; no \"is\" — zero copula.)"
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch02.txt
+++ b/code/learning/human-languages/tamil/narration/ch02.txt
@@ -3,144 +3,6 @@ Tamil, chapter 2: Chapter 2.
 
 
 Lesson 1 of 8.
-என் (eṉ) — "my".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-"My" — and, like peyar, a word with no European cousin at all.
-
-The letters in this word.
-(Skim if you read Tamil.) எ (independent vowel e, word-initial) + ன் (bare alveolar ṉ, puḷḷi) becomes eṉ.
-
-The word, taken apart.
-என் (eṉ, "my") is the possessive of நான் (nāṉ, "I") — native Dravidian, from the pronoun stem yān / nān. It has no Indo-European cousin: the Tamil "I/my" is built on a different root from English I/my (which go back to eǵ and me-). Two families, two entirely separate words for the self.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "eṉ"]
-[pause 8 seconds for the answer]
-[your turn — say: its source — nāṉ ("I") becomes eṉ ("my")]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What word is என் the possessive of, and does it share a root with English my? (nāṉ, "I"; no — different family entirely.)
-
-
-Lesson 2 of 8.
-என் பெயர் … (eṉ peyar …) — "my name is…," with no "is".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
-
-Warm-up.
-[pause 2 seconds]
-Assemble the two atoms — eṉ and peyar — and notice a whole word English needs that Tamil doesn't.
-
-The phrase, assembled.
-eṉ (my) + peyar (name) + your name.
-என் பெயர் … = "my name …" becomes "my name is…"
-Eṉ peyar Arun. becomes "My name is Arun."
-
-Grammar Lens: Tamil has no word for "is" here.
-Look at what's missing: there is no verb. Tamil sets "my name" beside "Arun" — eṉ peyar Arun — and the "is" is simply understood. This is the zero copula: for equational sentences (X is Y), Dravidian needs no "to be" at all — where English needs is, Hindi needs hai, Arabic (you'll see) also drops it. Tamil says only "my name Arun."
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "eṉ peyar …" with your name]
-[pause 8 seconds for the answer]
-[your turn — say: notice — no word for "is"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Give your name in Tamil. (Eṉ peyar ….) What does Tamil leave out that English requires? (The verb "is" — the zero copula.)
-
-
-Lesson 3 of 8.
-என்ன (eṉṉa) — "what".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The last piece of the question: "what."
-
-The letters in this word.
-(Skim if you read Tamil.) எ (e) + ன் (bare ṉ) + ன (ṉa) becomes eṉṉa — a doubled, held ṉṉ.
-
-The word, taken apart.
-என்ன (eṉṉa, "what") is native Dravidian, on the interrogative stem yā- / e- that heads Tamil's whole question family: eṉṉa (what), yār (who), eppo (when), enge (where), ēṉ (why). Like Hindi's k- words and English's wh- words — but from a different, Dravidian root.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "eṉṉa"]
-[pause 8 seconds for the answer]
-[your turn — say: the Tamil question family — eṉṉa, yār, enge]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What stem heads Tamil's question-words, and is it the same as English's wh-? (yā-/e-; same idea, different — Dravidian — root.)
-
-
-Lesson 4 of 8.
-மகிழ்ச்சி (magiḻcci) — "joy," and "pleased to meet you".
-
-Warm-up.
-[pause 2 seconds]
-The warm close — and a sound almost unique to Tamil.
-
-The phrase.
-The full form is உங்களை சந்தித்ததில் மகிழ்ச்சி (uṅgaḷai sandittatil magiḻcci) — "in having met you, joy."
-
-The word, taken apart.
-மகிழ்ச்சி (magiḻcci, "joy, gladness") is native Dravidian, from magiḻ ("to rejoice"). It carries the letter ழ (ḻ) — a retroflex glide almost unique to Tamil, with no English equivalent (the same sound in the name Tamiḻ itself). In casual speech, a smile or the English "nice to meet you" also does the job.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "magiḻcci" — feel the ழ (ḻ) glide]
-[pause 8 seconds for the answer]
-[your turn — say: the fuller form — "uṅgaḷai sandittatil magiḻcci"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does மகிழ்ச்சி mean and from what verb? ("Joy," from magiḻ, "to rejoice.") What rare Tamil sound does it contain? (ழ, ḻ — also in Tamiḻ.)
-
-
-Lesson 5 of 8.
-நீ / நீங்கள் (nī / nīṅgaḷ) — "you," familiar and respectful.
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-To ask a name you need "you" — and Tamil makes respect the same way French does.
-
-The letters in this word.
-(Skim if you read Tamil.) நீ: ந (dental na) + ீ (the long-ī sign) becomes nī. நீங்கள் adds ங்கள் (ṅgaḷ).
-
-The word, taken apart.
-நீ (nī, familiar "you") from Proto-Dravidian nīn — native, unrelated to the European "you" words (from tū). நீங்கள் (nīṅgaḷ) is nī + the plural ending -kaḷ.
-
-Grammar Lens: respect by the plural — again.
-Tamil grades "you" in two: nī (familiar — friends, children) and nīṅgaḷ (respectful — and literally the plural, "you-all"). This is the same politeness-by-plural as French vous: address one respected person as "you all." For a first meeting, always nīṅgaḷ.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "nī" (familiar), "nīṅgaḷ" (respectful)]
-[pause 8 seconds for the answer]
-[your turn — say: nīṅgaḷ = nī + plural -kaḷ]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-How does Tamil make "you" respectful, and which European language uses the same trick? (By the plural — nīṅgaḷ; French vous.)
-
-
-Lesson 6 of 8.
 பெயர் (peyar) — "name," where the family is not Indo-European.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -170,7 +32,172 @@ Wrap-up Recall.
 Is பெயர் related to English name? (No — it's native Dravidian, peyar; name/nām are Indo-European.) Which languages share peyar/pēru? (Tamil, Malayalam, Telugu — and Kannada's hesaru.)
 
 
+Lesson 2 of 8.
+என் (eṉ) — "my".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+"My" — and, like peyar, a word with no European cousin at all.
+
+The letters in this word.
+(Skim if you read Tamil.) எ (independent vowel e, word-initial) + ன் (bare alveolar ṉ, puḷḷi) becomes eṉ.
+
+The word, taken apart.
+என் (eṉ, "my") is the possessive of நான் (nāṉ, "I") — native Dravidian, from the pronoun stem yān / nān. It has no Indo-European cousin: the Tamil "I/my" is built on a different root from English I/my (which go back to eǵ and me-). Two families, two entirely separate words for the self.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "eṉ"]
+[pause 8 seconds for the answer]
+[your turn — say: its source — nāṉ ("I") becomes eṉ ("my")]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What word is என் the possessive of, and does it share a root with English my? (nāṉ, "I"; no — different family entirely.)
+
+
+Lesson 3 of 8.
+என் பெயர் … (eṉ peyar …) — "my name is…," with no "is".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down. You can listen to all of it now and come back to the parts that need looking at once you have stopped.
+
+Warm-up.
+[pause 2 seconds]
+Assemble the two atoms — eṉ and peyar — and notice a whole word English needs that Tamil doesn't.
+
+The phrase, assembled.
+eṉ (my) + peyar (name) + your name.
+என் பெயர் … = "my name …" becomes "my name is…"
+Eṉ peyar Arun. becomes "My name is Arun."
+
+Grammar Lens: Tamil has no word for "is" here.
+Look at what's missing: there is no verb. Tamil sets "my name" beside "Arun" — eṉ peyar Arun — and the "is" is simply understood. This is the zero copula: for equational sentences (X is Y), Dravidian needs no "to be" at all — where English needs is, Hindi needs hai, Arabic (you'll see) also drops it. Tamil says only "my name Arun."
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "eṉ peyar …" with your name]
+[pause 8 seconds for the answer]
+[your turn — say: notice — no word for "is"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Give your name in Tamil. (Eṉ peyar ….) What does Tamil leave out that English requires? (The verb "is" — the zero copula.)
+
+
+Lesson 4 of 8.
+நீ / நீங்கள் (nī / nīṅgaḷ) — "you," familiar and respectful.
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+To ask a name you need "you" — and Tamil makes respect the same way French does.
+
+The letters in this word.
+(Skim if you read Tamil.) நீ: ந (dental na) + ீ (the long-ī sign) becomes nī. நீங்கள் adds ங்கள் (ṅgaḷ).
+
+The word, taken apart.
+நீ (nī, familiar "you") from Proto-Dravidian nīn — native, unrelated to the European "you" words (from tū). நீங்கள் (nīṅgaḷ) is nī + the plural ending -kaḷ.
+
+Grammar Lens: respect by the plural — again.
+Tamil grades "you" in two: nī (familiar — friends, children) and nīṅgaḷ (respectful — and literally the plural, "you-all"). This is the same politeness-by-plural as French vous: address one respected person as "you all." For a first meeting, always nīṅgaḷ.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "nī" (familiar), "nīṅgaḷ" (respectful)]
+[pause 8 seconds for the answer]
+[your turn — say: nīṅgaḷ = nī + plural -kaḷ]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+How does Tamil make "you" respectful, and which European language uses the same trick? (By the plural — nīṅgaḷ; French vous.)
+
+
+Lesson 5 of 8.
+என்ன (eṉṉa) — "what".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The last piece of the question: "what."
+
+The letters in this word.
+(Skim if you read Tamil.) எ (e) + ன் (bare ṉ) + ன (ṉa) becomes eṉṉa — a doubled, held ṉṉ.
+
+The word, taken apart.
+என்ன (eṉṉa, "what") is native Dravidian, on the interrogative stem yā- / e- that heads Tamil's whole question family: eṉṉa (what), yār (who), eppo (when), enge (where), ēṉ (why). Like Hindi's k- words and English's wh- words — but from a different, Dravidian root.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "eṉṉa"]
+[pause 8 seconds for the answer]
+[your turn — say: the Tamil question family — eṉṉa, yār, enge]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What stem heads Tamil's question-words, and is it the same as English's wh-? (yā-/e-; same idea, different — Dravidian — root.)
+
+
+Lesson 6 of 8.
+உங்கள் பெயர் என்ன? (uṅgaḷ peyar eṉṉa?) — "what's your name?"
+
+Warm-up.
+[pause 2 seconds]
+Assemble the question — your + name + what — and note, again, no "is."
+
+The phrase, assembled.
+உங்கள் (uṅgaḷ, "your") = the possessive of nīṅgaḷ ("you," respectful).
+உங்கள் பெயர் என்ன? = literally "your name what?" = "what's your name?"
+Three words, no verb — the zero copula holds for questions too. Tamil never adds an "is."
+
+Grammar Lens: answer, and the familiar version.
+Answer with the sentence you built: Eṉ peyar Arun. The familiar "your" swaps uṅgaḷ for uṉ (from nī): uṉ peyar eṉṉa?
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "uṅgaḷ peyar eṉṉa?"]
+[pause 8 seconds for the answer]
+[your turn — say: ask, then answer — "uṅgaḷ peyar eṉṉa?" / "eṉ peyar …"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does உங்கள் பெயர் என்ன? literally say, and what's missing versus English? ("Your name what?"; no "is" — zero copula.)
+
+
 Lesson 7 of 8.
+மகிழ்ச்சி (magiḻcci) — "joy," and "pleased to meet you".
+
+Warm-up.
+[pause 2 seconds]
+The warm close — and a sound almost unique to Tamil.
+
+The phrase.
+The full form is உங்களை சந்தித்ததில் மகிழ்ச்சி (uṅgaḷai sandittatil magiḻcci) — "in having met you, joy."
+
+The word, taken apart.
+மகிழ்ச்சி (magiḻcci, "joy, gladness") is native Dravidian, from magiḻ ("to rejoice"). It carries the letter ழ (ḻ) — a retroflex glide almost unique to Tamil, with no English equivalent (the same sound in the name Tamiḻ itself). In casual speech, a smile or the English "nice to meet you" also does the job.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "magiḻcci" — feel the ழ (ḻ) glide]
+[pause 8 seconds for the answer]
+[your turn — say: the fuller form — "uṅgaḷai sandittatil magiḻcci"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does மகிழ்ச்சி mean and from what verb? ("Joy," from magiḻ, "to rejoice.") What rare Tamil sound does it contain? (ழ, ḻ — also in Tamiḻ.)
+
+
+Lesson 8 of 8.
 Chapter 2 — the introduction, whole.
 
 Warm-up.
@@ -203,30 +230,3 @@ Wrap-up Recall.
 [pause 3 seconds]
 Give your name, ask someone else's, say you're pleased. (Eṉ peyar …. / Uṅgaḷ peyar eṉṉa? / Magiḻcci.) What does Tamil leave out that English and Hindi require? (The verb "is" — zero copula.)
 Next chapter: eppaḍi irukkīṅgaḷ? ("how are you?") and answering with nallā — the responding cycle.
-
-
-Lesson 8 of 8.
-உங்கள் பெயர் என்ன? (uṅgaḷ peyar eṉṉa?) — "what's your name?"
-
-Warm-up.
-[pause 2 seconds]
-Assemble the question — your + name + what — and note, again, no "is."
-
-The phrase, assembled.
-உங்கள் (uṅgaḷ, "your") = the possessive of nīṅgaḷ ("you," respectful).
-உங்கள் பெயர் என்ன? = literally "your name what?" = "what's your name?"
-Three words, no verb — the zero copula holds for questions too. Tamil never adds an "is."
-
-Grammar Lens: answer, and the familiar version.
-Answer with the sentence you built: Eṉ peyar Arun. The familiar "your" swaps uṅgaḷ for uṉ (from nī): uṉ peyar eṉṉa?
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "uṅgaḷ peyar eṉṉa?"]
-[pause 8 seconds for the answer]
-[your turn — say: ask, then answer — "uṅgaḷ peyar eṉṉa?" / "eṉ peyar …"]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does உங்கள் பெயர் என்ன? literally say, and what's missing versus English? ("Your name what?"; no "is" — zero copula.)

--- a/code/learning/human-languages/tamil/narration/ch03.json
+++ b/code/learning/human-languages/tamil/narration/ch03.json
@@ -4,11 +4,11 @@
   "chapter": 3,
   "title": "Chapter 3",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:8ccf2dad23d346e7",
+  "sourceHash": "fnv1a64:1c736a85ee572d92",
   "lessons": [
     {
       "id": "TA-C03-eppadi",
-      "sequence": null,
+      "sequence": 180,
       "title": "எப்படி (eppaḍi) — \"how,\" another of the e- questions",
       "headword": "எப்படி",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:115a665d0b5ae3db",
+      "sourceHash": "fnv1a64:1d3bf7b5cc442f13",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -131,7 +131,7 @@
     },
     {
       "id": "TA-C03-eppadi-irukkirirgal",
-      "sequence": null,
+      "sequence": 190,
       "title": "நீங்கள் எப்படி இருக்கிறீர்கள்? (nīṅgaḷ eppaḍi irukkiṟīrgaḷ?)",
       "headword": "நீங்கள் எப்படி இருக்கிறீர்கள்?",
       "romanization": "",
@@ -142,7 +142,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:54b96e84af48f100",
+      "sourceHash": "fnv1a64:0a99d5e4478d95d7",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -273,7 +273,7 @@
     },
     {
       "id": "TA-C03-naan",
-      "sequence": null,
+      "sequence": 200,
       "title": "நான் (nāṉ) — \"I,\" the Dravidian first person",
       "headword": "நான்",
       "romanization": "",
@@ -284,7 +284,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bf125d1e56b58ba0",
+      "sourceHash": "fnv1a64:aaef6470e27b2b3d",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -407,7 +407,7 @@
     },
     {
       "id": "TA-C03-nalam",
-      "sequence": null,
+      "sequence": 210,
       "title": "நலம் (nalam) — \"well,\" and how to answer",
       "headword": "நலம்",
       "romanization": "",
@@ -418,7 +418,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:7085a36204532448",
+      "sourceHash": "fnv1a64:9e274834464afc76",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -549,7 +549,7 @@
     },
     {
       "id": "TA-C03-paravayillai",
-      "sequence": null,
+      "sequence": 220,
       "title": "பரவாயில்லை (paravāyillai) — \"no problem\"",
       "headword": "பரவாயில்லை",
       "romanization": "",
@@ -560,7 +560,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:706b526524e2e1ab",
+      "sourceHash": "fnv1a64:a7e6694023ebed70",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -687,7 +687,7 @@
     },
     {
       "id": "TA-C03-practice",
-      "sequence": null,
+      "sequence": 230,
       "title": "Chapter 3 — The how-are-you exchange",
       "headword": "(dialogue)",
       "romanization": "",
@@ -698,7 +698,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:38559b2a97d4823f",
+      "sourceHash": "fnv1a64:61cfedde655dc9d7",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch04.json
+++ b/code/learning/human-languages/tamil/narration/ch04.json
@@ -4,260 +4,11 @@
   "chapter": 4,
   "title": "Chapter 4",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:e6cc92ef0275935e",
+  "sourceHash": "fnv1a64:ac8d1a3a89c18c13",
   "lessons": [
     {
-      "id": "TA-C04-mindum-sandippom",
-      "sequence": null,
-      "title": "மீண்டும் சந்திப்போம் (mīṇḍum sandippōm) — \"we'll meet again\"",
-      "headword": "மீண்டும் சந்திப்போம்",
-      "romanization": "",
-      "gloss": "we'll meet again",
-      "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:2bd30145a8a3485b",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "A warmer, open-ended goodbye — and a chance to see Tamil's two vocabularies side by side."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "மீண்டும் (mīṇḍum): note the retroflex cluster ண்ட (ṇḍ). சந்திப்போம் (sandippōm): சந்தி (sandi) + -ப்போம் (-ppōm, \"we will\")."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "மீண்டும் சந்திப்போம் = மீண்டும் (mīṇḍum, \"again\") + சந்திப்போம் (sandippōm, \"we will meet\") — \"we'll meet again.\" Two vocabularies meet in these two words:"
-            },
-            {
-              "kind": "speech",
-              "text": "மீண்டும் (mīṇḍum, \"again\") is native Dravidian, from mīḷ (\"to return\")."
-            },
-            {
-              "kind": "speech",
-              "text": "சந்தி (sandi, \"to meet, a junction\") is a Sanskrit loan — from sandhi (\"a joining, union\"), the very word Sanskrit grammar uses for how sounds join at a word-boundary."
-            },
-            {
-              "kind": "speech",
-              "text": "So even a goodbye shows Tamil's balance: an ancient Dravidian core (mīṇḍum) beside a Sanskrit borrowing (sandi) — the recurring thread of this whole track."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"mīṇḍum sandippōm\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"mīṇḍum sandippōm\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "which word is native Dravidian and which is Sanskrit (mīṇḍum / sandi)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: which word is native Dravidian and which is Sanskrit (*mīṇḍum* / *sandi*)]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does the phrase mean, and which of its two words is the Sanskrit loan? (\"We'll meet again\"; sandi \"to meet\" from Sanskrit sandhi — while mīṇḍum \"again\" is native Dravidian.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-C04-naalai",
-      "sequence": null,
-      "title": "நாளை பார்க்கலாம் (nāḷai pārkkalām) — \"see you tomorrow\"",
-      "headword": "நாளை பார்க்கலாம்",
-      "romanization": "",
-      "gloss": "see you tomorrow",
-      "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:46d7d64986982553",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "A goodbye with a date on it — built on the Tamil word for \"day.\""
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "நாளை (nāḷai): நா (nā) + ளை (ḷai, with the retroflex ள ḷ, tongue curled back). பார்க்கலாம் (pārkkalām) = pār (\"see\") + -kkalām (\"let's / we may\")."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "நாளை (nāḷai, \"tomorrow\") is native Dravidian, from நாள் (nāḷ, \"day\") — the same nāḷ in iṉṟu / nāḷ counting and in nal-vāḻttukkaḷ (\"good [day]-wishes\"). பார்க்கலாம் (pārkkalām) is \"let's see / we may see,\" from பார் (pār, \"to see, to look\") — so the whole phrase is \"tomorrow, let's see [each other],\" the Tamil \"see you tomorrow.\" Note the retroflex ள் (ḷ) — a sound English lacks entirely, made with the tongue-tip curled up and back."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"nāḷai pārkkalām\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"nāḷai pārkkalām\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the word for \"day\" inside \"tomorrow\" (nāḷ)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the word for \"day\" inside \"tomorrow\" (*nāḷ*)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the verb \"to see\" (pār)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the verb \"to see\" (*pār*)]"
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "What does nāḷai come from, and what does pārkkalām add? (Nāḷ, \"day\"; \"let's see\" — from pār, \"to see\" — so \"tomorrow, let's see each other.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "TA-C04-po",
-      "sequence": null,
+      "sequence": 240,
       "title": "போ (pō) — \"go,\" and வா (come)",
       "headword": "போ",
       "romanization": "",
@@ -268,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:99257b30e11fb454",
+      "sourceHash": "fnv1a64:a137cdf96f4af1dd",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -371,7 +122,7 @@
     },
     {
       "id": "TA-C04-poy-varugiren",
-      "sequence": null,
+      "sequence": 250,
       "title": "போய் வருகிறேன் (pōy varugiṟēṉ) — \"I'll go and come back\"",
       "headword": "போய் வருகிறேன்",
       "romanization": "",
@@ -382,7 +133,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f14e5eedd7053032",
+      "sourceHash": "fnv1a64:b827e77978feac54",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -504,8 +255,413 @@
       ]
     },
     {
+      "id": "TA-C04-naalai",
+      "sequence": 255,
+      "title": "நாளை பார்க்கலாம் (nāḷai pārkkalām) — \"see you tomorrow\"",
+      "headword": "நாளை பார்க்கலாம்",
+      "romanization": "",
+      "gloss": "see you tomorrow",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:93385c7a8e7ee524",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A goodbye with a date on it — built on the Tamil word for \"day.\""
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "நாளை (nāḷai): நா (nā) + ளை (ḷai, with the retroflex ள ḷ, tongue curled back). பார்க்கலாம் (pārkkalām) = pār (\"see\") + -kkalām (\"let's / we may\")."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "நாளை (nāḷai, \"tomorrow\") is native Dravidian, from நாள் (nāḷ, \"day\") — the same nāḷ in iṉṟu / nāḷ counting and in nal-vāḻttukkaḷ (\"good [day]-wishes\"). பார்க்கலாம் (pārkkalām) is \"let's see / we may see,\" from பார் (pār, \"to see, to look\") — so the whole phrase is \"tomorrow, let's see [each other],\" the Tamil \"see you tomorrow.\" Note the retroflex ள் (ḷ) — a sound English lacks entirely, made with the tongue-tip curled up and back."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"nāḷai pārkkalām\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"nāḷai pārkkalām\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the word for \"day\" inside \"tomorrow\" (nāḷ)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the word for \"day\" inside \"tomorrow\" (*nāḷ*)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the verb \"to see\" (pār)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the verb \"to see\" (*pār*)]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does nāḷai come from, and what does pārkkalām add? (Nāḷ, \"day\"; \"let's see\" — from pār, \"to see\" — so \"tomorrow, let's see each other.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C04-mindum-sandippom",
+      "sequence": 260,
+      "title": "மீண்டும் சந்திப்போம் (mīṇḍum sandippōm) — \"we'll meet again\"",
+      "headword": "மீண்டும் சந்திப்போம்",
+      "romanization": "",
+      "gloss": "we'll meet again",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:8dd1d2b81b09c384",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A warmer, open-ended goodbye — and a chance to see Tamil's two vocabularies side by side."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "மீண்டும் (mīṇḍum): note the retroflex cluster ண்ட (ṇḍ). சந்திப்போம் (sandippōm): சந்தி (sandi) + -ப்போம் (-ppōm, \"we will\")."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "மீண்டும் சந்திப்போம் = மீண்டும் (mīṇḍum, \"again\") + சந்திப்போம் (sandippōm, \"we will meet\") — \"we'll meet again.\" Two vocabularies meet in these two words:"
+            },
+            {
+              "kind": "speech",
+              "text": "மீண்டும் (mīṇḍum, \"again\") is native Dravidian, from mīḷ (\"to return\")."
+            },
+            {
+              "kind": "speech",
+              "text": "சந்தி (sandi, \"to meet, a junction\") is a Sanskrit loan — from sandhi (\"a joining, union\"), the very word Sanskrit grammar uses for how sounds join at a word-boundary."
+            },
+            {
+              "kind": "speech",
+              "text": "So even a goodbye shows Tamil's balance: an ancient Dravidian core (mīṇḍum) beside a Sanskrit borrowing (sandi) — the recurring thread of this whole track."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"mīṇḍum sandippōm\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"mīṇḍum sandippōm\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "which word is native Dravidian and which is Sanskrit (mīṇḍum / sandi)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: which word is native Dravidian and which is Sanskrit (*mīṇḍum* / *sandi*)]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does the phrase mean, and which of its two words is the Sanskrit loan? (\"We'll meet again\"; sandi \"to meet\" from Sanskrit sandhi — while mīṇḍum \"again\" is native Dravidian.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W01-curves-va-ka",
+      "sequence": 270,
+      "title": "Tamil's curves — the writing surface leaves a trace",
+      "headword": "தமிழ் எழுத்து",
+      "romanization": "tamiḻ eḻuttu",
+      "gloss": "why Tamil writing is so round, with the palm-leaf account presented as a qualified explanation",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block",
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:2c2e171ca2be012a",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page",
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: The script is the shape of its writing surface",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script you'll notice: The script is the shape of its writing surface and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Before the first letter, look at a line of Tamil and notice what isn't there:"
+            },
+            {
+              "kind": "speech",
+              "text": "வணக்கம்."
+            },
+            {
+              "kind": "speech",
+              "text": "Nothing joins the letters together, and there are far fewer corners than in Devanagari — no hanging head-line, and a great deal of curve. (Straight strokes do exist: most of these letters have a flat bar across the top.) The roundness has a usual explanation, and it is the best story in this chapter."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: The script is the shape of its writing surface",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Tamil was written for centuries on palm leaves, scratched with a metal stylus and then rubbed with soot to make the scratches show."
+            },
+            {
+              "kind": "speech",
+              "text": "A palm leaf has a grain, like wood. Draw a long straight line along that grain and the stylus can split the leaf. The usual account is that scribes bent their strokes in response: a curve crosses the fibres at an angle instead of running with them."
+            },
+            {
+              "kind": "speech",
+              "text": "Treat that as the standard explanation rather than a settled fact. The earliest Tamil writing — Tamil-Brahmi, cut into stone and pottery — is noticeably angular; the rounding came later, through the Vaṭṭeḻuttu (\"round script\") stage. And Devanagari was written on the same leaves without going round. So the leaf is one pressure among several, not a complete answer."
+            },
+            {
+              "kind": "speech",
+              "text": "It is still worth carrying, because it makes the right general point: the tool leaves fingerprints on the letters. Latin's straight strokes suit a wax tablet and a chisel; Tamil's curves suit a stylus and a leaf."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "TRACE",
+              "instruction": "a curve crossing the imagined grain of a palm leaf",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU TRACE: a curve crossing the imagined grain of a palm leaf]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "angular Tamil-Brahmi, later rounded Vaṭṭeḻuttu",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: angular Tamil-Brahmi · later rounded Vaṭṭeḻuttu]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the usual reason for the curves — \"a straight line can split the leaf\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the usual reason for the curves — \"a straight line can **split the leaf**\"]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Why is Tamil round? (The usual explanation: it was incised on palm leaves, where a straight stroke along the grain can split them — though early Tamil-Brahmi was angular, so it is not the whole story.) What broader point does the account teach? (Tools and surfaces leave fingerprints on scripts.) Next: the chapter's own recap of the farewells."
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "TA-W01-curves-va-ka-writing-surface",
+              "prompt": "What writing surface is usually linked to Tamil's rounded shapes?",
+              "assesses": [
+                "TA-SCRIPT-CURVES-VA-KA-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "palm leaves",
+                "palm leaf",
+                "leaves of palm"
+              ],
+              "feedback": {
+                "correct": "Correct: the usual account links Tamil's curves to writing on palm leaves.",
+                "incorrect": "The usual explanation points to palm leaves, which straight strokes along the grain could split."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "TA-C04-practice",
-      "sequence": null,
+      "sequence": 290,
       "title": "Chapter 4 — The farewells",
       "headword": "(dialogue)",
       "romanization": "",
@@ -516,7 +672,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:65bb3e5878370184",
+      "sourceHash": "fnv1a64:849cf4a2e960db6a",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch04.txt
+++ b/code/learning/human-languages/tamil/narration/ch04.txt
@@ -1,67 +1,8 @@
 Tamil, chapter 4: Chapter 4.
-5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
-Lesson 1 of 5.
-மீண்டும் சந்திப்போம் (mīṇḍum sandippōm) — "we'll meet again".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-A warmer, open-ended goodbye — and a chance to see Tamil's two vocabularies side by side.
-
-The letters in this word.
-மீண்டும் (mīṇḍum): note the retroflex cluster ண்ட (ṇḍ). சந்திப்போம் (sandippōm): சந்தி (sandi) + -ப்போம் (-ppōm, "we will").
-
-The word, taken apart.
-மீண்டும் சந்திப்போம் = மீண்டும் (mīṇḍum, "again") + சந்திப்போம் (sandippōm, "we will meet") — "we'll meet again." Two vocabularies meet in these two words:
-மீண்டும் (mīṇḍum, "again") is native Dravidian, from mīḷ ("to return").
-சந்தி (sandi, "to meet, a junction") is a Sanskrit loan — from sandhi ("a joining, union"), the very word Sanskrit grammar uses for how sounds join at a word-boundary.
-So even a goodbye shows Tamil's balance: an ancient Dravidian core (mīṇḍum) beside a Sanskrit borrowing (sandi) — the recurring thread of this whole track.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "mīṇḍum sandippōm"]
-[pause 8 seconds for the answer]
-[your turn — say: which word is native Dravidian and which is Sanskrit (mīṇḍum / sandi)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does the phrase mean, and which of its two words is the Sanskrit loan? ("We'll meet again"; sandi "to meet" from Sanskrit sandhi — while mīṇḍum "again" is native Dravidian.)
-
-
-Lesson 2 of 5.
-நாளை பார்க்கலாம் (nāḷai pārkkalām) — "see you tomorrow".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-A goodbye with a date on it — built on the Tamil word for "day."
-
-The letters in this word.
-நாளை (nāḷai): நா (nā) + ளை (ḷai, with the retroflex ள ḷ, tongue curled back). பார்க்கலாம் (pārkkalām) = pār ("see") + -kkalām ("let's / we may").
-
-The word, taken apart.
-நாளை (nāḷai, "tomorrow") is native Dravidian, from நாள் (nāḷ, "day") — the same nāḷ in iṉṟu / nāḷ counting and in nal-vāḻttukkaḷ ("good [day]-wishes"). பார்க்கலாம் (pārkkalām) is "let's see / we may see," from பார் (pār, "to see, to look") — so the whole phrase is "tomorrow, let's see [each other]," the Tamil "see you tomorrow." Note the retroflex ள் (ḷ) — a sound English lacks entirely, made with the tongue-tip curled up and back.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "nāḷai pārkkalām"]
-[pause 8 seconds for the answer]
-[your turn — say: the word for "day" inside "tomorrow" (nāḷ)]
-[pause 8 seconds for the answer]
-[your turn — say: the verb "to see" (pār)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-What does nāḷai come from, and what does pārkkalām add? (Nāḷ, "day"; "let's see" — from pār, "to see" — so "tomorrow, let's see each other.")
-
-
-Lesson 3 of 5.
+Lesson 1 of 6.
 போ (pō) — "go," and வா (come).
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -88,7 +29,7 @@ Wrap-up Recall.
 What do pō and vā mean, and why will you need them both to say goodbye? ("Go" and "come"; the Tamil farewell is "I go and come back," not "I leave.")
 
 
-Lesson 4 of 5.
+Lesson 2 of 6.
 போய் வருகிறேன் (pōy varugiṟēṉ) — "I'll go and come back".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -120,7 +61,98 @@ Wrap-up Recall.
 What does the Tamil goodbye literally promise, and how do you answer it? ("I'll go and come back"; reply pōy vā, "go and come [back]".)
 
 
-Lesson 5 of 5.
+Lesson 3 of 6.
+நாளை பார்க்கலாம் (nāḷai pārkkalām) — "see you tomorrow".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+A goodbye with a date on it — built on the Tamil word for "day."
+
+The letters in this word.
+நாளை (nāḷai): நா (nā) + ளை (ḷai, with the retroflex ள ḷ, tongue curled back). பார்க்கலாம் (pārkkalām) = pār ("see") + -kkalām ("let's / we may").
+
+The word, taken apart.
+நாளை (nāḷai, "tomorrow") is native Dravidian, from நாள் (nāḷ, "day") — the same nāḷ in iṉṟu / nāḷ counting and in nal-vāḻttukkaḷ ("good [day]-wishes"). பார்க்கலாம் (pārkkalām) is "let's see / we may see," from பார் (pār, "to see, to look") — so the whole phrase is "tomorrow, let's see [each other]," the Tamil "see you tomorrow." Note the retroflex ள் (ḷ) — a sound English lacks entirely, made with the tongue-tip curled up and back.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "nāḷai pārkkalām"]
+[pause 8 seconds for the answer]
+[your turn — say: the word for "day" inside "tomorrow" (nāḷ)]
+[pause 8 seconds for the answer]
+[your turn — say: the verb "to see" (pār)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does nāḷai come from, and what does pārkkalām add? (Nāḷ, "day"; "let's see" — from pār, "to see" — so "tomorrow, let's see each other.")
+
+
+Lesson 4 of 6.
+மீண்டும் சந்திப்போம் (mīṇḍum sandippōm) — "we'll meet again".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+A warmer, open-ended goodbye — and a chance to see Tamil's two vocabularies side by side.
+
+The letters in this word.
+மீண்டும் (mīṇḍum): note the retroflex cluster ண்ட (ṇḍ). சந்திப்போம் (sandippōm): சந்தி (sandi) + -ப்போம் (-ppōm, "we will").
+
+The word, taken apart.
+மீண்டும் சந்திப்போம் = மீண்டும் (mīṇḍum, "again") + சந்திப்போம் (sandippōm, "we will meet") — "we'll meet again." Two vocabularies meet in these two words:
+மீண்டும் (mīṇḍum, "again") is native Dravidian, from mīḷ ("to return").
+சந்தி (sandi, "to meet, a junction") is a Sanskrit loan — from sandhi ("a joining, union"), the very word Sanskrit grammar uses for how sounds join at a word-boundary.
+So even a goodbye shows Tamil's balance: an ancient Dravidian core (mīṇḍum) beside a Sanskrit borrowing (sandi) — the recurring thread of this whole track.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "mīṇḍum sandippōm"]
+[pause 8 seconds for the answer]
+[your turn — say: which word is native Dravidian and which is Sanskrit (mīṇḍum / sandi)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does the phrase mean, and which of its two words is the Sanskrit loan? ("We'll meet again"; sandi "to meet" from Sanskrit sandhi — while mīṇḍum "again" is native Dravidian.)
+
+
+Lesson 5 of 6.
+Tamil's curves — the writing surface leaves a trace.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script you'll notice: The script is the shape of its writing surface and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Before the first letter, look at a line of Tamil and notice what isn't there:
+வணக்கம்.
+Nothing joins the letters together, and there are far fewer corners than in Devanagari — no hanging head-line, and a great deal of curve. (Straight strokes do exist: most of these letters have a flat bar across the top.) The roundness has a usual explanation, and it is the best story in this chapter.
+
+Script you'll notice: The script is the shape of its writing surface.
+Tamil was written for centuries on palm leaves, scratched with a metal stylus and then rubbed with soot to make the scratches show.
+A palm leaf has a grain, like wood. Draw a long straight line along that grain and the stylus can split the leaf. The usual account is that scribes bent their strokes in response: a curve crosses the fibres at an angle instead of running with them.
+Treat that as the standard explanation rather than a settled fact. The earliest Tamil writing — Tamil-Brahmi, cut into stone and pottery — is noticeably angular; the rounding came later, through the Vaṭṭeḻuttu ("round script") stage. And Devanagari was written on the same leaves without going round. So the leaf is one pressure among several, not a complete answer.
+It is still worth carrying, because it makes the right general point: the tool leaves fingerprints on the letters. Latin's straight strokes suit a wax tablet and a chisel; Tamil's curves suit a stylus and a leaf.
+
+Guided Practice.
+[pause 1 second]
+[once you have stopped driving — trace: a curve crossing the imagined grain of a palm leaf]
+[your turn — contrast: angular Tamil-Brahmi, later rounded Vaṭṭeḻuttu]
+[pause 8 seconds for the answer]
+[your turn — say: the usual reason for the curves — "a straight line can split the leaf"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Why is Tamil round? (The usual explanation: it was incised on palm leaves, where a straight stroke along the grain can split them — though early Tamil-Brahmi was angular, so it is not the whole story.) What broader point does the account teach? (Tools and surfaces leave fingerprints on scripts.) Next: the chapter's own recap of the farewells.
+[question — say your answer, then pause 8 seconds]
+What writing surface is usually linked to Tamil's rounded shapes?
+
+
+Lesson 6 of 6.
 Chapter 4 — The farewells.
 
 Warm-up.

--- a/code/learning/human-languages/tamil/narration/ch05.json
+++ b/code/learning/human-languages/tamil/narration/ch05.json
@@ -4,145 +4,11 @@
   "chapter": 5,
   "title": "Chapter 5",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:6e46aaef34f9ba78",
+  "sourceHash": "fnv1a64:0718a395630b7532",
   "lessons": [
     {
-      "id": "TA-C05-naan-tamizh-pesugiren",
-      "sequence": null,
-      "title": "நான் தமிழ் பேசுகிறேன் (nāṉ tamiḻ pēsugiṟēṉ) — \"I speak Tamil\"",
-      "headword": "நான் தமிழ் பேசுகிறேன்",
-      "romanization": "",
-      "gloss": "I speak Tamil",
-      "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:42a739df1441cc91",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Your first full, moving sentence — and it names the language itself, with a sound almost no other language has."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "தமிழ் (tamiḻ): த (ta) + மி (mi) + ழ் (ḻ) — that last letter, ழ, is the famous Tamil ḻ, a curled retroflex sound between \"r,\" \"l,\" and \"zh,\" found in almost no other language on earth. It is so identified with the language that Tamil is sometimes called \"the ḻ language.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The sentence, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "நான் தமிழ் பேசுகிறேன் = நான் (nāṉ, \"I\") + தமிழ் (tamiḻ, \"Tamil,\" the object) + பேசுகிறேன் (pēsugiṟēṉ, \"speak\") — \"I Tamil speak,\" the verb last as always. The name தமிழ் (tamiḻ) is native, of debated but clearly Dravidian origin (often linked to a sense of \"sweetness / one's own speech\"); it names one of the oldest living literary languages in the world, with poetry two thousand years old still read today."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: no gender on \"I speak\"",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Notice pēsugiṟēṉ is the same whether a man or a woman says it — Tamil marks no gender in the first or second person (only the third: pēsugiṟāṉ he / pēsugiṟāḷ she). This is unlike Hindi, where even \"I speak\" changes for a male or female speaker (boltā/boltī). Tamil saves gender for \"he/she/it.\""
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"nāṉ tamiḻ pēsugiṟēṉ\"",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"nāṉ tamiḻ pēsugiṟēṉ\"]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the special Tamil sound in tamiḻ (the retroflex ḻ)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the special Tamil sound in *tamiḻ* (the retroflex *ḻ*)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "does \"I speak\" change for a man vs. a woman? (No — Tamil marks no gender in the 1st person)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: does \"I speak\" change for a man vs. a woman? (No — Tamil marks no gender in the 1st person)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Say \"I speak Tamil,\" and name the rare sound in the word tamiḻ. (Nāṉ tamiḻ pēsugiṟēṉ; the retroflex ḻ — ழ.)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": "TA-C05-pesu",
-      "sequence": null,
+      "sequence": 300,
       "title": "பேசு (pēsu) — \"to speak,\" your first full verb",
       "headword": "பேசு",
       "romanization": "",
@@ -153,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5667a5594c84050d",
+      "sourceHash": "fnv1a64:d3ef5e5538b5a60d",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -283,8 +149,617 @@
       ]
     },
     {
+      "id": "TA-C05-naan-tamizh-pesugiren",
+      "sequence": 310,
+      "title": "நான் தமிழ் பேசுகிறேன் (nāṉ tamiḻ pēsugiṟēṉ) — \"I speak Tamil\"",
+      "headword": "நான் தமிழ் பேசுகிறேன்",
+      "romanization": "",
+      "gloss": "I speak Tamil",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:ea295f6dbc121380",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Your first full, moving sentence — and it names the language itself, with a sound almost no other language has."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "தமிழ் (tamiḻ): த (ta) + மி (mi) + ழ் (ḻ) — that last letter, ழ, is the famous Tamil ḻ, a curled retroflex sound between \"r,\" \"l,\" and \"zh,\" found in almost no other language on earth. It is so identified with the language that Tamil is sometimes called \"the ḻ language.\""
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The sentence, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "நான் தமிழ் பேசுகிறேன் = நான் (nāṉ, \"I\") + தமிழ் (tamiḻ, \"Tamil,\" the object) + பேசுகிறேன் (pēsugiṟēṉ, \"speak\") — \"I Tamil speak,\" the verb last as always. The name தமிழ் (tamiḻ) is native, of debated but clearly Dravidian origin (often linked to a sense of \"sweetness / one's own speech\"); it names one of the oldest living literary languages in the world, with poetry two thousand years old still read today."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: no gender on \"I speak\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Notice pēsugiṟēṉ is the same whether a man or a woman says it — Tamil marks no gender in the first or second person (only the third: pēsugiṟāṉ he / pēsugiṟāḷ she). This is unlike Hindi, where even \"I speak\" changes for a male or female speaker (boltā/boltī). Tamil saves gender for \"he/she/it.\""
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"nāṉ tamiḻ pēsugiṟēṉ\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"nāṉ tamiḻ pēsugiṟēṉ\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the special Tamil sound in tamiḻ (the retroflex ḻ)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the special Tamil sound in *tamiḻ* (the retroflex *ḻ*)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "does \"I speak\" change for a man vs. a woman? (No — Tamil marks no gender in the 1st person)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: does \"I speak\" change for a man vs. a woman? (No — Tamil marks no gender in the 1st person)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Say \"I speak Tamil,\" and name the rare sound in the word tamiḻ. (Nāṉ tamiḻ pēsugiṟēṉ; the retroflex ḻ — ழ.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W01-abugida-va-ka",
+      "sequence": 320,
+      "title": "வ and க — the vowel inside each consonant",
+      "headword": "வ, க",
+      "romanization": "va, ka",
+      "gloss": "the inherent vowel and the first two Tamil letters, including க's position-driven sounds",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:e60a2cf8db255147",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: The vowel you get for free",
+          "Script you'll notice: வ — \"va\"",
+          "Script you'll notice: க — \"ka\"",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The vowel you get for free, Script you'll notice: வ — \"va\", Script you'll notice: க — \"ka\" and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Tamil's letters do not join and they carry many curves. Now learn the sound that arrives for free inside every consonant."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: The vowel you get for free",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Tamil is an abugida, like Devanagari: a consonant already contains a vowel."
+            },
+            {
+              "kind": "speech",
+              "text": "க is not \"k\". க is \"ka\"."
+            },
+            {
+              "kind": "speech",
+              "text": "Every consonant carries a built-in a until a later mark removes or replaces it."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: வ — \"va\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "a near-closed loop on the left."
+            },
+            {
+              "kind": "speech",
+              "text": "a full-height arm across the top, ending in a descender on the right."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "script",
+          "title": "Script you'll notice: க — \"ka\"",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "a straight horizontal top bar."
+            },
+            {
+              "kind": "speech",
+              "text": "a bowl hanging from its left end."
+            },
+            {
+              "kind": "speech",
+              "text": "a short right stroke that hooks left below."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "pronunciation",
+          "title": "Sounds you'll need: One letter, three sounds",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Devanagari separates क, ख, ग, घ. Tamil uses க across that space: k at the start of a word and when doubled (க்க), g after a nasal (ங்க), and a softer h-like sound between vowels. Position, not a new spelling, selects the sound."
+            },
+            {
+              "kind": "speech",
+              "text": "Tamil therefore needs only 18 consonant letters where Devanagari needs 33; its native words do not depend on those written distinctions."
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "வ — \"left loop, top arm, descender\"",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: வ — \"left loop, top arm, descender\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "க — \"top bar, left bowl, hooking right stroke\"",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: க — \"top bar, left bowl, hooking right stroke\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"க is ka, not k\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"க is **ka**, not k\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "initial k, after a nasal g, between vowels soft h",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: initial *k* · after a nasal *g* · between vowels soft *h*]"
+            }
+          ]
+        },
+        {
+          "index": 6,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does க say alone? (Ka — the vowel is inherent.) What kind of script is this? (An abugida.) Which sounds can க spell? (k, g, and a softer h-like sound, chosen by position.) Draw வ and க."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C05-vaazh",
+      "sequence": 330,
+      "title": "வாழ் (vāḻ) — \"to live, to flourish\"",
+      "headword": "வாழ்",
+      "romanization": "",
+      "gloss": "to live, to flourish",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:c25a4a6426c60568",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A second verb — and one of the most beloved words in the language, the one Tamils use to bless."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "வா (vā) + ழ் (ḻ, the retroflex you just met in tamiḻ) becomes வாழ் (vāḻ)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "வாழ் (vāḻ, \"to live, to flourish, to thrive\") is native Dravidian, and carries more warmth than a plain \"to reside.\" From it grow வாழ்க்கை (vāḻkkai, \"life\") and the blessing வாழ்க (vāḻga, \"may you live / long live\"), heard in vāḻga tamiḻ (\"long live Tamil\"). To say \"I live,\" add the familiar ending: நான் … வாழ்கிறேன் (nāṉ … vāḻgiṟēṉ), stem + present -giṟ-."
+            },
+            {
+              "kind": "speech",
+              "text": "\"I\" -ēṉ, exactly like pēsugiṟēṉ."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: same engine, new verb",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "You already know the machine: vāḻ- (stem) + -giṟ- (present) + -ēṉ (\"I\") becomes vāḻgiṟēṉ (\"I live\"). Every verb you learn slots into the same three-part frame — that is the reward for learning pēsu carefully."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"vāḻ\" — feel the retroflex ḻ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"vāḻ\" — feel the retroflex *ḻ*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"I live\" — nāṉ vāḻgiṟēṉ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"I live\" — *nāṉ vāḻgiṟēṉ*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the blessing — vāḻga! (\"long live / may you flourish\")",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the blessing — *vāḻga!* (\"long live / may you flourish\")]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Build \"I live\" from vāḻ, and give the blessing made from it. (Vāḻgiṟēṉ; vāḻga!, \"may you live / long live.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-C05-velai-sey",
+      "sequence": 340,
+      "title": "வேலை செய் (vēlai sey) — \"to work\"",
+      "headword": "வேலை செய்",
+      "romanization": "",
+      "gloss": "to work (lit. \"work-do\")",
+      "script": "tamil",
+      "modality": "sight",
+      "derivedModality": "sight",
+      "modalityReasons": [
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:64528b6911be0db6",
+      "notice": {
+        "modality": "sight",
+        "needs": [
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "The letters in this word"
+        ],
+        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "The last verb of the chapter — and, like Hindi's karnā, it is a \"do\" verb that builds a hundred others."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "The letters in this word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "வேலை (vēlai, \"work\"): வே (vē) + லை (lai). செய் (sey, \"do\"): செ (se) + ய் (y)."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "etymology",
+          "title": "The word, taken apart",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "செய் (sey, \"to do, to make\") is a core native Dravidian verb, and Tamil — like Hindi with karnā — builds compound verbs by putting a noun in front of it:"
+            },
+            {
+              "kind": "speech",
+              "text": "வேலை செய் (vēlai sey) = \"work-do\" = \"to work\" (vēlai, \"work\")."
+            },
+            {
+              "kind": "speech",
+              "text": "சமையல் செய் (samaiyal sey) = \"to cook\"."
+            },
+            {
+              "kind": "speech",
+              "text": "உதவி செய் (udavi sey) = \"to help\"."
+            },
+            {
+              "kind": "speech",
+              "text": "So \"I work\" is நான் வேலை செய்கிறேன் (nāṉ vēlai seygiṟēṉ) — sey- + -giṟ-."
+            },
+            {
+              "kind": "speech",
+              "text": "-ēṉ, \"I do work.\" Master sey and a whole grammar of \"do-verbs\" opens up."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "grammar",
+          "title": "Grammar Lens: noun + செய் = a new verb",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "This \"noun + sey\" pattern is the exact twin of Hindi's \"noun + karnā\" (kām karnā, \"to work\"). Two unrelated language families — Dravidian and Indo-Aryan — landed on the same clever trick: make an all-purpose \"do\" verb, then bolt nouns onto it. Living side by side for millennia, Tamil and Hindi have quietly traded habits like this."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"vēlai sey\" (to work)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"vēlai sey\" (to work)]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"I work\" — nāṉ vēlai seygiṟēṉ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"I work\" — *nāṉ vēlai seygiṟēṉ*]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "the Hindi twin of this trick (noun + karnā)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: the Hindi twin of this trick (noun + *karnā*)]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "How does Tamil turn \"work\" into \"to work,\" and what Hindi verb works the same way? (Vēlai + sey = \"work-do\"; Hindi's karnā, as in kām karnā.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "TA-C05-practice",
-      "sequence": null,
+      "sequence": 350,
       "title": "Chapter 5 — The first verbs",
       "headword": "(dialogue)",
       "romanization": "",
@@ -295,7 +770,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:13bb1c850f393572",
+      "sourceHash": "fnv1a64:7672680a71915ae9",
       "notice": null,
       "blocks": [
         {
@@ -447,298 +922,6 @@
             {
               "kind": "speech",
               "text": "In one breath, say your language and your work in Tamil, then bless someone with the vāḻ verb. (Nāṉ tamiḻ pēsugiṟēṉ. Nāṉ vēlai seygiṟēṉ. Vāḻga!)"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-C05-vaazh",
-      "sequence": null,
-      "title": "வாழ் (vāḻ) — \"to live, to flourish\"",
-      "headword": "வாழ்",
-      "romanization": "",
-      "gloss": "to live, to flourish",
-      "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:9853bbbff15ebc67",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "A second verb — and one of the most beloved words in the language, the one Tamils use to bless."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "வா (vā) + ழ் (ḻ, the retroflex you just met in tamiḻ) becomes வாழ் (vāḻ)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "வாழ் (vāḻ, \"to live, to flourish, to thrive\") is native Dravidian, and carries more warmth than a plain \"to reside.\" From it grow வாழ்க்கை (vāḻkkai, \"life\") and the blessing வாழ்க (vāḻga, \"may you live / long live\"), heard in vāḻga tamiḻ (\"long live Tamil\"). To say \"I live,\" add the familiar ending: நான் … வாழ்கிறேன் (nāṉ … vāḻgiṟēṉ), stem + present -giṟ-."
-            },
-            {
-              "kind": "speech",
-              "text": "\"I\" -ēṉ, exactly like pēsugiṟēṉ."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: same engine, new verb",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "You already know the machine: vāḻ- (stem) + -giṟ- (present) + -ēṉ (\"I\") becomes vāḻgiṟēṉ (\"I live\"). Every verb you learn slots into the same three-part frame — that is the reward for learning pēsu carefully."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"vāḻ\" — feel the retroflex ḻ",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"vāḻ\" — feel the retroflex *ḻ*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"I live\" — nāṉ vāḻgiṟēṉ",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"I live\" — *nāṉ vāḻgiṟēṉ*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the blessing — vāḻga! (\"long live / may you flourish\")",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the blessing — *vāḻga!* (\"long live / may you flourish\")]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "Build \"I live\" from vāḻ, and give the blessing made from it. (Vāḻgiṟēṉ; vāḻga!, \"may you live / long live.\")"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "TA-C05-velai-sey",
-      "sequence": null,
-      "title": "வேலை செய் (vēlai sey) — \"to work\"",
-      "headword": "வேலை செய்",
-      "romanization": "",
-      "gloss": "to work (lit. \"work-do\")",
-      "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
-      "modalityReasons": [
-        "script-block"
-      ],
-      "sourceHash": "fnv1a64:ca5c5c9223f2aab4",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
-      "blocks": [
-        {
-          "index": 0,
-          "type": "warmup",
-          "title": "Warm-up",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 2,
-              "perItem": false,
-              "source": "[PAUSE 2s]"
-            },
-            {
-              "kind": "speech",
-              "text": "The last verb of the chapter — and, like Hindi's karnā, it is a \"do\" verb that builds a hundred others."
-            }
-          ]
-        },
-        {
-          "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "வேலை (vēlai, \"work\"): வே (vē) + லை (lai). செய் (sey, \"do\"): செ (se) + ய் (y)."
-            }
-          ]
-        },
-        {
-          "index": 2,
-          "type": "etymology",
-          "title": "The word, taken apart",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "செய் (sey, \"to do, to make\") is a core native Dravidian verb, and Tamil — like Hindi with karnā — builds compound verbs by putting a noun in front of it:"
-            },
-            {
-              "kind": "speech",
-              "text": "வேலை செய் (vēlai sey) = \"work-do\" = \"to work\" (vēlai, \"work\")."
-            },
-            {
-              "kind": "speech",
-              "text": "சமையல் செய் (samaiyal sey) = \"to cook\"."
-            },
-            {
-              "kind": "speech",
-              "text": "உதவி செய் (udavi sey) = \"to help\"."
-            },
-            {
-              "kind": "speech",
-              "text": "So \"I work\" is நான் வேலை செய்கிறேன் (nāṉ vēlai seygiṟēṉ) — sey- + -giṟ-."
-            },
-            {
-              "kind": "speech",
-              "text": "-ēṉ, \"I do work.\" Master sey and a whole grammar of \"do-verbs\" opens up."
-            }
-          ]
-        },
-        {
-          "index": 3,
-          "type": "grammar",
-          "title": "Grammar Lens: noun + செய் = a new verb",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "This \"noun + sey\" pattern is the exact twin of Hindi's \"noun + karnā\" (kām karnā, \"to work\"). Two unrelated language families — Dravidian and Indo-Aryan — landed on the same clever trick: make an all-purpose \"do\" verb, then bolt nouns onto it. Living side by side for millennia, Tamil and Hindi have quietly traded habits like this."
-            }
-          ]
-        },
-        {
-          "index": 4,
-          "type": "guided-production",
-          "title": "Guided Practice",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 1,
-              "perItem": false,
-              "source": "[PAUSE 1s]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"vēlai sey\" (to work)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"vēlai sey\" (to work)]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "\"I work\" — nāṉ vēlai seygiṟēṉ",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: \"I work\" — *nāṉ vēlai seygiṟēṉ*]"
-            },
-            {
-              "kind": "prompt",
-              "action": "SAY",
-              "instruction": "the Hindi twin of this trick (noun + karnā)",
-              "spoken": true,
-              "scored": false,
-              "responseSeconds": 8,
-              "source": "[YOU SAY: the Hindi twin of this trick (noun + *karnā*)]"
-            }
-          ]
-        },
-        {
-          "index": 5,
-          "type": "recall",
-          "title": "Wrap-up Recall",
-          "segments": [
-            {
-              "kind": "pause",
-              "seconds": 3,
-              "perItem": false,
-              "source": "[PAUSE 3s]"
-            },
-            {
-              "kind": "speech",
-              "text": "How does Tamil turn \"work\" into \"to work,\" and what Hindi verb works the same way? (Vēlai + sey = \"work-do\"; Hindi's karnā, as in kām karnā.)"
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch05.txt
+++ b/code/learning/human-languages/tamil/narration/ch05.txt
@@ -1,40 +1,8 @@
 Tamil, chapter 5: Chapter 5.
-5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
-Lesson 1 of 5.
-நான் தமிழ் பேசுகிறேன் (nāṉ tamiḻ pēsugiṟēṉ) — "I speak Tamil".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-Your first full, moving sentence — and it names the language itself, with a sound almost no other language has.
-
-The letters in this word.
-தமிழ் (tamiḻ): த (ta) + மி (mi) + ழ் (ḻ) — that last letter, ழ, is the famous Tamil ḻ, a curled retroflex sound between "r," "l," and "zh," found in almost no other language on earth. It is so identified with the language that Tamil is sometimes called "the ḻ language."
-
-The sentence, taken apart.
-நான் தமிழ் பேசுகிறேன் = நான் (nāṉ, "I") + தமிழ் (tamiḻ, "Tamil," the object) + பேசுகிறேன் (pēsugiṟēṉ, "speak") — "I Tamil speak," the verb last as always. The name தமிழ் (tamiḻ) is native, of debated but clearly Dravidian origin (often linked to a sense of "sweetness / one's own speech"); it names one of the oldest living literary languages in the world, with poetry two thousand years old still read today.
-
-Grammar Lens: no gender on "I speak".
-Notice pēsugiṟēṉ is the same whether a man or a woman says it — Tamil marks no gender in the first or second person (only the third: pēsugiṟāṉ he / pēsugiṟāḷ she). This is unlike Hindi, where even "I speak" changes for a male or female speaker (boltā/boltī). Tamil saves gender for "he/she/it."
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "nāṉ tamiḻ pēsugiṟēṉ"]
-[pause 8 seconds for the answer]
-[your turn — say: the special Tamil sound in tamiḻ (the retroflex ḻ)]
-[pause 8 seconds for the answer]
-[your turn — say: does "I speak" change for a man vs. a woman? (No — Tamil marks no gender in the 1st person)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Say "I speak Tamil," and name the rare sound in the word tamiḻ. (Nāṉ tamiḻ pēsugiṟēṉ; the retroflex ḻ — ழ.)
-
-
-Lesson 2 of 5.
+Lesson 1 of 6.
 பேசு (pēsu) — "to speak," your first full verb.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -68,7 +36,150 @@ Wrap-up Recall.
 Build "I speak" from pēsu, and name the three pieces of a Tamil verb. (Pēsugiṟēṉ; stem + tense + person.)
 
 
-Lesson 3 of 5.
+Lesson 2 of 6.
+நான் தமிழ் பேசுகிறேன் (nāṉ tamiḻ pēsugiṟēṉ) — "I speak Tamil".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Your first full, moving sentence — and it names the language itself, with a sound almost no other language has.
+
+The letters in this word.
+தமிழ் (tamiḻ): த (ta) + மி (mi) + ழ் (ḻ) — that last letter, ழ, is the famous Tamil ḻ, a curled retroflex sound between "r," "l," and "zh," found in almost no other language on earth. It is so identified with the language that Tamil is sometimes called "the ḻ language."
+
+The sentence, taken apart.
+நான் தமிழ் பேசுகிறேன் = நான் (nāṉ, "I") + தமிழ் (tamiḻ, "Tamil," the object) + பேசுகிறேன் (pēsugiṟēṉ, "speak") — "I Tamil speak," the verb last as always. The name தமிழ் (tamiḻ) is native, of debated but clearly Dravidian origin (often linked to a sense of "sweetness / one's own speech"); it names one of the oldest living literary languages in the world, with poetry two thousand years old still read today.
+
+Grammar Lens: no gender on "I speak".
+Notice pēsugiṟēṉ is the same whether a man or a woman says it — Tamil marks no gender in the first or second person (only the third: pēsugiṟāṉ he / pēsugiṟāḷ she). This is unlike Hindi, where even "I speak" changes for a male or female speaker (boltā/boltī). Tamil saves gender for "he/she/it."
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "nāṉ tamiḻ pēsugiṟēṉ"]
+[pause 8 seconds for the answer]
+[your turn — say: the special Tamil sound in tamiḻ (the retroflex ḻ)]
+[pause 8 seconds for the answer]
+[your turn — say: does "I speak" change for a man vs. a woman? (No — Tamil marks no gender in the 1st person)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Say "I speak Tamil," and name the rare sound in the word tamiḻ. (Nāṉ tamiḻ pēsugiṟēṉ; the retroflex ḻ — ழ.)
+
+
+Lesson 3 of 6.
+வ and க — the vowel inside each consonant.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The vowel you get for free, Script you'll notice: வ — "va", Script you'll notice: க — "ka" and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Tamil's letters do not join and they carry many curves. Now learn the sound that arrives for free inside every consonant.
+
+Script you'll notice: The vowel you get for free.
+Tamil is an abugida, like Devanagari: a consonant already contains a vowel.
+க is not "k". க is "ka".
+Every consonant carries a built-in a until a later mark removes or replaces it.
+
+Script you'll notice: வ — "va".
+a near-closed loop on the left.
+a full-height arm across the top, ending in a descender on the right.
+
+Script you'll notice: க — "ka".
+a straight horizontal top bar.
+a bowl hanging from its left end.
+a short right stroke that hooks left below.
+
+Sounds you'll need: One letter, three sounds.
+Devanagari separates क, ख, ग, घ. Tamil uses க across that space: k at the start of a word and when doubled (க்க), g after a nasal (ங்க), and a softer h-like sound between vowels. Position, not a new spelling, selects the sound.
+Tamil therefore needs only 18 consonant letters where Devanagari needs 33; its native words do not depend on those written distinctions.
+
+Guided Practice.
+[pause 1 second]
+[once you have stopped driving — write: வ — "left loop, top arm, descender"]
+[once you have stopped driving — write: க — "top bar, left bowl, hooking right stroke"]
+[your turn — say: "க is ka, not k"]
+[pause 8 seconds for the answer]
+[your turn — contrast: initial k, after a nasal g, between vowels soft h]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does க say alone? (Ka — the vowel is inherent.) What kind of script is this? (An abugida.) Which sounds can க spell? (k, g, and a softer h-like sound, chosen by position.) Draw வ and க.
+
+
+Lesson 4 of 6.
+வாழ் (vāḻ) — "to live, to flourish".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+A second verb — and one of the most beloved words in the language, the one Tamils use to bless.
+
+The letters in this word.
+வா (vā) + ழ் (ḻ, the retroflex you just met in tamiḻ) becomes வாழ் (vāḻ).
+
+The word, taken apart.
+வாழ் (vāḻ, "to live, to flourish, to thrive") is native Dravidian, and carries more warmth than a plain "to reside." From it grow வாழ்க்கை (vāḻkkai, "life") and the blessing வாழ்க (vāḻga, "may you live / long live"), heard in vāḻga tamiḻ ("long live Tamil"). To say "I live," add the familiar ending: நான் … வாழ்கிறேன் (nāṉ … vāḻgiṟēṉ), stem + present -giṟ-.
+"I" -ēṉ, exactly like pēsugiṟēṉ.
+
+Grammar Lens: same engine, new verb.
+You already know the machine: vāḻ- (stem) + -giṟ- (present) + -ēṉ ("I") becomes vāḻgiṟēṉ ("I live"). Every verb you learn slots into the same three-part frame — that is the reward for learning pēsu carefully.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "vāḻ" — feel the retroflex ḻ]
+[pause 8 seconds for the answer]
+[your turn — say: "I live" — nāṉ vāḻgiṟēṉ]
+[pause 8 seconds for the answer]
+[your turn — say: the blessing — vāḻga! ("long live / may you flourish")]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Build "I live" from vāḻ, and give the blessing made from it. (Vāḻgiṟēṉ; vāḻga!, "may you live / long live.")
+
+
+Lesson 5 of 6.
+வேலை செய் (vēlai sey) — "to work".
+
+Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+The last verb of the chapter — and, like Hindi's karnā, it is a "do" verb that builds a hundred others.
+
+The letters in this word.
+வேலை (vēlai, "work"): வே (vē) + லை (lai). செய் (sey, "do"): செ (se) + ய் (y).
+
+The word, taken apart.
+செய் (sey, "to do, to make") is a core native Dravidian verb, and Tamil — like Hindi with karnā — builds compound verbs by putting a noun in front of it:
+வேலை செய் (vēlai sey) = "work-do" = "to work" (vēlai, "work").
+சமையல் செய் (samaiyal sey) = "to cook".
+உதவி செய் (udavi sey) = "to help".
+So "I work" is நான் வேலை செய்கிறேன் (nāṉ vēlai seygiṟēṉ) — sey- + -giṟ-.
+-ēṉ, "I do work." Master sey and a whole grammar of "do-verbs" opens up.
+
+Grammar Lens: noun + செய் = a new verb.
+This "noun + sey" pattern is the exact twin of Hindi's "noun + karnā" (kām karnā, "to work"). Two unrelated language families — Dravidian and Indo-Aryan — landed on the same clever trick: make an all-purpose "do" verb, then bolt nouns onto it. Living side by side for millennia, Tamil and Hindi have quietly traded habits like this.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: "vēlai sey" (to work)]
+[pause 8 seconds for the answer]
+[your turn — say: "I work" — nāṉ vēlai seygiṟēṉ]
+[pause 8 seconds for the answer]
+[your turn — say: the Hindi twin of this trick (noun + karnā)]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+How does Tamil turn "work" into "to work," and what Hindi verb works the same way? (Vēlai + sey = "work-do"; Hindi's karnā, as in kām karnā.)
+
+
+Lesson 6 of 6.
 Chapter 5 — The first verbs.
 
 Warm-up.
@@ -105,73 +216,3 @@ tamiḻ — the language, and its signature retroflex ḻ.
 Wrap-up Recall.
 [pause 3 seconds]
 In one breath, say your language and your work in Tamil, then bless someone with the vāḻ verb. (Nāṉ tamiḻ pēsugiṟēṉ. Nāṉ vēlai seygiṟēṉ. Vāḻga!)
-
-
-Lesson 4 of 5.
-வாழ் (vāḻ) — "to live, to flourish".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-A second verb — and one of the most beloved words in the language, the one Tamils use to bless.
-
-The letters in this word.
-வா (vā) + ழ் (ḻ, the retroflex you just met in tamiḻ) becomes வாழ் (vāḻ).
-
-The word, taken apart.
-வாழ் (vāḻ, "to live, to flourish, to thrive") is native Dravidian, and carries more warmth than a plain "to reside." From it grow வாழ்க்கை (vāḻkkai, "life") and the blessing வாழ்க (vāḻga, "may you live / long live"), heard in vāḻga tamiḻ ("long live Tamil"). To say "I live," add the familiar ending: நான் … வாழ்கிறேன் (nāṉ … vāḻgiṟēṉ), stem + present -giṟ-.
-"I" -ēṉ, exactly like pēsugiṟēṉ.
-
-Grammar Lens: same engine, new verb.
-You already know the machine: vāḻ- (stem) + -giṟ- (present) + -ēṉ ("I") becomes vāḻgiṟēṉ ("I live"). Every verb you learn slots into the same three-part frame — that is the reward for learning pēsu carefully.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "vāḻ" — feel the retroflex ḻ]
-[pause 8 seconds for the answer]
-[your turn — say: "I live" — nāṉ vāḻgiṟēṉ]
-[pause 8 seconds for the answer]
-[your turn — say: the blessing — vāḻga! ("long live / may you flourish")]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-Build "I live" from vāḻ, and give the blessing made from it. (Vāḻgiṟēṉ; vāḻga!, "may you live / long live.")
-
-
-Lesson 5 of 5.
-வேலை செய் (vēlai sey) — "to work".
-
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
-Warm-up.
-[pause 2 seconds]
-The last verb of the chapter — and, like Hindi's karnā, it is a "do" verb that builds a hundred others.
-
-The letters in this word.
-வேலை (vēlai, "work"): வே (vē) + லை (lai). செய் (sey, "do"): செ (se) + ய் (y).
-
-The word, taken apart.
-செய் (sey, "to do, to make") is a core native Dravidian verb, and Tamil — like Hindi with karnā — builds compound verbs by putting a noun in front of it:
-வேலை செய் (vēlai sey) = "work-do" = "to work" (vēlai, "work").
-சமையல் செய் (samaiyal sey) = "to cook".
-உதவி செய் (udavi sey) = "to help".
-So "I work" is நான் வேலை செய்கிறேன் (nāṉ vēlai seygiṟēṉ) — sey- + -giṟ-.
--ēṉ, "I do work." Master sey and a whole grammar of "do-verbs" opens up.
-
-Grammar Lens: noun + செய் = a new verb.
-This "noun + sey" pattern is the exact twin of Hindi's "noun + karnā" (kām karnā, "to work"). Two unrelated language families — Dravidian and Indo-Aryan — landed on the same clever trick: make an all-purpose "do" verb, then bolt nouns onto it. Living side by side for millennia, Tamil and Hindi have quietly traded habits like this.
-
-Guided Practice.
-[pause 1 second]
-[your turn — say: "vēlai sey" (to work)]
-[pause 8 seconds for the answer]
-[your turn — say: "I work" — nāṉ vēlai seygiṟēṉ]
-[pause 8 seconds for the answer]
-[your turn — say: the Hindi twin of this trick (noun + karnā)]
-[pause 8 seconds for the answer]
-
-Wrap-up Recall.
-[pause 3 seconds]
-How does Tamil turn "work" into "to work," and what Hindi verb works the same way? (Vēlai + sey = "work-do"; Hindi's karnā, as in kām karnā.)

--- a/code/learning/human-languages/tamil/narration/ch06.json
+++ b/code/learning/human-languages/tamil/narration/ch06.json
@@ -3,12 +3,12 @@
   "language": "tamil",
   "chapter": 6,
   "title": "Dative Case and Dative Subjects",
-  "drivablePrefix": 4,
-  "sourceHash": "fnv1a64:f39b57f3b08140c4",
+  "drivablePrefix": 1,
+  "sourceHash": "fnv1a64:46861411f2d2c948",
   "lessons": [
     {
       "id": "TA-C06-dative-ukku",
-      "sequence": 180,
+      "sequence": 360,
       "title": "-உக்கு (-ukku) — \"to, for\"",
       "headword": "-உக்கு",
       "romanization": "-ukku",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:80d96e6884624d7c",
+      "sourceHash": "fnv1a64:fefd6585b85ebcb8",
       "notice": null,
       "blocks": [
         {
@@ -133,7 +133,185 @@
             },
             {
               "kind": "speech",
-              "text": "What does -உக்கு mean? (\"To\" or \"for.\") Where does it go? (On the end of the noun — Tamil adds, it doesn't put a word in front.) What is \"to me\"? (எனக்கு enakku — the pronoun's body changes to en- first.) Why does the suffix show up as -ukku and -kku? (One case, two shapes, chosen by the noun's ending.) Next: compare that visible one-purpose suffix with a fused Latin ending."
+              "text": "What does -உக்கு mean? (\"To\" or \"for.\") Where does it go? (On the end of the noun — Tamil adds, it doesn't put a word in front.) What is \"to me\"? (எனக்கு enakku — the pronoun's body changes to en- first.) Why does the suffix show up as -ukku and -kku? (One case, two shapes, chosen by the noun's ending.) Next: two more letters — ம and retroflex ண."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W02-ma-retroflex-na",
+      "sequence": 370,
+      "title": "ம and ண — a loop, and a curled tongue",
+      "headword": "ம, ண",
+      "romanization": "ma, ṇa",
+      "gloss": "write ம and retroflex ண while training the tongue to curl back",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:3dac8aa75e4a6c93",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: ம",
+          "Script you'll notice: ண",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ம, Script you'll notice: ண and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Two more letters, and with them you'll have every letter of this book's first word. One is easy. The other is a sound you may not be able to hear yet."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: ம",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "a straight vertical stroke on the LEFT."
+            },
+            {
+              "kind": "speech",
+              "text": "a horizontal along the bottom."
+            },
+            {
+              "kind": "speech",
+              "text": "a rounded arch closing it on the RIGHT."
+            },
+            {
+              "kind": "speech",
+              "text": "Get the sides the right way round. The upright is on the left and the curve on the right — which is the reverse of what most people guess, and the reverse of the Devanagari habit of hanging a shape off a right-hand spine."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: ண",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "a straight top bar."
+            },
+            {
+              "kind": "speech",
+              "text": "a loop on the left."
+            },
+            {
+              "kind": "speech",
+              "text": "two arches."
+            },
+            {
+              "kind": "speech",
+              "text": "a straight vertical on the right, down to the baseline."
+            },
+            {
+              "kind": "speech",
+              "text": "The dot under the romanization — ṇ, not plain n — is doing real work."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "pronunciation",
+          "title": "Sounds you'll need: Retroflex",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Say English n. Your tongue touches just behind your teeth."
+            },
+            {
+              "kind": "speech",
+              "text": "Now curl the tip of your tongue up and back toward the roof of your mouth, and say it again. That is ṇ, and it is a different letter in Tamil."
+            },
+            {
+              "kind": "speech",
+              "text": "English has no such sound and no way to write one, which is why an English speaker typically cannot hear the difference at first. That is expected. The ear learns it after the hand does, which is one good argument for writing the letters rather than only reading them."
+            },
+            {
+              "kind": "speech",
+              "text": "Retroflex sounds are a signature of the languages of India — they show up across Tamil, Telugu, Kannada, Malayalam, Hindi and Sanskrit alike, in families that are otherwise unrelated to each other. It's one of the features that makes South Asia a linguistic area: neighbouring languages that borrowed a sound from each other rather than inheriting it."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ம — \"left upright, bottom, right arch\"",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: ம — \"left upright, bottom, **right** arch\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ண — \"top bar, left loop, two arches, straight vertical\"",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: ண — \"top bar, left loop, **two** arches, straight vertical\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "plain n, then curl the tongue back — ṇ",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: plain *n*, then curl the tongue back — **ṇ**]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Draw ம — which side is the upright on? (The left; the arch closes it on the right.) Draw ண — what makes it not ன? (One extra arch: ண has two arches where ன has one. Both end in the same straight vertical.) What does the dot in ṇ mean? (Retroflex — the tongue curls back to the roof of the mouth.) Why can't you hear it yet? (English has no such sound; the ear learns it after the hand.) Next: stacking that dative suffix where Latin would fuse several meanings."
             }
           ]
         }
@@ -141,7 +319,7 @@
     },
     {
       "id": "TA-C06-dative-stacking",
-      "sequence": 190,
+      "sequence": 380,
       "title": "-உக்கு (-ukku) — one carriage in a suffix train",
       "headword": "பெயர் + உக்கு",
       "romanization": "peyar + ukku",
@@ -152,7 +330,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:4284bfb529666b68",
+      "sourceHash": "fnv1a64:b6735982d308a9b7",
       "notice": null,
       "blocks": [
         {
@@ -264,7 +442,7 @@
     },
     {
       "id": "TA-C06-dative-subject",
-      "sequence": 200,
+      "sequence": 390,
       "title": "எனக்குத் தமிழ் தெரியும் (enakkut tamiḻ teriyum) — \"I know Tamil\"",
       "headword": "எனக்குத் தமிழ் தெரியும்",
       "romanization": "enakkut tamiḻ teriyum",
@@ -275,7 +453,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5ac4c3bda06796be",
+      "sourceHash": "fnv1a64:f2af170cba5d5680",
       "notice": null,
       "blocks": [
         {
@@ -426,7 +604,7 @@
     },
     {
       "id": "TA-C06-dative-subject-family",
-      "sequence": 210,
+      "sequence": 400,
       "title": "-ukku, -ku, -ge, -ikku — the family shows its bones",
       "headword": "எனக்கு / నాకు / ನನಗೆ / എനിക്ക്",
       "romanization": "",
@@ -437,7 +615,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:2918677f2a6352d0",
+      "sourceHash": "fnv1a64:15d841e1d8f9bd2f",
       "notice": null,
       "blocks": [
         {
@@ -542,6 +720,153 @@
             {
               "kind": "speech",
               "text": "Do the four sisters agree on dative experiencers? (Yes.) Which four suffix shapes reveal the relationship? (-ukku, -ku, -ge, -ikku.) What stays plain in the sentence? (The thing known or experienced.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W02-three-ns",
+      "sequence": 410,
+      "title": "ந, ன, ண (na, ṉa, ṇa) — three stops on one tongue-map",
+      "headword": "ந, ன, ண",
+      "romanization": "na, ṉa, ṇa",
+      "gloss": "Tamil writes dental, alveolar, and retroflex n with three separate letters",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:ab29843a61b3d47c",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: The backward walk",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The backward walk and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "English writes one n. Tamil keeps three tongue positions apart."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: The backward walk",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "letter",
+                "sound",
+                "tongue"
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "letter: ந. sound: na. tongue: against the teeth (dental).",
+                "letter: ன. sound: ṉa. tongue: on the ridge behind the teeth (alveolar).",
+                "letter: ண. sound: ṇa. tongue: curled back to the roof (retroflex)."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Move backward: teeth becomes ridge becomes curled roof. English spells all three with one letter and initially hears them as the same sound; Tamil uses separate letters because its words depend on the contrast."
+            },
+            {
+              "kind": "speech",
+              "text": "You will draw ந and ன when nandri needs them. For now compare the last pair: ண is ன with one extra arch. Both open with a top bar and loop and finish with the same vertical. ன has one middle arch; ண has two."
+            },
+            {
+              "kind": "speech",
+              "text": "Retroflex sounds occur across unrelated South Asian language families. That shared geography makes the region a linguistic area: neighbors can borrow a sound pattern without inheriting it from one ancestor."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "dental ந at the teeth",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: dental ந at the teeth]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "alveolar ன at the ridge",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: alveolar ன at the ridge]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "retroflex ண with the tongue curled back",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: retroflex ண with the tongue curled back]"
+            },
+            {
+              "kind": "prompt",
+              "action": "TRACE",
+              "instruction": "one arch in ன, two arches in ண",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU TRACE: one arch in ன · two arches in ண]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "How many n-letters does Tamil have? (Three.) What separates them? (Tongue position: dental, alveolar, retroflex.) Which two differ by one arch? (ன has one; ண has two.) Next: the numbers one to five."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch06.txt
+++ b/code/learning/human-languages/tamil/narration/ch06.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 6: Dative Case and Dative Subjects.
-4 lessons. All 4 can be done entirely by ear.
+6 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 4.
+Lesson 1 of 6.
 -உக்கு (-ukku) — "to, for".
 
 Warm-up.
@@ -30,10 +30,50 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-What does -உக்கு mean? ("To" or "for.") Where does it go? (On the end of the noun — Tamil adds, it doesn't put a word in front.) What is "to me"? (எனக்கு enakku — the pronoun's body changes to en- first.) Why does the suffix show up as -ukku and -kku? (One case, two shapes, chosen by the noun's ending.) Next: compare that visible one-purpose suffix with a fused Latin ending.
+What does -உக்கு mean? ("To" or "for.") Where does it go? (On the end of the noun — Tamil adds, it doesn't put a word in front.) What is "to me"? (எனக்கு enakku — the pronoun's body changes to en- first.) Why does the suffix show up as -ukku and -kku? (One case, two shapes, chosen by the noun's ending.) Next: two more letters — ம and retroflex ண.
 
 
-Lesson 2 of 4.
+Lesson 2 of 6.
+ம and ண — a loop, and a curled tongue.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ம, Script you'll notice: ண and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Two more letters, and with them you'll have every letter of this book's first word. One is easy. The other is a sound you may not be able to hear yet.
+
+Script you'll notice: ம.
+a straight vertical stroke on the LEFT.
+a horizontal along the bottom.
+a rounded arch closing it on the RIGHT.
+Get the sides the right way round. The upright is on the left and the curve on the right — which is the reverse of what most people guess, and the reverse of the Devanagari habit of hanging a shape off a right-hand spine.
+
+Script you'll notice: ண.
+a straight top bar.
+a loop on the left.
+two arches.
+a straight vertical on the right, down to the baseline.
+The dot under the romanization — ṇ, not plain n — is doing real work.
+
+Sounds you'll need: Retroflex.
+Say English n. Your tongue touches just behind your teeth.
+Now curl the tip of your tongue up and back toward the roof of your mouth, and say it again. That is ṇ, and it is a different letter in Tamil.
+English has no such sound and no way to write one, which is why an English speaker typically cannot hear the difference at first. That is expected. The ear learns it after the hand does, which is one good argument for writing the letters rather than only reading them.
+Retroflex sounds are a signature of the languages of India — they show up across Tamil, Telugu, Kannada, Malayalam, Hindi and Sanskrit alike, in families that are otherwise unrelated to each other. It's one of the features that makes South Asia a linguistic area: neighbouring languages that borrowed a sound from each other rather than inheriting it.
+
+Guided Practice.
+[pause 1 second]
+[once you have stopped driving — write: ம — "left upright, bottom, right arch"]
+[once you have stopped driving — write: ண — "top bar, left loop, two arches, straight vertical"]
+[your turn — say: plain n, then curl the tongue back — ṇ]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Draw ம — which side is the upright on? (The left; the arch closes it on the right.) Draw ண — what makes it not ன? (One extra arch: ண has two arches where ன has one. Both end in the same straight vertical.) What does the dot in ṇ mean? (Retroflex — the tongue curls back to the roof of the mouth.) Why can't you hear it yet? (English has no such sound; the ear learns it after the hand.) Next: stacking that dative suffix where Latin would fuse several meanings.
+
+
+Lesson 3 of 6.
 -உக்கு (-ukku) — one carriage in a suffix train.
 
 Warm-up.
@@ -63,7 +103,7 @@ Wrap-up Recall.
 What does -ukku contribute? (Dative to/for, one meaning.) What does Latin -īs fuse? (Case, plural number, and declension class.) Which system leaves the seam visible? (Tamil's agglutinative stack.)
 
 
-Lesson 3 of 4.
+Lesson 4 of 6.
 எனக்குத் தமிழ் தெரியும் (enakkut tamiḻ teriyum) — "I know Tamil".
 
 Warm-up.
@@ -103,7 +143,7 @@ Wrap-up Recall.
 What does எனக்குத் தமிழ் தெரியும் (enakkut tamiḻ teriyum) literally say? ("To-me Tamil is-known.") Which word has English got that Tamil hasn't? (A nominative "I" — nāṉ is replaced by the dative enakku.) Why does Tamil use the dative here? (Because knowing happens to you; you don't do it.) Which English word preserves the same idea? (Methinks — "it seems to me".) Next: watch all four Dravidian sisters use the same experiencer shape.
 
 
-Lesson 4 of 4.
+Lesson 5 of 6.
 -ukku, -ku, -ge, -ikku — the family shows its bones.
 
 Warm-up.
@@ -130,3 +170,36 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Do the four sisters agree on dative experiencers? (Yes.) Which four suffix shapes reveal the relationship? (-ukku, -ku, -ge, -ikku.) What stays plain in the sentence? (The thing known or experienced.)
+
+
+Lesson 6 of 6.
+ந, ன, ண (na, ṉa, ṇa) — three stops on one tongue-map.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The backward walk and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+English writes one n. Tamil keeps three tongue positions apart.
+
+Script you'll notice: The backward walk.
+[a table of 3 rows, read aloud]
+letter: ந. sound: na. tongue: against the teeth (dental).
+letter: ன. sound: ṉa. tongue: on the ridge behind the teeth (alveolar).
+letter: ண. sound: ṇa. tongue: curled back to the roof (retroflex).
+Move backward: teeth becomes ridge becomes curled roof. English spells all three with one letter and initially hears them as the same sound; Tamil uses separate letters because its words depend on the contrast.
+You will draw ந and ன when nandri needs them. For now compare the last pair: ண is ன with one extra arch. Both open with a top bar and loop and finish with the same vertical. ன has one middle arch; ண has two.
+Retroflex sounds occur across unrelated South Asian language families. That shared geography makes the region a linguistic area: neighbors can borrow a sound pattern without inheriting it from one ancestor.
+
+Guided Practice.
+[pause 1 second]
+[your turn — say: dental ந at the teeth]
+[pause 8 seconds for the answer]
+[your turn — say: alveolar ன at the ridge]
+[pause 8 seconds for the answer]
+[your turn — say: retroflex ண with the tongue curled back]
+[pause 8 seconds for the answer]
+[once you have stopped driving — trace: one arch in ன, two arches in ண]
+
+Wrap-up Recall.
+[pause 3 seconds]
+How many n-letters does Tamil have? (Three.) What separates them? (Tongue position: dental, alveolar, retroflex.) Which two differ by one arch? (ன has one; ண has two.) Next: the numbers one to five.

--- a/code/learning/human-languages/tamil/narration/ch07.json
+++ b/code/learning/human-languages/tamil/narration/ch07.json
@@ -4,11 +4,11 @@
   "chapter": 7,
   "title": "Numbers One to Ten",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:1c193954d5aaadb3",
+  "sourceHash": "fnv1a64:3a0207b0f2cb9ddd",
   "lessons": [
     {
       "id": "TA-C07-numbers-1-5",
-      "sequence": 220,
+      "sequence": 420,
       "title": "ஒன்று, இரண்டு, மூன்று, நான்கு, ஐந்து — one to five",
       "headword": "ஒன்று இரண்டு மூன்று நான்கு ஐந்து",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:abb924eead9ea4ef",
+      "sourceHash": "fnv1a64:7f1fe2cf223f2795",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -128,7 +128,7 @@
     },
     {
       "id": "TA-C07-numbers-1-5-family",
-      "sequence": 230,
+      "sequence": 430,
       "title": "Two to five — one family in four regional coats",
       "headword": "இரண்டு மூன்று நான்கு ஐந்து",
       "romanization": "",
@@ -139,7 +139,7 @@
       "modalityReasons": [
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:43c348a1c52641ce",
+      "sourceHash": "fnv1a64:1348a3cd6d2254dc",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -269,7 +269,7 @@
     },
     {
       "id": "TA-C07-numbers-6-10",
-      "sequence": 240,
+      "sequence": 440,
       "title": "ஆறு, ஏழு, எட்டு, ஒன்பது, பத்து — six to ten",
       "headword": "ஆறு ஏழு எட்டு ஒன்பது பத்து",
       "romanization": "",
@@ -281,7 +281,7 @@
         "sight-cue",
         "wide-table"
       ],
-      "sourceHash": "fnv1a64:4ddc2af168d07ed1",
+      "sourceHash": "fnv1a64:401209a5981f3533",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -427,7 +427,168 @@
             },
             {
               "kind": "speech",
-              "text": "Count six to ten in Tamil. (Āṟu, ēḻu, eṭṭu, oṉpatu, pattu.) Which number is written with ழ, and where else does that letter appear? (Seven, ēḻu — the same letter that ends Tamiḻ.) How is nine built? (Oṉ \"one\" + patu \"ten\" becomes oṉpatu, one short of ten.) Next: follow these forms across the family and hear Kannada p soften to h."
+              "text": "Count six to ten in Tamil. (Āṟu, ēḻu, eṭṭu, oṉpatu, pattu.) Which number is written with ழ, and where else does that letter appear? (Seven, ēḻu — the same letter that ends Tamiḻ.) How is nine built? (Oṉ \"one\" + patu \"ten\" becomes oṉpatu, one short of ten.) Next: the puḷḷi — the dot that takes a consonant's built-in vowel away."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W03-pulli-vanakkam",
+      "sequence": 450,
+      "title": "் (puḷḷi) — the dot that leaves both letters visible",
+      "headword": "்",
+      "romanization": "puḷḷi",
+      "gloss": "the puḷḷi — a visible dot that removes the inherent vowel without creating a conjunct",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block",
+        "sight-cue"
+      ],
+      "sourceHash": "fnv1a64:64efe447e0048de5",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page",
+          "your eyes, because the lesson points at something written down"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: The puḷḷi",
+          "Script you'll notice: What Tamil does not do",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script you'll notice: The puḷḷi, Script you'll notice: What Tamil does not do and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Every consonant carries a built-in a. So how do you write a consonant with no vowel — the k in vaṇakkam, or the m at the end?"
+            },
+            {
+              "kind": "speech",
+              "text": "One dot."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: The puḷḷi",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "க = ka becomes க் = k."
+            },
+            {
+              "kind": "speech",
+              "text": "புள்ளி (puḷḷi) means simply \"the dot.\" Written above a letter, it removes the inherent vowel. That's the whole rule."
+            },
+            {
+              "kind": "speech",
+              "text": "A standing note for this whole track. These lessons quote real Tamil words and examples, and most of them contain letters the track has not taught you to draw yet — puḷḷi's own name uses ப, ள and the ு sign, and the comparisons below reach for others again. Read anything printed here; only draw the letters a lesson has actually broken into strokes. The data file behind this track covers 11 letters so far and says so (complete: false) — it grows as the chapters need it."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: What Tamil does not do",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "If you have done the Devanagari track, this is the moment to notice a real divergence."
+            },
+            {
+              "kind": "speech",
+              "text": "In Devanagari, killing the vowel makes the bare consonant fuse with the next one into a squeezed conjunct — स् + त becomes स्त, and the first letter loses its spine. The virama usually disappears into the ligature."
+            },
+            {
+              "kind": "speech",
+              "text": "Tamil doesn't do that. The dot stays visible, and both letters keep their full shape:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "Devanagari, स् + त becomes स्त — a new fused shape.",
+                "Tamil, க் + க becomes க்க — two letters, dot intact."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "The consequence is arithmetic. Tamil's whole set is 247 characters: 12 vowels + 18 consonants + the 216 consonant-vowel combinations + the āytam ஃ. That is genuinely all of them. Devanagari's conjuncts run to many hundreds of ligature shapes on top of its letters, each to be learned or at least recognised."
+            },
+            {
+              "kind": "speech",
+              "text": "(One honest exception: Tamil does have a few ligatures borrowed with Sanskrit words — க்ஷ kṣa and ஸ்ரீ śrī. They sit outside the 18 native consonants and outside the 247.)"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "க் — \"க, then the dot above\"",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: க் — \"க, then the dot above\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "க்க — two full letters, dot intact, no fusing",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: க்க — two full letters, dot intact, **no fusing**]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What does the puḷḷi do, and what does the word mean? (Removes the inherent vowel; puḷḷi is simply \"the dot\".) What does Devanagari do that Tamil doesn't? (Fuses the letters into a conjunct — Tamil keeps both shapes and the dot.) What does Tamil get in exchange? (A much smaller character set — 247, with almost no ligatures: only the borrowed க்ஷ and ஸ்ரீ.) Next: six, seven and ten across the family."
             }
           ]
         }
@@ -435,7 +596,7 @@
     },
     {
       "id": "TA-C07-numbers-6-10-family",
-      "sequence": 250,
+      "sequence": 460,
       "title": "Six to ten — family resemblances and one Kannada shift",
       "headword": "ஆறு ஏழு பத்து",
       "romanization": "",
@@ -446,7 +607,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:74ab19978e0308e0",
+      "sourceHash": "fnv1a64:cee9f967507bdf77",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch07.txt
+++ b/code/learning/human-languages/tamil/narration/ch07.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 7: Numbers One to Ten.
-4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
-Lesson 1 of 4.
+Lesson 1 of 5.
 ஒன்று, இரண்டு, மூன்று, நான்கு, ஐந்து — one to five.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called You'll want to know: The five until you have stopped, and I will say so again when we reach it.
@@ -28,7 +28,7 @@ Wrap-up Recall.
 Count to five in Tamil. (Oṉṟu, iraṇṭu, mūṉṟu, nāṉku, aintu.) Are Tamil's numbers borrowed from Sanskrit, like Hindi's? (No — they're native Dravidian.) Which two writing systems sit side by side? (Spelled-out words and Tamil's own numerals.) Next: compare these native forms across the family.
 
 
-Lesson 2 of 4.
+Lesson 2 of 5.
 Two to five — one family in four regional coats.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called The word, taken apart - The cousin table until you have stopped, and I will say so again when we reach it.
@@ -59,7 +59,7 @@ Wrap-up Recall.
 Are these forms borrowed? (No, native Dravidian.) Which numbers stay tidiest across the family? (Two through five.) Which language forms "one" differently? (Telugu, okaṭi.)
 
 
-Lesson 3 of 4.
+Lesson 3 of 5.
 ஆறு, ஏழு, எட்டு, ஒன்பது, பத்து — six to ten.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, because the lesson points at something written down and your eyes for one table that cannot be read aloud. You can listen to everything else now — leave the section called You'll want to know: The five until you have stopped, and I will say so again when we reach it.
@@ -93,10 +93,45 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-Count six to ten in Tamil. (Āṟu, ēḻu, eṭṭu, oṉpatu, pattu.) Which number is written with ழ, and where else does that letter appear? (Seven, ēḻu — the same letter that ends Tamiḻ.) How is nine built? (Oṉ "one" + patu "ten" becomes oṉpatu, one short of ten.) Next: follow these forms across the family and hear Kannada p soften to h.
+Count six to ten in Tamil. (Āṟu, ēḻu, eṭṭu, oṉpatu, pattu.) Which number is written with ழ, and where else does that letter appear? (Seven, ēḻu — the same letter that ends Tamiḻ.) How is nine built? (Oṉ "one" + patu "ten" becomes oṉpatu, one short of ten.) Next: the puḷḷi — the dot that takes a consonant's built-in vowel away.
 
 
-Lesson 4 of 4.
+Lesson 4 of 5.
+் (puḷḷi) — the dot that leaves both letters visible.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on, your eyes, for letter shapes on the page and your eyes, because the lesson points at something written down. You can listen to everything else now — leave the sections called Script you'll notice: The puḷḷi, Script you'll notice: What Tamil does not do and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Every consonant carries a built-in a. So how do you write a consonant with no vowel — the k in vaṇakkam, or the m at the end?
+One dot.
+
+Script you'll notice: The puḷḷi.
+க = ka becomes க் = k.
+புள்ளி (puḷḷi) means simply "the dot." Written above a letter, it removes the inherent vowel. That's the whole rule.
+A standing note for this whole track. These lessons quote real Tamil words and examples, and most of them contain letters the track has not taught you to draw yet — puḷḷi's own name uses ப, ள and the ு sign, and the comparisons below reach for others again. Read anything printed here; only draw the letters a lesson has actually broken into strokes. The data file behind this track covers 11 letters so far and says so (complete: false) — it grows as the chapters need it.
+
+Script you'll notice: What Tamil does not do.
+If you have done the Devanagari track, this is the moment to notice a real divergence.
+In Devanagari, killing the vowel makes the bare consonant fuse with the next one into a squeezed conjunct — स् + त becomes स्त, and the first letter loses its spine. The virama usually disappears into the ligature.
+Tamil doesn't do that. The dot stays visible, and both letters keep their full shape:
+[a table of 2 rows, read aloud]
+Devanagari, स् + त becomes स्त — a new fused shape.
+Tamil, க் + க becomes க்க — two letters, dot intact.
+The consequence is arithmetic. Tamil's whole set is 247 characters: 12 vowels + 18 consonants + the 216 consonant-vowel combinations + the āytam ஃ. That is genuinely all of them. Devanagari's conjuncts run to many hundreds of ligature shapes on top of its letters, each to be learned or at least recognised.
+(One honest exception: Tamil does have a few ligatures borrowed with Sanskrit words — க்ஷ kṣa and ஸ்ரீ śrī. They sit outside the 18 native consonants and outside the 247.)
+
+Guided Practice.
+[pause 1 second]
+[once you have stopped driving — write: க் — "க, then the dot above"]
+[once you have stopped driving — write: க்க — two full letters, dot intact, no fusing]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What does the puḷḷi do, and what does the word mean? (Removes the inherent vowel; puḷḷi is simply "the dot".) What does Devanagari do that Tamil doesn't? (Fuses the letters into a conjunct — Tamil keeps both shapes and the dot.) What does Tamil get in exchange? (A much smaller character set — 247, with almost no ligatures: only the borrowed க்ஷ and ஸ்ரீ.) Next: six, seven and ten across the family.
+
+
+Lesson 5 of 5.
 Six to ten — family resemblances and one Kannada shift.
 
 Warm-up.

--- a/code/learning/human-languages/tamil/narration/ch08.json
+++ b/code/learning/human-languages/tamil/narration/ch08.json
@@ -4,11 +4,11 @@
   "chapter": 8,
   "title": "Please",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:f6321c5249da200d",
+  "sourceHash": "fnv1a64:17e6eaaffab36d7e",
   "lessons": [
     {
       "id": "TA-C08-tayavuseytu",
-      "sequence": 260,
+      "sequence": 470,
       "title": "தயவுசெய்து (tayavu seytu) — please (do the kindness)",
       "headword": "தயவுசெய்து",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b64c5bd7dd10f8eb",
+      "sourceHash": "fnv1a64:b971e0b2bb303f4a",
       "notice": null,
       "blocks": [
         {
@@ -149,7 +149,7 @@
     },
     {
       "id": "TA-C08-please-register",
-      "sequence": 270,
+      "sequence": 480,
       "title": "தயவுசெய்து or -உங்கள்? — politeness in phrase or verb",
       "headword": "தயவுசெய்து / -உங்கள்",
       "romanization": "",
@@ -160,7 +160,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:11ca8536d913b3ec",
+      "sourceHash": "fnv1a64:623569769d69e6a3",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -277,6 +277,155 @@
             {
               "kind": "speech",
               "text": "What carries everyday \"please\"? (The respectful verb ending -uṅgaḷ.) When is tayavu seytu especially useful? (A markedly polite or emphatic request.) What silences y in ய்? (The puḷḷi.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W03-write-vanakkam",
+      "sequence": 490,
+      "title": "வணக்கம் (vaṇakkam) — the first whole written word",
+      "headword": "வணக்கம்",
+      "romanization": "vaṇakkam",
+      "gloss": "assemble the first greeting and hold its doubled consonant",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:fda8442069111930",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: Build the word",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: Build the word and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You know the four letter bodies and the vowel-killing dot. Assemble them left to right."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: Build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 5,
+              "utterances": [
+                "piece: வ, va, Lesson 1.",
+                "piece: ண, ṇa, Lesson 2.",
+                "piece: க், k — க with the dot, last lesson.",
+                "piece: க, ka, Lesson 1.",
+                "piece: ம், m — ம with the dot, this lesson."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "வ, ண, க், க, ம் becomes வணக்கம் (vaṇakkam)."
+            },
+            {
+              "kind": "speech",
+              "text": "Hear two details. க்க is a doubled consonant: hold it, vaṇak-kam, not vaṇakam. Tamil distinguishes single from double consonants. Final ம் is a bare m, so the word closes instead of trailing into ma."
+            },
+            {
+              "kind": "speech",
+              "text": "That is the first word of this book, written by hand."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "க் — க with the dot",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: க் — க with the dot]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "க்க — two full letters, dot intact",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: க்க — two full letters, dot intact]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "வணக்கம் (vaṇakkam) — five pieces, left to right",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **வணக்கம்** — five pieces, left to right]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"vaṇak-kam\" — hold the middle",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"vaṇa**k-k**am\" — hold the middle]"
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write வணக்கம் (vaṇakkam). What is special about க்க? (It is doubled and held.) Why does the word end in m, not ma? (Final ம் carries a puḷḷi.) Next: the formal way to say please forgive me."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch08.txt
+++ b/code/learning/human-languages/tamil/narration/ch08.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 8: Please.
-2 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
+3 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 2.
+Lesson 1 of 3.
 தயவுசெய்து (tayavu seytu) — please (do the kindness).
 
 Warm-up.
@@ -36,7 +36,7 @@ Wrap-up Recall.
 What is the Tamil phrase for please? (தயவுசெய்து tayavu seytu.) What do its two pieces mean? ("Kindness" tayavu + "having done" seytu — do the kindness.) Which languages ask the same way? (Kannada, Telugu, Malayalam with daya, and further off Arabic faḍl and Hindi kṛpā.) Next: decide when the standalone phrase is natural and when the verb carries the courtesy.
 
 
-Lesson 2 of 2.
+Lesson 2 of 3.
 தயவுசெய்து or -உங்கள்? — politeness in phrase or verb.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called Script you'll notice: Read the join in செய்து until you have stopped, and I will say so again when we reach it.
@@ -66,3 +66,36 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 What carries everyday "please"? (The respectful verb ending -uṅgaḷ.) When is tayavu seytu especially useful? (A markedly polite or emphatic request.) What silences y in ய்? (The puḷḷi.)
+
+
+Lesson 3 of 3.
+வணக்கம் (vaṇakkam) — the first whole written word.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: Build the word and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You know the four letter bodies and the vowel-killing dot. Assemble them left to right.
+
+Script you'll notice: Build the word.
+[a table of 5 rows, read aloud]
+piece: வ, va, Lesson 1.
+piece: ண, ṇa, Lesson 2.
+piece: க், k — க with the dot, last lesson.
+piece: க, ka, Lesson 1.
+piece: ம், m — ம with the dot, this lesson.
+வ, ண, க், க, ம் becomes வணக்கம் (vaṇakkam).
+Hear two details. க்க is a doubled consonant: hold it, vaṇak-kam, not vaṇakam. Tamil distinguishes single from double consonants. Final ம் is a bare m, so the word closes instead of trailing into ma.
+That is the first word of this book, written by hand.
+
+Guided Practice.
+[pause 1 second]
+[once you have stopped driving — write: க் — க with the dot]
+[once you have stopped driving — write: க்க — two full letters, dot intact]
+[once you have stopped driving — write: வணக்கம் (vaṇakkam) — five pieces, left to right]
+[your turn — say: "vaṇak-kam" — hold the middle]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Write வணக்கம் (vaṇakkam). What is special about க்க? (It is doubled and held.) Why does the word end in m, not ma? (Final ம் carries a puḷḷi.) Next: the formal way to say please forgive me.

--- a/code/learning/human-languages/tamil/narration/ch09.json
+++ b/code/learning/human-languages/tamil/narration/ch09.json
@@ -4,11 +4,11 @@
   "chapter": 9,
   "title": "Sorry",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:262d769ef6d9dc12",
+  "sourceHash": "fnv1a64:da456f87ee652d26",
   "lessons": [
     {
       "id": "TA-C09-mannikkavum",
-      "sequence": 280,
+      "sequence": 500,
       "title": "மன்னிக்கவும் (maṉṉikkavum) — please forgive",
       "headword": "மன்னிக்கவும்",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b6af60ab308e7049",
+      "sourceHash": "fnv1a64:2ca552bc0eb5b07e",
       "notice": null,
       "blocks": [
         {
@@ -158,7 +158,7 @@
     },
     {
       "id": "TA-C09-sorry-register",
-      "sequence": 290,
+      "sequence": 510,
       "title": "மன்னிக்கவும் — formal forgiveness and a doubled n",
       "headword": "மன்னிக்கவும் / sorry",
       "romanization": "",
@@ -169,7 +169,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:63705a2b1437e7b4",
+      "sourceHash": "fnv1a64:0b10828379b8e21d",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/tamil/narration/ch10.json
+++ b/code/learning/human-languages/tamil/narration/ch10.json
@@ -4,11 +4,11 @@
   "chapter": 10,
   "title": "Days of the Week",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:9bc3e175ebf3b9fd",
+  "sourceHash": "fnv1a64:e70145e0b10eb0f9",
   "lessons": [
     {
       "id": "TA-C10-vaara-kizhamai",
-      "sequence": 300,
+      "sequence": 520,
       "title": "திங்கள்–ஞாயிறு — a home-grown and borrowed week",
       "headword": "திங்கள்–ஞாயிறு",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7d4d6526c887f8d7",
+      "sourceHash": "fnv1a64:ff31b17db43deacb",
       "notice": null,
       "blocks": [
         {
@@ -133,6 +133,189 @@
             {
               "kind": "speech",
               "text": "What does every Tamil weekday end in, and where does that word come from? (கிழமை kizhamai, \"day\" — Tamil's own word, not Sanskrit vāra.) Which four planet-names are Tamil's own, and which three are Sanskrit borrowings? (Moon, Mars, Venus, Sun are native; Mercury, Jupiter, Saturn are Sanskrit — Budha, Bṛhaspati, Śani.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W04-vowel-signs-nandri",
+      "sequence": 530,
+      "title": "ந, ன, ற (na, ṉa, ṟa) — the letter bodies inside நன்றி",
+      "headword": "ந, ன, ற",
+      "romanization": "na, ṉa, ṟa",
+      "gloss": "write the remaining two n-letters and the hard r needed for நன்றி",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:b1f78acfb57601f8",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: The two remaining n's",
+          "Script you'll notice: ற — \"ṟa\", the hard r",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The two remaining n's, Script you'll notice: ற — \"ṟa\", the hard r and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Lesson 2 showed you that Tamil has three n-letters and promised you'd draw the other two when a word needed them. Chapter 1's thank you needs both."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: The two remaining n's",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ந — na, the dental n, tongue against the teeth:"
+            },
+            {
+              "kind": "speech",
+              "text": "a straight top bar."
+            },
+            {
+              "kind": "speech",
+              "text": "a vertical on the left."
+            },
+            {
+              "kind": "speech",
+              "text": "a second vertical in the middle."
+            },
+            {
+              "kind": "speech",
+              "text": "a right stroke that curls below the baseline and sweeps left into a descender."
+            },
+            {
+              "kind": "speech",
+              "text": "ன — ṉa, the alveolar n, tongue on the ridge behind the teeth:"
+            },
+            {
+              "kind": "speech",
+              "text": "a straight top bar."
+            },
+            {
+              "kind": "speech",
+              "text": "a loop on the left."
+            },
+            {
+              "kind": "speech",
+              "text": "one arch."
+            },
+            {
+              "kind": "speech",
+              "text": "a straight vertical on the right, down to the baseline."
+            },
+            {
+              "kind": "speech",
+              "text": "Compare it with Lesson 2's ண: same top bar, same loop, same closing vertical. ண simply has a second arch inserted before that vertical. So ன is ண minus one arch — one arch for ன, two for ண. That is the whole contrast, and it is the cheapest way to keep them apart."
+            },
+            {
+              "kind": "speech",
+              "text": "With Lesson 2's ண (retroflex), that completes the set. Same consonant to an English ear; three letters, three tongue positions, in Tamil."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: ற — \"ṟa\", the hard r",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "two arches side by side — giving it three legs down to the baseline."
+            },
+            {
+              "kind": "speech",
+              "text": "the right leg keeps going below the baseline, sweeps left, and drops into a long descender."
+            },
+            {
+              "kind": "speech",
+              "text": "It is the tallest thing you have drawn: most Tamil letters sit on the baseline, and ற hangs well beneath it."
+            },
+            {
+              "kind": "speech",
+              "text": "The dot under ṟ marks it as the hard or trilled r, distinct from Tamil's other r. You'll meet the contrast properly later; for now, learn the shape."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ந — \"top bar, two verticals, then the curl that sweeps left\"",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: ந — \"top bar, **two** verticals, then the curl that sweeps left\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ன — \"top bar, left loop, one arch, straight vertical\"",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: ன — \"top bar, left loop, **one** arch, straight vertical\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ற — \"two arches, then the leg that sweeps left and drops\"",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: ற — \"two arches, then the leg that sweeps left and drops\"]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Name Tamil's three n-letters and their tongue positions. (ந dental, ன alveolar, ண retroflex.) What are a consonant's three possibilities so far? (Keep the built-in a or remove it with the puḷḷi.) Which letter hangs below the baseline? (ற, the hard ṟ.) Next: the colours — black, white, red and blue."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch10.txt
+++ b/code/learning/human-languages/tamil/narration/ch10.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 10: Days of the Week.
-1 lesson. All 1 can be done entirely by ear.
+2 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 1.
+Lesson 1 of 2.
 திங்கள்–ஞாயிறு — a home-grown and borrowed week.
 
 Warm-up.
@@ -35,3 +35,43 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 What does every Tamil weekday end in, and where does that word come from? (கிழமை kizhamai, "day" — Tamil's own word, not Sanskrit vāra.) Which four planet-names are Tamil's own, and which three are Sanskrit borrowings? (Moon, Mars, Venus, Sun are native; Mercury, Jupiter, Saturn are Sanskrit — Budha, Bṛhaspati, Śani.)
+
+
+Lesson 2 of 2.
+ந, ன, ற (na, ṉa, ṟa) — the letter bodies inside நன்றி.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The two remaining n's, Script you'll notice: ற — "ṟa", the hard r and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Lesson 2 showed you that Tamil has three n-letters and promised you'd draw the other two when a word needed them. Chapter 1's thank you needs both.
+
+Script you'll notice: The two remaining n's.
+ந — na, the dental n, tongue against the teeth:
+a straight top bar.
+a vertical on the left.
+a second vertical in the middle.
+a right stroke that curls below the baseline and sweeps left into a descender.
+ன — ṉa, the alveolar n, tongue on the ridge behind the teeth:
+a straight top bar.
+a loop on the left.
+one arch.
+a straight vertical on the right, down to the baseline.
+Compare it with Lesson 2's ண: same top bar, same loop, same closing vertical. ண simply has a second arch inserted before that vertical. So ன is ண minus one arch — one arch for ன, two for ண. That is the whole contrast, and it is the cheapest way to keep them apart.
+With Lesson 2's ண (retroflex), that completes the set. Same consonant to an English ear; three letters, three tongue positions, in Tamil.
+
+Script you'll notice: ற — "ṟa", the hard r.
+two arches side by side — giving it three legs down to the baseline.
+the right leg keeps going below the baseline, sweeps left, and drops into a long descender.
+It is the tallest thing you have drawn: most Tamil letters sit on the baseline, and ற hangs well beneath it.
+The dot under ṟ marks it as the hard or trilled r, distinct from Tamil's other r. You'll meet the contrast properly later; for now, learn the shape.
+
+Guided Practice.
+[pause 1 second]
+[once you have stopped driving — write: ந — "top bar, two verticals, then the curl that sweeps left"]
+[once you have stopped driving — write: ன — "top bar, left loop, one arch, straight vertical"]
+[once you have stopped driving — write: ற — "two arches, then the leg that sweeps left and drops"]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Name Tamil's three n-letters and their tongue positions. (ந dental, ன alveolar, ண retroflex.) What are a consonant's three possibilities so far? (Keep the built-in a or remove it with the puḷḷi.) Which letter hangs below the baseline? (ற, the hard ṟ.) Next: the colours — black, white, red and blue.

--- a/code/learning/human-languages/tamil/narration/ch11.json
+++ b/code/learning/human-languages/tamil/narration/ch11.json
@@ -4,11 +4,11 @@
   "chapter": 11,
   "title": "Colours",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:690810fd97646553",
+  "sourceHash": "fnv1a64:479e39edeecc0c29",
   "lessons": [
     {
       "id": "TA-C11-nirangal",
-      "sequence": 310,
+      "sequence": 540,
       "title": "கருப்பு, வெள்ளை, சிவப்பு, நீலம் — three of Tamil's own, one borrowed",
       "headword": "கருப்பு வெள்ளை சிவப்பு நீலம்",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "sight-cue"
       ],
-      "sourceHash": "fnv1a64:442d28ae6ba4719a",
+      "sourceHash": "fnv1a64:4b1ab1ec3abd07dd",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/tamil/narration/ch12.json
+++ b/code/learning/human-languages/tamil/narration/ch12.json
@@ -4,11 +4,11 @@
   "chapter": 12,
   "title": "Family",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:37498296b121ed1e",
+  "sourceHash": "fnv1a64:643afe30d635fb6e",
   "lessons": [
     {
       "id": "TA-C12-kudumbam",
-      "sequence": 320,
+      "sequence": 550,
       "title": "அப்பா, அம்மா, and four sibling words",
       "headword": "அப்பா அம்மா அண்ணன் தம்பி அக்கா தங்கை",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d83e9a64372df884",
+      "sourceHash": "fnv1a64:418d1b0b702acbe3",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch13.json
+++ b/code/learning/human-languages/tamil/narration/ch13.json
@@ -4,11 +4,11 @@
   "chapter": 13,
   "title": "Body Parts",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:1dbbb29d47b23eee",
+  "sourceHash": "fnv1a64:93438d9d63e80927",
   "lessons": [
     {
       "id": "TA-C13-udal-uruppugal",
-      "sequence": 330,
+      "sequence": 560,
       "title": "தலை, கை — head and hand, both Tamil's own",
       "headword": "தலை கை",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:29bbeb31bbfd6439",
+      "sourceHash": "fnv1a64:a126d778478d4902",
       "notice": null,
       "blocks": [
         {
@@ -112,6 +112,182 @@
             {
               "kind": "speech",
               "text": "What are Tamil's words for head and hand? (தலை talai, கை kai.) Are either of these Sanskrit loans? (No — both native Dravidian, unlike Hindi's Sanskrit-descended sir and hāth.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W04-i-sign-write-nandri",
+      "sequence": 570,
+      "title": "ி and நன்றி — replace the vowel, then hear ndr",
+      "headword": "ி, நன்றி",
+      "romanization": "i, naṉṟi / nandri",
+      "gloss": "replace the inherent vowel with i, assemble நன்றி, and hear nasal-triggered voicing",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:3418015b917f2833",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: The first vowel sign",
+          "Script you'll notice: Assemble நன்றி",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The first vowel sign, Script you'll notice: Assemble நன்றி and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "A consonant can keep a or lose it under a puḷḷi. The third option is to replace it with a vowel sign."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: The first vowel sign",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ற = ṟa becomes றி = ṟi."
+            },
+            {
+              "kind": "speech",
+              "text": "ி is a hook above and to the right. The consonant keeps its shape; the sign hangs from it. Later, ை (ai) will appear before its consonant on the page but after it in speech, the same eye/ear trap as Devanagari ि."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: Assemble நன்றி",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ந, ன், றி becomes நன்றி."
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "piece: ந, na — dental, last lesson.",
+                "piece: ன், ṉ — alveolar, with puḷḷi, Lessons 3–4.",
+                "piece: றி, ṟi — ற plus the i-sign, this lesson."
+              ]
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "pronunciation",
+          "title": "Sounds you'll need: Why nandri has a d-sound",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ன் + ற is pronounced close to ndr. This follows a broader Tamil rule: a nasal voices the stop after it."
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "ந் + த, nd, வந்து vandu.",
+                "ண் + ட, ṇḍ, retroflex pair.",
+                "ன் + ற, ndr, நன்றி."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Each n-letter creates its own cluster. That payoff explains both the three spellings and the common English romanization nandri, whose d is heard but not separately written."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "றி — ற plus the hook above right",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: றி — ற plus the hook above right]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "நன்றி — three pieces",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **நன்றி** — three pieces]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ன் + ற = ndr\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ன் + ற = **ndr**\"]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "What are a consonant's three vowel choices? (Keep inherent a, remove it with puḷḷi, or replace it with a vowel sign.) Where does ி attach? (Above and right.) Why is naṉṟi often written nandri? (ன் + ற is pronounced ndr because a nasal voices the following stop.)"
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch13.txt
+++ b/code/learning/human-languages/tamil/narration/ch13.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 13: Body Parts.
-1 lesson. All 1 can be done entirely by ear.
+2 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 1.
+Lesson 1 of 2.
 தலை, கை — head and hand, both Tamil's own.
 
 Warm-up.
@@ -26,3 +26,43 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 What are Tamil's words for head and hand? (தலை talai, கை kai.) Are either of these Sanskrit loans? (No — both native Dravidian, unlike Hindi's Sanskrit-descended sir and hāth.)
+
+
+Lesson 2 of 2.
+ி and நன்றி — replace the vowel, then hear ndr.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: The first vowel sign, Script you'll notice: Assemble நன்றி and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+A consonant can keep a or lose it under a puḷḷi. The third option is to replace it with a vowel sign.
+
+Script you'll notice: The first vowel sign.
+ற = ṟa becomes றி = ṟi.
+ி is a hook above and to the right. The consonant keeps its shape; the sign hangs from it. Later, ை (ai) will appear before its consonant on the page but after it in speech, the same eye/ear trap as Devanagari ि.
+
+Script you'll notice: Assemble நன்றி.
+ந, ன், றி becomes நன்றி.
+[a table of 3 rows, read aloud]
+piece: ந, na — dental, last lesson.
+piece: ன், ṉ — alveolar, with puḷḷi, Lessons 3–4.
+piece: றி, ṟi — ற plus the i-sign, this lesson.
+
+Sounds you'll need: Why nandri has a d-sound.
+ன் + ற is pronounced close to ndr. This follows a broader Tamil rule: a nasal voices the stop after it.
+[a table of 3 rows, read aloud]
+ந் + த, nd, வந்து vandu.
+ண் + ட, ṇḍ, retroflex pair.
+ன் + ற, ndr, நன்றி.
+Each n-letter creates its own cluster. That payoff explains both the three spellings and the common English romanization nandri, whose d is heard but not separately written.
+
+Guided Practice.
+[pause 1 second]
+[once you have stopped driving — write: றி — ற plus the hook above right]
+[once you have stopped driving — write: நன்றி — three pieces]
+[your turn — say: "ன் + ற = ndr"]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+What are a consonant's three vowel choices? (Keep inherent a, remove it with puḷḷi, or replace it with a vowel sign.) Where does ி attach? (Above and right.) Why is naṉṟi often written nandri? (ன் + ற is pronounced ndr because a nasal voices the following stop.)

--- a/code/learning/human-languages/tamil/narration/ch14.json
+++ b/code/learning/human-languages/tamil/narration/ch14.json
@@ -4,11 +4,11 @@
   "chapter": 14,
   "title": "Seasons",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:efef50f495c96454",
+  "sourceHash": "fnv1a64:88494c15360167e5",
   "lessons": [
     {
       "id": "TA-C14-kaalangal",
-      "sequence": 340,
+      "sequence": 580,
       "title": "வசந்த காலம், கோடை, மழை, குளிர் — the four words, and the real season underneath",
       "headword": "வசந்த காலம் கோடைக் காலம் மழைக் காலம் குளிர் காலம்",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:555129c6b521a26a",
+      "sourceHash": "fnv1a64:3c8ce6fb6a613930",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch15.json
+++ b/code/learning/human-languages/tamil/narration/ch15.json
@@ -4,11 +4,11 @@
   "chapter": 15,
   "title": "Water and Rice",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:591fbb252f2da03b",
+  "sourceHash": "fnv1a64:bbff81bbd706c3c6",
   "lessons": [
     {
       "id": "TA-C15-thanneer-arisi",
-      "sequence": 350,
+      "sequence": 590,
       "title": "தண்ணீர், அரிசி, சாதம் — water, and rice, the real staple",
       "headword": "தண்ணீர் அரிசி சாதம்",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:69c3cb0567033e1e",
+      "sourceHash": "fnv1a64:1a1b674fcef23d70",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch16.json
+++ b/code/learning/human-languages/tamil/narration/ch16.json
@@ -4,11 +4,11 @@
   "chapter": 16,
   "title": "Tamil Months",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:3e3463dfa65338df",
+  "sourceHash": "fnv1a64:9aa25237c1a7fa85",
   "lessons": [
     {
       "id": "TA-C16-thamizh-maadangal",
-      "sequence": 360,
+      "sequence": 600,
       "title": "சித்திரை to பங்குனி — Tamil's own solar calendar",
       "headword": "சித்திரை வைகாசி ஆனி ஆடி ஆவணி புரட்டாசி ஐப்பசி கார்த்திகை மார்கழி தை மாசி பங்குனி",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:bc0905b8d3ab5ecc",
+      "sourceHash": "fnv1a64:14dab8c9cd8fec07",
       "notice": null,
       "blocks": [
         {
@@ -119,6 +119,205 @@
             {
               "kind": "speech",
               "text": "What kind of calendar is the Tamil month system — solar, lunar, or lunisolar? (Solar — a genuinely separate calendar from both Gregorian and Hindu lunisolar.) What are the twelve months traditionally named for? (Nakshatras, lunar-mansion star groups.) What two important occasions are dated by this calendar? (Tamil New Year (Chithirai 1) and Pongal (Thai 1).)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W05-write-aam",
+      "sequence": 610,
+      "title": "ஆம் (ām) — writing a word that starts with a vowel",
+      "headword": "ஆம்",
+      "romanization": "ām",
+      "gloss": "a word that begins with a vowel gets a full vowel letter, not a sign",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:2806a117ad48f726",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: a vowel standing alone",
+          "Script you'll notice: build the word",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: a vowel standing alone, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Every vowel sign so far has hooked onto a consonant — the ி on ற. This word has no consonant to hook onto."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: a vowel standing alone",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Tamil writes a vowel two ways, and which one you use depends on where it sits:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "inside a word, after a consonant, a small sign — ி in றி.",
+                "starting a word, with nothing before it, a full independent letter."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "ஆ is the independent letter for long ā. It is not a sign and never hangs off anything; it is a letter in its own right."
+            },
+            {
+              "kind": "speech",
+              "text": "Long ā is short அ plus a tail, so அ is where it starts — and you have not been shown that one yet. Its parts, then the tail:"
+            },
+            {
+              "kind": "speech",
+              "text": "a curl at the upper left."
+            },
+            {
+              "kind": "speech",
+              "text": "a long horizontal stroke."
+            },
+            {
+              "kind": "speech",
+              "text": "a straight vertical on the right — that is அ."
+            },
+            {
+              "kind": "speech",
+              "text": "a tail added on the right — and now it is ஆ."
+            },
+            {
+              "kind": "speech",
+              "text": "Those are the parts in writing order. Where the pen lifts is not settled: Tamil handwriting varies by region and by school, and this book only claims a pen path where it has a sourced one."
+            },
+            {
+              "kind": "speech",
+              "text": "That is a rule, not a special case: any Tamil word that opens on a vowel opens with a full vowel letter."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 2,
+              "utterances": [
+                "piece: ஆ, ā, this lesson — independent.",
+                "piece: ம், m — ம with the puḷḷi, the dot you already know."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "ஆ, ம் becomes ஆம் (ām)."
+            },
+            {
+              "kind": "speech",
+              "text": "Two pieces only. The puḷḷi on ம் closes the word on a bare m, exactly as it did at the end of வணக்கம்."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "அ — curl, horizontal, right vertical",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **அ** — curl, horizontal, right vertical]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ஆ — the same three parts, then the right-hand tail",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **ஆ** — the same three parts, then the right-hand tail]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ம் — ம with the dot",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **ம்** — ம with the dot]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ஆம் (ām) — two pieces, left to right",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **ஆம்** — two pieces, left to right]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write ஆம் (ām). When does a Tamil vowel get a full letter instead of a sign? (When it starts a word — nothing precedes it to hook onto.) What closes the word? (ம் — the puḷḷi on ம.) Next: noon and midnight."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch16.txt
+++ b/code/learning/human-languages/tamil/narration/ch16.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 16: Tamil Months.
-1 lesson. All 1 can be done entirely by ear.
+2 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 1.
+Lesson 1 of 2.
 சித்திரை to பங்குனி — Tamil's own solar calendar.
 
 Warm-up.
@@ -28,3 +28,45 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 What kind of calendar is the Tamil month system — solar, lunar, or lunisolar? (Solar — a genuinely separate calendar from both Gregorian and Hindu lunisolar.) What are the twelve months traditionally named for? (Nakshatras, lunar-mansion star groups.) What two important occasions are dated by this calendar? (Tamil New Year (Chithirai 1) and Pongal (Thai 1).)
+
+
+Lesson 2 of 2.
+ஆம் (ām) — writing a word that starts with a vowel.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: a vowel standing alone, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Every vowel sign so far has hooked onto a consonant — the ி on ற. This word has no consonant to hook onto.
+
+Script you'll notice: a vowel standing alone.
+Tamil writes a vowel two ways, and which one you use depends on where it sits:
+[a table of 2 rows, read aloud]
+inside a word, after a consonant, a small sign — ி in றி.
+starting a word, with nothing before it, a full independent letter.
+ஆ is the independent letter for long ā. It is not a sign and never hangs off anything; it is a letter in its own right.
+Long ā is short அ plus a tail, so அ is where it starts — and you have not been shown that one yet. Its parts, then the tail:
+a curl at the upper left.
+a long horizontal stroke.
+a straight vertical on the right — that is அ.
+a tail added on the right — and now it is ஆ.
+Those are the parts in writing order. Where the pen lifts is not settled: Tamil handwriting varies by region and by school, and this book only claims a pen path where it has a sourced one.
+That is a rule, not a special case: any Tamil word that opens on a vowel opens with a full vowel letter.
+
+Script you'll notice: build the word.
+[a table of 2 rows, read aloud]
+piece: ஆ, ā, this lesson — independent.
+piece: ம், m — ம with the puḷḷi, the dot you already know.
+ஆ, ம் becomes ஆம் (ām).
+Two pieces only. The puḷḷi on ம் closes the word on a bare m, exactly as it did at the end of வணக்கம்.
+
+Guided Practice.
+[pause 1 second]
+[once you have stopped driving — write: அ — curl, horizontal, right vertical]
+[once you have stopped driving — write: ஆ — the same three parts, then the right-hand tail]
+[once you have stopped driving — write: ம் — ம with the dot]
+[once you have stopped driving — write: ஆம் (ām) — two pieces, left to right]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Write ஆம் (ām). When does a Tamil vowel get a full letter instead of a sign? (When it starts a word — nothing precedes it to hook onto.) What closes the word? (ம் — the puḷḷi on ம.) Next: noon and midnight.

--- a/code/learning/human-languages/tamil/narration/ch17.json
+++ b/code/learning/human-languages/tamil/narration/ch17.json
@@ -4,11 +4,11 @@
   "chapter": 17,
   "title": "Noon and Midnight",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:06273003bfe95d72",
+  "sourceHash": "fnv1a64:6ffa0438a52caeaa",
   "lessons": [
     {
       "id": "TA-C17-nanpakal-nalliravu",
-      "sequence": 370,
+      "sequence": 620,
       "title": "நண்பகல், நள்ளிரவு — one old \"middle\" root, two survival stories",
       "headword": "நண்பகல் நள்ளிரவு",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:49f6e1ca6f73b6d4",
+      "sourceHash": "fnv1a64:f54b98fb24a35ebe",
       "notice": null,
       "blocks": [
         {
@@ -113,7 +113,7 @@
     },
     {
       "id": "TA-C17-transparent-middle-synonyms",
-      "sequence": 380,
+      "sequence": 630,
       "title": "நடுப்பகல் and நடு இரவு — the transparent twins",
       "headword": "நடுப்பகல், நடு இரவு",
       "romanization": "",
@@ -124,7 +124,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c43444f3c116f991",
+      "sourceHash": "fnv1a64:1a6961f763d05fc1",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch18.json
+++ b/code/learning/human-languages/tamil/narration/ch18.json
@@ -3,12 +3,12 @@
   "language": "tamil",
   "chapter": 18,
   "title": "Telling Time",
-  "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:b273f5380b760010",
+  "drivablePrefix": 1,
+  "sourceHash": "fnv1a64:6b1369c681d37000",
   "lessons": [
     {
       "id": "TA-C18-mani",
-      "sequence": 390,
+      "sequence": 640,
       "title": "மணி — Tamil's native \"bell,\" and a real homophone trap",
       "headword": "மணி",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7edef22adf32f80f",
+      "sourceHash": "fnv1a64:f0c21e500c9a13b9",
       "notice": null,
       "blocks": [
         {
@@ -85,7 +85,211 @@
             },
             {
               "kind": "speech",
-              "text": "Is Tamil's மணி (\"hour\") from the same Sanskrit root as Kannada/Telugu/Hindi's hour-words? (Most likely no — it's treated as a native Dravidian \"bell\" word that independently reached \"hour\" the same way, though even DEDR flags this as not fully settled.) What semantic path links the meanings? (A bell announces the hour.) Next: distinguish the likely Sanskrit gem homophone and tell the time."
+              "text": "Is Tamil's மணி (\"hour\") from the same Sanskrit root as Kannada/Telugu/Hindi's hour-words? (Most likely no — it's treated as a native Dravidian \"bell\" word that independently reached \"hour\" the same way, though even DEDR flags this as not fully settled.) What semantic path links the meanings? (A bell announces the hour.) Next: writing இல்லை (illai) — a second independent vowel, ல, and the ai sign."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W06-write-illai",
+      "sequence": 650,
+      "title": "இல்லை (illai) — a vowel in front, a vowel sign behind",
+      "headword": "இல்லை",
+      "romanization": "illai",
+      "gloss": "a second independent vowel, the letter ல, and the left-standing ai sign",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:8ac490a17d82b53a",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: இ and ல",
+          "Script you'll notice: build the word",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: இ and ல, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Last lesson gave you the rule: a word opening on a vowel opens with a full letter. Here is the same rule with a different vowel, plus one new sign."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: இ and ல",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "இ is the independent letter for short i — the same job ஆ did, one vowel over. Its parts, in writing order:"
+            },
+            {
+              "kind": "speech",
+              "text": "a crossing spiral on the left."
+            },
+            {
+              "kind": "speech",
+              "text": "a tall straight vertical on the right."
+            },
+            {
+              "kind": "speech",
+              "text": "ல is la, with its built-in a like every consonant:"
+            },
+            {
+              "kind": "speech",
+              "text": "a curl that turns back on itself."
+            },
+            {
+              "kind": "speech",
+              "text": "a stroke rising to the right."
+            },
+            {
+              "kind": "speech",
+              "text": "Put the puḷḷi on it and you get ல், a bare l."
+            },
+            {
+              "kind": "speech",
+              "text": "The new mark is ை, the sign for ai, and it does something ி did not. It is written to the LEFT of its consonant, but pronounced after it."
+            },
+            {
+              "kind": "speech",
+              "text": "ல + ை becomes லை, and on the page the hook stands before the ல — yet you say lai, not ail."
+            },
+            {
+              "kind": "speech",
+              "text": "Your eye meets the vowel first and your mouth says it second. Devanagari does the same thing with ि, and it catches everyone once."
+            },
+            {
+              "kind": "speech",
+              "text": "Tamil keeps three l-letters (ல ள ழ) and two r-letters (ர ற), the same way it keeps three n's. This is the first of the l's."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "piece: இ, i, independent — the word opens on a vowel.",
+                "piece: ல், l — ல with the puḷḷi, bare consonant.",
+                "piece: லை, lai — ல with the ai sign, this lesson."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "இ, ல், லை becomes இல்லை (illai)."
+            },
+            {
+              "kind": "speech",
+              "text": "The ல் + லை is a doubled l, held like the க்க of vaṇakkam: il-lai, not ilai."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "இ — spiral, then the right-hand vertical",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **இ** — spiral, then the right-hand vertical]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ல — curl, then rising stroke",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **ல** — curl, then rising stroke]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "லை — the ai hook goes on the LEFT",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **லை** — the ai hook goes on the LEFT]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "இல்லை (illai) — three pieces",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **இல்லை** — three pieces]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"il-lai\" — hold the doubled l",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"il-lai\" — hold the doubled *l*]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Write இல்லை (illai). Why does it open with இ rather than a sign? (The word starts on a vowel.) Which side of its consonant does ை sit on? (The left — written first, spoken second.) Next: the gem-word homophone, and telling clock time."
             }
           ]
         }
@@ -93,7 +297,7 @@
     },
     {
       "id": "TA-C18-mani-homophone-time",
-      "sequence": 400,
+      "sequence": 660,
       "title": "மணி — hour or jewel? Context decides",
       "headword": "மணி / மணி",
       "romanization": "",
@@ -104,7 +308,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f5c848b349d8fe58",
+      "sourceHash": "fnv1a64:e021e7775002900c",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch18.txt
+++ b/code/learning/human-languages/tamil/narration/ch18.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 18: Telling Time.
-2 lessons. All 2 can be done entirely by ear.
+3 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 2.
+Lesson 1 of 3.
 மணி — Tamil's native "bell," and a real homophone trap.
 
 Warm-up.
@@ -19,10 +19,54 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-Is Tamil's மணி ("hour") from the same Sanskrit root as Kannada/Telugu/Hindi's hour-words? (Most likely no — it's treated as a native Dravidian "bell" word that independently reached "hour" the same way, though even DEDR flags this as not fully settled.) What semantic path links the meanings? (A bell announces the hour.) Next: distinguish the likely Sanskrit gem homophone and tell the time.
+Is Tamil's மணி ("hour") from the same Sanskrit root as Kannada/Telugu/Hindi's hour-words? (Most likely no — it's treated as a native Dravidian "bell" word that independently reached "hour" the same way, though even DEDR flags this as not fully settled.) What semantic path links the meanings? (A bell announces the hour.) Next: writing இல்லை (illai) — a second independent vowel, ல, and the ai sign.
 
 
-Lesson 2 of 2.
+Lesson 2 of 3.
+இல்லை (illai) — a vowel in front, a vowel sign behind.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: இ and ல, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Last lesson gave you the rule: a word opening on a vowel opens with a full letter. Here is the same rule with a different vowel, plus one new sign.
+
+Script you'll notice: இ and ல.
+இ is the independent letter for short i — the same job ஆ did, one vowel over. Its parts, in writing order:
+a crossing spiral on the left.
+a tall straight vertical on the right.
+ல is la, with its built-in a like every consonant:
+a curl that turns back on itself.
+a stroke rising to the right.
+Put the puḷḷi on it and you get ல், a bare l.
+The new mark is ை, the sign for ai, and it does something ி did not. It is written to the LEFT of its consonant, but pronounced after it.
+ல + ை becomes லை, and on the page the hook stands before the ல — yet you say lai, not ail.
+Your eye meets the vowel first and your mouth says it second. Devanagari does the same thing with ि, and it catches everyone once.
+Tamil keeps three l-letters (ல ள ழ) and two r-letters (ர ற), the same way it keeps three n's. This is the first of the l's.
+
+Script you'll notice: build the word.
+[a table of 3 rows, read aloud]
+piece: இ, i, independent — the word opens on a vowel.
+piece: ல், l — ல with the puḷḷi, bare consonant.
+piece: லை, lai — ல with the ai sign, this lesson.
+இ, ல், லை becomes இல்லை (illai).
+The ல் + லை is a doubled l, held like the க்க of vaṇakkam: il-lai, not ilai.
+
+Guided Practice.
+[pause 1 second]
+[once you have stopped driving — write: இ — spiral, then the right-hand vertical]
+[once you have stopped driving — write: ல — curl, then rising stroke]
+[once you have stopped driving — write: லை — the ai hook goes on the LEFT]
+[once you have stopped driving — write: இல்லை (illai) — three pieces]
+[your turn — say: "il-lai" — hold the doubled l]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Write இல்லை (illai). Why does it open with இ rather than a sign? (The word starts on a vowel.) Which side of its consonant does ை sit on? (The left — written first, spoken second.) Next: the gem-word homophone, and telling clock time.
+
+
+Lesson 3 of 3.
 மணி — hour or jewel? Context decides.
 
 Warm-up.

--- a/code/learning/human-languages/tamil/narration/ch19.json
+++ b/code/learning/human-languages/tamil/narration/ch19.json
@@ -4,11 +4,11 @@
   "chapter": 19,
   "title": "Asking Someone's Age",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:1c8de13134073142",
+  "sourceHash": "fnv1a64:491071c339bc2838",
   "lessons": [
     {
       "id": "TA-C19-vayathu",
-      "sequence": 410,
+      "sequence": 670,
       "title": "உனக்கு எத்தனை வயது ஆகிறது? — Tamil actually has BOTH shapes",
       "headword": "உனக்கு எத்தனை வயது ஆகிறது?",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:707e217350c30e75",
+      "sourceHash": "fnv1a64:e7a729c0a3693e61",
       "notice": null,
       "blocks": [
         {
@@ -102,7 +102,7 @@
     },
     {
       "id": "TA-C19-age-register-grammar",
-      "sequence": 420,
+      "sequence": 680,
       "title": "Your age what? / To you how many years becomes?",
       "headword": "உன் வயசு என்ன? / உனக்கு எத்தனை வயது ஆகிறது?",
       "romanization": "",
@@ -113,7 +113,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:15d09bbc0d429868",
+      "sourceHash": "fnv1a64:e56e7a5816e08838",
       "notice": null,
       "blocks": [
         {
@@ -221,6 +221,186 @@
             {
               "kind": "speech",
               "text": "Which shape is casual? (Possessive: \"your age what?\") Which is formal? (Dative + aakirathu, \"become.\") Does Malayalam use the same verb? (No — it uses \"exists.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W07-write-sari",
+      "sequence": 690,
+      "title": "சரி (sari) — one letter, several sounds",
+      "headword": "சரி",
+      "romanization": "sari",
+      "gloss": "one letter for a whole family of sounds — ச — and the second r",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:e901b4d9eeba8fde",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: ச and ர",
+          "Script you'll notice: build the word",
+          "Guided Practice"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ச and ர, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You have seen க cover k, g and a soft h depending on where it sits. Here is the same economy on a second letter."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: ச and ர",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ச is written once and does the work English splits between s, ch and j. Position picks which:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "where",
+                "sound"
+              ],
+              "columns": 2,
+              "rowCount": 3,
+              "utterances": [
+                "where: starting a word. sound: s or ch.",
+                "where: between vowels. sound: softened.",
+                "where: after a nasal, as in ஞ்ச. sound: j."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "That is exactly the pattern க showed — k at the start, g after a nasal, a soft h between vowels. One letter per position of the mouth, and context fills in the rest."
+            },
+            {
+              "kind": "speech",
+              "text": "ர is ra, with its built-in a. It is the other of Tamil's two r-letters, alongside the ற you met in நன்றி."
+            },
+            {
+              "kind": "speech",
+              "text": "Read both letters here; do not draw them yet. This book gives a stroke order only where it has a sourced one, and ச and ர do not have one yet."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 2,
+              "utterances": [
+                "piece: ச, sa here, this lesson.",
+                "piece: ரி, ri — ர with the ி sign, the sign from நன்றி."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "ச, ரி becomes சரி (sari)."
+            },
+            {
+              "kind": "speech",
+              "text": "Two pieces, and both parts are things you already hold: a consonant, and the vowel sign you first hooked onto ற."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "ச — then சரி (sari)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **ச** — then **சரி**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"sari\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"sari\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "ரி and லை — the ி sign follows its letter, the ை sign precedes it",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **ரி** and **லை** — the ி sign follows its letter, the ை sign precedes it]"
+            },
+            {
+              "kind": "prompt",
+              "action": "WRITE",
+              "instruction": "ஆம் and இல்லை again, from memory — yes and no, the two you will reach for most",
+              "spoken": false,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU WRITE: **ஆம்** and **இல்லை** again, from memory — yes and no, the two you will reach for most]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read சரி (sari). Which English sounds does ச cover on its own? (s or ch at the start, softened between vowels, j after a nasal.) How many r-letters does Tamil keep? (Two — ர and ற.) In லை, which side of the ல does the ai sign sit on? (The left.) And why does இல்லை open with இ rather than a sign? (It starts on a vowel.) Next: the numbers eleven to twenty."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch19.txt
+++ b/code/learning/human-languages/tamil/narration/ch19.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 19: Asking Someone's Age.
-2 lessons. All 2 can be done entirely by ear.
+3 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 2.
+Lesson 1 of 3.
 உனக்கு எத்தனை வயது ஆகிறது? — Tamil actually has BOTH shapes.
 
 Warm-up.
@@ -24,7 +24,7 @@ Wrap-up Recall.
 Is Tamil's வயது the same Sanskrit word borrowed by all four Dravidian languages here? (Yes — none built a native alternative for this concept.) What did vayas originally include besides age? (Vigor.) Next: choose between Tamil's casual possessive and formal dative-plus-become shapes.
 
 
-Lesson 2 of 2.
+Lesson 2 of 3.
 Your age what? / To you how many years becomes? — casual Tamil uses a possessive age question while formal Tamil uses dative plus become.
 
 Warm-up.
@@ -52,3 +52,44 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Which shape is casual? (Possessive: "your age what?") Which is formal? (Dative + aakirathu, "become.") Does Malayalam use the same verb? (No — it uses "exists.")
+
+
+Lesson 3 of 3.
+சரி (sari) — one letter, several sounds.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ச and ர, Script you'll notice: build the word and Guided Practice until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You have seen க cover k, g and a soft h depending on where it sits. Here is the same economy on a second letter.
+
+Script you'll notice: ச and ர.
+ச is written once and does the work English splits between s, ch and j. Position picks which:
+[a table of 3 rows, read aloud]
+where: starting a word. sound: s or ch.
+where: between vowels. sound: softened.
+where: after a nasal, as in ஞ்ச. sound: j.
+That is exactly the pattern க showed — k at the start, g after a nasal, a soft h between vowels. One letter per position of the mouth, and context fills in the rest.
+ர is ra, with its built-in a. It is the other of Tamil's two r-letters, alongside the ற you met in நன்றி.
+Read both letters here; do not draw them yet. This book gives a stroke order only where it has a sourced one, and ச and ர do not have one yet.
+
+Script you'll notice: build the word.
+[a table of 2 rows, read aloud]
+piece: ச, sa here, this lesson.
+piece: ரி, ri — ர with the ி sign, the sign from நன்றி.
+ச, ரி becomes சரி (sari).
+Two pieces, and both parts are things you already hold: a consonant, and the vowel sign you first hooked onto ற.
+
+Guided Practice.
+[pause 1 second]
+[your turn — read: ச — then சரி (sari)]
+[pause 8 seconds for the answer]
+[your turn — say: "sari"]
+[pause 8 seconds for the answer]
+[your turn — contrast: ரி and லை — the ி sign follows its letter, the ை sign precedes it]
+[pause 8 seconds for the answer]
+[once you have stopped driving — write: ஆம் and இல்லை again, from memory — yes and no, the two you will reach for most]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read சரி (sari). Which English sounds does ச cover on its own? (s or ch at the start, softened between vowels, j after a nasal.) How many r-letters does Tamil keep? (Two — ர and ற.) In லை, which side of the ல does the ai sign sit on? (The left.) And why does இல்லை open with இ rather than a sign? (It starts on a vowel.) Next: the numbers eleven to twenty.

--- a/code/learning/human-languages/tamil/narration/ch20.json
+++ b/code/learning/human-languages/tamil/narration/ch20.json
@@ -4,11 +4,11 @@
   "chapter": 20,
   "title": "Numbers Eleven to Twenty and Weather",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:fdf0cc4db10b69be",
+  "sourceHash": "fnv1a64:2cf7f0e2e424d5a4",
   "lessons": [
     {
       "id": "TA-C20-pathinondru-irupathu",
-      "sequence": 430,
+      "sequence": 700,
       "title": "பதினொன்று–இருபது — shared Dravidian patterns",
       "headword": "பதினொன்று — இருபது",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:83599a85f76e0d2c",
+      "sourceHash": "fnv1a64:31182bc6d2e785e6",
       "notice": null,
       "blocks": [
         {
@@ -133,7 +133,7 @@
     },
     {
       "id": "TA-C20-vaanilai",
-      "sequence": 440,
+      "sequence": 710,
       "title": "வானிலை — \"the standing of the sky,\" most likely all native",
       "headword": "வானிலை",
       "romanization": "",
@@ -144,7 +144,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e976c1dcd9de69f6",
+      "sourceHash": "fnv1a64:661e8c72b79c3d22",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch21.json
+++ b/code/learning/human-languages/tamil/narration/ch21.json
@@ -4,11 +4,11 @@
   "chapter": 21,
   "title": "Dog and Cat",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:9723f9dcd572ac08",
+  "sourceHash": "fnv1a64:4c3e69eb6f237751",
   "lessons": [
     {
       "id": "TA-C21-naay-poonai",
-      "sequence": 450,
+      "sequence": 720,
       "title": "நாய், பூனை — solid ground to close the arc, and an honest three-way split",
       "headword": "நாய், பூனை",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:de5497918953d746",
+      "sourceHash": "fnv1a64:a2f119fd5362a2d8",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch22.json
+++ b/code/learning/human-languages/tamil/narration/ch22.json
@@ -4,11 +4,11 @@
   "chapter": 22,
   "title": "Green and Yellow",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:b8ec45b437f75500",
+  "sourceHash": "fnv1a64:093d888489413d50",
   "lessons": [
     {
       "id": "TA-C22-paccai-manjal",
-      "sequence": 460,
+      "sequence": 730,
       "title": "பச்சை, மஞ்சள் — closing the Dravidian arc, holding both patterns at once",
       "headword": "பச்சை, மஞ்சள்",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:7c72b7c8044cb6de",
+      "sourceHash": "fnv1a64:3114da16b86a47ea",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch23.json
+++ b/code/learning/human-languages/tamil/narration/ch23.json
@@ -4,11 +4,11 @@
   "chapter": 23,
   "title": "Day",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:5c6398928a9c2ba4",
+  "sourceHash": "fnv1a64:e101514a5078173a",
   "lessons": [
     {
       "id": "TA-C23-naal",
-      "sequence": 470,
+      "sequence": 740,
       "title": "நாள் (nāḷ) — \"day,\" the one this arc's Dravidian languages didn't lose",
       "headword": "நாள்",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ad1a9f6edfca5d2b",
+      "sourceHash": "fnv1a64:01ed309a4046ac0d",
       "notice": null,
       "blocks": [
         {
@@ -102,7 +102,7 @@
     },
     {
       "id": "TA-C23-day-family-register",
-      "sequence": 480,
+      "sequence": 750,
       "title": "நாள் and தினம் — everyday native, formal borrowed",
       "headword": "நாள் / தினம்",
       "romanization": "",
@@ -113,7 +113,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:be8dbaeab3323246",
+      "sourceHash": "fnv1a64:43a47e46c1189b5e",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch24.json
+++ b/code/learning/human-languages/tamil/narration/ch24.json
@@ -4,11 +4,11 @@
   "chapter": 24,
   "title": "Night",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:44ef396f3945a420",
+  "sourceHash": "fnv1a64:bcea2d1a3a4809af",
   "lessons": [
     {
       "id": "TA-C24-iravu",
-      "sequence": 490,
+      "sequence": 760,
       "title": "இரவு (iravu) — \"night,\" and a register question worth a native speaker's ear",
       "headword": "இரவு",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:32036d5e65c5aec1",
+      "sourceHash": "fnv1a64:7838990e6a1e86ab",
       "notice": null,
       "blocks": [
         {
@@ -113,7 +113,7 @@
     },
     {
       "id": "TA-C24-night-register-darkness",
-      "sequence": 500,
+      "sequence": 770,
       "title": "Night words — a register hypothesis and a semantic boundary",
       "headword": "இரவு / ராத்திரி / இருள்",
       "romanization": "",
@@ -124,7 +124,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b660a38234786f74",
+      "sourceHash": "fnv1a64:b3a2d9a756bc31c9",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch25.json
+++ b/code/learning/human-languages/tamil/narration/ch25.json
@@ -4,11 +4,11 @@
   "chapter": 25,
   "title": "Good Night",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:da98a42e0008636f",
+  "sourceHash": "fnv1a64:a476bb11b5f796c3",
   "lessons": [
     {
       "id": "TA-C25-iniya-iravu",
-      "sequence": 510,
+      "sequence": 780,
       "title": "இனிய இரவு (iṉiya iravu) — \"good night,\" and Tamil breaking the pattern one more time",
       "headword": "இனிய இரவு",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c412c2fd55012e40",
+      "sourceHash": "fnv1a64:3874dc4fc0a7afb5",
       "notice": null,
       "blocks": [
         {
@@ -113,7 +113,7 @@
     },
     {
       "id": "TA-C25-goodnight-alternatives",
-      "sequence": 520,
+      "sequence": 790,
       "title": "நல்ல இரவு and இரவு வணக்கம் — old roots recombined",
       "headword": "நல்ல இரவு / இரவு வணக்கம்",
       "romanization": "",
@@ -124,7 +124,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:bcf8703e4fee1dda",
+      "sourceHash": "fnv1a64:614ee145f16a1bf3",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch26.json
+++ b/code/learning/human-languages/tamil/narration/ch26.json
@@ -4,11 +4,11 @@
   "chapter": 26,
   "title": "Morning",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:a491a14d123de4c1",
+  "sourceHash": "fnv1a64:4487b829f729ae28",
   "lessons": [
     {
       "id": "TA-C26-kaalai",
-      "sequence": 530,
+      "sequence": 800,
       "title": "காலை (kālai) — \"morning,\" an honestly uncertain etymology",
       "headword": "காலை",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:f31e62ada32eba46",
+      "sourceHash": "fnv1a64:be68ac32ac9c4962",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch27.json
+++ b/code/learning/human-languages/tamil/narration/ch27.json
@@ -4,11 +4,11 @@
   "chapter": 27,
   "title": "Evening",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:771849e1943269f5",
+  "sourceHash": "fnv1a64:8a3ee365c271485b",
   "lessons": [
     {
       "id": "TA-C27-maalai",
-      "sequence": 540,
+      "sequence": 810,
       "title": "மாலை (mālai) — \"evening,\" and a garland that only looks like the same word",
       "headword": "மாலை",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c8b7ae0842bacb6d",
+      "sourceHash": "fnv1a64:9b58ae9e7d826a6f",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch28.json
+++ b/code/learning/human-languages/tamil/narration/ch28.json
@@ -4,11 +4,11 @@
   "chapter": 28,
   "title": "Afternoon",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:6419f9af0cbb8148",
+  "sourceHash": "fnv1a64:e2e6fd53c38b59e0",
   "lessons": [
     {
       "id": "TA-C28-pirpakal",
-      "sequence": 550,
+      "sequence": 820,
       "title": "பிற்பகல் (piṟpakal) — \"afternoon,\" a similar sandhi trick to நண்பகல்",
       "headword": "பிற்பகல்",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:0568dee970d8dc36",
+      "sourceHash": "fnv1a64:f0692fb16627812a",
       "notice": null,
       "blocks": [
         {
@@ -102,7 +102,7 @@
     },
     {
       "id": "TA-C28-afternoon-boundary",
-      "sequence": 560,
+      "sequence": 830,
       "title": "Noon or afternoon? — let the sources keep their blur",
       "headword": "நடுப்பகல் / மதியம்",
       "romanization": "",
@@ -113,7 +113,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:2e0fef18cdf187fb",
+      "sourceHash": "fnv1a64:52837d88f23a53f5",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch29.json
+++ b/code/learning/human-languages/tamil/narration/ch29.json
@@ -4,11 +4,11 @@
   "chapter": 29,
   "title": "Good Morning",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:0ee1e256b5928da8",
+  "sourceHash": "fnv1a64:c5303420ac3aa1b6",
   "lessons": [
     {
       "id": "TA-C29-kaalai-vanakkam",
-      "sequence": 570,
+      "sequence": 840,
       "title": "காலை வணக்கம் — \"morning greetings\"",
       "headword": "காலை வணக்கம்",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:0903cbd5df40e04f",
+      "sourceHash": "fnv1a64:824054e5b5c328eb",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch30.json
+++ b/code/learning/human-languages/tamil/narration/ch30.json
@@ -4,11 +4,11 @@
   "chapter": 30,
   "title": "Good Evening",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:f5c2a578b5b6df4d",
+  "sourceHash": "fnv1a64:543b13b5f49981c2",
   "lessons": [
     {
       "id": "TA-C30-maalai-vanakkam",
-      "sequence": 580,
+      "sequence": 850,
       "title": "மாலை வணக்கம் — \"evening greetings\"",
       "headword": "மாலை வணக்கம்",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:e605d22d0c8038e0",
+      "sourceHash": "fnv1a64:a569e6a16620cd0e",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch31.json
+++ b/code/learning/human-languages/tamil/narration/ch31.json
@@ -4,11 +4,11 @@
   "chapter": 31,
   "title": "Good Afternoon",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:f8ee12008eeeb646",
+  "sourceHash": "fnv1a64:9da02aa156c2f34f",
   "lessons": [
     {
       "id": "TA-C31-matiya-vanakkam",
-      "sequence": 590,
+      "sequence": 860,
       "title": "மதிய வணக்கம் (matiya vaṇakkam) — a sourced afternoon greeting",
       "headword": "மதிய வணக்கம்",
       "romanization": "",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:40bdf24325c6deef",
+      "sourceHash": "fnv1a64:ed3341669544458b",
       "notice": null,
       "blocks": [
         {
@@ -106,7 +106,7 @@
     },
     {
       "id": "TA-C31-afternoon-greeting-root",
-      "sequence": 600,
+      "sequence": 870,
       "title": "மதிய — the greeting takes a different root",
       "headword": "மதிய",
       "romanization": "",
@@ -117,7 +117,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:0f94f0e85cdff5f4",
+      "sourceHash": "fnv1a64:aebc39e8e3bbc929",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch32.json
+++ b/code/learning/human-languages/tamil/narration/ch32.json
@@ -4,11 +4,11 @@
   "chapter": 32,
   "title": "The Core Verbs",
   "drivablePrefix": 6,
-  "sourceHash": "fnv1a64:4dd37565979d56c1",
+  "sourceHash": "fnv1a64:35b9dc9110e4130e",
   "lessons": [
     {
       "id": "TA-C32-iru",
-      "sequence": 610,
+      "sequence": 880,
       "title": "இரு (iru) — \"to be,\" and the machine inside every Tamil verb",
       "headword": "இரு",
       "romanization": "iru",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d66cfc3bade90237",
+      "sourceHash": "fnv1a64:23936f7a7029f5e4",
       "notice": null,
       "blocks": [
         {
@@ -161,7 +161,7 @@
     },
     {
       "id": "TA-C32-po",
-      "sequence": 620,
+      "sequence": 890,
       "title": "போ (pō) — \"to go,\" and the bead that carries time",
       "headword": "போ",
       "romanization": "pō",
@@ -172,7 +172,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:19f2c25a59f0f982",
+      "sourceHash": "fnv1a64:9895466949df9e89",
       "notice": null,
       "blocks": [
         {
@@ -319,7 +319,7 @@
     },
     {
       "id": "TA-C32-vaa",
-      "sequence": 630,
+      "sequence": 900,
       "title": "வா (vā) — \"to come,\" and a stem with two shapes",
       "headword": "வா",
       "romanization": "vā",
@@ -330,7 +330,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:6d11abac17fa8c52",
+      "sourceHash": "fnv1a64:b8b7f1f6cbee9bd4",
       "notice": null,
       "blocks": [
         {
@@ -462,7 +462,7 @@
     },
     {
       "id": "TA-C32-saappidu",
-      "sequence": 640,
+      "sequence": 910,
       "title": "சாப்பிடு (sāppiḍu) — \"to eat,\" a verb built out of two words",
       "headword": "சாப்பிடு",
       "romanization": "sāppiḍu",
@@ -473,7 +473,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:bb3c1c1696795fe0",
+      "sourceHash": "fnv1a64:484b58557e1ab908",
       "notice": null,
       "blocks": [
         {
@@ -605,7 +605,7 @@
     },
     {
       "id": "TA-C32-paar",
-      "sequence": 650,
+      "sequence": 920,
       "title": "பார் (pār) — \"to see,\" and Tamil's two kinds of verb",
       "headword": "பார்",
       "romanization": "pār",
@@ -616,7 +616,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:39ea79380f0de2f5",
+      "sourceHash": "fnv1a64:7c0c7b2534e55fb3",
       "notice": null,
       "blocks": [
         {
@@ -758,7 +758,7 @@
     },
     {
       "id": "TA-C32-teri",
-      "sequence": 660,
+      "sequence": 930,
       "title": "தெரி (teri) — \"to know,\" the verb that drops the person",
       "headword": "தெரி",
       "romanization": "teri",
@@ -769,7 +769,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:43e3caa79eab7344",
+      "sourceHash": "fnv1a64:5c10a4213db12268",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch33.json
+++ b/code/learning/human-languages/tamil/narration/ch33.json
@@ -4,11 +4,11 @@
   "chapter": 33,
   "title": "Four Verbs of the Mind",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:0434296a320b16ff",
+  "sourceHash": "fnv1a64:87330318c12938c6",
   "lessons": [
     {
       "id": "TA-C33-ninai",
-      "sequence": 670,
+      "sequence": 940,
       "title": "நினை (ninai) — \"to think,\" which is also \"to remember\"",
       "headword": "நினை",
       "romanization": "ninai",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:bec4abda60466215",
+      "sourceHash": "fnv1a64:3da01ee3c6063b7b",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -174,7 +174,7 @@
     },
     {
       "id": "TA-C33-puri",
-      "sequence": 680,
+      "sequence": 950,
       "title": "புரி (puri) — \"to become clear,\" and who it becomes clear to",
       "headword": "புரி",
       "romanization": "puri",
@@ -185,7 +185,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:33fe6b5286b65e12",
+      "sourceHash": "fnv1a64:f02f6b37ae1e15ce",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -384,7 +384,7 @@
     },
     {
       "id": "TA-C33-padi",
-      "sequence": 690,
+      "sequence": 960,
       "title": "படி (paḍi) — \"to read,\" and the letter that is two sounds",
       "headword": "படி",
       "romanization": "paḍi",
@@ -395,7 +395,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:58ad67ba9a906ea4",
+      "sourceHash": "fnv1a64:7eae469fe811e74e",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -559,7 +559,7 @@
     },
     {
       "id": "TA-C33-ezhutu",
-      "sequence": 700,
+      "sequence": 970,
       "title": "எழுது (eḻudu) — \"to write,\" and the sound Tamil is named for",
       "headword": "எழுது",
       "romanization": "eḻudu",
@@ -570,7 +570,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3a36a9291ceaaf55",
+      "sourceHash": "fnv1a64:3cbfae9f73f99b68",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/tamil/narration/ch34.json
+++ b/code/learning/human-languages/tamil/narration/ch34.json
@@ -4,11 +4,11 @@
   "chapter": 34,
   "title": "Four Verbs Between People",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:b09af3aa1df4854a",
+  "sourceHash": "fnv1a64:0afe185a93c0169e",
   "lessons": [
     {
       "id": "TA-C34-edu",
-      "sequence": 710,
+      "sequence": 980,
       "title": "எடு (eḍu) — \"to take,\" beside the \"put\" you already own",
       "headword": "எடு",
       "romanization": "eḍu",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3247ff041aada7e8",
+      "sourceHash": "fnv1a64:5d6ea6f315808c33",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -180,7 +180,7 @@
     },
     {
       "id": "TA-C34-kel",
-      "sequence": 720,
+      "sequence": 990,
       "title": "கேள் (kēḷ) — one verb for asking and for hearing",
       "headword": "கேள்",
       "romanization": "kēḷ",
@@ -191,7 +191,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:5a4741225dff9092",
+      "sourceHash": "fnv1a64:f5e3b74b5b3bf025",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -369,7 +369,7 @@
     },
     {
       "id": "TA-C34-utavu",
-      "sequence": 730,
+      "sequence": 1000,
       "title": "உதவு (udavu) — \"to help,\" and a word Tamil did not borrow",
       "headword": "உதவு",
       "romanization": "udavu",
@@ -380,7 +380,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:cbacf37334d54ef5",
+      "sourceHash": "fnv1a64:39f1276ff0515dcc",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -532,7 +532,7 @@
     },
     {
       "id": "TA-C34-pidi",
-      "sequence": 740,
+      "sequence": 1010,
       "title": "பிடி (piḍi) — \"to catch,\" and therefore \"to like\"",
       "headword": "பிடி",
       "romanization": "piḍi",
@@ -543,7 +543,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:1480cdf0e8dbdd75",
+      "sourceHash": "fnv1a64:d9826b5358141478",
       "notice": null,
       "blocks": [
         {

--- a/code/learning/human-languages/tamil/narration/ch35.json
+++ b/code/learning/human-languages/tamil/narration/ch35.json
@@ -4,11 +4,11 @@
   "chapter": 35,
   "title": "Arriving at a House",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:2703e3459eee5f3a",
+  "sourceHash": "fnv1a64:c26956daee7bf61d",
   "lessons": [
     {
       "id": "TA-C35-veedu",
-      "sequence": 750,
+      "sequence": 1020,
       "title": "வீடு (vīḍu) — \"house,\" and the place the greeting happens",
       "headword": "வீடு",
       "romanization": "vīḍu",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:297479db3d817cd4",
+      "sourceHash": "fnv1a64:02cdeb414fe5f151",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -197,7 +197,7 @@
     },
     {
       "id": "TA-C35-kadavu",
-      "sequence": 760,
+      "sequence": 1030,
       "title": "கதவு (kadavu) — \"door,\" and a word Tamil never gave up",
       "headword": "கதவு",
       "romanization": "kadavu",
@@ -208,7 +208,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:563406c98419bdc3",
+      "sourceHash": "fnv1a64:939efbe63d9682c4",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -364,7 +364,7 @@
     },
     {
       "id": "TA-C35-arai",
-      "sequence": 770,
+      "sequence": 1040,
       "title": "அறை (aṟai) — \"room,\" and Tamil's second r",
       "headword": "அறை",
       "romanization": "aṟai",
@@ -375,7 +375,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:34d173f2cce6d96f",
+      "sourceHash": "fnv1a64:52db51b4d7161024",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -546,7 +546,7 @@
     },
     {
       "id": "TA-C35-naarkaali",
-      "sequence": 780,
+      "sequence": 1050,
       "title": "நாற்காலி (nāṟkāli) — \"chair,\" counted out in legs",
       "headword": "நாற்காலி",
       "romanization": "nāṟkāli",
@@ -557,7 +557,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f68ff6aa061a196c",
+      "sourceHash": "fnv1a64:cd96726728bb3047",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/tamil/narration/ch36.json
+++ b/code/learning/human-languages/tamil/narration/ch36.json
@@ -4,11 +4,11 @@
   "chapter": 36,
   "title": "What You Are Offered",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:f2d3d5c13c0737fe",
+  "sourceHash": "fnv1a64:402bf0320fcdb2c7",
   "lessons": [
     {
       "id": "TA-C36-teneer",
-      "sequence": 790,
+      "sequence": 1060,
       "title": "தேநீர் (tēnīr) — \"tea,\" half of it already yours",
       "headword": "தேநீர்",
       "romanization": "tēnīr",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:fbaac7d8134225e1",
+      "sourceHash": "fnv1a64:a16ff2a5db8e0872",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -179,7 +179,7 @@
     },
     {
       "id": "TA-C36-paal",
-      "sequence": 800,
+      "sequence": 1070,
       "title": "பால் (pāl) — \"milk,\" and a p that becomes an h next door",
       "headword": "பால்",
       "romanization": "pāl",
@@ -190,7 +190,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:6a72f2af11ebc2dc",
+      "sourceHash": "fnv1a64:fdcb199d987a2bd6",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -360,7 +360,7 @@
     },
     {
       "id": "TA-C36-unavu",
-      "sequence": 810,
+      "sequence": 1080,
       "title": "உணவு (uṇavu) — \"food,\" from the verb underneath it",
       "headword": "உணவு",
       "romanization": "uṇavu",
@@ -371,7 +371,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:044f1ad4f016e2c5",
+      "sourceHash": "fnv1a64:e042fc7d55223d2d",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -547,7 +547,7 @@
     },
     {
       "id": "TA-C36-tavaru",
-      "sequence": 820,
+      "sequence": 1090,
       "title": "தவறு (tavaṟu) — \"a mistake,\" and the rest of the apology",
       "headword": "தவறு",
       "romanization": "tavaṟu",
@@ -558,7 +558,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:46edc651e85b20f4",
+      "sourceHash": "fnv1a64:28d405c93048afda",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/tamil/narration/ch37.json
+++ b/code/learning/human-languages/tamil/narration/ch37.json
@@ -4,11 +4,11 @@
   "chapter": 37,
   "title": "Your Town, Your Friend",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:956feb3bb64ab0cb",
+  "sourceHash": "fnv1a64:f9fc24867a2d77c3",
   "lessons": [
     {
       "id": "TA-C37-uur",
-      "sequence": 830,
+      "sequence": 1100,
       "title": "ஊர் (ūr) — \"town,\" and the question Tamil asks early",
       "headword": "ஊர்",
       "romanization": "ūr",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3393a38bd4aca7f7",
+      "sourceHash": "fnv1a64:e9126594107cd522",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -217,7 +217,7 @@
     },
     {
       "id": "TA-C37-nanban",
-      "sequence": 840,
+      "sequence": 1110,
       "title": "நண்பன் (naṇbaṉ) — \"friend,\" with the ending doing the work",
       "headword": "நண்பன்",
       "romanization": "naṇbaṉ",
@@ -228,7 +228,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e3f3e23276e44561",
+      "sourceHash": "fnv1a64:3b1e135aa5ebe420",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -405,7 +405,7 @@
     },
     {
       "id": "TA-C37-ivar",
-      "sequence": 850,
+      "sequence": 1120,
       "title": "இவர் (ivar) — \"this person,\" and Tamil's pointing system",
       "headword": "இவர்",
       "romanization": "ivar",
@@ -416,7 +416,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:9ca3f8708b12b192",
+      "sourceHash": "fnv1a64:86cddb2e115cba53",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -582,7 +582,7 @@
     },
     {
       "id": "TA-C37-ivar-en-nanbar",
-      "sequence": 860,
+      "sequence": 1130,
       "title": "இவர் என் நண்பர் (ivar eṉ naṇbar) — \"this is my friend\"",
       "headword": "இவர் என் நண்பர்",
       "romanization": "ivar eṉ naṇbar",
@@ -593,7 +593,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:a2e2284ae61b8a8e",
+      "sourceHash": "fnv1a64:30fc8c871f6986df",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/learning/human-languages/tamil/narration/ch38.json
+++ b/code/learning/human-languages/tamil/narration/ch38.json
@@ -4,11 +4,11 @@
   "chapter": 38,
   "title": "Keeping Well, and Leaving",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:d9d5146731ccd6eb",
+  "sourceHash": "fnv1a64:02d8bcf3e16a7add",
   "lessons": [
     {
       "id": "TA-C38-udambu",
-      "sequence": 870,
+      "sequence": 1140,
       "title": "உடம்பு (uḍambu) — \"body,\" and how Tamil asks after your health",
       "headword": "உடம்பு",
       "romanization": "uḍambu",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:4c3a8be338bc60b3",
+      "sourceHash": "fnv1a64:fb6e418ebdb8be6c",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -197,7 +197,7 @@
     },
     {
       "id": "TA-C38-sugam",
-      "sequence": 880,
+      "sequence": 1150,
       "title": "சுகம் (sugam) — \"ease,\" the word Tamil did borrow",
       "headword": "சுகம்",
       "romanization": "sugam",
@@ -208,7 +208,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:e334b1613ee920fd",
+      "sourceHash": "fnv1a64:00918ca7669305da",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -375,7 +375,7 @@
     },
     {
       "id": "TA-C38-vidai",
-      "sequence": 890,
+      "sequence": 1160,
       "title": "விடை (viḍai) — \"leave,\" and the root under the house",
       "headword": "விடை",
       "romanization": "viḍai",
@@ -386,7 +386,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:f9300ce323ff2a68",
+      "sourceHash": "fnv1a64:9e168048336c9617",
       "notice": {
         "modality": "sight",
         "needs": [

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,108 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Changed — Tamil teaches speaking first, and the script arrives gently
+
+Tamil chapter 1 held **eleven writing lessons against nine speaking lessons**, and the
+curriculum path put all eleven at positions 3-13: a learner met வணக்கம், then did eleven
+consecutive lessons on letter shapes before reaching the word for *yes*. The chapter's
+own declared capability said so out loud — *"I can write வணக்கம் and நன்றி by hand, put
+the puḷḷi and the ி sign in the right places"* — a chapter about greeting people whose
+stated payoff was handwriting.
+
+You can speak a language without reading a letter of it, so the course now does that:
+
+- **Chapters 1-3 carry no writing lesson.** 23 lessons — greetings, yes/no, thanks,
+  names, how-are-you. Chapter 1's capability is now *greet someone, say yes, no and
+  thank you, agree with சரி, and hold a short exchange out loud — entirely by ear*,
+  and chapter 1 becomes the first Tamil chapter that is fully drivable by ear.
+    `TA-C01-practice` had a section headed *"Read them back"* that taught the puḷḷi,
+  vowel signs and word-initial vowels inside the chapter-1 recap; it now says the five
+  words aloud and states plainly that reading is not expected yet. The **book** said the
+  same thing more loudly and had to be fixed too: all five `sounds` boxes in
+  `ch01-greetings.tex` taught left-to-right reading, the inherent vowel, the puḷḷi and
+  the ி and ை signs, and its recap table was headed *"Read"*. Chapters 1-5 are
+  hand-authored, so `book-cli --check` never compares them against the lessons and
+  nothing flagged the divergence. Those boxes now teach **pronunciation** — retroflex ṇ,
+  the held *kk*, Tamil's three *n* sounds, vowel length, the *ai* diphthong — which is
+  what a box called "sounds" should have held all along.
+- **The script starts in chapter 4, one lesson at a time.** The eleven script lessons  are spread across chapters 4-19, admitted after every third speaking lesson.
+  Measured, they sit at 0-indexed reading positions 27, 31, 36, 40, 44, 48, 52, 56, 60,
+  64, 68. Chapter 4's lesson teaches no letter at all — it is the palm-leaf lesson on
+  why the script is round; the first actual letters, வ and க, arrive in chapter 5.
+- **Every script lesson spells a word already known by ear.** வணக்கம் is learned in
+  chapter 1 and written in chapter 8, once all its letters exist; நன்றி, ஆம், இல்லை and
+  சரி likewise. The writing strand carries no new vocabulary at all.
+- **The script is shown from page one but never taught early.** Tamil words still appear
+  in the speaking lessons so the shapes grow familiar; nothing asks the learner to read
+  or write them until chapter 4. `tamil/book/chapters/ch01-greetings.tex` said the
+  opposite — *"Each lesson introduces the letters its word needs"* — and now says what
+  the chapter actually does.
+
+### Known limitations of this change
+
+Two things this does **not** fix, stated plainly rather than implied away:
+
+- **Ten early lessons still teach script inside a speaking lesson.** Nine chapter 2-3
+  word lessons carry a `## The letters in this word` section. They are not moved here,
+  because the letters they teach (உ, ய, எ, and the ெ sign) are taught nowhere in the
+  writing strand — deleting the sections would remove the only place they exist. Moving
+  them needs new writing lessons authored first.
+- **Chapter 1's payoff is now unmeasured rather than passing.** `chapters.ts` guards the
+  representativeness check with `introduced.size > 0`, and chapter 1 introduces no atoms,
+  so the gate that used to report `tamil:1` at 5/24 now says nothing about it. The corpus
+  total `payoffsNotRepresentative: 25` holds only because `tamil:13` took its place —
+  `TA-W04-i-sign-write-nandri` moved to chapter 13, whose payoff now covers 1/4.
+
+### Added — `delivery: script` marks the writing strand
+
+The eleven writing lessons declare `delivery: script` in their frontmatter, so a
+spoken-only edition can filter on one field instead of inferring the strand from `type`,
+`skills` or a computed modality. A new test pins the marker to exactly the writing
+lessons of any track that adopts it, so a writing lesson that forgets it — or a speaking
+lesson that gains it by copy-paste — fails rather than shipping in the wrong edition.
+Script material *inside* a speaking lesson is already typed at the block level
+(`block.type === "script"`), so a spoken edition can drop those blocks with no new
+metadata.
+
+### Fixed — Tamil chapters 2-5 had no declared order at all
+
+24 Tamil lessons carried no `sequence`, so four whole chapters fell back to
+**alphabetical** order. Chapter 2 therefore taught the assembled phrase *en peyar*
+("my name") before *peyar* existed, and asked *"what is your name?"* last,
+after the practice lesson. Nothing caught it, because a chapter with no declared order
+has no order to contradict. All 116 Tamil lessons now carry a globally unique sequence,
+which also clears seven duplicate sequence values main was already carrying undetected
+(the duplicate gate only checks schema-v2 lessons, and each pair had a v1 lesson on one
+side, so the schema-v2 duplicate gate could not see them — though the continuity walk
+was already reporting all seven as `duplicate-sequence` order defects, unsummarised and
+unpinned). Two genuine forward reviews are fixed with it: `TA-C02-magizhcci` reviewed
+`TA-C02-ungal-peyar-enna` and `TA-C04-mindum-sandippom` reviewed `TA-C04-naalai`, both
+before those lessons existed. Tamil forward prerequisites and forward reviews are now
+both **zero**.
+
+Measured: `lessonsWithoutSequence` 507 → 483, `tracksWithUnorderedLessons` 19 → 18
+(Tamil joins chinese, japanese and latin — the fourth of 22), `forwardPrerequisites` 240 → 230,
+`forwardReviews` 285 → 273, `forwardReferences` 469 → 468, and `chapterViolations`
+25 → 24 — that last being the gate that measures how much a chapter throws at a reader
+at once, which Tamil chapter 1 had been failing at 24 atoms against a budget of 12.
+
+Three numbers moved the wrong way, all deliberate:
+
+- `missedByWindow.R1` 834 → 843. Consecutive script lessons now sit 4-5 apart and R1 is
+  a 1-3 window, so no script lesson can reinforce the previous one inside it. 24 atoms
+  miss R1 while their real revisit counts run 0 to 7, median 2 — reinforced, just never
+  within three lessons. An interleaved strand cannot satisfy R1 as defined.
+- `fullyDrivableChapters` 327 → 322, which is −6 +1 rather than a flat loss. Six
+  chapters that were entirely ear-only now hold a writing lesson (6, 10, 13, 16, 18, 19;
+  chapter 6 holds two), offset by chapter 1 becoming fully drivable for the first time.
+- Script-ramp `lessonViolations` 60 → 61, a net of three moves: `TA-W03-pulli-vanakkam`
+  (9 glyphs, the steepest in the corpus) stopped counting once it moved to chapter 7,
+  while `TA-C01-practice` (5) and `TA-C01-nandri` (4) joined — both **speaking** lessons
+  showing glyphs the writing strand has not reached. The gate counts a glyph the first
+  time it appears, which is the right rule for a track that teaches script alongside
+  speech and the wrong one for a track that shows before it teaches.
+
 ### Fixed — the seven script facts the one-word-per-lesson pilot orphaned
 
 Splitting Tamil chapter 1 moved letter-by-letter reading out of the word lessons and

--- a/code/packages/typescript/human-language-data/src/modality-manifest.ts
+++ b/code/packages/typescript/human-language-data/src/modality-manifest.ts
@@ -178,6 +178,13 @@ export interface ModalityManifestLesson {
    * than asserted: a reader can see WHICH sections were discounted and disagree.
    */
   detachableSegments?: string[];
+  /**
+   * The authored strand marker, present only when the lesson declares one.
+   *
+   * A spoken-only edition filters on this rather than inferring the strand from
+   * `type` or from the computed modality, both of which mean something else.
+   */
+  delivery?: string;
   /** Fingerprint of the lesson AST this row was derived from. */
   sourceHash: string;
   /** Present only when the author wrote an explicit `modality:`. */
@@ -354,6 +361,10 @@ function manifestLesson(entry: LessonModality, sourceHash: string): ModalityMani
   // on a thousand rows is noise a reader must learn to skip.
   if (entry.detachableSegments.length > 0) {
     row.detachableSegments = entry.detachableSegments;
+  }
+  // Omitted when absent, same rule: today only the Tamil writing strand declares it.
+  if (entry.delivery) {
+    row.delivery = entry.delivery;
   }
   // The three override fields are omitted rather than emitted empty. They apply to a
   // handful of lessons out of 1,096, and `"authoredReason": ""` a thousand times over

--- a/code/packages/typescript/human-language-data/src/modality.ts
+++ b/code/packages/typescript/human-language-data/src/modality.ts
@@ -239,6 +239,16 @@ export interface LessonModality {
   chapter: number | null;
   /** Authored `sequence`, or null on legacy lessons that carry none. */
   sequence: number | null;
+  /**
+   * Authored `delivery`, or null when the lesson does not declare one.
+   *
+   * This is the strand a lesson belongs to, declared rather than inferred. `type:
+   * writing` already implies "script", but a consumer building a spoken-only edition
+   * should not have to know that `type` doubles as a strand marker, nor re-parse the
+   * Markdown to find out. Carried here so it reaches the manifest, which is what book
+   * targets read.
+   */
+  delivery: string | null;
   /** What the structure says the lesson needs, with every block delivered. */
   derived: Modality;
   /** What the lesson actually claims — the override when one is accepted. */
@@ -675,6 +685,7 @@ export function deriveLessonModality(
     language: lesson.language,
     chapter: Number.isFinite(lesson.realization.chapter) ? lesson.realization.chapter : null,
     sequence: numberOrNull(stringValue(lesson.frontmatter.sequence)),
+    delivery: stringValue(lesson.frontmatter.delivery) || null,
     derived,
     modality: accepted,
     coreModality: coreAccepted,

--- a/code/packages/typescript/human-language-data/tests/chapters.test.ts
+++ b/code/packages/typescript/human-language-data/tests/chapters.test.ts
@@ -240,6 +240,11 @@ describe("corpus snapshot", () => {
     // below the 0.5 floor. That is recorded in the chapter's own `payoff.note` and is
     // a deliberate trade: a chapter with an opening and a thin payoff is better than
     // one with neither, and HL-C25 exists to author real payoff lessons.
+    // Still 25, but the Tamil member CHANGED and the total hides it. tamil:1 left the
+    // list (it introduces no atoms now, so the representativeness gate skips it
+    // entirely rather than passing it), and tamil:13 joined at 1/4 — it gained
+    // TA-W04-i-sign-write-nandri when the writing strand was spread out and its payoff
+    // was not widened. Both are recorded in tamil/chapters.json's own notes.
     expect(report.summary.payoffsNotRepresentative).toBe(25);
   });
 

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -305,20 +305,32 @@ describe("the real corpus", () => {
     // from the order the curriculum path already declared, so the continuity walk can
     // finally see it. The corpus GREW by a lesson over the same change, and that lesson
     // was born sequenced, so it never entered this count.
-    expect(report.summary.lessonsWithoutSequence).toBe(507);
-    expect(report.summary.tracksWithUnorderedLessons).toBe(19);
+    // 507 -> 483: exactly the 24 Tamil lessons in chapters 2-5 that had never declared
+    // a sequence. They had been falling back to ALPHABETICAL order, which is how
+    // chapter 2 came to teach the assembled phrase "en peyar" before "peyar" existed,
+    // and to ask "what is your name?" last, after the chapter's own practice lesson. Nothing detected it, because a chapter with no declared order
+    // has no order to contradict.
+    expect(report.summary.lessonsWithoutSequence).toBe(483);    // 19 -> 18: Tamil joins chinese, japanese and latin as a fully-ordered track —
+    // the fourth of 22, not the first.
+    expect(report.summary.tracksWithUnorderedLessons).toBe(18);
         // 245 -> 240. Not five prerequisites fixed — five that were never real. Without a
     // `sequence` the walk falls back to alphabetical, so "TA-C01-aam requires
     // TA-C01-vanakkam-family-register" read as a forward prerequisite purely because
-    // `aam` sorts first. Declaring chapter 1's order removed the artifact.
-    expect(report.summary.forwardPrerequisites).toBe(240);
+    // `aam` sorts first. Declaring chapter 1's order removed the artifact.    // 240 -> 230, and forwardReviews 285 -> 273 below: ten lessons each stopped
+    // depending on something taught later. No lesson changed; only Tamil's order did.
+    expect(report.summary.forwardPrerequisites).toBe(230);
 
     // Lessons claiming to review material the learner has not reached yet.
     // 300 -> 285. Fourteen are the same alphabetical-fallback artifact as
     // forwardPrerequisites above, four of them in the writing track rather than the
     // word lessons; the fifteenth is a `reviews_of` list that genuinely shrank when its
     // lesson was rewritten.
-    expect(report.summary.forwardReviews).toBe(285);
+    // 285 -> 273. Ten from the ordering above, and two more from a real fix:
+    // TA-C02-magizhcci reviewed TA-C02-ungal-peyar-enna and TA-C04-mindum-sandippom
+    // reviewed TA-C04-naalai, both before those lessons existed. Both were forward
+    // under the old alphabetical fallback too; the hand-authored book runs them the
+    // other way round, so the sequences now follow the book. Tamil forward reviews: 0.
+    expect(report.summary.forwardReviews).toBe(273);
 
     // REINFORCEMENT. The founding promise is that the course "constantly
     // re-emphasizes what was learnt previously". It shipped with HALF taught once.
@@ -414,7 +426,8 @@ describe("the real corpus", () => {
     // 439 too. All four dropped references sit in TA-W01-curves-va-ka,
     // TA-W03-pulli-vanakkam and TA-C01-practice, none of which had prose edited. They
     // stopped counting because chapter 1 now declares its order.
-    expect(report.summary.forwardReferences).toBe(469);
+    // -1, same cause.
+    expect(report.summary.forwardReferences).toBe(468);
 
     // HL09 step 3 closed 17 R1 windows in chapters 3-6, measured on the corpus of the
     // day as 766 -> 749. The absolute figures drift as main lands lessons; what the
@@ -449,8 +462,16 @@ describe("the real corpus", () => {
     // lessons sit within three of each other — a separate change, and one that would
     // also fix a pre-existing inversion where TA-W04 spells நன்றி forty sequence
     // numbers before TA-C01-nandri teaches the word.
-    expect(report.summary.missedByWindow.R1).toBe(834);
-    expect(report.summary.missedByWindow.R2).toBe(1627);
+    // 834 -> 843, the price of the gentle ramp, paid knowingly. Tamil teaches three
+    // chapters of pure speech and then admits one script lesson at a time. Measured,    // consecutive script lessons sit at 0-indexed reading positions 27,31,36,40,44,
+    // 48,52,56,60,64,68 — gaps of 4,5,4,4,4,4,4,4,4,4. R1 is a 1-3 window, so with this layout no
+    // script lesson can reinforce the previous one inside R1. 24 atoms introduced by
+    // writing lessons miss it; their real revisit counts run 0 to 7, median 2, so all
+    // but two ARE reinforced — just never within three lessons. An interleaved strand
+    // cannot satisfy R1 as that window is defined.
+    expect(report.summary.missedByWindow.R1).toBe(843);
+    // 1627 -> 1625: R2 spans 5-15, which this spacing does reach.
+    expect(report.summary.missedByWindow.R2).toBe(1625);
   });
 
   it("shows what a declared reading order was worth", () => {

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -628,6 +628,75 @@ describe("reading the manifest back", () => {
 // The real corpus
 // ---------------------------------------------------------------------------
 
+describe("the script strand is declared, not inferred", () => {
+  // A spoken-only edition has to know which lessons are writing lessons. `type: writing`
+  // already implies it, but a book target should not have to know that `type` doubles as
+  // a strand marker, so writing lessons declare `delivery: script` outright and the
+  // manifest carries it.
+  //
+  // Every assertion below runs through `buildModalityManifest`, not the frontmatter,
+  // because the manifest is what a consumer reads. Reading `lesson.frontmatter.delivery`
+  // here would pass even if the export were deleted or wired to the wrong field.
+  const built = () => buildModalityManifest(loadEverything().lessons);
+
+  it("never marks a lesson that is not a writing lesson, in any track", () => {
+    const { lessons } = loadEverything();
+    const type = new Map(lessons.map((l) => [l.realization.lessonId, l.realization.type]));
+    const misapplied = buildModalityManifest(lessons)
+      .lessons.filter((entry) => entry.delivery !== undefined)
+      .filter((entry) => type.get(entry.id) !== "writing")
+      .map((entry) => entry.id);
+    expect(misapplied).toEqual([]);
+
+    // `delivery` stays a two-state field: "script", or absent. A typo like `sript`
+    // reaches the published manifest unchallenged otherwise — nothing in validate.ts
+    // constrains it.
+    const values = new Set(
+      built()
+        .lessons.map((entry) => entry.delivery)
+        .filter((value) => value !== undefined),
+    );
+    expect([...values]).toEqual(["script"]);
+  });
+
+  it("covers every writing lesson of every track that has adopted it", () => {
+    const { lessons } = loadEverything();
+    const manifest = buildModalityManifest(lessons);
+    const marked = manifest.lessons.filter((entry) => entry.delivery === "script");
+    expect(marked.length).toBeGreaterThan(0);
+
+    const language = new Map(lessons.map((l) => [l.realization.lessonId, l.language]));
+    const adopted = new Set(marked.map((entry) => language.get(entry.id)));
+    for (const track of adopted) {
+      const writing = lessons
+        .filter((l) => l.language === track && l.realization.type === "writing")
+        .map((l) => l.realization.lessonId)
+        .sort();
+      const declared = marked
+        .filter((entry) => language.get(entry.id) === track)
+        .map((entry) => entry.id)
+        .sort();
+      expect(declared).toEqual(writing);
+      // Guard the vacuous case per track, not just globally: a track that adopted the
+      // marker and then lost every one of it would otherwise drop out of `adopted`.
+      expect(declared.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("carries the marker into the committed manifest, not just a freshly built one", () => {
+    const fresh = built().lessons.filter((entry) => entry.delivery === "script").map((e) => e.id);
+    const committed = loadModalityManifest()
+      .lessons.filter((entry) => entry.delivery === "script")
+      .map((entry) => entry.id);
+    expect(fresh.length).toBeGreaterThan(0);
+    expect(committed.sort()).toEqual([...fresh].sort());
+    // Absent, not empty, on everything else — the manifest's house rule for optionals.
+    expect(loadModalityManifest().lessons.filter((entry) => "delivery" in entry).length).toBe(
+      fresh.length,
+    );
+  });
+});
+
 describe("corpus regression", () => {
   // A pinned measurement, not a taste test. Everything upstream — the Markdown parser,
   // the table detector, the cue list, the chapter grouping — feeds these numbers, so a
@@ -819,9 +888,18 @@ describe("corpus regression", () => {
       // depends on ORDER. HL09 step 2 gave 50 Spanish lessons a declared `sequence`,
       // and the alphabetical fallback it replaced had been flattering this number by
       // putting eyes-needed lessons later than they really come. The real order is
-      // worse, which is the measurement becoming honest, not the corpus regressing.
-      drivablePrefixTotal: 870,
-      fullyDrivableChapters: 327,
+      // worse, which is the measurement becoming honest, not the corpus regressing.      // 870 -> 873, and the net hides three moves. Chapter 1 goes 2 -> 9: its whole
+      // nine-lesson run is now reachable by ear, which is the single thing this change
+      // exists to do. Against that, chapter 6 falls 4 -> 1 and chapter 18 falls 2 -> 1,
+      // because a writing lesson now sits second in each. Chapters 2 and 3 contribute
+      // nothing — their first lesson was never voice-core to begin with.
+      drivablePrefixTotal: 873,      // 327 -> 322 = -6 +1, not a flat loss of five. SIX Tamil chapters that were
+      // entirely ear-only now hold a writing lesson (6, 10, 13, 16, 18, 19 — chapter 6
+      // holds two), because spreading the strand is exactly what puts a pen lesson into
+      // chapters that had none. Offsetting them, chapter 1 becomes fully drivable for
+      // the first time, which is the whole point of the change. Concentrating the
+      // script back into one chapter would restore the metric and undo the ramp.
+      fullyDrivableChapters: 322,
       unstartableChapters: 129,
       overriddenLessons: 0,
       lessonsWithoutChapter: 0,

--- a/code/packages/typescript/human-language-data/tests/ramp.test.ts
+++ b/code/packages/typescript/human-language-data/tests/ramp.test.ts
@@ -98,7 +98,12 @@ describe("corpus snapshot", () => {
 
     expect(report.policy).toEqual({ maxNewAtomsPerLesson: 3, maxNewAtomsPerChapter: 12 });
     expect(report.summary.lessonViolations).toBe(40);
-    expect(report.summary.chapterViolations).toBe(25);
+    // 25 -> 24. Tamil chapter 1 used to hold all eleven script lessons and blew the
+    // per-chapter atom budget (24 atoms against a budget of 12). Chapters 1-3 are now
+    // pure speech and the script strand runs one lesson at a time from chapter 4, so
+    // no Tamil chapter exceeds the budget. This is the number that most directly
+    // measures "do not throw many things at the reader at once".
+    expect(report.summary.chapterViolations).toBe(24);
 
     // HALF THE CORPUS IS INVISIBLE HERE. 572 lessons declare no atoms, so they are
     // neither compliant nor violating — they are unmigrated. A track with few violations
@@ -254,7 +259,19 @@ describe("the script ramp against the real corpus", () => {
     // script lesson, so the five glyphs of வணக்கம் itself now register against the
     // three-glyph budget — which is honest. A five-letter word IS five new shapes on
     // page one; the old structure hid that behind a "letters in this word" heading.
-    expect(report.summary.lessonViolations).toBe(60);
+    // 60 -> 61, which is a net of three separate moves, not one.
+    // OUT: TA-W03-pulli-vanakkam, at 9 glyphs the steepest Tamil lesson in the corpus.
+    //      It moved to chapter 7, by which point its glyphs are no longer first
+    //      appearances, so it stopped counting.
+    // IN:  TA-C01-practice (5 glyphs, பயுேோ) and TA-C01-nandri (4, நனறி).
+    // Both additions are SPEAKING lessons, and that is the trade being made knowingly:
+    // Tamil now shows the script from page one and does not teach a letter until
+    // chapter 4, so early spoken lessons display glyphs the writing strand has not
+    // reached. This gate counts a glyph the first time it APPEARS, which is the right
+    // rule for a track that teaches script alongside speech and the wrong one for a
+    // track that deliberately shows before it teaches. The exposure is intended; the
+    // count is honest; what it measures is no longer quite what Tamil is doing.
+    expect(report.summary.lessonViolations).toBe(61);
 
     // All five are Japanese Chapter 1, which opens kanji beside hiragana in its very
     // first lesson and adds katakana in its fifth.


### PR DESCRIPTION
## The problem

Tamil chapter 1 held **eleven writing lessons against nine speaking ones**, and the curriculum path put all eleven at positions 3–13. A learner met வணக்கம், then did eleven consecutive lessons on letter shapes before reaching the word for *yes*.

The chapter said so itself. Its declared capability was:

> *"I can write வணக்கம் and நன்றி by hand, put the puḷḷi and the ி sign in the right places, and tell Tamil's three n-letters apart by name."*

A chapter about greeting people whose stated payoff was handwriting.

## The change

You can speak a language without reading a letter of it.

- **Chapters 1–3 carry no writing lesson** — 23 lessons of greetings, yes/no, thanks, names, how-are-you. Chapter 1 becomes the first Tamil chapter that is **fully drivable by ear**.
- **The writing strand starts in chapter 4** and adds one lesson at a time, admitted after every third speaking lesson, through chapter 19.
- **Every script lesson spells a word already known by ear.** வணக்கம் is learned in chapter 1 and written in chapter 8, once all its letters exist. The strand carries no new vocabulary at all.
- **The script is shown from page one and taught later**, so the shapes grow familiar without being tested.

## Two places the old model was still hiding

`TA-C01-practice` — the chapter 1 recap — had a section headed *"Read them back"* teaching the puḷḷi, vowel signs and word-initial vowels. And the **book** said it louder: all five `sounds` boxes in `ch01-greetings.tex` taught left-to-right reading, the inherent vowel, the puḷḷi and the ி/ை signs, with a recap table headed *"Read"*. Chapters 1–5 are hand-authored, so `book-cli --check` never compares them to the lessons and nothing flagged the divergence. Those boxes now teach **pronunciation** — retroflex ṇ, the held *kk*, Tamil's three *n* sounds, vowel length, the *ai* diphthong — which is what a box called "sounds" should have held.

## Ordering

Tamil chapters 2–5 had **no declared `sequence` at all** — 24 lessons — so four chapters fell back to **alphabetical** order. Chapter 2 taught the assembled phrase *en peyar* before *peyar* existed, and asked *"what is your name?"* last, after its own practice lesson. Nothing caught it: a chapter with no declared order has no order to contradict.

All 116 Tamil lessons now carry a globally unique sequence, clearing seven duplicate values the schema-v2 gate could not see. **Tamil forward prerequisites and forward reviews are both now zero.**

## `delivery: script`

Writing lessons declare the strand in frontmatter, and it is exported through the modality manifest — the file a book target actually reads — so a spoken-only edition filters on one field instead of inferring the strand from `type`. Three tests hold it, each checked by breaking it first.

## Measured

| | before | after |
|---|---|---|
| `lessonsWithoutSequence` | 507 | 483 |
| `tracksWithUnorderedLessons` | 19 | 18 |
| `forwardPrerequisites` | 240 | 230 |
| `forwardReviews` | 285 | 273 |
| `chapterViolations` | 25 | **24** |

`chapterViolations` is the gate for how much a chapter throws at a reader at once; chapter 1 was failing it at 24 atoms against a budget of 12.

**Three numbers move the wrong way, all deliberate and all commented at the pin:** R1 misses 834→843 (script lessons now sit 4–5 apart, R1 is a 1–3 window; the 24 affected atoms are revisited 0–7 times, median 2); `fullyDrivableChapters` 327→322, which is −6 +1; script-ramp violations 60→61, where the steepest Tamil lesson stopped counting and two speaking lessons started.

## Limitations, recorded rather than implied away

- **Nine chapter 2–3 word lessons still teach script inline.** They cannot move until the letters they teach (உ, ய, எ, the ெ sign) exist in the writing strand at all — deleting them would remove the only place those letters are taught.
- **Chapter 1's payoff is now unmeasured rather than passing**, because the representativeness gate skips a chapter that introduces no atoms. The corpus total holds only because chapter 13 took its place; both chapters now carry notes saying so.

411 tests pass; `check:books`, `check:narration`, `check:modality` clean. Three review rounds found 10, 15 and 9 defects; all are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)