### PR TITLE
Add JFET BEX parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `BEX` mobility temperature exponent.
 - Validate and lower JFET model-card `TNOM` / `T_NOM` nominal temperature.
 - Validate and lower JFET model-card `VTOTC` alternative threshold-voltage
   temperature coefficient.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1352,6 +1352,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Tnom=(
                 nominal_temperature + 273.15 if nominal_temperature is not None else None
             ),
+            Bex=model.params.get("BEX", 0.0),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2170,6 +2171,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0
         ):
             raise NetlistParseError("JFET TNOM must be finite and positive")
+        mobility_temperature_exponent = params.get("BEX")
+        if mobility_temperature_exponent is not None and not math.isfinite(
+            mobility_temperature_exponent
+        ):
+            raise NetlistParseError("JFET BEX must be finite")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1695,6 +1695,29 @@ def test_rejects_invalid_jfet_nominal_temperature(alias: str, value: str) -> Non
         parse_netlist(f".model fast NJF({alias}={value})")
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"), [("-2.5", -2.5), ("0", 0.0), ("1.75", 1.75)]
+)
+def test_parse_jfet_mobility_temperature_exponent(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NJF(BEX={value})
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert jfet.Bex == expected
+
+
+def test_rejects_non_finite_jfet_mobility_temperature_exponent() -> None:
+    with pytest.raises(NetlistParseError, match="JFET BEX must be finite"):
+        parse_netlist(".model fast NJF(BEX=1e999)")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `BEX` mobility temperature exponent.
 - Validate and lower JFET model-card `TNOM` / `T_NOM` nominal temperature.
 - Validate and lower JFET model-card `VTOTC` alternative threshold-voltage
   temperature coefficient.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1464,6 +1464,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET TNOM must be finite and positive");
   }
+  const jfetMobilityTemperatureExponent = params.get("BEX");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetMobilityTemperatureExponent !== undefined &&
+    !Number.isFinite(jfetMobilityTemperatureExponent)
+  ) {
+    throw new NetlistParseError("JFET BEX must be finite");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -2067,6 +2075,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("TCV") ?? 0.0,
       model.params.get("VTOTC"),
       nominalTemperature !== undefined ? nominalTemperature + 273.15 : undefined,
+      model.params.get("BEX") ?? 0.0,
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1749,6 +1749,28 @@ J1 drain gate source fast
     },
   );
 
+  it.each([
+    ["-2.5", -2.5],
+    ["0", 0.0],
+    ["1.75", 1.75],
+  ])("parses JFET mobility temperature exponent %s", (value, expected) => {
+    const parsed = parseNetlist(`
+.model fast NJF(BEX=${value})
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      mobilityTemperatureExponent: expected,
+    });
+  });
+
+  it("rejects a non-finite JFET mobility temperature exponent", () => {
+    expect(() => parseNetlist(".model fast NJF(BEX=1e999)")).toThrow(
+      "JFET BEX must be finite",
+    );
+  });
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4514,10 +4514,15 @@ the Rust, Python, and TypeScript surfaces together.
      shared engine optional alternative threshold-voltage temperature field.
 
 438. Python and TypeScript Berkeley SPICE JFET nominal-temperature parity.
-   - Status: implemented in this JFET TNOM parity slice.
+   - Status: completed in PR 10095.
    - Both parser facades accept `TNOM` / `T_NOM`, give `T_NOM` precedence,
      validate positive finite Celsius values, convert them to Kelvin, and lower
      them into the shared engine optional nominal-temperature field.
+
+439. Python and TypeScript Berkeley SPICE JFET beta temperature-exponent parity.
+   - Status: implemented in this JFET BEX parity slice.
+   - Both parser facades validate finite `BEX` values and lower them into the
+     shared engine mobility-temperature-exponent field.
 
 ## Backlog
 
@@ -4526,7 +4531,7 @@ the Rust, Python, and TypeScript surfaces together.
      currently use `B` as a legacy beta alias, while the engine model uses `B`
      for Parker-Skellern doping-tail shaping. Do not assign one card value to
      both fields silently.
-   - Continue the unambiguous audited JFET gaps with `BEX` and `BETATCE`.
+   - Continue the unambiguous audited JFET gaps with `BETATCE`.
    - Continue the audited BJT model-card gaps after the smaller JFET fields;
      prioritize direct engine fields before adding new model surfaces.
    - Re-audit MOS lowering after those direct JFET and BJT omissions close.


### PR DESCRIPTION
## Summary
- validate finite JFET `BEX` model-card values in both parser facades
- lower signed exponents into the shared engine mobility-temperature-exponent field
- add mirrored tests, changelogs, and implementation-plan tracking

## Testing
- `code/packages/python/spice-netlist-parser: bash BUILD` (419 passed, 89.66% coverage)
- `code/packages/python/spice-netlist-parser: .venv/bin/ruff check .`
- `code/packages/typescript/spice-netlist-parser: bash BUILD` (404 passed)
- `code/packages/typescript/spice-netlist-parser: npx vitest run --coverage` (86.96% lines)
- `code/packages/typescript/spice-engine: bash BUILD` (448 passed)