### PR TITLE
feat(human-language-data): give Tamil chapter 2's letters a home in the writing strand

### DIFF
--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -3756,9 +3756,10 @@
     {
       "language": "tamil",
       "chapter": 21,
-      "sourceHash": "fnv1a64:4e1e9c8c1a0e2f1d",
+      "sourceHash": "fnv1a64:8790eb8be3c68504",
       "lessonIds": [
-        "TA-C21-naay-poonai"
+        "TA-C21-naay-poonai",
+        "TA-W08-read-en"
       ],
       "tex": "tamil/book/chapters/ch21-dog-and-cat.tex"
     },
@@ -3774,10 +3775,11 @@
     {
       "language": "tamil",
       "chapter": 23,
-      "sourceHash": "fnv1a64:a2ce180ed0981b94",
+      "sourceHash": "fnv1a64:c774878bc344922f",
       "lessonIds": [
         "TA-C23-naal",
-        "TA-C23-day-family-register"
+        "TA-C23-day-family-register",
+        "TA-W09-read-peyar"
       ],
       "tex": "tamil/book/chapters/ch23-day.tex"
     },

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -7036,7 +7036,7 @@
     {
       "language": "tamil",
       "chapter": 2,
-      "sourceHash": "fnv1a64:5ddf50ce83788a95",
+      "sourceHash": "fnv1a64:8d5757d04fc5050e",
       "lessonIds": [
         "TA-C02-peyar",
         "TA-C02-en",
@@ -7047,12 +7047,12 @@
         "TA-C02-magizhcci",
         "TA-C02-practice"
       ],
-      "voiceLessons": 3,
-      "drivablePrefix": 0,
+      "voiceLessons": 6,
+      "drivablePrefix": 2,
       "text": "tamil/narration/ch02.txt",
       "json": "tamil/narration/ch02.json",
-      "textHash": "fnv1a64:16569d2844b716ae",
-      "jsonHash": "fnv1a64:d630085af5e8a783"
+      "textHash": "fnv1a64:15a4ea890299aca6",
+      "jsonHash": "fnv1a64:5102266a57d3d2f9"
     },
     {
       "language": "tamil",
@@ -7345,16 +7345,17 @@
     {
       "language": "tamil",
       "chapter": 21,
-      "sourceHash": "fnv1a64:4c3e69eb6f237751",
+      "sourceHash": "fnv1a64:676890fadc32e283",
       "lessonIds": [
-        "TA-C21-naay-poonai"
+        "TA-C21-naay-poonai",
+        "TA-W08-read-en"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 1,
       "text": "tamil/narration/ch21.txt",
       "json": "tamil/narration/ch21.json",
-      "textHash": "fnv1a64:48902886989d2146",
-      "jsonHash": "fnv1a64:6d432a2b71c2488d"
+      "textHash": "fnv1a64:bc4f6d639748430f",
+      "jsonHash": "fnv1a64:5ee48cd117c45700"
     },
     {
       "language": "tamil",
@@ -7373,17 +7374,18 @@
     {
       "language": "tamil",
       "chapter": 23,
-      "sourceHash": "fnv1a64:e101514a5078173a",
+      "sourceHash": "fnv1a64:89b27d26d650da3d",
       "lessonIds": [
         "TA-C23-naal",
-        "TA-C23-day-family-register"
+        "TA-C23-day-family-register",
+        "TA-W09-read-peyar"
       ],
       "voiceLessons": 2,
       "drivablePrefix": 2,
       "text": "tamil/narration/ch23.txt",
       "json": "tamil/narration/ch23.json",
-      "textHash": "fnv1a64:d94067274a15b0dd",
-      "jsonHash": "fnv1a64:bea80eb6ba8ae396"
+      "textHash": "fnv1a64:0c86a4e975ec4afd",
+      "jsonHash": "fnv1a64:d9288267a6fc8ae7"
     },
     {
       "language": "tamil",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,19 +7,19 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:4b2c6b3ce026852b",
+  "sourceHash": "fnv1a64:99f79b7601915af8",
   "summary": {
-    "totalLessons": 1667,
-    "voice": 1076,
-    "sight": 535,
-    "pen": 56,
-    "drivableLessons": 1076,
+    "totalLessons": 1669,
+    "voice": 1079,
+    "sight": 532,
+    "pen": 58,
+    "drivableLessons": 1079,
     "drivablePercent": 65,
     "trackCount": 22,
     "chapterCount": 513,
-    "drivablePrefixTotal": 876,
-    "fullyDrivableChapters": 323,
-    "unstartableChapters": 142,
+    "drivablePrefixTotal": 878,
+    "fullyDrivableChapters": 321,
+    "unstartableChapters": 141,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
   },
@@ -7518,12 +7518,12 @@
     },
     {
       "language": "tamil",
-      "lessonCount": 116,
-      "voice": 59,
-      "sight": 46,
-      "pen": 11,
-      "drivablePercent": 51,
-      "drivablePrefixTotal": 47,
+      "lessonCount": 118,
+      "voice": 62,
+      "sight": 43,
+      "pen": 13,
+      "drivablePercent": 53,
+      "drivablePrefixTotal": 49,
       "modalities": [
         "voice",
         "sight",
@@ -7557,17 +7557,20 @@
         {
           "chapter": 2,
           "lessonCount": 8,
-          "voice": 3,
-          "sight": 5,
+          "voice": 6,
+          "sight": 2,
           "pen": 0,
           "modalities": [
             "voice",
             "sight"
           ],
-          "drivablePrefix": 0,
-          "firstNonVoiceLesson": "TA-C02-peyar",
+          "drivablePrefix": 2,
+          "firstNonVoiceLesson": "TA-C02-en-peyar",
           "drivable": false,
-          "drivableLessonIds": []
+          "drivableLessonIds": [
+            "TA-C02-peyar",
+            "TA-C02-en"
+          ]
         },
         {
           "chapter": 3,
@@ -7874,16 +7877,18 @@
         },
         {
           "chapter": 21,
-          "lessonCount": 1,
+          "lessonCount": 2,
           "voice": 1,
           "sight": 0,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "voice"
+            "voice",
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 1,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
+          "firstNonVoiceLesson": "TA-W08-read-en",
+          "drivable": false,
           "drivableLessonIds": [
             "TA-C21-naay-poonai"
           ]
@@ -7906,16 +7911,18 @@
         },
         {
           "chapter": 23,
-          "lessonCount": 2,
+          "lessonCount": 3,
           "voice": 2,
           "sight": 0,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "voice"
+            "voice",
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 2,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
+          "firstNonVoiceLesson": "TA-W09-read-peyar",
+          "drivable": false,
           "drivableLessonIds": [
             "TA-C23-naal",
             "TA-C23-day-family-register"
@@ -36015,42 +36022,36 @@
       "language": "tamil",
       "chapter": 2,
       "sequence": 100,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a332e99363610b9e",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:2161da5980392e73"
     },
     {
       "id": "TA-C02-en",
       "language": "tamil",
       "chapter": 2,
       "sequence": 110,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:5d5a9c62328bb6c9",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:add24a5ae6f81e1d"
     },
     {
       "id": "TA-C02-en-peyar",
@@ -36096,21 +36097,18 @@
       "language": "tamil",
       "chapter": 2,
       "sequence": 150,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9d41a8ac0f94efe6",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:421ac73fe9673ba4"
     },
     {
       "id": "TA-C02-ungal-peyar-enna",
@@ -37271,6 +37269,30 @@
       "sourceHash": "fnv1a64:a2f119fd5362a2d8"
     },
     {
+      "id": "TA-W08-read-en",
+      "language": "tamil",
+      "chapter": 21,
+      "sequence": 725,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:0eab9a657dd7d20f",
+      "detachableSegments": [
+        "Script you'll notice: எ",
+        "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
+    },
+    {
       "id": "TA-C22-paccai-manjal",
       "language": "tamil",
       "chapter": 22,
@@ -37323,6 +37345,31 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:43a47e46c1189b5e"
+    },
+    {
+      "id": "TA-W09-read-peyar",
+      "language": "tamil",
+      "chapter": 23,
+      "sequence": 755,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:c0ecc7c2b714e39e",
+      "detachableSegments": [
+        "Script you'll notice: ப and ய",
+        "Script you'll notice: the ெ sign",
+        "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
     },
     {
       "id": "TA-C24-iravu",

--- a/code/learning/human-languages/tamil/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch02-introductions.tex
@@ -9,18 +9,13 @@ saying you're glad to meet them:
 \ta{உங்கள் பெயர் என்ன?} \quad(\emph{uṅgaḷ peyar eṉṉa} --- ``What is your name?'')
 \end{center}
 
-Built the same way as the greetings --- each piece taken apart, its letters and
-its root, then assembled. And here the roots run \emph{native}: this is where
+Built the same way as the greetings --- each piece taken apart, its root traced,
+then assembled. Like Chapter~1 this is work you can do by ear; the letters behind
+these words are taught in the writing strand, not here. And here the roots run \emph{native}: this is where
 Tamil is most itself.
 
 \section{\ta{பெயர்} \emph{(peyar)} --- ``name,'' and where the family is \emph{not} Indo-European}
 \label{lesson:peyar}
-
-\begin{sounds}
-\ta{ப} (\emph{pa}) $+$ \ta{ெ} (the \emph{e}-sign, written before, read after) $\to$
-\ta{பெ} (pe); \ta{ய} (\emph{ya}); \ta{ர்} (bare \emph{r}, with the puḷḷi). Read
-\ta{பெ·ய·ர்} $\to$ \emph{peyar}.
-\end{sounds}
 
 \begin{cousinweb}
 \ta{பெயர்} (\emph{peyar}, ``name'') is \textbf{native Dravidian}, from
@@ -52,11 +47,6 @@ have \emph{name/nām}.
 
 \section{\ta{என்} \emph{(eṉ)} --- ``my''}
 \label{lesson:en}
-
-\begin{sounds}
-\ta{எ} (independent vowel \emph{e}, word-initial) $+$ \ta{ன்} (bare alveolar
-\emph{ṉ}, puḷḷi) $\to$ \emph{eṉ}.
-\end{sounds}
 
 \begin{cousinweb}
 \ta{என்} (\emph{eṉ}, ``my'') is the possessive of \ta{நான்} (\emph{n\=aṉ}, ``I'')
@@ -107,11 +97,6 @@ one respected person as ``you all.'' For a first meeting, always
 
 \section{\ta{என்ன} \emph{(eṉṉa)} --- ``what''}
 \label{lesson:enna}
-
-\begin{sounds}
-\ta{எ} (\emph{e}) $+$ \ta{ன்} (bare \emph{ṉ}) $+$ \ta{ன} (\emph{ṉa}) $\to$
-\emph{eṉṉa} --- a doubled, held \emph{ṉṉ}.
-\end{sounds}
 
 \begin{cousinweb}
 \ta{என்ன} (\emph{eṉṉa}, ``what'') is native Dravidian, on the interrogative stem

--- a/code/learning/human-languages/tamil/book/chapters/ch21-dog-and-cat.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch21-dog-and-cat.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:4e1e9c8c1a0e2f1d
-% canonical-lessons: TA-C21-naay-poonai
+% canonical-source-hash: fnv1a64:8790eb8be3c68504
+% canonical-lessons: TA-C21-naay-poonai, TA-W08-read-en
 
 \chapter{Dog and Cat}
 \label{ch:ta-dog-and-cat}
@@ -40,4 +40,62 @@ Say these aloud:
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Is \textbf{\ta{நாய்}} a mystery word, like Spanish's \emph{perro}, English's \emph{dog}, or Hindi's \emph{kuttā}? (\textbf{No} — a solid, undisputed native Dravidian root, shared with Kannada and Malayalam.) Does \textbf{\ta{பூனை}} share a root with Kannada's \emph{bekku} or Telugu's \emph{pilli}? (\textbf{No} — all three are genuinely separate ancient Dravidian roots; Tamil even keeps rarer alternate cat-words, \emph{pilli} and \emph{veruku}, echoing both of them.) Which Dravidian cat-word is most likely the source of Sanskrit's \emph{biḍāla} and Hindi's \emph{billī}? (\textbf{Telugu's pilli}.)
+\end{tcolorbox}
+\section[eṉ]{\ta{என்} — the third vowel that opens a word}
+
+\label{lesson:TA-W08-read-en}
+
+
+
+\begin{quote}
+You know the rule already: a Tamil word that opens on a vowel opens with a \textbf{full vowel letter}, never a sign. You have seen it twice — \textbf{\ta{ஆ}} in \emph{ām}, \textbf{\ta{இ}} in \emph{illai}. Here is the third, in a word you have been saying since chapter 2.
+\end{quote}
+
+\subsection*{Script you'll notice: \ta{எ}}
+\textbf{\ta{எ}} is the independent letter for short \emph{e}. Same job as \textbf{\ta{ஆ}} and \textbf{\ta{இ}}, one more vowel along.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{ஆ}} & opens \emph{ām} \\
+\textbf{\ta{இ}} & opens \emph{illai} \\
+\textbf{\ta{எ}} & opens \emph{eṉ} \\
+\bottomrule
+\end{tabularx}
+
+Three words, three different vowels, one rule doing the work each time. That is what makes the rule worth having: you did not need to be told about \textbf{\ta{எ}} separately, only that word-initial vowels get a full letter.
+
+\begin{quote}
+Read \textbf{\ta{எ}}; do not draw it yet. This book gives a stroke order only where it has a sourced one, and \textbf{\ta{எ}} does not have one yet.
+\end{quote}
+
+\subsection*{Script you'll notice: build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{எ}} & \emph{e} & independent — the word opens on a vowel \\
+\textbf{\ta{ன்}} & bare \emph{ṉ} — \textbf{\ta{ன}} under a puḷḷi & the alveolar \emph{n}, from \ta{நன்றி} \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{எ} · \ta{ன்} $\to$ \ta{என்}}
+\end{quote}
+
+Two pieces, and you have met both halves before: the alveolar \textbf{\ta{ன}} is the middle one of Tamil's three \emph{n}'s, and the dot on top is the same puḷḷi that closes \textbf{\ta{வணக்கம்}}.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \textbf{\ta{எ}} — then \textbf{\ta{என்}}
+  \item \emph{Say it:} \textquotedblleft{}eṉ\textquotedblright{} — \textquotedblleft{}my\textquotedblright{}
+  \item \emph{Contrast:} \textbf{\ta{ஆம்}} · \textbf{\ta{இல்லை}} · \textbf{\ta{என்}} — three words, three opening vowels
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read \textbf{\ta{என்}}. Why does it open with a full \textbf{\ta{எ}} rather than a sign? (\textbf{The word starts on a vowel} — there is no consonant to hook onto.) Which vowel opens \textbf{\ta{இல்லை}}? (\textbf{\ta{இ}}.) What is the dot doing on \textbf{\ta{ன்}}? (\textbf{Removing the built-in \emph{a}}, leaving a bare \emph{ṉ}.) Next: green and yellow, and a colour word the whole Dravidian family shares.
 \end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch23-day.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch23-day.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:a2ce180ed0981b94
-% canonical-lessons: TA-C23-naal, TA-C23-day-family-register
+% canonical-source-hash: fnv1a64:c774878bc344922f
+% canonical-lessons: TA-C23-naal, TA-C23-day-family-register, TA-W09-read-peyar
 
 \chapter{Day}
 \label{ch:ta-day}
@@ -73,4 +73,83 @@ The language did not reject the loan; it gave native and borrowed forms differen
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Which track alone keeps a native everyday day-word? (\textbf{Tamil}.) Where does \emph{tiṉam} appear? (\textbf{Formal compounds}.) Is it unrelated to Kannada \emph{dina}? (\textbf{No} — it is the same Sanskrit tatsama.)
+\end{tcolorbox}
+\section[peyar]{\ta{பெயர்} — a sign that waits on the left}
+
+\label{lesson:TA-W09-read-peyar}
+
+
+
+\begin{quote}
+One vowel sign you have met does something strange: \textbf{\ta{ை}} stands to the \textbf{left} of its consonant and is spoken \textbf{after} it. That was not a one-off. Here is a second sign with the same habit.
+\end{quote}
+
+\subsection*{Script you'll notice: \ta{ப} and \ta{ய}}
+Two consonants, each carrying its built-in \emph{a} like every other:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{ப}} & \emph{pa} \\
+\textbf{\ta{ய}} & \emph{ya} \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+Read both; do not draw them yet. Neither has a sourced stroke order in this book's script data, so neither gets one here.
+\end{quote}
+
+\subsection*{Script you'll notice: the \ta{ெ} sign}
+\textbf{\ta{ெ}} is the sign for \emph{e}, and \textbf{it is written to the LEFT of its consonant and pronounced after it} — exactly what \textbf{\ta{ை}} does.
+
+\begin{quote}
+\textbf{\ta{ப} + \ta{ெ} $\to$ \ta{பெ}}, and on the page the hook stands \emph{before} the \ta{ப} — yet you say \emph{pe}, not \emph{ep}.
+\end{quote}
+
+So the left-standing signs are a family, not an exception you have to remember one member at a time. Compare the three vowel signs you now hold:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{sign} & \textbf{sound} & \textbf{where it sits} \\
+\midrule
+\textbf{\ta{ி}} & \emph{i} & above and to the right \\
+\textbf{\ta{ை}} & \emph{ai} & to the \textbf{left}, spoken after \\
+\textbf{\ta{ெ}} & \emph{e} & to the \textbf{left}, spoken after \\
+\bottomrule
+\end{tabularx}
+
+Be clear about how well attested each half of that is. The sourced description covers \textbf{\ta{ை}} — \emph{\textquotedblleft{}a double hook written BEFORE (to the left of) the consonant, though pronounced after it.\textquotedblright{}} There is no such entry for \textbf{\ta{ெ}} yet, so the claim that \textbf{\ta{ெ}} sits on the left is stated from the pattern the two signs share, not from a source for \textbf{\ta{ெ}} itself. It is reliable — this is ordinary Tamil orthography — but it is one step further from the page than the \textbf{\ta{ை}} rule is.
+
+\subsection*{Script you'll notice: build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{பெ}} & \emph{pe} — \ta{ப} with the \ta{ெ} sign on its left & this lesson \\
+\textbf{\ta{ய}} & \emph{ya} & this lesson \\
+\textbf{\ta{ர்}} & bare \emph{r} — \textbf{\ta{ர}} under a puḷḷi & \ta{ர} from \textbf{\ta{சரி}} \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{பெ} · \ta{ய} · \ta{ர்} $\to$ \ta{பெயர்}}
+\end{quote}
+
+Three pieces for a word you have used since chapter 2 without once needing to read it. That is the point of the order: the word came first, and the letters are catching up to a word you already own.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \textbf{\ta{ப}} · \textbf{\ta{ய}} — then \textbf{\ta{பெ}} — then \textbf{\ta{பெயர்}}
+  \item \emph{Say it:} \textquotedblleft{}peyar\textquotedblright{} — \textquotedblleft{}name\textquotedblright{}
+  \item \emph{Read it:} \textbf{\ta{என்} \ta{பெயர்}} — \textquotedblleft{}my name,\textquotedblright{} both words, straight off the page
+  \item \emph{Contrast:} \textbf{\ta{றி}} and \textbf{\ta{பெ}} — the \ta{ி} sign follows, the \ta{ெ} sign precedes
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read \textbf{\ta{பெயர்}}. Which side of its consonant does \textbf{\ta{ெ}} sit on, and when is it spoken? (\textbf{The left}, and \textbf{after} — like \ta{ை}.) Name the other left-standing sign you know. (\textbf{\ta{ை}}, as in \textbf{\ta{இல்லை}}.) Read \textbf{\ta{என்} \ta{பெயர்}} and say what it means. (\textbf{\textquotedblleft{}My name\textquotedblright{}} — \ta{எ} opens on a vowel, \ta{ர்} closes on a bare \emph{r}.) Next: the word for night.
 \end{tcolorbox}

--- a/code/learning/human-languages/tamil/curriculum.json
+++ b/code/learning/human-languages/tamil/curriculum.json
@@ -40,7 +40,9 @@
         "TA-W04-i-sign-write-nandri",
         "TA-W05-write-aam",
         "TA-W06-write-illai",
-        "TA-W07-write-sari"
+        "TA-W07-write-sari",
+        "TA-W08-read-en",
+        "TA-W09-read-peyar"
       ],
       "before": [],
       "inline": [
@@ -880,7 +882,9 @@
         "TA-W04-i-sign-write-nandri",
         "TA-W05-write-aam",
         "TA-W06-write-illai",
-        "TA-W07-write-sari"
+        "TA-W07-write-sari",
+        "TA-W08-read-en",
+        "TA-W09-read-peyar"
       ]
     },
     {

--- a/code/learning/human-languages/tamil/lessons/TA-C02-en.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-en.md
@@ -7,7 +7,7 @@ headword: என்
 gloss: my
 concept_tag: PRONOUN-MY
 prerequisites: [TA-C02-peyar]
-sounds: [independent-e, pulli]
+sounds: []
 roots: [naan-dravidian]
 est_minutes: 3
 reviews_of: [TA-C02-peyar]
@@ -18,11 +18,6 @@ reviews_of: [TA-C02-peyar]
 ## Warm-up
 
 [PAUSE 2s] "My" — and, like *peyar*, a word with no European cousin at all.
-
-## The letters in this word
-
-*(Skim if you read Tamil.)* **எ** (independent vowel *e*, word-initial) + **ன்**
-(bare alveolar *ṉ*, puḷḷi) → **eṉ**.
 
 ## The word, taken apart
 

--- a/code/learning/human-languages/tamil/lessons/TA-C02-enna.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-enna.md
@@ -7,7 +7,7 @@ headword: என்ன
 gloss: what
 concept_tag: QUESTION-WHAT
 prerequisites: [TA-C02-nii-niingal]
-sounds: [independent-e, doubled-nn]
+sounds: []
 roots: [yaa-dravidian]
 est_minutes: 3
 reviews_of: [TA-C02-nii-niingal, TA-C02-en-peyar]
@@ -18,11 +18,6 @@ reviews_of: [TA-C02-nii-niingal, TA-C02-en-peyar]
 ## Warm-up
 
 [PAUSE 2s] The last piece of the question: "what."
-
-## The letters in this word
-
-*(Skim if you read Tamil.)* **எ** (*e*) + **ன்** (bare *ṉ*) + **ன** (*ṉa*) →
-**eṉṉa** — a doubled, held *ṉṉ*.
 
 ## The word, taken apart
 

--- a/code/learning/human-languages/tamil/lessons/TA-C02-peyar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-peyar.md
@@ -7,7 +7,7 @@ headword: பெயர்
 gloss: name
 concept_tag: WORD-NAME
 prerequisites: []
-sounds: [e-sign, pulli]
+sounds: []
 roots: [peyar-dravidian]
 est_minutes: 4
 reviews_of: [TA-C01-vanakkam]
@@ -18,12 +18,6 @@ reviews_of: [TA-C01-vanakkam]
 ## Warm-up
 
 [PAUSE 2s] "Name" — and a word that shows Tamil at its most itself.
-
-## The letters in this word
-
-*(Skim if you read Tamil.)* **ப** (pa) + **ெ** (the *e*-sign, written before,
-read after) → **பெ** (pe); **ய** (ya); **ர்** (bare *r*, with the puḷḷi). Read
-**பெ·ய·ர்** → **peyar**.
 
 ## The word, taken apart
 

--- a/code/learning/human-languages/tamil/lessons/TA-W08-read-en.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W08-read-en.md
@@ -1,0 +1,88 @@
+---
+schema_version: 2
+id: TA-W08-read-en
+spine_node: SPINE-MEET-GREET
+sequence: 725
+delivery: script
+chapter: 21
+type: writing
+headword: "என்"
+gloss: a third word-initial vowel, reached by a rule you already had
+romanization: "eṉ"
+prerequisites: [TA-W06-write-illai, TA-W02-three-ns]
+sounds: [independent-vowel-e, pulli]
+roots: []
+duration:
+  max_seconds: 200
+requires:
+  knowledge: [TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-PULLI-VANAKKAM-01]
+introduces:
+  knowledge: [TA-SCRIPT-INDEPENDENT-VOWEL-E-01, TA-SCRIPT-READ-EN-02]
+practises:
+  knowledge: [TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-INDEPENDENT-VOWEL-E-01, TA-SCRIPT-READ-EN-02]
+skills: [reading]
+modes: [interpretive]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W06-write-illai, TA-C02-en]
+---
+
+# என் — the third vowel that opens a word
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-INDEPENDENT-VOWEL-I-01] -->
+
+[PAUSE 2s] You know the rule already: a Tamil word that opens on a vowel opens
+with a **full vowel letter**, never a sign. You have seen it twice — **ஆ** in
+*ām*, **இ** in *illai*. Here is the third, in a word you have been saying since
+chapter 2.
+
+## Script you'll notice: எ
+<!-- hl-knowledge: introduces=[TA-SCRIPT-INDEPENDENT-VOWEL-E-01]; assesses=[] -->
+
+**எ** is the independent letter for short *e*. Same job as **ஆ** and **இ**, one
+more vowel along.
+
+| | |
+|---|---|
+| **ஆ** | opens *ām* |
+| **இ** | opens *illai* |
+| **எ** | opens *eṉ* |
+
+Three words, three different vowels, one rule doing the work each time. That is
+what makes the rule worth having: you did not need to be told about **எ**
+separately, only that word-initial vowels get a full letter.
+
+> Read **எ**; do not draw it yet. This book gives a stroke order only where it
+> has a sourced one, and **எ** does not have one yet.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-READ-EN-02]; assesses=[TA-SCRIPT-INDEPENDENT-VOWEL-E-01, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+| piece | | |
+|---|---|---|
+| **எ** | *e* | independent — the word opens on a vowel |
+| **ன்** | bare *ṉ* — **ன** under a puḷḷi | the alveolar *n*, from நன்றி |
+
+> **எ · ன் → என்**
+
+Two pieces, and you have met both halves before: the alveolar **ன** is the
+middle one of Tamil's three *n*'s, and the dot on top is the same puḷḷi that
+closes **வணக்கம்**.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-INDEPENDENT-VOWEL-E-01, TA-SCRIPT-READ-EN-02] -->
+
+[PAUSE 1s]
+- [YOU READ: **எ** — then **என்**]
+- [YOU SAY: "eṉ" — "my"]
+- [YOU CONTRAST: **ஆம்** · **இல்லை** · **என்** — three words, three opening vowels]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-INDEPENDENT-VOWEL-E-01, TA-SCRIPT-READ-EN-02, TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+[PAUSE 3s] Read **என்**. Why does it open with a full **எ** rather than a sign?
+(**The word starts on a vowel** — there is no consonant to hook onto.) Which
+vowel opens **இல்லை**? (**இ**.) What is the dot doing on **ன்**? (**Removing the
+built-in *a***, leaving a bare *ṉ*.) Next: green and yellow, and a colour word the whole Dravidian family shares.

--- a/code/learning/human-languages/tamil/lessons/TA-W09-read-peyar.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W09-read-peyar.md
@@ -1,0 +1,109 @@
+---
+schema_version: 2
+id: TA-W09-read-peyar
+spine_node: SPINE-MEET-GREET
+sequence: 755
+delivery: script
+chapter: 23
+type: writing
+headword: "பெயர்"
+gloss: ப, ய, and a second vowel sign that stands to the left of its consonant
+romanization: "peyar"
+prerequisites: [TA-W08-read-en, TA-W07-write-sari]
+sounds: [matra-e, pulli]
+roots: []
+duration:
+  max_seconds: 220
+requires:
+  knowledge: [TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-READ-EN-02, TA-SCRIPT-INDEPENDENT-VOWEL-E-01]
+introduces:
+  knowledge: [TA-SCRIPT-PA-YA-01, TA-SCRIPT-E-SIGN-02, TA-SCRIPT-READ-PEYAR-03]
+practises:
+  knowledge: [TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-READ-EN-02, TA-SCRIPT-PA-YA-01, TA-SCRIPT-E-SIGN-02, TA-SCRIPT-READ-PEYAR-03, TA-SCRIPT-INDEPENDENT-VOWEL-E-01, TA-SCRIPT-CA-ONE-LETTER-01]
+skills: [reading]
+modes: [interpretive]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W08-read-en, TA-W06-write-illai, TA-C02-peyar]
+---
+
+# பெயர் — a sign that waits on the left
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-LA-AI-SIGN-02] -->
+
+[PAUSE 2s] One vowel sign you have met does something strange: **ை** stands to
+the **left** of its consonant and is spoken **after** it. That was not a
+one-off. Here is a second sign with the same habit.
+
+## Script you'll notice: ப and ய
+<!-- hl-knowledge: introduces=[TA-SCRIPT-PA-YA-01]; assesses=[] -->
+
+Two consonants, each carrying its built-in *a* like every other:
+
+| | |
+|---|---|
+| **ப** | *pa* |
+| **ய** | *ya* |
+
+> Read both; do not draw them yet. Neither has a sourced stroke order in this
+> book's script data, so neither gets one here.
+
+## Script you'll notice: the ெ sign
+<!-- hl-knowledge: introduces=[TA-SCRIPT-E-SIGN-02]; assesses=[TA-SCRIPT-LA-AI-SIGN-02] -->
+
+**ெ** is the sign for *e*, and **it is written to the LEFT of its consonant and
+pronounced after it** — exactly what **ை** does.
+
+> **ப + ெ → பெ**, and on the page the hook stands *before* the ப — yet you say
+> *pe*, not *ep*.
+
+So the left-standing signs are a family, not an exception you have to remember
+one member at a time. Compare the three vowel signs you now hold:
+
+| sign | sound | where it sits |
+|---|---|---|
+| **ி** | *i* | above and to the right |
+| **ை** | *ai* | to the **left**, spoken after |
+| **ெ** | *e* | to the **left**, spoken after |
+
+Be clear about how well attested each half of that is. The sourced description
+covers **ை** — *"a double hook written BEFORE (to the left of) the consonant,
+though pronounced after it."* There is no such entry for **ெ** yet, so the claim
+that **ெ** sits on the left is stated from the pattern the two signs share, not
+from a source for **ெ** itself. It is reliable — this is ordinary Tamil
+orthography — but it is one step further from the page than the **ை** rule is.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-READ-PEYAR-03]; assesses=[TA-SCRIPT-PA-YA-01, TA-SCRIPT-E-SIGN-02, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-CA-ONE-LETTER-01] -->
+
+| piece | | |
+|---|---|---|
+| **பெ** | *pe* — ப with the ெ sign on its left | this lesson |
+| **ய** | *ya* | this lesson |
+| **ர்** | bare *r* — **ர** under a puḷḷi | ர from **சரி** |
+
+> **பெ · ய · ர் → பெயர்**
+
+Three pieces for a word you have used since chapter 2 without once needing to
+read it. That is the point of the order: the word came first, and the letters
+are catching up to a word you already own.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-PA-YA-01, TA-SCRIPT-E-SIGN-02, TA-SCRIPT-READ-PEYAR-03, TA-SCRIPT-READ-EN-02] -->
+
+[PAUSE 1s]
+- [YOU READ: **ப** · **ய** — then **பெ** — then **பெயர்**]
+- [YOU SAY: "peyar" — "name"]
+- [YOU READ: **என் பெயர்** — "my name," both words, straight off the page]
+- [YOU CONTRAST: **றி** and **பெ** — the ி sign follows, the ெ sign precedes]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-PA-YA-01, TA-SCRIPT-E-SIGN-02, TA-SCRIPT-READ-PEYAR-03, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-READ-EN-02, TA-SCRIPT-INDEPENDENT-VOWEL-E-01] -->
+
+[PAUSE 3s] Read **பெயர்**. Which side of its consonant does **ெ** sit on, and
+when is it spoken? (**The left**, and **after** — like ை.) Name the other
+left-standing sign you know. (**ை**, as in **இல்லை**.) Read **என் பெயர்** and
+say what it means. (**"My name"** — எ opens on a vowel, ர் closes on a bare *r*.)
+Next: the word for night.

--- a/code/learning/human-languages/tamil/narration/ch02.json
+++ b/code/learning/human-languages/tamil/narration/ch02.json
@@ -3,8 +3,8 @@
   "language": "tamil",
   "chapter": 2,
   "title": "Chapter 2",
-  "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:5ddf50ce83788a95",
+  "drivablePrefix": 2,
+  "sourceHash": "fnv1a64:8d5757d04fc5050e",
   "lessons": [
     {
       "id": "TA-C02-peyar",
@@ -14,22 +14,13 @@
       "romanization": "",
       "gloss": "name",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a332e99363610b9e",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:2161da5980392e73",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -50,17 +41,6 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Tamil.) ப (pa) + ெ (the e-sign, written before, read after) becomes பெ (pe); ய (ya); ர் (bare r, with the puḷḷi). Read பெ, ய, ர் becomes peyar."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The word, taken apart",
           "segments": [
@@ -75,7 +55,7 @@
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -115,7 +95,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -141,22 +121,13 @@
       "romanization": "",
       "gloss": "my",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:5d5a9c62328bb6c9",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:add24a5ae6f81e1d",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -177,17 +148,6 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Tamil.) எ (independent vowel e, word-initial) + ன் (bare alveolar ṉ, puḷḷi) becomes eṉ."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The word, taken apart",
           "segments": [
@@ -198,7 +158,7 @@
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -229,7 +189,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -500,22 +460,13 @@
       "romanization": "",
       "gloss": "what",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9d41a8ac0f94efe6",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:421ac73fe9673ba4",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -536,17 +487,6 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Tamil.) எ (e) + ன் (bare ṉ) + ன (ṉa) becomes eṉṉa — a doubled, held ṉṉ."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The word, taken apart",
           "segments": [
@@ -557,7 +497,7 @@
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -588,7 +528,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [

--- a/code/learning/human-languages/tamil/narration/ch02.txt
+++ b/code/learning/human-languages/tamil/narration/ch02.txt
@@ -1,18 +1,13 @@
 Tamil, chapter 2: Chapter 2.
-8 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+8 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
 
 
 Lesson 1 of 8.
 பெயர் (peyar) — "name," where the family is not Indo-European.
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 "Name" — and a word that shows Tamil at its most itself.
-
-The letters in this word.
-(Skim if you read Tamil.) ப (pa) + ெ (the e-sign, written before, read after) becomes பெ (pe); ய (ya); ர் (bare r, with the puḷḷi). Read பெ, ய, ர் becomes peyar.
 
 The word, taken apart.
 பெயர் (peyar, "name") is native Dravidian, from Proto-Dravidian peyar / pēr — and it is not related to Sanskrit nāma (Hindi nām, English name). Here the two great families part: Indo-European shares one word for "name" from Ireland to North India, but the Dravidian south kept its own.
@@ -35,14 +30,9 @@ Is பெயர் related to English name? (No — it's native Dravidian, peyar
 Lesson 2 of 8.
 என் (eṉ) — "my".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 "My" — and, like peyar, a word with no European cousin at all.
-
-The letters in this word.
-(Skim if you read Tamil.) எ (independent vowel e, word-initial) + ன் (bare alveolar ṉ, puḷḷi) becomes eṉ.
 
 The word, taken apart.
 என் (eṉ, "my") is the possessive of நான் (nāṉ, "I") — native Dravidian, from the pronoun stem yān / nān. It has no Indo-European cousin: the Tamil "I/my" is built on a different root from English I/my (which go back to eǵ and me-). Two families, two entirely separate words for the self.
@@ -121,14 +111,9 @@ How does Tamil make "you" respectful, and which European language uses the same 
 Lesson 5 of 8.
 என்ன (eṉṉa) — "what".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 The last piece of the question: "what."
-
-The letters in this word.
-(Skim if you read Tamil.) எ (e) + ன் (bare ṉ) + ன (ṉa) becomes eṉṉa — a doubled, held ṉṉ.
 
 The word, taken apart.
 என்ன (eṉṉa, "what") is native Dravidian, on the interrogative stem yā- / e- that heads Tamil's whole question family: eṉṉa (what), yār (who), eppo (when), enge (where), ēṉ (why). Like Hindi's k- words and English's wh- words — but from a different, Dravidian root.

--- a/code/learning/human-languages/tamil/narration/ch21.json
+++ b/code/learning/human-languages/tamil/narration/ch21.json
@@ -4,7 +4,7 @@
   "chapter": 21,
   "title": "Dog and Cat",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:4c3e69eb6f237751",
+  "sourceHash": "fnv1a64:676890fadc32e283",
   "lessons": [
     {
       "id": "TA-C21-naay-poonai",
@@ -115,6 +115,172 @@
             {
               "kind": "speech",
               "text": "Is நாய் a mystery word, like Spanish's perro, English's dog, or Hindi's kuttā? (No — a solid, undisputed native Dravidian root, shared with Kannada and Malayalam.) Does பூனை share a root with Kannada's bekku or Telugu's pilli? (No — all three are genuinely separate ancient Dravidian roots; Tamil even keeps rarer alternate cat-words, pilli and veruku, echoing both of them.) Which Dravidian cat-word is most likely the source of Sanskrit's biḍāla and Hindi's billī? (Telugu's pilli.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W08-read-en",
+      "sequence": 725,
+      "title": "என் (eṉ) — the third vowel that opens a word",
+      "headword": "என்",
+      "romanization": "eṉ",
+      "gloss": "a third word-initial vowel, reached by a rule you already had",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:0eab9a657dd7d20f",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: எ",
+          "Script you'll notice: build the word"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: எ and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You know the rule already: a Tamil word that opens on a vowel opens with a full vowel letter, never a sign. You have seen it twice — ஆ in ām, இ in illai. Here is the third, in a word you have been saying since chapter 2."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: எ",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "எ is the independent letter for short e. Same job as ஆ and இ, one more vowel along."
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 3,
+              "utterances": [
+                "ஆ, opens ām.",
+                "இ, opens illai.",
+                "எ, opens eṉ."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Three words, three different vowels, one rule doing the work each time. That is what makes the rule worth having: you did not need to be told about எ separately, only that word-initial vowels get a full letter."
+            },
+            {
+              "kind": "speech",
+              "text": "Read எ; do not draw it yet. This book gives a stroke order only where it has a sourced one, and எ does not have one yet."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 2,
+              "utterances": [
+                "piece: எ, e, independent — the word opens on a vowel.",
+                "piece: ன், bare ṉ — ன under a puḷḷi, the alveolar n, from நன்றி."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "எ, ன் becomes என் (eṉ)."
+            },
+            {
+              "kind": "speech",
+              "text": "Two pieces, and you have met both halves before: the alveolar ன is the middle one of Tamil's three n's, and the dot on top is the same puḷḷi that closes வணக்கம்."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "எ — then என் (eṉ)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **எ** — then **என்**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"eṉ\" — \"my\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"eṉ\" — \"my\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "ஆம், இல்லை, என் (eṉ) — three words, three opening vowels",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **ஆம்** · **இல்லை** · **என்** — three words, three opening vowels]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read என் (eṉ). Why does it open with a full எ rather than a sign? (The word starts on a vowel — there is no consonant to hook onto.) Which vowel opens இல்லை? (இ.) What is the dot doing on ன்? (Removing the built-in a, leaving a bare ṉ.) Next: green and yellow, and a colour word the whole Dravidian family shares."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch21.txt
+++ b/code/learning/human-languages/tamil/narration/ch21.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 21: Dog and Cat.
-1 lesson. All 1 can be done entirely by ear.
+2 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 1.
+Lesson 1 of 2.
 நாய், பூனை — solid ground to close the arc, and an honest three-way split.
 
 Warm-up.
@@ -27,3 +27,42 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Is நாய் a mystery word, like Spanish's perro, English's dog, or Hindi's kuttā? (No — a solid, undisputed native Dravidian root, shared with Kannada and Malayalam.) Does பூனை share a root with Kannada's bekku or Telugu's pilli? (No — all three are genuinely separate ancient Dravidian roots; Tamil even keeps rarer alternate cat-words, pilli and veruku, echoing both of them.) Which Dravidian cat-word is most likely the source of Sanskrit's biḍāla and Hindi's billī? (Telugu's pilli.)
+
+
+Lesson 2 of 2.
+என் (eṉ) — the third vowel that opens a word.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: எ and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You know the rule already: a Tamil word that opens on a vowel opens with a full vowel letter, never a sign. You have seen it twice — ஆ in ām, இ in illai. Here is the third, in a word you have been saying since chapter 2.
+
+Script you'll notice: எ.
+எ is the independent letter for short e. Same job as ஆ and இ, one more vowel along.
+[a table of 3 rows, read aloud]
+ஆ, opens ām.
+இ, opens illai.
+எ, opens eṉ.
+Three words, three different vowels, one rule doing the work each time. That is what makes the rule worth having: you did not need to be told about எ separately, only that word-initial vowels get a full letter.
+Read எ; do not draw it yet. This book gives a stroke order only where it has a sourced one, and எ does not have one yet.
+
+Script you'll notice: build the word.
+[a table of 2 rows, read aloud]
+piece: எ, e, independent — the word opens on a vowel.
+piece: ன், bare ṉ — ன under a puḷḷi, the alveolar n, from நன்றி.
+எ, ன் becomes என் (eṉ).
+Two pieces, and you have met both halves before: the alveolar ன is the middle one of Tamil's three n's, and the dot on top is the same puḷḷi that closes வணக்கம்.
+
+Guided Practice.
+[pause 1 second]
+[your turn — read: எ — then என் (eṉ)]
+[pause 8 seconds for the answer]
+[your turn — say: "eṉ" — "my"]
+[pause 8 seconds for the answer]
+[your turn — contrast: ஆம், இல்லை, என் (eṉ) — three words, three opening vowels]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read என் (eṉ). Why does it open with a full எ rather than a sign? (The word starts on a vowel — there is no consonant to hook onto.) Which vowel opens இல்லை? (இ.) What is the dot doing on ன்? (Removing the built-in a, leaving a bare ṉ.) Next: green and yellow, and a colour word the whole Dravidian family shares.

--- a/code/learning/human-languages/tamil/narration/ch23.json
+++ b/code/learning/human-languages/tamil/narration/ch23.json
@@ -4,7 +4,7 @@
   "chapter": 23,
   "title": "Day",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:e101514a5078173a",
+  "sourceHash": "fnv1a64:89b27d26d650da3d",
   "lessons": [
     {
       "id": "TA-C23-naal",
@@ -229,6 +229,216 @@
             {
               "kind": "speech",
               "text": "Which track alone keeps a native everyday day-word? (Tamil.) Where does tiṉam appear? (Formal compounds.) Is it unrelated to Kannada dina? (No — it is the same Sanskrit tatsama.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W09-read-peyar",
+      "sequence": 755,
+      "title": "பெயர் (peyar) — a sign that waits on the left",
+      "headword": "பெயர்",
+      "romanization": "peyar",
+      "gloss": "ப, ய, and a second vowel sign that stands to the left of its consonant",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:c0ecc7c2b714e39e",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: ப and ய",
+          "Script you'll notice: the ெ sign",
+          "Script you'll notice: build the word"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ப and ய, Script you'll notice: the ெ sign and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "One vowel sign you have met does something strange: ை stands to the left of its consonant and is spoken after it. That was not a one-off. Here is a second sign with the same habit."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: ப and ய",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Two consonants, each carrying its built-in a like every other:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "ப, pa.",
+                "ய, ya."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Read both; do not draw them yet. Neither has a sourced stroke order in this book's script data, so neither gets one here."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: the ெ sign",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ெ is the sign for e, and it is written to the LEFT of its consonant and pronounced after it — exactly what ை does."
+            },
+            {
+              "kind": "speech",
+              "text": "ப + ெ becomes பெ, and on the page the hook stands before the ப — yet you say pe, not ep."
+            },
+            {
+              "kind": "speech",
+              "text": "So the left-standing signs are a family, not an exception you have to remember one member at a time. Compare the three vowel signs you now hold:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "sign",
+                "sound",
+                "where it sits"
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "sign: ி. sound: i. where it sits: above and to the right.",
+                "sign: ை. sound: ai. where it sits: to the left, spoken after.",
+                "sign: ெ. sound: e. where it sits: to the left, spoken after."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Be clear about how well attested each half of that is. The sourced description covers ை — \"a double hook written BEFORE (to the left of) the consonant, though pronounced after it.\" There is no such entry for ெ yet, so the claim that ெ sits on the left is stated from the pattern the two signs share, not from a source for ெ itself. It is reliable — this is ordinary Tamil orthography — but it is one step further from the page than the ை rule is."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "piece: பெ, pe — ப with the ெ sign on its left, this lesson.",
+                "piece: ய, ya, this lesson.",
+                "piece: ர், bare r — ர under a puḷḷi, ர from சரி."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "பெ, ய, ர் becomes பெயர் (peyar)."
+            },
+            {
+              "kind": "speech",
+              "text": "Three pieces for a word you have used since chapter 2 without once needing to read it. That is the point of the order: the word came first, and the letters are catching up to a word you already own."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "ப, ய — then பெ — then பெயர் (peyar)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **ப** · **ய** — then **பெ** — then **பெயர்**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"peyar\" — \"name\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"peyar\" — \"name\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "என் பெயர் (peyar) — \"my name,\" both words, straight off the page",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **என் பெயர்** — \"my name,\" both words, straight off the page]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "றி and பெ — the ி sign follows, the ெ sign precedes",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **றி** and **பெ** — the ி sign follows, the ெ sign precedes]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read பெயர் (peyar). Which side of its consonant does ெ sit on, and when is it spoken? (The left, and after — like ை.) Name the other left-standing sign you know. (ை, as in இல்லை.) Read என் பெயர் (peyar) and say what it means. (\"My name\" — எ opens on a vowel, ர் closes on a bare r.) Next: the word for night."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch23.txt
+++ b/code/learning/human-languages/tamil/narration/ch23.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 23: Day.
-2 lessons. All 2 can be done entirely by ear.
+3 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 2.
+Lesson 1 of 3.
 நாள் (nāḷ) — "day," the one this arc's Dravidian languages didn't lose.
 
 Warm-up.
@@ -24,7 +24,7 @@ Wrap-up Recall.
 Where did you already meet நாள் before this lesson? (Inside நாளை, nāḷai, "tomorrow," Chapter 4.) Is Tamil's everyday day-word a loanword? (No — நாள் is native Dravidian.) Is it marginal or literary? (No — it is the plain everyday counting word.) Next: compare the other sisters' borrowed day-words and Tamil's formal tiṉam.
 
 
-Lesson 2 of 2.
+Lesson 2 of 3.
 நாள் and தினம் — everyday native, formal borrowed.
 
 Warm-up.
@@ -54,3 +54,53 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Which track alone keeps a native everyday day-word? (Tamil.) Where does tiṉam appear? (Formal compounds.) Is it unrelated to Kannada dina? (No — it is the same Sanskrit tatsama.)
+
+
+Lesson 3 of 3.
+பெயர் (peyar) — a sign that waits on the left.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ப and ய, Script you'll notice: the ெ sign and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+One vowel sign you have met does something strange: ை stands to the left of its consonant and is spoken after it. That was not a one-off. Here is a second sign with the same habit.
+
+Script you'll notice: ப and ய.
+Two consonants, each carrying its built-in a like every other:
+[a table of 2 rows, read aloud]
+ப, pa.
+ய, ya.
+Read both; do not draw them yet. Neither has a sourced stroke order in this book's script data, so neither gets one here.
+
+Script you'll notice: the ெ sign.
+ெ is the sign for e, and it is written to the LEFT of its consonant and pronounced after it — exactly what ை does.
+ப + ெ becomes பெ, and on the page the hook stands before the ப — yet you say pe, not ep.
+So the left-standing signs are a family, not an exception you have to remember one member at a time. Compare the three vowel signs you now hold:
+[a table of 3 rows, read aloud]
+sign: ி. sound: i. where it sits: above and to the right.
+sign: ை. sound: ai. where it sits: to the left, spoken after.
+sign: ெ. sound: e. where it sits: to the left, spoken after.
+Be clear about how well attested each half of that is. The sourced description covers ை — "a double hook written BEFORE (to the left of) the consonant, though pronounced after it." There is no such entry for ெ yet, so the claim that ெ sits on the left is stated from the pattern the two signs share, not from a source for ெ itself. It is reliable — this is ordinary Tamil orthography — but it is one step further from the page than the ை rule is.
+
+Script you'll notice: build the word.
+[a table of 3 rows, read aloud]
+piece: பெ, pe — ப with the ெ sign on its left, this lesson.
+piece: ய, ya, this lesson.
+piece: ர், bare r — ர under a puḷḷi, ர from சரி.
+பெ, ய, ர் becomes பெயர் (peyar).
+Three pieces for a word you have used since chapter 2 without once needing to read it. That is the point of the order: the word came first, and the letters are catching up to a word you already own.
+
+Guided Practice.
+[pause 1 second]
+[your turn — read: ப, ய — then பெ — then பெயர் (peyar)]
+[pause 8 seconds for the answer]
+[your turn — say: "peyar" — "name"]
+[pause 8 seconds for the answer]
+[your turn — read: என் பெயர் (peyar) — "my name," both words, straight off the page]
+[pause 8 seconds for the answer]
+[your turn — contrast: றி and பெ — the ி sign follows, the ெ sign precedes]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read பெயர் (peyar). Which side of its consonant does ெ sit on, and when is it spoken? (The left, and after — like ை.) Name the other left-standing sign you know. (ை, as in இல்லை.) Read என் பெயர் (peyar) and say what it means. ("My name" — எ opens on a vowel, ர் closes on a bare r.) Next: the word for night.

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,71 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — the Tamil writing strand reaches chapter 2's words
+
+The speaking-first change left nine chapter 2-3 word lessons still teaching script
+inline, and they could not simply be deleted: the glyphs they explained existed nowhere
+in the writing strand, so removing them would have removed the only place those letters
+were taught. Two new reading lessons close that for chapter 2:
+
+- **`TA-W08-read-en`** (chapter 21) — **எ**, the third word-initial vowel, spelling
+  **என்**. The rule was already known from **ஆம்** and **இல்லை**; this is the same rule
+  meeting a third vowel, which is the point of having a rule.
+- **`TA-W09-read-peyar`** (chapter 23) — **ப**, **ய** and the **ெ** sign, spelling
+  **பெயர்**. ெ stands to the **left** of its consonant and is spoken after it, exactly
+  as **ை** does, so the left-standing signs become a family rather than a series of
+  exceptions.
+
+Both are reading-only. None of எ, ப, ய or ெ has a sourced stroke order in
+`data/scripts/tamil.json`, so neither lesson invents one and both say so. `TA-W09` also
+marks how well attested each half of its ெ claim is: the left-standing description is
+sourced for **ை** and inferred for **ெ** from the pattern the two share.
+
+Both sit at the strand's established cadence — one script lesson after every third
+speaking lesson — and both spell words the learner has said since chapter 2. Note the
+third removal is not symmetric: **என்ன** loses its section because every glyph in it is
+taught (எ by `TA-W08`, ன and the puḷḷi earlier), but no strand lesson ever assembles the
+doubled ன்ன itself.
+
+### Removed — three chapter 2 lessons stop teaching script
+
+With the glyphs housed, `TA-C02-en`, `TA-C02-enna` and `TA-C02-peyar` drop their
+`## The letters in this word` sections, and `ch02-introductions.tex` drops the three
+matching `sounds` boxes. Verified against the **generated** manifest rather than the
+source: all three now record `reasons: ["no-visual-dependency"]` and read as `voice`, so
+this is script teaching genuinely leaving the lesson, not a heading renamed out from
+under the classifier. Tamil chapter 2 becomes startable by ear for the first time
+(`unstartableChapters` 129 → 128, its drivable prefix 0 → 2).
+
+**`TA-C02-nii-niingal` keeps its section**, because ங, ள and the ீ sign are still taught
+nowhere else. A strict check — does a strand block make the glyph its own subject, in a
+heading, its own table row, or an "X is Y" sentence — was needed to see this: all three
+*appear* in strand lessons, but only inside examples (ஸ்ரீ, ங்க, புள்ளி). Mere
+appearance is not teaching, and the looser check would have licensed deleting the only
+explanation those letters have. The same test says ப was never taught either, which is
+why `TA-W09` teaches it rather than assuming it.
+
+Six chapter 3 lessons still teach script inline, and chapters 3-5's book `sounds` boxes
+still show ப, எ and ய before the strand reaches them. This closes chapter 2 only.
+
+Measured: `atomsTaught` 2502 → 2507, `voice` 1076 → 1079, `sight` 535 → 532, `pen`
+56 → 58, `unstartableChapters` 142 → 141, `drivablePrefixTotal` 876 → 878, and
+`fullyDrivableChapters` 323 → 321 as chapters 21 and 23 each take a writing lesson.
+
+`atomsNeverRevisited` **rises**, 472 → 474, and it is worth saying why rather than
+burying it. Three of the five new atoms are `TA-W09`'s, and nothing follows `TA-W09`, so
+they are orphans by construction. Against that, `TA-W09` re-uses ர when it spells
+**பெயர்**, and declaring `CA-ONE-LETTER-01` pulls that atom out of the orphan set for
+the first time. Three in, one out.
+
+`missedByWindow.R2` 1716 → 1718 is the same shape and the more interesting one: all five
+new atoms miss R2 too, offset by **three** pre-existing atoms that `TA-W09` pulls back
+into it. `TA-W09` sits 12 lessons after `TA-W06` and 8 after `TA-W07`, both inside R2's
+5-15 window, so practising `INDEPENDENT-VOWEL-I-01`, `LA-AI-SIGN-02` and
+`CA-ONE-LETTER-01` there reinforces them at a distance R1 can never reach. A strand
+spread thin misses the near window and starts hitting the far one.
+
+
 ### Changed — Tamil teaches speaking first, and the script arrives gently
 
 Tamil chapter 1 held **eleven writing lessons against nine speaking lessons**, and the

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -366,8 +366,17 @@ describe("the real corpus", () => {
     // Vocabulary wave 4 (marathi/punjabi/sanskrit/urdu, 51 pre-A1 nouns) kept both
     // trends moving the right way at once: atomsTaught +117 while atomsNeverRevisited
     // FELL a second time, by 7 more. 19% is the lowest reading yet, from 51%.
-    expect(report.summary.atomsTaught).toBe(2502);
-    expect(report.summary.atomsNeverRevisited).toBe(472);
+    // +5: TA-W08-read-en introduces 2, TA-W09-read-peyar 3. They teach எ, ப, ய and the
+    // ெ sign — the glyphs Tamil chapter 2 was still explaining inside its own speaking
+    // lessons because the writing strand had never covered them.
+    expect(report.summary.atomsTaught).toBe(2507);
+    // +2, and it goes UP, which is worth stating plainly. Three of the five new atoms
+    // are TA-W09's and nothing follows TA-W09, so they are orphans by construction:
+    // PA-YA-01, E-SIGN-02, READ-PEYAR-03. TA-W08's two are revisited by TA-W09.
+    // Against that, TA-W09 re-uses ர when it spells பெயர், so declaring
+    // CA-ONE-LETTER-01 pulls that atom out of the orphan set for the first time
+    // (revisits 0 -> 1). Three in, one out.
+    expect(report.summary.atomsNeverRevisited).toBe(474);
     expect(report.summary.neverRevisitedPercent).toBe(19);
 
     // 509 -> 517, and the eight split into TWO DIFFERENT PHENOMENA this number conflates.
@@ -466,8 +475,17 @@ describe("the real corpus", () => {
     // 1625 claimed in isolation). Re-measured against the merged corpus: R1 834 -> 847
     // (both effects add), R2 1627 -> 1716 (wave 4's growth dominates, Tamil's recovery
     // is a small offset against it, not the whole story either claim told alone).
-    expect(report.summary.missedByWindow.R1).toBe(847);
-    expect(report.summary.missedByWindow.R2).toBe(1716);
+    // +5, exactly the five new atoms and no offsets. The strand's cadence puts
+    // consecutive script lessons 4-5 apart and R1 is a 1-3 window, so an atom a script
+    // lesson introduces cannot be reinforced inside R1 by the next one.
+    expect(report.summary.missedByWindow.R1).toBe(852);
+    // +2 net, and the composition is the interesting part: all FIVE new atoms miss R2
+    // as well, offset by THREE pre-existing atoms that TA-W09 pulls back into it.
+    // TA-W09 sits 12 lessons after TA-W06 and 8 after TA-W07, both inside R2's 5-15
+    // window, so practising INDEPENDENT-VOWEL-I-01, LA-AI-SIGN-02 and CA-ONE-LETTER-01
+    // there reinforces them at a distance R1 could never reach. Measured: all three go
+    // from missing R1/R2/R3 to missing only R1/R3.
+    expect(report.summary.missedByWindow.R2).toBe(1718);
   });
 
   it("shows what a declared reading order was worth", () => {

--- a/code/packages/typescript/human-language-data/tests/levels.test.ts
+++ b/code/packages/typescript/human-language-data/tests/levels.test.ts
@@ -217,7 +217,8 @@ describe("corpus snapshot", () => {
     const { lessons, curricula: paths, spine } = loadEverything();
     const summary = summarizeLevels(lessons, paths, spine);
 
-    expect(summary.byLevel["pre-A1"]).toBe(864); // +52: vocabulary wave 4 (marathi/punjabi/sanskrit/urdu)
+    // +2: TA-W08-read-en and TA-W09-read-peyar.
+    expect(summary.byLevel["pre-A1"]).toBe(866); // +52: vocabulary wave 4 (marathi/punjabi/sanskrit/urdu)
     expect(summary.byLevel.A1).toBe(297);
     expect(summary.byLevel.A2).toBe(350);
     // 8, not 0: Spanish chapters 38 and 41 realize SPINE-NARRATE-EVENTS and
@@ -279,7 +280,7 @@ describe("corpus snapshot", () => {
     const { lessons, curricula: paths, spine } = loadEverything();
     const ramp = lessonsUpToLevel(lessons, paths, spine, "A1");
     // The whole point: this is a FILTER over the one corpus, not a second corpus.
-    expect(ramp).toHaveLength(1161); // +52: vocabulary wave 4, all of it pre-A1
+    expect(ramp).toHaveLength(1163); // +52: vocabulary wave 4, all of it pre-A1
     expect(ramp.length).toBeLessThan(lessons.length);
   });
 });

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -873,17 +873,23 @@ describe("corpus regression", () => {
       // several tracks' honest `## The letters in this word` blocks add `sight`, so
       // the whole-lesson share dips 66% -> 65% even though every one of these blocks
       // is detachable and `coreDrivable` again loses nothing.
-      totalLessons: 1667,
-      voice: 1076,
-      sight: 535,
+      totalLessons: 1669,
+      voice: 1079,
+      // -3 sight / +3 voice: TA-C02-en, -enna and -peyar dropped their "The letters in
+      // this word" sections once TA-W08 and TA-W09 gave those glyphs a home in the
+      // strand. Verified against the GENERATED manifest, not the source — all three now
+      // record reasons ["no-visual-dependency"], so the script teaching genuinely left
+      // the lesson rather than a heading being renamed out from under the classifier.
+      sight: 532,
       // +3 pen: the Tamil ch1 writing lessons. Rule 1 in src/modality.ts derives
       // this from the lesson TYPE alone — it says outright that it does not look at
       // the body — so all three record reasons ["writing-type","script-block"], and
       // TA-W07 is pen even though it deliberately gives no stroke instructions.
       // voice and drivable are unchanged, which is what a writing lesson should do
       // to this table.
-      pen: 56,
-      drivableLessons: 1076,
+      // +2: both new lessons are writing lessons.
+      pen: 58,
+      drivableLessons: 1079,
       drivablePercent: 65,
       trackCount: 22,
       chapterCount: 513,
@@ -904,9 +910,17 @@ describe("corpus regression", () => {
       // corpus: drivablePrefixTotal 876 (both gains add), fullyDrivableChapters 323
       // (wave 4's +1 and Tamil's net -5 combine), unstartableChapters 142 (wave 4's
       // rise; Tamil's restructure did not touch this count in the merged state).
-      drivablePrefixTotal: 876,
-      fullyDrivableChapters: 323,
-      unstartableChapters: 142,
+      // +2, and Tamil chapter 2 is the only chapter in the corpus that moves: 0 -> 2.
+      // Measured, not reasoned — ch2 runs peyar(100), en(110), en-peyar(120), so
+      // freeing the first two extends the ear-only run until en-peyar, which is still
+      // sight and stops it. TA-C02-enna sits behind that blocker and became drivable
+      // without adding to any prefix.
+      drivablePrefixTotal: 878,
+      // -2: chapters 21 and 23 each take a writing lesson and stop being ear-only.
+      // Spreading the strand cannot happen without landing a pen lesson somewhere.
+      fullyDrivableChapters: 321,
+      // -1: Tamil chapter 2 can now be started by ear.
+      unstartableChapters: 141,
       overriddenLessons: 0,
       lessonsWithoutChapter: 0,
     });


### PR DESCRIPTION
Follow-on to #10086, closing the first of the two limitations that PR recorded rather than fixed.

## The blocker

Nine Tamil chapter 2–3 word lessons still taught script inline, under `## The letters in this word`. They could not simply be deleted: **the glyphs they explained existed nowhere in the writing strand**, so removing the sections would have removed the only place those letters were taught.

## Two reading lessons

| lesson | teaches | spells |
|---|---|---|
| `TA-W08-read-en` (ch21) | **எ**, the third word-initial vowel | **என்** |
| `TA-W09-read-peyar` (ch23) | **ப**, **ய**, the **ெ** sign | **பெயர்** |

எ is reached by a rule the learner already has — from **ஆம்** and **இல்லை** — which is the point of having a rule. And **ெ** stands to the *left* of its consonant and is spoken after it, exactly as **ை** does, so the left-standing signs become a family rather than a run of exceptions.

Both are **reading-only**. None of எ, ப, ய or ெ has a sourced stroke order in `data/scripts/tamil.json`, so neither lesson invents one and both say so. `TA-W09` goes further and marks how well attested each half of its ெ claim is: the left-standing description is *sourced* for **ை** and *inferred* for **ெ** from the pattern they share.

## Three sections removed, one kept

`TA-C02-en`, `TA-C02-enna` and `TA-C02-peyar` drop their sections, and `ch02-introductions.tex` drops the three matching `sounds` boxes plus its promise to take letters apart. Verified against the **generated** manifest rather than the source — all three now record `reasons: ["no-visual-dependency"]`, so this is script teaching genuinely leaving the lesson, not a heading renamed out from under the classifier. **Tamil chapter 2 becomes startable by ear for the first time.**

**`TA-C02-nii-niingal` keeps its section**, because ங, ள and the ீ sign are still taught nowhere else.

Seeing that needed a strict test: *does a strand block make the glyph its own subject* — a heading, its own table row, or an "X is Y" sentence? All three **appear** in strand lessons, but only inside examples: ஸ்ரீ, ங்க, புள்ளி. Mere appearance is not teaching, and the looser check would have licensed deleting the only explanation those letters have. The same test showed **ப was never taught either**, which is why `TA-W09` teaches it rather than assuming it.

## Measured

`atomsTaught` 2502→2507 · `voice` 1076→1079 · `sight` 535→532 · `pen` 56→58 · `unstartableChapters` 142→141 · `drivablePrefixTotal` 876→878 (Tamil ch2 is the only chapter in the corpus that moves, 0→2) · `fullyDrivableChapters` 323→321.

**`atomsNeverRevisited` rises, 472→474**, and that is worth stating rather than burying. Three of the five new atoms are `TA-W09`'s, and nothing follows `TA-W09`, so they are orphans by construction. Against that, `TA-W09` re-uses ர when it spells **பெயர்**, and declaring `CA-ONE-LETTER-01` pulls that atom out of the orphan set for the first time. Three in, one out.

`missedByWindow.R2` 1716→1718 has the same shape and a better story: all five new atoms miss R2 as well, offset by **three** pre-existing atoms `TA-W09` pulls back into it from 8 and 12 lessons away — distances inside R2's 5–15 window that R1 can never reach. A strand spread thin misses the near window and starts hitting the far one.

## Still open

Chapter 3's six inline sections remain, and chapters 3–5's book `sounds` boxes still show ப, எ and ய before the strand reaches them. This closes chapter 2 only.

411 tests pass; `check:books`, `check:narration`, `check:modality` clean. A review pass found 12 defects, all fixed — including a fabricated before/after baseline in my own changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)