### PR TITLE
Add BJT XTI parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `XTI` temperature exponent.
 - Validate and lower JFET model-card `BETATCE` alternative mobility temperature
   coefficient while preserving omission for `BEX` fallback.
 - Validate and lower JFET model-card `BEX` mobility temperature exponent.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1314,6 +1314,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             ),
             Tf=model.params.get("TF", 0.0),
             Tr=model.params.get("TR", 0.0),
+            Xti=model.params.get("XTI", 3.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2077,6 +2078,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
                 raise NetlistParseError(
                     f"BJT {parameter_name} must be finite and non-negative"
                 )
+        temperature_exponent = params.get("XTI")
+        if temperature_exponent is not None and not math.isfinite(
+            temperature_exponent
+        ):
+            raise NetlistParseError("BJT XTI must be finite")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1297,6 +1297,27 @@ Q1 col base emit fast
     assert transistor.Tr == 5.0e-9
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"), [("-1", -1.0), ("0", 0.0), ("4.5", 4.5)]
+)
+def test_parse_bjt_temperature_exponent(value: str, expected: float) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NPN(XTI={value})
+Q1 col base emit fast
+"""
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Xti == expected
+
+
+def test_rejects_non_finite_bjt_temperature_exponent() -> None:
+    with pytest.raises(NetlistParseError, match="BJT XTI must be finite"):
+        parse_netlist(".model fast NPN(XTI=1e999)")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `XTI` temperature exponent.
 - Validate and lower JFET model-card `BETATCE` alternative mobility temperature
   coefficient while preserving omission for `BEX` fallback.
 - Validate and lower JFET model-card `BEX` mobility temperature exponent.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1329,6 +1329,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
       throw new NetlistParseError(`BJT ${name} must be finite and non-negative`);
     }
   }
+  const bjtTemperatureExponent = params.get("XTI");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtTemperatureExponent !== undefined &&
+    !Number.isFinite(bjtTemperatureExponent)
+  ) {
+    throw new NetlistParseError("BJT XTI must be finite");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2040,6 +2048,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
         0.0,
       model.params.get("TF") ?? 0.0,
       model.params.get("TR") ?? 0.0,
+      model.params.get("XTI") ?? 3.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1332,6 +1332,28 @@ Q1 col base emit fast
     });
   });
 
+  it.each([
+    ["-1", -1.0],
+    ["0", 0.0],
+    ["4.5", 4.5],
+  ])("parses BJT temperature exponent %s", (value, expected) => {
+    const parsed = parseNetlist(`
+.model fast NPN(XTI=${value})
+Q1 col base emit fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      saturationCurrentTemperatureExponent: expected,
+    });
+  });
+
+  it("rejects a non-finite BJT temperature exponent", () => {
+    expect(() => parseNetlist(".model fast NPN(XTI=1e999)")).toThrow(
+      "BJT XTI must be finite",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4526,10 +4526,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 440. Python and TypeScript Berkeley SPICE JFET alternative beta temperature
      coefficient parity.
-   - Status: implemented in this JFET BETATCE parity slice.
+   - Status: completed in PR 10097.
    - Both parser facades validate finite `BETATCE` values, preserve omission for
      `BEX` fallback, and lower explicit values into the shared engine optional
      mobility-temperature-coefficient field.
+
+441. Python and TypeScript Berkeley SPICE BJT temperature-exponent parity.
+   - Status: implemented in this BJT XTI parity slice.
+   - Both parser facades validate finite `XTI` values and lower them into the
+     shared engine saturation-current-temperature-exponent field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite BJT `XTI` model-card values in both parser facades
- lower signed exponents into the shared saturation-current temperature field
- add mirrored tests, changelogs, and implementation-plan tracking

## Testing
- `code/packages/python/spice-netlist-parser: bash BUILD` (428 passed, 89.70% coverage)
- `code/packages/python/spice-netlist-parser: .venv/bin/ruff check .`
- `code/packages/typescript/spice-netlist-parser: bash BUILD` (413 passed)
- `code/packages/typescript/spice-netlist-parser: npx vitest run --coverage` (87.04% lines)
- `code/packages/typescript/spice-engine: bash BUILD` (448 passed)