### PR TITLE
Add BJT NE parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `NE` base-emitter leakage emission
+  coefficient.
 - Validate and lower BJT model-card `ISE` base-emitter leakage saturation
   current with `C2 * IS` fallback semantics.
 - Validate and lower BJT model-card `IKF` / `IK` forward beta roll-off

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1331,6 +1331,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Var=model.params.get("VAR", model.params.get("VB", 0.0)),
             Ikf=model.params.get("IKF", model.params.get("IK", 0.0)),
             Ise=base_emitter_leakage_current,
+            Ne=model.params.get("NE", 1.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2181,6 +2182,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or base_emitter_leakage_current < 0.0
         ):
             raise NetlistParseError("BJT ISE must be finite and non-negative")
+        base_emitter_leakage_emission_coefficient = params.get("NE")
+        if base_emitter_leakage_emission_coefficient is not None and (
+            not math.isfinite(base_emitter_leakage_emission_coefficient)
+            or base_emitter_leakage_emission_coefficient <= 0.0
+        ):
+            raise NetlistParseError("BJT NE must be finite and positive")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1654,6 +1654,25 @@ def test_rejects_non_finite_bjt_c2_derived_leakage_current() -> None:
         parse_netlist(".model fast NPN(IS=1e308 C2=2)")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0.5", 0.5), ("2", 2.0)])
+def test_parse_bjt_base_emitter_leakage_emission_coefficient(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model fast NPN(NE={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Ne == expected
+
+
+@pytest.mark.parametrize("value", ["0", "-0.1", "1e999"])
+def test_rejects_invalid_bjt_base_emitter_leakage_emission_coefficient(
+    value: str,
+) -> None:
+    with pytest.raises(NetlistParseError, match="BJT NE must be finite and positive"):
+        parse_netlist(f".model fast NPN(NE={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `NE` base-emitter leakage emission
+  coefficient.
 - Validate and lower BJT model-card `ISE` base-emitter leakage saturation
   current with `C2 * IS` fallback semantics.
 - Validate and lower BJT model-card `IKF` / `IK` forward beta roll-off

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1452,6 +1452,15 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT ISE must be finite and non-negative");
   }
+  const bjtBaseEmitterLeakageEmissionCoefficient = params.get("NE");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtBaseEmitterLeakageEmissionCoefficient !== undefined &&
+    (!Number.isFinite(bjtBaseEmitterLeakageEmissionCoefficient) ||
+      bjtBaseEmitterLeakageEmissionCoefficient <= 0.0)
+  ) {
+    throw new NetlistParseError("BJT NE must be finite and positive");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2179,6 +2188,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("VAR") ?? model.params.get("VB") ?? 0.0,
       model.params.get("IKF") ?? model.params.get("IK") ?? 0.0,
       baseEmitterLeakageCurrent,
+      model.params.get("NE") ?? 1.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1722,6 +1722,27 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0.5", 0.5],
+    ["2", 2.0],
+  ])("parses BJT base-emitter leakage emission coefficient NE=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(NE=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseEmitterLeakageEmissionCoefficient: expected,
+    });
+  });
+
+  it.each(["0", "-0.1", "1e999"])(
+    "rejects invalid BJT base-emitter leakage emission coefficient NE=%s",
+    (value) => {
+      expect(() => parseNetlist(`.model fast NPN(NE=${value})`)).toThrow(
+        "BJT NE must be finite and positive",
+      );
+    },
+  );
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4599,10 +4599,15 @@ the Rust, Python, and TypeScript surfaces together.
      forward-beta-roll-off-current field.
 
 453. Python and TypeScript Berkeley SPICE BJT base-emitter-leakage parity.
-   - Status: implemented in this BJT ISE parity slice.
+   - Status: completed in PR 10118.
    - Both parser facades validate finite, non-negative `ISE` currents and `C2`
      ratios, prefer canonical `ISE`, preserve the engine's `C2 * IS` fallback,
      and reject non-finite derived currents before lowering.
+
+454. Python and TypeScript Berkeley SPICE BJT base-emitter-leakage-emission parity.
+   - Status: implemented in this BJT NE parity slice.
+   - Both parser facades validate positive finite `NE` values and lower them
+     into the shared engine base-emitter-leakage-emission-coefficient field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate positive finite BJT `NE` base-emitter leakage emission coefficients
- lower `NE` into both parser engine facades instead of retaining the default
- add valid and invalid boundary tests and reconcile the SPICE plan

## Verification
- Python parser `bash BUILD` (532 passed, 90.05% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (517 passed)
- TypeScript parser `npx vitest run --coverage` (87.55% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
- BUILD and package dependency audit (no changes)