### PR TITLE
Add BJT VAF parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `VAF` / `VA` forward Early voltage.
 - Validate and lower BJT model-card `EG` energy gap.
 - Validate and lower BJT model-card `XTI` temperature exponent.
 - Validate and lower JFET model-card `BETATCE` alternative mobility temperature

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1316,6 +1316,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Tr=model.params.get("TR", 0.0),
             Xti=model.params.get("XTI", 3.0),
             Eg=model.params.get("EG", 1.11),
+            Vaf=model.params.get("VAF", model.params.get("VA", 0.0)),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2089,6 +2090,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(energy_gap) or energy_gap <= 0.0
         ):
             raise NetlistParseError("BJT EG must be finite and positive")
+        forward_early_voltage = params.get("VAF", params.get("VA"))
+        if forward_early_voltage is not None and (
+            not math.isfinite(forward_early_voltage) or forward_early_voltage < 0.0
+        ):
+            raise NetlistParseError("BJT VAF must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1340,6 +1340,37 @@ def test_rejects_invalid_bjt_energy_gap(value: str) -> None:
         parse_netlist(f".model fast NPN(EG={value})")
 
 
+@pytest.mark.parametrize("alias", ["VAF", "VA"])
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("80", 80.0)])
+def test_parse_bjt_forward_early_voltage(
+    alias: str, value: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model fast NPN({alias}={value})\nQ1 col base emit fast"
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Vaf == expected
+
+
+def test_bjt_vaf_takes_precedence_over_va() -> None:
+    parsed = parse_netlist(".model fast NPN(VA=20 VAF=80)\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Vaf == 80.0
+
+
+@pytest.mark.parametrize("alias", ["VAF", "VA"])
+@pytest.mark.parametrize("value", ["-0.1", "1e999"])
+def test_rejects_invalid_bjt_forward_early_voltage(alias: str, value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT VAF must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN({alias}={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `VAF` / `VA` forward Early voltage.
 - Validate and lower BJT model-card `EG` energy gap.
 - Validate and lower BJT model-card `XTI` temperature exponent.
 - Validate and lower JFET model-card `BETATCE` alternative mobility temperature

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1345,6 +1345,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT EG must be finite and positive");
   }
+  const bjtForwardEarlyVoltage = params.get("VAF") ?? params.get("VA");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtForwardEarlyVoltage !== undefined &&
+    (!Number.isFinite(bjtForwardEarlyVoltage) || bjtForwardEarlyVoltage < 0.0)
+  ) {
+    throw new NetlistParseError("BJT VAF must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2058,6 +2066,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("TR") ?? 0.0,
       model.params.get("XTI") ?? 3.0,
       model.params.get("EG") ?? 1.11,
+      model.params.get("VAF") ?? model.params.get("VA") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1375,6 +1375,40 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["VAF", "0", 0.0],
+    ["VA", "0", 0.0],
+    ["VAF", "80", 80.0],
+    ["VA", "80", 80.0],
+  ])("parses BJT forward Early voltage %s=%s", (alias, value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(${alias}=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      forwardEarlyVoltage: expected,
+    });
+  });
+
+  it("gives BJT VAF precedence over VA", () => {
+    const parsed = parseNetlist(`.model fast NPN(VA=20 VAF=80)\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      forwardEarlyVoltage: 80.0,
+    });
+  });
+
+  it.each([
+    ["VAF", "-0.1"],
+    ["VA", "-0.1"],
+    ["VAF", "1e999"],
+    ["VA", "1e999"],
+  ])("rejects invalid BJT forward Early voltage %s=%s", (alias, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${alias}=${value})`)).toThrow(
+      "BJT VAF must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4537,9 +4537,15 @@ the Rust, Python, and TypeScript surfaces together.
      shared engine saturation-current-temperature-exponent field.
 
 442. Python and TypeScript Berkeley SPICE BJT energy-gap parity.
-   - Status: implemented in this BJT EG parity slice.
+   - Status: completed in PR 10101.
    - Both parser facades validate positive finite `EG` values and lower them
      into the shared engine energy-gap field.
+
+443. Python and TypeScript Berkeley SPICE BJT forward Early-voltage parity.
+   - Status: implemented in this BJT VAF parity slice.
+   - Both parser facades validate finite, non-negative `VAF` / `VA` values,
+     prefer canonical `VAF`, and lower the result into the shared engine
+     forward-Early-voltage field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite non-negative BJT `VAF` and legacy `VA` model parameters in Python and TypeScript
- prefer canonical `VAF` and lower the value into the shared forward Early-voltage engine field
- add parity, precedence, rejection, changelog, and SPICE plan coverage

## Validation
- `bash BUILD` (Python spice-netlist-parser: 442 passed, 89.75% coverage)
- `.venv/bin/ruff check .` (Python spice-netlist-parser)
- `bash BUILD` (TypeScript spice-netlist-parser: 427 passed)
- `npx vitest run --coverage` (TypeScript spice-netlist-parser: 87.11% lines)
- `bash BUILD` (TypeScript spice-engine: 448 passed)
- `git diff --check`
- touched package manifest and BUILD dependency audit (no changes required)