### PR TITLE
Add BJT MJC parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `MJC` / `MC` base-collector grading
+  coefficient.
 - Validate and lower BJT model-card `VJC` / `PC` base-collector junction
   potential.
 - Validate and lower BJT model-card `MJE` / `ME` base-emitter grading

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1322,6 +1322,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Vje=model.params.get("VJE", model.params.get("PE", 0.75)),
             Mje=model.params.get("MJE", model.params.get("ME", 0.33)),
             Vjc=model.params.get("VJC", model.params.get("PC", 0.75)),
+            Mjc=model.params.get("MJC", model.params.get("MC", 0.33)),
             Var=model.params.get("VAR", model.params.get("VB", 0.0)),
         )
     if prefix == "J":
@@ -2137,6 +2138,13 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or base_collector_junction_potential <= 0.0
         ):
             raise NetlistParseError("BJT VJC must be finite and positive")
+        base_collector_grading_coefficient = params.get("MJC", params.get("MC"))
+        if base_collector_grading_coefficient is not None and (
+            not math.isfinite(base_collector_grading_coefficient)
+            or base_collector_grading_coefficient < 0.0
+            or base_collector_grading_coefficient >= 1.0
+        ):
+            raise NetlistParseError("BJT MJC must be finite and in [0, 1)")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1527,6 +1527,39 @@ def test_rejects_invalid_bjt_base_collector_junction_potential(
         parse_netlist(f".model fast NPN({alias}={value})")
 
 
+@pytest.mark.parametrize("alias", ["MJC", "MC"])
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("0.4", 0.4)])
+def test_parse_bjt_base_collector_grading_coefficient(
+    alias: str, value: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model fast NPN({alias}={value})\nQ1 col base emit fast"
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Mjc == expected
+
+
+def test_bjt_mjc_takes_precedence_over_mc() -> None:
+    parsed = parse_netlist(".model fast NPN(MC=0.2 MJC=0.4)\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Mjc == 0.4
+
+
+@pytest.mark.parametrize("alias", ["MJC", "MC"])
+@pytest.mark.parametrize("value", ["-0.1", "1", "1e999"])
+def test_rejects_invalid_bjt_base_collector_grading_coefficient(
+    alias: str, value: str
+) -> None:
+    with pytest.raises(
+        NetlistParseError, match=r"BJT MJC must be finite and in \[0, 1\)"
+    ):
+        parse_netlist(f".model fast NPN({alias}={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `MJC` / `MC` base-collector grading
+  coefficient.
 - Validate and lower BJT model-card `VJC` / `PC` base-collector junction
   potential.
 - Validate and lower BJT model-card `MJE` / `ME` base-emitter grading

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1403,6 +1403,16 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT VJC must be finite and positive");
   }
+  const bjtBaseCollectorGradingCoefficient = params.get("MJC") ?? params.get("MC");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtBaseCollectorGradingCoefficient !== undefined &&
+    (!Number.isFinite(bjtBaseCollectorGradingCoefficient) ||
+      bjtBaseCollectorGradingCoefficient < 0.0 ||
+      bjtBaseCollectorGradingCoefficient >= 1.0)
+  ) {
+    throw new NetlistParseError("BJT MJC must be finite and in [0, 1)");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2122,7 +2132,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("VJE") ?? model.params.get("PE") ?? 0.75,
       model.params.get("MJE") ?? model.params.get("ME") ?? 0.33,
       model.params.get("VJC") ?? model.params.get("PC") ?? 0.75,
-      0.33,
+      model.params.get("MJC") ?? model.params.get("MC") ?? 0.33,
       0.5,
       model.params.get("VAR") ?? model.params.get("VB") ?? 0.0,
     );

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1593,6 +1593,42 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["MJC", "0", 0.0],
+    ["MC", "0", 0.0],
+    ["MJC", "0.4", 0.4],
+    ["MC", "0.4", 0.4],
+  ])("parses BJT base-collector grading coefficient %s=%s", (alias, value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(${alias}=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseCollectorGradingCoefficient: expected,
+    });
+  });
+
+  it("gives BJT MJC precedence over MC", () => {
+    const parsed = parseNetlist(`.model fast NPN(MC=0.2 MJC=0.4)\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseCollectorGradingCoefficient: 0.4,
+    });
+  });
+
+  it.each([
+    ["MJC", "-0.1"],
+    ["MC", "-0.1"],
+    ["MJC", "1"],
+    ["MC", "1"],
+    ["MJC", "1e999"],
+    ["MC", "1e999"],
+  ])("rejects invalid BJT base-collector grading coefficient %s=%s", (alias, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${alias}=${value})`)).toThrow(
+      "BJT MJC must be finite and in [0, 1)",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4576,10 +4576,16 @@ the Rust, Python, and TypeScript surfaces together.
      base-emitter-grading-coefficient field.
 
 449. Python and TypeScript Berkeley SPICE BJT base-collector-potential parity.
-   - Status: implemented in this BJT VJC parity slice.
+   - Status: completed in PR 10113.
    - Both parser facades validate positive finite `VJC` / `PC` values, prefer
      canonical `VJC`, and lower the result into the shared engine
      base-collector-junction-potential field.
+
+450. Python and TypeScript Berkeley SPICE BJT base-collector-grading parity.
+   - Status: implemented in this BJT MJC parity slice.
+   - Both parser facades validate finite `MJC` / `MC` values in `[0, 1)`,
+     prefer canonical `MJC`, and lower the result into the shared engine
+     base-collector-grading-coefficient field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite BJT `MJC` / `MC` grading coefficients in `[0, 1)`
- lower canonical `MJC` with `MC` fallback into both parser engine facades
- add alias, precedence, invalid-value tests and reconcile the SPICE plan

## Verification
- Python parser `bash BUILD` (505 passed, 89.91% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (490 passed)
- TypeScript parser `npx vitest run --coverage` (87.35% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
- BUILD and package dependency audit (no changes)