### PR TITLE
Add BJT IKF parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `IKF` / `IK` forward beta roll-off
+  current.
 - Validate and lower BJT model-card `FC` forward-bias depletion coefficient.
 - Validate and lower BJT model-card `MJC` / `MC` base-collector grading
   coefficient.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1325,6 +1325,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Mjc=model.params.get("MJC", model.params.get("MC", 0.33)),
             Fc=model.params.get("FC", 0.5),
             Var=model.params.get("VAR", model.params.get("VB", 0.0)),
+            Ikf=model.params.get("IKF", model.params.get("IK", 0.0)),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2153,6 +2154,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or forward_bias_depletion_coefficient >= 1.0
         ):
             raise NetlistParseError("BJT FC must be finite and in [0, 1)")
+        forward_beta_rolloff_current = params.get("IKF", params.get("IK"))
+        if forward_beta_rolloff_current is not None and (
+            not math.isfinite(forward_beta_rolloff_current)
+            or forward_beta_rolloff_current < 0.0
+        ):
+            raise NetlistParseError("BJT IKF must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1579,6 +1579,39 @@ def test_rejects_invalid_bjt_forward_bias_depletion_coefficient(value: str) -> N
         parse_netlist(f".model fast NPN(FC={value})")
 
 
+@pytest.mark.parametrize("alias", ["IKF", "IK"])
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("2m", 2.0e-3)])
+def test_parse_bjt_forward_beta_rolloff_current(
+    alias: str, value: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model fast NPN({alias}={value})\nQ1 col base emit fast"
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Ikf == expected
+
+
+def test_bjt_ikf_takes_precedence_over_ik() -> None:
+    parsed = parse_netlist(".model fast NPN(IK=1m IKF=2m)\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Ikf == 2.0e-3
+
+
+@pytest.mark.parametrize("alias", ["IKF", "IK"])
+@pytest.mark.parametrize("value", ["-1m", "1e999"])
+def test_rejects_invalid_bjt_forward_beta_rolloff_current(
+    alias: str, value: str
+) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT IKF must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN({alias}={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `IKF` / `IK` forward beta roll-off
+  current.
 - Validate and lower BJT model-card `FC` forward-bias depletion coefficient.
 - Validate and lower BJT model-card `MJC` / `MC` base-collector grading
   coefficient.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1423,6 +1423,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT FC must be finite and in [0, 1)");
   }
+  const bjtForwardBetaRolloffCurrent = params.get("IKF") ?? params.get("IK");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtForwardBetaRolloffCurrent !== undefined &&
+    (!Number.isFinite(bjtForwardBetaRolloffCurrent) || bjtForwardBetaRolloffCurrent < 0.0)
+  ) {
+    throw new NetlistParseError("BJT IKF must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2145,6 +2153,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("MJC") ?? model.params.get("MC") ?? 0.33,
       model.params.get("FC") ?? 0.5,
       model.params.get("VAR") ?? model.params.get("VB") ?? 0.0,
+      model.params.get("IKF") ?? model.params.get("IK") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1650,6 +1650,40 @@ Q1 col base emit fast
     },
   );
 
+  it.each([
+    ["IKF", "0", 0.0],
+    ["IK", "0", 0.0],
+    ["IKF", "2m", 2.0e-3],
+    ["IK", "2m", 2.0e-3],
+  ])("parses BJT forward beta roll-off current %s=%s", (alias, value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(${alias}=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      forwardBetaRolloffCurrent: expected,
+    });
+  });
+
+  it("gives BJT IKF precedence over IK", () => {
+    const parsed = parseNetlist(`.model fast NPN(IK=1m IKF=2m)\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      forwardBetaRolloffCurrent: 2.0e-3,
+    });
+  });
+
+  it.each([
+    ["IKF", "-1m"],
+    ["IK", "-1m"],
+    ["IKF", "1e999"],
+    ["IK", "1e999"],
+  ])("rejects invalid BJT forward beta roll-off current %s=%s", (alias, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${alias}=${value})`)).toThrow(
+      "BJT IKF must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4588,9 +4588,15 @@ the Rust, Python, and TypeScript surfaces together.
      base-collector-grading-coefficient field.
 
 451. Python and TypeScript Berkeley SPICE BJT forward-bias-depletion parity.
-   - Status: implemented in this BJT FC parity slice.
+   - Status: completed in PR 10115.
    - Both parser facades validate finite `FC` values in `[0, 1)` and lower
      them into the shared engine forward-bias-depletion-coefficient field.
+
+452. Python and TypeScript Berkeley SPICE BJT forward-beta-roll-off parity.
+   - Status: implemented in this BJT IKF parity slice.
+   - Both parser facades validate finite, non-negative `IKF` / `IK` values,
+     prefer canonical `IKF`, and lower the result into the shared engine
+     forward-beta-roll-off-current field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite non-negative BJT `IKF` / `IK` forward beta roll-off currents
- lower canonical `IKF` with `IK` fallback into both parser engine facades
- add alias, precedence, invalid-value tests and reconcile the SPICE plan

## Verification
- Python parser `bash BUILD` (519 passed, 89.96% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (504 passed)
- TypeScript parser `npx vitest run --coverage` (87.42% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
- BUILD and package dependency audit (no changes)