### PR TITLE
fix(human-language-data): clear development audit

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,9 +5,9 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-08, after HL-Q01 merged as #10089. HL-I03 moved next
-because four vocabulary waves had already made the hand-maintained track table stale;
-the index now needs to derive its claims before the next corpus expansion. Current
+Last prioritized: 2026-08-08, after HL-I03 merged as #10092. HL-I02 moved next
+because the exact package build exposed one high and one moderate fixable development
+advisory; clearing known dependency debt precedes the next corpus expansion. Current
 baseline after the Japanese Chapter 1 tranche (HL-C40), which followed the Mandarin
 Chinese scale test (HL-C39), the Latin chapter payoffs (HL-C24) and the Spanish
 gentle-ramp split (HL-C18A): **22** registered tracks, **1,133** Markdown lessons,
@@ -299,8 +299,8 @@ the next migrations; it deliberately does not fail CI on already-recorded debt.
 | HL-B12 | Complete (#9705) | Publish Bengali Chapter 6 from its canonical lesson rather than hand-copying another book chapter. | The schema-v2 lesson now generates the PDF chapter from the same source hash independently verified by Language Ladder. |
 | HL-B13 | Complete (#9711) | Remove Bengali's missing glyphs and LaTeX layout/bookmark warnings. | Main-font punctuation, stable recap labels, bookmark-safe Bengali, natural page bottoms, explicit static-font shapes, and a breakable long title make the forced six-chapter build warning-free. |
 | HL-I01 | Complete (#9715) | Reduce unified all-books workflow setup time without splitting the single publication bundle. | A focused, preflighted XeLaTeX dependency closure replaces `texlive-full`; the unchanged job still builds all 20 books, verifies one bundle, and publishes that bundle from `main`. |
-| HL-I02 | Queued — reprioritized after HL-I03 | Refresh the human-language data package's vulnerable transitive development locks. | A clean install now reports high-severity Nano ID GHSA-2v37-7h3g-55p8 and moderate PostCSS GHSA-fxqj-rqcc-2cmp through Vitest/Vite; both have fixes available and should leave `npm audit` at zero. |
-| HL-I03 | Complete in this PR | Derive the top-level track progress table from canonical curriculum and book-generation data. | A registry-ordered generated table reports canonical and mapped lesson counts plus authored/generated book progress for every track; CI fails byte-for-byte drift. |
+| HL-I02 | Complete in this PR | Refresh the human-language data package's vulnerable transitive development locks. | Nano ID 3.3.18 and PostCSS 8.5.26 clear GHSA-2v37-7h3g-55p8 and GHSA-fxqj-rqcc-2cmp; a clean install and `npm audit` report zero known vulnerabilities. |
+| HL-I03 | Complete (#10092) | Derive the top-level track progress table from canonical curriculum and book-generation data. | A registry-ordered generated table reports canonical and mapped lesson counts plus authored/generated book progress for every track; CI fails byte-for-byte drift. |
 | HL-I04 | Complete (#9908) | Restore exact-main full CI after `perl/wasm-module-encoder` exposed undeclared local test dependencies. | Its `cpanfile` and `Makefile.PL` declare every local package injected by `BUILD`; clean full-build metadata validation and focused Perl tests pass. |
 | HL-I05 | Complete (#9910) | Make the repository's Lua bootstrap resilient to a temporary lua.org connection outage. | All CI platforms install pinned Lua 5.4.7 through an OS-specific cache or checksum-verified byte-identical Debian/Ubuntu source fallback without weakening the Windows MSVC ordering or silently skipping Lua tests. |
 | HL-B14 | Complete (#9728) | Publish Italian Chapters 2–17 from their canonical lessons rather than hand-copying sixteen book chapters. | Forty-nine schema-v2 lessons now generate sixteen chapters whose source hashes are independently verified against the Language Ladder corpus. |
@@ -2386,6 +2386,17 @@ problem.
 - The exact package BUILD also refreshed HL-I02's evidence: the development tree
   now reports one high Nano ID advisory and one moderate PostCSS advisory, both
   with fixes available. HL-I02 moves ahead of non-security housekeeping next.
+
+## Findings from HL-I02
+
+- Both advisories were lockfile-only development dependency debt beneath
+  Vitest/Vite. No direct dependency range or curriculum runtime code changed.
+- Nano ID moves 3.3.16 → 3.3.18 and PostCSS moves 8.5.19 → 8.5.26. A clean
+  install resolves those exact versions and `npm audit` reports zero known
+  vulnerabilities.
+- The full data-package suite remains the behavioral guard: curriculum parsing,
+  generated books, narration, modality, and the derived progress table all run
+  against the refreshed toolchain before this item can merge.
 
 ## Completed foundations
 

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Fixed — clean development dependency audit
+
+- Refresh transitive Nano ID from 3.3.16 to 3.3.18 and PostCSS from 8.5.19 to
+  8.5.26, clearing GHSA-2v37-7h3g-55p8 and GHSA-fxqj-rqcc-2cmp without changing
+  the direct dependency range or runtime curriculum code.
+
 ### Added — generated top-level track progress
 
 - Derive every Human Languages index row from `core/languages.json`, canonical

--- a/code/packages/typescript/human-language-data/package-lock.json
+++ b/code/packages/typescript/human-language-data/package-lock.json
@@ -1129,9 +1129,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1189,9 +1189,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -1209,7 +1209,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary
- refresh the transitive Nano ID lock from 3.3.16 to 3.3.18
- refresh the transitive PostCSS lock from 8.5.19 to 8.5.26
- close HL-I02 after clearing the high and moderate development advisories without changing direct dependency ranges or curriculum runtime code

## Validation
- exact package BUILD: 26 files and 416 tests passed with 95.55% line coverage
- npm audit: zero known vulnerabilities
- TypeScript build: passed
- check:books, check:progress, check:modality, and check:narration: passed
- git diff --check: passed