### PR TITLE
Add BJT FC parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `FC` forward-bias depletion coefficient.
 - Validate and lower BJT model-card `MJC` / `MC` base-collector grading
   coefficient.
 - Validate and lower BJT model-card `VJC` / `PC` base-collector junction

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1323,6 +1323,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Mje=model.params.get("MJE", model.params.get("ME", 0.33)),
             Vjc=model.params.get("VJC", model.params.get("PC", 0.75)),
             Mjc=model.params.get("MJC", model.params.get("MC", 0.33)),
+            Fc=model.params.get("FC", 0.5),
             Var=model.params.get("VAR", model.params.get("VB", 0.0)),
         )
     if prefix == "J":
@@ -2145,6 +2146,13 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or base_collector_grading_coefficient >= 1.0
         ):
             raise NetlistParseError("BJT MJC must be finite and in [0, 1)")
+        forward_bias_depletion_coefficient = params.get("FC")
+        if forward_bias_depletion_coefficient is not None and (
+            not math.isfinite(forward_bias_depletion_coefficient)
+            or forward_bias_depletion_coefficient < 0.0
+            or forward_bias_depletion_coefficient >= 1.0
+        ):
+            raise NetlistParseError("BJT FC must be finite and in [0, 1)")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1560,6 +1560,25 @@ def test_rejects_invalid_bjt_base_collector_grading_coefficient(
         parse_netlist(f".model fast NPN({alias}={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("0.5", 0.5)])
+def test_parse_bjt_forward_bias_depletion_coefficient(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model fast NPN(FC={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Fc == expected
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1", "1e999"])
+def test_rejects_invalid_bjt_forward_bias_depletion_coefficient(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match=r"BJT FC must be finite and in \[0, 1\)"
+    ):
+        parse_netlist(f".model fast NPN(FC={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `FC` forward-bias depletion coefficient.
 - Validate and lower BJT model-card `MJC` / `MC` base-collector grading
   coefficient.
 - Validate and lower BJT model-card `VJC` / `PC` base-collector junction

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1413,6 +1413,16 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT MJC must be finite and in [0, 1)");
   }
+  const bjtForwardBiasDepletionCoefficient = params.get("FC");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtForwardBiasDepletionCoefficient !== undefined &&
+    (!Number.isFinite(bjtForwardBiasDepletionCoefficient) ||
+      bjtForwardBiasDepletionCoefficient < 0.0 ||
+      bjtForwardBiasDepletionCoefficient >= 1.0)
+  ) {
+    throw new NetlistParseError("BJT FC must be finite and in [0, 1)");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2133,7 +2143,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("MJE") ?? model.params.get("ME") ?? 0.33,
       model.params.get("VJC") ?? model.params.get("PC") ?? 0.75,
       model.params.get("MJC") ?? model.params.get("MC") ?? 0.33,
-      0.5,
+      model.params.get("FC") ?? 0.5,
       model.params.get("VAR") ?? model.params.get("VB") ?? 0.0,
     );
   }

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1629,6 +1629,27 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["0.5", 0.5],
+  ])("parses BJT forward-bias depletion coefficient FC=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(FC=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      forwardBiasDepletionCoefficient: expected,
+    });
+  });
+
+  it.each(["-0.1", "1", "1e999"])(
+    "rejects invalid BJT forward-bias depletion coefficient FC=%s",
+    (value) => {
+      expect(() => parseNetlist(`.model fast NPN(FC=${value})`)).toThrow(
+        "BJT FC must be finite and in [0, 1)",
+      );
+    },
+  );
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4582,10 +4582,15 @@ the Rust, Python, and TypeScript surfaces together.
      base-collector-junction-potential field.
 
 450. Python and TypeScript Berkeley SPICE BJT base-collector-grading parity.
-   - Status: implemented in this BJT MJC parity slice.
+   - Status: completed in PR 10114.
    - Both parser facades validate finite `MJC` / `MC` values in `[0, 1)`,
      prefer canonical `MJC`, and lower the result into the shared engine
      base-collector-grading-coefficient field.
+
+451. Python and TypeScript Berkeley SPICE BJT forward-bias-depletion parity.
+   - Status: implemented in this BJT FC parity slice.
+   - Both parser facades validate finite `FC` values in `[0, 1)` and lower
+     them into the shared engine forward-bias-depletion-coefficient field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite BJT `FC` values in `[0, 1)`
- lower `FC` into both parser engine facades instead of hard-coding the default
- add boundary and invalid-value tests and reconcile the SPICE plan

## Verification
- Python parser `bash BUILD` (510 passed, 89.93% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (495 passed)
- TypeScript parser `npx vitest run --coverage` (87.38% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
- BUILD and package dependency audit (no changes)