### PR TITLE
Add BJT MJE parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `MJE` / `ME` base-emitter grading
+  coefficient.
 - Validate and lower BJT model-card `VJE` / `PE` base-emitter junction
   potential.
 - Validate and lower BJT model-card `NR` reverse emission coefficient.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1320,6 +1320,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Nf=model.params.get("NF", 1.0),
             Nr=model.params.get("NR", 1.0),
             Vje=model.params.get("VJE", model.params.get("PE", 0.75)),
+            Mje=model.params.get("MJE", model.params.get("ME", 0.33)),
             Var=model.params.get("VAR", model.params.get("VB", 0.0)),
         )
     if prefix == "J":
@@ -2122,6 +2123,13 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or base_emitter_junction_potential <= 0.0
         ):
             raise NetlistParseError("BJT VJE must be finite and positive")
+        base_emitter_grading_coefficient = params.get("MJE", params.get("ME"))
+        if base_emitter_grading_coefficient is not None and (
+            not math.isfinite(base_emitter_grading_coefficient)
+            or base_emitter_grading_coefficient < 0.0
+            or base_emitter_grading_coefficient >= 1.0
+        ):
+            raise NetlistParseError("BJT MJE must be finite and in [0, 1)")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1463,6 +1463,39 @@ def test_rejects_invalid_bjt_base_emitter_junction_potential(
         parse_netlist(f".model fast NPN({alias}={value})")
 
 
+@pytest.mark.parametrize("alias", ["MJE", "ME"])
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("0.4", 0.4)])
+def test_parse_bjt_base_emitter_grading_coefficient(
+    alias: str, value: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model fast NPN({alias}={value})\nQ1 col base emit fast"
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Mje == expected
+
+
+def test_bjt_mje_takes_precedence_over_me() -> None:
+    parsed = parse_netlist(".model fast NPN(ME=0.2 MJE=0.4)\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Mje == 0.4
+
+
+@pytest.mark.parametrize("alias", ["MJE", "ME"])
+@pytest.mark.parametrize("value", ["-0.1", "1", "1e999"])
+def test_rejects_invalid_bjt_base_emitter_grading_coefficient(
+    alias: str, value: str
+) -> None:
+    with pytest.raises(
+        NetlistParseError, match=r"BJT MJE must be finite and in \[0, 1\)"
+    ):
+        parse_netlist(f".model fast NPN({alias}={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `MJE` / `ME` base-emitter grading
+  coefficient.
 - Validate and lower BJT model-card `VJE` / `PE` base-emitter junction
   potential.
 - Validate and lower BJT model-card `NR` reverse emission coefficient.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1385,6 +1385,16 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT VJE must be finite and positive");
   }
+  const bjtBaseEmitterGradingCoefficient = params.get("MJE") ?? params.get("ME");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtBaseEmitterGradingCoefficient !== undefined &&
+    (!Number.isFinite(bjtBaseEmitterGradingCoefficient) ||
+      bjtBaseEmitterGradingCoefficient < 0.0 ||
+      bjtBaseEmitterGradingCoefficient >= 1.0)
+  ) {
+    throw new NetlistParseError("BJT MJE must be finite and in [0, 1)");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2102,7 +2112,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("NF") ?? 1.0,
       model.params.get("NR") ?? 1.0,
       model.params.get("VJE") ?? model.params.get("PE") ?? 0.75,
-      0.33,
+      model.params.get("MJE") ?? model.params.get("ME") ?? 0.33,
       0.75,
       0.33,
       0.5,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1521,6 +1521,42 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["MJE", "0", 0.0],
+    ["ME", "0", 0.0],
+    ["MJE", "0.4", 0.4],
+    ["ME", "0.4", 0.4],
+  ])("parses BJT base-emitter grading coefficient %s=%s", (alias, value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(${alias}=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseEmitterGradingCoefficient: expected,
+    });
+  });
+
+  it("gives BJT MJE precedence over ME", () => {
+    const parsed = parseNetlist(`.model fast NPN(ME=0.2 MJE=0.4)\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseEmitterGradingCoefficient: 0.4,
+    });
+  });
+
+  it.each([
+    ["MJE", "-0.1"],
+    ["ME", "-0.1"],
+    ["MJE", "1"],
+    ["ME", "1"],
+    ["MJE", "1e999"],
+    ["ME", "1e999"],
+  ])("rejects invalid BJT base-emitter grading coefficient %s=%s", (alias, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${alias}=${value})`)).toThrow(
+      "BJT MJE must be finite and in [0, 1)",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4564,10 +4564,16 @@ the Rust, Python, and TypeScript surfaces together.
      into the shared engine reverse-emission-coefficient field.
 
 447. Python and TypeScript Berkeley SPICE BJT base-emitter-potential parity.
-   - Status: implemented in this BJT VJE parity slice.
+   - Status: completed in PR 10109.
    - Both parser facades validate positive finite `VJE` / `PE` values, prefer
      canonical `VJE`, and lower the result into the shared engine
      base-emitter-junction-potential field.
+
+448. Python and TypeScript Berkeley SPICE BJT base-emitter-grading parity.
+   - Status: implemented in this BJT MJE parity slice.
+   - Both parser facades validate finite `MJE` / `ME` values in `[0, 1)`,
+     prefer canonical `MJE`, and lower the result into the shared engine
+     base-emitter-grading-coefficient field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite BJT `MJE` and legacy `ME` model parameters in the engine-supported `[0, 1)` range
- prefer canonical `MJE` and lower the value into the shared base-emitter grading-coefficient field
- add parity, precedence, rejection, changelog, and SPICE plan coverage

## Validation
- `bash BUILD` (Python spice-netlist-parser: 483 passed, 89.86% coverage)
- `.venv/bin/ruff check .` (Python spice-netlist-parser)
- `bash BUILD` (TypeScript spice-netlist-parser: 468 passed)
- `npx vitest run --coverage` (TypeScript spice-netlist-parser: 87.28% lines)
- `bash BUILD` (TypeScript spice-engine: 448 passed)
- `git diff --check`
- touched package manifest and BUILD dependency audit (no changes required)