### PR TITLE
Add JFET TNOM parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `TNOM` / `T_NOM` nominal temperature.
 - Validate and lower JFET model-card `VTOTC` alternative threshold-voltage
   temperature coefficient.
 - Validate and lower JFET model-card `TCV` threshold-voltage temperature

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1324,6 +1324,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             raise NetlistParseError(
                 f"model {model.name!r} has kind {model.kind!r}, expected 'NJF' or 'PJF'"
             )
+        nominal_temperature = model.params.get("T_NOM", model.params.get("TNOM"))
         return JFET(
             name,
             fields[1],
@@ -1348,6 +1349,9 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Rs=model.params.get("RS", 0.0),
             Tcv=model.params.get("TCV", 0.0),
             Vtotc=model.params.get("VTOTC"),
+            Tnom=(
+                nominal_temperature + 273.15 if nominal_temperature is not None else None
+            ),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2161,6 +2165,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             )
         ):
             raise NetlistParseError("JFET VTOTC must be finite")
+        nominal_temperature = params.get("T_NOM", params.get("TNOM"))
+        if nominal_temperature is not None and (
+            not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0
+        ):
+            raise NetlistParseError("JFET TNOM must be finite and positive")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1659,6 +1659,42 @@ def test_rejects_non_finite_jfet_alternative_threshold_voltage_coefficient() -> 
         parse_netlist(".model fast NJF(VTOTC=1e999)")
 
 
+@pytest.mark.parametrize(("alias", "value"), [("TNOM", "50"), ("T_NOM", "75")])
+def test_parse_jfet_nominal_temperature(alias: str, value: str) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NJF({alias}={value})
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert jfet.Tnom == pytest.approx(float(value) + 273.15)
+
+
+def test_jfet_t_nom_takes_precedence_over_tnom() -> None:
+    parsed = parse_netlist(
+        """
+.model fast NJF(TNOM=25 T_NOM=50)
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert jfet.Tnom == pytest.approx(323.15)
+
+
+@pytest.mark.parametrize("alias", ["TNOM", "T_NOM"])
+@pytest.mark.parametrize("value", ["0", "-1", "1e999"])
+def test_rejects_invalid_jfet_nominal_temperature(alias: str, value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="JFET TNOM must be finite and positive"
+    ):
+        parse_netlist(f".model fast NJF({alias}={value})")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `TNOM` / `T_NOM` nominal temperature.
 - Validate and lower JFET model-card `VTOTC` alternative threshold-voltage
   temperature coefficient.
 - Validate and lower JFET model-card `TCV` threshold-voltage temperature

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1456,6 +1456,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET VTOTC must be finite");
   }
+  const jfetNominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetNominalTemperature !== undefined &&
+    (!Number.isFinite(jfetNominalTemperature) || jfetNominalTemperature <= 0.0)
+  ) {
+    throw new NetlistParseError("JFET TNOM must be finite and positive");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -2032,6 +2040,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       );
     }
     const polarity = model.kind as JfetPolarity;
+    const nominalTemperature = model.params.get("T_NOM") ?? model.params.get("TNOM");
     return jfet(
       name,
       fields[1],
@@ -2057,6 +2066,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("RS") ?? 0.0,
       model.params.get("TCV") ?? 0.0,
       model.params.get("VTOTC"),
+      nominalTemperature !== undefined ? nominalTemperature + 273.15 : undefined,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1706,6 +1706,49 @@ J1 drain gate source fast
     );
   });
 
+  it.each([
+    ["TNOM", "50"],
+    ["T_NOM", "75"],
+  ])("parses JFET nominal temperature alias %s", (alias, value) => {
+    const parsed = parseNetlist(`
+.model fast NJF(${alias}=${value})
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      nominalTemperatureKelvin: Number(value) + 273.15,
+    });
+  });
+
+  it("gives JFET T_NOM precedence over TNOM", () => {
+    const parsed = parseNetlist(`
+.model fast NJF(TNOM=25 T_NOM=50)
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      nominalTemperatureKelvin: 323.15,
+    });
+  });
+
+  it.each([
+    ["TNOM", "0"],
+    ["T_NOM", "0"],
+    ["TNOM", "-1"],
+    ["T_NOM", "-1"],
+    ["TNOM", "1e999"],
+    ["T_NOM", "1e999"],
+  ])(
+    "rejects invalid JFET nominal temperature %s=%s",
+    (alias, value) => {
+      expect(() => parseNetlist(`.model fast NJF(${alias}=${value})`)).toThrow(
+        "JFET TNOM must be finite and positive",
+      );
+    },
+  );
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4509,9 +4509,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 437. Python and TypeScript Berkeley SPICE JFET alternative threshold-voltage
      temperature coefficient parity.
-   - Status: implemented in this JFET VTOTC parity slice.
+   - Status: completed in PR 10093.
    - Both parser facades validate finite `VTOTC` values and lower them into the
      shared engine optional alternative threshold-voltage temperature field.
+
+438. Python and TypeScript Berkeley SPICE JFET nominal-temperature parity.
+   - Status: implemented in this JFET TNOM parity slice.
+   - Both parser facades accept `TNOM` / `T_NOM`, give `T_NOM` precedence,
+     validate positive finite Celsius values, convert them to Kelvin, and lower
+     them into the shared engine optional nominal-temperature field.
 
 ## Backlog
 
@@ -4520,8 +4526,7 @@ the Rust, Python, and TypeScript surfaces together.
      currently use `B` as a legacy beta alias, while the engine model uses `B`
      for Parker-Skellern doping-tail shaping. Do not assign one card value to
      both fields silently.
-   - Continue the unambiguous audited JFET gaps with `TNOM` / `T_NOM`, `BEX`,
-     and `BETATCE`.
+   - Continue the unambiguous audited JFET gaps with `BEX` and `BETATCE`.
    - Continue the audited BJT model-card gaps after the smaller JFET fields;
      prioritize direct engine fields before adding new model surfaces.
    - Re-audit MOS lowering after those direct JFET and BJT omissions close.


### PR DESCRIPTION
## Summary
- validate positive finite JFET `TNOM` / `T_NOM` model-card values in both parser facades
- give `T_NOM` precedence, convert Celsius to Kelvin, and lower into the shared optional engine field
- add mirrored alias, precedence, validation, changelog, and implementation-plan coverage

## Testing
- `code/packages/python/spice-netlist-parser: bash BUILD` (415 passed, 89.63% coverage)
- `code/packages/python/spice-netlist-parser: .venv/bin/ruff check .`
- `code/packages/typescript/spice-netlist-parser: bash BUILD` (400 passed)
- `code/packages/typescript/spice-netlist-parser: npx vitest run --coverage` (86.93% lines)
- `code/packages/typescript/spice-engine: bash BUILD` (448 passed)