### PR TITLE
Add BJT NF parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `NF` forward emission coefficient.
 - Validate and lower BJT model-card `VAR` / `VB` reverse Early voltage.
 - Validate and lower BJT model-card `VAF` / `VA` forward Early voltage.
 - Validate and lower BJT model-card `EG` energy gap.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1317,6 +1317,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Xti=model.params.get("XTI", 3.0),
             Eg=model.params.get("EG", 1.11),
             Vaf=model.params.get("VAF", model.params.get("VA", 0.0)),
+            Nf=model.params.get("NF", 1.0),
             Var=model.params.get("VAR", model.params.get("VB", 0.0)),
         )
     if prefix == "J":
@@ -2101,6 +2102,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(reverse_early_voltage) or reverse_early_voltage < 0.0
         ):
             raise NetlistParseError("BJT VAR must be finite and non-negative")
+        forward_emission_coefficient = params.get("NF")
+        if forward_emission_coefficient is not None and (
+            not math.isfinite(forward_emission_coefficient)
+            or forward_emission_coefficient <= 0.0
+        ):
+            raise NetlistParseError("BJT NF must be finite and positive")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1402,6 +1402,21 @@ def test_rejects_invalid_bjt_reverse_early_voltage(alias: str, value: str) -> No
         parse_netlist(f".model fast NPN({alias}={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0.5", 0.5), ("2", 2.0)])
+def test_parse_bjt_forward_emission_coefficient(value: str, expected: float) -> None:
+    parsed = parse_netlist(f".model fast NPN(NF={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Nf == expected
+
+
+@pytest.mark.parametrize("value", ["0", "-0.1", "1e999"])
+def test_rejects_invalid_bjt_forward_emission_coefficient(value: str) -> None:
+    with pytest.raises(NetlistParseError, match="BJT NF must be finite and positive"):
+        parse_netlist(f".model fast NPN(NF={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `NF` forward emission coefficient.
 - Validate and lower BJT model-card `VAR` / `VB` reverse Early voltage.
 - Validate and lower BJT model-card `VAF` / `VA` forward Early voltage.
 - Validate and lower BJT model-card `EG` energy gap.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1361,6 +1361,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT VAR must be finite and non-negative");
   }
+  const bjtForwardEmissionCoefficient = params.get("NF");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtForwardEmissionCoefficient !== undefined &&
+    (!Number.isFinite(bjtForwardEmissionCoefficient) || bjtForwardEmissionCoefficient <= 0.0)
+  ) {
+    throw new NetlistParseError("BJT NF must be finite and positive");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2075,7 +2083,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("XTI") ?? 3.0,
       model.params.get("EG") ?? 1.11,
       model.params.get("VAF") ?? model.params.get("VA") ?? 0.0,
-      1.0,
+      model.params.get("NF") ?? 1.0,
       1.0,
       0.75,
       0.33,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1443,6 +1443,27 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0.5", 0.5],
+    ["2", 2.0],
+  ])("parses BJT forward emission coefficient NF=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(NF=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      forwardEmissionCoefficient: expected,
+    });
+  });
+
+  it.each(["0", "-0.1", "1e999"])(
+    "rejects invalid BJT forward emission coefficient NF=%s",
+    (value) => {
+      expect(() => parseNetlist(`.model fast NPN(NF=${value})`)).toThrow(
+        "BJT NF must be finite and positive",
+      );
+    },
+  );
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4548,10 +4548,15 @@ the Rust, Python, and TypeScript surfaces together.
      forward-Early-voltage field.
 
 444. Python and TypeScript Berkeley SPICE BJT reverse Early-voltage parity.
-   - Status: implemented in this BJT VAR parity slice.
+   - Status: completed in PR 10105.
    - Both parser facades validate finite, non-negative `VAR` / `VB` values,
      prefer canonical `VAR`, and lower the result into the shared engine
      reverse-Early-voltage field.
+
+445. Python and TypeScript Berkeley SPICE BJT forward-emission parity.
+   - Status: implemented in this BJT NF parity slice.
+   - Both parser facades validate positive finite `NF` values and lower them
+     into the shared engine forward-emission-coefficient field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate positive finite BJT `NF` model parameters in Python and TypeScript
- lower `NF` into the shared forward emission-coefficient engine field
- add parity, rejection, changelog, and SPICE plan coverage

## Validation
- `bash BUILD` (Python spice-netlist-parser: 456 passed, 89.80% coverage)
- `.venv/bin/ruff check .` (Python spice-netlist-parser)
- `bash BUILD` (TypeScript spice-netlist-parser: 441 passed)
- `npx vitest run --coverage` (TypeScript spice-netlist-parser: 87.18% lines)
- `bash BUILD` (TypeScript spice-engine: 448 passed)
- `git diff --check`
- touched package manifest and BUILD dependency audit (no changes required)