### PR TITLE
Add BJT VJE parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `VJE` / `PE` base-emitter junction
+  potential.
 - Validate and lower BJT model-card `NR` reverse emission coefficient.
 - Validate and lower BJT model-card `NF` forward emission coefficient.
 - Validate and lower BJT model-card `VAR` / `VB` reverse Early voltage.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1319,6 +1319,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Vaf=model.params.get("VAF", model.params.get("VA", 0.0)),
             Nf=model.params.get("NF", 1.0),
             Nr=model.params.get("NR", 1.0),
+            Vje=model.params.get("VJE", model.params.get("PE", 0.75)),
             Var=model.params.get("VAR", model.params.get("VB", 0.0)),
         )
     if prefix == "J":
@@ -2115,6 +2116,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or reverse_emission_coefficient <= 0.0
         ):
             raise NetlistParseError("BJT NR must be finite and positive")
+        base_emitter_junction_potential = params.get("VJE", params.get("PE"))
+        if base_emitter_junction_potential is not None and (
+            not math.isfinite(base_emitter_junction_potential)
+            or base_emitter_junction_potential <= 0.0
+        ):
+            raise NetlistParseError("BJT VJE must be finite and positive")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1432,6 +1432,37 @@ def test_rejects_invalid_bjt_reverse_emission_coefficient(value: str) -> None:
         parse_netlist(f".model fast NPN(NR={value})")
 
 
+@pytest.mark.parametrize("alias", ["VJE", "PE"])
+@pytest.mark.parametrize(("value", "expected"), [("0.5", 0.5), ("0.8", 0.8)])
+def test_parse_bjt_base_emitter_junction_potential(
+    alias: str, value: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model fast NPN({alias}={value})\nQ1 col base emit fast"
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Vje == expected
+
+
+def test_bjt_vje_takes_precedence_over_pe() -> None:
+    parsed = parse_netlist(".model fast NPN(PE=0.5 VJE=0.8)\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Vje == 0.8
+
+
+@pytest.mark.parametrize("alias", ["VJE", "PE"])
+@pytest.mark.parametrize("value", ["0", "-0.1", "1e999"])
+def test_rejects_invalid_bjt_base_emitter_junction_potential(
+    alias: str, value: str
+) -> None:
+    with pytest.raises(NetlistParseError, match="BJT VJE must be finite and positive"):
+        parse_netlist(f".model fast NPN({alias}={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `VJE` / `PE` base-emitter junction
+  potential.
 - Validate and lower BJT model-card `NR` reverse emission coefficient.
 - Validate and lower BJT model-card `NF` forward emission coefficient.
 - Validate and lower BJT model-card `VAR` / `VB` reverse Early voltage.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1377,6 +1377,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT NR must be finite and positive");
   }
+  const bjtBaseEmitterJunctionPotential = params.get("VJE") ?? params.get("PE");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtBaseEmitterJunctionPotential !== undefined &&
+    (!Number.isFinite(bjtBaseEmitterJunctionPotential) || bjtBaseEmitterJunctionPotential <= 0.0)
+  ) {
+    throw new NetlistParseError("BJT VJE must be finite and positive");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2093,7 +2101,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("VAF") ?? model.params.get("VA") ?? 0.0,
       model.params.get("NF") ?? 1.0,
       model.params.get("NR") ?? 1.0,
-      0.75,
+      model.params.get("VJE") ?? model.params.get("PE") ?? 0.75,
       0.33,
       0.75,
       0.33,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1485,6 +1485,42 @@ Q1 col base emit fast
     },
   );
 
+  it.each([
+    ["VJE", "0.5", 0.5],
+    ["PE", "0.5", 0.5],
+    ["VJE", "0.8", 0.8],
+    ["PE", "0.8", 0.8],
+  ])("parses BJT base-emitter junction potential %s=%s", (alias, value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(${alias}=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseEmitterJunctionPotential: expected,
+    });
+  });
+
+  it("gives BJT VJE precedence over PE", () => {
+    const parsed = parseNetlist(`.model fast NPN(PE=0.5 VJE=0.8)\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseEmitterJunctionPotential: 0.8,
+    });
+  });
+
+  it.each([
+    ["VJE", "0"],
+    ["PE", "0"],
+    ["VJE", "-0.1"],
+    ["PE", "-0.1"],
+    ["VJE", "1e999"],
+    ["PE", "1e999"],
+  ])("rejects invalid BJT base-emitter junction potential %s=%s", (alias, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${alias}=${value})`)).toThrow(
+      "BJT VJE must be finite and positive",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4559,9 +4559,15 @@ the Rust, Python, and TypeScript surfaces together.
      into the shared engine forward-emission-coefficient field.
 
 446. Python and TypeScript Berkeley SPICE BJT reverse-emission parity.
-   - Status: implemented in this BJT NR parity slice.
+   - Status: completed in PR 10108.
    - Both parser facades validate positive finite `NR` values and lower them
      into the shared engine reverse-emission-coefficient field.
+
+447. Python and TypeScript Berkeley SPICE BJT base-emitter-potential parity.
+   - Status: implemented in this BJT VJE parity slice.
+   - Both parser facades validate positive finite `VJE` / `PE` values, prefer
+     canonical `VJE`, and lower the result into the shared engine
+     base-emitter-junction-potential field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate positive finite BJT `VJE` and legacy `PE` model parameters in Python and TypeScript
- prefer canonical `VJE` and lower the value into the shared base-emitter junction-potential engine field
- add parity, precedence, rejection, changelog, and SPICE plan coverage

## Validation
- `bash BUILD` (Python spice-netlist-parser: 472 passed, 89.84% coverage)
- `.venv/bin/ruff check .` (Python spice-netlist-parser)
- `bash BUILD` (TypeScript spice-netlist-parser: 457 passed)
- `npx vitest run --coverage` (TypeScript spice-netlist-parser: 87.25% lines)
- `bash BUILD` (TypeScript spice-engine: 448 passed)
- `git diff --check`
- touched package manifest and BUILD dependency audit (no changes required)