### PR TITLE
Add JFET VTOTC parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `VTOTC` alternative threshold-voltage
+  temperature coefficient.
 - Validate and lower JFET model-card `TCV` threshold-voltage temperature
   coefficient.
 - Validate and lower JFET model-card `RS` source resistance.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1347,6 +1347,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Rd=model.params.get("RD", 0.0),
             Rs=model.params.get("RS", 0.0),
             Tcv=model.params.get("TCV", 0.0),
+            Vtotc=model.params.get("VTOTC"),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2152,6 +2153,14 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             threshold_voltage_temperature_coefficient
         ):
             raise NetlistParseError("JFET TCV must be finite")
+        alternative_threshold_voltage_temperature_coefficient = params.get("VTOTC")
+        if (
+            alternative_threshold_voltage_temperature_coefficient is not None
+            and not math.isfinite(
+                alternative_threshold_voltage_temperature_coefficient
+            )
+        ):
+            raise NetlistParseError("JFET VTOTC must be finite")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1636,6 +1636,29 @@ def test_rejects_non_finite_jfet_threshold_voltage_temperature_coefficient() -> 
         parse_netlist(".model fast NJF(TCV=1e999)")
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"), [("-0.004", -0.004), ("0", 0.0), ("0.006", 0.006)]
+)
+def test_parse_jfet_alternative_threshold_voltage_temperature_coefficient(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NJF(VTOTC={value})
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert jfet.Vtotc == expected
+
+
+def test_rejects_non_finite_jfet_alternative_threshold_voltage_coefficient() -> None:
+    with pytest.raises(NetlistParseError, match="JFET VTOTC must be finite"):
+        parse_netlist(".model fast NJF(VTOTC=1e999)")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `VTOTC` alternative threshold-voltage
+  temperature coefficient.
 - Validate and lower JFET model-card `TCV` threshold-voltage temperature
   coefficient.
 - Validate and lower JFET model-card `RS` source resistance.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1448,6 +1448,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET TCV must be finite");
   }
+  const jfetAlternativeThresholdVoltageTemperatureCoefficient = params.get("VTOTC");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetAlternativeThresholdVoltageTemperatureCoefficient !== undefined &&
+    !Number.isFinite(jfetAlternativeThresholdVoltageTemperatureCoefficient)
+  ) {
+    throw new NetlistParseError("JFET VTOTC must be finite");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -2048,6 +2056,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("RD") ?? 0.0,
       model.params.get("RS") ?? 0.0,
       model.params.get("TCV") ?? 0.0,
+      model.params.get("VTOTC"),
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1681,6 +1681,31 @@ J1 drain gate source fast
     );
   });
 
+  it.each([
+    ["-0.004", -0.004],
+    ["0", 0.0],
+    ["0.006", 0.006],
+  ])(
+    "parses JFET alternative threshold-voltage temperature coefficient %s",
+    (value, expected) => {
+      const parsed = parseNetlist(`
+.model fast NJF(VTOTC=${value})
+J1 drain gate source fast
+`);
+
+      expect(parsed.circuit.elements()[0]).toMatchObject({
+        kind: "jfet",
+        alternativeThresholdVoltageTemperatureCoefficient: expected,
+      });
+    },
+  );
+
+  it("rejects a non-finite JFET alternative threshold-voltage temperature coefficient", () => {
+    expect(() => parseNetlist(".model fast NJF(VTOTC=1e999)")).toThrow(
+      "JFET VTOTC must be finite",
+    );
+  });
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4503,9 +4503,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 436. Python and TypeScript Berkeley SPICE JFET threshold-voltage temperature
      coefficient parity.
-   - Status: implemented in this JFET TCV parity slice.
+   - Status: completed in PR 10091.
    - Both parser facades validate finite `TCV` values and lower them into the
      shared engine threshold-voltage temperature-coefficient field.
+
+437. Python and TypeScript Berkeley SPICE JFET alternative threshold-voltage
+     temperature coefficient parity.
+   - Status: implemented in this JFET VTOTC parity slice.
+   - Both parser facades validate finite `VTOTC` values and lower them into the
+     shared engine optional alternative threshold-voltage temperature field.
 
 ## Backlog
 
@@ -4514,8 +4520,8 @@ the Rust, Python, and TypeScript surfaces together.
      currently use `B` as a legacy beta alias, while the engine model uses `B`
      for Parker-Skellern doping-tail shaping. Do not assign one card value to
      both fields silently.
-   - Continue the unambiguous audited JFET gaps with `VTOTC`, `TNOM` / `T_NOM`,
-     `BEX`, and `BETATCE`.
+   - Continue the unambiguous audited JFET gaps with `TNOM` / `T_NOM`, `BEX`,
+     and `BETATCE`.
    - Continue the audited BJT model-card gaps after the smaller JFET fields;
      prioritize direct engine fields before adding new model surfaces.
    - Re-audit MOS lowering after those direct JFET and BJT omissions close.


### PR DESCRIPTION
## Summary
- validate finite signed JFET model-card `VTOTC` values in the Python and TypeScript parser facades
- preserve omission while lowering explicit coefficients into the shared optional alternative threshold-voltage temperature field
- add mirrored acceptance/rejection tests and reconcile the SPICE implementation plan

## Verification
- `code/packages/python/spice-netlist-parser/BUILD` (406 passed, 89.60% coverage)
- `.venv/bin/ruff check .`
- `code/packages/typescript/spice-netlist-parser/BUILD` (391 passed)
- `npx vitest run --coverage` (86.88% line coverage)
- `code/packages/typescript/spice-engine/BUILD` (448 passed)