### PR TITLE
Add BJT EG parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `EG` energy gap.
 - Validate and lower BJT model-card `XTI` temperature exponent.
 - Validate and lower JFET model-card `BETATCE` alternative mobility temperature
   coefficient while preserving omission for `BEX` fallback.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1315,6 +1315,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Tf=model.params.get("TF", 0.0),
             Tr=model.params.get("TR", 0.0),
             Xti=model.params.get("XTI", 3.0),
+            Eg=model.params.get("EG", 1.11),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2083,6 +2084,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             temperature_exponent
         ):
             raise NetlistParseError("BJT XTI must be finite")
+        energy_gap = params.get("EG")
+        if energy_gap is not None and (
+            not math.isfinite(energy_gap) or energy_gap <= 0.0
+        ):
+            raise NetlistParseError("BJT EG must be finite and positive")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1318,6 +1318,28 @@ def test_rejects_non_finite_bjt_temperature_exponent() -> None:
         parse_netlist(".model fast NPN(XTI=1e999)")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0.5", 0.5), ("1.2", 1.2)])
+def test_parse_bjt_energy_gap(value: str, expected: float) -> None:
+    parsed = parse_netlist(
+        f"""
+.model fast NPN(EG={value})
+Q1 col base emit fast
+"""
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Eg == expected
+
+
+@pytest.mark.parametrize("value", ["0", "-0.1", "1e999"])
+def test_rejects_invalid_bjt_energy_gap(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT EG must be finite and positive"
+    ):
+        parse_netlist(f".model fast NPN(EG={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `EG` energy gap.
 - Validate and lower BJT model-card `XTI` temperature exponent.
 - Validate and lower JFET model-card `BETATCE` alternative mobility temperature
   coefficient while preserving omission for `BEX` fallback.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1337,6 +1337,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT XTI must be finite");
   }
+  const bjtEnergyGap = params.get("EG");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtEnergyGap !== undefined &&
+    (!Number.isFinite(bjtEnergyGap) || bjtEnergyGap <= 0.0)
+  ) {
+    throw new NetlistParseError("BJT EG must be finite and positive");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2049,6 +2057,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("TF") ?? 0.0,
       model.params.get("TR") ?? 0.0,
       model.params.get("XTI") ?? 3.0,
+      model.params.get("EG") ?? 1.11,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1354,6 +1354,27 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0.5", 0.5],
+    ["1.2", 1.2],
+  ])("parses BJT energy gap %s", (value, expected) => {
+    const parsed = parseNetlist(`
+.model fast NPN(EG=${value})
+Q1 col base emit fast
+`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      energyGapElectronVolts: expected,
+    });
+  });
+
+  it.each(["0", "-0.1", "1e999"])("rejects invalid BJT energy gap %s", (value) => {
+    expect(() => parseNetlist(`.model fast NPN(EG=${value})`)).toThrow(
+      "BJT EG must be finite and positive",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4532,9 +4532,14 @@ the Rust, Python, and TypeScript surfaces together.
      mobility-temperature-coefficient field.
 
 441. Python and TypeScript Berkeley SPICE BJT temperature-exponent parity.
-   - Status: implemented in this BJT XTI parity slice.
+   - Status: completed in PR 10099.
    - Both parser facades validate finite `XTI` values and lower them into the
      shared engine saturation-current-temperature-exponent field.
+
+442. Python and TypeScript Berkeley SPICE BJT energy-gap parity.
+   - Status: implemented in this BJT EG parity slice.
+   - Both parser facades validate positive finite `EG` values and lower them
+     into the shared engine energy-gap field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate positive finite BJT `EG` model-card values in both parser facades
- lower accepted values into the shared engine energy-gap field
- add mirrored tests, changelogs, and implementation-plan tracking

## Testing
- `code/packages/python/spice-netlist-parser: bash BUILD` (433 passed, 89.73% coverage)
- `code/packages/python/spice-netlist-parser: .venv/bin/ruff check .`
- `code/packages/typescript/spice-netlist-parser: bash BUILD` (418 passed)
- `code/packages/typescript/spice-netlist-parser: npx vitest run --coverage` (87.07% lines)
- `code/packages/typescript/spice-engine: bash BUILD` (448 passed)