### PR TITLE
Generate missing pronunciation appendices

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,10 +5,10 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-08, after HL-U01 merged as #10104. HL-I06 moved next
-because this file had duplicate and reused IDs, stale `this PR` statuses, and queued
-rows for work already merged. Repairing the backlog's identity and evidence trail is
-required before it can safely choose another corpus tranche.
+Last prioritized: 2026-08-08, after HL-C50A entered #10112. With all 22
+downloadable books now carrying pronunciation back matter, HL-C50 remains the
+highest-value standalone-book program: generate each track's glossary next, then
+its answer key and index from the same canonical curriculum data.
 Current generated baseline: **22** registered tracks, **1,669** canonical lessons,
 **1,521** mapped lessons, and **22** downloadable LaTeX books spanning **513**
 chapters, **408** of them generated from the canonical lesson AST. Twenty-five mapped
@@ -177,7 +177,8 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C18D | Queued | Burn down the 61 lessons over the script budget, steepest first, and split the 5 Japanese lessons that open two writing systems at once. | No lesson introduces more than `maxNewGlyphsPerLesson` new glyphs or opens more than one writing system; the corpus maximum drops from 12 to 3. Starts with `HI-W01-shirorekha-na-ma`, `MR-C01-dhanyavad` and `RU-C01-da` at twelve each. Follows HL-C18C, which produced the list. |
 | HL-C48 | Queued | Generate the cousin/cognate layer from `concept_tag` instead of hand-typing it, and make it visually skippable. | The cross-language comparison table exists in **18 hand-typed instances across 4 Dravidian tracks** (4.6% of chapters) while four prefaces promise it per-lesson; `parse.ts` has no block type for it, so an author cannot write one into a canonical lesson. `concept_tag` (1,131 lessons) is the join key that would generate them, and the book renderer ignores it — as it ignores 708 `etymology_hook` fields (~25,400 words) that the app already displays cross-language. Per the owner's rule, the layer is a bonus for readers who know a relative: it must never gate comprehension, and its foreign glyphs must stay out of the target-script ramp. |
 | HL-C49 | Complete (#10055) | Give every chapter a short, well-written intro, generated from `chapters.json`. | Generated chapters derive a standalone capability-led introduction from canonical metadata; the already-authored chapter openings remain authored. |
-| HL-C50 | Queued — reader-link cleanup complete (#10058, #10060, #10062, #10064, #10066) | Finish making every book a standalone artifact. | Add the missing pronunciation appendices, then generate a glossary, answer key, and index for every track from canonical data. |
+| HL-C50 | Queued — reader-link cleanup complete (#10058, #10060, #10062, #10064, #10066); pronunciation appendices complete (#10112) | Finish making every book a standalone artifact. | Generate a glossary, answer key, and index for every track from canonical data. |
+| HL-C50A | Complete (#10112) | Generate the five missing pronunciation appendices from each track's canonical `pronunciation-reference.md`. | Chinese, Japanese, Persian, Russian, and Urdu join the other 17 books in carrying pronunciation back matter; `book-cli --check` byte-gates all five generated `.tex` files, and all five PDFs compile with no warning regressions. |
 | HL-C19 | Queued | Verify every prose `strokeOrder` against an authored ductus, so no letter's step list implies a pen lift nothing has checked. | All 190 prose stroke orders across the nine scripts (`arabic` 21, `chinese` 24, `cyrillic` 33, `devanagari` 28, `gujarati` 29, `hebrew` 22, `perso-arabic` 9, `tamil` 10, `urdu-nastaliq` 13) either carry a font-checked pen path with `penLifts` + `strokeOrderSource`, or are worded so they claim part order only. Today exactly one letter — Tamil ம — is verified; the audit that found it is written up in [`data/scripts/README.md`](data/scripts/README.md). Follows HL-C09, which authors the paths this check consumes. |
 | HL-C30 | Closed — no move is both legal and useful | Recover Arabic's drivable prefix by moving the writing lessons that open Chapters 3 and 4 later in their chapters. | Measured and answered: zero. Both chapters are prefix-0 under **every** legal ordering because neither has a `voice` lesson without an in-chapter prerequisite, and all 18 of Arabic's `sight` lessons are tables, not script. Corpus-wide only 2 chapters (`portuguese ch2`, `italian ch2`, +4 lessons) can be improved by reordering at all; 116 of the 123 zero-prefix chapters are table-blocked at the root and belong to HL-C17. See *Findings from HL-C30*. |
 | HL-C24 | Complete (#9979) | Pilot real chapter payoff lessons on the weakest Latin chapters. | Latin chapters 19, 21, 33, and 36 each own a dedicated terminal consolidation lesson built only from already-taught material, and `chapters.json` points their `payoff.lesson` at it. |
@@ -2483,9 +2484,10 @@ problem.
   table. Those results now have stable IDs HL-C57 through HL-C62; the legacy
   aliases remain beside their PR numbers so repository history stays searchable.
 - HL-C49's generated chapter introductions are recorded complete in #10055.
-  HL-C50 now names only the unfinished standalone-book work: pronunciation
-  appendices and generated glossaries, answer keys, and indexes. Its five merged
-  link and cross-volume cleanup slices remain visible in the status.
+  HL-C50A's generated pronunciation appendices are recorded complete in #10112.
+  HL-C50 now names only the unfinished standalone-book work: generated glossaries,
+  answer keys, and indexes. Its five merged link and cross-volume cleanup slices
+  remain visible in the status.
 - A completed row must name at least one merge PR, an ID may occur only once,
   and `this PR` is not a durable status. HL-I06 was kept `In progress` until its
   own PR number existed so the repair did not violate the rule while making it.

--- a/code/learning/human-languages/chinese/book/book.tex
+++ b/code/learning/human-languages/chinese/book/book.tex
@@ -70,6 +70,8 @@ substitute.
 
 \backmatter
 
+\input{chapters/appendix-pronunciation}
+
 \chapter*{Sources for this starter edition}
 \addcontentsline{toc}{chapter}{Sources for this starter edition}
 

--- a/code/learning/human-languages/chinese/book/chapters/appendix-pronunciation.tex
+++ b/code/learning/human-languages/chinese/book/chapters/appendix-pronunciation.tex
@@ -1,0 +1,64 @@
+% GENERATED FILE. Edit chinese/pronunciation-reference.md, then run npm run generate:books.
+
+\chapter*{Pronunciation \& Character Guide}
+\addcontentsline{toc}{chapter}{Pronunciation \& Character Guide}
+\markboth{Pronunciation}{Pronunciation}
+
+Reference material, never a gate. Every lesson teaches the sounds its own word needs, inline, and links here for anyone who wants the fuller picture. Nobody has to read this page before Lesson 1, and most readers never will.
+
+The ids in each heading are the values a lesson's \texttt{sounds:} frontmatter list points at.
+
+\section*{Why this page is different from every other track's}
+
+In an alphabetic or abugida track, \textquotedblleft{}the sounds you'll need\textquotedblright{} is a list of \emph{segments}: this letter is silent, that vowel is long, this consonant is retroflex. Each fact is attached to a letter, and the letter is on the page.
+
+Mandarin adds a second, orthogonally different kind of fact. \textbf{Tone} rides on a whole syllable, is not written in the characters at all, and is \emph{phonemic} — it distinguishes words the way a consonant does. A segmental note cannot express it. So this page has two halves: tones first, because they are the part an English speaker has no instinct for, then the segments.
+
+The machine-readable form of the first half lives in the Chinese script reference under \texttt{tones} and \texttt{toneSandhi}.
+
+\section*{Tones}
+
+Mandarin has four tones plus a neutral one. Pinyin writes the tone as a mark over the vowel; the characters do not record it anywhere.
+
+The classic demonstration uses one syllable, \emph{ma}:
+
+\begin{itemize}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item \texttt{tone-1} — first, high level (contour 55). Held high and flat, one steady note. \emph{mā} — mother.
+  \item \texttt{tone-2} — second, rising (35). Climbs from mid to high, like the pitch on a surprised English \textquotedblleft{}huh?\textquotedblright{}. \emph{má} — hemp.
+  \item \texttt{tone-3} — third, dipping (214). Sinks low and creaky; said alone it rises again a little at the end, but in running speech it usually just stays low. \emph{mǎ} — horse.
+  \item \texttt{tone-4} — fourth, falling (51). Drops sharply from high to low, like a clipped \textquotedblleft{}No!\textquotedblright{}. \emph{mà} — to scold.
+  \item \texttt{tone-neutral} — unstressed. Short and light, with no mark written at all, pitched by whatever came before it. \emph{ma} — a question particle.
+\end{itemize}
+
+\subsection*{tone-lexical — tone is part of the word}
+
+The single fact that matters most, taught in the first lesson: changing the pitch of a Mandarin syllable changes \textbf{which word it is}, not how you feel about it. \emph{mā}, \emph{má}, \emph{mǎ} and \emph{mà} are four separate words. English uses pitch for mood and emphasis only, so this is a genuinely new job for an English speaker's voice.
+
+\subsection*{tone-sandhi-third — two third tones in a row}
+
+\textbf{When a third tone is followed by another third tone, the first is spoken as a rising second tone.}
+
+Written \textbf{nǐ hǎo}, said \textbf{ní hǎo}. Neither the pinyin nor the characters record the change; dictionaries print the citation tone each word carries alone. This is why a reader who trusts only the page mispronounces the commonest greeting in the language.
+
+\subsection*{tone-sandhi-bu — \zh{不} before a fourth tone}
+
+\zh{不} \emph{bù} is said \emph{bú} when the next syllable has a fourth tone: \emph{bù shì} $\to$ \emph{bú shì}. Recorded here for completeness; no Chapter 1 lesson needs it.
+
+\section*{Segments}
+
+Pinyin is a romanization, not English spelling. A few letters do work you would not guess.
+
+\begin{itemize}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item \texttt{pinyin-n} — as in English \emph{no}.
+  \item \texttt{pinyin-i} — after most consonants, the \emph{ee} of \textquotedblleft{}see\textquotedblright{}. (After \emph{z-, c-, s-, zh-, ch-, sh-, r-} it is a different, buzzier vowel; no Chapter 1 word uses those.)
+  \item \texttt{pinyin-h} — rougher than English \emph{h}, scraped at the back of the mouth, closer to the \emph{ch} of Scottish \emph{loch} softened.
+  \item \texttt{pinyin-ao} — one gliding vowel, the \emph{ow} of \textquotedblleft{}how\textquotedblright{}. Not two syllables.
+\end{itemize}
+
+\section*{The characters themselves}
+
+Stroke shapes, components, and stroke order for every character this track has introduced live in Chinese script reference. Unlike the Indic scripts in this curriculum, where stroke order is conventional, Chinese stroke order is a \textbf{taught, standardised system} — top before bottom, left before right, horizontal before vertical, outside before inside, and close a box last. That file marks its stroke orders \texttt{authoritative} for exactly that reason.

--- a/code/learning/human-languages/chinese/pronunciation-reference.md
+++ b/code/learning/human-languages/chinese/pronunciation-reference.md
@@ -19,8 +19,8 @@ distinguishes words the way a consonant does. A segmental note cannot express it
 So this page has two halves: tones first, because they are the part an English
 speaker has no instinct for, then the segments.
 
-The machine-readable form of the first half lives in
-[`data/scripts/chinese.json`](../data/scripts/chinese.json) under `tones` and
+The machine-readable form of the first half lives in the
+[Chinese script reference](../data/scripts/chinese.json) under `tones` and
 `toneSandhi`.
 
 ## Tones
@@ -30,26 +30,26 @@ the vowel; the characters do not record it anywhere.
 
 The classic demonstration uses one syllable, *ma*:
 
-- **`tone-1`** — first, high level (contour 55). Held high and flat, one steady
+- `tone-1` — first, high level (contour 55). Held high and flat, one steady
   note. *mā* — mother.
-- **`tone-2`** — second, rising (35). Climbs from mid to high, like the pitch on
+- `tone-2` — second, rising (35). Climbs from mid to high, like the pitch on
   a surprised English "huh?". *má* — hemp.
-- **`tone-3`** — third, dipping (214). Sinks low and creaky; said alone it rises
+- `tone-3` — third, dipping (214). Sinks low and creaky; said alone it rises
   again a little at the end, but in running speech it usually just stays low.
   *mǎ* — horse.
-- **`tone-4`** — fourth, falling (51). Drops sharply from high to low, like a
+- `tone-4` — fourth, falling (51). Drops sharply from high to low, like a
   clipped "No!". *mà* — to scold.
-- **`tone-neutral`** — unstressed. Short and light, with no mark written at all,
+- `tone-neutral` — unstressed. Short and light, with no mark written at all,
   pitched by whatever came before it. *ma* — a question particle.
 
-### `tone-lexical` — tone is part of the word
+### tone-lexical — tone is part of the word
 
 The single fact that matters most, taught in the first lesson: changing the pitch
 of a Mandarin syllable changes **which word it is**, not how you feel about it.
 *mā*, *má*, *mǎ* and *mà* are four separate words. English uses pitch for mood
 and emphasis only, so this is a genuinely new job for an English speaker's voice.
 
-### `tone-sandhi-third` — two third tones in a row
+### tone-sandhi-third — two third tones in a row
 
 **When a third tone is followed by another third tone, the first is spoken as a
 rising second tone.**
@@ -59,7 +59,7 @@ the change; dictionaries print the citation tone each word carries alone. This i
 why a reader who trusts only the page mispronounces the commonest greeting in the
 language.
 
-### `tone-sandhi-bu` — 不 before a fourth tone
+### tone-sandhi-bu — 不 before a fourth tone
 
 不 *bù* is said *bú* when the next syllable has a fourth tone: *bù shì* → *bú
 shì*. Recorded here for completeness; no Chapter 1 lesson needs it.
@@ -69,19 +69,19 @@ shì*. Recorded here for completeness; no Chapter 1 lesson needs it.
 Pinyin is a romanization, not English spelling. A few letters do work you would
 not guess.
 
-- **`pinyin-n`** — as in English *no*.
-- **`pinyin-i`** — after most consonants, the *ee* of "see". (After *z-, c-, s-,
+- `pinyin-n` — as in English *no*.
+- `pinyin-i` — after most consonants, the *ee* of "see". (After *z-, c-, s-,
   zh-, ch-, sh-, r-* it is a different, buzzier vowel; no Chapter 1 word uses
   those.)
-- **`pinyin-h`** — rougher than English *h*, scraped at the back of the mouth,
+- `pinyin-h` — rougher than English *h*, scraped at the back of the mouth,
   closer to the *ch* of Scottish *loch* softened.
-- **`pinyin-ao`** — one gliding vowel, the *ow* of "how". Not two syllables.
+- `pinyin-ao` — one gliding vowel, the *ow* of "how". Not two syllables.
 
 ## The characters themselves
 
 Stroke shapes, components, and stroke order for every character this track has
 introduced live in
-[`data/scripts/chinese.json`](../data/scripts/chinese.json). Unlike the Indic
+[Chinese script reference](../data/scripts/chinese.json). Unlike the Indic
 scripts in this curriculum, where stroke order is conventional, Chinese stroke
 order is a **taught, standardised system** — top before bottom, left before
 right, horizontal before vertical, outside before inside, and close a box last.

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -145,6 +145,47 @@
       }
     ]
   },
+  "referenceAppendices": [
+    {
+      "language": "chinese",
+      "title": "Pronunciation & Character Guide",
+      "source": "chinese/pronunciation-reference.md",
+      "output": "chinese/book/chapters/appendix-pronunciation.tex",
+      "unicodeScript": "Han",
+      "scriptCommand": "zh"
+    },
+    {
+      "language": "japanese",
+      "title": "Pronunciation & Writing Reference",
+      "source": "japanese/pronunciation-reference.md",
+      "output": "japanese/book/chapters/appendix-pronunciation.tex",
+      "scriptSet": "japanese-main"
+    },
+    {
+      "language": "persian",
+      "title": "Pronunciation & Script Reference",
+      "source": "persian/pronunciation-reference.md",
+      "output": "persian/book/chapters/appendix-pronunciation.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "fa"
+    },
+    {
+      "language": "russian",
+      "title": "Pronunciation & Cyrillic Reference",
+      "source": "russian/pronunciation-reference.md",
+      "output": "russian/book/chapters/appendix-pronunciation.tex",
+      "unicodeScript": "Cyrillic",
+      "scriptCommand": "ru"
+    },
+    {
+      "language": "urdu",
+      "title": "Pronunciation & Script Reference",
+      "source": "urdu/pronunciation-reference.md",
+      "output": "urdu/book/chapters/appendix-pronunciation.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "ur"
+    }
+  ],
   "targets": [
     {
       "language": "arabic",

--- a/code/learning/human-languages/japanese/book/book.tex
+++ b/code/learning/human-languages/japanese/book/book.tex
@@ -68,6 +68,8 @@ are used. Nothing else is.
 
 \backmatter
 
+\input{chapters/appendix-pronunciation}
+
 \chapter*{Sources for this starter edition}
 \addcontentsline{toc}{chapter}{Sources for this starter edition}
 

--- a/code/learning/human-languages/japanese/book/chapters/appendix-pronunciation.tex
+++ b/code/learning/human-languages/japanese/book/chapters/appendix-pronunciation.tex
@@ -1,0 +1,51 @@
+% GENERATED FILE. Edit japanese/pronunciation-reference.md, then run npm run generate:books.
+
+\chapter*{Pronunciation \& Writing Reference}
+\addcontentsline{toc}{chapter}{Pronunciation \& Writing Reference}
+\markboth{Pronunciation}{Pronunciation}
+
+A \textbf{reference}, not a chapter. Look a sound up when a lesson names it; do not read this page first. Japanese script is taught inside words the learner can already use, one sign at a time.
+
+Romanization on this track is Hepburn with macrons (\emph{arigatō}, \emph{kōhī}). It is temporary scaffolding. Where a lesson is teaching beat count, it also spells the word out mora by mora (\emph{a-ri-ga-to-o}), because a macron hides exactly the thing being taught.
+
+\section*{The writing system in four facts}
+
+\begin{enumerate}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item \textbf{There are three systems, and they run together.} An ordinary sentence uses all three at once: \textbf{hiragana} for grammar, \textbf{kanji} for content words, \textbf{katakana} for borrowings. None of them is a stage the others replace.
+  \item \textbf{Hiragana and katakana are moraic twins.} One sign is one beat, normally a consonant plus a vowel already fused. The two sets cover the same beats with different shapes; katakana marks a word as coming from outside.
+  \item \textbf{Kanji carry meaning, not a fixed sound.} \ja{日} is read \emph{nichi}, \emph{jitsu}, \emph{hi}, \emph{bi}, or \emph{ka}. A lesson therefore teaches the reading a \textbf{word} uses, never \textquotedblleft{}the sound of the character.\textquotedblright{}
+  \item \textbf{Beats are counted, not stressed.} Every mora is the same length, and length is contrastive: \textbf{\ja{いえ}} (2 beats) is a house, \textbf{\ja{いいえ}} (3) is \textquotedblleft{}no.\textquotedblright{}
+\end{enumerate}
+
+Japanese has no case, no grammatical gender, no articles, and no plural agreement — so several standing methods in this curriculum simply do not apply here. It does have an obligatory politeness level on every predicate, which nothing else in the corpus has.
+
+\section*{Sound ids used by the Chapter 1 lessons}
+
+\begin{itemize}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item \texttt{mora} — give every written sign one equal beat; do not stress one over another. First anchor: \textbf{\ja{はい}} \emph{hai}.
+  \item \texttt{pure-vowels} — five vowels, held steady, no English glide: \emph{a, i, u, e, o}. First anchor: \textbf{\ja{はい}} \emph{hai}.
+  \item \texttt{mora-length} — a long vowel is a second beat, and it changes meaning. First anchor: \textbf{\ja{いいえ}} \emph{iie} against \textbf{\ja{いえ}} \emph{ie}.
+  \item \texttt{moraic-n} — \textbf{\ja{ん}} is a consonant that owns a whole beat of its own. First anchor: \textbf{\ja{こんにちは}} \emph{konnichiwa}.
+  \item \texttt{particle-wa} — the sign \textbf{\ja{は}} is read \emph{wa} when it is working as the topic particle. First anchor: \textbf{\ja{こんにちは}}.
+  \item \texttt{chouon} — the katakana bar \textbf{\ja{ー}} adds one more beat of the vowel before it. First anchor: \textbf{\ja{コーヒー}} \emph{kōhī}.
+  \item \texttt{dakuten} — two short strokes voice a kana: \emph{ka$\to$ga}, \emph{sa$\to$za}, \emph{ta$\to$da}, \emph{ha$\to$ba}. First anchor: \textbf{\ja{ありがとう}} \emph{arigatō}.
+  \item \texttt{long-o} — in hiragana a long \emph{o} is normally written with \textbf{\ja{う}}, not a bar. First anchor: \textbf{\ja{ありがとう}} \emph{arigatō}.
+\end{itemize}
+
+\section*{Two things this page deliberately does not do}
+
+It does not print the kana chart. A learner who wants the full grid will find it anywhere; a learner who is told to memorise it before Lesson 1 usually stops there, which is the wall HL00 exists to remove.
+
+It does not claim a stroke count as a prerequisite. Stroke order for kana and kanji is real and taught, and it lives in Japanese script reference beside each sign, to be consulted when a hand is free.
+
+\section*{Sources}
+
+\begin{itemize}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item Wiktionary: \href{https://en.wiktionary.org/wiki/\%E3\%81\%AF\%E3\%81\%84}{\ja{はい}}, \href{https://en.wiktionary.org/wiki/\%E4\%BB\%8A\%E6\%97\%A5\%E3\%81\%AF}{\ja{今日}\ja{は}}, \href{https://en.wiktionary.org/wiki/\%E6\%9C\%89\%E9\%9B\%A3\%E3\%81\%86}{\ja{有難}\ja{う}}, and \href{https://en.wiktionary.org/wiki/\%E3\%82\%B3\%E3\%83\%BC\%E3\%83\%92\%E3\%83\%BC}{\ja{コーヒー}}.
+\end{itemize}

--- a/code/learning/human-languages/japanese/pronunciation-reference.md
+++ b/code/learning/human-languages/japanese/pronunciation-reference.md
@@ -55,12 +55,12 @@ there, which is the wall HL00 exists to remove.
 
 It does not claim a stroke count as a prerequisite. Stroke order for kana and
 kanji is real and taught, and it lives in
-[`../data/scripts/japanese.json`](../data/scripts/japanese.json) beside each
+[Japanese script reference](../data/scripts/japanese.json) beside each
 sign, to be consulted when a hand is free.
 
 ## Sources
 
-- [Wiktionary: はい](https://en.wiktionary.org/wiki/%E3%81%AF%E3%81%84)
-- [Wiktionary: 今日は](https://en.wiktionary.org/wiki/%E4%BB%8A%E6%97%A5%E3%81%AF)
-- [Wiktionary: 有難う](https://en.wiktionary.org/wiki/%E6%9C%89%E9%9B%A3%E3%81%86)
-- [Wiktionary: コーヒー](https://en.wiktionary.org/wiki/%E3%82%B3%E3%83%BC%E3%83%92%E3%83%BC)
+- Wiktionary: [はい](https://en.wiktionary.org/wiki/%E3%81%AF%E3%81%84),
+  [今日は](https://en.wiktionary.org/wiki/%E4%BB%8A%E6%97%A5%E3%81%AF),
+  [有難う](https://en.wiktionary.org/wiki/%E6%9C%89%E9%9B%A3%E3%81%86), and
+  [コーヒー](https://en.wiktionary.org/wiki/%E3%82%B3%E3%83%BC%E3%83%92%E3%83%BC).

--- a/code/learning/human-languages/persian/book/book.tex
+++ b/code/learning/human-languages/persian/book/book.tex
@@ -83,6 +83,8 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \backmatter
 
+\input{chapters/appendix-pronunciation}
+
 \chapter*{A note on sources}
 \addcontentsline{toc}{chapter}{A note on sources}
 

--- a/code/learning/human-languages/persian/book/chapters/appendix-pronunciation.tex
+++ b/code/learning/human-languages/persian/book/chapters/appendix-pronunciation.tex
@@ -1,0 +1,135 @@
+% GENERATED FILE. Edit persian/pronunciation-reference.md, then run npm run generate:books.
+
+\chapter*{Pronunciation \& Script Reference}
+\addcontentsline{toc}{chapter}{Pronunciation \& Script Reference}
+\markboth{Pronunciation}{Pronunciation}
+
+A \textbf{reference}, not a chapter. Look up a sound when a lesson names it; do not memorize this page first. The lessons introduce Persian script inside language the learner can already understand, one word-sized pattern at a time.
+
+This track uses a learner romanization: \textbf{â} marks long \emph{a}; \textbf{u} marks the long vowel in \emph{mamnun}. Romanization is temporary scaffolding. Train your eye on the Persian form and gradually cover the Latin line.
+
+\section*{The script in three facts}
+
+\begin{enumerate}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item \textbf{Read right to left} (\texttt{rtl}). Words and sentences begin at the right edge.
+  \item \textbf{Most letters join}, and their shape responds to position. Some letters do not connect leftward to the next letter. In \textbf{\fa{سلام}}, \textbf{\fa{ا}} creates the visible break before final \textbf{\fa{م}}.
+  \item \textbf{Short vowels are normally unwritten} (\texttt{short-vowels-unwritten}). Learn the vowel pattern with the word. The long vowels are represented with \textbf{\fa{ا}} \emph{â}, \textbf{\fa{و}} \emph{u}, and \textbf{\fa{ی}} \emph{i}.
+\end{enumerate}
+
+Persian has no uppercase/lowercase distinction. Its alphabet adds \textbf{\fa{پ}} \emph{p}, \textbf{\fa{چ}} \emph{ch}, \textbf{\fa{ژ}} \emph{zh}, and \textbf{\fa{گ}} \emph{g} to the inherited Arabic inventory; the lessons will introduce them only when a useful word needs them.
+
+\section*{Sound ids used by the starter lessons}
+
+\begin{itemize}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{rtl}
+  \par \textbf{What to do:} start at the right edge and follow the word leftward
+  \par \textbf{First anchor:} \textbf{\fa{سلام}} \emph{salâm}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{long-a}
+  \par \textbf{What to do:} hold \textbf{\fa{ا}} as a steady \emph{â}, near the vowel in “father”
+  \par \textbf{First anchor:} \textbf{\fa{سلام}} \emph{salâm}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{long-u}
+  \par \textbf{What to do:} hold \textbf{\fa{و}} as \emph{u}, near “oo” in “food,” without an English off-glide
+  \par \textbf{First anchor:} \textbf{\fa{ممنون}} \emph{mamnun}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{long-i}
+  \par \textbf{What to do:} hold \textbf{\fa{ی}} as long \emph{i} in the learned word
+  \par \textbf{First anchor:} \textbf{\fa{چیست}} \emph{chist}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{short-vowels-unwritten}
+  \par \textbf{What to do:} supply learned \emph{a, e,} or \emph{o} even when no separate vowel letter appears
+  \par \textbf{First anchor:} \textbf{\fa{بله}} \emph{bale}, \textbf{\fa{نه}} \emph{na}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{ezafe-e}
+  \par \textbf{What to do:} say a light linking \emph{-e} after a noun before its owner or description; ordinary text often leaves it unmarked
+  \par \textbf{First anchor:} \textbf{\fa{اسمِ} \fa{من}} \emph{esm-e man}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{sh}
+  \par \textbf{What to do:} read three-dotted \textbf{\fa{ش}} as \emph{sh}
+  \par \textbf{First anchor:} \textbf{\fa{شما}} \emph{shomâ}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{persian-che}
+  \par \textbf{What to do:} read Persian \textbf{\fa{چ}} as \emph{ch}
+  \par \textbf{First anchor:} \textbf{\fa{چیست}} \emph{chist}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{kh}
+  \par \textbf{What to do:} make \textbf{\fa{خ}} farther back than English \emph{h}; a gentle approximation is acceptable first
+  \par \textbf{First anchor:} \textbf{\fa{خوب}} \emph{khub}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{gh}
+  \par \textbf{What to do:} use the modern Iranian Persian voiced back-of-the-mouth sound for \textbf{\fa{غ}}
+  \par \textbf{First anchor:} \textbf{\fa{خوشوقتم}} \emph{khoshvaghtam}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{vav-o}
+  \par \textbf{What to do:} let \textbf{\fa{و}} carry the learned \emph{o} value in this word
+  \par \textbf{First anchor:} \textbf{\fa{چطور}} \emph{chetor}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{persian-question-mark}
+  \par \textbf{What to do:} recognize \textbf{\fa{؟}} at the left end of a right-to-left question
+  \par \textbf{First anchor:} \textbf{\fa{اسم} \fa{شما} \fa{چیست؟}}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{alef-madde}
+  \par \textbf{What to do:} read \textbf{\fa{آ}} — alef under a wavy \emph{madde} — as a word-initial long \emph{â}
+  \par \textbf{First anchor:} \textbf{\fa{آمدن}} \emph{âmadan}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{persian-gaf}
+  \par \textbf{What to do:} read \textbf{\fa{گ}} \emph{gâf} as English \emph{g} in “go”; it is a Persian addition to the Arabic set
+  \par \textbf{First anchor:} \textbf{\fa{گفتن}} \emph{goftan}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{persian-pe}
+  \par \textbf{What to do:} read \textbf{\fa{پ}} \emph{pe} as English \emph{p}; a \textbf{\fa{ب}} shape with three dots beneath, and the third of Persian's four additions
+  \par \textbf{First anchor:} \textbf{\fa{پرسیدن}} \emph{porsidan}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{silent-vav}
+  \par \textbf{What to do:} after \textbf{\fa{خ}} and before \textbf{\fa{ا}}, leave \textbf{\fa{و}} unpronounced — it is written, never said
+  \par \textbf{First anchor:} \textbf{\fa{خواندن}} \emph{khândan}
+  \end{minipage}
+\end{itemize}
+
+\section*{Read the current word before the whole alphabet}
+
+\begin{itemize}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item \textbf{\fa{سلام}} gives \textbf{\fa{س} \fa{ل} \fa{ا} \fa{م}}, right-to-left direction, joining, and long \emph{â}.
+  \item \textbf{\fa{ممنون}} reuses \textbf{\fa{م}}, adds \textbf{\fa{ن} \fa{و}}, and assigns \textbf{\fa{و}} its long-\emph{u} job in this word.
+  \item \textbf{\fa{بله}} and \textbf{\fa{نه}} make the missing short vowels visible by contrast: the spelling supplies a consonantal frame; the learned word supplies \emph{a/e}.
+  \item \textbf{\fa{اسم} \fa{من} ... \fa{است}} recombines familiar letters and adds one spoken grammar cue, ezafe \textbf{-e}. The cue is often heard but not printed.
+  \item \textbf{\fa{شما}}, \textbf{\fa{چیست}}, and \textbf{\fa{خوشوقتم}} add \emph{sh}, Persian \textbf{\fa{چ}}, and the back sounds in \textbf{\fa{خ}/\fa{غ}} only inside the name exchange.
+  \item \textbf{\fa{حال} \fa{شما} \fa{چطور} \fa{است؟}} reuses ezafe and the Persian question mark; \textbf{\fa{چطور}} gives \textbf{\fa{و}} its learned \emph{o} value, while \textbf{\fa{خوبم}} returns to long-\emph{u} \textbf{\fa{و}}.
+  \item \textbf{\fa{خدا}} reuses \textbf{\fa{خ}} and long-\emph{â} \textbf{\fa{ا}}; \textbf{\fa{حافظ}} adds a clear initial \emph{h} and a final \textbf{\fa{ظ}} pronounced \emph{z} in modern Persian. The complete farewell is normally joined in Persian as \textbf{\fa{خداحافظ}}.
+  \item \textbf{\fa{بودن}}, \textbf{\fa{رفتن}}, and \textbf{\fa{دانستن}} need no new letters at all; the verb chapter adds only \textbf{\fa{آ}} (alef wearing a \emph{madde}, for a word opening on long \emph{â}) inside \textbf{\fa{آمدن}}, and \textbf{\fa{گ}} \emph{gâf} inside \textbf{\fa{گفتن}} — the second of the four Persian additions \textbf{\fa{پ} \fa{چ} \fa{ژ} \fa{گ}} the learner has now met.
+\end{itemize}
+
+One spelling symbol can do more than one job in later words—especially \textbf{\fa{و}} and \textbf{\fa{ی}}—so read from the word and context rather than assigning each shape one English value forever.
+
+\section*{Sources}
+
+\begin{itemize}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item \href{https://sites.la.utexas.edu/persian\_online\_resources/the-writing-system/}{Persian Online: The Writing System}
+  \item \href{https://sites.la.utexas.edu/persian\_online\_resources/the-writing-system/initial-medial-final-and-freestanding-letters/}{Persian Online: Connecting Characters}
+  \item \href{https://sites.la.utexas.edu/persian\_online\_resources/phonology/phonology-1/}{Persian Online: Vowels}
+\end{itemize}

--- a/code/learning/human-languages/russian/book/book.tex
+++ b/code/learning/human-languages/russian/book/book.tex
@@ -87,6 +87,8 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \backmatter
 
+\input{chapters/appendix-pronunciation}
+
 \chapter*{A note on sources}
 \addcontentsline{toc}{chapter}{A note on sources}
 

--- a/code/learning/human-languages/russian/book/chapters/appendix-pronunciation.tex
+++ b/code/learning/human-languages/russian/book/chapters/appendix-pronunciation.tex
@@ -1,0 +1,72 @@
+% GENERATED FILE. Edit russian/pronunciation-reference.md, then run npm run generate:books.
+
+\chapter*{Pronunciation \& Cyrillic Reference}
+\addcontentsline{toc}{chapter}{Pronunciation \& Cyrillic Reference}
+\markboth{Pronunciation}{Pronunciation}
+
+A \textbf{reference}, not a chapter — a place to look things up. You are \emph{not} meant to read this before the lessons: the lessons teach reading through real words, introducing each letter as a word needs it. This page gathers the system in one spot. Full letter-by-letter decomposition (components + stroke order) lives in the machine-readable Cyrillic script reference.
+
+\section*{The one thing that trips everyone: false friends}
+
+Cyrillic descends, like the Latin and Greek alphabets, from the Greek alphabet — so some letters are shared, but others look identical to Latin letters and say something completely different. These four cause 90\% of beginner misreadings:
+
+\begin{itemize}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Cyrillic:} \textbf{\ru{в}}
+  \par \textbf{looks like Latin…:} B
+  \par \textbf{actually says:} \textbf{v}
+  \par \textbf{mnemonic:} Greek \emph{beta} drifted to a \textquotedblleft{}v\textquotedblright{} sound
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Cyrillic:} \textbf{\ru{р}}
+  \par \textbf{looks like Latin…:} P
+  \par \textbf{actually says:} \textbf{r}
+  \par \textbf{mnemonic:} Greek \emph{rho}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Cyrillic:} \textbf{\ru{с}}
+  \par \textbf{looks like Latin…:} C
+  \par \textbf{actually says:} \textbf{s}
+  \par \textbf{mnemonic:} Greek \emph{sigma} (a \textquotedblleft{}c\textquotedblright{} that hisses)
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Cyrillic:} \textbf{\ru{н}}
+  \par \textbf{looks like Latin…:} H
+  \par \textbf{actually says:} \textbf{n}
+  \par \textbf{mnemonic:} Greek \emph{eta} / Latin N with a level bar
+  \end{minipage}
+\end{itemize}
+
+Two vowels also mislead: \textbf{\ru{у}} looks like Latin \emph{y} but says \textbf{\textquotedblleft{}oo\textquotedblright{}}; \textbf{\ru{х}} looks like Latin \emph{x} but says a raspy \textbf{\textquotedblleft{}kh.\textquotedblright{}}
+
+\section*{The letters, grouped by how they behave}
+
+\begin{itemize}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item \textbf{Same look, same sound}: \textbf{\ru{а}} (a), \textbf{\ru{е}} (ye), \textbf{\ru{к}} (k), \textbf{\ru{м}} (m), \textbf{\ru{о}} (o), \textbf{\ru{т}} (t).
+  \item \textbf{False friends} (look Latin, sound different): \textbf{\ru{в}} (v), \textbf{\ru{р}} (r), \textbf{\ru{с}} (s), \textbf{\ru{н}} (n), \textbf{\ru{у}} (oo), \textbf{\ru{х}} (kh).
+  \item \textbf{Greek-shaped}: \textbf{\ru{г}} (g, gamma Γ), \textbf{\ru{д}} (d, delta Δ), \textbf{\ru{л}} (l, lambda Λ), \textbf{\ru{п}} (p, pi Π), \textbf{\ru{ф}} (f, phi Φ).
+  \item \textbf{Sounds English writes with two letters}: \textbf{\ru{ж}} (zh, as in \emph{measure}), \textbf{\ru{ч}} (ch), \textbf{\ru{ш}} (sh), \textbf{\ru{щ}} (shch), \textbf{\ru{ц}} (ts), \textbf{\ru{ю}} (yu), \textbf{\ru{я}} (ya), \textbf{\ru{ё}} (yo).
+  \item \textbf{The vowel English hasn't got}: \textbf{\ru{ы}} (\texttt{yery-vowel}) — not the \emph{ee} of \textbf{\ru{и}}, but a tighter sound made with the tongue \textbf{drawn back}. Say English \emph{ill}, then say it again with your tongue pulled towards your throat. It is the single hardest Russian vowel for an English speaker, and it carries real meaning: \textbf{\ru{ты}} (\emph{you}) and \textbf{\ru{вы}} (\emph{you}, formal) both turn on it.
+  \item \textbf{The two signs} — \textbf{\ru{ъ}} (hard sign) and \textbf{\ru{ь}} (soft sign) — spell \emph{no sound of their own}; they only tell you how to pronounce the consonant before them (\ru{ь} softens it).
+\end{itemize}
+
+\section*{Two rules that make you sound native}
+
+\begin{itemize}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item \textbf{Stress is unmarked and it matters.} Russian never prints its stress accent, but stress governs the vowels — so you learn each word \emph{with} its stress. (This reference marks it with an acute, \emph{privét}, but real text won't.)
+  \item \textbf{Unstressed \ru{о} $\to$ \textquotedblleft{}a\textquotedblright{} (akanye).} An \textbf{\ru{о}} not under stress reduces toward an \emph{a}-ish sound: \emph{\ru{спасибо}} is said \emph{\textquotedblleft{}spa-SEE-ba,\textquotedblright{}} \emph{\ru{хорошо}} as \emph{\textquotedblleft{}kha-ra-SHO.\textquotedblright{}}
+\end{itemize}
+
+\section*{Sound ids used in the lessons}
+
+The lessons' \texttt{sounds:} frontmatter points here: \texttt{cyrillic-false-friends} (the table above), \texttt{stress-unmarked} and \texttt{o-reduction} (the two rules), \texttt{e-ye} (\ru{е} carries a \emph{y}-glide), \texttt{zh-sound} (\ru{ж}), \texttt{b-vs-v} (\ru{б} vs \ru{в}), \texttt{silent-v} (the dropped \ru{в} in \emph{\ru{здравствуйте}}), \texttt{syllable-drop} (spoken contractions like \emph{pa-ZHAL-sta}), \texttt{a-clear} / \texttt{a-father} (the pure \emph{a}).
+
+\section*{Russian in the Slavic family}
+
+\textbf{Slavic} is a branch of \textbf{Indo-European}, so Russian is a distant cousin of English, Latin, and Sanskrit — which is why its deepest words (\emph{\ru{нет}} $\leftarrow$ \emph{*ne}, \emph{\ru{есть}} \textquotedblleft{}is\textquotedblright{} $\leftarrow$ the same root as English \emph{is}) line up with words you already own. Cyrillic itself was built in the 9th century from Greek letters (plus a few invented for Slavic sounds Greek lacked) to write Old Church Slavonic — which is why so many letters are Greek in disguise.

--- a/code/learning/human-languages/russian/pronunciation-reference.md
+++ b/code/learning/human-languages/russian/pronunciation-reference.md
@@ -4,7 +4,7 @@ A **reference**, not a chapter — a place to look things up. You are *not* mean
 to read this before the lessons: the lessons teach reading through real words,
 introducing each letter as a word needs it. This page gathers the system in one
 spot. Full letter-by-letter decomposition (components + stroke order) lives in
-the machine-readable [`data/scripts/cyrillic.json`](../data/scripts/cyrillic.json).
+the machine-readable [Cyrillic script reference](../data/scripts/cyrillic.json).
 
 ## The one thing that trips everyone: false friends
 

--- a/code/learning/human-languages/urdu/book/book.tex
+++ b/code/learning/human-languages/urdu/book/book.tex
@@ -87,6 +87,8 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \backmatter
 
+\input{chapters/appendix-pronunciation}
+
 \chapter*{A note on sources}
 \addcontentsline{toc}{chapter}{A note on sources}
 

--- a/code/learning/human-languages/urdu/book/chapters/appendix-pronunciation.tex
+++ b/code/learning/human-languages/urdu/book/chapters/appendix-pronunciation.tex
@@ -1,0 +1,169 @@
+% GENERATED FILE. Edit urdu/pronunciation-reference.md, then run npm run generate:books.
+
+\chapter*{Pronunciation \& Script Reference}
+\addcontentsline{toc}{chapter}{Pronunciation \& Script Reference}
+\markboth{Pronunciation}{Pronunciation}
+
+A \textbf{reference}, not a chapter. Use it when a lesson names a sound; do not clear it as an alphabet gate. Urdu script is introduced through useful expressions, with only the shapes and sound contrasts needed on that page.
+
+The track shows a learner romanization beside new Urdu. A line above a vowel marks length (\textbf{ā, ī}), and a tilde marks nasalization (\textbf{ā̃, ī̃}). Cover the romanization once the Urdu form is familiar.
+
+\section*{Script, spelling, and type style}
+
+\begin{itemize}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item \textbf{Read right to left} (\texttt{rtl}). Start each word at its right edge.
+  \item \textbf{Letters usually join} and change shape by position. Some letters, including \textbf{\ur{ا}} and \textbf{\ur{ر}} in current words, break the connection to the following shape on their left.
+  \item Urdu is an \textbf{abjad}: some vowels are unwritten and inferred from the learned word (\texttt{short-vowels-unwritten}). Long vowels use letter shapes such as \textbf{\ur{ا}}, \textbf{\ur{و}}, and \textbf{\ur{ی}}; \textbf{\ur{ے}} can carry \emph{e/ai}.
+  \item Urdu is traditionally printed in \textbf{Nastaliq}, whose connected words descend in a flowing slope. The book and app use the vendored static Noto Nastaliq Urdu family, including its Urdu OpenType localization and contextual joins. Naskh remains an accessibility fallback when a learner's browser cannot load the course font; it is no longer the normal presentation.
+\end{itemize}
+
+\section*{Sound ids used by the starter lessons}
+
+\begin{itemize}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{rtl}
+  \par \textbf{What to do:} follow the word from its right edge leftward
+  \par \textbf{First anchor:} \textbf{\ur{سلام}} \emph{salām}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{long-a}
+  \par \textbf{What to do:} hold \emph{ā} steady; \textbf{\ur{ا}} carries it in \textbf{\ur{سلام}}
+  \par \textbf{First anchor:} \textbf{\ur{سلام}} \emph{salām}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{alif-madd}
+  \par \textbf{What to do:} read \textbf{\ur{آ}} as word-initial long \emph{ā}
+  \par \textbf{First anchor:} \textbf{\ur{آپ}} \emph{āp}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{short-vowels-unwritten}
+  \par \textbf{What to do:} supply the learned short vowels even when vowel marks are absent
+  \par \textbf{First anchor:} \textbf{\ur{شکریہ}} \emph{shukriyā}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{long-i}
+  \par \textbf{What to do:} hold \textbf{\ur{ی}} as \emph{ī} in this word
+  \par \textbf{First anchor:} \textbf{\ur{جی}} \emph{jī}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{long-u}
+  \par \textbf{What to do:} hold \textbf{\ur{و}} as long \emph{ū} in the learned word
+  \par \textbf{First anchor:} \textbf{\ur{ہوں}} \emph{hūṅ}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{nasal-vowel}
+  \par \textbf{What to do:} let air pass through the nose; final \textbf{\ur{ں}} does not add a full English \emph{n}
+  \par \textbf{First anchor:} \textbf{\ur{ہاں}} \emph{hā̃}, \textbf{\ur{نہیں}} \emph{nahī̃}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{long-vowels}
+  \par \textbf{What to do:} read the word's written long-vowel cues rather than stretching every vowel
+  \par \textbf{First anchor:} \textbf{\ur{میرا} \ur{نام}} \emph{merā nām}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{hai-diphthong}
+  \par \textbf{What to do:} say \textbf{\ur{ہے}} as one \emph{hai} syllable, ending in an \emph{ai} glide
+  \par \textbf{First anchor:} \textbf{\ur{ہے}} \emph{hai}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{sh}
+  \par \textbf{What to do:} read three-dotted \textbf{\ur{ش}} as \emph{sh}
+  \par \textbf{First anchor:} \textbf{\ur{شکریہ}} \emph{shukriyā}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{kh}
+  \par \textbf{What to do:} make \textbf{\ur{خ}} farther back than English \emph{h}
+  \par \textbf{First anchor:} \textbf{\ur{خوشی}} \emph{khushī}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{consonantal-ye}
+  \par \textbf{What to do:} let \textbf{\ur{ی}} supply consonantal \emph{y} before a vowel
+  \par \textbf{First anchor:} \textbf{\ur{کیا}} \emph{kyā}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{ai-diphthong}
+  \par \textbf{What to do:} say \emph{ai} as one glide in the learned question word
+  \par \textbf{First anchor:} \textbf{\ur{کیسے}} \emph{kaise}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{final-ye}
+  \par \textbf{What to do:} distinguish broad final \textbf{\ur{ے}} \emph{e} from final \textbf{\ur{ی}} long \emph{ī}
+  \par \textbf{First anchor:} \textbf{\ur{کیسے} / \ur{کیسی}} \emph{kaise / kaisī}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{retroflex-aspirated-th}
+  \par \textbf{What to do:} curl the tongue slightly back for \textbf{\ur{ٹ}}, then release the aspiration marked by \textbf{\ur{ھ}}
+  \par \textbf{First anchor:} \textbf{\ur{ٹھیک}} \emph{ṭhīk}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{urdu-question-mark}
+  \par \textbf{What to do:} recognize \textbf{\ur{؟}} at the left end of a right-to-left question
+  \par \textbf{First anchor:} \textbf{\ur{آپ} \ur{کا} \ur{نام} \ur{کیا} \ur{ہے؟}}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{be-vs-pe-dots}
+  \par \textbf{What to do:} count the dots under the shared low scoop: one below is \textbf{\ur{ب}} \emph{b}, three below are \textbf{\ur{پ}} \emph{p}
+  \par \textbf{First anchor:} \textbf{\ur{بولنا}} \emph{bolnā} against \textbf{\ur{آپ}} \emph{āp}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{geminate-nun}
+  \par \textbf{What to do:} hold the \emph{n} long when two \textbf{\ur{ن}} letters are written in a row
+  \par \textbf{First anchor:} \textbf{\ur{جاننا}} \emph{jānnā}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{che-vs-jim-dots}
+  \par \textbf{What to do:} count the dots below the \emph{jīm} body: one is \textbf{\ur{ج}} \emph{j}, three are \textbf{\ur{چ}} \emph{ch}
+  \par \textbf{First anchor:} \textbf{\ur{سوچنا}} \emph{sochnā} against \textbf{\ur{جانا}} \emph{jānā}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{do-chashmi-he}
+  \par \textbf{What to do:} give \textbf{\ur{ھ}} no sound of its own; let it aspirate the letter to its right
+  \par \textbf{First anchor:} \textbf{\ur{سمجھنا}} \emph{samajhnā}, \textbf{\ur{لکھنا}} \emph{likhnā}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{retroflex-flap-rre}
+  \par \textbf{What to do:} flick a curled-back tongue once for \textbf{\ur{ڑ}}; do not roll it
+  \par \textbf{First anchor:} \textbf{\ur{پڑھنا}} \emph{paṛhnā}
+  \end{minipage}
+  \item \begin{minipage}[t]{\linewidth}
+  \textbf{Sound id:} \texttt{majhul-e}
+  \par \textbf{What to do:} read medial \textbf{\ur{ی}} as long \emph{e} where the learned word calls for it
+  \par \textbf{First anchor:} \textbf{\ur{لینا}} \emph{lenā}
+  \end{minipage}
+\end{itemize}
+
+\section*{Shape families already in use}
+
+\begin{itemize}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item \textbf{\ur{س}} \emph{s} and \textbf{\ur{ش}} \emph{sh} share a skeleton; three dots distinguish \textbf{\ur{ش}}.
+  \item \textbf{\ur{ن}} is consonantal \emph{n}. Final dotless \textbf{\ur{ں}} is \emph{nūn-e ghunna} and marks nasalization in \textbf{\ur{ہاں}} and \textbf{\ur{نہیں}}.
+  \item \textbf{\ur{ی}} supplies the long \emph{ī} in \textbf{\ur{جی}} and \textbf{\ur{نہیں}}. Final \textbf{\ur{ے}} participates in \emph{hai} in \textbf{\ur{ہے}}. Learn each role in its word before generalizing.
+  \item \textbf{\ur{کیا}} gives \textbf{\ur{ی}} its consonantal \emph{y} job; \textbf{\ur{کیسے} / \ur{کیسی}} then contrast broad final \textbf{\ur{ے}} with long-\emph{ī} final \textbf{\ur{ی}}.
+  \item \textbf{\ur{ٹھیک}} introduces the Indic retroflex-plus-aspiration sequence \textbf{\ur{ٹھ}} only when the wellbeing reply needs it.
+  \item \textbf{\ur{خدا} \ur{حافظ}} reuses \textbf{\ur{خ}} and long \textbf{\ur{ا}}, adds a clear initial \emph{h} in \textbf{\ur{حافظ}}, and reads final \textbf{\ur{ظ}} as \emph{z}. Urdu conventionally keeps the two words visibly spaced, even though Persian normally joins its local spelling.
+  \item \textbf{\ur{بولنا}} adds the only new consonant the verb chapter needs: \textbf{\ur{ب}} \emph{b}, one low scoop with a single dot below. It shares that skeleton with \textbf{\ur{پ}} \emph{p}, already read in \textbf{\ur{آپ}}, which carries three dots below instead. Dot count is the whole difference, and it is load-bearing throughout the alphabet.
+  \item \textbf{\ur{جاننا}} writes two \textbf{\ur{ن}} letters in a row and pronounces both, which is the only thing separating it from \textbf{\ur{جانا}} \emph{jānā}. Nothing about the doubling is decorative: \textbf{\ur{جانا}} is “to go” and \textbf{\ur{جاننا}} is “to know.”
+  \item \textbf{\ur{چ}} \emph{ch} is the \textbf{\ur{ج}} \emph{j} body with \textbf{three dots below} instead of one — the same dot-count contrast as \textbf{\ur{ب}} against \textbf{\ur{پ}}, on a second skeleton.
+  \item \textbf{\ur{ھ}} is \emph{do-chashmī he}, “two-eyed he.” It is never a consonant on its own; it aspirates whatever letter stands to its right. \textbf{\ur{ٹھیک}} used it first, and \textbf{\ur{سمجھنا}}, \textbf{\ur{پڑھنا}}, \textbf{\ur{پوچھنا}} and \textbf{\ur{لکھنا}} use it again in \textbf{\ur{جھ}}, \textbf{\ur{ڑھ}}, \textbf{\ur{چھ}} and \textbf{\ur{کھ}}. Keep it apart from round \textbf{\ur{ہ}} \emph{gol he}, which is a real \emph{h} and is the letter in \textbf{\ur{ہوں}} and \textbf{\ur{ہونا}}.
+  \item \textbf{\ur{ڑ}} is \textbf{\ur{ر}} \emph{r} wearing the small retroflex mark that also rides on \textbf{\ur{ٹ}}. One diacritic, one instruction — curl the tongue back — now on two letters.
+  \item \textbf{\ur{ی}} takes a \textbf{third} value in \textbf{\ur{لینا}} \emph{lenā}: a long \emph{e}. With consonantal \emph{y} in \textbf{\ur{کیا}} and long \emph{ī} in \textbf{\ur{جی}}, and broad final \textbf{\ur{ے}} beside it, the \emph{ye} family covers \emph{y}, \emph{ī} and \emph{e}; the learned word decides.
+\end{itemize}
+
+\section*{The Persian-Arabic and Indo-Aryan layers}
+
+Script does not determine a word's history. \textbf{\ur{سلام}} and \textbf{\ur{شکریہ}} expose the Persian-Arabic literary layer; \textbf{\ur{نہیں}}, \textbf{\ur{میرا}}, \textbf{\ur{نام}}, and \textbf{\ur{ہے}} expose the inherited Indo-Aryan core that Urdu shares with Hindi. Mixed-language practice may use that relationship as a bridge, but the Urdu script remains the assessed form for this track.
+
+\section*{Sources}
+
+\begin{itemize}
+\raggedright
+\setlength{\itemsep}{0.35em}
+  \item \href{https://openbooks.library.northwestern.edu/zerozabar/front-matter/introduction/}{\emph{Zero Zabar}: How the Urdu script works}
+  \item \href{https://openbooks.library.northwestern.edu/zerozabar/chapter/the-urdu-alphabet/}{\emph{Zero Zabar}: The Urdu alphabet}
+\end{itemize}

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — canonical pronunciation back matter
+
+- Render canonical pronunciation-reference Markdown into LaTeX back matter,
+  including headings, ordered and unordered lists, tables, citations, and each
+  track's configured script font commands.
+- Byte-gate the new Chinese, Japanese, Persian, Russian, and Urdu appendices with
+  `book-cli --check`, bringing pronunciation back matter to all 22 books.
+
 ### Fixed — clean development dependency audit
 
 - Refresh transitive Nano ID from 3.3.16 to 3.3.18 and PostCSS from 8.5.19 to

--- a/code/packages/typescript/human-language-data/src/book-cli.ts
+++ b/code/packages/typescript/human-language-data/src/book-cli.ts
@@ -3,12 +3,19 @@ import { dirname, join, normalize, relative as pathRelative, resolve } from "nod
 import { pathToFileURL } from "node:url";
 import {
   renderBookChapter,
+  renderReferenceAppendix,
   type BookGenerationTarget,
+  type BookReferenceAppendixTarget,
   type InlineRenderOptions,
 } from "./book.js";
 import { defaultCurriculumRoot, loadLessons, loadTrackChapters } from "./loader.js";
 
 interface ConfiguredBookGenerationTarget extends BookGenerationTarget {
+  /** Named reusable mapping from the config's scriptSets table. */
+  scriptSet?: string;
+}
+
+interface ConfiguredReferenceAppendixTarget extends BookReferenceAppendixTarget {
   /** Named reusable mapping from the config's scriptSets table. */
   scriptSet?: string;
 }
@@ -46,6 +53,8 @@ interface BookGenerationConfig {
   sourceBaseUrl: string;
   scriptSets?: Record<string, InlineRenderOptions[]>;
   targets: ConfiguredBookGenerationTarget[];
+  /** Canonical Markdown references rendered into book back matter. */
+  referenceAppendices?: ConfiguredReferenceAppendixTarget[];
   /** Never rendered. See {@link HandwrittenBookChapter}. */
   handwritten?: HandwrittenBookChapter[];
 }
@@ -82,6 +91,20 @@ function safeOutput(root: string, relative: string): string {
     throw new Error(`unsafe generated book output '${relative}'`);
   }
   return output;
+}
+
+function safeMarkdownSource(root: string, relative: string): string {
+  const source = resolve(root, relative);
+  const fromRoot = normalize(pathRelative(resolve(root), source)).replaceAll("\\", "/");
+  if (
+    fromRoot === "" ||
+    fromRoot === ".." ||
+    fromRoot.startsWith("../") ||
+    !fromRoot.endsWith(".md")
+  ) {
+    throw new Error(`unsafe generated book source '${relative}'`);
+  }
+  return source;
 }
 
 /**
@@ -162,6 +185,38 @@ export function generatedBookOutputs(root = defaultCurriculumRoot()): Map<string
       lessonIds: generated.lessonIds,
       tex: target.output,
     });
+  }
+  for (const configuredAppendix of config.referenceAppendices ?? []) {
+    const { scriptSet, ...plainAppendix } = configuredAppendix;
+    let appendix: BookReferenceAppendixTarget = { ...plainAppendix };
+    if (scriptSet !== undefined) {
+      if (
+        appendix.inlineScripts !== undefined ||
+        appendix.unicodeScript !== undefined ||
+        appendix.scriptCommand !== undefined
+      ) {
+        throw new Error(
+          `${appendix.language} reference appendix: scriptSet cannot be combined with inline script options`,
+        );
+      }
+      const inlineScripts = config.scriptSets?.[scriptSet];
+      if (!inlineScripts) {
+        throw new Error(
+          `${appendix.language} reference appendix: unknown scriptSet '${scriptSet}'`,
+        );
+      }
+      appendix = { ...appendix, inlineScripts };
+    }
+    const source = safeMarkdownSource(root, appendix.source);
+    safeOutput(root, appendix.output);
+    if (!existsSync(source)) throw new Error(`${appendix.source}: reference source is missing`);
+    if (outputs.has(appendix.output)) {
+      throw new Error(`${appendix.output}: duplicate generated book output`);
+    }
+    outputs.set(
+      appendix.output,
+      renderReferenceAppendix(appendix, readFileSync(source, "utf8")),
+    );
   }
   manifest.chapters.sort(
     (left, right) => left.language.localeCompare(right.language) || left.chapter - right.chapter,

--- a/code/packages/typescript/human-language-data/src/book.ts
+++ b/code/packages/typescript/human-language-data/src/book.ts
@@ -17,6 +17,20 @@ export interface BookGenerationTarget {
   inlineScripts?: InlineRenderOptions[];
 }
 
+/** A generated back-matter reference sourced from canonical Markdown. */
+export interface BookReferenceAppendixTarget {
+  language: string;
+  title: string;
+  source: string;
+  output: string;
+  /** Unicode Script property whose runs need the book's dedicated font command. */
+  unicodeScript?: string;
+  /** LaTeX command name, without the leading backslash, used for those runs. */
+  scriptCommand?: string;
+  /** Multiple script/font mappings for references that compare writing systems inline. */
+  inlineScripts?: InlineRenderOptions[];
+}
+
 export interface InlineRenderOptions {
   unicodeScript: string;
   scriptCommand: string;
@@ -653,6 +667,7 @@ export function renderInlineMarkdown(
 function renderMarkdown(
   markdown: string,
   options?: InlineRenderOptionsInput,
+  tableLayout: "grid" | "records" = "grid",
 ): string {
   const output: string[] = [];
   const paragraph: string[] = [];
@@ -700,6 +715,32 @@ function renderMarkdown(
           renderInlineMarkdown(`| ${row.join(" | ")} |`, options),
           "",
         ]),
+      );
+      tableRows.length = 0;
+      return;
+    }
+    if (tableLayout === "records") {
+      const renderedHeader = header.map((cell) => renderInlineMarkdown(cell, options));
+      output.push(
+        "\\begin{itemize}",
+        "\\raggedright",
+        "\\setlength{\\itemsep}{0.35em}",
+        ...body.flatMap((row) => {
+          const rendered = Array.from({ length: header.length }, (_, index) =>
+            renderInlineMarkdown(row[index] ?? "", options),
+          );
+          return [
+            "  \\item \\begin{minipage}[t]{\\linewidth}",
+            `  \\textbf{${renderedHeader[0] ?? ""}:} ${rendered[0] ?? ""}`,
+            ...rendered.slice(1).map(
+              (cell, index) =>
+                `  \\par \\textbf{${renderedHeader[index + 1] ?? ""}:} ${cell}`,
+            ),
+            "  \\end{minipage}",
+          ];
+        }),
+        "\\end{itemize}",
+        "",
       );
       tableRows.length = 0;
       return;
@@ -767,6 +808,7 @@ function renderMarkdown(
       flushQuote();
       if (!listOpen) {
         output.push("\\begin{itemize}", "\\raggedright");
+        if (tableLayout === "records") output.push("\\setlength{\\itemsep}{0.35em}");
         listOpen = true;
       }
       flushListItem();
@@ -785,6 +827,53 @@ function renderMarkdown(
   flushQuote();
   closeList();
   flushTable();
+  return output.join("\n").trimEnd();
+}
+
+/** Render reference prose, adding ordered-list support without changing lesson rendering. */
+function renderReferenceMarkdown(
+  markdown: string,
+  options?: InlineRenderOptionsInput,
+): string {
+  const lines = markdown.split(/\r?\n/);
+  const output: string[] = [];
+  const ordinary: string[] = [];
+  const flushOrdinary = (): void => {
+    if (ordinary.length === 0) return;
+    const rendered = renderMarkdown(ordinary.join("\n"), options, "records");
+    if (rendered !== "") output.push(rendered, "");
+    ordinary.length = 0;
+  };
+
+  let cursor = 0;
+  while (cursor < lines.length) {
+    const first = /^(\d+)[.)]\s+(.+)$/.exec((lines[cursor] ?? "").trimEnd());
+    if (!first) {
+      ordinary.push(lines[cursor] ?? "");
+      cursor += 1;
+      continue;
+    }
+
+    flushOrdinary();
+    output.push(
+      "\\begin{enumerate}",
+      "\\raggedright",
+      "\\setlength{\\itemsep}{0.35em}",
+    );
+    while (cursor < lines.length) {
+      const item = /^(\d+)[.)]\s+(.+)$/.exec((lines[cursor] ?? "").trimEnd());
+      if (!item) break;
+      const content = [item[2] ?? ""];
+      cursor += 1;
+      while (cursor < lines.length && /^\s+\S/.test(lines[cursor] ?? "")) {
+        content.push((lines[cursor] ?? "").trim());
+        cursor += 1;
+      }
+      output.push(`  \\item ${renderInlineMarkdown(content.join(" "), options)}`);
+    }
+    output.push("\\end{enumerate}", "");
+  }
+  flushOrdinary();
   return output.join("\n").trimEnd();
 }
 
@@ -835,25 +924,82 @@ function sectionShortTitle(lesson: ParsedLesson, options?: InlineRenderOptionsIn
   );
 }
 
-function targetRenderOptions(target: BookGenerationTarget): InlineRenderOptionsInput | undefined {
+interface InlineRenderTarget {
+  inlineScripts?: InlineRenderOptions[];
+  unicodeScript?: string;
+  scriptCommand?: string;
+}
+
+function targetRenderOptions(
+  target: InlineRenderTarget,
+  description: string,
+): InlineRenderOptionsInput | undefined {
   if (target.inlineScripts !== undefined) {
     if (target.unicodeScript !== undefined || target.scriptCommand !== undefined) {
       throw new Error(
-        `${target.language} chapter ${target.chapter}: inlineScripts cannot be combined with unicodeScript or scriptCommand`,
+        `${description}: inlineScripts cannot be combined with unicodeScript or scriptCommand`,
       );
     }
     if (target.inlineScripts.length === 0) {
-      throw new Error(`${target.language} chapter ${target.chapter}: inlineScripts must not be empty`);
+      throw new Error(`${description}: inlineScripts must not be empty`);
     }
     return target.inlineScripts;
   }
   if (target.unicodeScript === undefined && target.scriptCommand === undefined) return undefined;
   if (target.unicodeScript === undefined || target.scriptCommand === undefined) {
     throw new Error(
-      `${target.language} chapter ${target.chapter}: unicodeScript and scriptCommand must be declared together`,
+      `${description}: unicodeScript and scriptCommand must be declared together`,
     );
   }
   return { unicodeScript: target.unicodeScript, scriptCommand: target.scriptCommand };
+}
+
+/** Render one canonical Markdown pronunciation/script reference as book back matter. */
+export function renderReferenceAppendix(
+  target: BookReferenceAppendixTarget,
+  markdown: string,
+): string {
+  const renderOptions = targetRenderOptions(target, `${target.language} reference appendix`);
+  const lines = markdown.replaceAll("\r\n", "\n").split("\n");
+  const firstContent = lines.findIndex((line) => line.trim() !== "");
+  if (firstContent < 0 || !/^#\s+\S/.test(lines[firstContent] ?? "")) {
+    throw new Error(`${target.source}: reference must begin with a level-one Markdown heading`);
+  }
+  lines.splice(firstContent, 1);
+
+  const output = [
+    `% GENERATED FILE. Edit ${target.source}, then run npm run generate:books.`,
+    "",
+    `\\chapter*{${renderInlineMarkdown(target.title, renderOptions)}}`,
+    `\\addcontentsline{toc}{chapter}{${renderInlineMarkdown(target.title, renderOptions)}}`,
+    "\\markboth{Pronunciation}{Pronunciation}",
+    "",
+  ];
+  const body: string[] = [];
+  const flushBody = (): void => {
+    const rendered = renderReferenceMarkdown(body.join("\n"), renderOptions);
+    if (rendered !== "") output.push(rendered, "");
+    body.length = 0;
+  };
+
+  for (const line of lines) {
+    const heading = /^(#{2,3})\s+(.+)$/.exec(line.trimEnd());
+    if (!heading) {
+      if (/^#\s+/.test(line)) {
+        throw new Error(`${target.source}: reference may contain only one level-one heading`);
+      }
+      body.push(line);
+      continue;
+    }
+    flushBody();
+    const command = (heading[1] ?? "").length === 2 ? "section" : "subsection";
+    output.push(
+      `\\${command}*{${renderInlineMarkdown(heading[2] ?? "", renderOptions)}}`,
+      "",
+    );
+  }
+  flushBody();
+  return `${output.join("\n").trimEnd()}\n`;
 }
 
 /** Render one configured chapter from the same typed lesson AST the app receives. */
@@ -897,7 +1043,7 @@ export function renderBookChapter(
   allLessons: ParsedLesson[],
   capability?: ChapterCapability,
 ): GeneratedBookChapter {
-  const renderOptions = targetRenderOptions(target);
+  const renderOptions = targetRenderOptions(target, `${target.language} chapter ${target.chapter}`);
   const lessons = allLessons
     .filter(
       (lesson) =>

--- a/code/packages/typescript/human-language-data/tests/book-cli.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book-cli.test.ts
@@ -131,6 +131,64 @@ describe("canonical book generator filesystem shell", () => {
     expect(chapter).toContain("\\te{తెలుగు} \\ta{தமிழ்}");
   });
 
+  it("writes and byte-checks configured canonical reference appendices", () => {
+    const root = fixture();
+    const configPath = join(root, "core", "book-generation.json");
+    const config = JSON.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
+    writeFileSync(join(root, "test", "pronunciation-reference.md"), `# Test reference
+
+## The script
+
+- Read **తెలుగు**.
+`);
+    writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        ...config,
+        referenceAppendices: [{
+          language: "test",
+          title: "Pronunciation Reference",
+          source: "test/pronunciation-reference.md",
+          output: "test/book/chapters/appendix-pronunciation.tex",
+          unicodeScript: "Telugu",
+          scriptCommand: "te",
+        }],
+      })}\n`,
+    );
+
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(runBookGeneration(["--write"], root)).toBe(0);
+    const appendix = join(root, "test", "book", "chapters", "appendix-pronunciation.tex");
+    expect(readFileSync(appendix, "utf8")).toContain("\\textbf{\\te{తెలుగు}}");
+    expect(runBookGeneration(["--check"], root)).toBe(0);
+
+    writeFileSync(appendix, "stale\n");
+    expect(runBookGeneration(["--check"], root)).toBe(1);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      "test/book/chapters/appendix-pronunciation.tex: generated output is missing or stale\n",
+    );
+  });
+
+  it("rejects reference sources outside the curriculum root", () => {
+    const root = fixture();
+    const configPath = join(root, "core", "book-generation.json");
+    const config = JSON.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
+    writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        ...config,
+        referenceAppendices: [{
+          language: "test",
+          title: "Pronunciation Reference",
+          source: "../escape.md",
+          output: "test/book/chapters/appendix-pronunciation.tex",
+        }],
+      })}\n`,
+    );
+    expect(() => generatedBookOutputs(root)).toThrow(/unsafe generated book source/);
+  });
+
   it("fails closed on an unknown reusable script set", () => {
     const root = fixture();
     const config = join(root, "core", "book-generation.json");
@@ -302,6 +360,34 @@ describe("hand-written chapters", () => {
           true,
         );
       }
+    }
+  });
+});
+
+describe("pronunciation reference coverage", () => {
+  const root = defaultCurriculumRoot();
+
+  it("includes pronunciation back matter in every registered book", () => {
+    const registry = JSON.parse(
+      readFileSync(join(root, "core", "languages.json"), "utf8"),
+    ) as { languages: Array<{ id: string }> };
+    expect(registry.languages.length).toBeGreaterThan(0);
+    for (const { id } of registry.languages) {
+      const book = join(root, id, "book", "book.tex");
+      const appendix = join(root, id, "book", "chapters", "appendix-pronunciation.tex");
+      expect(existsSync(book), `${id} book`).toBe(true);
+      expect(readFileSync(book, "utf8"), `${id} book input`).toContain(
+        "\\input{chapters/appendix-pronunciation}",
+      );
+      expect(existsSync(appendix), `${id} pronunciation appendix`).toBe(true);
+    }
+  });
+
+  it("generates and byte-gates the five references that were missing", () => {
+    const outputs = generatedBookOutputs(root);
+    for (const language of ["chinese", "japanese", "persian", "russian", "urdu"]) {
+      const relative = `${language}/book/chapters/appendix-pronunciation.tex`;
+      expect(outputs.get(relative), relative).toMatch(/^% GENERATED FILE\./);
     }
   });
 });

--- a/code/packages/typescript/human-language-data/tests/book.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book.test.ts
@@ -4,6 +4,7 @@ import {
   bookVoice,
   renderBookChapter,
   renderInlineMarkdown,
+  renderReferenceAppendix,
 } from "../src/book.js";
 import { parseLesson } from "../src/parse.js";
 
@@ -100,6 +101,50 @@ describe("canonical LaTeX chapter rendering", () => {
     expect(generated.tex).toContain("\\begin{tabularx}{\\linewidth}");
     expect(generated.tex).toContain("\\textbf{person} & \\textbf{form} \\\\");
     expect(generated.tex).toContain("I & \\textbf{hablo} \\\\");
+  });
+
+  it("renders a canonical Markdown reference as structured book back matter", () => {
+    const generated = renderReferenceAppendix(
+      {
+        language: "test",
+        title: "Pronunciation & Script Reference",
+        source: "test/pronunciation-reference.md",
+        output: "test/book/chapters/appendix-pronunciation.tex",
+        unicodeScript: "Devanagari",
+        scriptCommand: "dv",
+      },
+      `# Test — Pronunciation Reference
+
+A [repository note](../data/script.json) and an [external source](https://example.test/ref).
+
+## Read देवनागरी
+
+1. Start with **दे**.
+   Keep the continuation with the same step.
+2. Then read **वन**.
+
+### Sound ids
+
+| id | anchor |
+|---|---|
+| \`first\` | **दे** |
+`,
+    );
+
+    expect(generated).toContain("% GENERATED FILE. Edit test/pronunciation-reference.md");
+    expect(generated).toContain("\\chapter*{Pronunciation \\& Script Reference}");
+    expect(generated).toContain("A repository note and an \\href{https://example.test/ref}");
+    expect(generated).toContain("\\section*{Read \\dv{देवनागरी}}");
+    expect(generated).toContain("\\begin{enumerate}\n\\raggedright");
+    expect(generated).toContain(
+      "\\item Start with \\textbf{\\dv{दे}}. Keep the continuation with the same step.",
+    );
+    expect(generated).toContain("\\subsection*{Sound ids}");
+    expect(generated).toContain(
+      "\\item \\begin{minipage}[t]{\\linewidth}\n  \\textbf{id:} \\texttt{first}",
+    );
+    expect(generated).toContain("\\par \\textbf{anchor:} \\textbf{\\dv{दे}}");
+    expect(generated).not.toContain("# Test");
   });
 
   it("keeps indented Markdown quote continuations in one LaTeX quote", () => {

--- a/code/packages/typescript/human-language-data/tests/chapter-intro.test.ts
+++ b/code/packages/typescript/human-language-data/tests/chapter-intro.test.ts
@@ -6,10 +6,11 @@ import { loadTrackChapters } from "../src/loader.js";
 import { renderBookChapter } from "../src/book.js";
 import { loadLessons } from "../src/loader.js";
 
-// `.tex` only: generatedBookOutputs also carries the generated hashes JSON, which is
-// not a chapter and has no opening.
+// Numbered chapter `.tex` only: generatedBookOutputs also carries the generated
+// hashes JSON and canonical reference appendices, neither of which has a chapter
+// capability opening.
 const generated = [...generatedBookOutputs().entries()]
-  .filter(([path]) => path.endsWith(".tex"))
+  .filter(([path]) => /\/ch\d+[^/]*\.tex$/.test(path))
   .map(([, tex]) => tex);
 
 describe("the chapter opening", () => {
@@ -33,7 +34,7 @@ describe("the chapter opening", () => {
           ?.chapters.find((c) => c.chapter === chapter)?.canDo,
       );
     const withoutOpening = [...generatedBookOutputs().entries()]
-      .filter(([path]) => path.endsWith(".tex"))
+      .filter(([path]) => /\/ch\d+[^/]*\.tex$/.test(path))
       .filter(([, tex]) => !tex.includes("\\begin{chapteropening}"))
       .map(([path]) => path);
 


### PR DESCRIPTION
## Summary

- generate pronunciation/script back matter for Chinese, Japanese, Persian, Russian, and Urdu from canonical Markdown
- render long reference tables as page-break-safe record cards and preserve each track's script font
- byte-gate the five outputs and assert all registered books include pronunciation back matter

## Why

Five of the 22 downloadable books omitted references their lessons point to. Hand-maintained TeX would drift from the app/canonical sources, so this extends the existing book generator.

## Validation

- `bash BUILD` in `code/packages/typescript/human-language-data` (421 tests)
- `npm run build`
- `npm run check:books`
- XeLaTeX builds of all five books
- LaTeX warning gate; no missing glyph, font substitution, or appendix overfull regressions
- visual inspection of every generated appendix page