### PR TITLE
fix(language-ladder): restore strict typecheck

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -285,7 +285,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-V02 | Complete (#9653) | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
 | HL-V03 | Complete (#9900) | Compile individual prompt, answer, accepted-variant, feedback, and response-time contracts from typed activity blocks. | Compact JSON directives compile into validated runtime answer sets; each activity names a non-empty assessed-atom subset, carries feedback/time, and never scrapes prose. |
 | HL-A01 | In progress (#9901 + Russian and Persian/Urdu slices) | Author objective activity coverage for every mapped non-lexical frontier. | The first tranche covers every ready schema-v2 track; later slices cover Russian's naming chain and Persian/Urdu Chapters 3–5 practice. Coverage is 25 of 119 across 18 tracks; 94 lessons remain, including 16 that first need schema-v2 migration. |
-| HL-Q01 | Queued | Restore a clean standalone TypeScript typecheck for Language Ladder. | `npx tsc --noEmit` should pass after fixing the pre-existing DOM element type, review-log cast, missing Node test types, and unused/implicit test symbols; HL-V03 introduces no additional type errors. |
+| HL-Q01 | Complete in this PR after #9916 | Restore a clean standalone TypeScript typecheck for Language Ladder. | `npm run typecheck` passes after fixing the pre-existing DOM element type, review-log cast, ESM fixture paths, and unused test symbols; BUILD now keeps the gate enforced. |
+| HL-Q02 | Queued | Split Language Ladder's monolithic production JavaScript bundle. | Vite should no longer emit its 500 kB chunk warning; initial Learn-mode loading should not require the current 7.12 MB script while all modes and offline-relative deployment keep working. |
 | HL-B04 | Complete (#9661) | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
 | HL-B05 | Complete (#9663) | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
 | HL-B06 | Complete (#9669) | Publish Gujarati Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
@@ -2342,6 +2343,29 @@ problem.
   stroke order this repository cannot cite. HL-C42 carries that forward: the first
   interspersed lesson should land in a track whose ductus is already sourced —
   Tamil's ம traces to the UT Austin primer — rather than waiting on Telugu.
+
+## Findings from HL-Q01
+
+- Strict `tsc --noEmit` now passes across both `src/` and `tests/`. The shared
+  DOM factory preserves the concrete element type for literal tag names, so
+  button-only properties no longer require scattered casts.
+- Defensive review-state loading keeps its runtime validation while making the
+  intentional untrusted-object boundary explicit to TypeScript.
+- Vendored-font tests use the Node declarations owned in #9916 plus ESM-safe
+  `import.meta.url` paths rather than relying on a CommonJS global.
+- The standalone BUILD runs typecheck before Vite and Vitest. A clean pass
+  typechecks, produces the app, and passes all 523 tests in 31 files from the app
+  package.
+- Directly executing `BUILD` exposed that its dependency-install `cd` persisted
+  despite a comment promising a subshell. The command is now actually grouped
+  and uses deterministic `npm ci`, so the app gates run from the correct package
+  without rewriting the dependency lockfile.
+- The clean install also exposed a high-severity Nano ID development advisory.
+  Refreshing the transitive lock entry from 3.3.16 to 3.3.18 leaves the app's
+  standalone `npm audit` at zero known vulnerabilities.
+- The production build emits one 7,115.81 kB JavaScript chunk (1,800.06 kB
+  gzip), above Vite's 500 kB warning threshold. HL-Q02 records that separate
+  learner-loading concern without coupling a bundle redesign to this repair.
 
 ## Completed foundations
 

--- a/code/programs/typescript/language-ladder/BUILD
+++ b/code/programs/typescript/language-ladder/BUILD
@@ -20,7 +20,8 @@ set -e
 # Tools (npm, npx, node) are expected on PATH (mise shims locally; CI installs
 # Node directly via actions/setup-node).
 
-cd ../../../packages/typescript/human-language-data && npm install --silent
+(cd ../../../packages/typescript/human-language-data && npm ci --silent)
 npm install
+npm run typecheck
 npm run build
 npx vitest run

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased — schema-v2 lesson compatibility
 
+### Fixed — standalone TypeScript validation
+
+- Restore a clean strict typecheck across the application and all tests by
+  typing the shared DOM factory, making the untrusted review-log conversion
+  explicit, and removing stale test symbols.
+- Use the repository-owned Node test types and ESM-safe fixture paths for
+  vendored-font tests.
+- Run `npm run typecheck` in the standalone BUILD before the production bundle
+  and test suite, and keep the deterministic dependency install in its intended
+  subshell so those gates run in Language Ladder rather than its data package or
+  rewrite that package's lockfile.
+- Refresh the transitive Nano ID lock entry to 3.3.18, clearing the high-severity
+  development audit finding reported by the standalone install.
+
 ### Added — the stroke-order filmstrip (HL-C08)
 
 - Add `src/ductusview.ts`: a pure SVG renderer that composes the authored pen

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -281,6 +281,7 @@ read-only — `letters` / `isSyllabary` / the matrix untouched).
 ```sh
 npm install
 npm run dev        # local dev server
+npm run typecheck  # strict source + test typecheck
 npm test           # unit tests (vitest)
 npm run build      # production build to dist/
 npm run preview    # serve the production build

--- a/code/programs/typescript/language-ladder/package-lock.json
+++ b/code/programs/typescript/language-ladder/package-lock.json
@@ -1739,9 +1739,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -1812,7 +1812,10 @@ function chooseConfusableShuffled(ranked: number[], count: number): number[] {
   return pool.slice(0, count);
 }
 
-function el(tag: string, className: string): HTMLElement {
+function el<Tag extends keyof HTMLElementTagNameMap>(
+  tag: Tag,
+  className: string,
+): HTMLElementTagNameMap[Tag] {
   const node = document.createElement(tag);
   if (className) node.className = className;
   return node;

--- a/code/programs/typescript/language-ladder/src/reviewstore.ts
+++ b/code/programs/typescript/language-ladder/src/reviewstore.ts
@@ -119,7 +119,7 @@ export function fromSavedReview(saved: SavedReview): { progress: Progress; sessi
   const savedLog = Array.isArray(saved.log) ? saved.log : [];
   for (const row of savedLog) {
     if (typeof row !== "object" || row === null || Array.isArray(row)) continue;
-    const r = row as Record<string, unknown>;
+    const r = row as unknown as Record<string, unknown>;
     if (typeof r.cellKey !== "string" || typeof r.correct !== "boolean") continue;
     const record: AnswerRecord = { cellKey: r.cellKey, correct: r.correct };
     // chosenKey is only meaningful on a miss; keep it only when it's a string.

--- a/code/programs/typescript/language-ladder/tests/scheduler.test.ts
+++ b/code/programs/typescript/language-ladder/tests/scheduler.test.ts
@@ -4,7 +4,6 @@ import {
   MAX_BOX,
   intervalFor,
   initStates,
-  isDue,
   dueCount,
   masteredCount,
   pickNext,

--- a/code/programs/typescript/language-ladder/tests/strokes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/strokes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { parseFont, boundsOf, type Contour } from "../src/truetype";
 import {
   DUCTUS,
@@ -13,7 +14,8 @@ import {
   type Point,
 } from "../src/strokes";
 
-const FONT_DIR = resolve(__dirname, "../../../../learning/human-languages/_fonts");
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const FONT_DIR = resolve(TEST_DIR, "../../../../learning/human-languages/_fonts");
 const load = (name: string) => {
   const b = readFileSync(resolve(FONT_DIR, name));
   return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength) as ArrayBuffer;

--- a/code/programs/typescript/language-ladder/tests/truetype.test.ts
+++ b/code/programs/typescript/language-ladder/tests/truetype.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync, readdirSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { parseFont, contoursToPath, boundsOf, type Contour } from "../src/truetype";
 
-const FONT_DIR = resolve(__dirname, "../../../../learning/human-languages/_fonts");
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const FONT_DIR = resolve(TEST_DIR, "../../../../learning/human-languages/_fonts");
 const load = (name: string) => {
   const b = readFileSync(resolve(FONT_DIR, name));
   return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength) as ArrayBuffer;
@@ -132,10 +134,6 @@ function raster(contours: Contour[], win: Window, W = 110, H = 26): boolean[][] 
   }
   return grid;
 }
-
-const inkColumns = (g: boolean[][]) => g[0].map((_, c) => g.some((row) => row[c]));
-/** Count runs of ink along a row — i.e. how many separate strokes it crosses. */
-const runsInRow = (row: boolean[]) => row.reduce((n, v, i) => n + (v && !row[i - 1] ? 1 : 0), 0);
 
 describe("truetype: reading the vendored fonts", () => {
   it("parses Noto Sans Tamil and finds a Unicode cmap", () => {


### PR DESCRIPTION
## Summary
- restore strict TypeScript validation for the Language Ladder app and tests
- make the standalone BUILD run dependency setup in a real subshell, typecheck before bundling, and use deterministic npm ci for the data package
- update the transitive Nano ID lock to 3.3.18 and record the separate bundle-splitting follow-up as HL-Q02

## Validation
- bash BUILD: 31 test files and 523 tests passed
- TypeScript tsconfig portability validator: passed across 458 projects
- npm audit: zero known vulnerabilities in Language Ladder
- git diff --check: passed

## Follow-up
HL-Q02 tracks the 7.12 MB production JavaScript chunk separately so this correctness repair stays focused.