### PR TITLE
Add JFET TCV parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `TCV` threshold-voltage temperature
+  coefficient.
 - Validate and lower JFET model-card `RS` source resistance.
 - Validate and lower JFET model-card `RD` drain resistance.
 - Validate and lower JFET model-card `GDSNOI` channel-noise coefficient.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1346,6 +1346,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Gdsnoi=model.params.get("GDSNOI", 1.0),
             Rd=model.params.get("RD", 0.0),
             Rs=model.params.get("RS", 0.0),
+            Tcv=model.params.get("TCV", 0.0),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2146,6 +2147,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(source_resistance) or source_resistance < 0.0
         ):
             raise NetlistParseError("JFET RS must be finite and non-negative")
+        threshold_voltage_temperature_coefficient = params.get("TCV")
+        if threshold_voltage_temperature_coefficient is not None and not math.isfinite(
+            threshold_voltage_temperature_coefficient
+        ):
+            raise NetlistParseError("JFET TCV must be finite")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1613,6 +1613,29 @@ def test_rejects_invalid_jfet_source_resistance(value: str) -> None:
         parse_netlist(f".model fast NJF(RS={value})")
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"), [("-0.01", -0.01), ("0", 0.0), ("0.02", 0.02)]
+)
+def test_parse_jfet_threshold_voltage_temperature_coefficient(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NJF(TCV={value})
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert jfet.Tcv == expected
+
+
+def test_rejects_non_finite_jfet_threshold_voltage_temperature_coefficient() -> None:
+    with pytest.raises(NetlistParseError, match="JFET TCV must be finite"):
+        parse_netlist(".model fast NJF(TCV=1e999)")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `TCV` threshold-voltage temperature
+  coefficient.
 - Validate and lower JFET model-card `RS` source resistance.
 - Validate and lower JFET model-card `RD` drain resistance.
 - Validate and lower JFET model-card `GDSNOI` channel-noise coefficient.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1440,6 +1440,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET RS must be finite and non-negative");
   }
+  const jfetThresholdVoltageTemperatureCoefficient = params.get("TCV");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetThresholdVoltageTemperatureCoefficient !== undefined &&
+    !Number.isFinite(jfetThresholdVoltageTemperatureCoefficient)
+  ) {
+    throw new NetlistParseError("JFET TCV must be finite");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -2039,6 +2047,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("GDSNOI") ?? 1.0,
       model.params.get("RD") ?? 0.0,
       model.params.get("RS") ?? 0.0,
+      model.params.get("TCV") ?? 0.0,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1656,6 +1656,31 @@ J1 drain gate source fast
     },
   );
 
+  it.each([
+    ["-0.01", -0.01],
+    ["0", 0.0],
+    ["0.02", 0.02],
+  ])(
+    "parses JFET threshold-voltage temperature coefficient %s",
+    (value, expected) => {
+      const parsed = parseNetlist(`
+.model fast NJF(TCV=${value})
+J1 drain gate source fast
+`);
+
+      expect(parsed.circuit.elements()[0]).toMatchObject({
+        kind: "jfet",
+        thresholdVoltageTemperatureCoefficient: expected,
+      });
+    },
+  );
+
+  it("rejects a non-finite JFET threshold-voltage temperature coefficient", () => {
+    expect(() => parseNetlist(".model fast NJF(TCV=1e999)")).toThrow(
+      "JFET TCV must be finite",
+    );
+  });
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4497,9 +4497,15 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine intrinsic-drain-resistance field.
 
 435. Python and TypeScript Berkeley SPICE JFET source-resistance parity.
-   - Status: implemented in this JFET source-resistance parity slice.
+   - Status: completed in PR 10090.
    - Both parser facades validate finite, non-negative `RS` values and lower
      them into the shared engine intrinsic-source-resistance field.
+
+436. Python and TypeScript Berkeley SPICE JFET threshold-voltage temperature
+     coefficient parity.
+   - Status: implemented in this JFET TCV parity slice.
+   - Both parser facades validate finite `TCV` values and lower them into the
+     shared engine threshold-voltage temperature-coefficient field.
 
 ## Backlog
 
@@ -4508,8 +4514,8 @@ the Rust, Python, and TypeScript surfaces together.
      currently use `B` as a legacy beta alias, while the engine model uses `B`
      for Parker-Skellern doping-tail shaping. Do not assign one card value to
      both fields silently.
-   - Continue the unambiguous audited JFET gaps with `TCV`, `VTOTC`,
-     `TNOM` / `T_NOM`, `BEX`, and `BETATCE`.
+   - Continue the unambiguous audited JFET gaps with `VTOTC`, `TNOM` / `T_NOM`,
+     `BEX`, and `BETATCE`.
    - Continue the audited BJT model-card gaps after the smaller JFET fields;
      prioritize direct engine fields before adding new model surfaces.
    - Re-audit MOS lowering after those direct JFET and BJT omissions close.


### PR DESCRIPTION
## Summary
- validate finite signed JFET model-card `TCV` values in the Python and TypeScript parser facades
- lower accepted coefficients into the shared JFET threshold-voltage temperature field
- add mirrored acceptance/rejection tests and reconcile the SPICE implementation plan

## Verification
- `code/packages/python/spice-netlist-parser/BUILD` (402 passed, 89.58% coverage)
- `.venv/bin/ruff check .`
- `code/packages/typescript/spice-netlist-parser/BUILD` (387 passed)
- `npx vitest run --coverage` (86.84% line coverage)
- `code/packages/typescript/spice-engine/BUILD` (448 passed)