### PR TITLE
Add BJT ISE parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `ISE` base-emitter leakage saturation
+  current with `C2 * IS` fallback semantics.
 - Validate and lower BJT model-card `IKF` / `IK` forward beta roll-off
   current.
 - Validate and lower BJT model-card `FC` forward-bias depletion coefficient.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1292,13 +1292,17 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             raise NetlistParseError(
                 f"model {model.name!r} has kind {model.kind!r}, expected 'NPN' or 'PNP'"
             )
+        saturation_current = model.params.get("IS", 1e-14)
+        base_emitter_leakage_current = model.params.get(
+            "ISE", model.params.get("C2", 0.0) * saturation_current
+        )
         return BJT(
             name,
             fields[1],
             fields[2],
             fields[3],
             polarity=model.kind,
-            Is=model.params.get("IS", 1e-14),
+            Is=saturation_current,
             beta_f=model.params.get(
                 "BF",
                 model.params.get(
@@ -1326,6 +1330,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Fc=model.params.get("FC", 0.5),
             Var=model.params.get("VAR", model.params.get("VB", 0.0)),
             Ikf=model.params.get("IKF", model.params.get("IK", 0.0)),
+            Ise=base_emitter_leakage_current,
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2160,6 +2165,22 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or forward_beta_rolloff_current < 0.0
         ):
             raise NetlistParseError("BJT IKF must be finite and non-negative")
+        base_emitter_leakage_ratio = params.get("C2")
+        base_emitter_leakage_current = params.get("ISE")
+        if base_emitter_leakage_current is None and base_emitter_leakage_ratio is not None and (
+            not math.isfinite(base_emitter_leakage_ratio)
+            or base_emitter_leakage_ratio < 0.0
+        ):
+            raise NetlistParseError("BJT C2 must be finite and non-negative")
+        if base_emitter_leakage_current is None and base_emitter_leakage_ratio is not None:
+            base_emitter_leakage_current = base_emitter_leakage_ratio * params.get(
+                "IS", 1e-14
+            )
+        if base_emitter_leakage_current is not None and (
+            not math.isfinite(base_emitter_leakage_current)
+            or base_emitter_leakage_current < 0.0
+        ):
+            raise NetlistParseError("BJT ISE must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1612,6 +1612,48 @@ def test_rejects_invalid_bjt_forward_beta_rolloff_current(
         parse_netlist(f".model fast NPN({alias}={value})")
 
 
+@pytest.mark.parametrize(("parameter", "value", "expected"), [("ISE", "3p", 3e-12), ("C2", "2", 2e-14)])
+def test_parse_bjt_base_emitter_leakage_current(
+    parameter: str, value: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model fast NPN({parameter}={value})\nQ1 col base emit fast"
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Ise == expected
+
+
+def test_bjt_ise_takes_precedence_over_c2() -> None:
+    parsed = parse_netlist(
+        ".model fast NPN(IS=2p C2=-1 ISE=4p)\nQ1 col base emit fast"
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Ise == 4e-12
+
+
+@pytest.mark.parametrize("parameter", ["ISE", "C2"])
+@pytest.mark.parametrize("value", ["-1p", "1e999"])
+def test_rejects_invalid_bjt_base_emitter_leakage_parameter(
+    parameter: str, value: str
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match=f"BJT {parameter} must be finite and non-negative",
+    ):
+        parse_netlist(f".model fast NPN({parameter}={value})")
+
+
+def test_rejects_non_finite_bjt_c2_derived_leakage_current() -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT ISE must be finite and non-negative"
+    ):
+        parse_netlist(".model fast NPN(IS=1e308 C2=2)")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `ISE` base-emitter leakage saturation
+  current with `C2 * IS` fallback semantics.
 - Validate and lower BJT model-card `IKF` / `IK` forward beta roll-off
   current.
 - Validate and lower BJT model-card `FC` forward-bias depletion coefficient.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1431,6 +1431,27 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT IKF must be finite and non-negative");
   }
+  const bjtBaseEmitterLeakageRatio = params.get("C2");
+  const explicitBjtBaseEmitterLeakageCurrent = params.get("ISE");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    explicitBjtBaseEmitterLeakageCurrent === undefined &&
+    bjtBaseEmitterLeakageRatio !== undefined &&
+    (!Number.isFinite(bjtBaseEmitterLeakageRatio) || bjtBaseEmitterLeakageRatio < 0.0)
+  ) {
+    throw new NetlistParseError("BJT C2 must be finite and non-negative");
+  }
+  const bjtBaseEmitterLeakageCurrent = explicitBjtBaseEmitterLeakageCurrent ??
+    (bjtBaseEmitterLeakageRatio === undefined
+      ? undefined
+      : bjtBaseEmitterLeakageRatio * (params.get("IS") ?? 1.0e-14));
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtBaseEmitterLeakageCurrent !== undefined &&
+    (!Number.isFinite(bjtBaseEmitterLeakageCurrent) || bjtBaseEmitterLeakageCurrent < 0.0)
+  ) {
+    throw new NetlistParseError("BJT ISE must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2119,13 +2140,16 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
         `model ${JSON.stringify(model.name)} has kind ${JSON.stringify(model.kind)}, expected "NPN" or "PNP"`,
       );
     }
+    const saturationCurrent = model.params.get("IS") ?? 1.0e-14;
+    const baseEmitterLeakageCurrent = model.params.get("ISE") ??
+      (model.params.get("C2") ?? 0.0) * saturationCurrent;
     return bjt(
       name,
       fields[1],
       fields[2],
       fields[3],
       model.kind,
-      model.params.get("IS") ?? 1.0e-14,
+      saturationCurrent,
       model.params.get("BF") ??
         model.params.get("BETA") ??
         model.params.get("BETA_F") ??
@@ -2154,6 +2178,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("FC") ?? 0.5,
       model.params.get("VAR") ?? model.params.get("VB") ?? 0.0,
       model.params.get("IKF") ?? model.params.get("IK") ?? 0.0,
+      baseEmitterLeakageCurrent,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1684,6 +1684,44 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["ISE", "3p", 3.0e-12],
+    ["C2", "2", 2.0e-14],
+  ])("parses BJT base-emitter leakage parameter %s=%s", (parameter, value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(${parameter}=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseEmitterLeakageSaturationCurrent: expected,
+    });
+  });
+
+  it("gives BJT ISE precedence over C2", () => {
+    const parsed = parseNetlist(`.model fast NPN(IS=2p C2=-1 ISE=4p)\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseEmitterLeakageSaturationCurrent: 4.0e-12,
+    });
+  });
+
+  it.each([
+    ["ISE", "-1p"],
+    ["ISE", "1e999"],
+    ["C2", "-1"],
+    ["C2", "1e999"],
+  ])("rejects invalid BJT base-emitter leakage parameter %s=%s", (parameter, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${parameter}=${value})`)).toThrow(
+      `BJT ${parameter} must be finite and non-negative`,
+    );
+  });
+
+  it("rejects a non-finite BJT C2-derived leakage current", () => {
+    expect(() => parseNetlist(`.model fast NPN(IS=1e308 C2=2)`)).toThrow(
+      "BJT ISE must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4593,10 +4593,16 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine forward-bias-depletion-coefficient field.
 
 452. Python and TypeScript Berkeley SPICE BJT forward-beta-roll-off parity.
-   - Status: implemented in this BJT IKF parity slice.
+   - Status: completed in PR 10117.
    - Both parser facades validate finite, non-negative `IKF` / `IK` values,
      prefer canonical `IKF`, and lower the result into the shared engine
      forward-beta-roll-off-current field.
+
+453. Python and TypeScript Berkeley SPICE BJT base-emitter-leakage parity.
+   - Status: implemented in this BJT ISE parity slice.
+   - Both parser facades validate finite, non-negative `ISE` currents and `C2`
+     ratios, prefer canonical `ISE`, preserve the engine's `C2 * IS` fallback,
+     and reject non-finite derived currents before lowering.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite non-negative BJT `ISE` leakage current and `C2` fallback ratio
- preserve canonical `ISE` precedence and the engine-defined `C2 * IS` fallback
- reject non-finite derived currents and reconcile the SPICE plan

## Verification
- Python parser `bash BUILD` (527 passed, 90.03% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (512 passed)
- TypeScript parser `npx vitest run --coverage` (87.52% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
- BUILD and package dependency audit (no changes)