### PR TITLE
Add JFET RS parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `RS` source resistance.
 - Validate and lower JFET model-card `RD` drain resistance.
 - Validate and lower JFET model-card `GDSNOI` channel-noise coefficient.
 - Validate and lower JFET model-card `NLEV` noise equation level.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1345,6 +1345,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Nlev=model.params.get("NLEV", 1.0),
             Gdsnoi=model.params.get("GDSNOI", 1.0),
             Rd=model.params.get("RD", 0.0),
+            Rs=model.params.get("RS", 0.0),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2140,6 +2141,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(drain_resistance) or drain_resistance < 0.0
         ):
             raise NetlistParseError("JFET RD must be finite and non-negative")
+        source_resistance = params.get("RS")
+        if source_resistance is not None and (
+            not math.isfinite(source_resistance) or source_resistance < 0.0
+        ):
+            raise NetlistParseError("JFET RS must be finite and non-negative")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1591,6 +1591,28 @@ def test_rejects_invalid_jfet_drain_resistance(value: str) -> None:
         parse_netlist(f".model fast NJF(RD={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("9.75", 9.75)])
+def test_parse_jfet_source_resistance(value: str, expected: float) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NJF(RS={value})
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert jfet.Rs == expected
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1e999"])
+def test_rejects_invalid_jfet_source_resistance(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="JFET RS must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NJF(RS={value})")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `RS` source resistance.
 - Validate and lower JFET model-card `RD` drain resistance.
 - Validate and lower JFET model-card `GDSNOI` channel-noise coefficient.
 - Validate and lower JFET model-card `NLEV` noise equation level.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1432,6 +1432,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET RD must be finite and non-negative");
   }
+  const jfetSourceResistance = params.get("RS");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetSourceResistance !== undefined &&
+    (!Number.isFinite(jfetSourceResistance) || jfetSourceResistance < 0.0)
+  ) {
+    throw new NetlistParseError("JFET RS must be finite and non-negative");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -2030,6 +2038,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("NLEV") ?? 1.0,
       model.params.get("GDSNOI") ?? 1.0,
       model.params.get("RD") ?? 0.0,
+      model.params.get("RS") ?? 0.0,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1632,6 +1632,30 @@ J1 drain gate source fast
     },
   );
 
+  it.each([
+    ["0", 0.0],
+    ["9.75", 9.75],
+  ])("parses JFET source resistance %s", (value, expected) => {
+    const parsed = parseNetlist(`
+.model fast NJF(RS=${value})
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      sourceResistance: expected,
+    });
+  });
+
+  it.each(["-0.1", "1e999"])(
+    "rejects invalid JFET source resistance %s",
+    (value) => {
+      expect(() => parseNetlist(`.model fast NJF(RS=${value})`)).toThrow(
+        "JFET RS must be finite and non-negative",
+      );
+    },
+  );
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4492,9 +4492,14 @@ the Rust, Python, and TypeScript surfaces together.
      lower them into the shared engine channel-noise-coefficient field.
 
 434. Python and TypeScript Berkeley SPICE JFET drain-resistance parity.
-   - Status: implemented in this JFET drain-resistance parity slice.
+   - Status: completed in PR 9860.
    - Both parser facades validate finite, non-negative `RD` values and lower
      them into the shared engine intrinsic-drain-resistance field.
+
+435. Python and TypeScript Berkeley SPICE JFET source-resistance parity.
+   - Status: implemented in this JFET source-resistance parity slice.
+   - Both parser facades validate finite, non-negative `RS` values and lower
+     them into the shared engine intrinsic-source-resistance field.
 
 ## Backlog
 
@@ -4503,8 +4508,8 @@ the Rust, Python, and TypeScript surfaces together.
      currently use `B` as a legacy beta alias, while the engine model uses `B`
      for Parker-Skellern doping-tail shaping. Do not assign one card value to
      both fields silently.
-   - Continue the unambiguous audited JFET gaps with `RS`,
-     `TCV`, `VTOTC`, `TNOM` / `T_NOM`, `BEX`, and `BETATCE`.
+   - Continue the unambiguous audited JFET gaps with `TCV`, `VTOTC`,
+     `TNOM` / `T_NOM`, `BEX`, and `BETATCE`.
    - Continue the audited BJT model-card gaps after the smaller JFET fields;
      prioritize direct engine fields before adding new model surfaces.
    - Re-audit MOS lowering after those direct JFET and BJT omissions close.


### PR DESCRIPTION
## Summary
- validate finite, non-negative JFET model-card `RS` values in the Python and TypeScript parser facades
- lower accepted source resistance into the shared JFET engine field
- add mirrored acceptance/rejection tests and reconcile the SPICE implementation plan

## Verification
- `code/packages/python/spice-netlist-parser/BUILD` (398 passed, 89.55% coverage)
- `.venv/bin/ruff check .`
- `code/packages/typescript/spice-netlist-parser/BUILD` (383 passed)
- `npx vitest run --coverage` (86.81% line coverage)
- `code/packages/typescript/spice-engine/BUILD` (448 passed)