### PR TITLE
feat(human-languages): derive track progress table

### DIFF
--- a/.github/workflows/human-languages-books.yml
+++ b/.github/workflows/human-languages-books.yml
@@ -141,6 +141,11 @@ jobs:
           npm ci
           npm run build
           npm run check:books
+          # The top-level track table is a generated view over the registry,
+          # curriculum maps, lessons, and book manifest. Keep every registered
+          # language visible without hand-maintained chapter or lesson claims.
+          # Regenerate with `npm run generate:progress`.
+          npm run check:progress
           # The modality manifest (core/lesson-modality.json) is derived from the
           # lessons and is what lets the complete book, the app, and the future
           # dictation-friendly driving edition be filtered out of one source. A stale

--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,8 +5,9 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-06, when the Step-by-Step capability program (HL05–HL07)
-was specified and placed ahead of the remaining roadmap and migration work. Current
+Last prioritized: 2026-08-08, after HL-Q01 merged as #10089. HL-I03 moved next
+because four vocabulary waves had already made the hand-maintained track table stale;
+the index now needs to derive its claims before the next corpus expansion. Current
 baseline after the Japanese Chapter 1 tranche (HL-C40), which followed the Mandarin
 Chinese scale test (HL-C39), the Latin chapter payoffs (HL-C24) and the Spanish
 gentle-ramp split (HL-C18A): **22** registered tracks, **1,133** Markdown lessons,
@@ -285,7 +286,7 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-V02 | Complete (#9653) | Validate learner-facing target-language prompts against block-level knowledge declarations and prerequisite closure. | Schema-v2 production and recall blocks cannot ask for an undeclared form or a form absent from the lesson's transitive knowledge frontier. |
 | HL-V03 | Complete (#9900) | Compile individual prompt, answer, accepted-variant, feedback, and response-time contracts from typed activity blocks. | Compact JSON directives compile into validated runtime answer sets; each activity names a non-empty assessed-atom subset, carries feedback/time, and never scrapes prose. |
 | HL-A01 | In progress (#9901 + Russian and Persian/Urdu slices) | Author objective activity coverage for every mapped non-lexical frontier. | The first tranche covers every ready schema-v2 track; later slices cover Russian's naming chain and Persian/Urdu Chapters 3–5 practice. Coverage is 25 of 119 across 18 tracks; 94 lessons remain, including 16 that first need schema-v2 migration. |
-| HL-Q01 | Complete in this PR after #9916 | Restore a clean standalone TypeScript typecheck for Language Ladder. | `npm run typecheck` passes after fixing the pre-existing DOM element type, review-log cast, ESM fixture paths, and unused test symbols; BUILD now keeps the gate enforced. |
+| HL-Q01 | Complete (#10089, after #9916) | Restore a clean standalone TypeScript typecheck for Language Ladder. | `npm run typecheck` passes after fixing the pre-existing DOM element type, review-log cast, ESM fixture paths, and unused test symbols; BUILD now keeps the gate enforced. |
 | HL-Q02 | Queued | Split Language Ladder's monolithic production JavaScript bundle. | Vite should no longer emit its 500 kB chunk warning; initial Learn-mode loading should not require the current 7.12 MB script while all modes and offline-relative deployment keep working. |
 | HL-B04 | Complete (#9661) | Publish Marathi Chapter 6 from its two canonical lessons rather than hand-copying another book chapter. | Both schema-v2 lessons now generate the PDF chapter from the same source hashes independently verified by Language Ladder. |
 | HL-B05 | Complete (#9663) | Remove Marathi's duplicate practice labels and Unicode bookmark warnings. | Stable recap labels, bookmark-safe Devanagari, natural page bottoms, and explicit static-font shapes make the forced six-chapter build warning-free. |
@@ -298,8 +299,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B12 | Complete (#9705) | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The schema-v2 lesson now generates the PDF chapter from the same source hash independently verified by Language Ladder. |
 | HL-B13 | Complete (#9711) | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | Main-font punctuation, stable recap labels, bookmark-safe Bengali, natural page bottoms, explicit static-font shapes, and a breakable long title make the forced six-chapter build warning-free. |
 | HL-I01 | Complete (#9715) | Reduce unified all-books workflow setup time without splitting the single publication bundle. | A focused, preflighted XeLaTeX dependency closure replaces `texlive-full`; the unchanged job still builds all 20 books, verifies one bundle, and publishes that bundle from `main`. |
-| HL-I02 | Queued | Update the human-language data package beyond the vulnerable PostCSS 8.5.19 transitive development dependency. | A clean install reports GHSA-fxqj-rqcc-2cmp through Vitest/Vite; PostCSS 8.5.25 is available, but this development-only moderate finding remains behind reader-facing book and app gaps. |
-| HL-I03 | Queued | Derive the top-level track progress table from canonical curriculum and book-generation data. | The hand-maintained table can lag shipped chapters after a generated-book migration; a checked or generated summary should keep every prior language visible without repeating stale progress claims. |
+| HL-I02 | Queued — reprioritized after HL-I03 | Refresh the human-language data package's vulnerable transitive development locks. | A clean install now reports high-severity Nano ID GHSA-2v37-7h3g-55p8 and moderate PostCSS GHSA-fxqj-rqcc-2cmp through Vitest/Vite; both have fixes available and should leave `npm audit` at zero. |
+| HL-I03 | Complete in this PR | Derive the top-level track progress table from canonical curriculum and book-generation data. | A registry-ordered generated table reports canonical and mapped lesson counts plus authored/generated book progress for every track; CI fails byte-for-byte drift. |
 | HL-I04 | Complete (#9908) | Restore exact-main full CI after `perl/wasm-module-encoder` exposed undeclared local test dependencies. | Its `cpanfile` and `Makefile.PL` declare every local package injected by `BUILD`; clean full-build metadata validation and focused Perl tests pass. |
 | HL-I05 | Complete (#9910) | Make the repository's Lua bootstrap resilient to a temporary lua.org connection outage. | All CI platforms install pinned Lua 5.4.7 through an OS-specific cache or checksum-verified byte-identical Debian/Ubuntu source fallback without weakening the Windows MSVC ordering or silently skipping Lua tests. |
 | HL-B14 | Complete (#9728) | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Forty-nine schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
@@ -2367,10 +2368,29 @@ problem.
   gzip), above Vite's 500 kB warning threshold. HL-Q02 records that separate
   learner-loading concern without coupling a bundle redesign to this repair.
 
+## Findings from HL-I03
+
+- The index table now follows the authored registry order and derives every row
+  from the language registry, parsed lessons, realization maps, authored book
+  files, and the generated-book manifest. A newly registered track therefore
+  appears even when all of its progress counts are still zero.
+- The first generated snapshot keeps all 22 tracks visible and measures 1,669
+  canonical lessons, 1,521 uniquely mapped lessons, 513 authored book chapters,
+  and 408 generated chapters. These are outputs, not new hand-maintained claims.
+- Each row reports the canonical/mapped lesson gap instead of hiding it inside a
+  prose status. That makes unfinished one-source migration visible without
+  confusing it with missing book publication.
+- `generate:progress` rewrites only the marked table. `check:progress` compares
+  the complete README byte for byte in the unified publication job before TeX is
+  installed, so curriculum or book growth cannot silently stale the index again.
+- The exact package BUILD also refreshed HL-I02's evidence: the development tree
+  now reports one high Nano ID advisory and one moderate PostCSS advisory, both
+  with fixes available. HL-I02 moves ahead of non-security housekeeping next.
+
 ## Completed foundations
 
 - HL04 defines the 45-concept shared spine and migration contract.
-- The 20-track registry, Persian/Urdu pilots, full Markdown bodies, registry-driven
+- The multi-track registry, Persian/Urdu pilots, full Markdown bodies, registry-driven
   language selection, RTL app rendering, and fail-closed prerequisites are merged.
 - One CI job now installs TeX once, compiles every book, uploads one publication
   bundle, and publishes the catalog after changes reach `main`.

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -49,7 +49,7 @@ Every registered track has one `curriculum.json`. Its ordered path can revisit a
 shared spine node, attaches required/supporting/reference extensions before,
 inline with, or after a local segment, and explicitly records canonical concepts
 that the track omits or deliberately teaches elsewhere. The data-package gate
-proves that all 21 maps cover their schema-v2 and canonical lessons without
+proves that every registered map covers its schema-v2 and canonical lessons without
 jumping over a prerequisite. Books and the app still read the lesson Markdown;
 the map is the shared scheduling contract, not a second copy of the content.
 
@@ -76,8 +76,9 @@ edition filters on `drivable` and keeps only what a driver can actually do. The 
 job that builds the books runs `check:modality`, so the manifest cannot drift away from
 the lessons it describes — a lesson that silently gained a paradigm table would
 otherwise still advertise itself as safe to learn at 70mph. Modality stays derived
-rather than written into 1,096 frontmatter files, which would be 1,096 places for it to
-go stale; the authored `modality:` override with a `modality_reason:` remains available
+rather than written into every lesson frontmatter file, which would create one place
+per lesson for it to go stale; the authored `modality:` override with a
+`modality_reason:` remains available
 for the genuinely exceptional lesson.
 
 The data package also loads every existing `book/book.tex` and `book/chapters/ch*.tex`
@@ -99,30 +100,32 @@ edition is authored.
 
 ## Tracks
 
-| Language | Family / script | Status |
-|---|---|---|
-| [Spanish](./spanish/README.md) | Romance / Latin | Reference track — Chapters 1–39 authored; 169 lessons; 36 of the 40 core verbs — and the tranche that leaves **none** unrealized corpus-wide |
-| [French](./french/README.md) | Romance / Latin | Chapters 1–27 authored; 89 lessons; 22 of the 40 core verbs |
-| [German](./german/README.md) | Germanic / Latin | Chapters 1–27 authored; 92 lessons; 22 of the 40 core verbs |
-| [Italian](./italian/README.md) | Romance / Latin | Chapters 1–21 authored; Chapters 2–21 canonical/generated for app + book; 73 lessons; 21 of the 40 core verbs |
-| [Portuguese](./portuguese/README.md) | Romance / Latin | Chapters 1–22 authored; Chapters 2–22 canonical/generated for app + book; 22 of the 40 core verbs |
-| [Arabic](./arabic/README.md) | Semitic / Arabic (vendored font) | Chapters 1–30 authored; Chapters 3–30 canonical/generated for app + book; first track to realize core `VERB-*` concepts and the first to reach A2 |
-| [Hindi](./hindi/README.md) | Indo-Aryan / Devanagari | Chapters 1–33 authored; Chapters 6–33 canonical/generated for app + book; 11 inline writing steps |
-| [Marathi](./marathi/README.md) | Indo-Aryan / Devanagari | Chapters 1–9 authored (lessons + book; Chapters 6–9 canonical/generated; Ch. 7–9 = 14 core verbs, 98% drivable) |
-| [Punjabi](./punjabi/README.md) | Indo-Aryan / Gurmukhi (vendored font) | Chapters 1-6 authored (lessons + book, script inline) |
-| [Bengali](./bengali/README.md) | Indo-Aryan / Bengali (vendored font) | Chapters 1–9 authored (lessons + book; Chapters 6–9 canonical/generated; Ch. 7–9 = 14 core verbs, 98% drivable) |
-| [Gujarati](./gujarati/README.md) | Indo-Aryan / Gujarati (vendored font) | Chapters 1-6 authored (lessons + book, script inline) |
-| [Tamil](./tamil/README.md) | Dravidian / Tamil (vendored font) | Chapters 1–31 authored; Chapters 6–31 canonical/generated for app + book; 8 inline writing steps |
-| [Kannada](./kannada/README.md) | Dravidian / Kannada (vendored font) | Chapters 1-2 authored (lessons + book) |
-| [Telugu](./telugu/README.md) | Dravidian / Telugu (vendored font) | Chapters 1-2 authored (lessons + book) |
-| [Malayalam](./malayalam/README.md) | Dravidian / Malayalam (vendored font) | Chapters 1–31 authored; Chapters 6–31 canonical/generated for app + book |
-| [Latin](./latin/README.md) | Italic / Latin (**taproot**) | Chapters 1–43 authored; 88 lessons; 31 of the 40 core verbs |
-| [Sanskrit](./sanskrit/README.md) | Indo-Aryan / Devanagari (**taproot**) | Chapters 1–9 authored (lessons + book; Chapters 6–9 canonical/generated) |
-| [Russian](./russian/README.md) | Slavic / Cyrillic | Chapters 1–5 authored (lessons + book; Chapters 3–5 canonical/generated). Chapters 4–5 are the eight core verbs; aspect is named, not finished |
-| [Persian](./persian/README.md) | Iranian / Perso-Arabic | Eight authored shared-spine chapters; 33 canonical lessons, including thirteen core verbs |
-| [Urdu](./urdu/README.md) | Indo-Aryan / Urdu Nastaliq | Five authored shared-spine chapters; 20 canonical lessons |
-| [Mandarin Chinese](./chinese/README.md) | Sinitic / Chinese (vendored font subset) | Chapter 1 authored; 7 canonical lessons, book chapter generated. **Scale test** — see that README for what the method does and does not carry outside Indo-European |
-| [Japanese](./japanese/README.md) | Japonic / hiragana + katakana + kanji (vendored font) | Chapter 1 authored; 8 canonical lessons, chapter generated for app + book |
+<!-- BEGIN GENERATED TRACK PROGRESS -->
+| Language | Family / script | Canonical lessons | Mapped lessons | Book progress |
+|---|---|---:|---:|---|
+| [Spanish](./spanish/README.md) | Romance / Latin | 177 | 139 | 41 chapters; through Ch. 41; 29 generated |
+| [Latin](./latin/README.md) | Italic / Latin | 88 | 88 | 43 chapters; through Ch. 43; 42 generated |
+| [French](./french/README.md) | Romance / Latin | 105 | 89 | 31 chapters; through Ch. 31; 15 generated |
+| [German](./german/README.md) | Germanic / Latin | 106 | 89 | 31 chapters; through Ch. 31; 15 generated |
+| [Arabic](./arabic/README.md) | Semitic / Arabic | 100 | 98 | 36 chapters; through Ch. 36; 34 generated |
+| [Hindi](./hindi/README.md) | Indo-Aryan / Devanagari | 109 | 103 | 39 chapters; through Ch. 39; 34 generated |
+| [Tamil](./tamil/README.md) | Dravidian / Tamil | 118 | 114 | 38 chapters; through Ch. 38; 33 generated |
+| [Kannada](./kannada/README.md) | Dravidian / Kannada | 88 | 84 | 40 chapters; through Ch. 40; 35 generated |
+| [Telugu](./telugu/README.md) | Dravidian / Telugu | 74 | 70 | 34 chapters; through Ch. 34; 29 generated |
+| [Malayalam](./malayalam/README.md) | Dravidian / Malayalam | 78 | 74 | 34 chapters; through Ch. 34; 29 generated |
+| [Italian](./italian/README.md) | Romance / Latin | 88 | 87 | 25 chapters; through Ch. 25; 24 generated |
+| [Portuguese](./portuguese/README.md) | Romance / Latin | 96 | 95 | 26 chapters; through Ch. 26; 25 generated |
+| [Marathi](./marathi/README.md) | Indo-Aryan / Devanagari | 62 | 52 | 13 chapters; through Ch. 13; 8 generated |
+| [Punjabi](./punjabi/README.md) | Indo-Aryan / Gurmukhi | 61 | 54 | 13 chapters; through Ch. 13; 8 generated |
+| [Bengali](./bengali/README.md) | Indo-Aryan / Bengali | 57 | 48 | 12 chapters; through Ch. 12; 7 generated |
+| [Gujarati](./gujarati/README.md) | Indo-Aryan / Gujarati | 59 | 50 | 12 chapters; through Ch. 12; 7 generated |
+| [Russian](./russian/README.md) | Slavic / Cyrillic | 50 | 42 | 10 chapters; through Ch. 10; 8 generated |
+| [Sanskrit](./sanskrit/README.md) | Indo-Aryan / Devanagari | 59 | 51 | 13 chapters; through Ch. 13; 8 generated |
+| [Persian](./persian/README.md) | Iranian / Perso-Arabic | 33 | 33 | 8 chapters; through Ch. 8; 6 generated |
+| [Urdu](./urdu/README.md) | Indo-Aryan / Urdu-Nastaliq | 46 | 46 | 12 chapters; through Ch. 12; 10 generated |
+| [Mandarin Chinese](./chinese/README.md) | Sinitic / Chinese | 7 | 7 | 1 chapter; through Ch. 1; 1 generated |
+| [Japanese](./japanese/README.md) | Japonic / Japanese | 8 | 8 | 1 chapter; through Ch. 1; 1 generated |
+<!-- END GENERATED TRACK PROGRESS -->
 
 Spanish is the pilot that proved the format; every other track replicates it,
 grounding each word against English plus whatever languages the learner already

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — generated top-level track progress
+
+- Derive every Human Languages index row from `core/languages.json`, canonical
+  lessons, realization maps, authored book chapters, and the generated-book hash
+  manifest instead of repeating hand-maintained chapter and lesson claims.
+- Add `generate:progress` and the byte-for-byte `check:progress` publication gate;
+  a new registered language appears even when it has no lessons or book yet.
+
 ### Added — the Tamil writing strand reaches chapter 2's words
 
 The speaking-first change left nine chapter 2-3 word lessons still teaching script

--- a/code/packages/typescript/human-language-data/README.md
+++ b/code/packages/typescript/human-language-data/README.md
@@ -16,9 +16,14 @@ It also produces the versioned migration-gap report published with every book
 bundle and deterministically renders configured LaTeX chapters from that same
 lesson AST.
 
+The Human Languages index is derived too. `npm run generate:progress` rewrites
+only the marked track table in `code/learning/human-languages/README.md`; CI runs
+`npm run check:progress` so registry additions, curriculum growth, and generated
+book chapters cannot leave its counts stale.
+
 ```
 lessons/*.md frontmatter  ─┐
-curriculum.json × 20       ─┼─►  Dataset + local realization paths
+<track>/curriculum.json    ─┼─►  Dataset + local realization paths
 concepts/taxonomy.json     ─┤         + validate() / validateCurriculum()
 data/scripts/*.json        ─┘         + independent frontier planning
 ```
@@ -410,6 +415,15 @@ npm run generate:books
 npm run check:books
 ```
 
+Regenerate or verify the registry-ordered track table in the top-level Human
+Languages index:
+
+```bash
+npm run build
+npm run generate:progress
+npm run check:progress
+```
+
 `core/book-generation.json` declares each generated chapter. The generator
 orders schema-v2 lessons by `sequence`, writes the LaTeX chapter, and records a
 stable FNV-1a fingerprint in `core/generated-book-hashes.json`. The fingerprint
@@ -447,20 +461,18 @@ until the existing corpus has been split.
 | `modality.ts` | per-lesson channel (voice/sight/pen) and per-chapter drivable prefix | ✅ |
 | `speech.ts` | Markdown → speakable words; Markdown tables → spoken utterances or a reasoned refusal | ✅ |
 | `narration.ts` | typed lesson AST → narration segments and the continuous voice script | ✅ |
-
 | `modality-manifest.ts` | that derivation as an emittable, filterable JSON artifact | ✅ |
 | `report.ts` | deterministic duration, prerequisite, book, schema, and modality gap report | ✅ |
 | `loader.ts` | reads the curriculum off disk | ⛔ (fs) |
 | `cli.ts` | `validate` command + report | ⛔ (fs) |
 | `report-cli.ts` | prints JSON or text for CI artifact capture | ⛔ (fs) |
 | `book-cli.ts` | writes or checks generated chapters and their hash manifest | ⛔ (fs) |
-| `narration-cli.ts` | writes or checks the narration export and its hash manifest | ⛔ (fs) |
-
-Only `loader.ts`, `cli.ts`, `report-cli.ts`, `book-cli.ts`, and `narration-cli.ts` touch the filesystem (declared in
-
 | `modality-cli.ts` | writes or checks `core/lesson-modality.json` | ⛔ (fs) |
+| `narration-cli.ts` | writes or checks the narration export and its hash manifest | ⛔ (fs) |
+| `track-progress.ts` | registry/curriculum/book facts → top-level progress rows | ✅ |
+| `track-progress-cli.ts` | rewrites or checks the marked README track table | ⛔ (fs) |
 
-Only `loader.ts`, `cli.ts`, `report-cli.ts`, `book-cli.ts`, and `modality-cli.ts` touch the filesystem (declared in
+Only the modules marked `fs` touch the filesystem (declared in
 `required_capabilities.json`); everything the app relies on is pure and unit-tested
 against inline fixtures.
 

--- a/code/packages/typescript/human-language-data/package.json
+++ b/code/packages/typescript/human-language-data/package.json
@@ -12,6 +12,8 @@
     "check:modality": "node dist/modality-cli.js --check",
     "generate:narration": "node dist/narration-cli.js --write",
     "check:narration": "node dist/narration-cli.js --check",
+    "generate:progress": "node dist/track-progress-cli.js --write",
+    "check:progress": "node dist/track-progress-cli.js --check",
     "report": "node dist/report-cli.js",
     "validate": "vitest run tests/integration.test.ts",
     "test": "vitest run",

--- a/code/packages/typescript/human-language-data/required_capabilities.json
+++ b/code/packages/typescript/human-language-data/required_capabilities.json
@@ -50,7 +50,13 @@
       "action": "write",
       "target": "../../learning/human-languages/core/generated-narration-hashes.json",
       "justification": "The explicit generate:narration command refreshes the narration source-hash manifest that detects drift between the lessons and the committed voice script; CI normally verifies it without writing."
+    },
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "../../learning/human-languages/README.md",
+      "justification": "The explicit generate:progress command refreshes only the marked registry-ordered track table; CI normally uses the read-only check:progress drift gate."
     }
   ],
-  "justification": "Filesystem access stays in loader-backed CLI entry points. Validation/reporting are read-only; the explicit book and narration generators write only configured LaTeX chapters, per-chapter narration scripts, and their shared source-hash manifests, each path checked against the curriculum root before opening. No network or process access is needed."
+  "justification": "Filesystem access stays in loader-backed CLI entry points. Validation/reporting are read-only; the explicit book, narration, and progress generators write only configured LaTeX chapters, per-chapter narration scripts, shared source-hash manifests, and the marked top-level README table. No network or process access is needed."
 }

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -72,6 +72,12 @@ export {
   loadEverything,
 } from "./loader.js";
 export {
+  buildTrackProgress,
+  renderTrackProgressTable,
+  type GeneratedBookChapterRef,
+  type TrackProgress,
+} from "./track-progress.js";
+export {
   MODALITIES,
   MODALITY_SIGNS,
   SIGHT_CUES,

--- a/code/packages/typescript/human-language-data/src/track-progress-cli.ts
+++ b/code/packages/typescript/human-language-data/src/track-progress-cli.ts
@@ -1,0 +1,92 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  defaultCurriculumRoot,
+  loadBookCorpus,
+  loadLanguageCurricula,
+  loadLanguageRegistry,
+  loadLessons,
+} from "./loader.js";
+import {
+  buildTrackProgress,
+  renderTrackProgressTable,
+  type GeneratedBookChapterRef,
+} from "./track-progress.js";
+
+export const TRACK_PROGRESS_START = "<!-- BEGIN GENERATED TRACK PROGRESS -->";
+export const TRACK_PROGRESS_END = "<!-- END GENERATED TRACK PROGRESS -->";
+
+interface GeneratedBookManifest {
+  version: number;
+  chapters: GeneratedBookChapterRef[];
+}
+
+/** Replace exactly one marked section while preserving the file's newline style. */
+export function replaceTrackProgressSection(source: string, table: string): string {
+  const start = source.indexOf(TRACK_PROGRESS_START);
+  const end = source.indexOf(TRACK_PROGRESS_END);
+  if (
+    start < 0 ||
+    end < 0 ||
+    end <= start ||
+    source.lastIndexOf(TRACK_PROGRESS_START) !== start ||
+    source.lastIndexOf(TRACK_PROGRESS_END) !== end
+  ) {
+    throw new Error("README.md must contain exactly one ordered track-progress marker pair");
+  }
+  const newline = source.includes("\r\n") ? "\r\n" : "\n";
+  const rendered = table.replaceAll("\n", newline);
+  return `${source.slice(0, start + TRACK_PROGRESS_START.length)}${newline}${rendered}${newline}${source.slice(end)}`;
+}
+
+function loadGeneratedBookChapters(root: string): GeneratedBookChapterRef[] {
+  const path = join(root, "core", "generated-book-hashes.json");
+  const manifest = JSON.parse(readFileSync(path, "utf8")) as GeneratedBookManifest;
+  if (manifest.version !== 1 || !Array.isArray(manifest.chapters)) {
+    throw new Error("generated-book-hashes.json must declare version 1 and chapters[]");
+  }
+  return manifest.chapters;
+}
+
+/** Produce the complete expected README without mutating the filesystem. */
+export function generatedTrackProgressReadme(root = defaultCurriculumRoot()): string {
+  const readmePath = join(root, "README.md");
+  const source = readFileSync(readmePath, "utf8");
+  const tracks = buildTrackProgress(
+    loadLanguageRegistry(root),
+    loadLessons(root),
+    loadLanguageCurricula(root),
+    loadBookCorpus(root),
+    loadGeneratedBookChapters(root),
+  );
+  return replaceTrackProgressSection(source, renderTrackProgressTable(tracks));
+}
+
+export function runTrackProgress(
+  args = process.argv.slice(2),
+  root = defaultCurriculumRoot(),
+): number {
+  const mode = args.length === 1 ? args[0] : undefined;
+  if (mode !== "--check" && mode !== "--write") {
+    process.stderr.write("usage: track-progress-cli (--check | --write)\n");
+    return 2;
+  }
+  const output = join(root, "README.md");
+  const expected = generatedTrackProgressReadme(root);
+  if (mode === "--write") {
+    writeFileSync(output, expected, "utf8");
+    process.stdout.write("generated README.md track progress\n");
+    return 0;
+  }
+  const actual = existsSync(output) ? readFileSync(output, "utf8") : undefined;
+  if (actual !== expected) {
+    process.stderr.write("README.md: generated track progress is stale\n");
+    return 1;
+  }
+  return 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  process.exit(runTrackProgress());
+}

--- a/code/packages/typescript/human-language-data/src/track-progress.ts
+++ b/code/packages/typescript/human-language-data/src/track-progress.ts
@@ -1,0 +1,120 @@
+import type { ParsedLesson } from "./parse.js";
+import type {
+  BookCorpus,
+  LanguageCurriculum,
+  LanguageRegistry,
+} from "./types.js";
+
+/** The small part of generated-book-hashes.json needed by the progress table. */
+export interface GeneratedBookChapterRef {
+  language: string;
+  chapter: number;
+}
+
+/** One registry-ordered, entirely derived track summary. */
+export interface TrackProgress {
+  id: string;
+  name: string;
+  family: string;
+  script: string;
+  canonicalLessons: number;
+  mappedLessons: number;
+  bookChapters: number;
+  latestBookChapter?: number;
+  generatedBookChapters: number;
+}
+
+function addToSetMap(map: Map<string, Set<number>>, key: string, value: number): void {
+  const values = map.get(key) ?? new Set<number>();
+  values.add(value);
+  map.set(key, values);
+}
+
+/**
+ * Derive progress from the same registry, lessons, realization maps, and generated
+ * book manifest consumed by the app and publication job.
+ *
+ * Registry order is load-bearing: it is the authored default mixed-language walk,
+ * and using it here guarantees that a newly registered language appears in the README
+ * even before it has a lesson or book chapter.
+ */
+export function buildTrackProgress(
+  registry: LanguageRegistry,
+  lessons: ParsedLesson[],
+  curricula: LanguageCurriculum[],
+  books: BookCorpus,
+  generatedBookChapters: GeneratedBookChapterRef[],
+): TrackProgress[] {
+  const lessonCounts = new Map<string, number>();
+  for (const lesson of lessons) {
+    lessonCounts.set(lesson.language, (lessonCounts.get(lesson.language) ?? 0) + 1);
+  }
+
+  const mappedLessonIds = new Map<string, Set<string>>();
+  for (const curriculum of curricula) {
+    const ids = new Set<string>();
+    for (const segment of curriculum.path) {
+      for (const lessonId of segment.lessons) ids.add(lessonId);
+    }
+    for (const extension of curriculum.extensions) {
+      for (const lessonId of extension.lessons) ids.add(lessonId);
+    }
+    mappedLessonIds.set(curriculum.language, ids);
+  }
+
+  const authoredChapterNumbers = new Map<string, Set<number>>();
+  for (const book of books.books) {
+    for (const chapter of book.chapters) {
+      addToSetMap(authoredChapterNumbers, book.language, chapter.chapter);
+    }
+  }
+
+  const generatedChapterNumbers = new Map<string, Set<number>>();
+  for (const chapter of generatedBookChapters) {
+    addToSetMap(generatedChapterNumbers, chapter.language, chapter.chapter);
+  }
+
+  return registry.languages.map((language) => {
+    const authored = authoredChapterNumbers.get(language.id) ?? new Set<number>();
+    const generated = generatedChapterNumbers.get(language.id) ?? new Set<number>();
+    const latestBookChapter = authored.size === 0 ? undefined : Math.max(...authored);
+    return {
+      id: language.id,
+      name: language.name,
+      family: language.family,
+      script: language.script,
+      canonicalLessons: lessonCounts.get(language.id) ?? 0,
+      mappedLessons: mappedLessonIds.get(language.id)?.size ?? 0,
+      bookChapters: authored.size,
+      latestBookChapter,
+      generatedBookChapters: generated.size,
+    };
+  });
+}
+
+function titleCaseScript(script: string): string {
+  return script
+    .split("-")
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join("-");
+}
+
+function bookProgress(track: TrackProgress): string {
+  if (track.latestBookChapter === undefined) return "No authored chapters";
+  const chapterWord = track.bookChapters === 1 ? "chapter" : "chapters";
+  return `${track.bookChapters} ${chapterWord}; through Ch. ${track.latestBookChapter}; ${track.generatedBookChapters} generated`;
+}
+
+/** Render only facts that can be recomputed; prose distinctions belong below the table. */
+export function renderTrackProgressTable(tracks: TrackProgress[]): string {
+  const lines = [
+    "| Language | Family / script | Canonical lessons | Mapped lessons | Book progress |",
+    "|---|---|---:|---:|---|",
+  ];
+  for (const track of tracks) {
+    lines.push(
+      `| [${track.name}](./${track.id}/README.md) | ${track.family} / ${titleCaseScript(track.script)} | ${track.canonicalLessons} | ${track.mappedLessons} | ${bookProgress(track)} |`,
+    );
+  }
+  return lines.join("\n");
+}

--- a/code/packages/typescript/human-language-data/tests/track-progress.test.ts
+++ b/code/packages/typescript/human-language-data/tests/track-progress.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { defaultCurriculumRoot } from "../src/loader.js";
+import type { ParsedLesson } from "../src/parse.js";
+import {
+  generatedTrackProgressReadme,
+  replaceTrackProgressSection,
+  runTrackProgress,
+  TRACK_PROGRESS_END,
+  TRACK_PROGRESS_START,
+} from "../src/track-progress-cli.js";
+import { buildTrackProgress, renderTrackProgressTable } from "../src/track-progress.js";
+import type { BookCorpus, LanguageCurriculum, LanguageRegistry } from "../src/types.js";
+
+const lesson = (language: string) => ({ language }) as ParsedLesson;
+
+describe("track progress", () => {
+  it("derives registry-ordered counts from lessons, maps, and book data", () => {
+    const registry: LanguageRegistry = {
+      version: 1,
+      languages: [
+        { id: "beta", name: "Beta", family: "Test", script: "perso-arabic", status: "active", bridges: [] },
+        { id: "alpha", name: "Alpha", family: "Test", script: "latin", status: "active", bridges: [] },
+      ],
+    };
+    const curricula = [
+      {
+        version: 1,
+        language: "alpha",
+        path: [{ id: "p", spine_node: "s", lessons: ["a1", "a2"], before: [], inline: [], after: [] }],
+        spine: {},
+        extensions: [{ id: "e", stage: "A1", kind: "required", category: "grammar", canDo: "x", prerequisites: [], lessons: ["a2", "a3"] }],
+      },
+    ] as LanguageCurriculum[];
+    const books: BookCorpus = {
+      books: [{ language: "alpha", entrypoint: "alpha/book/book.tex", chapters: [
+        { language: "alpha", chapter: 1, slug: "one", title: "One", source: "one.tex", tex: "" },
+        { language: "alpha", chapter: 3, slug: "three", title: "Three", source: "three.tex", tex: "" },
+      ] }],
+    };
+
+    const tracks = buildTrackProgress(
+      registry,
+      [lesson("alpha"), lesson("alpha"), lesson("beta")],
+      curricula,
+      books,
+      [{ language: "alpha", chapter: 3 }, { language: "alpha", chapter: 3 }],
+    );
+
+    expect(tracks.map((track) => track.id)).toEqual(["beta", "alpha"]);
+    expect(tracks[0]).toMatchObject({ canonicalLessons: 1, mappedLessons: 0, bookChapters: 0 });
+    expect(tracks[1]).toMatchObject({ canonicalLessons: 2, mappedLessons: 3, bookChapters: 2, latestBookChapter: 3, generatedBookChapters: 1 });
+    expect(renderTrackProgressTable(tracks)).toContain(
+      "| [Alpha](./alpha/README.md) | Test / Latin | 2 | 3 | 2 chapters; through Ch. 3; 1 generated |",
+    );
+    expect(renderTrackProgressTable(tracks)).toContain("Test / Perso-Arabic");
+  });
+
+  it("replaces one marker pair and preserves CRLF", () => {
+    const source = `before\r\n${TRACK_PROGRESS_START}\r\nstale\r\n${TRACK_PROGRESS_END}\r\nafter\r\n`;
+    expect(replaceTrackProgressSection(source, "| a |\n| b |")).toBe(
+      `before\r\n${TRACK_PROGRESS_START}\r\n| a |\r\n| b |\r\n${TRACK_PROGRESS_END}\r\nafter\r\n`,
+    );
+  });
+
+  it("fails closed on absent, repeated, or reversed markers", () => {
+    expect(() => replaceTrackProgressSection("none", "table")).toThrow(/exactly one/);
+    expect(() => replaceTrackProgressSection(`${TRACK_PROGRESS_START}${TRACK_PROGRESS_START}${TRACK_PROGRESS_END}`, "table")).toThrow(/exactly one/);
+    expect(() => replaceTrackProgressSection(`${TRACK_PROGRESS_END}${TRACK_PROGRESS_START}`, "table")).toThrow(/exactly one/);
+  });
+
+  it("keeps the committed top-level table byte-current and complete", () => {
+    const root = defaultCurriculumRoot();
+    const expected = generatedTrackProgressReadme(root);
+    expect(readFileSync(join(root, "README.md"), "utf8")).toBe(expected);
+    expect(expected.match(/^\| \[[^\]]+\]\(\.\/[^/]+\/README\.md\)/gm)).toHaveLength(22);
+    expect(runTrackProgress(["--check"], root)).toBe(0);
+  });
+
+  it("rejects an unknown CLI mode", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(runTrackProgress(["--wat"])).toBe(2);
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("usage:"));
+    stderr.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the stale hand-maintained Human Languages track statuses with a registry-ordered generated table
- derive canonical lesson, mapped lesson, authored chapter, latest chapter, and generated chapter progress from the same curriculum and book data used by the app and publication job
- add generate:progress and a byte-for-byte check:progress gate before the expensive TeX build

## First generated snapshot
- 22 tracks
- 1,669 canonical lessons
- 1,521 mapped lessons
- 513 authored book chapters
- 408 generated chapters

## Validation
- exact package BUILD: 26 files, 416 tests, 95.55% line coverage
- TypeScript build and check:progress: passed
- check:books, check:modality, and check:narration: passed
- required-capability schema suite: 7 tests passed
- git diff --check: passed

## Discovered follow-up
HL-I02 is reprioritized in the backlog: the package development tree currently reports one high Nano ID advisory and one moderate PostCSS advisory, both with fixes available.