### PR TITLE
Generate glossaries for every language book

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,10 +5,10 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-08, after HL-C50A entered #10112. With all 22
-downloadable books now carrying pronunciation back matter, HL-C50 remains the
-highest-value standalone-book program: generate each track's glossary next, then
-its answer key and index from the same canonical curriculum data.
+Last prioritized: 2026-08-08, after HL-C50B entered #10116. With all 22
+downloadable books now carrying pronunciation and glossary back matter, HL-C50
+remains the highest-value standalone-book program: generate each track's answer
+key next, then its index from the same canonical curriculum data.
 Current generated baseline: **22** registered tracks, **1,669** canonical lessons,
 **1,521** mapped lessons, and **22** downloadable LaTeX books spanning **513**
 chapters, **408** of them generated from the canonical lesson AST. Twenty-five mapped
@@ -177,8 +177,9 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C18D | Queued | Burn down the 61 lessons over the script budget, steepest first, and split the 5 Japanese lessons that open two writing systems at once. | No lesson introduces more than `maxNewGlyphsPerLesson` new glyphs or opens more than one writing system; the corpus maximum drops from 12 to 3. Starts with `HI-W01-shirorekha-na-ma`, `MR-C01-dhanyavad` and `RU-C01-da` at twelve each. Follows HL-C18C, which produced the list. |
 | HL-C48 | Queued | Generate the cousin/cognate layer from `concept_tag` instead of hand-typing it, and make it visually skippable. | The cross-language comparison table exists in **18 hand-typed instances across 4 Dravidian tracks** (4.6% of chapters) while four prefaces promise it per-lesson; `parse.ts` has no block type for it, so an author cannot write one into a canonical lesson. `concept_tag` (1,131 lessons) is the join key that would generate them, and the book renderer ignores it — as it ignores 708 `etymology_hook` fields (~25,400 words) that the app already displays cross-language. Per the owner's rule, the layer is a bonus for readers who know a relative: it must never gate comprehension, and its foreign glyphs must stay out of the target-script ramp. |
 | HL-C49 | Complete (#10055) | Give every chapter a short, well-written intro, generated from `chapters.json`. | Generated chapters derive a standalone capability-led introduction from canonical metadata; the already-authored chapter openings remain authored. |
-| HL-C50 | Queued — reader-link cleanup complete (#10058, #10060, #10062, #10064, #10066); pronunciation appendices complete (#10112) | Finish making every book a standalone artifact. | Generate a glossary, answer key, and index for every track from canonical data. |
+| HL-C50 | Queued — reader-link cleanup complete (#10058, #10060, #10062, #10064, #10066); pronunciation appendices complete (#10112); glossaries complete (#10116) | Finish making every book a standalone artifact. | Generate an answer key and index for every track from canonical data. |
 | HL-C50A | Complete (#10112) | Generate the five missing pronunciation appendices from each track's canonical `pronunciation-reference.md`. | Chinese, Japanese, Persian, Russian, and Urdu join the other 17 books in carrying pronunciation back matter; `book-cli --check` byte-gates all five generated `.tex` files, and all five PDFs compile with no warning regressions. |
+| HL-C50B | Complete (#10116) | Generate a compact glossary for every book from canonical word and phrase lessons. | All 22 books carry byte-gated glossary back matter with headword, non-redundant romanization, gloss, and introduction chapter; duplicate realizations merge without losing distinct senses, every script uses the book's configured font, and all PDFs compile without warning regressions. |
 | HL-C19 | Queued | Verify every prose `strokeOrder` against an authored ductus, so no letter's step list implies a pen lift nothing has checked. | All 190 prose stroke orders across the nine scripts (`arabic` 21, `chinese` 24, `cyrillic` 33, `devanagari` 28, `gujarati` 29, `hebrew` 22, `perso-arabic` 9, `tamil` 10, `urdu-nastaliq` 13) either carry a font-checked pen path with `penLifts` + `strokeOrderSource`, or are worded so they claim part order only. Today exactly one letter — Tamil ம — is verified; the audit that found it is written up in [`data/scripts/README.md`](data/scripts/README.md). Follows HL-C09, which authors the paths this check consumes. |
 | HL-C30 | Closed — no move is both legal and useful | Recover Arabic's drivable prefix by moving the writing lessons that open Chapters 3 and 4 later in their chapters. | Measured and answered: zero. Both chapters are prefix-0 under **every** legal ordering because neither has a `voice` lesson without an in-chapter prerequisite, and all 18 of Arabic's `sight` lessons are tables, not script. Corpus-wide only 2 chapters (`portuguese ch2`, `italian ch2`, +4 lessons) can be improved by reordering at all; 116 of the 123 zero-prefix chapters are table-blocked at the root and belong to HL-C17. See *Findings from HL-C30*. |
 | HL-C24 | Complete (#9979) | Pilot real chapter payoff lessons on the weakest Latin chapters. | Latin chapters 19, 21, 33, and 36 each own a dedicated terminal consolidation lesson built only from already-taught material, and `chapters.json` points their `payoff.lesson` at it. |
@@ -2485,9 +2486,10 @@ problem.
   aliases remain beside their PR numbers so repository history stays searchable.
 - HL-C49's generated chapter introductions are recorded complete in #10055.
   HL-C50A's generated pronunciation appendices are recorded complete in #10112.
-  HL-C50 now names only the unfinished standalone-book work: generated glossaries,
-  answer keys, and indexes. Its five merged link and cross-volume cleanup slices
-  remain visible in the status.
+  HL-C50B's generated glossaries are recorded complete in #10116. HL-C50 now
+  names only the unfinished standalone-book work: generated answer keys and
+  indexes. Its five merged link and cross-volume cleanup slices remain visible
+  in the status.
 - A completed row must name at least one merge PR, an ID may occur only once,
   and `this PR` is not a durable status. HL-I06 was kept `In progress` until its
   own PR number existed so the repair did not violate the rule while making it.

--- a/code/learning/human-languages/arabic/book/book.tex
+++ b/code/learning/human-languages/arabic/book/book.tex
@@ -154,5 +154,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/arabic/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/arabic/book/chapters/appendix-glossary.tex
@@ -1,0 +1,568 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 80
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{أكل}}\enspace\emph{akala}\par
+\small \textquotedblleft{}he ate\textquotedblright{} — no new letters, no English cousin, and a Hebrew twin close enough to hear; the sixth verb, closing the set\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{الحمد} \ar{لله}}\enspace\emph{al-ḥamdu lillāh}\par
+\small praise be to God — the everyday answer to 'how are you?'\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{السلامة}}\enspace\emph{as-salāma}\par
+\small the safety — Chapter 1's salām, plus a pattern and a feminine ending\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{بخير}}\enspace\emph{bi-khayr}\par
+\small well, fine — literally 'in goodness'\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{ذهب}}\enspace\emph{dhahaba}\par
+\small he went" — the track's first verb, and the clearest possible view of the root-and-pattern engine, since the same three consonants also give \textquotedblleft{}gold\textquotedblright{} and "a school of law\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{فهم}}\enspace\emph{fahima}\par
+\small \textquotedblleft{}he understood\textquotedblright{} — the first verb whose middle vowel is not an a, marking it a state rather than a deed, and the done-to shape that turns it into the word for a concept\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{فكّر}}\enspace\emph{fakkara}\par
+\small \textquotedblleft{}he thought\textquotedblright{} — the first verb that is not a bare root at all, but a root rebuilt by doubling its middle letter, and the mu- doer that comes with the rebuild\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{حال}}\enspace\emph{ḥāl}\par
+\small state, condition — the thing Arabic actually asks about\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{حليب}}\enspace\emph{ḥalīb}\par
+\small \textquotedblleft{}milk\textquotedblright{} — the opposite case to shāy: a home-grown noun sitting straight on the verb for milking, and a Hebrew twin that is the same word\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{ابن} \ar{بنت}}\enspace\emph{ibn, bint}\par
+\small son and daughter — one pair gendered by a single added \ar{ت}, exactly as \ar{أخ} and \ar{أخت} were, and the ibn that stands in the middle of names English already knows\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{إلى} \ar{الغد}}\enspace\emph{ilā l-ghad}\par
+\small see you tomorrow — literally 'until tomorrow', reusing the same ilā ('until') already met in see you later\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{إلى} \ar{اللقاء}}\enspace\emph{ilā l-liqāʾ}\par
+\small see you — literally 'until the meeting', the structure Spanish borrowed a word for\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{جار}}\enspace\emph{jār}\par
+\small \textquotedblleft{}neighbour\textquotedblright{} — the person you introduce most often, built on a hollow root whose middle letter hides exactly as qāla's does\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{جاء}}\enspace\emph{jāʾa}\par
+\small \textquotedblleft{}he came\textquotedblright{} — the partner of dhahaba, and the first root whose middle letter is weak enough to vanish, showing that even Arabic's irregularities are patterned\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{جبن}}\enspace\emph{jubn}\par
+\small \textquotedblleft{}cheese\textquotedblright{} — and an honest limit on the root system, because the very same three letters also spell cowardice and the two are not one idea\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{كتب}}\enspace\emph{kataba}\par
+\small \textquotedblleft{}he wrote\textquotedblright{} — the chapter's payoff, where one root and the patterns you already own hand you a book, a writer, an office and a library with nothing new to memorise\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{كيف}}\enspace\emph{kayfa}\par
+\small how\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{كيف} \ar{حالك؟}}\enspace\emph{kayfa ḥāluka / kayfa ḥāluki}\par
+\small how are you? — literally 'how {[}is{]} your state?', gendered -ka / -ki\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{كوب}}\enspace\emph{kūb}\par
+\small \textquotedblleft{}a cup\textquotedblright{} — the word that opens Arabic's broken plural, where more than one is not made by adding anything but by re-pouring the word into a new shape\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{لحم}}\enspace\emph{laḥm}\par
+\small \textquotedblleft{}meat\textquotedblright{} — one Semitic root that Arabic settled on meat and Hebrew settled on bread, with Bethlehem sitting on the seam between them\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{مع}}\enspace\emph{maʿa}\par
+\small with\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{مع} \ar{السلامة}}\enspace\emph{maʿa s-salāma}\par
+\small goodbye — literally 'with safety', closing the greeting arc on the root that opened it\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{ملح}}\enspace\emph{milḥ}\par
+\small \textquotedblleft{}salt\textquotedblright{} — a plain Semitic word whose root also gives Arabic its sailor and its word for handsome, and which shows ḥāʾ in its final shape\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{ملعقة}}\enspace\emph{milʿaqa}\par
+\small \textquotedblleft{}a spoon\textquotedblright{} — the closing payoff, where the mi- tool shape stands beside the ma- place shape you already own, and where sound and broken plurals finally sort themselves out\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{قهوة}}\enspace\emph{qahwa}\par
+\small \textquotedblleft{}coffee\textquotedblright{} — the chapter's payoff, where the tied tāʾ finally earns its keep as Arabic's visible gender marker, and where you can order everything the chapter taught\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{قال}}\enspace\emph{qāla}\par
+\small \textquotedblleft{}he said\textquotedblright{} — the letter qāf finally named, and one root that yields a saying, an article, a speaker and a spoken thing\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{قرأ}}\enspace\emph{qaraʾa}\par
+\small \textquotedblleft{}he read, he recited\textquotedblright{} — hamza's three seats sorted out at last, and the one root in this chapter that really did give English a word\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{رأى}}\enspace\emph{raʾā}\par
+\small \textquotedblleft{}he saw\textquotedblright{} — the dotless alif maqṣūra named at last, and a root whose seeing turns into opinion and into the word for a mirror\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{صديق}}\enspace\emph{ṣadīq}\par
+\small \textquotedblleft{}friend\textquotedblright{} — the chapter's payoff, where a root meaning truth explains the word, the faʿīl pattern turns up for the third time, and every family word you own lines up behind it\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{سأل}}\enspace\emph{saʾala}\par
+\small \textquotedblleft{}he asked\textquotedblright{} — one root that builds a question, a problem, an asker and the word for being answerable, plus the Hebrew twin hiding inside the name Saul\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{ساعد}}\enspace\emph{sāʿada}\par
+\small \textquotedblleft{}he helped\textquotedblright{} — a root that means good fortune, stretched by one long vowel into a verb aimed at somebody else, and the family name behind the word Saudi\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{شاي}}\enspace\emph{shāy}\par
+\small \textquotedblleft{}tea\textquotedblright{} — the first noun in this book with no Arabic root at all, and a word that reached Arabic and English from the same Chinese original by two different roads\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{سكر}}\enspace\emph{sukkar}\par
+\small \textquotedblleft{}sugar\textquotedblright{} — a word that crossed Asia and Europe, and the one that shows Arabic's own al- fused onto the front of a Spanish noun\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{طبق}}\enspace\emph{ṭabaq}\par
+\small \textquotedblleft{}a plate\textquotedblright{} — a second broken plural in the very same shape as akwāb, which turns a surprise into a pattern, and a root whose other child is a storey of a building\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{طعام}}\enspace\emph{ṭaʿām}\par
+\small \textquotedblleft{}food\textquotedblright{} — the chapter's payoff, where a root you have never met hands you the word for restaurant free of charge, because you already own the pattern\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{تصبح} \ar{على} \ar{خير}}\enspace\emph{tuṣbiḥ ʿalā khayr}\par
+\small \textquotedblleft{}good night\textquotedblright{} — but honestly, it doesn't wish you a good NIGHT at all; it wishes you a good morning, reusing both roots from ṣabāḥ al-khayr and masāʾ al-khayr\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{زيت}}\enspace\emph{zayt}\par
+\small \textquotedblleft{}oil\textquotedblright{} — one new letter that is only rā wearing a dot, and a second Spanish word carrying Arabic's article welded to its front\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{أحبّ}}\enspace\emph{ʾaḥabba}\par
+\small \textquotedblleft{}he loved\textquotedblright{} — the chapter's payoff, closing the ladder of four verb shapes, and the root behind the ḥabībī of every second Arabic song\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{أخذ}}\enspace\emph{ʾakhadha}\par
+\small \textquotedblleft{}he took\textquotedblright{} — the last plain-shaped verb in the book, kept as the control against the three rebuilt verbs that follow, with a Hebrew twin reached by two regular consonant swaps\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{عرف}}\enspace\emph{ʿarafa}\par
+\small \textquotedblleft{}he knew, he recognised\textquotedblright{} — one of Arabic's two words for knowing, whose root reached Spain and named a palace in Granada\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{أب} \ar{أم}}\par
+\small father and mother — ancient Semitic roots, cousins of Hebrew's own family words\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{أحد} \ar{عشر} — \ar{عشرون}}\par
+\small 11-15, plain \textquotedblleft{}X-and-ten\textquotedblright{} compounds — then twenty, NOT \textquotedblleft{}two-ten\textquotedblright{} but its OWN plural form of \textquotedblleft{}ten\textquotedblright{}\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{أحمر} \ar{أزرق}}\par
+\small red and blue — the same gendered color template as black and white\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{أخ} \ar{أخت}}\par
+\small brother and sister — one shared Semitic root, gendered by a single added letter\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{أخضر}, \ar{أصفر}}\par
+\small green and yellow — akhdar's root also gives \textquotedblleft{}vegetables\textquotedblright{} (echoing English's own \textquotedblleft{}greens\textquotedblright{}), and asfar shares its root with sifr, \textquotedblleft{}zero\textquotedblright{} — the very word behind English \textquotedblleft{}zero\textquotedblright{} and \textquotedblleft{}cipher\textquotedblright{}\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{آسف} / \ar{آسفة}}\par
+\small sorry (āsif masc. / āsifa fem. — a GENDERED adjective, from asifa \textquotedblleft{}to grieve, regret\textquotedblright{})\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{اسم}}\par
+\small name\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{اسمي} …}\par
+\small my name is… (with no \textquotedblleft{}is\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{أسود} \ar{أبيض}}\par
+\small black and white — color adjectives that change shape with gender, more than \textquotedblleft{}sorry\textquotedblright{} did\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{ال}}\par
+\small the (al- — the attached article)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{الأحد} \ar{الإثنين} \ar{الثلاثاء} \ar{الأربعاء} \ar{الخميس}}\par
+\small Sunday–Thursday — Arabic counts its weekdays instead of naming them for planets\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{الجمعة} \ar{السبت}}\par
+\small Friday and Saturday — the two days that break the counting pattern\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{الساعة}}\par
+\small hour / o'clock — and the same word Arabic uses for \textquotedblleft{}clock\textquotedblright{} and \textquotedblleft{}a while\textquotedblright{}\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{السلام} \ar{عليكم}}\par
+\small peace be upon you (as-salāmu ʿalaykum)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{الطقس}}\par
+\small weather — the SAME root also gives \textquotedblleft{}rite, religious ceremony\textquotedblright{}; hot/cold are verbless adjectives, but rain gets its own personal verb\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{الظهر} \ar{منتصف} \ar{الليل}}\par
+\small noon (also the name of the midday Islamic prayer) and midnight (\textquotedblleft{}the half of the night\textquotedblright{})\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{أنت}}\par
+\small you (anta m. / anti f.)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{تشرفنا}}\par
+\small pleased to meet you (literally \textquotedblleft{}we have been honoured\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{رأس}}\par
+\small the head — a Semitic root cognate with Hebrew rosh, and the source of \textquotedblleft{}president\textquotedblright{} in Arabic itself\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{ربيع} \ar{صيف} \ar{خريف} \ar{شتاء}}\par
+\small the four seasons — Modern Standard Arabic's set, though the classical calendar didn't always carve up the year this way\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{سلام}}\par
+\small peace / hello (salām)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{شكرا}}\par
+\small thank you (shukran)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{صباح} \ar{الخير}}\par
+\small good morning (ṣabāḥ al-khayr — \textquotedblleft{}morning of goodness\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{عفوا}}\par
+\small \textquotedblleft{}you're welcome\textquotedblright{} (also \textquotedblleft{}excuse me/pardon/sorry,\textquotedblright{} depending on context) — root ʿ-f-w, \textquotedblleft{}to erase, to pardon\textquotedblright{}; grammatically the same construction as shukran itself\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{كلب}, \ar{قط}}\par
+\small dog and cat — kalb is a solid, well-attested Semitic root (cousin of Hebrew's own dog-word), unlike the tangled dog-words of Spanish, Hindi, and English; qitt most likely closes the loop, widely compared to the SAME ancient root behind Latin's cattus/gato/chat/Katze, though the exact relationship is still debated\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{كم} \ar{عمرك؟}}\par
+\small how old are you? — literally \textquotedblleft{}how much {[}is{]} your lifetime?\textquotedblright{}; age as a NOUN you possess, not a verb you conjugate\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{لا}}\par
+\small no (lā)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{ليل}}\par
+\small \textquotedblleft{}night\textquotedblright{} — the word already hiding inside muntaṣaf al-layl ('midnight'), and yawm's pan-Semitic partner, cognate with Hebrew layla\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{ما}}\par
+\small what\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{ما} \ar{اسمك؟}}\par
+\small what's your name?\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{ماء} \ar{خبز}}\par
+\small water and bread — one of Arabic's most irregular common words, and one built on a clean, ordinary Semitic root\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{مرحبا}}\par
+\small hello / welcome (marḥaban — \textquotedblleft{}there's room for you\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{مساء} \ar{الخير}}\par
+\small good evening (masāʾ al-khayr — \textquotedblleft{}evening of goodness\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{من} \ar{فضلك}}\par
+\small please (min faḍlik — literally \textquotedblleft{}from your grace\textquotedblright{})\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{نعم}}\par
+\small yes (naʿam)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{واحد} \ar{اثنان} \ar{ثلاثة} \ar{أربعة} \ar{خمسة}}\par
+\small one through five — the Arabic WORDS for numbers, genuinely different from \textquotedblleft{}Arabic numerals\textquotedblright{} (the written digit shapes 0-9), which actually trace back to India\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{ي}}\par
+\small my (possessive suffix -ī)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{يد}}\par
+\small the hand — an ancient Semitic root, nearly unchanged since its Hebrew cousin\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{يناير} \ar{فبراير} \ar{مارس} \ar{أبريل} \ar{مايو} \ar{يونيو} \ar{يوليو} \ar{أغسطس} \ar{سبتمبر} \ar{أكتوبر} \ar{نوفمبر} \ar{ديسمبر}}\par
+\small the Gregorian months — Latin names borrowed almost intact, running ALONGSIDE the Islamic calendar's own, entirely different lunar months\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ar{يوم}}\par
+\small day" — a true pan-Semitic word, cognate with Hebrew yom (as in Yom Kippur), and possibly tracing all the way back to an ancient word for "sun\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/bengali/book/book.tex
+++ b/code/learning/human-languages/bengali/book/book.tex
@@ -104,5 +104,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/bengali/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/bengali/book/chapters/appendix-glossary.tex
@@ -1,0 +1,372 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 52
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{আসা}}\enspace\emph{āsā}\par
+\small to come — the verb that never asks whether a man or a woman is speaking\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{ভাবা}}\enspace\emph{bhābā}\par
+\small to think — and the machinery that made a \textquotedblleft{}become\textquotedblright{} verb into a \textquotedblleft{}think\textquotedblright{} verb\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{ভাই}}\enspace\emph{bhāi}\par
+\small brother — not borrowed, not a cousin, but the same word as English \textquotedblleft{}brother,\textquotedblright{} worn down by six thousand years and two different roads\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{ভালো} \bn{লাগা}}\enspace\emph{bhālo lāgā}\par
+\small to like — \textquotedblleft{}good sticks to me\textquotedblright{} — and beside it \bn{ভালোবাসা}, to love\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{ভাত}}\enspace\emph{bhāt}\par
+\small cooked rice — the meal itself, and a Sanskrit root for \textquotedblleft{}share\textquotedblright{} that will resurface two lessons from now in a very different word\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{বোঝা}}\enspace\emph{bojhā}\par
+\small to understand — the third knowing, and the harmony that this time moves the spelling\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{বোন}}\enspace\emph{bon}\par
+\small sister — not built on the root behind English \textquotedblleft{}sister\textquotedblright{} at all, but on the very root that named this book's rice two lessons ago\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{বন্ধু}}\enspace\emph{bôndhu}\par
+\small friend — a word built openly on \textquotedblleft{}to bind,\textquotedblright{} and the rare case where Bengali and English share both the word and the picture behind it\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{চা}}\enspace\emph{chā}\par
+\small tea — a loanword that crossed from China into Bengali overland, and the drink this chapter's polite offers run on\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{চোখ}}\enspace\emph{chokh}\par
+\small eye — built on the same Sanskrit root as \textquotedblleft{}to see,\textquotedblright{} worn down through three centuries of Bengali spelling before it looked like this\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{দুধ}}\enspace\emph{dudh}\par
+\small milk — a word whose spelling could ask for a trailing vowel but doesn't, and a root whose one secure English cousin is not the word it looks like\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{দেখা}}\enspace\emph{dækhā}\par
+\small to see, to look — and the vowel that changes while the spelling stands still\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{এক} \bn{দুই} \bn{তিন} \bn{চার} \bn{পাঁচ}}\enspace\emph{ek dui tin chār pā̃ch}\par
+\small one to five — and the \textquotedblleft{}two\textquotedblright{} that kept its Sanskrit vowel\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{হওয়া}}\enspace\emph{hôwā}\par
+\small to be, to become — the second of Bengali's two be-verbs, and the one that does what \bn{আছে} cannot\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{হৃদয়}}\enspace\emph{hridoy}\par
+\small heart — a word kept whole from Sanskrit, and the oldest, most secure English cousin this book has shown you\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{জানা}}\enspace\emph{jānā}\par
+\small to know a fact — beside \bn{চেনা}, the second knowing that English merged away\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{যাওয়া}}\enspace\emph{jāwā}\par
+\small to go — and the verb ending that carries how much respect you are paying\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{জিজ্ঞাসা} \bn{করা}}\enspace\emph{jijñāsā kôrā}\par
+\small to ask — literally \textquotedblleft{}to do a wanting-to-know,\textquotedblright{} and the door into a thousand verbs\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{জল}}\enspace\emph{jôl}\par
+\small water — the word Chapter 7 already used to say \textquotedblleft{}drink water,\textquotedblright{} now taught on its own, beside the Bangladesh-register \bn{পানি}\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{খাওয়া}}\enspace\emph{khāwā}\par
+\small to eat — and, in everyday Bengali, to drink as well\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{লেখা}}\enspace\emph{lekhā}\par
+\small to write — and the dictionary form that is quietly a noun\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{মুখ}}\enspace\emph{mukh}\par
+\small mouth, face — a word so old that scholars still argue over which language family it belongs to\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{নাক}}\enspace\emph{nāk}\par
+\small nose — the direct cousin of English \textquotedblleft{}nose,\textquotedblright{} worn down by Bengali's own sound changes rather than Latin's or English's\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{নেওয়া}}\enspace\emph{neowā}\par
+\small to take — and the verb that finishes other verbs\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{পড়া}}\enspace\emph{pôṛā}\par
+\small to read — and the flapped letter Sanskrit never wrote\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{পরিবার}}\enspace\emph{pôribār}\par
+\small family — literally \textquotedblleft{}what surrounds you,\textquotedblright{} a second word Bengali kept whole from Sanskrit rather than wearing down\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{সাহায্য} \bn{করা}}\enspace\emph{sāhājjo kôrā}\par
+\small to help — \textquotedblleft{}to go together with,\textquotedblright{} and the word that finally shows you the inherent vowel\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{আচ্ছা}}\par
+\small okay / alright / I see (āchchhā)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{আবার}}\par
+\small again\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{আবার} \bn{দেখা} \bn{হবে}}\par
+\small we'll meet again (goodbye)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{আমি}}\par
+\small I\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{আমি} \bn{বাংলা} \bn{বলি}}\par
+\small I speak Bengali\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{আমার}}\par
+\small my\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{আমার} \bn{নাম} …}\par
+\small my name is… (with no \textquotedblleft{}is\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{আলাপ} \bn{করে} \bn{ভালো} \bn{লাগলো}}\par
+\small pleased to meet you (lit. \textquotedblleft{}having made acquaintance, {[}it{]} felt good\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{আসি}}\par
+\small goodbye, lit. \textquotedblleft{}I'll come {[}again{]}\textquotedblright{} (āshi)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{কি}}\par
+\small what\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{কাজ} \bn{করা}}\par
+\small to work (lit. \textquotedblleft{}work-do\textquotedblright{})\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{কোনো} \bn{ব্যাপার} \bn{না}}\par
+\small it's no matter / no problem / you're welcome\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{কেমন}}\par
+\small how\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{কাল} \bn{দেখা} \bn{হবে}}\par
+\small see you tomorrow (and the \bn{কাল} puzzle)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{তুমি} / \bn{আপনি}}\par
+\small you (familiar / respectful; also \bn{তুই} intimate)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{তুমি} \bn{কেমন} \bn{আছো}?}\par
+\small how are you? (familiar)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{তোমার} \bn{নাম} \bn{কি}?}\par
+\small what's your name?\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{থাকা}}\par
+\small to live, to stay, to remain\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{দেখা} \bn{হবে}}\par
+\small (we) will meet (lit. \textquotedblleft{}seeing will happen\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{ধন্যবাদ}}\par
+\small thank you (dhônyobad)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{নাম}}\par
+\small name\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{নমস্কার}}\par
+\small hello / goodbye (nômoshkar)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{বলা}}\par
+\small to speak, to say\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{ভালো}}\par
+\small well, good — and the reply \textquotedblleft{}\bn{আমি} \bn{ভালো} \bn{আছি}\textquotedblright{}\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\bn{হ্যাঁ} / \bn{না}}\par
+\small yes / no (hyã / nā)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/chinese/book/book.tex
+++ b/code/learning/human-languages/chinese/book/book.tex
@@ -71,6 +71,7 @@ substitute.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \chapter*{Sources for this starter edition}
 \addcontentsline{toc}{chapter}{Sources for this starter edition}

--- a/code/learning/human-languages/chinese/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/chinese/book/chapters/appendix-glossary.tex
@@ -1,0 +1,29 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 3
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\zh{好}}\enspace\emph{hǎo}\par
+\small good, well\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\zh{你}}\enspace\emph{nǐ}\par
+\small you (one person)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\zh{你好}}\enspace\emph{nǐ hǎo}\par
+\small hello (literally \textquotedblleft{}you good\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -186,6 +186,125 @@
       "scriptCommand": "ur"
     }
   ],
+  "glossaries": [
+    {
+      "language": "arabic",
+      "output": "arabic/book/chapters/appendix-glossary.tex",
+      "scriptSet": "arabic-main"
+    },
+    {
+      "language": "bengali",
+      "output": "bengali/book/chapters/appendix-glossary.tex",
+      "unicodeScript": "Bengali",
+      "scriptCommand": "bn"
+    },
+    {
+      "language": "chinese",
+      "output": "chinese/book/chapters/appendix-glossary.tex",
+      "unicodeScript": "Han",
+      "scriptCommand": "zh"
+    },
+    {
+      "language": "french",
+      "output": "french/book/chapters/appendix-glossary.tex"
+    },
+    {
+      "language": "german",
+      "output": "german/book/chapters/appendix-glossary.tex"
+    },
+    {
+      "language": "gujarati",
+      "output": "gujarati/book/chapters/appendix-glossary.tex",
+      "unicodeScript": "Gujarati",
+      "scriptCommand": "gu"
+    },
+    {
+      "language": "hindi",
+      "output": "hindi/book/chapters/appendix-glossary.tex",
+      "scriptSet": "hindi-main"
+    },
+    {
+      "language": "italian",
+      "output": "italian/book/chapters/appendix-glossary.tex"
+    },
+    {
+      "language": "japanese",
+      "output": "japanese/book/chapters/appendix-glossary.tex",
+      "scriptSet": "japanese-main"
+    },
+    {
+      "language": "kannada",
+      "output": "kannada/book/chapters/appendix-glossary.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "latin",
+      "output": "latin/book/chapters/appendix-glossary.tex"
+    },
+    {
+      "language": "malayalam",
+      "output": "malayalam/book/chapters/appendix-glossary.tex",
+      "scriptSet": "malayalam-comparisons"
+    },
+    {
+      "language": "marathi",
+      "output": "marathi/book/chapters/appendix-glossary.tex",
+      "unicodeScript": "Devanagari",
+      "scriptCommand": "mr"
+    },
+    {
+      "language": "persian",
+      "output": "persian/book/chapters/appendix-glossary.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "fa"
+    },
+    {
+      "language": "portuguese",
+      "output": "portuguese/book/chapters/appendix-glossary.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "ptar"
+    },
+    {
+      "language": "punjabi",
+      "output": "punjabi/book/chapters/appendix-glossary.tex",
+      "unicodeScript": "Gurmukhi",
+      "scriptCommand": "pa"
+    },
+    {
+      "language": "russian",
+      "output": "russian/book/chapters/appendix-glossary.tex",
+      "unicodeScript": "Cyrillic",
+      "scriptCommand": "ru"
+    },
+    {
+      "language": "sanskrit",
+      "output": "sanskrit/book/chapters/appendix-glossary.tex",
+      "unicodeScript": "Devanagari",
+      "scriptCommand": "sk"
+    },
+    {
+      "language": "spanish",
+      "output": "spanish/book/chapters/appendix-glossary.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "esar"
+    },
+    {
+      "language": "tamil",
+      "output": "tamil/book/chapters/appendix-glossary.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "telugu",
+      "output": "telugu/book/chapters/appendix-glossary.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "urdu",
+      "output": "urdu/book/chapters/appendix-glossary.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "ur"
+    }
+  ],
   "targets": [
     {
       "language": "arabic",

--- a/code/learning/human-languages/french/book/book.tex
+++ b/code/learning/human-languages/french/book/book.tex
@@ -111,5 +111,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/french/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/french/book/chapters/appendix-glossary.tex
@@ -1,0 +1,666 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 94
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{(s')appeler}\par
+\small to call / to call oneself\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{à bientôt}\par
+\small see you soon (literally \textquotedblleft{}to well-soon\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{à demain}\par
+\small see you tomorrow (literally \textquotedblleft{}to tomorrow\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{à plus tard}\par
+\small see you later (literally \textquotedblleft{}to more late\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{aider}\par
+\small to help — English aid arriving by the Latin road, while English help came by the Germanic one; the two words are unrelated\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{aimer}\par
+\small to like AND to love — one French verb where English keeps two, so the strength comes from what follows it, and adding bien makes it WEAKER\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{aller}\par
+\small to go (and, oddly, \textquotedblleft{}to be\textquotedblright{} in \textquotedblleft{}how are you?\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{au revoir}\par
+\small goodbye (literally \textquotedblleft{}until the seeing-again\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{avoir}\par
+\small to have — the most worn-down verb in French, and a root you already met\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bien}\par
+\small well / good / fine\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bon / bonne}\par
+\small good (adjective)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bonjour}\par
+\small hello / good day\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bonne nuit}\par
+\small good night (going to bed)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bonsoir}\par
+\small good evening\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{chien, chat}\par
+\small dog and cat — chien is the REGULAR, expected descendant of canis (unlike Spanish's mysterious perro); chat continues cattus, the same Egypt-to-Rome story as Spanish's gato\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{comme ci, comme ça}\par
+\small so-so (literally \textquotedblleft{}like this, like that\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{comment}\par
+\small how\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{comment ça va ?}\par
+\small how are you? — the neutral everyday question\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{comment vous appelez-vous?}\par
+\small what's your name? (literally \textquotedblleft{}how do you call yourself?\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{comprendre}\par
+\small to understand — literally com- + prendre, \textquotedblleft{}to take together,\textquotedblright{} so in French understanding IS grasping, and the verb conjugates exactly like the one it is built from\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{courir}\par
+\small to run — Latin currere, the root under current, course, courier and curriculum, and the verb that shows why chien palatalized its c and courir did not\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{de rien}\par
+\small you're welcome (literally \textquotedblleft{}of nothing\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{demander}\par
+\small to ask — an ordinary, polite, everyday word, and one of the sharpest false friends French holds for an English speaker\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{dix-sept — vingt}\par
+\small 17–20 — the seam where French gives up fusing and just says \textquotedblleft{}ten-seven\textquotedblright{}\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{dormir}\par
+\small to sleep — Latin dormīre, unchanged in French, and the source of dormitory and dormant, though not of the dormouse\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{écrire}\par
+\small to write — Latin scrībere, \textquotedblleft{}to scratch,\textquotedblright{} with a propped-up é- that French added in front of every borrowed sc-, sp- and st- word\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{enchanté(e)}\par
+\small pleased to meet you (literally \textquotedblleft{}enchanted\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{entendre}\par
+\small to hear — from a Latin verb meaning \textquotedblleft{}to stretch toward,\textquotedblright{} so English's intend is its closest surviving cousin, and French still keeps the older sense in entendu and s'entendre\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{être}\par
+\small to be — the six present forms\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{fermer}\par
+\small to close — from Latin firmāre, \textquotedblleft{}to make firm,\textquotedblright{} so a French door is not shut but made fast; the same verb gave Italian \textquotedblleft{}to stop\textquotedblright{} and Spanish \textquotedblleft{}to sign\textquotedblright{}\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{habiter}\par
+\small to live / to dwell (a second -er verb — same pattern)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{heure}\par
+\small hour / o'clock — telling the time\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{il parla}\par
+\small the passé simple — the tense the passé composé drove out of speech, alive only in books\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{j'ai parlé}\par
+\small the passé composé — a past tense built out of \textquotedblleft{}have\textquotedblright{}, and a possessive that hardened\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{j'ai vingt ans}\par
+\small age — French HAS its years, it doesn't BE them\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{je}\par
+\small I\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{je m'appelle…}\par
+\small my name is… (literally \textquotedblleft{}I call myself…\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Je parle français}\par
+\small \textquotedblleft{}I speak French\textquotedblright{} — your first full sentence (français = French)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{je suis allé(e)}\par
+\small the compound past with être and subject agreement\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{je suis désolé(e)}\par
+\small I'm sorry (literally \textquotedblleft{}I am desolate\textquotedblright{})\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{jour}\par
+\small day (le jour — masculine)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{l'ami, l'amie}\par
+\small friend — masculine or feminine by a regular swap, and the reason le/la elides to l' before a vowel\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{l'eau, le vin}\par
+\small water and wine — eau, the most eroded Latin word of all\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{l'enfant}\par
+\small child — one spelling for both genders, the article alone showing which; literally \textquotedblleft{}not yet speaking\textquotedblright{}\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{l'œil, les yeux}\par
+\small eye — masculine, with a plural that looks irregular but is the REGULAR outcome of Latin oculos; œil's own singular is the piece that changed\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{l'œuf, les œufs}\par
+\small egg — masculine, a genuine cousin of English egg, and the one French noun whose final consonant vanishes only in the plural\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la bouche}\par
+\small mouth — feminine, and originally the Latin word for cheek, not mouth at all\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la famille}\par
+\small family — feminine and fixed, whoever is in it, and once meant the household's servants\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la main}\par
+\small the hand — feminine despite ending in a consonant, and the root of half the words you know\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la personne}\par
+\small person — feminine no matter who is meant, even a man, and secretly \textquotedblleft{}nobody\textquotedblright{} when it stands next to ne\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la tête}\par
+\small the head — from Latin for a clay pot\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{le / la / les}\par
+\small the (masculine / feminine / plural)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{le beurre}\par
+\small butter — masculine, and the same borrowed word as English butter, not two separate coinages\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{le café}\par
+\small coffee — masculine, and the one drink-word nearly all of Europe borrowed along the same single road\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{le frère, la sœur}\par
+\small brother and sister — frater and soror, behind fraternal and sorority\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{le fromage}\par
+\small cheese — masculine, and named for its MOULD rather than for the milk it's made from\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{le lait}\par
+\small milk — masculine, and the one drink in this chapter French did not have to borrow\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{le nez}\par
+\small nose — masculine, a silent final z, and another genuine cousin of its English counterpart\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{le pain}\par
+\small bread — and the \textquotedblleft{}companion\textquotedblright{} who shares it\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{le père, la mère}\par
+\small father and mother — the PIE root behind paternal and maternal\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{le sel}\par
+\small salt — masculine, cousin of English salt by common descent, and the source of a salary story no ancient writer actually tells\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{le sucre}\par
+\small sugar — masculine, closing a chapter where every drink-word is; the fourth and longest road of the four\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{le temps, il pleut}\par
+\small weather — le temps means BOTH \textquotedblleft{}time\textquotedblright{} and \textquotedblleft{}weather,\textquotedblright{} the SAME Latin tempus polysemy as Spanish's tiempo; il pleut keeps Latin's pl- UNCHANGED, unlike Spanish's llueve\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{le thé}\par
+\small tea — masculine, and the drink whose name split in two depending which Chinese port a trader dealt with\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{le ventre}\par
+\small stomach — masculine, nasal like la main but through a different vowel, and the word that closes four chapters of everyday nouns\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{les mois}\par
+\small the months — a parade of Roman gods and emperors\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{les saisons}\par
+\small the seasons — spring, summer, autumn, winter\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{lire}\par
+\small to read — from a Latin verb that first meant \textquotedblleft{}to gather,\textquotedblright{} which is why reading, electing, collecting and being elegant all turn out to be the same act\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{lundi, mardi, mercredi, jeudi, vendredi}\par
+\small the weekdays (Monday–Friday) — named for the planets\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{marcher}\par
+\small to walk — and also to work, so ça marche is the most useful two words in the chapter; its own origin is genuinely unsettled between a Frankish verb and a Latin hammer\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{me}\par
+\small me / myself (reflexive \& object pronoun)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{merci}\par
+\small thank you\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{midi, minuit}\par
+\small noon and midnight — the \textquotedblleft{}mid-day\textquotedblright{} and \textquotedblleft{}mid-night\textquotedblright{} hours\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{noir, blanc}\par
+\small black and white — one word inherited from Latin, one borrowed from the Germanic neighbours\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{non}\par
+\small no / not\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{nuit}\par
+\small night (la nuit — feminine)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{onze — seize}\par
+\small 11–16, the six fused numbers French inherited whole from Latin\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{oui}\par
+\small yes\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ouvrir}\par
+\small to open — an -ir verb that takes -er endings, from a Latin verb reshaped to look like its own opposite, and the source of English overt and overture\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{parler}\par
+\small to speak / to talk (your first regular -er verb)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{penser}\par
+\small to think — from a Latin verb meaning \textquotedblleft{}to weigh,\textquotedblright{} which is why English pensive, ponder, compensate, expense and even the flower pansy all sit in one family\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{prendre}\par
+\small to take — the grasping verb English borrowed a dozen times over, from prehensile to prison to surprise\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{rouge, bleu}\par
+\small red and blue — one ancient inherited root, and a second Germanic loan\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{s'asseoir}\par
+\small to sit down — a verb you do to yourself, from Latin sedēre, and the one French verb that ships with two accepted sets of forms\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{s'il vous plaît}\par
+\small please (literally \textquotedblleft{}if it pleases you\textquotedblright{})\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{salut}\par
+\small hi / bye (informal)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{samedi, dimanche}\par
+\small the weekend (Saturday, Sunday) — where the planets give way to religion\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{se lever, debout}\par
+\small to stand — French has no single verb for it, so the movement is se lever (\textquotedblleft{}to lighten yourself\textquotedblright{}) and the state is être debout, literally \textquotedblleft{}on end\textquotedblright{}\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{six, sept, huit, neuf, dix}\par
+\small the numbers 6–10 (and the months hidden in them)\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{soir}\par
+\small evening (le soir — masculine)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{travailler}\par
+\small to work (a third -er verb — and the origin of \textquotedblleft{}travel\textquotedblright{})\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{tu / vous}\par
+\small you (familiar / formal)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{un, deux, trois, quatre, cinq}\par
+\small the numbers 1–5\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{vert, jaune}\par
+\small green and yellow — vert is the standard, expected Latin viridis descendant shared by nearly every Romance language; jaune comes from a Latin word that literally meant \textquotedblleft{}yellow-GREEN,\textquotedblright{} and is usually said to share its ultimate PIE root with German's gelb, though that particular link is less secure than it first appears\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/german/book/book.tex
+++ b/code/learning/human-languages/german/book/book.tex
@@ -116,5 +116,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/german/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/german/book/chapters/appendix-glossary.tex
@@ -1,0 +1,659 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 93
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Abend}\par
+\small evening (der Abend — masculine)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{auf Wiedersehen}\par
+\small goodbye (formal — literally \textquotedblleft{}on the seeing-again\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bis bald}\par
+\small see you soon (literally \textquotedblleft{}until soon\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bis morgen}\par
+\small see you tomorrow (literally \textquotedblleft{}until tomorrow\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bis später}\par
+\small see you later (literally \textquotedblleft{}until later\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bitte}\par
+\small please — and also \textquotedblleft{}you're welcome\textquotedblright{} (and \textquotedblleft{}here you go,\textquotedblright{} and \textquotedblleft{}pardon?\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bitte}\par
+\small please — place the familiar courtesy word after a small request\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{danke}\par
+\small thank you\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{das Auge}\par
+\small eye — the third gender back on a body part, and a direct Germanic cousin of English eye\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{das Brot}\par
+\small bread — inherited Germanic, the twin of English bread\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{das Herz}\par
+\small heart — the last name from Chapter 17's table, closing it with the same k-to-h Grimm's law swap already heard on hören and Hund\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{das Ohr}\par
+\small ear — another direct Germanic cousin of its English translation, and the sense Chapter 26's hören already named\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{das Wasser, der Wein}\par
+\small water and wine — one native Germanic, one ancient Latin loan\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{das Wetter, es regnet}\par
+\small weather — a NATIVE Germanic word, unlike Romance's shared Latin tempus family; Wetter is the SAME word as English \textquotedblleft{}weather,\textquotedblright{} and regnet is the SAME word as English \textquotedblleft{}rain\textquotedblright{}\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{denken}\par
+\small to think — the verb you already met hiding inside danke, and the same inherited word as English think\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{der / die / das}\par
+\small the (masculine / feminine / neuter)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{der Arm}\par
+\small arm — named on Chapter 17's own table and now finally taught, a word Grimm's law never had to touch\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{der Bruder, die Schwester}\par
+\small brother and sister — again Germanic twins of the English words\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{der Finger}\par
+\small finger — identical to its English cousin, and possibly, though not certainly, built on the word for \textquotedblleft{}five\textquotedblright{}\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{der Freund}\par
+\small friend — a Germanic cousin of English friend, both frozen out of the same old verb meaning \textquotedblleft{}to love\textquotedblright{}\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{der Fuß}\par
+\small foot — the fourth name from Chapter 17's table, and the same p-to-f Grimm's law pattern Vater already taught\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{der Kaffee}\par
+\small coffee — a loanword that crossed from Arabic to German by way of Turkish and Italian, and the first word in a new polite request\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{der Kopf}\par
+\small the head — masculine, capitalised, with final pf\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{der Mund}\par
+\small mouth — the same inherited word as English mouth, with a root the standard accounts do not agree on past Proto-Germanic\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{der Tee}\par
+\small tea — a word that looks like its English cousin and is not said like it, and travelled to Europe by sea rather than overland\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{der Vater, die Mutter}\par
+\small father and mother — Grimm's law makes them twins of English father/mother\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{die Familie}\par
+\small family — the whole group Chapter 10's Eltern and Geschwister already named the members of, and this chapter's one Latin loan beside two native words\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{die Freundin}\par
+\small friend (female) — built on Freund with the native feminine suffix -in, the same suffix English kept in exactly one fossil word, vixen\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{die Hand}\par
+\small the hand — the same word as English, and unrelated to Romance manus\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{die Jahreszeiten}\par
+\small the seasons — native Germanic, unlike the Latin months\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{die Milch}\par
+\small milk — the native Germanic word that closes this trio, standing beside two loanwords the way Wasser once stood beside the loanword Wein\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{die Monate}\par
+\small the months — Latin loans, like the clock-word Uhr\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{die Nase}\par
+\small nose — the fourth face-part, cousin of English nose and of Latin nasus, and the payoff that completes the face Chapter 17 only started\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{dreizehn — zwanzig}\par
+\small 13–20 — perfectly regular digit+zehn compounds, step for step with English\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{du / Sie}\par
+\small you (familiar / formal)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{eins, zwei, drei, vier, fünf}\par
+\small the numbers 1–5\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{elf, zwölf}\par
+\small 11 and 12 — literally \textquotedblleft{}one left over\textquotedblright{} and \textquotedblleft{}two left over,\textquotedblright{} the exact twins of eleven and twelve\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Entschuldigung}\par
+\small sorry / excuse me (literally \textquotedblleft{}un-guilting,\textquotedblright{} from Schuld \textquotedblleft{}guilt/fault\textquotedblright{})\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{es geht}\par
+\small so-so / okay (literally \textquotedblleft{}it goes\textquotedblright{}); also \textquotedblleft{}so lala\textquotedblright{}\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{fragen}\par
+\small to ask — a weak verb whose vowel stays put, and whose closest English relatives came in from Latin as pray and precarious\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{freut mich}\par
+\small pleased to meet you (literally \textquotedblleft{}it gladdens me\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{gehen}\par
+\small to go — and the verb German uses for \textquotedblleft{}how are you?\textquotedblright{}\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{gehen}\par
+\small to go, and to walk — because German has no separate word for walking, and English's walk turns out to be a word about cloth\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{grün, gelb}\par
+\small green and yellow — grün is native Germanic, the direct cousin of English's OWN \textquotedblleft{}green\textquotedblright{} (a different root entirely from Latin's viridis); gelb is native too, and is usually said to share its ultimate PIE root with French's jaune, though that particular link is less secure than it first appears\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{gut}\par
+\small good; well\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Gute Nacht}\par
+\small good night\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Guten Abend}\par
+\small good evening\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Guten Morgen}\par
+\small good morning\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Guten Tag}\par
+\small hello / good day (polite)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{haben}\par
+\small to have — identical to Latin habēre in sound and sense, and unrelated to it\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hallo}\par
+\small hello (informal)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{heißen}\par
+\small to be called / to be named\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{helfen}\par
+\small to help — the same word as English help, separated by one sound law, and still strong in German the way English's help once was\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hören}\par
+\small to hear — the same verb as English hear, and the closing of a chapter of four things you do without going anywhere\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Hund, Katze}\par
+\small dog and cat — Hund is native Germanic, cognate with English's OWN discarded word \textquotedblleft{}hound\textquotedblright{}; Katze, surprisingly, is NOT native — it's the same borrowed Latin word behind French chat and Spanish gato (though not every European language shares it)\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ich}\par
+\small I\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ich bin gegangen}\par
+\small the perfect with sein for motion, arrival, and change of state\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ich bin zwanzig Jahre alt}\par
+\small age — the one place German refuses haben, siding with English against every Romance sister\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ich habe gesagt}\par
+\small the Perfekt — haben plus a participle wrapped in ge-…-t, and sent to the end of the clause\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ich heiße…}\par
+\small my name is… (literally \textquotedblleft{}I am called…\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Ich lerne Deutsch}\par
+\small \textquotedblleft{}I'm learning German\textquotedblright{} — your first full sentence (Deutsch = German)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ich sagte}\par
+\small the Präteritum — the simple past in writing and high-frequency speech\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ja}\par
+\small yes\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{laufen}\par
+\small to run — and to walk, because German draws the line in a different place from English, with rennen at the fast end\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{lernen}\par
+\small to learn (a third weak verb — the pattern is yours)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{lesen}\par
+\small to read — a verb that first meant \textquotedblleft{}to gather\textquotedblright{}, and the first one in this book whose vowel changes in the du and er forms\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{machen}\par
+\small to make / to do (a second weak verb — same endings)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Mittag, Mitternacht}\par
+\small noon and midnight — native \textquotedblleft{}mid-day\textquotedblright{} and \textquotedblleft{}mid-night\textquotedblright{}\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{mögen, lieben}\par
+\small to like and to love — plus gern, the adverb that lets any verb say \textquotedblleft{}I like doing this\textquotedblright{} and has no English shape at all\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Montag, Dienstag, Mittwoch, Donnerstag, Freitag}\par
+\small the weekdays (Monday–Friday) — Germanic gods, twins of the English days\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Morgen}\par
+\small morning (der Morgen — masculine)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Nacht}\par
+\small night (die Nacht — feminine)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{nehmen}\par
+\small to take — the verb English lost, though it left numb and nimble behind as fossils\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{nein}\par
+\small no\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{öffnen}\par
+\small to open — built on offen, which is English open, which is really the word up; and the doorway into German's separable verbs\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{rot, blau}\par
+\small red and blue — an ancient shared root, and a second word German lent to its neighbours\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Samstag, Sonntag}\par
+\small the weekend (Saturday, Sunday) — the Sabbath and the Sun\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{schlafen}\par
+\small to sleep — the same word as English sleep under two coats of German paint, and a second way for a strong verb to break\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{schließen}\par
+\small to close — the second verb in these chapters that German kept and English lost, and the one that locked up Schloss, Schlüssel and Schluss\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{schreiben}\par
+\small to write — the one verb in this chapter German did not inherit but borrowed, from Latin scribere\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{schwarz, weiß}\par
+\small black and white — both native Germanic, and one of them German lent to half of Europe\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{sechs, sieben, acht, neun, zehn}\par
+\small the numbers 6–10\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{sein}\par
+\small to be — one verb assembled from three different ancient roots\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{sitzen}\par
+\small to sit — the same inherited word as English sit, respelt by the other branch of the shift that separated helfen from help\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{stehen}\par
+\small to stand — the verb Chapter 24 found inside verstehen, and the one place German keeps a letter English put in the wrong tense\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Tag}\par
+\small day (der Tag — masculine)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{tschüss}\par
+\small bye (casual)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Uhr}\par
+\small clock / o'clock — and a Latin word inside German\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{verstehen}\par
+\small to understand — literally \textquotedblleft{}to stand around a thing\textquotedblright{}, the same picture English built independently in understand\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{wie}\par
+\small how\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Wie geht es dir?}\par
+\small how are you? — informal and everyday\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{wie heißen Sie?}\par
+\small what's your name? (literally \textquotedblleft{}how are you called?\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{wohnen}\par
+\small to live / to dwell (your first regular \textquotedblleft{}weak\textquotedblright{} verb)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/gujarati/book/book.tex
+++ b/code/learning/human-languages/gujarati/book/book.tex
@@ -105,5 +105,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/gujarati/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/appendix-glossary.tex
@@ -1,0 +1,379 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 53
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{આંખ}}\enspace\emph{āṅkh}\par
+\small eye — a straight cousin of the English word, and a nasal mark that is not the neuter tell you might expect\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{આવવું}}\enspace\emph{āvvũ}\par
+\small to come — from a root meaning “reach,” and a cousin of the word copula\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{બહેન}}\enspace\emph{bahen}\par
+\small sister — which, unlike its brother, is not the same word as the English one at all\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{ભાઈ}}\enspace\emph{bhāī}\par
+\small brother — the plainest possible cousin of the English word for the very same person\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{ચા}}\enspace\emph{chā}\par
+\small tea — a word that took the overland road out of China, so it rhymes with Hindi and Persian rather than with English\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{દૂધ}}\enspace\emph{dūdh}\par
+\small milk — inherited straight from Sanskrit, and a root English keeps in an unexpected word\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{એક} \gu{બે} \gu{ત્રણ} \gu{ચાર} \gu{પાંચ}}\enspace\emph{ek be traṇ chār pā̃ch}\par
+\small one to five — the two numbers that don't look like their neighbours'\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{ગમવું}}\enspace\emph{gamvũ}\par
+\small to like — the chapter's payoff, a verb that will not let you be its subject, born as the passive of \textquotedblleft{}to go\textquotedblright{}\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{હોવું}}\enspace\emph{hovũ}\par
+\small to be — and the neuter ending that names every Gujarati verb\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{જાણવું}}\enspace\emph{jāṇvũ}\par
+\small to know — the word English has been carrying all along\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{જવું}}\enspace\emph{javũ}\par
+\small to go — and the Sanskrit y- that Prakrit turned into j-\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{જોવું}}\enspace\emph{jovũ}\par
+\small to see — one vowel sign away from “to go,” and an origin still argued over\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{કાન}}\enspace\emph{kān}\par
+\small ear — a word Sanskrit itself could not settle the origin of, and one that changed gender on the way to Gujarati\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{ખાવું}}\enspace\emph{khāvũ}\par
+\small to eat — the verb whose family reaches its Indian sisters and stops there\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{કુટુંબ}}\enspace\emph{kuṭumb}\par
+\small family — the whole group, and a word that arrived in Gujarati already finished rather than growing there\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{લખવું}}\enspace\emph{lakhvũ}\par
+\small to write — the chapter's payoff, on a root that meant to scratch, and a family that stops before English again\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{લેવું}}\enspace\emph{levũ}\par
+\small to take — the shortest verb yet, and a family tree that is disputed rather than empty\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{મદદ} \gu{કરવી}}\enspace\emph{madad karvī}\par
+\small to help — an Arabic word that came by way of Persian, and the one place the verb ending stops being neuter\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{મિત્ર}}\enspace\emph{mitra}\par
+\small friend — a word this chapter will link to the very phrase you used to ask for water\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{મોઢું}}\enspace\emph{moḍhũ}\par
+\small mouth — the clearest example yet of Gujarati's neuter tell, the nasalized -ũ you have been hearing on every verb\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{નાક}}\enspace\emph{nāk}\par
+\small nose — the fourth body word, closing the chapter by running the whole face back through gender, sound, and certainty\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{પાણી}}\enspace\emph{pāṇī}\par
+\small water — Gujarati's first noun for something you would actually ask for, and the phrase that asks for it politely\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{પૂછવું}}\enspace\emph{pūchhvũ}\par
+\small to ask — the verb English kept only for praying, and a p that stayed put because of where it stood\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{રોટલી}}\enspace\emph{roṭlī}\par
+\small flatbread — the fourth request, an honest dead end for its origin, and the letter -ī does not always mean what you'd guess\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{સમજવું}}\enspace\emph{samajvũ}\par
+\small to understand — built on a root that meant \textquotedblleft{}to wake up,\textquotedblright{} and the cluster it lost on the way\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{વાંચવું}}\enspace\emph{vā̃chvũ}\par
+\small to read — which once meant \textquotedblleft{}to make something speak,\textquotedblright{} and a nasal that lives in the middle of the word\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{વિચારવું}}\enspace\emph{vichārvũ}\par
+\small to think — a verb Gujarati built for itself, on a root that meant to wander\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{આભાર}}\par
+\small thank you (ābhār)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{આવજો}}\par
+\small goodbye (lit. \textquotedblleft{}{[}please{]} come {[}again{]}\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{કેમ}}\par
+\small how (also \textquotedblleft{}why\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{કામ} \gu{કરવું}}\par
+\small to work (lit. \textquotedblleft{}work-do\textquotedblright{})\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{કાલે} \gu{મળીશું}}\par
+\small see you tomorrow (and the \gu{કાલ} puzzle)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{છે}}\par
+\small is (the copula)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{તું} / \gu{તમે}}\par
+\small you (familiar / respectful)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{તમે} \gu{કેમ} \gu{છો}?}\par
+\small how are you? (respectful)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{તમને} \gu{મળીને} \gu{આનંદ} \gu{થયો}}\par
+\small pleased to meet you (lit. \textquotedblleft{}meeting you, joy happened\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{તમારું} \gu{નામ} \gu{શું} \gu{છે}?}\par
+\small what's your name?\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{નામ}}\par
+\small name\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{નમસ્તે}}\par
+\small hello / goodbye (namaste)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{પાછા}}\par
+\small again, back\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{પાછા} \gu{મળીશું}}\par
+\small we'll meet again (goodbye)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{બોલવું}}\par
+\small to speak\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{મજા}}\par
+\small enjoyment, fun — and the reply \textquotedblleft{}\gu{હું} \gu{મજામાં} \gu{છું}\textquotedblright{}\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{મારું}}\par
+\small my (neuter; also \gu{મારો} m. / \gu{મારી} f.)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{મારું} \gu{નામ} … \gu{છે}}\par
+\small my name is…\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{મળીશું}}\par
+\small (we) will meet\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{રહેવું}}\par
+\small to live, to stay\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{વાંધો} \gu{નહીં}}\par
+\small no problem / it's okay / you're welcome\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{શું}}\par
+\small what\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{સારું}}\par
+\small good, okay, fine (sārũ)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{હું}}\par
+\small I\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{હા} / \gu{ના}}\par
+\small yes / no (hā / nā)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\gu{હું} \gu{ગુજરાતી} \gu{બોલું} \gu{છું}}\par
+\small I speak Gujarati\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/hindi/book/book.tex
+++ b/code/learning/human-languages/hindi/book/book.tex
@@ -156,5 +156,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/hindi/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/hindi/book/chapters/appendix-glossary.tex
@@ -1,0 +1,610 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 86
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{अलविदा}}\par
+\small goodbye (alvidā — a final farewell, Persian/Arabic-derived)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{आँख}}\par
+\small eye — feminine, and a word-for-word cousin of English \textquotedblleft{}eye\textquotedblright{} and Latin \textquotedblleft{}oculus\textquotedblright{}\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{आदमी}}\par
+\small man, person — masculine despite its -ī ending, and literally \textquotedblleft{}of Adam\textquotedblright{}\par
+\footnotesize Introduced in Chapter 39.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{आप} / \hi{तुम}}\par
+\small you (respectful / familiar)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{आप} \hi{कैसे} \hi{हैं}?}\par
+\small how are you? (respectful)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{आपका} \hi{नाम} \hi{क्या} \hi{है}?}\par
+\small what's your name?\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{आपका} \hi{स्वागत} \hi{है}}\par
+\small you're welcome (also \textquotedblleft{}welcome!\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{उम्र}}\par
+\small age — the same word as Arabic's ʿumr, borrowed through Persian, beside formal Sanskrit āyu\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{एक} \hi{दो} \hi{तीन} \hi{चार} \hi{पाँच}}\par
+\small one to five, with familiar Devanagari pieces and the chandrabindu in \hi{पाँच}\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{औरत}}\par
+\small woman — feminine, an Arabic word that only came to mean \textquotedblleft{}woman\textquotedblright{} in Persian, and one of three Hindi words separated by register\par
+\footnotesize Introduced in Chapter 39.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{कुत्ता}}\par
+\small dog — a third uncertain-origin everyday word displacing an inherited PIE dog-word\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{किताब}}\par
+\small book — feminine, built on the Arabic root for writing, and one of three Hindi words for a book that differ by register\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{कृपया}}\par
+\small please (kṛpayā — \textquotedblleft{}kindly,\textquotedblright{} from kṛpā \textquotedblleft{}grace/compassion\textquotedblright{})\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{कमरा}}\par
+\small room — masculine, and the same Latin word as English \textquotedblleft{}camera\textquotedblright{}, brought to India by Portuguese ships\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{क्या}}\par
+\small what\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{करना}}\par
+\small to do, to make (and \hi{काम} \hi{करना}, \textquotedblleft{}to work\textquotedblright{})\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{कुर्सी}}\par
+\small chair — your first feminine noun, and a word that has been passing between Middle Eastern languages for four thousand years\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{कल} \hi{मिलते} \hi{हैं}}\par
+\small see you tomorrow (and the \hi{कल} puzzle)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{काला} \hi{सफ़ेद}}\par
+\small black and white — one Sanskrit word tangled up with time and death, one a Persian loan\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{कैसे}}\par
+\small how (also \hi{कैसा}/\hi{कैसी}, agreeing)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{खाना}}\par
+\small food — masculine, from a Sanskrit verb of eating, and not to be confused with its Persian look-alike meaning \textquotedblleft{}house\textquotedblright{}\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{ख़ुशी}}\par
+\small happiness / pleased to meet you\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{ग्यारह} — \hi{बीस}}\par
+\small 11-20 — genuinely irregular, must be memorized individually; but \hi{उन्नीस} (19) most likely preserves Sanskrit's OWN subtractive naming, the same logic as Latin's ūndēvīgintī\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{घंटा}}\par
+\small hour — literally \textquotedblleft{}bell,\textquotedblright{} from the historical practice of striking a bell to mark the hour\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{घर}}\par
+\small house, home — masculine, and from a Sanskrit word that meant a fenced enclosure before it meant a building\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{चाय}}\par
+\small tea — feminine, and one of the two names the world uses for the same leaf\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{चलता} \hi{हूँ}}\par
+\small I'll be off (lit. \textquotedblleft{}I go\textquotedblright{}), gendered\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{छह} \hi{सात} \hi{आठ} \hi{नौ} \hi{दस}}\par
+\small six to ten, with seven and eight repeating the same Prakrit weight trade as three\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{जनवरी} \hi{फ़रवरी} \hi{मार्च} \hi{अप्रैल} \hi{मई} \hi{जून} \hi{जुलाई} \hi{अगस्त} \hi{सितंबर} \hi{अक्टूबर} \hi{नवंबर} \hi{दिसंबर}}\par
+\small the Gregorian months — borrowed English/international names, running ALONGSIDE the traditional Vikram Samvat calendar's own six-ritu-linked months\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{ठीक}}\par
+\small fine, well, correct — and the reply \textquotedblleft{}\hi{मैं} \hi{ठीक} \hi{हूँ}\textquotedblright{}\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{दाँत}}\par
+\small tooth — masculine, though it is built exactly like the feminine \hi{आँख}, and a cousin of Latin dēns and English tooth\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{दूध}}\par
+\small milk — masculine, and literally \textquotedblleft{}the milked thing\textquotedblright{}, a past participle that hardened into a noun\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{दिन}}\par
+\small \textquotedblleft{}day\textquotedblright{} — shares its ultimate PIE root with Latin's diēs, but through a separate derivational branch (din patterns with Baltic/Slavic \textquotedblleft{}day\textquotedblright{}-words); Sanskrit's own \hi{दिव्}/\hi{द्यु} are actually the closer, more direct cousins of diēs\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{दोपहर}}\par
+\small \textquotedblleft{}afternoon\textquotedblright{} — the same word already met meaning precisely \textquotedblleft{}noon\textquotedblright{} (two pahars after sunrise, HI-C17), now widened in modern everyday usage to cover the whole afternoon stretch, not just the exact midday moment\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{दोपहर} \hi{आधी} \hi{रात}}\par
+\small noon (literally \textquotedblleft{}two pahars,\textquotedblright{} a traditional \textasciitilde{}3-hour time unit) and midnight (\textquotedblleft{}half night,\textquotedblright{} fully transparent)\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{दरवाज़ा}}\par
+\small door — masculine, a Persian loan whose first syllable is the same ancient word as English \textquotedblleft{}door\textquotedblright{}\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{दोस्त}}\par
+\small friend — a Persian word for \textquotedblleft{}the one chosen\textquotedblright{}, masculine by default but taking either possessive depending on who the friend is\par
+\footnotesize Introduced in Chapter 39.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{धन्यवाद}}\par
+\small thank you (dhanyavād — formal, Sanskritic)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{नाम}}\par
+\small name\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{नमस्कार}}\par
+\small hello (namaskār — more formal)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{नमस्ते}}\par
+\small hello / goodbye (namaste — \textquotedblleft{}I bow to you\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{नहीं}}\par
+\small no / not (nahīṃ)\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{पूछना}}\par
+\small to ask — the same inherited verb as English \textquotedblleft{}pray\textquotedblright{}, which once meant nothing more than asking\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{पेट}}\par
+\small stomach, belly — masculine, and the one word in this chapter with no clean ancestry at all\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{पढ़ना}}\par
+\small to read — and equally \textquotedblleft{}to study\textquotedblright{}, because the Sanskrit verb underneath it meant \textquotedblleft{}to recite aloud\textquotedblright{}\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{पिता} \hi{माता}}\par
+\small father and mother — Sanskrit cousins of Latin pater/mater and English father/mother\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{पानी} \hi{रोटी}}\par
+\small water (literally \textquotedblleft{}the drinkable one,\textquotedblright{} not the ancient Sanskrit word for water) and bread/flatbread\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{पैर}}\par
+\small foot — masculine, and NOT the descendant of Sanskrit pāda; that honour belongs to \hi{पाँव}\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{पसंद}}\par
+\small liked, pleasing — a Persian noun, not a verb, in a sentence where the thing you like is the subject and you are only the person it happens to\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{फिर}}\par
+\small again, then\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{फिर} \hi{मिलेंगे}}\par
+\small we'll meet again (goodbye)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{बच्चा}}\par
+\small child — masculine, with a feminine \hi{बच्ची}, and a Persian word that landed on top of an inherited Sanskrit cousin\par
+\footnotesize Introduced in Chapter 39.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{बोलता} \hi{हूँ}, \hi{बोलती} \hi{हूँ}, \hi{बोलते} \hi{हैं}}\par
+\small the present-habitual template — stem + -tā/-tī/-te + honā\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{बोलना}}\par
+\small to speak\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{भाई} \hi{बहन}}\par
+\small brother (a PIE cousin of English \textquotedblleft{}brother\textquotedblright{}) and sister (a DIFFERENT Sanskrit word entirely, not the PIE cousin of \textquotedblleft{}sister\textquotedblright{})\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{मैं}}\par
+\small I\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{मैं} \hi{हिंदी} \hi{बोलता} \hi{हूँ}}\par
+\small I speak Hindi (gendered)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{मदद} \hi{करना}}\par
+\small to help — a noun plus \hi{करना}, which is how Hindi turns almost anything into a verb\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{माफ़} \hi{कीजिए}}\par
+\small please forgive me / sorry (māf kījiye — \textquotedblleft{}please do forgiveness\textquotedblright{})\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{मेरा}}\par
+\small my\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{मेरा} \hi{नाम} … \hi{है}}\par
+\small my name is…\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{मिलेंगे}}\par
+\small (we) will meet\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{मौसम}}\par
+\small weather — the SAME root as English \textquotedblleft{}monsoon\textquotedblright{}; rain has TWO words that sound alike but are NOT related, a real false-friend trap\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{रात}}\par
+\small \textquotedblleft{}night\textquotedblright{} — already met inside aadhi raat (\textquotedblleft{}midnight\textquotedblright{}); despite meaning the same thing as Latin's nox, in a related Indo-European language, it comes from a COMPLETELY DIFFERENT PIE root — a genuine false cousin\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{रहना}}\par
+\small to live, to stay\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{लिखना}}\par
+\small to write — from a Sanskrit verb meaning \textquotedblleft{}to scratch\textquotedblright{}, the same picture five language families reached independently\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{लेना}}\par
+\small to take — worn down from Sanskrit labh-, which also sits, undisguised, in the noun \hi{लाभ}\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{लाल} \hi{नीला}}\par
+\small red and blue — a Persian gemstone-name, and the Sanskrit word behind the world's word for \textquotedblleft{}indigo\textquotedblright{}\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{वसंत} \hi{ग्रीष्म} \hi{वर्षा} \hi{शरद्} \hi{हेमंत} \hi{शिशिर}}\par
+\small SIX traditional seasons, not four — India's own \hi{ऋतु} system, which the Western four-season frame doesn't map onto cleanly\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{शुक्रिया}}\par
+\small thanks (shukriyā — everyday, Persian/Arabic-derived)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{शनिवार} \hi{रविवार}}\par
+\small Saturday and Sunday — completing Hindi's planet-week\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{शुभ} \hi{दोपहर}}\par
+\small \textquotedblleft{}good afternoon\textquotedblright{} (shubh dopahar) — uses \hi{दोपहर} in its modern, widened \textquotedblleft{}afternoon\textquotedblright{} sense (HI-C30), not the narrow etymological \textquotedblleft{}noon\textquotedblright{}; the rarest of this arc's three \hi{शुभ}+noun greetings in actual casual use, with \hi{नमस्ते}/\hi{नमस्कार} covering the afternoon in practice\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{शुभ} \hi{रात्रि}}\par
+\small good night" — literally \textquotedblleft{}auspicious night,\textquotedblright{} using the formal literary raatri, not the everyday raat just taught, plus shubh, an \textquotedblleft{}auspicious\textquotedblright{} word that started life meaning "shining\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{शुभ} \hi{संध्या}}\par
+\small \textquotedblleft{}good evening\textquotedblright{} — sandhyā is the Sanskrit junction of day and night, with the register-crossing doublet sāñjh\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{शाम}}\par
+\small \textquotedblleft{}evening\textquotedblright{} (shaam) — another genuine Persian loanword, like subah; looks tempting to connect to Sanskrit \hi{श्यामा} (śyāmā, \textquotedblleft{}night/dark\textquotedblright{}), but that's a false cognate — different root entirely, despite the resemblance\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{सोचना}}\par
+\small to think — a verb that began life meaning \textquotedblleft{}to grieve,\textquotedblright{} and still keeps the worry inside the noun \hi{सोच}\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{सुप्रभात}}\par
+\small \textquotedblleft{}good morning\textquotedblright{} (suprabhat) — \hi{सु} (\textquotedblleft{}good\textquotedblright{}) + \hi{प्रभात} (prabhāt, native Sanskrit \textquotedblleft{}dawn,\textquotedblright{} from prabhā, \textquotedblleft{}light, splendour,\textquotedblright{} itself from bhā, \textquotedblleft{}to shine\textquotedblright{}) — a completely different word from \hi{सुबह}, the Persian-loan everyday noun; skews formal/written (radio, greeting cards) rather than casual spoken Hindi, where \hi{नमस्ते} covers mornings too — but there's no strong evidence it's being displaced by English the way some other languages' night greetings were found to be\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{सुबह}}\par
+\small \textquotedblleft{}morning\textquotedblright{} (subah) — a Persian/Arabic loanword, NOT Sanskrit tatsama like din/raat; shares the Arabic root \ar{ص}-\ar{ب}-\ar{ح} with ṣabāḥ (\textquotedblleft{}morning\textquotedblright{}) and with the tuṣbiḥ inside the Arabic \textquotedblleft{}good night\textquotedblright{} phrase\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{समझना}}\par
+\small to understand — literally \textquotedblleft{}to wake up fully,\textquotedblright{} on the same root as Buddha\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{सोमवार} \hi{मंगलवार} \hi{बुधवार} \hi{गुरुवार} \hi{शुक्रवार}}\par
+\small Monday–Friday — Hindi's own planet-week, independent of Rome's\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{सिर}}\par
+\small the head — from Sanskrit śiras, worn down through a thousand years of everyday speech\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{हाँ}}\par
+\small yes (hāṃ)\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{हूँ}}\par
+\small am (1st-person of \hi{होना}, \textquotedblleft{}to be\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{है}}\par
+\small is\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{हाथ}}\par
+\small the hand — from Sanskrit hasta, with a real (if non-obvious) sound-change story\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\hi{हरा}}\par
+\small green — a deep cousin of German gelb and English yellow from an ancient shining-color root\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/italian/book/book.tex
+++ b/code/learning/human-languages/italian/book/book.tex
@@ -100,5 +100,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/italian/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/italian/book/chapters/appendix-glossary.tex
@@ -1,0 +1,582 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 82
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{a domani}\par
+\small see you tomorrow (literally \textquotedblleft{}to tomorrow\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{a più tardi}\par
+\small see you later (literally \textquotedblleft{}to more late\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{a presto}\par
+\small see you soon (literally \textquotedblleft{}to soon\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{abitare}\par
+\small to live / to dwell (a second -are verb — same pattern)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{aiutare}\par
+\small to help — and the shout an Italian street uses for it\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{andare}\par
+\small to go — one verb built from two historical stems\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{arrivederci}\par
+\small goodbye (literally \textquotedblleft{}until we see each other again\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{aspettare}\par
+\small to wait — and, with one small word in front, to expect\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{avere}\par
+\small to have — and Italy's only silent letter, which exists purely to prevent confusion\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{buongiorno}\par
+\small good day / good morning\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{buono / buon}\par
+\small good (adjective)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{capire}\par
+\small to understand — literally \textquotedblleft{}to take hold of\textquotedblright{}, and Italian's third conjugation with its own infix\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{chiedere}\par
+\small to ask — from Latin \textquotedblleft{}to seek\textquotedblright{}, with a second verb beside it that is a false friend in English\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ciao}\par
+\small hi / bye (informal)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{come}\par
+\small how / like, as\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Come sta?}\par
+\small formal “how are you?”\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Come stai?}\par
+\small how are you? (informal)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Come ti chiami?}\par
+\small what's your name? (informal); formal Come si chiama?\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Come va?}\par
+\small how is it going?\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{comprare}\par
+\small to buy — from procuring, not from comparing, however much the two look alike\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{così così}\par
+\small so-so (literally \textquotedblleft{}thus, thus\textquotedblright{} — \textquotedblleft{}this way, that way\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{diciassette — venti}\par
+\small 17–20 — Italian flips the order at 17: the ten jumps to the FRONT\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{essere}\par
+\small to be — the other Italian “to be”\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{giocare, suonare}\par
+\small the two verbs English calls \textquotedblleft{}play\textquotedblright{} — one for games, one for instruments, and no relation between them\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{giorno}\par
+\small day (masculine)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{grazie}\par
+\small thank you\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ho parlato}\par
+\small the passato prossimo — avere plus a participle, the everyday Italian past\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ho venti anni}\par
+\small age — Italian HAS its years, and the last lesson's silent h finally earns its keep\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{i mesi}\par
+\small the months — the Roman calendar, barely worn down\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{il / la / lo}\par
+\small the (masculine / feminine)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{il caffè}\par
+\small coffee — the pan-European word Italy took from an Ottoman drink\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{il cuore}\par
+\small heart — the root behind courage, accord, and record\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{il fratello, la sorella}\par
+\small brother and sister — frater/soror plus Italy's favourite little-endings\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{il latte}\par
+\small milk — the one drink here Italian never had to borrow\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{il naso}\par
+\small nose — twisted by its own name\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{il nome}\par
+\small name — the word Chapter 3 never actually needed\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{il padre, la madre}\par
+\small father and mother — Italian keeps them closest to Latin pater/mater\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{il pane}\par
+\small bread — closest to Latin pānis, and the \textquotedblleft{}companion\textquotedblright{} who shares it\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{il tè}\par
+\small tea — the sea-route word, where \textquotedblleft{}chai\textquotedblright{} is the overland one\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{incontrare}\par
+\small to meet — literally \textquotedblleft{}to come against\textquotedblright{}, with a second meeting-verb hiding inside a past tense\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{io}\par
+\small I (first-person subject pronoun)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{l'acqua, il vino}\par
+\small water and wine — acqua kept Latin's whole aqua, where French wore it to eau\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{l'amico, l'amica}\par
+\small friend (m./f.) — from loving, and the reason \textquotedblleft{}enemy\textquotedblright{} is its own opposite\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{l'occhio}\par
+\small eye — three Latin syllables worn down to one\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{l'orecchio}\par
+\small ear — the same sound-law as the eye, one lesson later\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la bocca}\par
+\small mouth — not Latin's real word for it, but the one that won\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la famiglia}\par
+\small family — the one word here Italian never had to borrow\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la gola}\par
+\small throat — and possibly the swallow at the bottom of \textquotedblleft{}glutton\textquotedblright{}\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la mano}\par
+\small the hand — the noun that breaks Italian's own gender rule\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la persona}\par
+\small person — always feminine, no matter who it is\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la testa}\par
+\small the head — the pot-word, kept in its original shape\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{lavorare}\par
+\small to work (a third -are verb — and the \textquotedblleft{}labour\textquotedblright{} road, not the \textquotedblleft{}torture\textquotedblright{} one)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{le stagioni}\par
+\small the seasons — and \textquotedblleft{}primavera,\textquotedblright{} the first green\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{leggere}\par
+\small to read — literally \textquotedblleft{}to gather up\textquotedblright{}, and Italian's third and last verb family\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{lo stomaco}\par
+\small stomach — the one body word that stopped in Greece before it reached Rome\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{lo zucchero}\par
+\small sugar — Arabic again, but by the French road this time, not the Turkish one\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{lunedì, martedì, mercoledì, giovedì, venerdì}\par
+\small the weekdays (Monday–Friday) — the planets, with the day-word at the end\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{mezzogiorno, mezzanotte}\par
+\small noon and midnight — \textquotedblleft{}mid-day\textquotedblright{} and \textquotedblleft{}mid-night\textquotedblright{}\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{mi chiamo}\par
+\small my name is (literally \textquotedblleft{}I call myself\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{mi piace}\par
+\small I like it — built backwards, as \textquotedblleft{}it is pleasing to me\textquotedblright{}\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{nero, bianco}\par
+\small black and white — nero straight from Latin, bianco borrowed from the Germanic invaders\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{notte / buonanotte}\par
+\small night / good night\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ora}\par
+\small hour / o'clock — telling the time with the feminine article\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ottenere}\par
+\small to get, to obtain — a holding-verb, and a b that flattened into a t\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{parlare}\par
+\small to speak / to talk (your first regular -are verb)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{parlò}\par
+\small the passato remoto — the simple past, alive in the south and in books\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Parlo italiano}\par
+\small \textquotedblleft{}I speak Italian\textquotedblright{} — your first full sentence (italiano = Italian)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{pensare}\par
+\small to think — literally \textquotedblleft{}to weigh out\textquotedblright{}, and a fourth verb on the -are pattern\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{piacere}\par
+\small pleased to meet you (literally \textquotedblleft{}a pleasure\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{portare}\par
+\small to carry, to bring — and, without warning, to wear\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{prego}\par
+\small you're welcome (and please, go ahead, after you)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{prendere}\par
+\small to take — and, at a table, to have; Italian's other verb of seizing\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{rispondere}\par
+\small to answer — literally \textquotedblleft{}to pledge back\textquotedblright{}, the other half of Chapter 19's asking\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{rosso, blu}\par
+\small red and blue — an ancient inherited root, a second Germanic loan, and the Arabic blue of the Azzurri\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{sabato, domenica}\par
+\small the weekend (Saturday, Sunday) — Sabbath and the Lord's day\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{scrivere}\par
+\small to write — literally \textquotedblleft{}to scratch\textquotedblright{}, and the chapter's four minds in one run\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{sei, sette, otto, nove, dieci}\par
+\small the numbers 6–10 (and the months hidden in them)\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{sera / buonasera}\par
+\small evening / good evening\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{sono andato}\par
+\small the passato prossimo built on essere, with the participle agreeing with the subject\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{stare}\par
+\small to be (a state — how you're doing); literally \textquotedblleft{}to stay/stand\textquotedblright{}\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{undici — sedici}\par
+\small 11–16 — Italian keeps Latin's fusions so clearly you can still read the \textquotedblleft{}ten\textquotedblright{} in them\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{uno, due, tre, quattro, cinque}\par
+\small the numbers 1–5\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/japanese/book/book.tex
+++ b/code/learning/human-languages/japanese/book/book.tex
@@ -69,6 +69,7 @@ are used. Nothing else is.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \chapter*{Sources for this starter edition}
 \addcontentsline{toc}{chapter}{Sources for this starter edition}

--- a/code/learning/human-languages/japanese/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/japanese/book/chapters/appendix-glossary.tex
@@ -1,0 +1,57 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 7
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{ありがとう}}\enspace\emph{arigatō}\par
+\small thank you (plain)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{ありがとうございます}}\enspace\emph{arigatō gozaimasu}\par
+\small thank you (polite)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{はい}}\enspace\emph{hai}\par
+\small yes\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{いいえ}}\enspace\emph{iie}\par
+\small no; not at all\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{コーヒー}}\enspace\emph{kōhī}\par
+\small coffee\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{こんにちは}}\enspace\emph{konnichiwa}\par
+\small hello (daytime greeting)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ja{日本語}}\enspace\emph{nihongo}\par
+\small the Japanese language\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/kannada/book/book.tex
+++ b/code/learning/human-languages/kannada/book/book.tex
@@ -127,5 +127,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/kannada/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/kannada/book/chapters/appendix-glossary.tex
@@ -1,0 +1,582 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 82
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{-\kn{ಗೆ}}\enspace\emph{-ge}\par
+\small the dative suffix -ge, 'to / for,' and its family sound history\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಅರ್ಥಮಾಡಿಕೊ}}\enspace\emph{arthamāḍiko}\par
+\small to understand — \textquotedblleft{}meaning, having done, take for yourself,\textquotedblright{} three pieces in a row, and the ending that hands an action back to its doer\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಬಾ}}\enspace\emph{bā / baru}\par
+\small come — the form you call the verb by is not the form the beads attach to\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಬರೆ}}\enspace\emph{bare}\par
+\small to write, to draw — an old Dravidian word for scratching a line, and the third proof of the sound law that gave Kannada its b\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಬಾಯಿ}}\enspace\emph{bāyi}\par
+\small mouth — a word this book has already shown you twice, in two sound-law tables, without ever saying what it means\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಚಹಾ}}\enspace\emph{cahā}\par
+\small tea — a word that travelled overland from China through Persia before it ever reached Kannada, the same road Chapter 20's weather-word took\par
+\footnotesize Introduced in Chapter 39.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಗೊತ್ತು}}\enspace\emph{gottu}\par
+\small known — the chapter's closer, a know-word with no stem, no tense and no person, so the knower has to sit outside the verb\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಹಾಲು}}\enspace\emph{hālu}\par
+\small milk — a word Chapter 32 already used, unexplained, as one of its four proof-pairs for the sound law that made Kannada sound like Kannada\par
+\footnotesize Introduced in Chapter 39.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಹೋಗು}}\enspace\emph{hōgu}\par
+\small to go — and the one sound-law that separates Kannada from all three of its sisters\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಹೃದಯ}}\enspace\emph{hṛdaya}\par
+\small heart — a Sanskrit word that is, astonishingly, a genuine cousin of the English one\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಇರು}}\enspace\emph{iru}\par
+\small to be, to exist, to stay — and the three-piece machine every Kannada verb is built on\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಕಣ್ಣು}}\enspace\emph{kaṇṇu}\par
+\small eye — matching Telugu almost letter for letter, and Tamil and Malayalam nearly as closely\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಕಾಫಿ}}\enspace\emph{kāphi}\par
+\small coffee — a word that crossed Arabic, Turkish, Dutch and English before it ever reached Kannada, the longest chain of loans in this book\par
+\footnotesize Introduced in Chapter 39.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಕೇಳು}}\enspace\emph{kēḷu}\par
+\small to ask, and equally to hear — one Kannada verb doing two jobs English keeps apart, and Telugu does too\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಕಿವಿ}}\enspace\emph{kivi}\par
+\small ear — matching Tamil and Telugu's literary word, where everyday spoken Tamil actually reaches for a different one\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಕುಟುಂಬ}}\enspace\emph{kuṭumba}\par
+\small family — the collective word Chapter 12's parents and siblings never needed, because each of them was already the name of one specific person\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಮಗ}}\enspace\emph{maga}\par
+\small son — the same root as \textquotedblleft{}child,\textquotedblright{} with its ending changed\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಮಗಳು}}\enspace\emph{magaḷu}\par
+\small daughter — one more ending on the same root, where Chapter 12 needed four whole words to do a similar job\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಮಗು}}\enspace\emph{magu}\par
+\small baby, child — gender-neutral, and the root that the next two lessons split by gender\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಮೂಗು}}\enspace\emph{mūgu}\par
+\small nose — matching Tamil and Malayalam closely, with Telugu the odd one out this time\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ನನಗೆ} \kn{ಕನ್ನಡ} \kn{ಗೊತ್ತು}}\enspace\emph{nanage kannaḍa gottu}\par
+\small 'I know Kannada' — built with no subject, because knowing happens TO you\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ನನಗೆ} \kn{ಕನ್ನಡ} \kn{ಇಷ್ಟ}}\enspace\emph{nanage kannaḍa iṣṭa}\par
+\small 'I like Kannada' — a sentence with no verb anywhere in it, the liker pushed into the dative and the liked thing left standing plain\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ನೋಡು}}\enspace\emph{nōḍu}\par
+\small to see, to look — the third slot, and the one everyday word the four sisters do NOT share\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಓದು}}\enspace\emph{ōdu}\par
+\small to read, to study — an inherited Dravidian word that once meant reciting aloud, and that Kannada alone kept in the everyday job\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಸಹಾಯ} \kn{ಮಾಡು}}\enspace\emph{sahāya māḍu}\par
+\small to help — literally \textquotedblleft{}help-do,\textquotedblright{} a Sanskrit noun in front of a native Dravidian verb, and the single most useful thing you can say to a stranger\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಸ್ನೇಹಿತ}}\enspace\emph{snēhita}\par
+\small friend — built on the Sanskrit word for oil, sitting beside a native Dravidian word that means exactly the same thing\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ತೆಗೆದುಕೊ}}\enspace\emph{tegeduko}\par
+\small to take — \textquotedblleft{}having pulled it out, keep it for yourself,\textquotedblright{} a two-verb design all three Dravidian sisters share where English has one flat word\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ತಿನ್ನು}}\enspace\emph{tinnu}\par
+\small to eat — and the middle bead, which carries the past but does not bother to separate the future\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಊಟ}}\enspace\emph{ūṭa}\par
+\small a meal — the word Chapter 32 already used to explain what \textquotedblleft{}eating\textquotedblright{} doesn't cover, without ever teaching it, and the word that sits at the hour of two greetings you already know\par
+\footnotesize Introduced in Chapter 40.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಯೋಚಿಸು}}\enspace\emph{yōcisu}\par
+\small to think — a Sanskrit noun wearing Kannada's own verb-making suffix, beside the inherited root Kannada kept for remembering\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಅಪ್ಪ} \kn{ಅಮ್ಮ} \kn{ಅಣ್ಣ} \kn{ತಮ್ಮ} \kn{ಅಕ್ಕ} \kn{ತಂಗಿ}}\par
+\small father, mother, and four age-graded sibling words — nearly identical to Tamil's own set\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಅಪರಾಹ್ನ}}\par
+\small \textquotedblleft{}afternoon\textquotedblright{} (aparāhna) — a genuine Sanskrit tatsama distinct from \kn{ಮಧ್ಯಾಹ್ನ}/madhyāhna (\textquotedblleft{}noon\textquotedblright{}), sharing its \textquotedblleft{}-ahna\textquotedblright{} (\textquotedblleft{}day\textquotedblright{}) suffix; apara (\textquotedblleft{}latter\textquotedblright{}) vs madhya (\textquotedblleft{}middle\textquotedblright{}), the same clean structure applied to two different day-parts\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಆರು} \kn{ಏಳು} \kn{ಎಂಟು} \kn{ಒಂಬತ್ತು} \kn{ಹತ್ತು}}\par
+\small six to ten — and the sound-change that turns Tamil p- into Kannada h-\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಇರು}}\par
+\small to be, to stay, to live\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಇಲ್ಲ}}\par
+\small no / there isn't (illa — the negative)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಏನು}}\par
+\small what\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಒಂದು} \kn{ಎರಡು} \kn{ಮೂರು} \kn{ನಾಲ್ಕು} \kn{ಐದು}}\par
+\small one to five — the same Dravidian numbers as Tamil, with a Kannada accent\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಕಪ್ಪು} \kn{ಬಿಳಿ} \kn{ಕೆಂಪು} \kn{ನೀಲಿ}}\par
+\small black, white, red, blue — Kannada's own basic colors, and the same shared Sanskrit blue\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಕೆಲಸ} \kn{ಮಾಡು}}\par
+\small to work (lit. \textquotedblleft{}work-do\textquotedblright{})\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಕ್ಷಮಿಸಿ}}\par
+\small forgive me / sorry (kṣamisi — imperative of kṣamisu, \textquotedblleft{}to forgive,\textquotedblright{} from Sanskrit kṣamā)\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಗಂಟೆ}}\par
+\small hour — the SAME Sanskrit \textquotedblleft{}bell\textquotedblright{} word behind Hindi's ghantā, borrowed via Prakrit\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಚೈತ್ರ} \kn{ವೈಶಾಖ} \kn{ಜ್ಯೇಷ್ಠ} \kn{ಆಷಾಢ} \kn{ಶ್ರಾವಣ} \kn{ಭಾದ್ರಪದ} \kn{ಆಶ್ವಯುಜ} \kn{ಕಾರ್ತೀಕ} \kn{ಮಾರ್ಗಶಿರ} \kn{ಪುಷ್ಯ} \kn{ಮಾಘ} \kn{ಫಾಲ್ಗುಣ}}\par
+\small the twelve lunisolar months — NOT Kannada's own calendar like Tamil/Malayalam's, but the same pan-Indian Sanskritic system Hindi's Vikram Samvat uses\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಚೆನ್ನಾಗಿ}}\par
+\small well, nicely — and the reply \textquotedblleft{}\kn{ನಾನು} \kn{ಚೆನ್ನಾಗಿದ್ದೇನೆ}\textquotedblright{}\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ತಲೆ} \kn{ಕೈ}}\par
+\small head and hand — native Dravidian, matching Tamil/Malayalam closely\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ದಿನ}}\par
+\small day" — a Sanskrit tatsama word, kept whole and unworn, unlike Hindi's own eroded din; Kannada also has a real native Dravidian word, hagalu, but it means specifically \textquotedblleft{}daytime,\textquotedblright{} not "a day\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ದಯವಿಟ್ಟು}}\par
+\small please (dayaviṭṭu — \textquotedblleft{}having placed compassion,\textquotedblright{} from \kn{ದಯ} daya \textquotedblleft{}compassion\textquotedblright{})\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಧನ್ಯವಾದ}}\par
+\small thank you (dhanyavāda — \textquotedblleft{}an utterance of 'worthy'\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ನಾನು}}\par
+\small I\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ನೀನು} / \kn{ನೀವು}}\par
+\small you (familiar / respectful)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ನಾನು} \kn{ಕನ್ನಡ} \kn{ಮಾತನಾಡುತ್ತೇನೆ}}\par
+\small I speak Kannada\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ನನ್ನ}}\par
+\small my\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ನಿನ್ನ} \kn{ವಯಸ್ಸು} \kn{ಎಷ್ಟು}?}\par
+\small how old are you? — literally \textquotedblleft{}your age how-much?\textquotedblright{}; \kn{ವಯಸ್ಸು} is a Sanskrit loan, distant cousin of Latin's own vīs\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ನನ್ನ} \kn{ಹೆಸರು} …}\par
+\small my name is… (with no \textquotedblleft{}is\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ನಿಮ್ಮ} \kn{ಹೆಸರು} \kn{ಏನು}?}\par
+\small what's your name?\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ನಮಸ್ಕಾರ}}\par
+\small hello / greetings (namaskāra — \textquotedblleft{}a making of a bow\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ನಾಯಿ}, \kn{ಬೆಕ್ಕು}}\par
+\small dog and cat — naayi is a solid, ancient native Dravidian root, no mystery at all; bekku is a DIFFERENT ancient Dravidian \textquotedblleft{}wildcat\textquotedblright{} root, distinct from Tamil's everyday word for cat\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ನೀರು} \kn{ಅಕ್ಕಿ} \kn{ಅನ್ನ}}\par
+\small water (matching Tamil's neer, unlike Malayalam), and rice raw/cooked\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ನಾಳೆ} \kn{ಸಿಗೋಣ}}\par
+\small see you tomorrow\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ನೀವು} \kn{ಹೇಗಿದ್ದೀರಾ}?}\par
+\small how are you? (respectful)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಪರವಾಗಿಲ್ಲ}}\par
+\small it's okay / no problem / you're welcome\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಬೆಳಗ್ಗೆ}}\par
+\small \textquotedblleft{}morning\textquotedblright{} (beḷagge) — genuine native Dravidian, from beḷagu (\textquotedblleft{}to shine, to dawn\textquotedblright{}) + beḷaku (\textquotedblleft{}light\textquotedblright{}); unlike Kannada's Sanskrit tatsama day/night/noon words (dina, ratri, madhyāhna), this one is Kannada's own\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಮತ್ತೆ} \kn{ಸಿಗೋಣ}}\par
+\small we'll meet again\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಮಾತನಾಡು}}\par
+\small to speak\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಮಧ್ಯಾಹ್ನ} \kn{ಮಧ್ಯರಾತ್ರಿ}}\par
+\small noon and midnight — both direct Sanskrit tatsama compounds built on the SAME \textquotedblleft{}middle\textquotedblright{} root, madhya\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ರಾತ್ರಿ}}\par
+\small \textquotedblleft{}night\textquotedblright{} — the same Sanskrit tatsama word already hiding inside madhyarātri; Kannada's real native Dravidian word, irulu, has been pushed into archaism, unlike hagalu's living daytime sense\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ವಸಂತ} \kn{ಋತು} \kn{ಬೇಸಿಗೆ} \kn{ಮಳೆಗಾಲ} \kn{ಚಳಿಗಾಲ}}\par
+\small spring, summer, monsoon, winter — native heat/rain/cold words, one shared Sanskrit \textquotedblleft{}spring\textquotedblright{}\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಶುಭ} \kn{ಮಧ್ಯಾಹ್ನ}}\par
+\small \textquotedblleft{}good afternoon\textquotedblright{} (śubha madhyāhna) — reuses \kn{ಮಧ್ಯಾಹ್ನ}, KA-C17's \textquotedblleft{}noon\textquotedblright{} word, not the more precise \kn{ಅಪರಾಹ್ನ} from KA-C28; one directly-fetched source describes it leaning formal/workplace, though this wasn't cross-corroborated the way \kn{ನಮಸ್ಕಾರ}'s universal, any-time-of-day status was\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಶುಭ} \kn{ರಾತ್ರಿ}}\par
+\small good night" — literally \textquotedblleft{}auspicious night,\textquotedblright{} pairing rātri (already met) with shubha, a word that started life meaning "to be beautiful\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಶುಭ} \kn{ಸಂಜೆ}}\par
+\small \textquotedblleft{}good evening\textquotedblright{} (śubha sañje) — pairs with \kn{ಸಂಜೆ}, already established (KA-C27) as Sanskrit-via-Prakrit, NOT native Dravidian, whatever an unverified claim you might encounter elsewhere says; leans formal, with \kn{ನಮಸ್ಕಾರ} likely covering casual use, echoing (with real hedging) the formal-skew question already raised for \dv{सुप्रभात} and \kn{ಶುಭೋದಯ}\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಶುಭೋದಯ}}\par
+\small \textquotedblleft{}good morning\textquotedblright{} (śubhōdaya) — śubha (\textquotedblleft{}good\textquotedblright{}) + udaya (\textquotedblleft{}rising, sunrise,\textquotedblright{} $\leftarrow$ ud- \textquotedblleft{}up\textquotedblright{} + i \textquotedblleft{}to go\textquotedblright{}), a DIFFERENT root from \kn{ಬೆಳಗ್ಗೆ}; sources conflict on its everyday spoken commonality, but the more careful ones describe it skewing formal/written, similar to Hindi's \dv{सुप्रभात}, with \kn{ನಮಸ್ಕಾರ} likely covering casual mornings\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಸಂಜೆ}}\par
+\small \textquotedblleft{}evening\textquotedblright{} (sañje) — borrowed from Maharashtri Prakrit sañjhā, itself from Sanskrit \dv{संध्या} (saṃdhyā); a striking cross-family convergence with Hindi's \dv{साँझ}/sāñjh, same Sanskrit root, arriving via a DIFFERENT sister Prakrit dialect\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಸಂತೋಷ}}\par
+\small joy / pleased to meet you\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಸೋಮವಾರ} \kn{ಮಂಗಳವಾರ} \kn{ಬುಧವಾರ} \kn{ಗುರುವಾರ} \kn{ಶುಕ್ರವಾರ} \kn{ಶನಿವಾರ} \kn{ಭಾನುವಾರ}}\par
+\small the seven weekdays — fully Sanskritic, like Hindi, but Sunday uses a DIFFERENT sun-name\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಸರಿ}}\par
+\small okay / alright / correct (sari)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಹೇಗೆ}}\par
+\small how\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಹೋಗು}}\par
+\small to go (and \kn{ಬಾ}, come)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಹೋಗಿ} \kn{ಬರುತ್ತೇನೆ}}\par
+\small goodbye (lit. \textquotedblleft{}I'll go and come back\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಹೌದು}}\par
+\small yes (haudu)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಹನ್ನೊಂದು} — \kn{ಇಪ್ಪತ್ತು}}\par
+\small 11-20 — additive \textquotedblleft{}ten-echo\textquotedblright{} compounds for the teens, then \kn{ಇಪ್ಪತ್ತು} (20), compositionally \textquotedblleft{}two-tens\textquotedblright{} from OLD Dravidian roots — though the pieces have shifted enough that it no longer looks like the MODERN words eraḍu/hattu on the surface\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಹವಾಮಾನ}}\par
+\small weather — a Persian+Sanskrit HYBRID compound: hava (\textquotedblleft{}air,\textquotedblright{} from Persian/Arabic) + maana (\textquotedblleft{}measure,\textquotedblright{} Sanskrit)\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಹೆಸರು}}\par
+\small name\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\kn{ಹಸಿರು}, \kn{ಹಳದಿ}}\par
+\small green and yellow — hasiru is genuine pan-Dravidian, sharing its Proto-Dravidian root with Tamil's paccai and Telugu's pacca; haladi is a Sanskrit/Hindi loan built on the word for turmeric, and traces back to the SAME ancient PIE root already behind Hindi's harā (green) and German's gelb (yellow)\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/latin/book/book.tex
+++ b/code/learning/human-languages/latin/book/book.tex
@@ -126,5 +126,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/latin/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/latin/book/chapters/appendix-glossary.tex
@@ -1,0 +1,547 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 77
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{accipiō, obtineō}\par
+\small \textquotedblleft{}I get\textquotedblright{} — two verbs, each one a prefix bolted onto a verb you already know, and each one bent out of shape by the join\par
+\footnotesize Introduced in Chapter 42.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{adiuvō, adiuvāre}\par
+\small \textquotedblleft{}I help\textquotedblright{} — the verb hiding inside English aid, aide and adjutant, and no relation to juvenile\par
+\footnotesize Introduced in Chapter 39.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ambulō, ambulāre}\par
+\small \textquotedblleft{}I walk\textquotedblright{} — the verb behind ambulance, preamble and the pram, and a rare case where the front half is clear and the back half is not\par
+\footnotesize Introduced in Chapter 41.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{amō, amāre}\par
+\small \textquotedblleft{}I love\textquotedblright{} — the chapter's fourth verb, the first thing generations of pupils ever chanted, and the word inside enemy\par
+\footnotesize Introduced in Chapter 39.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{aperiō, aperīre}\par
+\small \textquotedblleft{}I open\textquotedblright{} — half of a matched pair, built from one root with two opposite prefixes\par
+\footnotesize Introduced in Chapter 41.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{aqua, vīnum}\par
+\small water and wine — one word French wore down to almost nothing, one that barely changed anywhere\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{audiō, audīre}\par
+\small \textquotedblleft{}I hear\textquotedblright{} — the verb inside audio, audience and audit, and, less obviously, inside obey\par
+\footnotesize Introduced in Chapter 40.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{avē / avēte}\par
+\small hail (a formal greeting)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bene}\par
+\small \textquotedblleft{}well\textquotedblright{} — a morphologically simple inheritance: French bien and Spanish bien are just bene plus one regular sound change (the same short-e-diphthongizes-to-ie shift as mel$\to$miel), with no extra grafted-on suffix, unlike quōmodo's more roundabout Romance history\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bonam noctem}\par
+\small \textquotedblleft{}good night\textquotedblright{} — genuine Latin grammar (wishes take the accusative, not the nominative), though the fixed phrase itself may be a later/modern convention rather than a directly-attested ancient formula\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bonum māne}\par
+\small \textquotedblleft{}good morning\textquotedblright{} — a modern, pedagogical phrase (not classically attested); unlike bonam noctem, its grammar is genuinely invisible, since māne is neuter and Latin neuters never distinguish nominative from accusative — Romans instead had a real, richly documented morning GREETING RITUAL, the salūtātiō, whose root is a doublet of salvē's own\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bonum vesperum}\par
+\small \textquotedblleft{}good evening\textquotedblright{} — a modern, pedagogical phrase (not classically attested), but unlike bonum māne, this one CAN show the real Accusative-of-Exclamation grammar again, since vesper is masculine, not neuter\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{canis, fēlēs, cattus}\par
+\small dog and (two words for) cat — canis is the \textquotedblleft{}expected\textquotedblright{} ancestor Spanish's perro mysteriously replaced; fēlēs was Classical Latin's OWN word for cat, later pushed out by the newcomer cattus\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{capiō, capere}\par
+\small \textquotedblleft{}I take\textquotedblright{} — the verb the habeō lesson promised, and the true relative of English have\par
+\footnotesize Introduced in Chapter 39.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{caput}\par
+\small the head — the word French abandoned, but Spanish and English kept working hard\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{claudō, claudere}\par
+\small \textquotedblleft{}I close\textquotedblright{} — the word English calls \emph{close}, and the fourth of four\par
+\footnotesize Introduced in Chapter 41.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{cōgitō, cōgitāre}\par
+\small I think" — the verb of \emph{cōgitō ergō sum}, built from a word meaning "to shake together\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{conveniō, occurrō}\par
+\small \textquotedblleft{}I meet\textquotedblright{} — two verbs for meeting, each one a prefix on a verb you already know, and the verb hiding inside a phrase from chapter 21\par
+\footnotesize Introduced in Chapter 43.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{crās tē vidēbō}\par
+\small \textquotedblleft{}see you tomorrow\textquotedblright{} — built from two genuinely classical pieces (crās, \textquotedblleft{}tomorrow,\textquotedblright{} and vidēbō, already met last lesson) using the exact same pattern as the attested propediem tē vidēbō, though this specific combination isn't itself pulled from one surviving letter\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{currō, currere}\par
+\small \textquotedblleft{}I run\textquotedblright{} — the verb inside current, curriculum, courier and corridor, and, by way of a Celtic wagon, inside car\par
+\footnotesize Introduced in Chapter 41.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{dīcō, dīcere}\par
+\small \textquotedblleft{}I say\textquotedblright{} — a verb that originally meant \textquotedblleft{}point out\textquotedblright{}, which is why English got both dictionary and teach from it\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{diēs}\par
+\small \textquotedblleft{}day\textquotedblright{} — the word you've already been using all along, inside diēs Lūnae and medius diēs, now on its own\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{diēs Lūnae, Mārtis, Mercuriī, Iovis, Veneris}\par
+\small the weekdays (Monday–Friday) — the full, un-worn-down planet-god phrases\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{diēs Saturnī, diēs Sōlis}\par
+\small Saturday and Sunday — Rome's own pagan names, and how Christianity later renamed them\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{dō, dare}\par
+\small \textquotedblleft{}I give\textquotedblright{} — the last of the chapter's eight verbs, and the one that gave English data, date, tradition and dose\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{dormiō, dormīre}\par
+\small \textquotedblleft{}I sleep\textquotedblright{} — the verb behind dormitory and dormant, and the one word English may only look as though it borrowed\par
+\footnotesize Introduced in Chapter 40.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{emō, emere}\par
+\small \textquotedblleft{}I buy\textquotedblright{} — a verb that once meant simply \textquotedblleft{}I take\textquotedblright{}, which is the only reason redeem, example and premium mean what they do\par
+\footnotesize Introduced in Chapter 43.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{eō, īre}\par
+\small \textquotedblleft{}I go\textquotedblright{} — the shortest verb in Latin, whose bare stem is a single vowel\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{exspectō, exspectāre}\par
+\small \textquotedblleft{}I wait\textquotedblright{} — to wait, in Latin, is to look out for something, and the four verbs of this chapter together\par
+\footnotesize Introduced in Chapter 42.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ferō, ferre}\par
+\small \textquotedblleft{}I bring, I carry\textquotedblright{} — one verb built out of two unrelated roots, and the parent of transfer, refer, prefer, differ, offer and suffer\par
+\footnotesize Introduced in Chapter 42.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{frater, soror}\par
+\small brother and sister — the words Vulgar Latin later abandoned in favor of germanus\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{grātiās (tibi) agō}\par
+\small thank you (lit. \textquotedblleft{}I give thanks to you\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{habeō, habēre}\par
+\small \textquotedblleft{}I have\textquotedblright{} — a verb that looks exactly like its English translation and is not related to it at all\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hōra}\par
+\small hour — the source word itself, and the Roman hour was NOT a fixed length\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Iānuārius, Februārius, Mārtius, Aprīlis, Māius, Iūnius, Quīntīlis, Sextīlis, September, Octōber, November, December}\par
+\small the twelve months — and the two ORIGINAL names, Quintilis and Sextilis, before Rome renamed them\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ignōsce mihi}\par
+\small forgive me / I'm sorry (imperative of ignōscere, \textquotedblleft{}to not-know, overlook, pardon\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{intellegō, intellegere}\par
+\small \textquotedblleft{}I understand\textquotedblright{} — literally \emph{inter} plus \emph{legō}, \textquotedblleft{}to read between\textquotedblright{}, and the ancestor of intellect and intelligence\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ita / nōn}\par
+\small yes / no (lit. \textquotedblleft{}thus\textquotedblright{} / \textquotedblleft{}not\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{legō, legere}\par
+\small \textquotedblleft{}I read\textquotedblright{} — a verb that first meant \textquotedblleft{}to gather\textquotedblright{}, which is why English got collect, elegant, lecture and legible from it\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{lūdō, lūdere}\par
+\small \textquotedblleft{}I play\textquotedblright{} — a small verb with an outsized English family, most of which is about being fooled rather than about play\par
+\footnotesize Introduced in Chapter 42.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{māne}\par
+\small \textquotedblleft{}morning, early\textquotedblright{} — the word already hiding inside dē māne (the source of French demain, Italian domani, and Catalan demà, all rebuilt \textquotedblleft{}tomorrow\textquotedblright{} from this phrase) and, without the dē-, the direct base of Spanish mañana too, now standing alone\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{manus}\par
+\small the hand — a rare feminine noun in an overwhelmingly masculine group of Latin words\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{medius diēs, media nox}\par
+\small noon and midnight — the source phrase daughters kept whole, wore down unevenly, or eroded almost entirely\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{merīdiēs}\par
+\small \textquotedblleft{}midday, noon\textquotedblright{} — the same medius diēs you already know, contracted into one word; Romans split the day around IT (ante/post merīdiem), not into a separate colloquial \textquotedblleft{}afternoon\textquotedblright{} the way Spanish's tarde or French's après-midi do\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{niger, albus}\par
+\small black and white — the source words for Spanish/French/Italian, each with a shine-vs-matte twin\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{nihil est}\par
+\small \textquotedblleft{}you're welcome\textquotedblright{} — another honest gap: Classical Latin has no single fixed reply to thanks, and nihil est (\textquotedblleft{}it's nothing\textquotedblright{}) is a modern conversational-Latin convention built from genuinely real words, not a specific classical citation for this exact job\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{nox}\par
+\small \textquotedblleft{}night\textquotedblright{} — the word already hiding inside media nox ('midnight'), one of the most rock-solid PIE roots in the whole Indo-European family\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{pānis}\par
+\small bread — the source of \textquotedblleft{}companion,\textquotedblright{} and of the friendship-word every Romance daughter still shares with it\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{pater, mater}\par
+\small father and mother — the PIE ancestor Latin and English both inherited, in parallel\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{propediem tē vidēbō}\par
+\small \textquotedblleft{}see you later/soon\textquotedblright{} — a genuine change of pace from the last few lessons: this one IS solidly attested, twice, in Cicero's own letters\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{quaesō}\par
+\small please (literally \textquotedblleft{}I ask, I beg\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{quid agis? / ut valēs?}\par
+\small how are you? — two colloquial questions genuinely attested in Plautus and Terence, unlike a popular modern spoken-Latin alternative\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{quid tibi nōmen est? / mihi nōmen est...}\par
+\small what's your name? / my name is... — the genuinely classical dative of possession, literally what is the name to you?\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{quōmodo}\par
+\small how, in what way" — the genuine classical word behind Italian come, Spanish cómo, and French comment, which went one step further and double-marked "manner\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{respondeō, respondēre}\par
+\small \textquotedblleft{}I answer\textquotedblright{} — literally \textquotedblleft{}I pledge back\textquotedblright{}, from the verb Romans used for a solemn promise, and the reason a husband is a spouse\par
+\footnotesize Introduced in Chapter 43.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{rogō, rogāre}\par
+\small \textquotedblleft{}I ask\textquotedblright{} — a verb probably built on \textquotedblleft{}stretching straight out\textquotedblright{}, and a cousin of regal, direct and right\par
+\footnotesize Introduced in Chapter 39.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ruber, caeruleus}\par
+\small red (rock-solid) and blue (surprisingly shaky) — Latin's clearest color word, and one of its weakest\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{salvē (post merīdiem)}\par
+\small why no two-word good-afternoon phrase exists — Latin has no simplex afternoon noun, and a grammatical three-word workaround is not attested as a greeting\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{salvē / salvēte}\par
+\small hello (lit. \textquotedblleft{}be well\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{sciō, scīre}\par
+\small \textquotedblleft{}I know\textquotedblright{} — one of Latin's two verbs for knowing, and the one that gave English science and nice\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{scrībō, scrībere}\par
+\small \textquotedblleft{}I write\textquotedblright{} — a verb whose root means \textquotedblleft{}to scratch\textquotedblright{}, and the fourth of this chapter's four\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{sedeō, sedēre}\par
+\small \textquotedblleft{}I sit\textquotedblright{} — the verb that is English \emph{sit} by descent and English \emph{session} by loan, and the clearest case of the difference\par
+\footnotesize Introduced in Chapter 40.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{sex septem octō novem decem}\par
+\small six to ten — and the four that got frozen into the calendar\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{stō, stāre}\par
+\small \textquotedblleft{}I stand\textquotedblright{} — the shortest verb in the chapter and the most productive in English, and the fourth of four\par
+\footnotesize Introduced in Chapter 40.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{sum, esse}\par
+\small \textquotedblleft{}I am\textquotedblright{} — the verb every sentence leans on, and the one whose forms English still shares outright\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{tempestās}\par
+\small weather or storm — a derivative of tempus that specialized for weather in Classical Latin, while tempus itself meant only time; later tempus widened to weather and tempestās narrowed to storm\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{tū / vōs}\par
+\small you (singular) / you (plural) — a PURELY grammatical number distinction in Classical Latin, with no politeness dimension at all; the polite-vous pattern (a Late Latin innovation) is vōs's own direct descendant, unlike German's Sie, which solved the same politeness problem independently via a completely different pronoun (3rd-person plural, not 2nd)\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ūndecim — vīgintī}\par
+\small 11-20, the source numbers themselves — including Latin's own genuine oddity, SUBTRACTIVE 18 and 19, which Spanish quietly regularized away\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ūnus duo trēs quattuor quīnque}\par
+\small one to five — the Roman originals that became every Romance number\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{valē / valēte}\par
+\small goodbye (lit. \textquotedblleft{}be strong\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{veniō, venīre}\par
+\small \textquotedblleft{}I come\textquotedblright{} — a Latin verb that really is the same inherited word as English come\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{vēr, aestās, autumnus, hiems}\par
+\small the four seasons — and why Romance languages often skipped the plain noun for an adjective phrase instead\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{vesper}\par
+\small evening — a genuine everyday classical word sharing a deep root with English west through the direction of sunset\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{videō, vidēre}\par
+\small \textquotedblleft{}I see\textquotedblright{} — the widest root in this chapter, because seeing and knowing were once one idea\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{vīgintī annōs nātus sum}\par
+\small \textquotedblleft{}I am twenty years old\textquotedblright{} — literally \textquotedblleft{}I am, having been born, twenty years {[}so far{]}\textquotedblright{}; NEITHER Romance's \textquotedblleft{}have\textquotedblright{} NOR Germanic's \textquotedblleft{}be my years\textquotedblright{} — Latin used a THIRD construction, later abandoned\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{viridis, flāvus}\par
+\small green and yellow — viridis is the direct, kept source of Spanish's verde; flāvus is Latin's own real word for yellow, and almost NO Romance language kept it as their everyday color word — most (French, Italian, Romanian) converged on a DIFFERENT shared Latin word instead\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{volup est convēnisse}\par
+\small \textquotedblleft{}it is a pleasure to have met you\textquotedblright{} — an attested Plautine phrase that can fill a conversational slot for which Classical Latin has no single fixed idiom\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/malayalam/book/book.tex
+++ b/code/learning/human-languages/malayalam/book/book.tex
@@ -151,5 +151,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/malayalam/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/appendix-glossary.tex
@@ -1,0 +1,498 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 70
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{-\ml{ിക്ക്}}\enspace\emph{-ikku}\par
+\small the dative suffix -ikku, 'to / for' — and the idea of stacking\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{അറിയുക}}\enspace\emph{aṟiyuka}\par
+\small to know — the verb inside \ml{എനിക്ക്} \ml{മലയാളം} \ml{അറിയാം}, and the one that will not let you be the subject\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ചിന്തിക്കുക}}\enspace\emph{cintikkuka}\par
+\small to think — a Sanskrit noun turned into a verb by the same ‑\ml{ഇക്കുക} that made \ml{ക്ഷമിക്കുക}, and the first of four verbs about what happens inside a head\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ചോദിക്കുക}}\enspace\emph{cōdikkuka}\par
+\small to ask — a Sanskrit word for pushing that walked into a gap Malayalam had made by narrowing its own inherited verb to \textquotedblleft{}hear\textquotedblright{}\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{എഴുതുക}}\enspace\emph{eḻutuka}\par
+\small to write — the same word as Tamil \ta{எழுது}, carrying the \ml{ഴ} that only these two sisters kept, and the chapter's closing count of four\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{എനിക്ക്} \ml{മലയാളം} \ml{അറിയാം}}\enspace\emph{enikku malayāḷam aṟiyām}\par
+\small 'I know Malayalam' — built with no subject, because knowing happens TO you\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{എനിക്ക്} \ml{മലയാളം} \ml{ഇഷ്ടമാണ്}}\enspace\emph{enikku malayāḷaṁ iṣṭamāṇŭ}\par
+\small 'I like Malayalam' — a noun, a copula, and a dative; the one sentence in this book where putting yourself in the subject slot is not merely odd but impossible\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{എടുക്കുക}}\enspace\emph{eṭukkuka}\par
+\small to take — native to the bone, yet ending in ‑\ml{ക്കുക} like the borrowings; the letter that actually does the stamping is the \ml{ഇ}\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{കാണുക}}\enspace\emph{kāṇuka}\par
+\small to see — the family's shared see-root, kept as Malayalam's everyday word, and the mood endings that share one slot with tense\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{മനസ്സിലാക്കുക}}\enspace\emph{manassilākkuka}\par
+\small to understand — literally \textquotedblleft{}to put it in the mind,\textquotedblright{} a three-piece word you can take apart by ear, with a second form that hands the understanding to you instead\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{പോകുക}}\enspace\emph{pōkuka}\par
+\small to go — one stem, three tense endings, and each of the three is the entire conjugation\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{സഹായിക്കുക}}\enspace\emph{sahāyikkuka}\par
+\small to help — \textquotedblleft{}to go along with somebody,\textquotedblright{} and the fourth time in two chapters that a Sanskrit word has taken an everyday job from an inherited one\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{തിന്നുക}}\enspace\emph{tinnuka}\par
+\small to eat — the inherited Dravidian eat-word Malayalam kept as its everyday one, and the ending that tells a native verb from a borrowed one\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ഉണ്ട്}}\enspace\emph{uṇṭŭ}\par
+\small there is, there are, {[}someone{]} has — and \ml{ഇരിക്കുക}, to be somewhere; the two-piece machine every Malayalam verb is built on\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{വരുക}}\enspace\emph{varuka}\par
+\small to come — and the past tense, the one slot where a Malayalam verb can still surprise you\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{വായിക്കുക}}\enspace\emph{vāyikkuka}\par
+\small to read — a word that looks as though it were built on \ml{വായ്}, \textquotedblleft{}mouth,\textquotedblright{} and is not; the trail runs to Sanskrit \ml{വാച്}, \textquotedblleft{}speech\textquotedblright{}\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{അച്ഛൻ} \ml{അമ്മ} \ml{ചേട്ടൻ} \ml{അനിയൻ} \ml{ചേച്ചി} \ml{അനിയത്തി}}\par
+\small father, mother, and four age-graded sibling words — Malayalam's own distinct set, still following the shared Dravidian age-first pattern\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{അതെ}}\par
+\small yes (athe — \textquotedblleft{}that {[}is so{]}\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ആണ്}}\par
+\small is (the copula)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ആറ്} \ml{ഏഴ്} \ml{എട്ട്} \ml{ഒമ്പത്} \ml{പത്ത്}}\par
+\small six to ten — Malayalam keeps Tamil's rare ḻ where the others lost it\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ഇല്ല}}\par
+\small no / there isn't (illa — the negative)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ഉച്ച}}\par
+\small noon, most likely from a different Sanskrit metaphor than Kannada and Telugu — height rather than middle\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ഉച്ചകഴിഞ്ഞ്}}\par
+\small \textquotedblleft{}afternoon\textquotedblright{} (uchakaḻiññ) — a transparent two-word phrase, not a single dictionary headword: \ml{ഉച്ച} (ML-C17's \textquotedblleft{}noon\textquotedblright{}) + \ml{കഴിഞ്ഞ്}, the past converb form of \ml{കഴിയുക} (kaḻiyuka, Wiktionary-confirmed Proto-Dravidian \emph{kaẓi, \textquotedblleft{}to be over, spent\textquotedblright{}) — Wiktionary itself directly shows only the finite past tense \ml{കഴിഞ്ഞു} (kaḻiññu); the converb form used in this compound is a reasonable grammatical inference, not itself the form Wiktionary lists; literally \textquotedblleft{}noon having passed\textquotedblright{} — a structurally different strategy than Telugu's, where the SAME noon-word (\te{మధ్యాహ్నం}) simply widened its own meaning rather than compounding with a second word}\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{എങ്ങനെ}}\par
+\small how\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{എന്ത്}}\par
+\small what\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{എന്റെ}}\par
+\small my\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{എന്റെ} \ml{പേര്} … \ml{ആണ്}}\par
+\small my name is…\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ഒന്ന്} \ml{രണ്ട്} \ml{മൂന്ന്} \ml{നാല്} \ml{അഞ്ച്}}\par
+\small one to five — Tamil's closest sister, its numbers almost unchanged\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{കറുപ്പ്} \ml{വെള്ള} \ml{ചുവപ്പ്} \ml{നീല}}\par
+\small black, white, red, blue — Malayalam shares Tamil's native colors, and its Sanskrit blue too\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{കാലാവസ്ഥ}}\par
+\small weather — a Sanskrit compound literally meaning \textquotedblleft{}state of TIME\textquotedblright{}: kaala (\textquotedblleft{}time\textquotedblright{}) + avastha (\textquotedblleft{}state, condition\textquotedblright{}) — a real echo of Spanish's tiempo meaning both \textquotedblleft{}time\textquotedblright{} AND \textquotedblleft{}weather\textquotedblright{}\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ക്ഷമിക്കണം}}\par
+\small (you) should forgive / sorry (kṣamikkaṇaṁ — from kṣamikkuka \textquotedblleft{}to forgive,\textquotedblright{} Sanskrit kṣama + necessitative -aṇaṁ)\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ചിങ്ങം} \ml{കന്നി} \ml{തുലാം} \ml{വൃശ്ചികം} \ml{ധനു} \ml{മകരം} \ml{കുംഭം} \ml{മീനം} \ml{മേടം} \ml{ഇടവം} \ml{മിഥുനം} \ml{കർക്കടകം}}\par
+\small the twelve months of the Malayalam (Kollam Era) solar calendar — also solar, like Tamil's, but named for ZODIAC SIGNS rather than nakshatras\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ജോലി} \ml{ചെയ്യുക}}\par
+\small to work (lit. \textquotedblleft{}work-do\textquotedblright{})\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ഞാൻ}}\par
+\small I\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ഞാൻ} \ml{മലയാളം} \ml{സംസാരിക്കുന്നു}}\par
+\small I speak Malayalam\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{തിങ്കൾ} \ml{ചൊവ്വ} \ml{ബുധൻ} \ml{വ്യാഴം} \ml{വെള്ളി} \ml{ശനി} \ml{ഞായർ}}\par
+\small the seven weekdays — Malayalam shares Tamil's native planet-words, being its closest cousin\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{താമസിക്കുക}}\par
+\small to live, to stay\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{തല} \ml{കൈ}}\par
+\small head and hand — matching Tamil's native pair almost exactly\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ദയവായി}}\par
+\small please (dayavāyi — \textquotedblleft{}as a compassion,\textquotedblright{} from \ml{ദയ} daya \textquotedblleft{}compassion\textquotedblright{})\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ദിവസം}}\par
+\small \textquotedblleft{}day\textquotedblright{} — everyday Sanskrit divasam beside the more literary Sanskrit dinam\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{നീ} / \ml{നിങ്ങൾ}}\par
+\small you (familiar / respectful)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{നിങ്ങൾക്ക്} \ml{എത്ര} \ml{വയസ്സുണ്ട്}?}\par
+\small how old are you? — literally \textquotedblleft{}to you how much age exists?\textquotedblright{}; the SAME Sanskrit vayas word, but Malayalam adds a dative-subject + existential verb, a genuinely different shape than Kannada/Telugu's plain possessive\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{നന്ദി}}\par
+\small thank you (nandi — the native Dravidian word, Tamil's cousin)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{നിന്റെ} \ml{പേര്} \ml{എന്താണ്}?}\par
+\small what's your name?\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{നമസ്കാരം}}\par
+\small hello / greetings (namaskāram — \textquotedblleft{}a making of a bow\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{നായ}, \ml{പൂച്ച}}\par
+\small dog and cat — naaya continues the solid, ancient native Dravidian dog-root shared with Kannada and Tamil, no mystery; poocha matches Tamil's everyday cat-word closely, part of the pattern where Dravidian genuinely splits on \textquotedblleft{}cat\textquotedblright{} more than \textquotedblleft{}dog\textquotedblright{}\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{നാളെ} \ml{കാണാം}}\par
+\small see you tomorrow\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{പോകുക}}\par
+\small to go (and \ml{വരിക}, to come)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{പച്ച}, \ml{മഞ്ഞ}}\par
+\small green and yellow — paccha matches Tamil's paccai almost exactly (the same pan-Dravidian \emph{pac- root already seen in Kannada and Telugu); manja is a completely separate native Dravidian root, a doublet of manjal (\textquotedblleft{}turmeric\textquotedblright{}), matching Tamil's own mañcaḷ — a third, independent solution to this arc's recurring green/yellow puzzle}\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{പതിനൊന്ന്} — \ml{ഇരുപത്}}\par
+\small 11-20 — additive \textquotedblleft{}ten-echo\textquotedblright{} compounds for the teens, then irupathu (20), transparently \textquotedblleft{}two-tens\textquotedblright{} — iru (\textquotedblleft{}two\textquotedblright{}) + pathu (\textquotedblleft{}ten\textquotedblright{}), matching Tamil closely\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{പാതിരാ}}\par
+\small midnight, built on Malayalam paathi \textquotedblleft{}half\textquotedblright{} rather than Sanskrit ardha\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{പോയി} \ml{വരാം}}\par
+\small goodbye (lit. \textquotedblleft{}I'll go and come back\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{പേര്}}\par
+\small name\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{മണി}}\par
+\small hour — Malayalam's OWN dictionary tradition treats bell/hour/gem as ONE Sanskrit word, unlike Tamil's closely related mani, which its own dictionaries split into two unrelated homophones\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{രാത്രി}}\par
+\small \textquotedblleft{}night\textquotedblright{} — the Sanskrit tatsama already shortened inside paathira, with a different PIE root from Latin nox\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{രാവിലെ}}\par
+\small \textquotedblleft{}morning\textquotedblright{} (rāvile) — a compound of \ml{രാവ്} (rāvŭ, \textquotedblleft{}night,\textquotedblright{} a cognate doublet of \ml{ഇരവ്}/iravŭ already met in ML-C24 — same root, not literally the same word) + locative-ish suffixes -il/-e; literally built from NIGHT, not light or rising — a genuinely different strategy than Kannada's \textquotedblleft{}the shining\textquotedblright{} or Telugu's Sanskrit \textquotedblleft{}rise\textquotedblright{}; \ml{പ്രഭാതം} (Sanskrit tatsama, the same prabhāta root Telugu draws on) and \ml{പുലർച്ച} (native, thinner etymology) also exist as alternatives\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{വൈകുന്നേരം}}\par
+\small \textquotedblleft{}evening\textquotedblright{} (vaikunnēraṁ) — native Dravidian compound, Wiktionary-glossed \textquotedblleft{}latening time,\textquotedblright{} from \ml{വൈക്} (vaikŭ, plausibly the root of \ml{വൈകുക}, \textquotedblleft{}to get late\textquotedblright{} — a reasonable inference, not something Wiktionary's compound entry states outright) + -\ml{ഉം} (-uṁ) + \ml{നേരം} (nēraṁ, \textquotedblleft{}time,\textquotedblright{} itself native Dravidian, not Sanskrit); Wiktionary itself ALSO lists \textquotedblleft{}afternoon\textquotedblright{} as a second sense, though phrasebook sources cleanly split evening (this word) from afternoon (a separate compound built on \ml{ഉച്ച}, ML-C17's \textquotedblleft{}noon,\textquotedblright{} plus \ml{കഴിഞ്ഞ്}) — an honest source-tension worth flagging, not smoothing over\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{വീണ്ടും} \ml{കാണാം}}\par
+\small we'll meet again\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{വെള്ളം} \ml{അരി} \ml{ചോറ്}}\par
+\small water (a genuinely DIFFERENT word than Tamil's), and rice raw/cooked, closely matching Tamil\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{വസന്തകാലം} \ml{വേനൽക്കാലം} \ml{മഴക്കാലം} \ml{ശൈത്യകാലം}}\par
+\small spring, summer, monsoon, winter — matching Tamil's pattern of native heat/rain/cold words plus a Sanskrit \textquotedblleft{}spring\textquotedblright{}\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ശുഭ} \ml{മധ്യാഹ്നം}}\par
+\small \textquotedblleft{}good afternoon\textquotedblright{} (śubha madhyāhnaṁ), a formal greeting built on a noon synonym rather than the everyday afternoon compound\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ശുഭ} \ml{രാത്രി}}\par
+\small \textquotedblleft{}good night\textquotedblright{} — the standard Sanskrit-tatsama phrase (rāthri already met, śubha new); some sources describe modern Malayalam speakers often code-switching to English \textquotedblleft{}good night\textquotedblright{} instead — the same claim, similarly thinly sourced, is also made about Telugu\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ശുഭ} \ml{സായാഹ്നം}}\par
+\small \textquotedblleft{}good evening\textquotedblright{} (śubha sāyāhnaṁ) — confirmed real, used \textquotedblleft{}from late afternoon until sunset\textquotedblright{} per a directly-fetched source; built on \ml{ശുഭ} (ML-C25) + \ml{സായാഹ്നം} (sāyāhnaṁ), a SEPARATE Sanskrit tatsama for \textquotedblleft{}evening,\textquotedblright{} Wiktionary-labeled \textquotedblleft{}poetic\textquotedblright{} — NOT built on ML-C27's native \ml{വൈകുന്നേരം}; \ml{സായാഹ്നം}'s own root, \dv{साय} (\textquotedblleft{}end\textquotedblright{}), is CONFIRMED via Wiktionary's separate \dv{साय} entry to trace to the same PIE \emph{seh\textsubscript{1}- as Telugu's \te{సాయంత్రం} (sāyam) and Latin sērus — a properly-verified cognate, not just a plausible guess}\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{ശരി}}\par
+\small okay / alright / correct (śari)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{സുഖം}}\par
+\small well-being — and the reply \textquotedblleft{}\ml{സുഖമാണ്}\textquotedblright{}\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{സുഖമാണോ}?}\par
+\small how are you? (lit. \textquotedblleft{}are you well?\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{സന്തോഷം}}\par
+\small joy / pleased to meet you\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{സുപ്രഭാതം}}\par
+\small \textquotedblleft{}good morning\textquotedblright{} (suprabhātaṁ) — Malayalam's actual, most common morning greeting, confirmed used in BOTH formal and informal contexts, and independently corroborated as the \textquotedblleft{}most general\textquotedblright{} morning greeting by a SECOND directly-fetched source (not just one); built from su- (\textquotedblleft{}good\textquotedblright{}) + \ml{പ്രഭാതം} (already met, ML-C26, \textquotedblleft{}morning/dawn\textquotedblright{}), NOT from \ml{ശുഭ} (ML-C25's \textquotedblleft{}auspicious,\textquotedblright{} used for Malayalam's own GREETING-GOODNIGHT) — a genuinely different Sanskrit \textquotedblleft{}good\textquotedblright{} morpheme; the SAME word as Telugu's \te{సుప్రభాతం}, but with an inverted role: PRIMARY greeting in Malayalam, only a SECONDARY alternative in Telugu (where \te{శుభోదయం}, a different root, is primary)\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{സാരമില്ല}}\par
+\small it doesn't matter / no problem / you're welcome\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ml{സംസാരിക്കുക}}\par
+\small to speak, to converse\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/marathi/book/book.tex
+++ b/code/learning/human-languages/marathi/book/book.tex
@@ -105,5 +105,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/marathi/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/marathi/book/chapters/appendix-glossary.tex
@@ -1,0 +1,400 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 56
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{असणे}}\enspace\emph{asṇe}\par
+\small to be — the verb behind \mr{आहे}, the word a Marathi sentence ends on\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{आवडणे}}\enspace\emph{āvaḍṇe}\par
+\small to like — a native Marathi verb that puts you in the dative, beside \mr{प्रेम} \mr{करणे}, to love\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{बहीण}}\enspace\emph{bahīṇ}\par
+\small sister — worn down like \mr{भाऊ}, but deliberately not its English counterpart's cousin\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{भाकरी}}\enspace\emph{bhākarī}\par
+\small a round flatbread — the one word in this chapter that never left Marathi's own neighborhood, and Hindi's word for bread altogether\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{भाऊ}}\enspace\emph{bhāū}\par
+\small brother — worn down by sound change rather than borrowed whole, and a secure cousin of the English word\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{चहा}}\enspace\emph{chahā}\par
+\small tea — the one request in this chapter that is not inherited at all, and Marathi's first masculine noun\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{डोळा}}\enspace\emph{ḍoḷā}\par
+\small eye — carrying Marathi's signature extra letter \mr{ळ}, and a word that started life meaning something else entirely\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{दूध}}\enspace\emph{dūdh}\par
+\small milk — back to inherited Sanskrit, and the same PIE root behind English doughty\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{एक} \mr{दोन} \mr{तीन} \mr{चार} \mr{पाच}}\enspace\emph{ek don tīn chār pāch}\par
+\small one to five — nearly Hindi's, with two tells in the spelling and one in the sound\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{घेणे}}\enspace\emph{gheṇe}\par
+\small to take — the verb hiding inside \textquotedblleft{}take care,\textquotedblright{} on the Indo-European root behind English grab\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{हृदय}}\enspace\emph{hṛdaya}\par
+\small heart — the surest cognate taught so far, and a new vowel sign that has waited thirteen chapters\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{जाणे}}\enspace\emph{jāṇe}\par
+\small to go — and the present tense you cannot say without declaring your own gender\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{कान}}\enspace\emph{kān}\par
+\small ear — a consonant cluster simplified the same way don copied teen, and a root disputed among Sanskrit scholars\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{खाणे}}\enspace\emph{khāṇe}\par
+\small to eat — and an infinitive that doubles as a noun of the third gender Hindi lost\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{कुटुंब}}\enspace\emph{kuṭumb}\par
+\small family — another word borrowed whole from Sanskrit, and neuter where Hindi made the same word masculine\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{लिहिणे}}\enspace\emph{lihiṇe}\par
+\small to write — from a root that meant \textquotedblleft{}to scratch,\textquotedblright{} and the chapter's four verbs run back together\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{मदत} \mr{करणे}}\enspace\emph{madat karṇe}\par
+\small to help — an Arabic word for \textquotedblleft{}reinforcements\textquotedblright{} that came through Persian and took \mr{करणे}\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{माहीत} \mr{असणे}}\enspace\emph{māhīt asṇe}\par
+\small to know — built as \textquotedblleft{}is known to me\textquotedblright{}, so the knower is never the subject\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{मित्र}}\enspace\emph{mitra}\par
+\small friend — taken up whole from Sanskrit rather than worn down, and a cousin of the god-name Mithra\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{नाक}}\enspace\emph{nāk}\par
+\small nose — completing the face, and the one of the four with the most secure English cousin\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{पाहणे}}\enspace\emph{pāhṇe}\par
+\small to see — from Sanskrit paś-, the root that reached English as spectacle, inspect and spy\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{पाणी}}\enspace\emph{pāṇī}\par
+\small water — the first thing you would actually ask for, and the request pattern that opens a spine node this track had never realized\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{समजणे}}\enspace\emph{samajṇe}\par
+\small to understand — built on the root that gave the Buddha his name, and taking the dative like knowing\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{तोंड}}\enspace\emph{tõḍ}\par
+\small mouth — the everyday word, beside a formal Sanskrit doublet you already half-know\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{वाचणे}}\enspace\emph{vāchṇe}\par
+\small to read — from a causative meaning \textquotedblleft{}to make speak,\textquotedblright{} cousin of voice and vocal\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{विचार} \mr{करणे}}\enspace\emph{vichār karṇe}\par
+\small to think — literally \textquotedblleft{}to do a thought,\textquotedblright{} on a root that means turning something over\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{विचारणे}}\enspace\emph{vichārṇe}\par
+\small to ask — the word for thinking with an infinitive ending on it, so asking and thinking share a root\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{येणे}}\enspace\emph{yeṇe}\par
+\small to come — the same Sanskrit going-root as \mr{जाणे}, turned around by one small prefix\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{आहे}}\par
+\small is (āhe)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{उद्या} \mr{भेटू}}\par
+\small see you tomorrow (udyā bheṭū)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{काम} \mr{करणे}}\par
+\small to work (kām karṇe)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{काय}}\par
+\small what (kāy)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{काळजी} \mr{घ्या}}\par
+\small take care (kāḷjī ghyā)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{कसा} / \mr{कशी} / \mr{कसं}}\par
+\small how (kasā m. / kaśī f. / kasaṁ n.)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{काही} \mr{हरकत} \mr{नाही}}\par
+\small no problem / you're welcome (kāhī harkat nāhī)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{तू} / \mr{तुम्ही}}\par
+\small you (tū familiar / tumhī respectful)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{तुमचं} \mr{नाव} \mr{काय} \mr{आहे}?}\par
+\small what's your name? (tumchaṁ nāv kāy āhe?)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{तुम्ही} \mr{कसे} \mr{आहात}?}\par
+\small how are you? (tumhī kase āhāt?)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{धन्यवाद}}\par
+\small thank you (dhanyavād)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{नमस्कार}}\par
+\small hello / goodbye (namaskār)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{नाव}}\par
+\small name (nāv)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{नाही}}\par
+\small no / is not (nāhī)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{पुन्हा}}\par
+\small again (punhā)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{पुन्हा} \mr{भेटू}}\par
+\small see you again (punhā bheṭū)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{बरं}}\par
+\small okay / fine (baraṃ)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{बोलणे}}\par
+\small to speak (bolṇe)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{भेटू}}\par
+\small (we'll) meet (bheṭū)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{भेटून} \mr{आनंद} \mr{झाला}}\par
+\small pleased to meet you (bheṭūn ānand jhālā)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{मी}}\par
+\small I (mī)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{मी} \mr{बरा} \mr{आहे}}\par
+\small I'm well, thank you (mī barā āhe)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{मी} \mr{मराठी} \mr{बोलतो}}\par
+\small I speak Marathi (gendered)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{माझं}}\par
+\small my (mājhaṁ, neuter)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{माझं} \mr{नाव} … \mr{आहे}}\par
+\small my name is… (mājhaṁ nāv … āhe)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{येतो} / \mr{येते}}\par
+\small \textquotedblleft{}I'll be going\textquotedblright{} (yeto m. / yete f.)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{राहणे}}\par
+\small to live, to stay (rāhṇe)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\mr{हो}}\par
+\small yes (ho)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/persian/book/book.tex
+++ b/code/learning/human-languages/persian/book/book.tex
@@ -84,6 +84,7 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \chapter*{A note on sources}
 \addcontentsline{toc}{chapter}{A note on sources}

--- a/code/learning/human-languages/persian/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/persian/book/chapters/appendix-glossary.tex
@@ -1,0 +1,218 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 30
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{آمدن}}\enspace\emph{âmadan}\par
+\small to come — with the hat-wearing alef and a root English kept as \emph{come}\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{بله}}\enspace\emph{bale}\par
+\small yes\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{بودن}}\enspace\emph{budan}\par
+\small to be — and the ending every Persian verb wears\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{چطور}}\enspace\emph{chetor}\par
+\small how; in what manner\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{چیست}}\enspace\emph{chist}\par
+\small what is?\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{دانستن}}\enspace\emph{dânestan}\par
+\small to know — the chapter's clearest cousin, and the place all five pairs come back\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{دوست} \fa{داشتن}}\enspace\emph{dust dâshtan}\par
+\small to like, to love — “to have as friend,” and the place all thirteen verbs run together\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{اسم} \fa{من} ... \fa{است}}\enspace\emph{esm-e man ... ast}\par
+\small my name is ...\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{اسم} \fa{شما} \fa{چیست؟}}\enspace\emph{esm-e shomâ chist?}\par
+\small What is your name? (respectful)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{فهمیدن}}\enspace\emph{fahmidan}\par
+\small to understand — and the one Persian verb class whose stem you can predict\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{فکر} \fa{کردن}}\enspace\emph{fekr kardan}\par
+\small to think — two words bolted into one verb, and the pattern that builds hundreds more\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{گرفتن}}\enspace\emph{gereftan}\par
+\small to take — and the clearest English cousin in this book\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{گفتن}}\enspace\emph{goftan}\par
+\small to say — and the Persian-only letter \fa{گ} that starts it\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{حافظ}}\enspace\emph{hâfez}\par
+\small guardian, protector — the Arabic-rooted half of the farewell\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{حال}}\enspace\emph{hâl}\par
+\small state, condition — the state in “How are you?”\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{حال} \fa{شما} \fa{چطور} \fa{است؟}}\enspace\emph{hâl-e shomâ chetor ast?}\par
+\small How are you? (careful, respectful)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{خواندن}}\enspace\emph{khândan}\par
+\small to read — and to recite, and to sing, because all three are sounding\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{خدا}}\enspace\emph{khodâ}\par
+\small God — the inherited Persian half of the standard farewell\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{خداحافظ}}\enspace\emph{khodâ hâfez}\par
+\small goodbye — the standard Persian farewell\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{خوشوقتم}}\enspace\emph{khoshvaghtam}\par
+\small pleased to meet you\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{خوب}}\enspace\emph{khub}\par
+\small good, well\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{خوبم،} \fa{ممنون}}\enspace\emph{khubam, mamnun}\par
+\small I am well, thank you\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{کمک} \fa{کردن}}\enspace\emph{komak kardan}\par
+\small to help — the compound pattern proving itself, and a third layer in the vocabulary\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{ممنون}}\enspace\emph{mamnun}\par
+\small thank you / grateful\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{نه}}\enspace\emph{na}\par
+\small no\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{نوشتن}}\enspace\emph{neveshtan}\par
+\small to write — the chapter's last pair, and the place all four run together\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{پرسیدن}}\enspace\emph{porsidan}\par
+\small to ask — the verb behind a question you have been asking since Chapter 3\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{رفتن}}\enspace\emph{raftan}\par
+\small to go — the verb that shows why every Persian verb comes in two pieces\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{سلام}}\enspace\emph{salâm}\par
+\small hello / peace\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\fa{شما} / \fa{تو}}\enspace\emph{shomâ / to}\par
+\small you — respectful or plural / familiar singular\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/portuguese/book/book.tex
+++ b/code/learning/human-languages/portuguese/book/book.tex
@@ -123,5 +123,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/portuguese/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/appendix-glossary.tex
@@ -1,0 +1,617 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 87
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{a água, o vinho}\par
+\small water and wine — água keeps aqua's shape; vinho shows the -nh- for Latin -n-\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{a boca}\par
+\small mouth — Vulgar Latin's word for \textquotedblleft{}cheek,\textquotedblright{} promoted to cover the whole mouth\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{a cabeça}\par
+\small the head — feminine, with cedilla ç pronounced s\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{a família}\par
+\small family — a word that used to mean the household's servants, not its blood relatives\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{a mão}\par
+\small the hand — feminine, and a showcase of the -ão ending that swallowed three Latin endings\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{a mulher}\par
+\small woman — the fourth Romance sister to pick a fourth different Latin word\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{a orelha}\par
+\small ear — a second word built by the same -cl- to -lh- law, and the same PT/ES split as trabalhar\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{adeus}\par
+\small goodbye (literally \textquotedblleft{}to God\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ajudar}\par
+\small to help — and the Latin i that hardened into Portuguese j\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{as estações}\par
+\small the seasons — and verão, a \textquotedblleft{}summer\textquotedblright{} that came from \textquotedblleft{}spring\textquotedblright{}\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{até amanhã}\par
+\small see you tomorrow (literally \textquotedblleft{}until tomorrow\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{até breve}\par
+\small see you soon (literally \textquotedblleft{}until {[}a{]} short {[}while{]}\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{até logo}\par
+\small see you later (literally \textquotedblleft{}until soon/then\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bom / boa}\par
+\small good (adjective)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bom dia}\par
+\small good morning / good day\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{como}\par
+\small how / like, as\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Como se chama?}\par
+\small what's your name? (literally \textquotedblleft{}how do you call yourself?\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Como vai? / Como está?}\par
+\small how are you? — the “go” and “stand” versions\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{comprar}\par
+\small to buy — from a Latin verb spelled exactly like the one behind 'compare', and not the same verb at all\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{conseguir / obter}\par
+\small to get — the everyday verb that also means 'to manage to', and the formal twin built on ter\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{de nada}\par
+\small you're welcome (literally \textquotedblleft{}of nothing\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{dezesseis — vinte}\par
+\small 16–20 — Portuguese breaks earliest, and rebuilds numbers as \textquotedblleft{}ten AND six\textquotedblright{}\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{dia}\par
+\small day (masculine)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{dizer}\par
+\small to say — and the Latin verb that also produced the judge\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{encontrar}\par
+\small to meet, to find, to run into — and how it divides the work of meeting with conhecer\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{entender / compreender}\par
+\small to understand — one verb that stretches toward the thing, one that seizes it whole\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{escrever}\par
+\small to write — to scratch, and the propped-up e- that decodes a hundred other words\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{esperar}\par
+\small to wait, to hope, to expect — one Portuguese verb doing the work of three English ones\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{eu}\par
+\small I (first-person subject pronoun)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{falar}\par
+\small to speak / to talk (your first regular -ar verb)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{falei}\par
+\small the pretérito perfeito — Portuguese kept its simple past, where three sisters gave theirs up\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Falo português}\par
+\small \textquotedblleft{}I speak Portuguese\textquotedblright{} — your first full sentence (português = Portuguese)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{gostar de}\par
+\small to like, to love — the verb that will not let go of its preposition\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hora}\par
+\small hour / o'clock — telling the time\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ir}\par
+\small to go — two letters long, and welded together out of three separate Latin verbs\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{jogar / brincar / tocar}\par
+\small to play — split three ways, by whether it is a game, a child at play, or an instrument\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ler}\par
+\small to read — three letters, irregular, and the same broken row as ver\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{mais ou menos}\par
+\small so-so (literally \textquotedblleft{}more or less\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{me chamo / chamo-me}\par
+\small my name is (literally \textquotedblleft{}I call myself\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{meio-dia, meia-noite}\par
+\small noon and midnight — \textquotedblleft{}mid-day\textquotedblright{} and \textquotedblleft{}mid-night\textquotedblright{}\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{morar}\par
+\small to live / to dwell (a second -ar verb — from \textquotedblleft{}to linger\textquotedblright{})\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{noite / boa noite}\par
+\small night / good night\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{o / a}\par
+\small the (masculine / feminine)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{o açúcar}\par
+\small sugar — the same route as arroz, and the same cedilla as cabeça\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{o amigo, a amiga}\par
+\small friend — from the verb \textquotedblleft{}to love,\textquotedblright{} and the word you close an introduction with\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{o arroz}\par
+\small rice — Greek by way of Arabic, the al-Andalus thread again\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{o café}\par
+\small coffee — a word Portuguese never inherited from Latin at all\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{o chá}\par
+\small tea — Portuguese is the ONE Western European exception in how it got this word\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{o coração}\par
+\small heart — the same nasal -ão ending as pão, but GROWN rather than worn down\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{o homem}\par
+\small man — from the Latin word for \textquotedblleft{}human being,\textquotedblright{} narrowed to just one sex\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{o irmão, a irmã}\par
+\small brother and sister — NOT from frater, but from germanus \textquotedblleft{}of the same stock\textquotedblright{}\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{o leite}\par
+\small milk — the one drink of the three that IS plain inherited Latin\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{o olho}\par
+\small eye — the same -cl- to -lh- sound law that gave Chapter 13 its \textquotedblleft{}worm\textquotedblright{} red\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{o ovo}\par
+\small egg — three letters, unchanged for two thousand years\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{o pai, a mãe}\par
+\small father and mother — the most worn-down of all: pater$\to$pai, mater$\to$mãe\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{o pão}\par
+\small bread — pānis worn to a single nasal syllable, just like pai\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{o queijo}\par
+\small cheese — the word English and Portuguese still share, though French and Italian moved on\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{obrigado / obrigada}\par
+\small thank you\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{olá}\par
+\small hi\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{onze — quinze}\par
+\small 11–15 — the only five teens Portuguese kept fused; it breaks earliest of all\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{os meses}\par
+\small the months — Roman gods, emperors, and the numbers 7–10\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{pensar}\par
+\small to think — from a Latin verb that meant to weigh a thing in a balance\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{perguntar}\par
+\small to ask a question — and why it is not the verb for asking for a coffee\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{prazer}\par
+\small pleased to meet you (literally \textquotedblleft{}a pleasure\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{preto, branco}\par
+\small black and white — Portuguese has TWO blacks, and its white is a Germanic loan\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{responder}\par
+\small to answer — literally to pledge something back, and the other half of asking\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{sábado, domingo}\par
+\small the weekend (Saturday, Sunday) — the two days that kept their names\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{saber / conhecer}\par
+\small to know — the second place Portuguese answers one English verb with two\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{segunda, terça, quarta, quinta, sexta(-feira)}\par
+\small the weekdays (Mon–Fri) — Portuguese NUMBERS its days instead of naming planets\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{seis, sete, oito, nove, dez}\par
+\small the numbers 6–10 (and the months hidden in them)\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ser}\par
+\small to be — present, imperfect, and preterite forms\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ser / estar}\par
+\small to be — the one English verb that Portuguese answers with two, and the line it draws its own way\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ser vs. estar}\par
+\small identity or nature against location or resulting condition\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{tarde / boa tarde}\par
+\small afternoon / good afternoon\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{tenho falado}\par
+\small ter + participle — which does NOT mean 'I have spoken', the trap English speakers walk into\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{tenho vinte anos}\par
+\small age — Portuguese HOLDS its years, and annus loses its double n\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ter}\par
+\small to have — where Portuguese and Spanish broke ranks with the rest of Romance\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ter / haver}\par
+\small to have — the verb that took the job, and the one it pushed aside\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{tomar / pegar}\par
+\small to take — split by whether the thing ends up in your hand or inside you\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{trabalhar}\par
+\small to work (a third -ar verb — back on the \textquotedblleft{}torture\textquotedblright{} road)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{trazer}\par
+\small to bring — carrying a thing toward the person speaking, from a Latin verb that meant to drag\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{tudo}\par
+\small everything / all\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Tudo bem?}\par
+\small everything well? — the verb-free everyday “how are you?”\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{um, dois, três, quatro, cinco}\par
+\small the numbers 1–5\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ver}\par
+\small to see — and the one form that belongs to two different verbs at once\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{vermelho, azul}\par
+\small red and blue — a red named after a worm, and a blue named after a stone\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{vir}\par
+\small to come — and the missing n that explains why the infinitive is so short\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/punjabi/book/book.tex
+++ b/code/learning/human-languages/punjabi/book/book.tex
@@ -104,5 +104,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/punjabi/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/appendix-glossary.tex
@@ -1,0 +1,393 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 55
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਅੱਖ}}\enspace\emph{akkh}\par
+\small eye — a doubled consonant that survived whole, so it never had a tone to lose\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਆਉਣਾ}}\enspace\emph{āuṇā}\par
+\small to come — “go” with “toward” glued on the front, and the “go” half is English come\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਭੈਣ}}\enspace\emph{bhaiṇ}\par
+\small sister — the same low tone as brother, but not the same family of words\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਭਰਾ}}\enspace\emph{bharā}\par
+\small brother — spelled with a breathy bh, said with a plain p and a low tone\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਚਾਹ}}\enspace\emph{cāh}\par
+\small tea — a word that took the overland road out of China, and a level high tone hiding inside its own spelling\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਦਿਲ}}\enspace\emph{dil}\par
+\small heart — a Persian loan, not the Sanskrit word Punjabi's other body parts have all used\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਦੋਸਤ}}\enspace\emph{dost}\par
+\small friend — a Persian word that literally means \textquotedblleft{}the one you chose\textquotedblright{}\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਦੁੱਧ}}\enspace\emph{dudh}\par
+\small milk — \textquotedblleft{}that which has been milked,\textquotedblright{} said flat, with no tone at all\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਹੋਣਾ}}\enspace\emph{hoṇā}\par
+\small to be — the infinitive that sounds nothing like \pa{ਹੈ}, because two ancient verbs are braided inside it\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਇੱਕ} \pa{ਦੋ} \pa{ਤਿੰਨ} \pa{ਚਾਰ} \pa{ਪੰਜ}}\enspace\emph{ikk do tinn chār panj}\par
+\small one to five — meeting the panj of Punjabi as an actual number\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਜਾਣਾ}}\enspace\emph{jāṇā}\par
+\small to go — and the one sound law that turns Sanskrit words into Punjabi ones\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਜਾਣਨਾ}}\enspace\emph{jāṇnā}\par
+\small to know — one letter away from “to go,” and the same word as English know\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਕੰਨ}}\enspace\emph{kann}\par
+\small ear — a word that looks like it hides \textquotedblleft{}to do\textquotedblright{} inside it, and does not\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਖਾਣਾ}}\enspace\emph{khāṇā}\par
+\small to eat — and the letter next door that stopped being a consonant and became a tone\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਲੈਣਾ}}\enspace\emph{laiṇā}\par
+\small to take — a verb that lost a whole consonant on the way here\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਲਿਖਣਾ}}\enspace\emph{likhṇā}\par
+\small to write — from a root meaning to scratch, which is how three unrelated languages named it\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਮਦਦ} \pa{ਕਰਨਾ}}\enspace\emph{madad karnā}\par
+\small to help — literally “to do help,” and the help half is Arabic\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਮੂੰਹ}}\enspace\emph{mūnh}\par
+\small mouth, face — the second word this book has found with a level high tone\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਨੱਕ}}\enspace\emph{nakk}\par
+\small nose — the plainest possible cousin of the English word for the very same part\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਪਾਣੀ}}\enspace\emph{pāṇī}\par
+\small water — Punjabi's first noun for something you would actually ask for, and the phrase that asks for it politely\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਪੜ੍ਹਨਾ}}\enspace\emph{paṛhnā}\par
+\small to read — and in the language it came from, reading meant saying it out loud\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਪਰਿਵਾਰ}}\enspace\emph{parivār}\par
+\small family — literally \textquotedblleft{}what surrounds you,\textquotedblright{} built from two Sanskrit pieces you can pull apart\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਪਸੰਦ}}\enspace\emph{pasand}\par
+\small liked, pleasing — a Persian noun, not a verb, in the one sentence that will not let you be its subject\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਪੁੱਛਣਾ}}\enspace\emph{puchhṇā}\par
+\small to ask — cousin to the Persian word for asking, and neither borrowed it from the other\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਰੋਟੀ}}\enspace\emph{roṭī}\par
+\small bread — the fourth request, and the retroflex letter this book only mentioned in passing until now\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਸਮਝਣਾ}}\enspace\emph{samajhṇā}\par
+\small to understand — from a root meaning “to wake up,” and the word carries a tone\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਸਿਰ}}\enspace\emph{sir}\par
+\small head — a cousin of English horn, not of English head, and an unborrowed twin of Persian sar\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਸੋਚਣਾ}}\enspace\emph{sochṇā}\par
+\small to think — a verb that started out meaning to burn, and then to grieve\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਵੇਖਣਾ}}\enspace\emph{vekhṇā}\par
+\small to see — built on the old word for the eye itself, the root behind eye, optic, and window\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਕੀ}}\par
+\small what\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਕੋਈ} \pa{ਗੱਲ} \pa{ਨਹੀਂ}}\par
+\small it's nothing / no problem / you're welcome\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਕੰਮ} \pa{ਕਰਨਾ}}\par
+\small to work (lit. \textquotedblleft{}work-do\textquotedblright{})\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਕਿਵੇਂ}}\par
+\small how\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਖ਼ੁਸ਼ੀ} \pa{ਹੋਈ}}\par
+\small pleased to meet you (lit. \textquotedblleft{}happiness happened\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਠੀਕ}}\par
+\small fine, well — and the reply \textquotedblleft{}\pa{ਮੈਂ} \pa{ਠੀਕ} \pa{ਹਾਂ}\textquotedblright{}\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਤੂੰ} / \pa{ਤੁਸੀਂ}}\par
+\small you (familiar / respectful)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਤੁਸੀਂ} \pa{ਕਿਵੇਂ} \pa{ਹੋ}?}\par
+\small how are you? (respectful)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਤੁਹਾਡਾ} \pa{ਨਾਂ} \pa{ਕੀ} \pa{ਹੈ}?}\par
+\small what's your name?\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਧੰਨਵਾਦ}}\par
+\small thank you (Sanskritic) (dhannavād)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਨਾਂ}}\par
+\small name\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਨਮਸਤੇ}}\par
+\small hello (general, pan-Indian) (namaste)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਫਿਰ}}\par
+\small again, then\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਫਿਰ} \pa{ਮਿਲਾਂਗੇ}}\par
+\small we'll meet again (goodbye)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਬੋਲਣਾ}}\par
+\small to speak\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਮੈਂ}}\par
+\small I\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਮੈਂ} \pa{ਪੰਜਾਬੀ} \pa{ਬੋਲਦਾ} \pa{ਹਾਂ}}\par
+\small I speak Punjabi (gendered)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਮੇਰਾ}}\par
+\small my\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਮੇਰਾ} \pa{ਨਾਂ} … \pa{ਹੈ}}\par
+\small my name is…\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਮਿਲਾਂਗੇ}}\par
+\small (we) will meet\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਰੱਬ} \pa{ਰਾਖਾ}}\par
+\small goodbye (lit. \textquotedblleft{}God {[}be your{]} keeper\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਰਹਿਣਾ}}\par
+\small to live, to stay\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਸ਼ੁਕਰੀਆ}}\par
+\small thank you (Perso-Arabic) (shukrīā)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਸਤਿ} \pa{ਸ੍ਰੀ} \pa{ਅਕਾਲ}}\par
+\small hello / goodbye, the Sikh greeting (sat srī akāl)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਹੈ}}\par
+\small is\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\pa{ਹਾਂ} / \pa{ਨਹੀਂ}}\par
+\small yes / no (hāṇ / nahīṇ)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/russian/book/book.tex
+++ b/code/learning/human-languages/russian/book/book.tex
@@ -88,6 +88,7 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \chapter*{A note on sources}
 \addcontentsline{toc}{chapter}{A note on sources}

--- a/code/learning/human-languages/russian/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/russian/book/chapters/appendix-glossary.tex
@@ -1,0 +1,281 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 39
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{брат}}\enspace\emph{brat}\par
+\small brother — masculine, one soft sign away from a verb you already know, and this time it really is your English cousin\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{брать}}\enspace\emph{brat'}\par
+\small to take — English bear, and a partner from a completely different root\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{быть}}\enspace\emph{byt'}\par
+\small to be — and the one tense in which Russian refuses to say it\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{чай}}\enspace\emph{chai}\par
+\small tea — masculine, regular this time, and the overland twin of \ru{кофе}'s sea route\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{читать}}\enspace\emph{chitát'}\par
+\small to read — and why Russian has no separate way to say I am reading\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{да}}\enspace\emph{da}\par
+\small yes (da)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{друг}}\enspace\emph{drug}\par
+\small friend (male, or unspecified) — masculine, and the reason you own \ru{ты} at all\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{думать}}\enspace\emph{dúmat'}\par
+\small to think — and the fact that shapes every Russian verb you will ever meet\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{глаз}}\enspace\emph{glaz}\par
+\small eye — masculine, and the word that quietly evicted Russian's inherited word for eye\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{говорить}}\enspace\emph{govorít'}\par
+\small to speak — one new letter, and a false friend worth killing early\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{идти}}\enspace\emph{idtí}\par
+\small to go — the one-way verb, and a past tense from a different root entirely\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{как} \ru{вас} \ru{зовут}?}\enspace\emph{kak vas zovút}\par
+\small what's your name? — literally 'HOW do they call you?', not 'what'\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{хлеб}}\enspace\emph{khleb}\par
+\small bread — masculine, and not a Slavic word at all\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{кофе}}\enspace\emph{kófe}\par
+\small coffee — masculine, the one exception worth meeting on purpose\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{любить}}\enspace\emph{lyubít'}\par
+\small to love, and to like — English love itself, with a letter that appears from nowhere\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{меня} \ru{зовут}…}\enspace\emph{menyá zovút}\par
+\small my name is… — literally 'they call me', with no word for 'my' and no word for 'name'\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{нос}}\enspace\emph{nos}\par
+\small nose — masculine, and the same word as English nose and Latin nasus\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{нет}}\enspace\emph{nyet}\par
+\small no (nyet)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{очень} \ru{приятно}}\enspace\emph{óchen priyátno}\par
+\small pleased to meet you — literally 'very pleasant', and a cousin of English FRIEND\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{писать}}\enspace\emph{pisát'}\par
+\small to write — one new letter, and the one stress mistake you must not make\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{подруга}}\enspace\emph{podrúga}\par
+\small friend (female) — feminine, and \ru{друг} with a prefix and an ending stitched on\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{помогать}}\enspace\emph{pomogát'}\par
+\small to help — built on can, which is English may and might\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{понимать}}\enspace\emph{ponimát'}\par
+\small to understand — literally to take hold of, which is what comprehend means too\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{пожалуйста}}\enspace\emph{pozhálusta}\par
+\small please / you're welcome (pozhálusta)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{привет}}\enspace\emph{privét}\par
+\small hi / hello (privét — informal)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{рот}}\enspace\emph{rot}\par
+\small mouth — masculine, and this time the resemblance to English is not there to trust\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{семья}}\enspace\emph{sem'yá}\par
+\small family — feminine, and an unexpected cousin of the English word home\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{сердце}}\enspace\emph{sérdtse}\par
+\small heart — neuter, a silent letter, and one of the surest cognates in the entire Indo-European family\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{сестра}}\enspace\emph{sestrá}\par
+\small sister — feminine, brat's other half, and a cognate just as secure\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{спасибо}}\enspace\emph{spasíbo}\par
+\small thank you (spasíbo)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{спрашивать}}\enspace\emph{spráshivat'}\par
+\small to ask a question — the verb behind the question you have asked since Chapter 2\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{ты}, \ru{вы}}\enspace\emph{ty, vy}\par
+\small you (informal) and you (formal) — the split English threw away\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{ухо}}\enspace\emph{úkho}\par
+\small ear — neuter, the first word Russian gives its third gender, and a word-for-word cousin of the English ear\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{видеть}}\enspace\emph{vídet'}\par
+\small to see — the root behind both vision and wisdom\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{вода}}\enspace\emph{vodá}\par
+\small water — feminine, and the first noun in this book, so it also teaches how every Russian noun announces itself\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{я}}\enspace\emph{ya}\par
+\small I — one letter, and one of the oldest words in Europe\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{здравствуйте}}\enspace\emph{zdrávstvuyte}\par
+\small hello (zdrávstvuyte — formal / polite)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{жить}}\enspace\emph{zhit'}\par
+\small to live — and the English word that used to mean 'alive'\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ru{знать}}\enspace\emph{znat'}\par
+\small to know — the same root as English know, and the sentence you will use most\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/sanskrit/book/book.tex
+++ b/code/learning/human-languages/sanskrit/book/book.tex
@@ -111,5 +111,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/sanskrit/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/appendix-glossary.tex
@@ -1,0 +1,379 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 53
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{आगच्छति}}\enspace\emph{āgacchati}\par
+\small he, she, or it comes — the same verb as \textquotedblleft{}goes\textquotedblright{} with a prefix pointing it homeward\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{अक्षि}}\enspace\emph{akṣi}\par
+\small eye — unbroken from Sanskrit to English, and the reason eyes get their own grammatical number\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{अन्नम्}}\enspace\emph{annam}\par
+\small food, grain — literally \textquotedblleft{}the eaten thing,\textquotedblright{} built on the very root \sk{खादति} left uneaten\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{अस्ति} · \sk{भवति}}\enspace\emph{asti · bhavati}\par
+\small is, and becomes — the two be-verbs Sanskrit keeps apart, and the root-plus-class system behind every Sanskrit verb\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{अवगच्छति} · \sk{बुध्यते}}\enspace\emph{avagacchati · budhyate}\par
+\small he, she, or it understands — \textquotedblleft{}goes down into\textquotedblright{} a thing, or wakes up to it\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{भगिनी}}\enspace\emph{bhaginī}\par
+\small sister — not built on English \textquotedblleft{}sister\textquotedblright{}'s root at all, but on \textquotedblleft{}one with a share\textquotedblright{}\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{भ्राता}}\enspace\emph{bhrātā}\par
+\small brother — unbroken from Sanskrit to English, worn down two different ways\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{चिन्तयति}}\enspace\emph{cintayati}\par
+\small he, she, or it thinks — the tenth class, which plants a whole syllable \sk{अय} between root and ending\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{एक} \sk{द्व} \sk{त्रि} \sk{चतुर्} \sk{पञ्च}}\enspace\emph{eka dva tri catur pañca}\par
+\small one to five — Old Indo-Aryan ancestors preserved in Sanskrit, and cousins of the English ones\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{गच्छति}}\enspace\emph{gacchati}\par
+\small he, she, or it goes — the verb whose present stem you could never guess from its root\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{गृह्णाति}}\enspace\emph{gṛhṇāti}\par
+\small he, she, or it takes, seizes — the ninth class again, and the root English grabs with\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{हृदयम्}}\enspace\emph{hṛdayam}\par
+\small heart — the oldest, most secure cousin this book has shown, and kept whole two chapters east\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{जानाति}}\enspace\emph{jānāti}\par
+\small he, she, or it knows — the root \sk{ज्ञा}, the class that plants a syllable inside the verb, and the chapter's six roots gathered up\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{कर्णः}}\enspace\emph{karṇaḥ}\par
+\small ear — a word Sanskrit itself never settled the origin of\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{खादति}}\enspace\emph{khādati}\par
+\small he, she, or it eats — the everyday eat-verb, which is not the one English is related to\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{क्षीरम्}}\enspace\emph{kṣīram}\par
+\small milk — an origin scholars still argue over, and the dessert word it left behind\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{कुटुम्बम्}}\enspace\emph{kuṭumbam}\par
+\small family, household — a word Sanskrit itself borrowed, before other languages borrowed it back\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{लिखति}}\enspace\emph{likhati}\par
+\small he, she, or it writes — a root that means \textquotedblleft{}scratch,\textquotedblright{} and the chapter's four verbs gathered up\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{मित्रम्}}\enspace\emph{mitram}\par
+\small friend — the word behind a covenant-god's name, naming a person while itself being neuter\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{मुखम्}}\enspace\emph{mukham}\par
+\small mouth, face — a word so old, scholars still argue which family it belongs to\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{नासिका}}\enspace\emph{nāsikā}\par
+\small nose — kin to two modern words, but the parent of neither\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{पानीयम्}}\enspace\emph{pānīyam}\par
+\small water — \textquotedblleft{}the thing to be drunk,\textquotedblright{} and the exact word your neighbors' \sk{पानी} grew from\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{पश्यति}}\enspace\emph{paśyati}\par
+\small he, she, or it sees — a verb assembled from two different roots, one of which you already met\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{पठति}}\enspace\emph{paṭhati}\par
+\small he, she, or it reads — reading as reciting aloud, and the two ways a Sanskrit word survives into a modern language\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{पृच्छति}}\enspace\emph{pṛcchati}\par
+\small he, she, or it asks — the root that became Latin prayer and German fragen\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{साहाय्यं} \sk{करोति}}\enspace\emph{sāhāyyaṁ karoti}\par
+\small he, she, or it helps — a noun plus \textquotedblleft{}does,\textquotedblright{} and help named as going along with someone\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{स्निह्यति} · \sk{प्रियम्}}\enspace\emph{snihyati · priyam}\par
+\small he, she, or it loves, and what is dear — affection named as stickiness, and the word behind English friend\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{अस्ति}}\par
+\small is\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{अहं} \sk{संस्कृतं} \sk{वदामि}}\par
+\small I speak Sanskrit\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{अहम्}}\par
+\small I\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{आनन्दः}}\par
+\small joy — and \textquotedblleft{}meeting you is a joy\textquotedblright{}\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{आम्} / \sk{न}}\par
+\small yes / no (ām / na)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{कथम्}}\par
+\small how\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{किम्}}\par
+\small what\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{करोमि}}\par
+\small I do, I make (\sk{कार्यं} \sk{करोमि}, \textquotedblleft{}I work\textquotedblright{})\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{कुशलम्}}\par
+\small well-being — and the reply \textquotedblleft{}\sk{अहं} \sk{कुशली} \sk{अस्मि}\textquotedblright{}\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{गच्छामि}}\par
+\small I go (a way to take leave)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{तव} \sk{नाम} \sk{किम्}?}\par
+\small what's your name?\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{धन्यवादः}}\par
+\small thank you (dhanyavādaḥ)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{न} \sk{चिन्ता}}\par
+\small no worry / it's nothing / you're welcome\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{नाम}}\par
+\small name\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{नमस्कारः}}\par
+\small hello (lit. \textquotedblleft{}the making of a bow\textquotedblright{}) (namaskāraḥ)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{नमस्ते}}\par
+\small hello (lit. \textquotedblleft{}a bow to you\textquotedblright{}) (namaste)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{पुनः}}\par
+\small again\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{पुनर्दर्शनाय}}\par
+\small until we meet again (lit. \textquotedblleft{}for seeing again\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{भवान्} / \sk{त्वम्}}\par
+\small you (respectful / familiar)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{भवान्} \sk{कथम्} \sk{अस्ति}?}\par
+\small how are you? (respectful)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{मम}}\par
+\small my\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{मम} \sk{नाम} … \sk{अस्ति}}\par
+\small my name is…\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{वदामि}}\par
+\small I speak (from \sk{वद्}, to speak)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{वसामि}}\par
+\small I live, I dwell (from \sk{वस्}, to dwell)\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{श्वः}}\par
+\small tomorrow — and \textquotedblleft{}see you tomorrow\textquotedblright{}\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\sk{स्वागतम्}}\par
+\small welcome (lit. \textquotedblleft{}well come\textquotedblright{}) (svāgatam)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/spanish/book/book.tex
+++ b/code/learning/human-languages/spanish/book/book.tex
@@ -129,5 +129,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/spanish/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/spanish/book/chapters/appendix-glossary.tex
@@ -1,0 +1,960 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 136
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{-go}\par
+\small the \textquotedblleft{}-go\textquotedblright{} verbs — a small club whose yo-form ends in -go\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{abrir}\par
+\small to open — a regular -ir verb with one irregular part, the participle abierto\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{adiós}\par
+\small goodbye\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{amarillo}\par
+\small yellow — from \textquotedblleft{}a little bitter,\textquotedblright{} not from any Latin word for yellow at all\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{así que}\par
+\small thus, in that way — and with que after it, \textquotedblleft{}so\textquotedblright{}; built on the same sīc that gave you sí\par
+\footnotesize Introduced in Chapter 41.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ayudar}\par
+\small to help — literally the same word as English \textquotedblleft{}aid\textquotedblright{}, arriving by a different road\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{azul}\par
+\small blue — an Arabic loan that became the plain everyday word, where French's cousin stayed poetic\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{beber}\par
+\small to drink (another -er verb — cementing the pattern)\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{bien}\par
+\small well / good / fine\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{buenas noches}\par
+\small good evening / good night\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{buenas tardes}\par
+\small good afternoon\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{buenos días}\par
+\small good morning (literally \textquotedblleft{}good days\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{café}\par
+\small coffee / a café — one useful noun before the polite request that follows\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{caminar}\par
+\small to walk — built on a Celtic word for a path, beside andar, whose own past is unsettled\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{cerrar}\par
+\small to close — from the bar dropped across a door, not from the Latin verb English inherited\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{comer}\par
+\small to eat (your first -er verb)\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{comí, viví}\par
+\small the regular -er/-ir preterite — where two conjugations collapse into one\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{cómo}\par
+\small how — a whole Latin phrase, quo modo, worn smooth into one word\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{comprar}\par
+\small to buy — from Latin's \textquotedblleft{}get ready, procure\textquotedblright{}, and not from the verb behind English compare\par
+\footnotesize Introduced in Chapter 40.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{conocer}\par
+\small to meet, to be acquainted with — a verb built out of the moment knowing begins\par
+\footnotesize Introduced in Chapter 39.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{conseguir}\par
+\small to get, to obtain — getting as following a thing until you have it\par
+\footnotesize Introduced in Chapter 39.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{contar}\par
+\small to tell a story — and also to count, because in Spanish, as once in English, a story is something you reckon up\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{contestar}\par
+\small to answer — a Roman courtroom word that English turned into a fight and Spanish turned into a reply\par
+\footnotesize Introduced in Chapter 40.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{correr}\par
+\small to run — a plain -er verb sitting on one of the largest roots English ever borrowed\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{creer}\par
+\small to believe, to think — putting your heart somewhere, where pensar weighs it up\par
+\footnotesize Introduced in Chapter 41.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{de nada}\par
+\small you're welcome (literally \textquotedblleft{}of nothing\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{deber}\par
+\small should, ought to — and to owe, because the word is literally \textquotedblleft{}to have something from someone\textquotedblright{}\par
+\footnotesize Introduced in Chapter 41.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{decir}\par
+\small to say / to tell — doubly irregular, digo + e$\to$i\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{día}\par
+\small day (el día — masculine)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{dieciséis — diecinueve}\par
+\small 16-19 — not words to memorise but a formula, diez y X, with the seam still visible\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{dónde}\par
+\small where?\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{dormir}\par
+\small to sleep — and the other half of the boot, where a stressed o breaks to ue\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{el / la}\par
+\small the (masculine / feminine)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{el agua}\par
+\small water — a word that barely changed from Latin, and takes el without ever stopping being feminine\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{el hermano, la hermana}\par
+\small brother and sister — NOT from frater/soror, but from an adjective meaning \textquotedblleft{}of the same seed\textquotedblright{}\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{el padre, la madre}\par
+\small father and mother — among the oldest reconstructible words in the whole family\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{el pan}\par
+\small bread — and the compañero who shares it with you\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{el tiempo}\par
+\small the one noun that covers both \textquotedblleft{}time\textquotedblright{} and \textquotedblleft{}weather\textquotedblright{} — because Latin tempus already did\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{el vino}\par
+\small wine — one Latin root that reached English by three separate roads, plus one English built at home\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{entender}\par
+\small to understand — literally \textquotedblleft{}to stretch toward\textquotedblright{}; the second e$\to$ie stem-changer\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{era, iba, veía}\par
+\small the only three irregular imperfects in the entire language\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{escribir}\par
+\small to write — from a Latin verb meaning \textquotedblleft{}to scratch\textquotedblright{}, and the reason Spanish puts an e- in front\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{español}\par
+\small \textquotedblleft{}Spanish\textquotedblright{} — the language, the people, and the Roman name for the peninsula underneath it\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{esperar}\par
+\small to wait — and to hope, and to expect, all in one verb\par
+\footnotesize Introduced in Chapter 40.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{está en…}\par
+\small \textquotedblleft{}is in/at…\textquotedblright{} — location always takes estar\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{estar}\par
+\small to be — but the \emph{standing} kind, straight from Latin stāre\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{estás / está}\par
+\small what estar is for — a current state or location — and the only two forms you need this chapter\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{estudiar}\par
+\small to study (a third -ar verb — the pattern is automatic now)\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{explicar}\par
+\small to explain — literally to unfold, and the verb that names what this whole chapter has been building\par
+\footnotesize Introduced in Chapter 41.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{e$\to$ie, o$\to$ue}\par
+\small the stem-change patterns, side by side — the \textquotedblleft{}boot\textquotedblright{}\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{fui}\par
+\small the preterite (past) — and the astonishing fact that \textquotedblleft{}I was\textquotedblright{} and \textquotedblleft{}I went\textquotedblright{} are the same word\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{gato}\par
+\small cat — a word that travelled out of Africa with the animal, pushing Latin's own fēlēs aside\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{gracias}\par
+\small thank you\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{gustar}\par
+\small to please — the verb English calls \textquotedblleft{}to like\textquotedblright{}, built the other way round\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hablaba, comía}\par
+\small the imperfect — the past that kept going, and the most regular tense in Spanish\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hablar}\par
+\small to speak / to talk — at root, \textquotedblleft{}to tell stories\textquotedblright{}\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hablaré}\par
+\small the future — a compound tense that welded itself shut\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hablaría}\par
+\small the conditional — the same weld, using the imperfect of haber instead\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hablé}\par
+\small the regular -ar preterite — hablé, hablaste, habló — and why the accent matters\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hable, coma, viva}\par
+\small the regular present subjunctive — built from the yo form, with the vowel flipped\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{Hablo español}\par
+\small your first sentence built from parts — and the rule that languages take no article\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hablo, hablas, habla}\par
+\small the -ar present-tense template, and why Spanish leaves the subject pronoun out\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hace calor, hace frío, hace sol}\par
+\small the three weather words Spanish reports with hacer — \textquotedblleft{}it makes heat,\textquotedblright{} \textquotedblleft{}it makes cold,\textquotedblright{} \textquotedblleft{}it makes sun\textquotedblright{}\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hacer}\par
+\small to do / to make — an irregular yo-form, hago\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hasta}\par
+\small until / up to\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hasta luego}\par
+\small see you later (literally \textquotedblleft{}until later\textquotedblright{})\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hasta mañana}\par
+\small see you tomorrow (literally \textquotedblleft{}until tomorrow\textquotedblright{})\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hasta pronto}\par
+\small see you soon (literally \textquotedblleft{}until soon\textquotedblright{})\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{hola}\par
+\small hello / hi\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ir}\par
+\small to go (the most irregular Spanish verb — three Latin verbs in one)\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{jugar}\par
+\small to play — from Latin's word for joking, and the only verb in the language that breaks u to ue\par
+\footnotesize Introduced in Chapter 39.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la cabeza}\par
+\small the head — Spanish KEPT Latin's real word, unlike French, which replaced it with slang for \textquotedblleft{}pot\textquotedblright{}\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la hora}\par
+\small hour / o'clock — telling the time, and a word Spanish inherited almost unchanged from Latin\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la mano}\par
+\small the hand — feminine despite ending in -o, Spanish's most famous gender exception\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la noche}\par
+\small night / evening (la noche — feminine)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la primavera, el verano, el otoño, el invierno}\par
+\small the four seasons — three straightforward, and one whose MEANING quietly shifted from \textquotedblleft{}spring\textquotedblright{} to \textquotedblleft{}summer\textquotedblright{}\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{la tarde}\par
+\small afternoon (la tarde — feminine; also: late)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{leer}\par
+\small to read — from a Latin verb meaning \textquotedblleft{}to gather, to pick out\textquotedblright{}\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{levantarse}\par
+\small to get up, to stand up — \textquotedblleft{}to raise oneself\textquotedblright{}, built from a participle exactly as sentarse was\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{llamo}\par
+\small I call (from llamar, to call)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{llovía / llovió}\par
+\small the same rain in two tenses — how a story uses the imperfect for the scene and the preterite for the events\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{llueve}\par
+\small rain refuses the hacer pattern and brings its own verb — and its ll- is the sound change you already met in llamar\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{lo siento}\par
+\small I'm sorry — literally \textquotedblleft{}I feel it,\textquotedblright{} a naming of the feeling rather than a claim about yourself\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{los meses}\par
+\small the months — Roman gods and emperors, marching almost unchanged from Latin\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{luego}\par
+\small then, next — a word you already own from hasta luego, now doing a second job: joining two events in order\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{lunes, martes, miércoles, jueves, viernes}\par
+\small the weekdays (Monday–Friday) — worn-down planet-god names\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{me}\par
+\small me / myself\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{me llamo}\par
+\small my name is (literally \textquotedblleft{}I call myself\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{mediodía, medianoche}\par
+\small noon and midnight — both halves still fully alive as ordinary Spanish words, unlike French's worn-down midi/minuit\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{mi, tu, su}\par
+\small my, your, his/her/your-formal (the possessives)\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{mucho}\par
+\small much / a lot\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{mucho gusto}\par
+\small pleased to meet you (literally \textquotedblleft{}much pleasure\textquotedblright{})\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{negro, blanco}\par
+\small black and white — the two words, and the straight-line Latin history of the first one\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{no}\par
+\small no / not\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{nuestro}\par
+\small our (and vuestro, \textquotedblleft{}your\textquotedblright{}-plural) — the possessive that agrees fully\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{oír}\par
+\small to hear — the half of listening you do not choose, and a verb that sprouts a y\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{once — quince}\par
+\small 11-15 — five single opaque words, each one a Latin compound worn down until the seam disappeared\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{pensar}\par
+\small to think — at root \textquotedblleft{}to weigh\textquotedblright{}, and a stem-changer that breaks e$\to$ie\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{perdón}\par
+\small the other sorry — \textquotedblleft{}give completely\textquotedblright{} — for fault and for getting past people, where lo siento is for regret\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{perro}\par
+\small dog — a genuinely unsolved etymology, and the Latin word it pushed out\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{poder}\par
+\small to be able / can — a stem-changing verb, o$\to$ue\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{poner}\par
+\small to put / to place — a -go yo-form, pongo\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{por favor}\par
+\small please (literally \textquotedblleft{}for {[}a{]} favour\textquotedblright{})\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{porque}\par
+\small because — two tiny words fused into one, and the reason a sequence becomes a story\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{preguntar}\par
+\small to ask (a question) — and the reason English's one \textquotedblleft{}ask\textquotedblright{} becomes two Spanish verbs\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{qué}\par
+\small what? (your first question word)\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{querer}\par
+\small to want (and to love) — a stem-changing verb, e$\to$ie\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{quiero que…}\par
+\small what triggers the subjunctive — one subject wanting another to act\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{regular}\par
+\small so-so / not great (also \textquotedblleft{}más o menos\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{rojo}\par
+\small red — a cousin of French rouge and English red, but by a different branch of the same very old family\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{sábado, domingo}\par
+\small the weekend (Saturday, Sunday) — where religion overwrote astronomy\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{salir}\par
+\small to leave / to go out — a -go yo-form, salgo, from a root that means \textquotedblleft{}to leap\textquotedblright{}\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{se llama}\par
+\small he/she calls himself; you (formal) call yourself\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{seis, siete, ocho, nueve, diez}\par
+\small the numbers 6–10 (and the months hidden in them)\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{sentarse}\par
+\small to sit down — literally \textquotedblleft{}to seat oneself\textquotedblright{}, the reflexive that lands the action back on you\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ser}\par
+\small to be (identity — permanent, essential)\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{ser vs estar}\par
+\small the two \textquotedblleft{}to be\textquotedblright{} verbs, contrasted — essence vs state\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{sí}\par
+\small yes\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{soy de…}\par
+\small \textquotedblleft{}I'm from…\textquotedblright{} — origin and identity take ser\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{tener}\par
+\small to have (your first irregular / stem-changing verb)\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{tomar}\par
+\small to take (and, across Latin America, to drink) — an everyday word with no settled origin\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{trabajar}\par
+\small to work (a second -ar verb — same pattern)\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{traer}\par
+\small to bring — Latin's word for dragging, and a verb with a direction built into it\par
+\footnotesize Introduced in Chapter 39.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{tú / usted}\par
+\small the two words Spanish has for \textquotedblleft{}you\textquotedblright{} — and the one English quietly retired\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{tú o usted}\par
+\small the choice English lost — and the surprise that usted takes he/she verb forms\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{tuve, hice, estuve}\par
+\small the strong preterites — where the stress moves off the ending and the accent disappears\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{uno, dos, tres, cuatro, cinco}\par
+\small the numbers 1–5\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{veinte}\par
+\small twenty — the ceiling of the teens, and a word that was worn but never fused\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{venir}\par
+\small to come — doubly irregular, vengo + e$\to$ie, completing the -go club\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{verde}\par
+\small green — from a verb meaning \textquotedblleft{}to flourish,\textquotedblright{} and a cousin of verdant but not of English green\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{vivir}\par
+\small to live (your first -ir verb)\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{voy a + infinitive}\par
+\small the near future — \textquotedblleft{}I'm going to…\textquotedblright{}\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{y / ¿y tú?}\par
+\small and / and you? — a tiny connector that hands the conversation back\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{¿cómo está usted?}\par
+\small how are you? — assemble the formal question from cómo, estar, and usted\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{¿cómo se llama usted?}\par
+\small what's your name? (formal)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{¿Cuántos años tienes?}\par
+\small how old are you? (literally \textquotedblleft{}how many years do you have?\textquotedblright{})\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/tamil/book/book.tex
+++ b/code/learning/human-languages/tamil/book/book.tex
@@ -130,5 +130,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/tamil/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/tamil/book/chapters/appendix-glossary.tex
@@ -1,0 +1,596 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 84
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{-\ta{உக்கு}}\enspace\emph{-ukku}\par
+\small the dative suffix -ukku, 'to / for,' including its two surface forms and irregular enakku\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{அறை}}\enspace\emph{aṟai}\par
+\small room — and the letter \ta{ற}, the hard r that is not the r you think it is\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{எடு}}\enspace\emph{eḍu}\par
+\small to take, to pick up — one vowel away from \ta{இடு}, \textquotedblleft{}to put,\textquotedblright{} and pointing the opposite way\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{எழுது}}\enspace\emph{eḻudu}\par
+\small to write — carrying \ta{ழ}, the retroflex glide Tamil and Malayalam kept and their sisters gave up\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{எனக்குத்} \ta{தமிழ்} \ta{தெரியும்}}\enspace\emph{enakkut tamiḻ teriyum}\par
+\small 'I know Tamil' — built with no subject, because knowing happens TO you\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{இரு}}\enspace\emph{iru}\par
+\small to be, to exist, to stay — and the three-piece machine every Tamil verb is built on\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{இவர்}}\enspace\emph{ivar}\par
+\small this person, spoken of with respect — the near end of Tamil's \ta{இ} / \ta{அ} / \ta{எ} pointing system\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{இவர்} \ta{என்} \ta{நண்பர்}}\enspace\emph{ivar eṉ naṇbar}\par
+\small \textquotedblleft{}this is my friend\textquotedblright{} — three words, no verb, and a choice of ending that says how you regard them\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{கதவு}}\enspace\emph{kadavu}\par
+\small door — Tamil's everyday word is its own, while the Sanskrit one stayed in books\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{கேள்}}\enspace\emph{kēḷ}\par
+\small to ask — and to hear, because Tamil gives both jobs to one verb, whose stem changes shape before the beads\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{நண்பன்}}\enspace\emph{naṇbaṉ}\par
+\small friend — one word with three endings for man, woman and respect, and a root meaning \textquotedblleft{}close\textquotedblright{}\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{நாற்காலி}}\enspace\emph{nāṟkāli}\par
+\small chair — a word you can take apart into \textquotedblleft{}four\textquotedblright{} and \textquotedblleft{}leg,\textquotedblright{} and the thing a guest is offered\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{நினை}}\enspace\emph{ninai}\par
+\small to think — and, with no second word, to remember, because Tamil files thinking and recalling under one verb\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{படி}}\enspace\emph{paḍi}\par
+\small to read, to study — and the reason this book writes it paḍi with a d when the letter is \ta{ட}\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{பால்}}\enspace\emph{pāl}\par
+\small milk — one syllable, inherited whole, and the word that shows Kannada turning p into h\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{பார்}}\enspace\emph{pār}\par
+\small to see, to look — and the doubled consonant that sorts every Tamil verb into strong or weak\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{பிடி}}\enspace\emph{piḍi}\par
+\small to catch, to hold — and so, in \ta{பிடிக்கும்}, to please, with the liker pushed into the dative\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{போ}}\enspace\emph{pō}\par
+\small to go — the same three-slot verb with the middle bead swapped for past, present or future\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{புரி}}\enspace\emph{puri}\par
+\small to be understood, to become clear — so the understander is not the subject but sits in the dative, as with \ta{தெரி}\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{சாப்பிடு}}\enspace\emph{sāppiḍu}\par
+\small to eat — a verb Tamil assembled from a noun plus a light verb, alongside the inherited eat-word it kept\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{சுகம்}}\enspace\emph{sugam}\par
+\small wellbeing, ease — the Sanskrit word Tamil did take in, sitting beside the native \ta{நலம்} it never dropped\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{தவறு}}\enspace\emph{tavaṟu}\par
+\small a mistake — the noun that lets you finish an apology, and the same word as the verb \textquotedblleft{}to slip\textquotedblright{}\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{தேநீர்}}\enspace\emph{tēnīr}\par
+\small tea — a borrowed syllable welded onto the \ta{நீர்} that is already inside \ta{தண்ணீர்}\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{தெரி}}\enspace\emph{teri}\par
+\small to know, to be apparent — the verb that takes no person ending, because knowing happens to you\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{உடம்பு}}\enspace\emph{uḍambu}\par
+\small body — the noun in the everyday Tamil way of asking after someone's health\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{உதவு}}\enspace\emph{udavu}\par
+\small to help, to be of use — a native word where three sisters and Hindi all reach for Sanskrit instead\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{உணவு}}\enspace\emph{uṇavu}\par
+\small food — the noun standing on \ta{உண்}, the older eating verb behind \ta{சாப்பிடு}'s everyday one\par
+\footnotesize Introduced in Chapter 36.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{ஊர்}}\enspace\emph{ūr}\par
+\small town, village — where you are from, which a Tamil introduction asks for, and the -ore in Bangalore\par
+\footnotesize Introduced in Chapter 37.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{வா}}\enspace\emph{vā}\par
+\small to come — the word you say it by is \ta{வா}, but the beads attach to a different shape, \ta{வரு}-\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{விடை}}\enspace\emph{viḍai}\par
+\small leave to depart — the noun for taking your leave, from the same root as \ta{வீடு}\par
+\footnotesize Introduced in Chapter 38.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{வீடு}}\enspace\emph{vīḍu}\par
+\small house, home — the word behind the door you say \ta{வணக்கம்} at, and a v where Kannada says b\par
+\footnotesize Introduced in Chapter 35.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{அப்பா} \ta{அம்மா} \ta{அண்ணன்} \ta{தம்பி} \ta{அக்கா} \ta{தங்கை}}\par
+\small father, mother, and FOUR sibling words — Tamil splits \textquotedblleft{}brother\textquotedblright{}/\textquotedblleft{}sister\textquotedblright{} by age, where Spanish/French use just one word each\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{ஆம்}}\par
+\small yes (ām)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{ஆம்} / \ta{இல்லை} / \ta{சரி}}\par
+\small answering in Tamil — the five words in use, and the two habits behind them\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{ஆறு} \ta{ஏழு} \ta{எட்டு} \ta{ஒன்பது} \ta{பத்து}}\par
+\small six to ten — and the number that carries Tamil's own letter\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{இனிய} \ta{இரவு}}\par
+\small \textquotedblleft{}good night\textquotedblright{} — fully native Dravidian, \textquotedblleft{}sweet/pleasant night,\textquotedblright{} unlike Hindi, Kannada, Telugu, and Malayalam's shared Sanskrit-descended śubha rātri phrase; Tamil breaks the pattern this arc found in every other language\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{இரவு}}\par
+\small \textquotedblleft{}night\textquotedblright{} — native Dravidian, already used standalone inside \textquotedblleft{}midnight\textquotedblright{} (naḷḷiravu); a Sanskrit loan alternative, rāttiri, also exists — and per at least one dictionary source, rāttiri may actually be the MORE common word in everyday spoken Tamil, the opposite direction from \ta{நாள்}'s story last lesson\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{இல்லை}}\par
+\small no / there isn't (illai — the negative)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{உங்கள்} \ta{பெயர்} \ta{என்ன}?}\par
+\small what's your name?\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{உனக்கு} \ta{எத்தனை} \ta{வயது} \ta{ஆகிறது}?}\par
+\small how old are you? — literally \textquotedblleft{}to you how many years is becoming?\textquotedblright{}; the SAME Sanskrit vayas word as Kannada/Telugu/Malayalam; Tamil actually spans BOTH grammatical shapes seen so far, from a plain possessive in casual speech to this more formal dative+verb construction\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{என்}}\par
+\small my\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{என்} \ta{பெயர்} …}\par
+\small my name is… (with no \textquotedblleft{}is\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{என்ன}}\par
+\small what\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{எப்படி}}\par
+\small how\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{ஒன்று} \ta{இரண்டு} \ta{மூன்று} \ta{நான்கு} \ta{ஐந்து}}\par
+\small one to five — Tamil's own Dravidian numbers, not borrowed\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{கருப்பு} \ta{வெள்ளை} \ta{சிவப்பு} \ta{நீலம்}}\par
+\small black, white, red, blue — three native Tamil colors, and one Sanskrit loan\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{காலை}}\par
+\small morning (kālai) — Wiktionary itself HEDGES the etymology (\textquotedblleft{}possibly from Sanskrit \dv{काल्य}/kālya\textquotedblright{}), not a confirmed Dravidian root; genuinely uncertain, unlike Kannada's confidently-native or Telugu's confidently-Sanskrit morning-words; \ta{பகல்} (already met, TA-C17, \textquotedblleft{}daytime\textquotedblright{}) is Wiktionary's own listed coordinate term; \ta{அதிகாலை} (\textquotedblleft{}early dawn\textquotedblright{}) is a transparent ati-+kālai compound\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{காலை} \ta{வணக்கம்}}\par
+\small good morning (kālai vaṇakkam), literally \textquotedblleft{}morning greetings\textquotedblright{} — a transparent compound of \ta{காலை} (already met, TA-C26) + \ta{வணக்கம்} (already met, TA-C01, \textquotedblleft{}reverence, homage\textquotedblright{}); confirmed via TWO independently-fetched sources as the standard, formal greeting, used from sunrise until around 11 AM; NOT a śubha-equivalent construction, breaking the pattern its neighbours share; a WebSearch summary's claim that a Sanskrit-borrowed \textquotedblleft{}suprabhatham\textquotedblright{} is a casual alternative could NOT be traced to either directly-fetched source and is therefore not asserted here\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{சித்திரை} \ta{வைகாசி} \ta{ஆனி} \ta{ஆடி} \ta{ஆவணி} \ta{புரட்டாசி} \ta{ஐப்பசி} \ta{கார்த்திகை} \ta{மார்கழி} \ta{தை} \ta{மாசி} \ta{பங்குனி}}\par
+\small the twelve months of the Tamil solar calendar — Tamil's OWN calendar, distinct from both the Gregorian and Hindu lunisolar systems\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{சரி}}\par
+\small okay / alright / correct (sari)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{திங்கள்}–\ta{ஞாயிறு}}\par
+\small the seven weekdays — a mix of Tamil's OWN planet-words and Sanskrit borrowings\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{தண்ணீர்} \ta{அரிசி} \ta{சாதம்}}\par
+\small water, and rice — the actual staple food here, not bread — with a widely-cited (if not fully certain) link from arisi to the English word \textquotedblleft{}rice\textquotedblright{} itself\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{தயவுசெய்து}}\par
+\small please (tayavu seytu — \textquotedblleft{}do the kindness,\textquotedblright{} from \ta{தயவு} tayavu \textquotedblleft{}compassion/grace\textquotedblright{})\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{தலை} \ta{கை}}\par
+\small head and hand — both native Dravidian words, unlike Hindi's Sanskrit-descended pair\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{நீ} / \ta{நீங்கள்}}\par
+\small you (familiar / respectful)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{நீங்கள்} \ta{எப்படி} \ta{இருக்கிறீர்கள்}?}\par
+\small how are you? (respectful)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{நண்பகல்} \ta{நள்ளிரவு}}\par
+\small noon and midnight — NO Sanskrit here at all (unlike Kannada/Telugu); both trace to the same old \textquotedblleft{}middle\textquotedblright{} root, \ta{நள்} (naḷ), but Tamil ALSO keeps fully transparent synonyms built on \ta{நடு}, the everyday word for \textquotedblleft{}middle\textquotedblright{}\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{நான்}}\par
+\small I\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{நான்} \ta{தமிழ்} \ta{பேசுகிறேன்}}\par
+\small I speak Tamil\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{நன்றி}}\par
+\small thank you (naṉṟi — \textquotedblleft{}goodness, gratitude\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{நாய்}, \ta{பூனை}}\par
+\small dog and cat — \ta{நாய்} is THE solid, ancient, undisputed Dravidian root behind Kannada/Malayalam's dog-words too, the honest opposite of the tangled dog-words of Spanish, Hindi, and English; \ta{பூனை} is Tamil's everyday cat-word, one of (at least) three genuinely separate Dravidian cat-word families\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{நலம்}}\par
+\small well, wellness, good — and the reply \textquotedblleft{}\ta{நான்} \ta{நலமாக} \ta{இருக்கிறேன்}\textquotedblright{}\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{நாள்}}\par
+\small \textquotedblleft{}day\textquotedblright{} — Tamil's everyday, native Dravidian word, already met inside \textquotedblleft{}tomorrow\textquotedblright{}; unlike Kannada's dina, Telugu's rōju, and Malayalam's divasam, Tamil's plain day-word is NOT a loanword at all — \ta{நாள்} just is the everyday word, no Sanskrit or Persian substitute doing that job\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{நாளை} \ta{பார்க்கலாம்}}\par
+\small see you tomorrow\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{போ}}\par
+\small to go (and \ta{வா}, to come)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{பேசு}}\par
+\small to speak\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{பச்சை}, \ta{மஞ்சள்}}\par
+\small green and yellow — paccai is the pan-Dravidian \emph{pac- word already met in Kannada, Telugu, and Malayalam; manjal (\textquotedblleft{}yellow, turmeric\textquotedblright{}) is a separate native Dravidian root, matching Malayalam's mañña/maññaḷ closely — and Tamil dictionaries also record a rarer, less-commonly-used pacuppu (\textquotedblleft{}greenish yellow\textquotedblright{}), a genuine doublet of paccai itself, echoing Telugu's pattern in miniature}\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{பதினொன்று} — \ta{இருபது}}\par
+\small 11-20 — additive \textquotedblleft{}ten-echo\textquotedblright{} compounds for the teens, then \ta{இருபது} (20), transparently \textquotedblleft{}two-tens\textquotedblright{} — closing out the arc: all four Dravidian languages build twenty compositionally, unlike Sanskrit, Latin, or Arabic's opaque special words\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{போய்} \ta{வருகிறேன்}}\par
+\small goodbye (lit. \textquotedblleft{}I'll go and come back\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{பெயர்}}\par
+\small name\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{பரவாயில்லை}}\par
+\small it's okay / no problem / you're welcome\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{பிற்பகல்}}\par
+\small afternoon (piṟpakal) — a transparent compound, \ta{பின்} (piṉ, \textquotedblleft{}after\textquotedblright{}) + \ta{நண்பகல்}'s own \ta{பகல்} (\textquotedblleft{}daytime\textquotedblright{}), with \ta{பின்} surfacing as \ta{பிற்}- before \ta{ப}, a SIMILAR kind of consonant sandhi to the one already taught in TA-C17 (\ta{நள்}$\to$\ta{நண்}) — though Wiktionary itself does not discuss the sandhi mechanism, and the two changes move in different phonetic directions (nasal$\to$stop vs. lateral$\to$nasal), so this is the lesson's own analysis, not a sourced claim; Wiktionary-listed formal register; a real, citable overlap worth flagging honestly: Wiktionary's OWN afternoon-word page ALSO lists \ta{நடுப்பகல்} as a synonym, even though TA-C17 established \ta{நடுப்பகல்} as a synonym of NOON specifically; also related but distinct: \ta{மதியம்}, a Sanskrit tatsama (from madhya, \textquotedblleft{}middle\textquotedblright{}) meaning \textquotedblleft{}noon,\textquotedblright{} a synonym of \ta{நண்பகல்} — NOT specifically \textquotedblleft{}afternoon,\textquotedblright{} despite an unverified WebSearch claim that matiyam \textquotedblleft{}originally meant moon,\textquotedblright{} which does not appear anywhere on its actual Wiktionary page and is therefore not asserted here\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{மகிழ்ச்சி}}\par
+\small joy / pleased to meet you\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{மணி}}\par
+\small hour — Tamil's OWN dictionaries treat this as a native Dravidian \textquotedblleft{}bell\textquotedblright{} word, most likely NOT Kannada/Telugu/Hindi's Sanskrit ghaṇṭā, and a probable homophone trap with an unrelated Sanskrit \textquotedblleft{}gem\textquotedblright{} word spelled the same way\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{மீண்டும்} \ta{சந்திப்போம்}}\par
+\small we'll meet again\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{மதிய} \ta{வணக்கம்}}\par
+\small good afternoon (matiya vaṇakkam), confirmed by two sources for roughly noon to 4 PM, while a third source does not teach a separate afternoon greeting\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{மன்னிக்கவும்}}\par
+\small please forgive (maṉṉikkavum — a formal/written polite request, from \ta{மன்னி} maṉṉi \textquotedblleft{}to forgive\textquotedblright{})\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{மாலை}}\par
+\small evening (mālai) — a genuine HOMONYM: Wiktionary lists TWO separate etymologies for this exact spelling — \textquotedblleft{}garland/necklace\textquotedblright{} (possibly a Dravidian word BORROWED INTO Sanskrit as \dv{माला}/mālā, a reverse-direction loan) and, unrelated, \textquotedblleft{}evening\textquotedblright{} (compared to \ta{மால்}, Proto-Dravidian \emph{mā/}māl, whose senses include \textquotedblleft{}\ta{கருமை},\textquotedblright{} darkness); confidently native for the evening sense, unlike TA-C26's uncertain \ta{காலை}, though the exact semantic mechanism (\textquotedblleft{}evening\textquotedblright{} $\leftarrow$ \textquotedblleft{}darkness\textquotedblright{} specifically) isn't spelled out with full certainty by the source\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{மாலை} \ta{வணக்கம்}}\par
+\small good evening (mālai vaṇakkam), literally \textquotedblleft{}evening greetings\textquotedblright{} — the SAME compositional pattern as TA-C29's kālai vaṇakkam: \ta{மாலை} (already met, TA-C27, \textquotedblleft{}evening\textquotedblright{}) + \ta{வணக்கம்} (already met, TA-C01); confirmed via TWO independently-fetched sources (talkpal.ai, preply.com — same practical-content tier as TA-C29's sources) as real and used from afternoon/late-afternoon through nightfall, one labeling it formal; no śubha-equivalent word here either, consistent with TA-C29's finding, not just assumed to carry over automatically\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{வசந்த} \ta{காலம்} \ta{கோடைக்} \ta{காலம்} \ta{மழைக்} \ta{காலம்} \ta{குளிர்} \ta{காலம்}}\par
+\small spring, summer, monsoon, winter — and the honest note that the REAL locally central season is the rains, not a Western four-way split\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{வணக்கம்}}\par
+\small hello / greetings (vaṇakkam — \textquotedblleft{}reverence, homage\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{வானிலை}}\par
+\small weather — most likely a NATIVE Dravidian compound, unlike Kannada/Telugu/Malayalam's Sanskrit compounds: vaanam (\textquotedblleft{}sky\textquotedblright{}) + nilai (\textquotedblleft{}state, standing\textquotedblright{})\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{வேலை} \ta{செய்}}\par
+\small to work (lit. \textquotedblleft{}work-do\textquotedblright{})\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{வாழ்}}\par
+\small to live, to flourish\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/telugu/book/book.tex
+++ b/code/learning/human-languages/telugu/book/book.tex
@@ -122,5 +122,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \end{document}

--- a/code/learning/human-languages/telugu/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/telugu/book/chapters/appendix-glossary.tex
@@ -1,0 +1,484 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 68
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{-\te{కు}}\enspace\emph{-ku}\par
+\small the dative suffix -ku, 'to / for' — and the idea of stacking\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{అడుగు}}\enspace\emph{aḍugu}\par
+\small to ask — a native verb none of the three literary sisters share, and the clue to which branch of Dravidian Telugu actually sits on\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{అనుకో}}\enspace\emph{anukō}\par
+\small to think — literally \textquotedblleft{}say it to yourself\textquotedblright{}, built from the family's say-verb plus the ending that turns a verb back on its own doer\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{అర్థం} \te{చేసుకో}}\enspace\emph{arthaṁ cēsukō}\par
+\small to understand — \textquotedblleft{}make the meaning your own\textquotedblright{}, a Sanskrit noun on the native do-verb with the ending that hands the action back to you\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{చదువు}}\enspace\emph{caduvu}\par
+\small to read — and, with no second word, to study; the same form is the noun for an education, and its middle vowel moves as the endings change\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{చూడు}}\enspace\emph{cūḍu}\par
+\small to see, to look — Telugu's own everyday see-word, and the respectful -\te{అండి} ending that fits any verb stem\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{నాకు} \te{తెలుగు} \te{ఇష్టం}}\enspace\emph{nāku telugu iṣṭaṁ}\par
+\small 'I like Telugu' — a sentence with no verb in it at all, the liker in the dative and the liked thing left standing plain\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{నాకు} \te{తెలుగు} \te{వచ్చు}}\enspace\emph{nāku telugu vaccu}\par
+\small 'I know Telugu' — literally 'to me Telugu comes', with no subject at all\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{రా}}\enspace\emph{rā}\par
+\small to come — the command is \te{రా}, but every ending attaches to \te{వచ్చు} instead\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{రాయు}}\enspace\emph{rāyu}\par
+\small to write — an old Dravidian word for drawing a line, still spelled \te{వ్రాయు} in books, and the chapter's fourth mind-verb\par
+\footnotesize Introduced in Chapter 33.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{సహాయం} \te{చేయు}}\enspace\emph{sahāyaṁ cēyu}\par
+\small to help — a Sanskrit noun on the native do-verb, and the noun takes apart into \textquotedblleft{}a going with somebody\textquotedblright{}\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{తెలుసు}}\enspace\emph{telusu}\par
+\small it is known — the verb that carries no person at all, so the knower rides in the dative\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{తిను}}\enspace\emph{tinu}\par
+\small to eat — the inherited Dravidian root Telugu kept as its plain everyday verb, with the mealtime nouns borrowed from Sanskrit\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{తీసుకో}}\enspace\emph{tīsukō}\par
+\small to take — \te{తీయు}, \textquotedblleft{}to pull out\textquotedblright{}, wearing the same -\te{కో} as the last chapter's two mind-verbs, so taking is pulling something out for yourself\par
+\footnotesize Introduced in Chapter 34.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{ఉండు}}\enspace\emph{uṇḍu}\par
+\small to be, to exist, to stay — and the negative Telugu has to fetch from a different verb\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{వెళ్ళు}}\enspace\emph{veḷḷu}\par
+\small to go — with one tense-piece covering both \textquotedblleft{}I go\textquotedblright{} and \textquotedblleft{}I will go\textquotedblright{}, and \textquotedblleft{}right now\textquotedblright{} built out of the be-verb\par
+\footnotesize Introduced in Chapter 32.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{అవును}}\par
+\small yes (avunu)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{ఆరు} \te{ఏడు} \te{ఎనిమిది} \te{తొమ్మిది} \te{పది}}\par
+\small six to ten — where Telugu wanders furthest from its Dravidian cousins\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{ఉండు}}\par
+\small to be, to stay, to live\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{ఉదయం}}\par
+\small \textquotedblleft{}morning\textquotedblright{} (udayam) — Sanskrit tatsama from udaya (\textquotedblleft{}rise\textquotedblright{}) + Telugu -mu, Telugu's most general everyday word, though genuine native competitors (poddu/podduna, vēkuva) also do real everyday work; unlike Kannada, where the same Sanskrit root (udaya) shows up ONLY inside the greeting śubhōdaya, Telugu's everyday noun and its greeting-root are the SAME word\par
+\footnotesize Introduced in Chapter 26.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{ఎలా}}\par
+\small how\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{ఏమిటి}}\par
+\small what\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{ఒకటి} \te{రెండు} \te{మూడు} \te{నాలుగు} \te{ఐదు}}\par
+\small one to five — the Dravidian family numbers, with Telugu's maverick \textquotedblleft{}one\textquotedblright{}\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{కుక్క}, \te{పిల్లి}}\par
+\small dog and cat — kukka genuinely breaks from its Dravidian cousins' shared naayi root, debated as onomatopoeic or a Sanskrit loan; pilli most likely closes the ENTIRE arc's cat-story loop, the probable Dravidian source behind Sanskrit's biDaala and so Hindi's billi\par
+\footnotesize Introduced in Chapter 21.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{క్షమించండి}}\par
+\small please forgive / sorry (kṣamin̄caṇḍi — from kṣamin̄cu \textquotedblleft{}to forgive,\textquotedblright{} Sanskrit kṣamā + respectful -aṇḍi)\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{గంట}}\par
+\small hour — matching Kannada and Hindi exactly, the same Sanskrit \textquotedblleft{}bell\textquotedblright{} word\par
+\footnotesize Introduced in Chapter 18.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{చైత్రం} \te{వైశాఖం} \te{జ్యేష్ఠం} \te{ఆషాఢం} \te{శ్రావణం} \te{భాద్రపదం} \te{ఆశ్వయుజం} \te{కార్తీకం} \te{మార్గశిరం} \te{పుష్యం} \te{మాఘం} \te{ఫాల్గుణం}}\par
+\small the twelve lunisolar months — matching Kannada and Hindi's shared pan-Indian calendar, completing the split with Tamil/Malayalam's own solar systems\par
+\footnotesize Introduced in Chapter 16.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{తల} \te{చెయ్యి}}\par
+\small head (matching its cousins) and hand (the SAME Dravidian root as the others, transformed almost past recognition)\par
+\footnotesize Introduced in Chapter 13.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{దయచేసి}}\par
+\small please (dayacēsi — \textquotedblleft{}having done compassion,\textquotedblright{} from \te{దయ} daya \textquotedblleft{}compassion\textquotedblright{})\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{ధన్యవాదములు}}\par
+\small thank you (dhanyavādamulu — \textquotedblleft{}utterances of 'worthy'\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{నా}}\par
+\small my\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{నా} \te{పేరు} …}\par
+\small my name is… (with no \textquotedblleft{}is\textquotedblright{})\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{నీ} \te{వయసెంత}?}\par
+\small how old are you? — literally \textquotedblleft{}your age how-much?\textquotedblright{}, matching Kannada's simple verbless possessive exactly\par
+\footnotesize Introduced in Chapter 19.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{నేను}}\par
+\small I\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{నేను} \te{తెలుగు} \te{మాట్లాడతాను}}\par
+\small I speak Telugu\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{నాన్న} \te{అమ్మ} \te{అన్న} \te{తమ్ముడు} \te{అక్క} \te{చెల్లి}}\par
+\small father, mother, and four age-graded sibling words — Telugu's own father-word and \textquotedblleft{}younger sister\textquotedblright{} word, but the same age-first system\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{నమస్కారం}}\par
+\small hello / greetings (namaskāram — \textquotedblleft{}a making of a bow\textquotedblright{})\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{నలుపు} \te{తెలుపు} \te{ఎరుపు} \te{నీలం}}\par
+\small black, white, red, blue — Telugu's own basic colors, completing the whole family's shared blue\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{నీళ్ళు} \te{బియ్యం} \te{అన్నం}}\par
+\small water (matching Tamil/Kannada's neer/niiru), and rice raw/cooked — completing the family's water and rice pattern\par
+\footnotesize Introduced in Chapter 15.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{నువ్వు} / \te{మీరు}}\par
+\small you (familiar / respectful)\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{పచ్చ}, \te{పసుపు}}\par
+\small green and yellow — a genuine Telugu doublet pair, both from the same Proto-Dravidian \emph{pac- root, unlike Kannada, where the yellow word broke away as a Sanskrit loan}\par
+\footnotesize Introduced in Chapter 22.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{పదకొండు} — \te{ఇరవై}}\par
+\small 11-20 — additive \textquotedblleft{}ten-echo\textquotedblright{} compounds for the teens; \te{ఇరవై} (20) most likely continues the SAME pan-Dravidian \textquotedblleft{}two-tens\textquotedblright{} pattern as Kannada's ippattu, though worn down further and less transparent on the surface today\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{పని} \te{చేయు}}\par
+\small to work (lit. \textquotedblleft{}work-do\textquotedblright{})\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{పేరు}}\par
+\small name\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{పరవాలేదు}}\par
+\small it's okay / no problem / you're welcome\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{బాగా}}\par
+\small well, fine — and the reply \textquotedblleft{}\te{నేను} \te{బాగున్నాను}\textquotedblright{}\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{మీ} \te{పేరు} \te{ఏమిటి}?}\par
+\small what's your name?\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{మాట్లాడు}}\par
+\small to speak\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{మధ్యాహ్నం}}\par
+\small \textquotedblleft{}afternoon\textquotedblright{} — the same word already met meaning precisely \textquotedblleft{}noon\textquotedblright{} (TE-C17), confirmed via a directly-fetched source to also cover \textquotedblleft{}the time between noon and evening\textquotedblright{} in modern usage — the same kind of semantic widening already found for Hindi's \dv{दोपहर} and, more thinly, Kannada's \te{మధ్యాహ్న}\par
+\footnotesize Introduced in Chapter 28.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{మధ్యాహ్నం} \te{అర్ధరాత్రి}}\par
+\small noon (Sanskrit \textquotedblleft{}middle of day,\textquotedblright{} same as Kannada) and midnight (Sanskrit \textquotedblleft{}HALF of night\textquotedblright{} — a different root than Kannada's midnight word)\par
+\footnotesize Introduced in Chapter 17.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{మీరు} \te{ఎలా} \te{ఉన్నారు}?}\par
+\small how are you? (respectful)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{మళ్ళీ} \te{కలుద్దాం}}\par
+\small we'll meet again\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{రోజు}}\par
+\small \textquotedblleft{}day\textquotedblright{} — a genuine surprise: Telugu's everyday word isn't Sanskrit or native Dravidian at all, it's a Persian loanword; \te{దినము}, the Sanskrit tatsama form, is the more formal alternate here — the mirror image of Kannada's pattern\par
+\footnotesize Introduced in Chapter 23.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{రాత్రి}}\par
+\small \textquotedblleft{}night\textquotedblright{} — the same Sanskrit tatsama word already hiding inside ardharātri; unlike day's Persian surprise, night genuinely follows the Sanskrit-tatsama-as-everyday pattern, matching Kannada\par
+\footnotesize Introduced in Chapter 24.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{రేపు} \te{కలుద్దాం}}\par
+\small see you tomorrow\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{లేదు}}\par
+\small no / there isn't (lēdu)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{వాతావరణం}}\par
+\small weather/atmosphere — a PURE Sanskrit compound, unlike Kannada's Persian+Sanskrit hybrid: vata (\textquotedblleft{}air/wind\textquotedblright{}) + avarana (\textquotedblleft{}covering\textquotedblright{})\par
+\footnotesize Introduced in Chapter 20.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{వెళ్ళు}}\par
+\small to go (and \te{వచ్చు}, to come)\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{వెళ్ళి} \te{వస్తాను}}\par
+\small goodbye (lit. \textquotedblleft{}I'll go and come back\textquotedblright{})\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{వసంత} \te{ఋతువు} \te{వేసవి} \te{వానాకాలం} \te{శీతాకాలం}}\par
+\small spring, summer, monsoon, winter — completing the Dravidian pattern of native heat/rain words plus Sanskrit spring\par
+\footnotesize Introduced in Chapter 14.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{శుభ} \te{మధ్యాహ్నం}}\par
+\small \textquotedblleft{}good afternoon\textquotedblright{} (śubha madhyāhnam), built on the widened \textquotedblleft{}noon\textquotedblright{} word rather than the classical later-afternoon term\par
+\footnotesize Introduced in Chapter 31.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{శుభ} \te{రాత్రి}}\par
+\small \textquotedblleft{}good night\textquotedblright{} — the standard Sanskrit-tatsama translation (rātri already met, śubha new); some sources describe everyday speakers often code-switching to English \textquotedblleft{}good night\textquotedblright{} instead\par
+\footnotesize Introduced in Chapter 25.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{శుభ} \te{సాయంత్రం}}\par
+\small \textquotedblleft{}good evening\textquotedblright{} (śubha sāyantram) — pairs with \te{సాయంత్రం} (TE-C27, the word with the striking Latin sērus/French soir cognate); unlike GREETING-MORNING's single, dramatic \textquotedblleft{}displaced by English\textquotedblright{} source, TWO independently-fetched sources agree this one is genuinely, commonly used in both formal and casual speech, with \te{నమస్కారం} as a time-independent alternative rather than a replacement\par
+\footnotesize Introduced in Chapter 30.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{శుభోదయం}}\par
+\small \textquotedblleft{}good morning\textquotedblright{} (subhodayam) — \te{శుభ} + \te{ఉదయం}, the traditional phrase; one directly-fetched source (a Telugu-learning blog, the same low-authority genre already found overstated for Hindi/Kannada) claims it's archaic, displaced by English \textquotedblleft{}good morning\textquotedblright{} — treat with real skepticism, not as confirmed; \te{నమస్కారం} remains a safer everyday-greeting bet regardless\par
+\footnotesize Introduced in Chapter 29.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{సంతోషం}}\par
+\small joy / pleased to meet you\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{సోమవారం} \te{మంగళవారం} \te{బుధవారం} \te{గురువారం} \te{శుక్రవారం} \te{శనివారం} \te{ఆదివారం}}\par
+\small the seven weekdays — Sanskritic like Hindi, but Sunday means \textquotedblleft{}the FIRST day,\textquotedblright{} not \textquotedblleft{}Sun's day\textquotedblright{}\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{సాయంత్రం}}\par
+\small \textquotedblleft{}evening\textquotedblright{} (sāyantram) — Sanskrit tatsama from \te{సాయం} (sāyam, \textquotedblleft{}in the evening\textquotedblright{}) + a \textquotedblleft{}-tana\textquotedblright{} time-adjective suffix; \te{సాయం} itself traces to PIE \emph{seh\textsubscript{1}- (\textquotedblleft{}long, lasting\textquotedblright{}), the SAME root as Latin's sērus — attested as the root of French soir and Italian sera — a genuine distant cognate across two completely different Indo-European branches}\par
+\footnotesize Introduced in Chapter 27.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\te{సరే}}\par
+\small okay / alright (sarē)\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/urdu/book/book.tex
+++ b/code/learning/human-languages/urdu/book/book.tex
@@ -88,6 +88,7 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 \backmatter
 
 \input{chapters/appendix-pronunciation}
+\input{chapters/appendix-glossary}
 
 \chapter*{A note on sources}
 \addcontentsline{toc}{chapter}{A note on sources}

--- a/code/learning/human-languages/urdu/book/chapters/appendix-glossary.tex
+++ b/code/learning/human-languages/urdu/book/chapters/appendix-glossary.tex
@@ -1,0 +1,309 @@
+% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.
+% canonical-entries: 43
+
+\chapter*{Glossary}
+\addcontentsline{toc}{chapter}{Glossary}
+\markboth{Glossary}{Glossary}
+
+This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{آنا}}\enspace\emph{ānā}\par
+\small to come — literally “go toward,” built from a prefix and the verb for going\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{آنکھ}}\enspace\emph{āṅkh}\par
+\small eye — a fifth base letter for the two-eyed he, and another real cousin of an English word\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{آپ} / \ur{تم} / \ur{تو}}\enspace\emph{āp / tum / tū}\par
+\small you — respectful / familiar / intimate\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{آپ} \ur{کا} \ur{نام} \ur{کیا} \ur{ہے؟}}\enspace\emph{āp kā nām kyā hai?}\par
+\small What is your name? (respectful)\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{آپ} \ur{کیسے} \ur{ہیں؟} / \ur{آپ} \ur{کیسی} \ur{ہیں؟}}\enspace\emph{āp kaise haiṅ? / āp kaisī haiṅ?}\par
+\small How are you? — respectfully to a man / woman\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{آپ} \ur{سے} \ur{مل} \ur{کر} \ur{خوشی} \ur{ہوئی}}\enspace\emph{āp se mil kar khushī huī}\par
+\small pleased to meet you\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{بہن}}\enspace\emph{bahan}\par
+\small sister — feminine, where \ur{بھائی} was masculine, and the reason \ur{میرا} has to change shape\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{بھائی}}\enspace\emph{bhāī}\par
+\small brother — the first noun this book has taught with a real grammatical gender, and a genuine English cousin\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{بولنا}}\enspace\emph{bolnā}\par
+\small to speak — the plain Indo-Aryan verb under Urdu's Persian and Arabic finery\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{چائے}}\enspace\emph{chāy}\par
+\small tea — Persian again, this time by an overland road from Chinese, and the hamza-ye letter's second word\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{دل}}\enspace\emph{dil}\par
+\small heart — Persian, and a real cousin of English heart by the Iranian road, not the Sanskrit one\par
+\footnotesize Introduced in Chapter 11.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{دوست}}\enspace\emph{dost}\par
+\small friend — a Persian word that refuses to pick a gender, and exactly the relationship \ur{تم} was made for\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{دودھ}}\enspace\emph{dūdh}\par
+\small milk — a sixth letter learns to breathe, and an English cousin that is NOT the word you'd guess\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{حافظ}}\enspace\emph{hāfiz}\par
+\small guardian, protector — the Arabic-rooted half of the farewell\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{ہونا}}\enspace\emph{honā}\par
+\small to be — and the ending every Urdu verb wears when you name it\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{جانا}}\enspace\emph{jānā}\par
+\small to go — the verb that shows the two agreements an Urdu present tense makes at once\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{جاننا}}\enspace\emph{jānnā}\par
+\small to know — the Urdu cousin of English know, Latin notice, and Greek gnosis\par
+\footnotesize Introduced in Chapter 6.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{جی} \ur{ہاں}}\enspace\emph{jī hā̃}\par
+\small yes\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{کیسے} / \ur{کیسی}}\enspace\emph{kaise / kaisī}\par
+\small how — addressing a man / addressing a woman\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{کان}}\enspace\emph{kān}\par
+\small ear — the first body word since Chapter 4 folded \ur{آپ} \ur{کیسے} \ur{ہیں؟} into a single wellbeing check\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{خاندان}}\enspace\emph{khāndān}\par
+\small family — the collective word this chapter's three people-words never needed, and Persian, like every social word Urdu has borrowed so far\par
+\footnotesize Introduced in Chapter 9.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{خدا}}\enspace\emph{khudā}\par
+\small God — the Persian-borrowed half of the standard Urdu farewell\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{خدا} \ur{حافظ}}\enspace\emph{khudā hāfiz}\par
+\small goodbye — a standard Urdu farewell\par
+\footnotesize Introduced in Chapter 5.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{کیا}}\enspace\emph{kyā}\par
+\small what\par
+\footnotesize Introduced in Chapter 3.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{لینا}}\enspace\emph{lenā}\par
+\small to take — a verb worn down to one syllable, and the third job Urdu gives the letter \ur{ی}\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{لکھنا}}\enspace\emph{likhnā}\par
+\small to write — an inherited verb for an act whose every tool Urdu named in Arabic and Persian\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{مدد} \ur{کرنا}}\enspace\emph{madad karnā}\par
+\small to help — an Arabic noun plus a native verb, which is the machine Urdu used to swallow two foreign vocabularies whole\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{میں} ... \ur{ہوں}}\enspace\emph{maiṅ ... hūṅ}\par
+\small I am ...\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{میں} \ur{ٹھیک} \ur{ہوں،} \ur{شکریہ}}\enspace\emph{maiṅ ṭhīk hūṅ, shukriyā}\par
+\small I am fine, thank you\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{میرا} \ur{نام} ... \ur{ہے}}\enspace\emph{merā nām ... hai}\par
+\small my name is ...\par
+\footnotesize Introduced in Chapter 2.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{منہ}}\enspace\emph{muṅh}\par
+\small mouth — the plain \ur{نون} that already nasalized \ur{آنکھ}, unglossed, and a Greek word possibly hiding behind the same root\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{نہیں}}\enspace\emph{nahī̃}\par
+\small no / not\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{ناک}}\enspace\emph{nāk}\par
+\small nose — the same three letters as \ur{کان}, read in reverse, and a real cousin of the English word this time\par
+\footnotesize Introduced in Chapter 10.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{پانی}}\enspace\emph{pānī}\par
+\small water — the first word you would actually ask for, and a verb from three chapters ago put back to work\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{پڑھنا}}\enspace\emph{paṛhnā}\par
+\small to read — and to study, and to recite, because it never meant reading silently\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{پسند}}\enspace\emph{pasand}\par
+\small liked, pleasing — a Persian word, not a verb, in the one Urdu sentence that refuses to let you be its subject\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{پوچھنا}}\enspace\emph{pūchhnā}\par
+\small to ask — and the one place where Urdu's inherited half and its Persian half turn out to be the same word\par
+\footnotesize Introduced in Chapter 8.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{روٹی}}\enspace\emph{roṭī}\par
+\small bread — an honest dead end, and \ur{پسند} put back to work on everything this chapter taught\par
+\footnotesize Introduced in Chapter 12.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{سلام}}\enspace\emph{salām}\par
+\small hello / peace\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{سمجھنا}}\enspace\emph{samajhnā}\par
+\small to understand — literally to wake up fully, on the root that named the Buddha\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{شکریہ}}\enspace\emph{shukriyā}\par
+\small thank you\par
+\footnotesize Introduced in Chapter 1.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{سوچنا}}\enspace\emph{sochnā}\par
+\small to think — a verb that began as a word for burning and grieving\par
+\footnotesize Introduced in Chapter 7.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ur{ٹھیک}}\enspace\emph{ṭhīk}\par
+\small fine, well, correct\par
+\footnotesize Introduced in Chapter 4.
+\end{minipage}\par\medskip

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added — generated book glossaries
+
+- Derive a compact glossary from every track's canonical word and phrase lessons,
+  with non-redundant romanization, distinct senses, and the chapter where each
+  entry first appears.
+- Byte-gate and include the generated back matter in all 22 books, using each
+  volume's configured script fonts and page-safe record layout.
+
 ### Added — canonical pronunciation back matter
 
 - Render canonical pronunciation-reference Markdown into LaTeX back matter,

--- a/code/packages/typescript/human-language-data/src/book-cli.ts
+++ b/code/packages/typescript/human-language-data/src/book-cli.ts
@@ -3,8 +3,10 @@ import { dirname, join, normalize, relative as pathRelative, resolve } from "nod
 import { pathToFileURL } from "node:url";
 import {
   renderBookChapter,
+  renderBookGlossary,
   renderReferenceAppendix,
   type BookGenerationTarget,
+  type BookGlossaryTarget,
   type BookReferenceAppendixTarget,
   type InlineRenderOptions,
 } from "./book.js";
@@ -16,6 +18,11 @@ interface ConfiguredBookGenerationTarget extends BookGenerationTarget {
 }
 
 interface ConfiguredReferenceAppendixTarget extends BookReferenceAppendixTarget {
+  /** Named reusable mapping from the config's scriptSets table. */
+  scriptSet?: string;
+}
+
+interface ConfiguredBookGlossaryTarget extends BookGlossaryTarget {
   /** Named reusable mapping from the config's scriptSets table. */
   scriptSet?: string;
 }
@@ -55,6 +62,8 @@ interface BookGenerationConfig {
   targets: ConfiguredBookGenerationTarget[];
   /** Canonical Markdown references rendered into book back matter. */
   referenceAppendices?: ConfiguredReferenceAppendixTarget[];
+  /** Canonical word and phrase lessons rendered into book glossaries. */
+  glossaries?: ConfiguredBookGlossaryTarget[];
   /** Never rendered. See {@link HandwrittenBookChapter}. */
   handwritten?: HandwrittenBookChapter[];
 }
@@ -217,6 +226,31 @@ export function generatedBookOutputs(root = defaultCurriculumRoot()): Map<string
       appendix.output,
       renderReferenceAppendix(appendix, readFileSync(source, "utf8")),
     );
+  }
+  for (const configuredGlossary of config.glossaries ?? []) {
+    const { scriptSet, ...plainGlossary } = configuredGlossary;
+    let glossary: BookGlossaryTarget = { ...plainGlossary };
+    if (scriptSet !== undefined) {
+      if (
+        glossary.inlineScripts !== undefined ||
+        glossary.unicodeScript !== undefined ||
+        glossary.scriptCommand !== undefined
+      ) {
+        throw new Error(
+          `${glossary.language} glossary: scriptSet cannot be combined with inline script options`,
+        );
+      }
+      const inlineScripts = config.scriptSets?.[scriptSet];
+      if (!inlineScripts) {
+        throw new Error(`${glossary.language} glossary: unknown scriptSet '${scriptSet}'`);
+      }
+      glossary = { ...glossary, inlineScripts };
+    }
+    safeOutput(root, glossary.output);
+    if (outputs.has(glossary.output)) {
+      throw new Error(`${glossary.output}: duplicate generated book output`);
+    }
+    outputs.set(glossary.output, renderBookGlossary(glossary, lessons));
   }
   manifest.chapters.sort(
     (left, right) => left.language.localeCompare(right.language) || left.chapter - right.chapter,

--- a/code/packages/typescript/human-language-data/src/book.ts
+++ b/code/packages/typescript/human-language-data/src/book.ts
@@ -1,5 +1,5 @@
 import { canonicalChapterHash } from "./hash.js";
-import { hasOwn } from "./constants.js";
+import { CONTENT_TYPES, hasOwn } from "./constants.js";
 import type { LessonBodyBlock, ChapterCapability } from "./types.js";
 import type { ParsedLesson } from "./parse.js";
 
@@ -28,6 +28,18 @@ export interface BookReferenceAppendixTarget {
   /** LaTeX command name, without the leading backslash, used for those runs. */
   scriptCommand?: string;
   /** Multiple script/font mappings for references that compare writing systems inline. */
+  inlineScripts?: InlineRenderOptions[];
+}
+
+/** A generated book glossary derived from canonical word and phrase lessons. */
+export interface BookGlossaryTarget {
+  language: string;
+  output: string;
+  /** Unicode Script property whose runs need the book's dedicated font command. */
+  unicodeScript?: string;
+  /** LaTeX command name, without the leading backslash, used for those runs. */
+  scriptCommand?: string;
+  /** Multiple script/font mappings for entries that compare writing systems inline. */
   inlineScripts?: InlineRenderOptions[];
 }
 
@@ -999,6 +1011,117 @@ export function renderReferenceAppendix(
     );
   }
   flushBody();
+  return `${output.join("\n").trimEnd()}\n`;
+}
+
+interface BookGlossaryEntry {
+  headword: string;
+  romanization: string;
+  gloss: string;
+  chapters: number[];
+}
+
+function glossarySortKey(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/\p{Mark}/gu, "")
+    .toLowerCase();
+}
+
+function compareGlossaryEntries(left: BookGlossaryEntry, right: BookGlossaryEntry): number {
+  const leftKey = glossarySortKey(left.romanization || left.headword);
+  const rightKey = glossarySortKey(right.romanization || right.headword);
+  if (leftKey < rightKey) return -1;
+  if (leftKey > rightKey) return 1;
+  if (left.headword < right.headword) return -1;
+  if (left.headword > right.headword) return 1;
+  if (left.gloss < right.gloss) return -1;
+  if (left.gloss > right.gloss) return 1;
+  return 0;
+}
+
+function chapterList(chapters: number[]): string {
+  const labels = chapters.map(String);
+  if (labels.length === 1) return `Chapter ${labels[0]}`;
+  if (labels.length === 2) return `Chapters ${labels[0]} and ${labels[1]}`;
+  return `Chapters ${labels.slice(0, -1).join(", ")}, and ${labels.at(-1)}`;
+}
+
+/** Render one track's canonical words and phrases as compact, page-safe book back matter. */
+export function renderBookGlossary(
+  target: BookGlossaryTarget,
+  allLessons: ParsedLesson[],
+): string {
+  const renderOptions = targetRenderOptions(target, `${target.language} glossary`);
+  const entries = new Map<string, BookGlossaryEntry>();
+  const lessons = allLessons.filter(
+    (lesson) =>
+      lesson.language === target.language && CONTENT_TYPES.has(lesson.realization.type),
+  );
+
+  for (const lesson of lessons) {
+    const headword = lesson.realization.headword.trim();
+    const romanization = lesson.realization.romanization.trim();
+    const gloss = lesson.realization.gloss.trim();
+    if (headword === "" || gloss === "") {
+      throw new Error(
+        `${lesson.realization.lessonId}: glossary entries require a headword and gloss`,
+      );
+    }
+    if (!Number.isInteger(lesson.realization.chapter) || lesson.realization.chapter < 1) {
+      throw new Error(`${lesson.realization.lessonId}: glossary entries require a chapter`);
+    }
+    const key = JSON.stringify([headword, romanization, gloss]);
+    const existing = entries.get(key);
+    if (existing) {
+      if (!existing.chapters.includes(lesson.realization.chapter)) {
+        existing.chapters.push(lesson.realization.chapter);
+      }
+      continue;
+    }
+    entries.set(key, {
+      headword,
+      romanization,
+      gloss,
+      chapters: [lesson.realization.chapter],
+    });
+  }
+  if (entries.size === 0) {
+    throw new Error(`${target.language} glossary: no canonical word or phrase lessons`);
+  }
+
+  const ordered = [...entries.values()].sort(compareGlossaryEntries);
+  const output = [
+    "% GENERATED FILE. Edit canonical lesson frontmatter, then run npm run generate:books.",
+    `% canonical-entries: ${ordered.length}`,
+    "",
+    "\\chapter*{Glossary}",
+    "\\addcontentsline{toc}{chapter}{Glossary}",
+    "\\markboth{Glossary}{Glossary}",
+    "",
+    "This glossary collects every word and phrase taught in the book. Pronunciation appears when it differs from the written form; chapter numbers show where each entry is introduced.",
+    "",
+  ];
+
+  for (const entry of ordered) {
+    const headword = renderInlineMarkdown(entry.headword, renderOptions);
+    const showRomanization =
+      entry.romanization !== "" &&
+      glossarySortKey(entry.romanization) !== glossarySortKey(entry.headword);
+    const romanization = showRomanization
+      ? `\\enspace\\emph{${renderInlineMarkdown(entry.romanization, renderOptions)}}`
+      : "";
+    const gloss = renderInlineMarkdown(entry.gloss, renderOptions);
+    output.push(
+      "\\noindent\\begin{minipage}[t]{\\linewidth}",
+      "\\raggedright",
+      `\\textbf{${headword}}${romanization}\\par`,
+      `\\small ${gloss}\\par`,
+      `\\footnotesize Introduced in ${chapterList(entry.chapters.sort((a, b) => a - b))}.`,
+      "\\end{minipage}\\par\\medskip",
+      "",
+    );
+  }
   return `${output.join("\n").trimEnd()}\n`;
 }
 

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -29,9 +29,13 @@ export {
 export {
   renderInlineMarkdown,
   renderBookChapter,
+  renderBookGlossary,
+  renderReferenceAppendix,
   bookVoice,
   bookBlockTitle,
   type BookGenerationTarget,
+  type BookGlossaryTarget,
+  type BookReferenceAppendixTarget,
   type GeneratedBookChapter,
 } from "./book.js";
 export {

--- a/code/packages/typescript/human-language-data/tests/book-cli.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book-cli.test.ts
@@ -170,6 +170,35 @@ describe("canonical book generator filesystem shell", () => {
     );
   });
 
+  it("writes and byte-checks configured canonical glossaries", () => {
+    const root = fixture();
+    const configPath = join(root, "core", "book-generation.json");
+    const config = JSON.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
+    writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        ...config,
+        glossaries: [{
+          language: "test",
+          output: "test/book/chapters/appendix-glossary.tex",
+        }],
+      })}\n`,
+    );
+
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(runBookGeneration(["--write"], root)).toBe(0);
+    const glossary = join(root, "test", "book", "chapters", "appendix-glossary.tex");
+    expect(readFileSync(glossary, "utf8")).toContain("\\textbf{hello}");
+    expect(runBookGeneration(["--check"], root)).toBe(0);
+
+    writeFileSync(glossary, "stale\n");
+    expect(runBookGeneration(["--check"], root)).toBe(1);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      "test/book/chapters/appendix-glossary.tex: generated output is missing or stale\n",
+    );
+  });
+
   it("rejects reference sources outside the curriculum root", () => {
     const root = fixture();
     const configPath = join(root, "core", "book-generation.json");
@@ -388,6 +417,26 @@ describe("pronunciation reference coverage", () => {
     for (const language of ["chinese", "japanese", "persian", "russian", "urdu"]) {
       const relative = `${language}/book/chapters/appendix-pronunciation.tex`;
       expect(outputs.get(relative), relative).toMatch(/^% GENERATED FILE\./);
+    }
+  });
+});
+
+describe("glossary coverage", () => {
+  const root = defaultCurriculumRoot();
+
+  it("generates, byte-gates, and includes a glossary in every registered book", () => {
+    const registry = JSON.parse(
+      readFileSync(join(root, "core", "languages.json"), "utf8"),
+    ) as { languages: Array<{ id: string }> };
+    const outputs = generatedBookOutputs(root);
+    expect(registry.languages.length).toBeGreaterThan(0);
+    for (const { id } of registry.languages) {
+      const relative = `${id}/book/chapters/appendix-glossary.tex`;
+      expect(outputs.get(relative), relative).toMatch(/^% GENERATED FILE\./);
+      expect(existsSync(join(root, relative)), `${id} glossary`).toBe(true);
+      expect(readFileSync(join(root, id, "book", "book.tex"), "utf8"), `${id} book input`).toContain(
+        "\\input{chapters/appendix-glossary}",
+      );
     }
   });
 });

--- a/code/packages/typescript/human-language-data/tests/book.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book.test.ts
@@ -3,6 +3,7 @@ import {
   bookBlockTitle,
   bookVoice,
   renderBookChapter,
+  renderBookGlossary,
   renderInlineMarkdown,
   renderReferenceAppendix,
 } from "../src/book.js";
@@ -145,6 +146,60 @@ A [repository note](../data/script.json) and an [external source](https://exampl
     );
     expect(generated).toContain("\\par \\textbf{anchor:} \\textbf{\\dv{दे}}");
     expect(generated).not.toContain("# Test");
+  });
+
+  it("renders a deduplicated, romanization-sorted glossary from content lessons", () => {
+    const devanagari = (id: string, sequence: number, headword: string, romanization: string, gloss: string) =>
+      parseLesson(
+        source(id, sequence, headword).replace(
+          `gloss: ${headword}`,
+          `gloss: ${gloss}\nromanization: ${romanization}`,
+        ),
+        "test",
+        "devanagari",
+      );
+    const two = devanagari("A", 10, "दो", "do", "two");
+    const repeatedTwo = parseLesson(
+      source("B", 20, "दो")
+        .replace("chapter: 1", "chapter: 2")
+        .replace("gloss: दो", "gloss: two\nromanization: do"),
+      "test",
+      "devanagari",
+    );
+    const ten = devanagari("C", 30, "दस", "das", "ten");
+    const practice = parseLesson(
+      source("D", 40, "drill").replace("type: word", "type: practice"),
+      "test",
+    );
+    const generated = renderBookGlossary(
+      {
+        language: "test",
+        output: "test/book/chapters/appendix-glossary.tex",
+        unicodeScript: "Devanagari",
+        scriptCommand: "dv",
+      },
+      [two, repeatedTwo, ten, practice],
+    );
+
+    expect(generated).toContain("% canonical-entries: 2");
+    expect(generated).toContain("\\textbf{\\dv{दस}}\\enspace\\emph{das}");
+    expect(generated).toContain("\\textbf{\\dv{दो}}\\enspace\\emph{do}");
+    expect(generated.indexOf("\\dv{दस}")).toBeLessThan(generated.indexOf("\\dv{दो}"));
+    expect(generated).toContain("Introduced in Chapters 1 and 2.");
+    expect(generated).not.toContain("drill");
+  });
+
+  it("rejects glossary entries without a valid introduction chapter", () => {
+    const lesson = parseLesson(
+      source("A", 10, "hello").replace("chapter: 1\n", "chapter: 0\n"),
+      "test",
+    );
+    expect(() =>
+      renderBookGlossary(
+        { language: "test", output: "test/book/chapters/appendix-glossary.tex" },
+        [lesson],
+      ),
+    ).toThrow(/require a chapter/);
   });
 
   it("keeps indented Markdown quote continuations in one LaTeX quote", () => {


### PR DESCRIPTION
## Summary

- generate a compact glossary for each of the 22 language books from canonical word and phrase lessons
- include headword, non-redundant romanization, gloss, and introduction chapter while merging exact duplicate realizations
- render every script with its configured book font and byte-gate all 22 generated appendices
- include the glossary in each book after its pronunciation reference

## Why

The books are meant to stand alone, but readers had no consolidated way to find vocabulary after learning it. Hand-authored glossaries would drift from the same canonical curriculum data used by the app, so this extends the shared book generator instead.

## Validation

- `bash BUILD` in `code/packages/typescript/human-language-data` (425 tests; coverage gates pass)
- `npm run check:books`
- `git diff --check`
- XeLaTeX/latexmk builds of all 22 books
- LaTeX warning scan: zero glossary-introduced overfull, underfull, missing-glyph, or font-substitution warnings
- rendered and visually inspected all 138 glossary pages, with full-size checks across Latin, Indic, CJK, Cyrillic, Persian, and Urdu scripts