### PR TITLE
Add BJT VAR parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `VAR` / `VB` reverse Early voltage.
 - Validate and lower BJT model-card `VAF` / `VA` forward Early voltage.
 - Validate and lower BJT model-card `EG` energy gap.
 - Validate and lower BJT model-card `XTI` temperature exponent.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1317,6 +1317,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Xti=model.params.get("XTI", 3.0),
             Eg=model.params.get("EG", 1.11),
             Vaf=model.params.get("VAF", model.params.get("VA", 0.0)),
+            Var=model.params.get("VAR", model.params.get("VB", 0.0)),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2095,6 +2096,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(forward_early_voltage) or forward_early_voltage < 0.0
         ):
             raise NetlistParseError("BJT VAF must be finite and non-negative")
+        reverse_early_voltage = params.get("VAR", params.get("VB"))
+        if reverse_early_voltage is not None and (
+            not math.isfinite(reverse_early_voltage) or reverse_early_voltage < 0.0
+        ):
+            raise NetlistParseError("BJT VAR must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1371,6 +1371,37 @@ def test_rejects_invalid_bjt_forward_early_voltage(alias: str, value: str) -> No
         parse_netlist(f".model fast NPN({alias}={value})")
 
 
+@pytest.mark.parametrize("alias", ["VAR", "VB"])
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("120", 120.0)])
+def test_parse_bjt_reverse_early_voltage(
+    alias: str, value: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model fast NPN({alias}={value})\nQ1 col base emit fast"
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Var == expected
+
+
+def test_bjt_var_takes_precedence_over_vb() -> None:
+    parsed = parse_netlist(".model fast NPN(VB=40 VAR=120)\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Var == 120.0
+
+
+@pytest.mark.parametrize("alias", ["VAR", "VB"])
+@pytest.mark.parametrize("value", ["-0.1", "1e999"])
+def test_rejects_invalid_bjt_reverse_early_voltage(alias: str, value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT VAR must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN({alias}={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `VAR` / `VB` reverse Early voltage.
 - Validate and lower BJT model-card `VAF` / `VA` forward Early voltage.
 - Validate and lower BJT model-card `EG` energy gap.
 - Validate and lower BJT model-card `XTI` temperature exponent.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1353,6 +1353,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT VAF must be finite and non-negative");
   }
+  const bjtReverseEarlyVoltage = params.get("VAR") ?? params.get("VB");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtReverseEarlyVoltage !== undefined &&
+    (!Number.isFinite(bjtReverseEarlyVoltage) || bjtReverseEarlyVoltage < 0.0)
+  ) {
+    throw new NetlistParseError("BJT VAR must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2067,6 +2075,14 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("XTI") ?? 3.0,
       model.params.get("EG") ?? 1.11,
       model.params.get("VAF") ?? model.params.get("VA") ?? 0.0,
+      1.0,
+      1.0,
+      0.75,
+      0.33,
+      0.75,
+      0.33,
+      0.5,
+      model.params.get("VAR") ?? model.params.get("VB") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1409,6 +1409,40 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["VAR", "0", 0.0],
+    ["VB", "0", 0.0],
+    ["VAR", "120", 120.0],
+    ["VB", "120", 120.0],
+  ])("parses BJT reverse Early voltage %s=%s", (alias, value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(${alias}=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      reverseEarlyVoltage: expected,
+    });
+  });
+
+  it("gives BJT VAR precedence over VB", () => {
+    const parsed = parseNetlist(`.model fast NPN(VB=40 VAR=120)\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      reverseEarlyVoltage: 120.0,
+    });
+  });
+
+  it.each([
+    ["VAR", "-0.1"],
+    ["VB", "-0.1"],
+    ["VAR", "1e999"],
+    ["VB", "1e999"],
+  ])("rejects invalid BJT reverse Early voltage %s=%s", (alias, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${alias}=${value})`)).toThrow(
+      "BJT VAR must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4542,10 +4542,16 @@ the Rust, Python, and TypeScript surfaces together.
      into the shared engine energy-gap field.
 
 443. Python and TypeScript Berkeley SPICE BJT forward Early-voltage parity.
-   - Status: implemented in this BJT VAF parity slice.
+   - Status: completed in PR 10103.
    - Both parser facades validate finite, non-negative `VAF` / `VA` values,
      prefer canonical `VAF`, and lower the result into the shared engine
      forward-Early-voltage field.
+
+444. Python and TypeScript Berkeley SPICE BJT reverse Early-voltage parity.
+   - Status: implemented in this BJT VAR parity slice.
+   - Both parser facades validate finite, non-negative `VAR` / `VB` values,
+     prefer canonical `VAR`, and lower the result into the shared engine
+     reverse-Early-voltage field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite non-negative BJT `VAR` and legacy `VB` model parameters in Python and TypeScript
- prefer canonical `VAR` and lower the value into the shared reverse Early-voltage engine field
- add parity, precedence, rejection, changelog, and SPICE plan coverage

## Validation
- `bash BUILD` (Python spice-netlist-parser: 451 passed, 89.77% coverage)
- `.venv/bin/ruff check .` (Python spice-netlist-parser)
- `bash BUILD` (TypeScript spice-netlist-parser: 436 passed)
- `npx vitest run --coverage` (TypeScript spice-netlist-parser: 87.14% lines)
- `bash BUILD` (TypeScript spice-engine: 448 passed)
- `git diff --check`
- touched package manifest and BUILD dependency audit (no changes required)