### PR TITLE
Add JFET BETATCE parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `BETATCE` alternative mobility temperature
+  coefficient while preserving omission for `BEX` fallback.
 - Validate and lower JFET model-card `BEX` mobility temperature exponent.
 - Validate and lower JFET model-card `TNOM` / `T_NOM` nominal temperature.
 - Validate and lower JFET model-card `VTOTC` alternative threshold-voltage

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1353,6 +1353,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
                 nominal_temperature + 273.15 if nominal_temperature is not None else None
             ),
             Bex=model.params.get("BEX", 0.0),
+            Betatce=model.params.get("BETATCE"),
         )
     if prefix == "M":
         _require_min_fields(fields, 6, "MOSFET")
@@ -2176,6 +2177,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             mobility_temperature_exponent
         ):
             raise NetlistParseError("JFET BEX must be finite")
+        mobility_temperature_coefficient = params.get("BETATCE")
+        if mobility_temperature_coefficient is not None and not math.isfinite(
+            mobility_temperature_coefficient
+        ):
+            raise NetlistParseError("JFET BETATCE must be finite")
     if kind in {"NMOS", "PMOS"}:
         if "LEVEL" in params:
             level = params["LEVEL"]

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1718,6 +1718,37 @@ def test_rejects_non_finite_jfet_mobility_temperature_exponent() -> None:
         parse_netlist(".model fast NJF(BEX=1e999)")
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"), [("-0.5", -0.5), ("0", 0.0), ("1.25", 1.25)]
+)
+def test_parse_jfet_alternative_mobility_temperature_coefficient(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NJF(BETATCE={value})
+J1 drain gate source fast
+"""
+    )
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert jfet.Betatce == expected
+
+
+def test_omitted_jfet_alternative_mobility_temperature_coefficient_stays_none() -> None:
+    parsed = parse_netlist(".model fast NJF(BEX=1.5)\nJ1 drain gate source fast")
+
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert jfet.Betatce is None
+
+
+def test_rejects_non_finite_jfet_alternative_mobility_temperature_coefficient() -> None:
+    with pytest.raises(NetlistParseError, match="JFET BETATCE must be finite"):
+        parse_netlist(".model fast NJF(BETATCE=1e999)")
+
+
 def test_parse_pjf_model_aliases_beta() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower JFET model-card `BETATCE` alternative mobility temperature
+  coefficient while preserving omission for `BEX` fallback.
 - Validate and lower JFET model-card `BEX` mobility temperature exponent.
 - Validate and lower JFET model-card `TNOM` / `T_NOM` nominal temperature.
 - Validate and lower JFET model-card `VTOTC` alternative threshold-voltage

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1472,6 +1472,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET BEX must be finite");
   }
+  const jfetMobilityTemperatureCoefficient = params.get("BETATCE");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetMobilityTemperatureCoefficient !== undefined &&
+    !Number.isFinite(jfetMobilityTemperatureCoefficient)
+  ) {
+    throw new NetlistParseError("JFET BETATCE must be finite");
+  }
   const level = params.get("LEVEL");
   if (
     (kind === "NMOS" || kind === "PMOS") &&
@@ -2076,6 +2084,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("VTOTC"),
       nominalTemperature !== undefined ? nominalTemperature + 273.15 : undefined,
       model.params.get("BEX") ?? 0.0,
+      model.params.get("BETATCE"),
     );
   }
   if (prefix === "M") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1771,6 +1771,43 @@ J1 drain gate source fast
     );
   });
 
+  it.each([
+    ["-0.5", -0.5],
+    ["0", 0.0],
+    ["1.25", 1.25],
+  ])(
+    "parses JFET alternative mobility temperature coefficient %s",
+    (value, expected) => {
+      const parsed = parseNetlist(`
+.model fast NJF(BETATCE=${value})
+J1 drain gate source fast
+`);
+
+      expect(parsed.circuit.elements()[0]).toMatchObject({
+        kind: "jfet",
+        mobilityTemperatureCoefficient: expected,
+      });
+    },
+  );
+
+  it("preserves an omitted JFET alternative mobility temperature coefficient", () => {
+    const parsed = parseNetlist(`
+.model fast NJF(BEX=1.5)
+J1 drain gate source fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      mobilityTemperatureCoefficient: undefined,
+    });
+  });
+
+  it("rejects a non-finite JFET alternative mobility temperature coefficient", () => {
+    expect(() => parseNetlist(".model fast NJF(BETATCE=1e999)")).toThrow(
+      "JFET BETATCE must be finite",
+    );
+  });
+
   it("parses PJF model beta aliases", () => {
     const parsed = parseNetlist(`
 .model pslow PJF(B=750u)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4520,9 +4520,16 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine optional nominal-temperature field.
 
 439. Python and TypeScript Berkeley SPICE JFET beta temperature-exponent parity.
-   - Status: implemented in this JFET BEX parity slice.
+   - Status: completed in PR 10096.
    - Both parser facades validate finite `BEX` values and lower them into the
      shared engine mobility-temperature-exponent field.
+
+440. Python and TypeScript Berkeley SPICE JFET alternative beta temperature
+     coefficient parity.
+   - Status: implemented in this JFET BETATCE parity slice.
+   - Both parser facades validate finite `BETATCE` values, preserve omission for
+     `BEX` fallback, and lower explicit values into the shared engine optional
+     mobility-temperature-coefficient field.
 
 ## Backlog
 
@@ -4531,7 +4538,7 @@ the Rust, Python, and TypeScript surfaces together.
      currently use `B` as a legacy beta alias, while the engine model uses `B`
      for Parker-Skellern doping-tail shaping. Do not assign one card value to
      both fields silently.
-   - Continue the unambiguous audited JFET gaps with `BETATCE`.
+   - Reconcile the JFET `B` policy before any remaining doping-tail lowering.
    - Continue the audited BJT model-card gaps after the smaller JFET fields;
      prioritize direct engine fields before adding new model surfaces.
    - Re-audit MOS lowering after those direct JFET and BJT omissions close.


### PR DESCRIPTION
## Summary
- validate finite JFET `BETATCE` model-card values in both parser facades
- preserve omission for the engine's `BEX` fallback and lower explicit coefficients
- add mirrored present, omitted, validation, changelog, and plan coverage

## Testing
- `code/packages/python/spice-netlist-parser: bash BUILD` (424 passed, 89.68% coverage)
- `code/packages/python/spice-netlist-parser: .venv/bin/ruff check .`
- `code/packages/typescript/spice-netlist-parser: bash BUILD` (409 passed)
- `code/packages/typescript/spice-netlist-parser: npx vitest run --coverage` (87% lines)
- `code/packages/typescript/spice-engine: bash BUILD` (448 passed)