### PR TITLE
Add BJT VJC parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `VJC` / `PC` base-collector junction
+  potential.
 - Validate and lower BJT model-card `MJE` / `ME` base-emitter grading
   coefficient.
 - Validate and lower BJT model-card `VJE` / `PE` base-emitter junction

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1321,6 +1321,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Nr=model.params.get("NR", 1.0),
             Vje=model.params.get("VJE", model.params.get("PE", 0.75)),
             Mje=model.params.get("MJE", model.params.get("ME", 0.33)),
+            Vjc=model.params.get("VJC", model.params.get("PC", 0.75)),
             Var=model.params.get("VAR", model.params.get("VB", 0.0)),
         )
     if prefix == "J":
@@ -2130,6 +2131,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or base_emitter_grading_coefficient >= 1.0
         ):
             raise NetlistParseError("BJT MJE must be finite and in [0, 1)")
+        base_collector_junction_potential = params.get("VJC", params.get("PC"))
+        if base_collector_junction_potential is not None and (
+            not math.isfinite(base_collector_junction_potential)
+            or base_collector_junction_potential <= 0.0
+        ):
+            raise NetlistParseError("BJT VJC must be finite and positive")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1496,6 +1496,37 @@ def test_rejects_invalid_bjt_base_emitter_grading_coefficient(
         parse_netlist(f".model fast NPN({alias}={value})")
 
 
+@pytest.mark.parametrize("alias", ["VJC", "PC"])
+@pytest.mark.parametrize(("value", "expected"), [("0.5", 0.5), ("0.8", 0.8)])
+def test_parse_bjt_base_collector_junction_potential(
+    alias: str, value: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model fast NPN({alias}={value})\nQ1 col base emit fast"
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Vjc == expected
+
+
+def test_bjt_vjc_takes_precedence_over_pc() -> None:
+    parsed = parse_netlist(".model fast NPN(PC=0.5 VJC=0.8)\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Vjc == 0.8
+
+
+@pytest.mark.parametrize("alias", ["VJC", "PC"])
+@pytest.mark.parametrize("value", ["0", "-0.1", "1e999"])
+def test_rejects_invalid_bjt_base_collector_junction_potential(
+    alias: str, value: str
+) -> None:
+    with pytest.raises(NetlistParseError, match="BJT VJC must be finite and positive"):
+        parse_netlist(f".model fast NPN({alias}={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `VJC` / `PC` base-collector junction
+  potential.
 - Validate and lower BJT model-card `MJE` / `ME` base-emitter grading
   coefficient.
 - Validate and lower BJT model-card `VJE` / `PE` base-emitter junction

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1395,6 +1395,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT MJE must be finite and in [0, 1)");
   }
+  const bjtBaseCollectorJunctionPotential = params.get("VJC") ?? params.get("PC");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtBaseCollectorJunctionPotential !== undefined &&
+    (!Number.isFinite(bjtBaseCollectorJunctionPotential) || bjtBaseCollectorJunctionPotential <= 0.0)
+  ) {
+    throw new NetlistParseError("BJT VJC must be finite and positive");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2113,7 +2121,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("NR") ?? 1.0,
       model.params.get("VJE") ?? model.params.get("PE") ?? 0.75,
       model.params.get("MJE") ?? model.params.get("ME") ?? 0.33,
-      0.75,
+      model.params.get("VJC") ?? model.params.get("PC") ?? 0.75,
       0.33,
       0.5,
       model.params.get("VAR") ?? model.params.get("VB") ?? 0.0,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1557,6 +1557,42 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["VJC", "0.5", 0.5],
+    ["PC", "0.5", 0.5],
+    ["VJC", "0.8", 0.8],
+    ["PC", "0.8", 0.8],
+  ])("parses BJT base-collector junction potential %s=%s", (alias, value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(${alias}=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseCollectorJunctionPotential: expected,
+    });
+  });
+
+  it("gives BJT VJC precedence over PC", () => {
+    const parsed = parseNetlist(`.model fast NPN(PC=0.5 VJC=0.8)\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseCollectorJunctionPotential: 0.8,
+    });
+  });
+
+  it.each([
+    ["VJC", "0"],
+    ["PC", "0"],
+    ["VJC", "-0.1"],
+    ["PC", "-0.1"],
+    ["VJC", "1e999"],
+    ["PC", "1e999"],
+  ])("rejects invalid BJT base-collector junction potential %s=%s", (alias, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${alias}=${value})`)).toThrow(
+      "BJT VJC must be finite and positive",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4570,10 +4570,16 @@ the Rust, Python, and TypeScript surfaces together.
      base-emitter-junction-potential field.
 
 448. Python and TypeScript Berkeley SPICE BJT base-emitter-grading parity.
-   - Status: implemented in this BJT MJE parity slice.
+   - Status: completed in PR 10111.
    - Both parser facades validate finite `MJE` / `ME` values in `[0, 1)`,
      prefer canonical `MJE`, and lower the result into the shared engine
      base-emitter-grading-coefficient field.
+
+449. Python and TypeScript Berkeley SPICE BJT base-collector-potential parity.
+   - Status: implemented in this BJT VJC parity slice.
+   - Both parser facades validate positive finite `VJC` / `PC` values, prefer
+     canonical `VJC`, and lower the result into the shared engine
+     base-collector-junction-potential field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate positive finite BJT `VJC` and legacy `PC` model parameters in Python and TypeScript
- prefer canonical `VJC` and lower the value into the shared base-collector junction-potential engine field
- add parity, precedence, rejection, changelog, and SPICE plan coverage

## Validation
- `bash BUILD` (Python spice-netlist-parser: 494 passed, 89.89% coverage)
- `.venv/bin/ruff check .` (Python spice-netlist-parser)
- `bash BUILD` (TypeScript spice-netlist-parser: 479 passed)
- `npx vitest run --coverage` (TypeScript spice-netlist-parser: 87.32% lines)
- `bash BUILD` (TypeScript spice-engine: 448 passed)
- `git diff --check`
- touched package manifest and BUILD dependency audit (no changes required)