### PR TITLE
Generate canonical book answer keys

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,10 +5,19 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-08, after HL-C50B entered #10116. With all 22
-downloadable books now carrying pronunciation and glossary back matter, HL-C50
-remains the highest-value standalone-book program: generate each track's answer
-key next, then its index from the same canonical curriculum data.
+Last prioritized: 2026-08-08, after HL-C50C entered #10120. With all 22
+downloadable books now carrying pronunciation, glossary, review-question, and
+answer-key back matter, HL-C50 remains the highest-value standalone-book
+program: generate each track's index from the same canonical curriculum data.
+The answer-key
+audit found **113** executable `hl-activity` contracts across **20** tracks;
+French and Bengali had none before HL-C50C backfilled one in each, bringing the
+corpus to **115** contracts across all **22** tracks. The **5,255** legacy
+`[YOU ...]` cues are delivery directions rather than answer contracts and must
+never be scraped or guessed. Eight contracts belong to still-handwritten book
+chapters, so the generated back matter must print a canonical review-question
+section before the answers instead of assuming every source chapter can render
+the typed prompt yet.
 Current generated baseline: **22** registered tracks, **1,669** canonical lessons,
 **1,521** mapped lessons, and **22** downloadable LaTeX books spanning **513**
 chapters, **408** of them generated from the canonical lesson AST. Twenty-five mapped
@@ -177,9 +186,10 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C18D | Queued | Burn down the 61 lessons over the script budget, steepest first, and split the 5 Japanese lessons that open two writing systems at once. | No lesson introduces more than `maxNewGlyphsPerLesson` new glyphs or opens more than one writing system; the corpus maximum drops from 12 to 3. Starts with `HI-W01-shirorekha-na-ma`, `MR-C01-dhanyavad` and `RU-C01-da` at twelve each. Follows HL-C18C, which produced the list. |
 | HL-C48 | Queued | Generate the cousin/cognate layer from `concept_tag` instead of hand-typing it, and make it visually skippable. | The cross-language comparison table exists in **18 hand-typed instances across 4 Dravidian tracks** (4.6% of chapters) while four prefaces promise it per-lesson; `parse.ts` has no block type for it, so an author cannot write one into a canonical lesson. `concept_tag` (1,131 lessons) is the join key that would generate them, and the book renderer ignores it — as it ignores 708 `etymology_hook` fields (~25,400 words) that the app already displays cross-language. Per the owner's rule, the layer is a bonus for readers who know a relative: it must never gate comprehension, and its foreign glyphs must stay out of the target-script ramp. |
 | HL-C49 | Complete (#10055) | Give every chapter a short, well-written intro, generated from `chapters.json`. | Generated chapters derive a standalone capability-led introduction from canonical metadata; the already-authored chapter openings remain authored. |
-| HL-C50 | Queued — reader-link cleanup complete (#10058, #10060, #10062, #10064, #10066); pronunciation appendices complete (#10112); glossaries complete (#10116) | Finish making every book a standalone artifact. | Generate an answer key and index for every track from canonical data. |
+| HL-C50 | In progress — reader-link cleanup complete (#10058, #10060, #10062, #10064, #10066); pronunciation appendices complete (#10112); glossaries complete (#10116); review questions and answer keys complete (#10120) | Finish making every book a standalone artifact. | Generate an index for every track from canonical data. |
 | HL-C50A | Complete (#10112) | Generate the five missing pronunciation appendices from each track's canonical `pronunciation-reference.md`. | Chinese, Japanese, Persian, Russian, and Urdu join the other 17 books in carrying pronunciation back matter; `book-cli --check` byte-gates all five generated `.tex` files, and all five PDFs compile with no warning regressions. |
 | HL-C50B | Complete (#10116) | Generate a compact glossary for every book from canonical word and phrase lessons. | All 22 books carry byte-gated glossary back matter with headword, non-redundant romanization, gloss, and introduction chapter; duplicate realizations merge without losing distinct senses, every script uses the book's configured font, and all PDFs compile without warning regressions. |
+| HL-C50C | Complete (#10120) | Generate review questions and an answer key for every book from the same compiled `hl-activity` contracts Language Ladder scores. Backfill one schema-v2 activity in French and Bengali, the two tracks with zero contracts; never infer an answer from a legacy `[YOU ...]` cue. | Every track has nonempty, byte-gated review-question and answer-key back matter; each entry identifies its source chapter and lesson and resolves to the authored canonical answer plus accepted variants from the typed AST; all 22 PDFs compile without warning regressions. |
 | HL-C19 | Queued | Verify every prose `strokeOrder` against an authored ductus, so no letter's step list implies a pen lift nothing has checked. | All 190 prose stroke orders across the nine scripts (`arabic` 21, `chinese` 24, `cyrillic` 33, `devanagari` 28, `gujarati` 29, `hebrew` 22, `perso-arabic` 9, `tamil` 10, `urdu-nastaliq` 13) either carry a font-checked pen path with `penLifts` + `strokeOrderSource`, or are worded so they claim part order only. Today exactly one letter — Tamil ம — is verified; the audit that found it is written up in [`data/scripts/README.md`](data/scripts/README.md). Follows HL-C09, which authors the paths this check consumes. |
 | HL-C30 | Closed — no move is both legal and useful | Recover Arabic's drivable prefix by moving the writing lessons that open Chapters 3 and 4 later in their chapters. | Measured and answered: zero. Both chapters are prefix-0 under **every** legal ordering because neither has a `voice` lesson without an in-chapter prerequisite, and all 18 of Arabic's `sight` lessons are tables, not script. Corpus-wide only 2 chapters (`portuguese ch2`, `italian ch2`, +4 lessons) can be improved by reordering at all; 116 of the 123 zero-prefix chapters are table-blocked at the root and belong to HL-C17. See *Findings from HL-C30*. |
 | HL-C24 | Complete (#9979) | Pilot real chapter payoff lessons on the weakest Latin chapters. | Latin chapters 19, 21, 33, and 36 each own a dedicated terminal consolidation lesson built only from already-taught material, and `chapters.json` points their `payoff.lesson` at it. |
@@ -2486,10 +2496,11 @@ problem.
   aliases remain beside their PR numbers so repository history stays searchable.
 - HL-C49's generated chapter introductions are recorded complete in #10055.
   HL-C50A's generated pronunciation appendices are recorded complete in #10112.
-  HL-C50B's generated glossaries are recorded complete in #10116. HL-C50 now
-  names only the unfinished standalone-book work: generated answer keys and
-  indexes. Its five merged link and cross-volume cleanup slices remain visible
-  in the status.
+  HL-C50B's generated glossaries are recorded complete in #10116, and HL-C50C's
+  generated review questions and answer keys are recorded complete in #10120.
+  HL-C50 now names only the unfinished standalone-book work: generated indexes.
+  Its five merged link and cross-volume cleanup slices remain visible in the
+  status.
 - A completed row must name at least one merge PR, an ID may occur only once,
   and `this PR` is not a durable status. HL-I06 was kept `In progress` until its
   own PR number existed so the repair did not violate the rule while making it.

--- a/code/learning/human-languages/arabic/book/book.tex
+++ b/code/learning/human-languages/arabic/book/book.tex
@@ -155,5 +155,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/arabic/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/arabic/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,31 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 1
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 3}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-AR-W07-hook-family-ha-kha-dot-position}{\textbf{3.1}} \emph{\ar{ح،} \ar{خ،} \ar{ج} — the dots trick, on a brand-new body}\par
+\small Where is the dot on \ar{خ}?
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 3}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-AR-W07-hook-family-ha-kha-dot-position}{\textbf{3.1}} \emph{\ar{ح،} \ar{خ،} \ar{ج} — the dots trick, on a brand-new body}\par
+\small \textbf{Answer:} above\par
+\footnotesize \textbf{Also accepted:} one above; above the body
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/bengali/book/book.tex
+++ b/code/learning/human-languages/bengali/book/book.tex
@@ -105,5 +105,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/bengali/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/bengali/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,31 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 1
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 10}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-BN-C10-jol-water}{\textbf{10.1}} \emph{\bn{জল} (jôl) — \textquotedblleft{}water,\textquotedblright{} prised out of a phrase you already know}\par
+\small Type the Bengali word jôl, meaning 'water'.
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 10}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-BN-C10-jol-water}{\textbf{10.1}} \emph{\bn{জল} (jôl) — \textquotedblleft{}water,\textquotedblright{} prised out of a phrase you already know}\par
+\small \textbf{Answer:} \bn{জল}\par
+\footnotesize \textbf{Also accepted:} jôl; jol
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/bengali/book/chapters/ch10-tea-water-milk-rice.tex
+++ b/code/learning/human-languages/bengali/book/chapters/ch10-tea-water-milk-rice.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:f8e481ad0313cbcc
+% canonical-source-hash: fnv1a64:2fba548954e7c642
 % canonical-lessons: BN-C10-cha, BN-C10-jol, BN-C10-dudh, BN-C10-bhat
 
 \chapter{Tea, Water, Milk, and Rice}

--- a/code/learning/human-languages/bengali/lessons/BN-C10-jol.md
+++ b/code/learning/human-languages/bengali/lessons/BN-C10-jol.md
@@ -78,6 +78,7 @@ thing, one of disputed origin and one you can trace all the way home.
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[BN-LEX-C10-JOL-01, BN-LEX-C10-CHA-01, BN-GRAMMAR-C10-KHAN-REQUEST-02] -->
+<!-- hl-activity: {"id":"BN-C10-jol-water","kind":"text","assesses":["BN-LEX-C10-JOL-01"],"prompt":"Type the Bengali word jôl, meaning 'water'.","answer":"জল","accepted":["jôl","jol"],"feedback":{"correct":"Right: জল is jôl, water.","incorrect":"The word is জল - jôl."},"response_seconds":8} -->
 
 [PAUSE 3s] What did Chapter 7 already say with জল, without teaching it as a
 word? (**জল খাওয়া**, "to drink water.") Is জল's root secure? (**No** —

--- a/code/learning/human-languages/bengali/narration/ch10.json
+++ b/code/learning/human-languages/bengali/narration/ch10.json
@@ -4,7 +4,7 @@
   "chapter": 10,
   "title": "Tea, Water, Milk, and Rice",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:80e992cd9bd7e18c",
+  "sourceHash": "fnv1a64:522e9ad053b71b7f",
   "lessons": [
     {
       "id": "BN-C10-cha",
@@ -190,7 +190,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3688d07268864e2c",
+      "sourceHash": "fnv1a64:a824d2e918679d3f",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -323,6 +323,25 @@
             {
               "kind": "speech",
               "text": "What did Chapter 7 already say with জল (jôl), without teaching it as a word? (জল (jôl) খাওয়া, \"to drink water.\") Is জল (jôl)'s root secure? (No — genuinely disputed.) Which everyday synonym for water traces cleanly to \"drinkable,\" from the root behind potion? (পানি.)"
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "BN-C10-jol-water",
+              "prompt": "Type the Bengali word jôl, meaning 'water'.",
+              "assesses": [
+                "BN-LEX-C10-JOL-01"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "জল",
+                "jôl",
+                "jol"
+              ],
+              "feedback": {
+                "correct": "Right: জল is jôl, water.",
+                "incorrect": "The word is জল - jôl."
+              }
             }
           ]
         }

--- a/code/learning/human-languages/bengali/narration/ch10.txt
+++ b/code/learning/human-languages/bengali/narration/ch10.txt
@@ -77,6 +77,8 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 What did Chapter 7 already say with জল (jôl), without teaching it as a word? (জল (jôl) খাওয়া, "to drink water.") Is জল (jôl)'s root secure? (No — genuinely disputed.) Which everyday synonym for water traces cleanly to "drinkable," from the root behind potion? (পানি.)
+[question — say your answer, then pause 8 seconds]
+Type the Bengali word jôl, meaning 'water'.
 
 
 Lesson 3 of 4.

--- a/code/learning/human-languages/chinese/book/book.tex
+++ b/code/learning/human-languages/chinese/book/book.tex
@@ -72,6 +72,7 @@ substitute.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \chapter*{Sources for this starter edition}
 \addcontentsline{toc}{chapter}{Sources for this starter edition}

--- a/code/learning/human-languages/chinese/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/chinese/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,109 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 7
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 1}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-ZH-C01-tones-count}{\textbf{1.1}} \emph{mā má mǎ mà — one syllable, four words}\par
+\small How many marked tones does Mandarin have, not counting the neutral one? Type the number as a word.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-ZH-C01-ni-meaning}{\textbf{1.2}} \emph{\zh{你} — \textquotedblleft{}you\textquotedblright{}, and the first character}\par
+\small Type the Mandarin word, in pinyin with its tone mark, that means 'you' (one person).
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-ZH-C01-hao-components}{\textbf{1.3}} \emph{\zh{好} — \textquotedblleft{}good\textquotedblright{}, and what replaces etymology here}\par
+\small \zh{好} is built from two components. Type the meaning of the one on the left.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-ZH-C01-nihao-greeting}{\textbf{1.4}} \emph{\zh{你好} — the greeting, assembled from two things you already have}\par
+\small You have just been introduced to someone. Type the Mandarin greeting in characters.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-ZH-C01-tone-sandhi-spoken}{\textbf{1.5}} \emph{ní hǎo — why the greeting is not said the way it is written}\par
+\small A dictionary prints the greeting as nǐ hǎo. Type it in pinyin the way it is actually spoken.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-ZH-C01-hao-fond-tone}{\textbf{1.6}} \emph{\zh{好} again — proof, on a character you own, that tone is the word}\par
+\small Read in the falling fourth tone, \zh{好} stops meaning 'good'. Type its meaning with that tone, in English.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-ZH-C01-practice-greet}{\textbf{1.7}} \emph{Practice — greet someone, and be greeted back}\par
+\small Someone greets you with \zh{你好}. Type your reply in characters.
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 1}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-ZH-C01-tones-count}{\textbf{1.1}} \emph{mā má mǎ mà — one syllable, four words}\par
+\small \textbf{Answer:} four\par
+\footnotesize \textbf{Also accepted:} 4
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-ZH-C01-ni-meaning}{\textbf{1.2}} \emph{\zh{你} — \textquotedblleft{}you\textquotedblright{}, and the first character}\par
+\small \textbf{Answer:} nǐ\par
+\footnotesize \textbf{Also accepted:} ni3; ni
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-ZH-C01-hao-components}{\textbf{1.3}} \emph{\zh{好} — \textquotedblleft{}good\textquotedblright{}, and what replaces etymology here}\par
+\small \textbf{Answer:} woman\par
+\footnotesize \textbf{Also accepted:} female; \zh{女}
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-ZH-C01-nihao-greeting}{\textbf{1.4}} \emph{\zh{你好} — the greeting, assembled from two things you already have}\par
+\small \textbf{Answer:} \zh{你好}\par
+\footnotesize \textbf{Also accepted:} ni hao; nǐ hǎo; ní hǎo; nihao
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-ZH-C01-tone-sandhi-spoken}{\textbf{1.5}} \emph{ní hǎo — why the greeting is not said the way it is written}\par
+\small \textbf{Answer:} ní hǎo\par
+\footnotesize \textbf{Also accepted:} ni2 hao3; nihao (ní hǎo); ní hao
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-ZH-C01-hao-fond-tone}{\textbf{1.6}} \emph{\zh{好} again — proof, on a character you own, that tone is the word}\par
+\small \textbf{Answer:} to be fond of\par
+\footnotesize \textbf{Also accepted:} to like; like; fond of; be fond of
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-ZH-C01-practice-greet}{\textbf{1.7}} \emph{Practice — greet someone, and be greeted back}\par
+\small \textbf{Answer:} \zh{你好}\par
+\footnotesize \textbf{Also accepted:} ni hao; nǐ hǎo; ní hǎo; nihao
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/core/book-generation.json
+++ b/code/learning/human-languages/core/book-generation.json
@@ -305,6 +305,125 @@
       "scriptCommand": "ur"
     }
   ],
+  "answerKeys": [
+    {
+      "language": "arabic",
+      "output": "arabic/book/chapters/appendix-answer-key.tex",
+      "scriptSet": "arabic-main"
+    },
+    {
+      "language": "bengali",
+      "output": "bengali/book/chapters/appendix-answer-key.tex",
+      "unicodeScript": "Bengali",
+      "scriptCommand": "bn"
+    },
+    {
+      "language": "chinese",
+      "output": "chinese/book/chapters/appendix-answer-key.tex",
+      "unicodeScript": "Han",
+      "scriptCommand": "zh"
+    },
+    {
+      "language": "french",
+      "output": "french/book/chapters/appendix-answer-key.tex"
+    },
+    {
+      "language": "german",
+      "output": "german/book/chapters/appendix-answer-key.tex"
+    },
+    {
+      "language": "gujarati",
+      "output": "gujarati/book/chapters/appendix-answer-key.tex",
+      "unicodeScript": "Gujarati",
+      "scriptCommand": "gu"
+    },
+    {
+      "language": "hindi",
+      "output": "hindi/book/chapters/appendix-answer-key.tex",
+      "scriptSet": "hindi-main"
+    },
+    {
+      "language": "italian",
+      "output": "italian/book/chapters/appendix-answer-key.tex"
+    },
+    {
+      "language": "japanese",
+      "output": "japanese/book/chapters/appendix-answer-key.tex",
+      "scriptSet": "japanese-main"
+    },
+    {
+      "language": "kannada",
+      "output": "kannada/book/chapters/appendix-answer-key.tex",
+      "scriptSet": "kannada-comparisons"
+    },
+    {
+      "language": "latin",
+      "output": "latin/book/chapters/appendix-answer-key.tex"
+    },
+    {
+      "language": "malayalam",
+      "output": "malayalam/book/chapters/appendix-answer-key.tex",
+      "scriptSet": "malayalam-comparisons"
+    },
+    {
+      "language": "marathi",
+      "output": "marathi/book/chapters/appendix-answer-key.tex",
+      "unicodeScript": "Devanagari",
+      "scriptCommand": "mr"
+    },
+    {
+      "language": "persian",
+      "output": "persian/book/chapters/appendix-answer-key.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "fa"
+    },
+    {
+      "language": "portuguese",
+      "output": "portuguese/book/chapters/appendix-answer-key.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "ptar"
+    },
+    {
+      "language": "punjabi",
+      "output": "punjabi/book/chapters/appendix-answer-key.tex",
+      "unicodeScript": "Gurmukhi",
+      "scriptCommand": "pa"
+    },
+    {
+      "language": "russian",
+      "output": "russian/book/chapters/appendix-answer-key.tex",
+      "unicodeScript": "Cyrillic",
+      "scriptCommand": "ru"
+    },
+    {
+      "language": "sanskrit",
+      "output": "sanskrit/book/chapters/appendix-answer-key.tex",
+      "unicodeScript": "Devanagari",
+      "scriptCommand": "sk"
+    },
+    {
+      "language": "spanish",
+      "output": "spanish/book/chapters/appendix-answer-key.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "esar"
+    },
+    {
+      "language": "tamil",
+      "output": "tamil/book/chapters/appendix-answer-key.tex",
+      "scriptSet": "tamil-comparisons"
+    },
+    {
+      "language": "telugu",
+      "output": "telugu/book/chapters/appendix-answer-key.tex",
+      "scriptSet": "telugu-comparisons"
+    },
+    {
+      "language": "urdu",
+      "output": "urdu/book/chapters/appendix-answer-key.tex",
+      "unicodeScript": "Arabic",
+      "scriptCommand": "ur"
+    }
+  ],
   "targets": [
     {
       "language": "arabic",

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -398,7 +398,7 @@
     {
       "language": "bengali",
       "chapter": 10,
-      "sourceHash": "fnv1a64:f8e481ad0313cbcc",
+      "sourceHash": "fnv1a64:2fba548954e7c642",
       "lessonIds": [
         "BN-C10-cha",
         "BN-C10-jol",
@@ -459,7 +459,7 @@
     {
       "language": "french",
       "chapter": 18,
-      "sourceHash": "fnv1a64:3e08b2ac320671fa",
+      "sourceHash": "fnv1a64:96df1c2c9c56c79a",
       "lessonIds": [
         "FR-C18-oui",
         "FR-C18-non"

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -736,7 +736,7 @@
     {
       "language": "bengali",
       "chapter": 10,
-      "sourceHash": "fnv1a64:80e992cd9bd7e18c",
+      "sourceHash": "fnv1a64:522e9ad053b71b7f",
       "lessonIds": [
         "BN-C10-cha",
         "BN-C10-jol",
@@ -747,8 +747,8 @@
       "drivablePrefix": 0,
       "text": "bengali/narration/ch10.txt",
       "json": "bengali/narration/ch10.json",
-      "textHash": "fnv1a64:7a9a0ab2033e93dc",
-      "jsonHash": "fnv1a64:db57b1d6f17e34b5"
+      "textHash": "fnv1a64:eea9fbb90287eb68",
+      "jsonHash": "fnv1a64:2429dc14cf122ad4"
     },
     {
       "language": "bengali",
@@ -1094,7 +1094,7 @@
     {
       "language": "french",
       "chapter": 18,
-      "sourceHash": "fnv1a64:52b8d81257884801",
+      "sourceHash": "fnv1a64:ae316f8e0976bf1a",
       "lessonIds": [
         "FR-C18-oui",
         "FR-C18-non"
@@ -1103,8 +1103,8 @@
       "drivablePrefix": 2,
       "text": "french/narration/ch18.txt",
       "json": "french/narration/ch18.json",
-      "textHash": "fnv1a64:dccbb9439f6b0191",
-      "jsonHash": "fnv1a64:0e8c52d7922eff5a"
+      "textHash": "fnv1a64:f9499173477cb6d8",
+      "jsonHash": "fnv1a64:4f041e7dbeef104c"
     },
     {
       "language": "french",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,7 +7,7 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:99f79b7601915af8",
+  "sourceHash": "fnv1a64:fb91aea40ab44b00",
   "summary": {
     "totalLessons": 1669,
     "voice": 1079,
@@ -11824,7 +11824,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:3688d07268864e2c",
+      "sourceHash": "fnv1a64:a824d2e918679d3f",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -13385,7 +13385,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:cc9c2e7599edddd0"
+      "sourceHash": "fnv1a64:c40bbf179d6212c1"
     },
     {
       "id": "FR-C18-non",

--- a/code/learning/human-languages/french/book/book.tex
+++ b/code/learning/human-languages/french/book/book.tex
@@ -112,5 +112,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/french/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/french/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,31 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 1
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 18}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FR-C18-oui-negative}{\textbf{18.1}} \emph{oui — yes}\par
+\small French has two words for yes. Which one contradicts a negative?
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 18}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FR-C18-oui-negative}{\textbf{18.1}} \emph{oui — yes}\par
+\small \textbf{Answer:} si\par
+\footnotesize \textbf{Also accepted:} si!
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/french/book/chapters/ch18-yes-and-no.tex
+++ b/code/learning/human-languages/french/book/chapters/ch18-yes-and-no.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:3e08b2ac320671fa
+% canonical-source-hash: fnv1a64:96df1c2c9c56c79a
 % canonical-lessons: FR-C18-oui, FR-C18-non
 
 \chapter{Yes and No}

--- a/code/learning/human-languages/french/lessons/FR-C18-oui.md
+++ b/code/learning/human-languages/french/lessons/FR-C18-oui.md
@@ -83,6 +83,7 @@ only for this contradicting move.)
 
 ## Wrap-up Recall
 <!-- hl-knowledge: introduces=[]; assesses=[FR-LEX-OUI-02, FR-ETYMON-OUI-03, FR-CULTURE-OUI-04, FR-PRAGMATICS-SI-05] -->
+<!-- hl-activity: {"id":"FR-C18-oui-negative","kind":"text","assesses":["FR-PRAGMATICS-SI-05"],"prompt":"French has two words for yes. Which one contradicts a negative?","answer":"si","accepted":["si!"],"feedback":{"correct":"Right: si contradicts a negative; oui answers an ordinary positive question.","incorrect":"Use si when you insist that a negative statement is wrong."},"response_seconds":8} -->
 
 [PAUSE 3s] How do you say yes in French? (**oui**.) What Latin phrase is it worn
 down from? (**hoc ille**, "this is it," via *oïl*.) What were the *langue d'oïl*

--- a/code/learning/human-languages/french/narration/ch18.json
+++ b/code/learning/human-languages/french/narration/ch18.json
@@ -4,7 +4,7 @@
   "chapter": 18,
   "title": "Yes and No",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:52b8d81257884801",
+  "sourceHash": "fnv1a64:ae316f8e0976bf1a",
   "lessons": [
     {
       "id": "FR-C18-oui",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:cc9c2e7599edddd0",
+      "sourceHash": "fnv1a64:c40bbf179d6212c1",
       "notice": null,
       "blocks": [
         {
@@ -158,6 +158,24 @@
             {
               "kind": "speech",
               "text": "How do you say yes in French? (oui.) What Latin phrase is it worn down from? (hoc ille, \"this is it,\" via oïl.) What were the langue d'oïl and langue d'oc named after? (The two medieval words for yes.) When do you answer si instead of oui? (To contradict a negative — Tu ne viens pas? — Si!)"
+            },
+            {
+              "kind": "activity",
+              "scored": true,
+              "id": "FR-C18-oui-negative",
+              "prompt": "French has two words for yes. Which one contradicts a negative?",
+              "assesses": [
+                "FR-PRAGMATICS-SI-05"
+              ],
+              "responseSeconds": 8,
+              "acceptedResponses": [
+                "si",
+                "si!"
+              ],
+              "feedback": {
+                "correct": "Right: si contradicts a negative; oui answers an ordinary positive question.",
+                "incorrect": "Use si when you insist that a negative statement is wrong."
+              }
             }
           ]
         }

--- a/code/learning/human-languages/french/narration/ch18.txt
+++ b/code/learning/human-languages/french/narration/ch18.txt
@@ -38,6 +38,8 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 How do you say yes in French? (oui.) What Latin phrase is it worn down from? (hoc ille, "this is it," via oïl.) What were the langue d'oïl and langue d'oc named after? (The two medieval words for yes.) When do you answer si instead of oui? (To contradict a negative — Tu ne viens pas? — Si!)
+[question — say your answer, then pause 8 seconds]
+French has two words for yes. Which one contradicts a negative?
 
 
 Lesson 2 of 2.

--- a/code/learning/human-languages/german/book/book.tex
+++ b/code/learning/human-languages/german/book/book.tex
@@ -117,5 +117,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/german/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/german/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,30 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 1
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 17}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-GE-C17-kopf-haupt-compound-word}{\textbf{17.1}} \emph{Kopf / Haupt — two head-words}\par
+\small Which inherited German head-word survives in compounds such as Hauptstadt?
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 17}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-GE-C17-kopf-haupt-compound-word}{\textbf{17.1}} \emph{Kopf / Haupt — two head-words}\par
+\small \textbf{Answer:} Haupt\par
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/gujarati/book/book.tex
+++ b/code/learning/human-languages/gujarati/book/book.tex
@@ -106,5 +106,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/gujarati/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/gujarati/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,31 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 1
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 6}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-GU-C06-number-histories-be-source}{\textbf{6.1}} \emph{Two number histories: \emph{be} and \emph{traṇ}}\par
+\small Does Gujarati be descend from the same Sanskrit form as Hindi do?
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 6}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-GU-C06-number-histories-be-source}{\textbf{6.1}} \emph{Two number histories: \emph{be} and \emph{traṇ}}\par
+\small \textbf{Answer:} no\par
+\footnotesize \textbf{Also accepted:} no it does not; different Sanskrit forms
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/hindi/book/book.tex
+++ b/code/learning/human-languages/hindi/book/book.tex
@@ -157,5 +157,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/hindi/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/hindi/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,31 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 1
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 1}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-HI-W01-shirorekha-na-ma-drawing-order}{\textbf{1.1}} \emph{The line on top — Devanagari's head-line}\par
+\small When is the shirorekha usually drawn?
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 1}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-HI-W01-shirorekha-na-ma-drawing-order}{\textbf{1.1}} \emph{The line on top — Devanagari's head-line}\par
+\small \textbf{Answer:} last\par
+\footnotesize \textbf{Also accepted:} at the end; after the letter bodies
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/italian/book/book.tex
+++ b/code/learning/human-languages/italian/book/book.tex
@@ -101,5 +101,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/italian/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/italian/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,31 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 1
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 3}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-IT-C03-practice-drop-io}{\textbf{3.1}} \emph{Practice — introducing yourself in Italian}\par
+\small Why can Italian usually omit io?
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 3}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-IT-C03-practice-drop-io}{\textbf{3.1}} \emph{Practice — introducing yourself in Italian}\par
+\small \textbf{Answer:} the verb ending says who\par
+\footnotesize \textbf{Also accepted:} the verb ending identifies the subject; the verb ending carries the subject
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/japanese/book/book.tex
+++ b/code/learning/human-languages/japanese/book/book.tex
@@ -70,6 +70,7 @@ are used. Nothing else is.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \chapter*{Sources for this starter edition}
 \addcontentsline{toc}{chapter}{Sources for this starter edition}

--- a/code/learning/human-languages/japanese/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/japanese/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,122 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 8
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 1}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C01-hai-beats}{\textbf{1.1}} \emph{\ja{はい} — yes, in two equal beats}\par
+\small Write the Japanese word for 'yes' in hiragana.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C01-iie-length}{\textbf{1.2}} \emph{\ja{いいえ} — no, and why the extra beat matters}\par
+\small How many beats (morae) does \ja{いいえ} hold?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C01-konnichiwa-particle}{\textbf{1.3}} \emph{\ja{こんにちは} — hello, and a sign that lies about its sound}\par
+\small The greeting ends in the sign \ja{は}. How is it pronounced there?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C01-nihongo-readings}{\textbf{1.4}} \emph{\ja{日本語} — three characters, and no single sound each}\par
+\small How is the character \ja{日} read inside \ja{日本語}?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C01-koohii-bar}{\textbf{1.5}} \emph{\ja{コーヒー} — the third system, and a word that really is a cousin}\par
+\small What does the bar \ja{ー} do in \ja{コーヒー}?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C01-arigatou-dakuten}{\textbf{1.6}} \emph{\ja{ありがとう} — thanks, from “this hardly ever happens”}\par
+\small Which hiragana sign becomes \ja{が} when the dakuten is added?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C01-gozaimasu-level}{\textbf{1.7}} \emph{\ja{ありがとうございます} — politeness you cannot leave out}\par
+\small You are thanking a shop assistant you have never met. Which form do you use?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-JA-C01-practice-final-line}{\textbf{1.8}} \emph{Practice — one daytime exchange, three scripts}\par
+\small Someone has just thanked you politely. Give the modest one-word reply this chapter taught.
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 1}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C01-hai-beats}{\textbf{1.1}} \emph{\ja{はい} — yes, in two equal beats}\par
+\small \textbf{Answer:} \ja{はい}\par
+\footnotesize \textbf{Also accepted:} hai; ha-i
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C01-iie-length}{\textbf{1.2}} \emph{\ja{いいえ} — no, and why the extra beat matters}\par
+\small \textbf{Answer:} three\par
+\footnotesize \textbf{Also accepted:} 3; three beats; three morae
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C01-konnichiwa-particle}{\textbf{1.3}} \emph{\ja{こんにちは} — hello, and a sign that lies about its sound}\par
+\small \textbf{Answer:} wa\par
+\footnotesize \textbf{Also accepted:} as wa; \ja{わ}; the topic particle wa
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C01-nihongo-readings}{\textbf{1.4}} \emph{\ja{日本語} — three characters, and no single sound each}\par
+\small \textbf{Answer:} ni\par
+\footnotesize \textbf{Also accepted:} as ni; \ja{に}; read ni
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C01-koohii-bar}{\textbf{1.5}} \emph{\ja{コーヒー} — the third system, and a word that really is a cousin}\par
+\small \textbf{Answer:} it holds the vowel for one more beat\par
+\footnotesize \textbf{Also accepted:} lengthens the vowel; long vowel; it lengthens the previous vowel; adds a beat to the vowel
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C01-arigatou-dakuten}{\textbf{1.6}} \emph{\ja{ありがとう} — thanks, from “this hardly ever happens”}\par
+\small \textbf{Answer:} \ja{か}\par
+\footnotesize \textbf{Also accepted:} ka; \ja{か} ka
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C01-gozaimasu-level}{\textbf{1.7}} \emph{\ja{ありがとうございます} — politeness you cannot leave out}\par
+\small \textbf{Answer:} \ja{ありがとうございます}\par
+\footnotesize \textbf{Also accepted:} arigato gozaimasu; arigatou gozaimasu; arigatō gozaimasu; the polite one
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-JA-C01-practice-final-line}{\textbf{1.8}} \emph{Practice — one daytime exchange, three scripts}\par
+\small \textbf{Answer:} \ja{いいえ}\par
+\footnotesize \textbf{Also accepted:} iie; no; not at all
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/kannada/book/book.tex
+++ b/code/learning/human-languages/kannada/book/book.tex
@@ -128,5 +128,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/kannada/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/kannada/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,31 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 1
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 6}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-KA-C06-dative-stacking-agglutinative}{\textbf{6.1}} \emph{-\kn{ಗೆ} — one suffix, one job}\par
+\small Why is Kannada called agglutinative?
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 6}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-KA-C06-dative-stacking-agglutinative}{\textbf{6.1}} \emph{-\kn{ಗೆ} — one suffix, one job}\par
+\small \textbf{Answer:} it stacks visible pieces with one job each\par
+\footnotesize \textbf{Also accepted:} it stacks visible pieces each with one job; it stacks one-job pieces
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/latin/book/book.tex
+++ b/code/learning/human-languages/latin/book/book.tex
@@ -127,5 +127,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/latin/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/latin/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,99 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 5
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 1}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-LA-C01-practice-vale-root}{\textbf{1.1}} \emph{Chapter 1 — Practice and Recall}\par
+\small Which Latin root links vale to English valid and value?
+\end{minipage}\par\medskip
+
+\section*{Chapter 19}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-LA-C19-practice-answer-line}{\textbf{19.1}} \emph{Practice — open, check, answer, close}\par
+\small Someone has just asked you ut vales? Type the one-word Latin answer.
+\end{minipage}\par\medskip
+
+\section*{Chapter 21}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-LA-C21-practice-name-reply}{\textbf{21.1}} \emph{Practice — two meetings, each with the right words}\par
+\small You have been asked quid tibi nomen est? Type the first three Latin words of your reply.
+\end{minipage}\par\medskip
+
+\section*{Chapter 33}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-LA-C33-practice-soir-family}{\textbf{33.1}} \emph{Practice — sort the evening words, then read the Latin}\par
+\small French soir and Italian sera descend from which Latin word?
+\end{minipage}\par\medskip
+
+\section*{Chapter 36}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-LA-C36-practice-afternoon-line}{\textbf{36.1}} \emph{Practice — one whole day, in the words you have}\par
+\small You meet one person at three in the afternoon and want words a Roman would have used. Type them.
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 1}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-LA-C01-practice-vale-root}{\textbf{1.1}} \emph{Chapter 1 — Practice and Recall}\par
+\small \textbf{Answer:} valere\par
+\footnotesize \textbf{Also accepted:} valēre
+\end{minipage}\par\medskip
+
+\section*{Chapter 19}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-LA-C19-practice-answer-line}{\textbf{19.1}} \emph{Practice — open, check, answer, close}\par
+\small \textbf{Answer:} valeo\par
+\footnotesize \textbf{Also accepted:} valeō
+\end{minipage}\par\medskip
+
+\section*{Chapter 21}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-LA-C21-practice-name-reply}{\textbf{21.1}} \emph{Practice — two meetings, each with the right words}\par
+\small \textbf{Answer:} mihi nomen est\par
+\footnotesize \textbf{Also accepted:} mihi nōmen est
+\end{minipage}\par\medskip
+
+\section*{Chapter 33}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-LA-C33-practice-soir-family}{\textbf{33.1}} \emph{Practice — sort the evening words, then read the Latin}\par
+\small \textbf{Answer:} serus\par
+\footnotesize \textbf{Also accepted:} sērus; serus (late)
+\end{minipage}\par\medskip
+
+\section*{Chapter 36}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-LA-C36-practice-afternoon-line}{\textbf{36.1}} \emph{Practice — one whole day, in the words you have}\par
+\small \textbf{Answer:} salve\par
+\footnotesize \textbf{Also accepted:} salvē
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/malayalam/book/book.tex
+++ b/code/learning/human-languages/malayalam/book/book.tex
@@ -152,5 +152,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/malayalam/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/malayalam/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,31 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 1
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 23}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-ML-C23-naal-survival}{\textbf{23.1}} \emph{\ml{നാൾ} — the native day-word that narrowed its job}\par
+\small Has Sanskrit divasam erased native naal?
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 23}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-ML-C23-naal-survival}{\textbf{23.1}} \emph{\ml{നാൾ} — the native day-word that narrowed its job}\par
+\small \textbf{Answer:} no\par
+\footnotesize \textbf{Also accepted:} no it has not; nāḷ still survives; naal still survives
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/marathi/book/book.tex
+++ b/code/learning/human-languages/marathi/book/book.tex
@@ -106,5 +106,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/marathi/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/marathi/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,31 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 1
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 6}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-MR-C06-number-differences-don-ending}{\textbf{6.1}} \emph{Why Marathi \emph{two} rhymes with \emph{three}}\par
+\small Did Marathi don preserve an ancient final n?
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 6}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-MR-C06-number-differences-don-ending}{\textbf{6.1}} \emph{Why Marathi \emph{two} rhymes with \emph{three}}\par
+\small \textbf{Answer:} no\par
+\footnotesize \textbf{Also accepted:} no it copied three; it copied the pattern of three
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/persian/book/book.tex
+++ b/code/learning/human-languages/persian/book/book.tex
@@ -85,6 +85,7 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \chapter*{A note on sources}
 \addcontentsline{toc}{chapter}{A note on sources}

--- a/code/learning/human-languages/persian/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/persian/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,419 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 29
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 2}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C02-esm-e-man-sara}{\textbf{2.1}} \emph{\fa{اسم} \fa{من} ... \fa{است} — my name is ...}\par
+\small Type the careful Persian sentence 'My name is Sara.'
+\end{minipage}\par\medskip
+
+\section*{Chapter 3}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C03-shoma-to-first-meeting}{\textbf{3.1}} \emph{\fa{شما} / \fa{تو} — two relationships inside “you”}\par
+\small Type the Persian 'you' safest in a first meeting.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C03-chist-fusion}{\textbf{3.2}} \emph{\fa{چیست} — “what is?” in one joined word}\par
+\small Join Persian chi + ast into the careful form 'what is?'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C03-esm-e-shoma-chist-question}{\textbf{3.3}} \emph{\fa{اسم} \fa{شما} \fa{چیست؟} — ask a name respectfully}\par
+\small Type the respectful Persian question 'What is your name?'
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C03-khoshvaghtam-close}{\textbf{3.4}} \emph{\fa{خوشوقتم} — pleased to meet you}\par
+\small Type the Persian response 'Pleased to meet you.'
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C03-practice-next-line}{\textbf{3.5}} \emph{Practice — a complete Persian name exchange}\par
+\small After someone asks \fa{اسم} \fa{شما} \fa{چیست؟}, type the careful Persian answer using Sara.
+\end{minipage}\par\medskip
+
+\section*{Chapter 4}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C04-hal-meaning}{\textbf{4.1}} \emph{\fa{حال} — the “state” in a wellbeing question}\par
+\small Type the Persian word meaning 'state' or 'condition'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C04-chetor-how}{\textbf{4.2}} \emph{\fa{چطور} — “how?” one layer at a time}\par
+\small Type the Persian question word meaning 'how?'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C04-hal-e-shoma-chetor-ast-question}{\textbf{4.3}} \emph{\fa{حال} \fa{شما} \fa{چطور} \fa{است؟} — ask “How are you?” respectfully}\par
+\small Type the careful respectful Persian question 'How are you?'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C04-khub-good}{\textbf{4.4}} \emph{\fa{خوب} — “good” and “well”}\par
+\small Type the Persian word meaning 'good' or 'well'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C04-khubam-reply}{\textbf{4.5}} \emph{\fa{خوبم،} \fa{ممنون} — “I am well, thank you”}\par
+\small Reply in Persian: 'I am well, thank you.'
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C04-practice-next-line}{\textbf{4.6}} \emph{Practice — a Persian wellbeing exchange}\par
+\small After \fa{حال} \fa{شما} \fa{چطور} \fa{است؟}, type the polite Persian reply.
+\end{minipage}\par\medskip
+
+\section*{Chapter 5}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C05-khoda-meaning}{\textbf{5.1}} \emph{\fa{خدا} — the Persian half of a farewell}\par
+\small Type the Persian word khodâ, meaning 'God'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C05-hafez-meaning}{\textbf{5.2}} \emph{\fa{حافظ} — “guardian” or “protector”}\par
+\small Type the Persian word hâfez, meaning 'guardian' or 'protector'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C05-khodahafez-goodbye}{\textbf{5.3}} \emph{\fa{خداحافظ} — goodbye}\par
+\small Type the standard Persian expression for 'goodbye'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C05-practice-final-line}{\textbf{5.4}} \emph{Practice — open, check, and close}\par
+\small The short Persian interaction is ending. Type the final expression.
+\end{minipage}\par\medskip
+
+\section*{Chapter 6}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C06-budan-infinitive}{\textbf{6.1}} \emph{\fa{بودن} — “to be,” and the ending every Persian verb wears}\par
+\small Type the Persian verb meaning 'to be'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C06-raftan-stem}{\textbf{6.2}} \emph{\fa{رفتن} — “to go,” and the second form that travels with it}\par
+\small Give the present stem that goes with \fa{رفتن} (raftan).
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C06-amadan-verb}{\textbf{6.3}} \emph{\fa{آمدن} — “to come,” and an alef that wears a hat}\par
+\small Type the Persian verb meaning 'to come'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C06-goftan-stem}{\textbf{6.4}} \emph{\fa{گفتن} — “to say,” written with a letter Arabic does not have}\par
+\small Give the present stem that goes with \fa{گفتن} (goftan).
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C06-danestan-pair}{\textbf{6.5}} \emph{\fa{دانستن} — “to know,” and five pairs held together}\par
+\small Give the present stem that goes with \fa{دانستن} (dânestan).
+\end{minipage}\par\medskip
+
+\section*{Chapter 7}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C07-fekr-kardan-verb}{\textbf{7.1}} \emph{\fa{فکر} \fa{کردن} — “to think,” written as two words}\par
+\small Type the two Persian words that together mean 'to think'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C07-fahmidan-stem}{\textbf{7.2}} \emph{\fa{فهمیدن} — “to understand,” and the class that gives its stem away}\par
+\small Give the present stem that goes with \fa{فهمیدن} (fahmidan).
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C07-khandan-silent-vav}{\textbf{7.3}} \emph{\fa{خواندن} — “to read,” and a letter that is written but not said}\par
+\small In \fa{خواندن}, which written letter is not pronounced?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C07-neveshtan-stem}{\textbf{7.4}} \emph{\fa{نوشتن} — “to write,” and four verbs of the mind held together}\par
+\small Give the present stem that goes with \fa{نوشتن} (neveshtan).
+\end{minipage}\par\medskip
+
+\section*{Chapter 8}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C08-gereftan-stem}{\textbf{8.1}} \emph{\fa{گرفتن} — “to take,” and a cousin you can hear}\par
+\small Give the present stem that goes with \fa{گرفتن} (gereftan).
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C08-porsidan-stem}{\textbf{8.2}} \emph{\fa{پرسیدن} — “to ask,” and the questions you could already ask}\par
+\small Give the present stem that goes with \fa{پرسیدن} (porsidan).
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C08-komak-kardan-verb}{\textbf{8.3}} \emph{\fa{کمک} \fa{کردن} — “to help,” and the machine on its second run}\par
+\small Type the two Persian words that together mean 'to help'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-FA-C08-dust-dashtan-literal}{\textbf{8.4}} \emph{\fa{دوست} \fa{داشتن} — “to love,” which Persian says as “to have as friend”}\par
+\small Type the two Persian words that together mean 'to love'.
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 2}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C02-esm-e-man-sara}{\textbf{2.1}} \emph{\fa{اسم} \fa{من} ... \fa{است} — my name is ...}\par
+\small \textbf{Answer:} \fa{اسم} \fa{من} \fa{سارا} \fa{است}\par
+\footnotesize \textbf{Also accepted:} esm-e man Sara ast; esm-e man Sârâ ast
+\end{minipage}\par\medskip
+
+\section*{Chapter 3}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C03-shoma-to-first-meeting}{\textbf{3.1}} \emph{\fa{شما} / \fa{تو} — two relationships inside “you”}\par
+\small \textbf{Answer:} \fa{شما}\par
+\footnotesize \textbf{Also accepted:} shoma; shomâ; shomā
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C03-chist-fusion}{\textbf{3.2}} \emph{\fa{چیست} — “what is?” in one joined word}\par
+\small \textbf{Answer:} \fa{چیست}\par
+\footnotesize \textbf{Also accepted:} chist; chīst
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C03-esm-e-shoma-chist-question}{\textbf{3.3}} \emph{\fa{اسم} \fa{شما} \fa{چیست؟} — ask a name respectfully}\par
+\small \textbf{Answer:} \fa{اسم} \fa{شما} \fa{چیست؟}\par
+\footnotesize \textbf{Also accepted:} \fa{اسم} \fa{شما} \fa{چیست}; esm-e shoma chist; esm-e shomâ chist
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C03-khoshvaghtam-close}{\textbf{3.4}} \emph{\fa{خوشوقتم} — pleased to meet you}\par
+\small \textbf{Answer:} \fa{خوشوقتم}\par
+\footnotesize \textbf{Also accepted:} khoshvaghtam; khoshvaqtam
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C03-practice-next-line}{\textbf{3.5}} \emph{Practice — a complete Persian name exchange}\par
+\small \textbf{Answer:} \fa{اسم} \fa{من} \fa{سارا} \fa{است}\par
+\footnotesize \textbf{Also accepted:} esm-e man Sara ast; esm-e man Sârâ ast
+\end{minipage}\par\medskip
+
+\section*{Chapter 4}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C04-hal-meaning}{\textbf{4.1}} \emph{\fa{حال} — the “state” in a wellbeing question}\par
+\small \textbf{Answer:} \fa{حال}\par
+\footnotesize \textbf{Also accepted:} hal; hâl; hāl
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C04-chetor-how}{\textbf{4.2}} \emph{\fa{چطور} — “how?” one layer at a time}\par
+\small \textbf{Answer:} \fa{چطور}\par
+\footnotesize \textbf{Also accepted:} chetor; chetowr
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C04-hal-e-shoma-chetor-ast-question}{\textbf{4.3}} \emph{\fa{حال} \fa{شما} \fa{چطور} \fa{است؟} — ask “How are you?” respectfully}\par
+\small \textbf{Answer:} \fa{حال} \fa{شما} \fa{چطور} \fa{است؟}\par
+\footnotesize \textbf{Also accepted:} \fa{حال} \fa{شما} \fa{چطور} \fa{است}; hal-e shoma chetor ast; hâl-e shomâ chetor ast
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C04-khub-good}{\textbf{4.4}} \emph{\fa{خوب} — “good” and “well”}\par
+\small \textbf{Answer:} \fa{خوب}\par
+\footnotesize \textbf{Also accepted:} khub; khūb; khoob
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C04-khubam-reply}{\textbf{4.5}} \emph{\fa{خوبم،} \fa{ممنون} — “I am well, thank you”}\par
+\small \textbf{Answer:} \fa{خوبم،} \fa{ممنون}\par
+\footnotesize \textbf{Also accepted:} \fa{خوبم} \fa{ممنون}; khubam mamnun; khūbam mamnūn
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C04-practice-next-line}{\textbf{4.6}} \emph{Practice — a Persian wellbeing exchange}\par
+\small \textbf{Answer:} \fa{خوبم،} \fa{ممنون}\par
+\footnotesize \textbf{Also accepted:} \fa{خوبم} \fa{ممنون}; khubam mamnun; khūbam mamnūn
+\end{minipage}\par\medskip
+
+\section*{Chapter 5}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C05-khoda-meaning}{\textbf{5.1}} \emph{\fa{خدا} — the Persian half of a farewell}\par
+\small \textbf{Answer:} \fa{خدا}\par
+\footnotesize \textbf{Also accepted:} khoda; khodâ; xodā; xoda
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C05-hafez-meaning}{\textbf{5.2}} \emph{\fa{حافظ} — “guardian” or “protector”}\par
+\small \textbf{Answer:} \fa{حافظ}\par
+\footnotesize \textbf{Also accepted:} hafez; hâfez; hāfez; hafiz
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C05-khodahafez-goodbye}{\textbf{5.3}} \emph{\fa{خداحافظ} — goodbye}\par
+\small \textbf{Answer:} \fa{خداحافظ}\par
+\footnotesize \textbf{Also accepted:} khodahafez; khoda hafez; khodâ hâfez; khodā hāfez; xodāhāfez
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C05-practice-final-line}{\textbf{5.4}} \emph{Practice — open, check, and close}\par
+\small \textbf{Answer:} \fa{خداحافظ}\par
+\footnotesize \textbf{Also accepted:} khodahafez; khoda hafez; khodâ hâfez; khodā hāfez
+\end{minipage}\par\medskip
+
+\section*{Chapter 6}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C06-budan-infinitive}{\textbf{6.1}} \emph{\fa{بودن} — “to be,” and the ending every Persian verb wears}\par
+\small \textbf{Answer:} \fa{بودن}\par
+\footnotesize \textbf{Also accepted:} budan; būdan
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C06-raftan-stem}{\textbf{6.2}} \emph{\fa{رفتن} — “to go,” and the second form that travels with it}\par
+\small \textbf{Answer:} \fa{رو}\par
+\footnotesize \textbf{Also accepted:} rav; raw; rav-; ro
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C06-amadan-verb}{\textbf{6.3}} \emph{\fa{آمدن} — “to come,” and an alef that wears a hat}\par
+\small \textbf{Answer:} \fa{آمدن}\par
+\footnotesize \textbf{Also accepted:} amadan; âmadan; āmadan
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C06-goftan-stem}{\textbf{6.4}} \emph{\fa{گفتن} — “to say,” written with a letter Arabic does not have}\par
+\small \textbf{Answer:} \fa{گو}\par
+\footnotesize \textbf{Also accepted:} gu; gu-; gū; goo
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C06-danestan-pair}{\textbf{6.5}} \emph{\fa{دانستن} — “to know,” and five pairs held together}\par
+\small \textbf{Answer:} \fa{دان}\par
+\footnotesize \textbf{Also accepted:} dan; dân; dān; dan-
+\end{minipage}\par\medskip
+
+\section*{Chapter 7}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C07-fekr-kardan-verb}{\textbf{7.1}} \emph{\fa{فکر} \fa{کردن} — “to think,” written as two words}\par
+\small \textbf{Answer:} \fa{فکر} \fa{کردن}\par
+\footnotesize \textbf{Also accepted:} fekr kardan; fikr kardan; fekr-kardan
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C07-fahmidan-stem}{\textbf{7.2}} \emph{\fa{فهمیدن} — “to understand,” and the class that gives its stem away}\par
+\small \textbf{Answer:} \fa{فهم}\par
+\footnotesize \textbf{Also accepted:} fahm; fahm-; fehm
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C07-khandan-silent-vav}{\textbf{7.3}} \emph{\fa{خواندن} — “to read,” and a letter that is written but not said}\par
+\small \textbf{Answer:} \fa{و}\par
+\footnotesize \textbf{Also accepted:} vav; waw; v; the vav
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C07-neveshtan-stem}{\textbf{7.4}} \emph{\fa{نوشتن} — “to write,” and four verbs of the mind held together}\par
+\small \textbf{Answer:} \fa{نویس}\par
+\footnotesize \textbf{Also accepted:} nevis; nevis-; nivis; navis
+\end{minipage}\par\medskip
+
+\section*{Chapter 8}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C08-gereftan-stem}{\textbf{8.1}} \emph{\fa{گرفتن} — “to take,” and a cousin you can hear}\par
+\small \textbf{Answer:} \fa{گیر}\par
+\footnotesize \textbf{Also accepted:} gir; gir-; gīr; geer
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C08-porsidan-stem}{\textbf{8.2}} \emph{\fa{پرسیدن} — “to ask,” and the questions you could already ask}\par
+\small \textbf{Answer:} \fa{پرس}\par
+\footnotesize \textbf{Also accepted:} pors; pors-; purs; pursh
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C08-komak-kardan-verb}{\textbf{8.3}} \emph{\fa{کمک} \fa{کردن} — “to help,” and the machine on its second run}\par
+\small \textbf{Answer:} \fa{کمک} \fa{کردن}\par
+\footnotesize \textbf{Also accepted:} komak kardan; komak-kardan; kumak kardan
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-FA-C08-dust-dashtan-literal}{\textbf{8.4}} \emph{\fa{دوست} \fa{داشتن} — “to love,” which Persian says as “to have as friend”}\par
+\small \textbf{Answer:} \fa{دوست} \fa{داشتن}\par
+\footnotesize \textbf{Also accepted:} dust dashtan; dust dâshtan; dost dashtan; doost dashtan; dūst dāštan
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/portuguese/book/book.tex
+++ b/code/learning/human-languages/portuguese/book/book.tex
@@ -124,5 +124,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/portuguese/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/portuguese/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,31 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 1
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 2}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PT-C02-practice-neutral-question}{\textbf{2.1}} \emph{Practice — Tudo bem?, start to finish}\par
+\small Which Portuguese phrase is the safest register-neutral wellbeing question?
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 2}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PT-C02-practice-neutral-question}{\textbf{2.1}} \emph{Practice — Tudo bem?, start to finish}\par
+\small \textbf{Answer:} Tudo bem?\par
+\footnotesize \textbf{Also accepted:} tudo bem
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/punjabi/book/book.tex
+++ b/code/learning/human-languages/punjabi/book/book.tex
@@ -105,5 +105,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/punjabi/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/punjabi/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,319 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 21
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 6}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C06-panj-convergence-borrowing}{\textbf{6.1}} \emph{Why two branches both arrived at \emph{panj}}\par
+\small Was Punjabi panj borrowed from Persian?
+\end{minipage}\par\medskip
+
+\section*{Chapter 7}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C07-janna-two-js}{\textbf{7.1}} \emph{\pa{ਜਾਣਨਾ} — “to know,” one letter from “to go”}\par
+\small Which Punjabi verb means to know, jana or janna?
+\end{minipage}\par\medskip
+
+\section*{Chapter 8}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C08-sochna-soch}{\textbf{8.1}} \emph{\pa{ਸੋਚਣਾ} — “to think,” and it once meant “to burn”}\par
+\small The Punjabi noun soch means a thought and one other thing. What?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C08-samajhna-tone}{\textbf{8.2}} \emph{\pa{ਸਮਝਣਾ} — “to understand,” and the tone you can hear in it}\par
+\small In samajhna the jh is not heard as breath. What is heard instead?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C08-parhna-subjoined}{\textbf{8.3}} \emph{\pa{ਪੜ੍ਹਨਾ} — “to read,” which used to mean “to say out loud”}\par
+\small In the cluster rrha, where is the h written relative to the letter before it?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C08-likhna-four-roots}{\textbf{8.4}} \emph{\pa{ਲਿਖਣਾ} — “to write,” which is scratching}\par
+\small What did the Sanskrit root behind likhna mean before it meant to write?
+\end{minipage}\par\medskip
+
+\section*{Chapter 9}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C09-laina-labhate}{\textbf{9.1}} \emph{\pa{ਲੈਣਾ} — “to take,” worn down to almost nothing}\par
+\small Which Sanskrit verb is laina worn down from?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C09-puchhna-addak}{\textbf{9.2}} \emph{\pa{ਪੁੱਛਣਾ} — “to ask,” and a Persian cousin that is not a loan}\par
+\small What does the addak mark tell you to do to the consonant after it?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C09-madad-karna-root}{\textbf{9.3}} \emph{\pa{ਮਦਦ} \pa{ਕਰਨਾ} — “to help,” which is two words}\par
+\small Which language does the word madad come from originally?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C09-pasand-dative}{\textbf{9.4}} \emph{\pa{ਪਸੰਦ} — Punjabi does not like things; things please Punjabi}\par
+\small Type the Punjabi for 'to me' — the form main takes when it cannot be the subject.
+\end{minipage}\par\medskip
+
+\section*{Chapter 10}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C10-paani-please}{\textbf{10.1}} \emph{\pa{ਪਾਣੀ} — the first thing you'll actually ask for}\par
+\small Ask for water politely, in Punjabi.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C10-chaa-tone}{\textbf{10.2}} \emph{\pa{ਚਾਹ} — the \pa{ਹ} that is not a consonant}\par
+\small Is chaa's tone falling or level?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C10-roti-requests}{\textbf{10.3}} \emph{\pa{ਰੋਟੀ} — a request pattern, run four times}\par
+\small Ask for bread politely, in Punjabi.
+\end{minipage}\par\medskip
+
+\section*{Chapter 11}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C11-parivar-split}{\textbf{11.1}} \emph{\pa{ਪਰਿਵਾਰ} — what surrounds you}\par
+\small parivar splits into two Sanskrit pieces meaning 'around' and 'to cover'. What is the whole word's literal sense?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C11-bhara-tone}{\textbf{11.2}} \emph{\pa{ਭਰਾ} — a breathy letter you have not met yet}\par
+\small bharā's bh is said as which consonant, and what tone does the vowel after it carry?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C11-bhain-cognate}{\textbf{11.3}} \emph{\pa{ਭੈਣ} — the same tone, a different family tree}\par
+\small Is bhaiṇ the same word as English sister by unbroken descent, the way bharā is the same word as brother?
+\end{minipage}\par\medskip
+
+\section*{Chapter 12}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C12-kann-false-friend}{\textbf{12.1}} \emph{\pa{ਕੰਨ} — a false friend hiding in plain sight}\par
+\small Does kann, 'ear', share a root with karnā, 'to do'?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C12-munh-tone}{\textbf{12.2}} \emph{\pa{ਮੂੰਹ} — a consonant that wore all the way down to a tone}\par
+\small What Sanskrit word does mūnh come from, and what learned Punjabi word keeps the same source intact?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C12-nakk-face}{\textbf{12.3}} \emph{\pa{ਨੱਕ} — the whole face, run back}\par
+\small Name all four Punjabi face words taught in this chapter, in any order.
+\end{minipage}\par\medskip
+
+\section*{Chapter 13}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C13-dil-source}{\textbf{13.1}} \emph{\pa{ਦਿਲ} — the one body word that is not Sanskrit}\par
+\small Is dil, Punjabi's everyday word for heart, inherited from Sanskrit or borrowed from Persian?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-PA-C13-sir-cousin}{\textbf{13.2}} \emph{\pa{ਸਿਰ} — a cousin of \textquotedblleft{}horn,\textquotedblright{} and a twin nobody borrowed}\par
+\small sir shares its Proto-Indo-European root with which English word — head, or horn?
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 6}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C06-panj-convergence-borrowing}{\textbf{6.1}} \emph{Why two branches both arrived at \emph{panj}}\par
+\small \textbf{Answer:} no\par
+\footnotesize \textbf{Also accepted:} no it was not; it inherits Sanskrit pañca; it comes from Sanskrit pañca
+\end{minipage}\par\medskip
+
+\section*{Chapter 7}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C07-janna-two-js}{\textbf{7.1}} \emph{\pa{ਜਾਣਨਾ} — “to know,” one letter from “to go”}\par
+\small \textbf{Answer:} janna\par
+\footnotesize \textbf{Also accepted:} jāṇnā; jannaa; jaanna
+\end{minipage}\par\medskip
+
+\section*{Chapter 8}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C08-sochna-soch}{\textbf{8.1}} \emph{\pa{ਸੋਚਣਾ} — “to think,” and it once meant “to burn”}\par
+\small \textbf{Answer:} a worry\par
+\footnotesize \textbf{Also accepted:} worry; worrying; anxiety; a worry or a care
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C08-samajhna-tone}{\textbf{8.2}} \emph{\pa{ਸਮਝਣਾ} — “to understand,” and the tone you can hear in it}\par
+\small \textbf{Answer:} a falling tone\par
+\footnotesize \textbf{Also accepted:} falling tone; a falling pitch; the pitch falls; high falling tone; tone
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C08-parhna-subjoined}{\textbf{8.3}} \emph{\pa{ਪੜ੍ਹਨਾ} — “to read,” which used to mean “to say out loud”}\par
+\small \textbf{Answer:} underneath\par
+\footnotesize \textbf{Also accepted:} below; under; beneath; underneath it; under it
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C08-likhna-four-roots}{\textbf{8.4}} \emph{\pa{ਲਿਖਣਾ} — “to write,” which is scratching}\par
+\small \textbf{Answer:} to scratch\par
+\footnotesize \textbf{Also accepted:} scratch; scrape; to scrape; scratching; scraping
+\end{minipage}\par\medskip
+
+\section*{Chapter 9}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C09-laina-labhate}{\textbf{9.1}} \emph{\pa{ਲੈਣਾ} — “to take,” worn down to almost nothing}\par
+\small \textbf{Answer:} labhate\par
+\footnotesize \textbf{Also accepted:} labh; labh-; labhati; sanskrit labhate
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C09-puchhna-addak}{\textbf{9.2}} \emph{\pa{ਪੁੱਛਣਾ} — “to ask,” and a Persian cousin that is not a loan}\par
+\small \textbf{Answer:} double it\par
+\footnotesize \textbf{Also accepted:} double; doubles it; hold it long; lengthen it
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C09-madad-karna-root}{\textbf{9.3}} \emph{\pa{ਮਦਦ} \pa{ਕਰਨਾ} — “to help,” which is two words}\par
+\small \textbf{Answer:} Arabic\par
+\footnotesize \textbf{Also accepted:} from arabic; arabic via persian; arabic through persian
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C09-pasand-dative}{\textbf{9.4}} \emph{\pa{ਪਸੰਦ} — Punjabi does not like things; things please Punjabi}\par
+\small \textbf{Answer:} \pa{ਮੈਨੂੰ}\par
+\footnotesize \textbf{Also accepted:} mainu; mainun; mainoo; mainū̃
+\end{minipage}\par\medskip
+
+\section*{Chapter 10}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C10-paani-please}{\textbf{10.1}} \emph{\pa{ਪਾਣੀ} — the first thing you'll actually ask for}\par
+\small \textbf{Answer:} \pa{ਪਾਣੀ}, \pa{ਕਿਰਪਾ} \pa{ਕਰਕੇ}\par
+\footnotesize \textbf{Also accepted:} pani kirpa karke; paani, kirpa karke; pāṇī, kirpā karke; pani kirpa karke.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C10-chaa-tone}{\textbf{10.2}} \emph{\pa{ਚਾਹ} — the \pa{ਹ} that is not a consonant}\par
+\small \textbf{Answer:} level\par
+\footnotesize \textbf{Also accepted:} high level; level high; high and level; stays high
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C10-roti-requests}{\textbf{10.3}} \emph{\pa{ਰੋਟੀ} — a request pattern, run four times}\par
+\small \textbf{Answer:} \pa{ਰੋਟੀ}, \pa{ਕਿਰਪਾ} \pa{ਕਰਕੇ}\par
+\footnotesize \textbf{Also accepted:} roti kirpa karke; roṭī, kirpā karke; roti, kirpa karke.
+\end{minipage}\par\medskip
+
+\section*{Chapter 11}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C11-parivar-split}{\textbf{11.1}} \emph{\pa{ਪਰਿਵਾਰ} — what surrounds you}\par
+\small \textbf{Answer:} what surrounds you\par
+\footnotesize \textbf{Also accepted:} that which surrounds; surrounding; what encloses you; that which covers around
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C11-bhara-tone}{\textbf{11.2}} \emph{\pa{ਭਰਾ} — a breathy letter you have not met yet}\par
+\small \textbf{Answer:} p, low tone\par
+\footnotesize \textbf{Also accepted:} p and low; plain p, low; p, low; voiceless p and a low tone
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C11-bhain-cognate}{\textbf{11.3}} \emph{\pa{ਭੈਣ} — the same tone, a different family tree}\par
+\small \textbf{Answer:} no\par
+\footnotesize \textbf{Also accepted:} no it is not; no, unrelated; no different root
+\end{minipage}\par\medskip
+
+\section*{Chapter 12}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C12-kann-false-friend}{\textbf{12.1}} \emph{\pa{ਕੰਨ} — a false friend hiding in plain sight}\par
+\small \textbf{Answer:} no\par
+\footnotesize \textbf{Also accepted:} no it does not; no unrelated; no, coincidence
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C12-munh-tone}{\textbf{12.2}} \emph{\pa{ਮੂੰਹ} — a consonant that wore all the way down to a tone}\par
+\small \textbf{Answer:} mukha, and mukh\par
+\footnotesize \textbf{Also accepted:} mukha and mukh; mukha; mukh; mukha, mukh
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C12-nakk-face}{\textbf{12.3}} \emph{\pa{ਨੱਕ} — the whole face, run back}\par
+\small \textbf{Answer:} akkh, kann, munh, nakk\par
+\footnotesize \textbf{Also accepted:} akkh kann munh nakk; \pa{ਅੱਖ} \pa{ਕੰਨ} \pa{ਮੂੰਹ} \pa{ਨੱਕ}; eye ear mouth nose
+\end{minipage}\par\medskip
+
+\section*{Chapter 13}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C13-dil-source}{\textbf{13.1}} \emph{\pa{ਦਿਲ} — the one body word that is not Sanskrit}\par
+\small \textbf{Answer:} borrowed from Persian\par
+\footnotesize \textbf{Also accepted:} persian; borrowed persian; persian loan
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-PA-C13-sir-cousin}{\textbf{13.2}} \emph{\pa{ਸਿਰ} — a cousin of \textquotedblleft{}horn,\textquotedblright{} and a twin nobody borrowed}\par
+\small \textbf{Answer:} horn\par
+\footnotesize \textbf{Also accepted:} horn not head; its horn
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/russian/book/book.tex
+++ b/code/learning/human-languages/russian/book/book.tex
@@ -89,6 +89,7 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \chapter*{A note on sources}
 \addcontentsline{toc}{chapter}{A note on sources}

--- a/code/learning/human-languages/russian/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/russian/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,56 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 3
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 2}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-RU-C02-vy-formality-safe-default}{\textbf{2.1}} \emph{Why plural \emph{\ru{вы}} became polite}\par
+\small Which Russian form is safest with an adult when you are unsure?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-RU-C02-kak-cross-language-what-language}{\textbf{2.2}} \emph{Why Russian asks \emph{how}, not \emph{what}}\par
+\small Which language in this comparison asks what instead of how?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-RU-C02-practice-informal-question}{\textbf{2.3}} \emph{Chapter 2 practice — run the exchange}\par
+\small Turn \ru{Как} \ru{вас} \ru{зовут}? into the form you use with one friend.
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 2}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-RU-C02-vy-formality-safe-default}{\textbf{2.1}} \emph{Why plural \emph{\ru{вы}} became polite}\par
+\small \textbf{Answer:} \ru{вы}\par
+\footnotesize \textbf{Also accepted:} vy
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-RU-C02-kak-cross-language-what-language}{\textbf{2.2}} \emph{Why Russian asks \emph{how}, not \emph{what}}\par
+\small \textbf{Answer:} English\par
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-RU-C02-practice-informal-question}{\textbf{2.3}} \emph{Chapter 2 practice — run the exchange}\par
+\small \textbf{Answer:} \ru{Как} \ru{тебя} \ru{зовут}?\par
+\footnotesize \textbf{Also accepted:} Kak tebya zovut?; \ru{Как} \ru{тебя} \ru{зовут}; Kak tebya zovut
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/sanskrit/book/book.tex
+++ b/code/learning/human-languages/sanskrit/book/book.tex
@@ -112,5 +112,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/sanskrit/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/sanskrit/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,31 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 1
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 6}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-SA-C06-number-cognates-inheritance}{\textbf{6.1}} \emph{The Sanskrit numbers are English cousins}\par
+\small Were the Latin and Sanskrit number forms borrowed from one another?
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 6}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-SA-C06-number-cognates-inheritance}{\textbf{6.1}} \emph{The Sanskrit numbers are English cousins}\par
+\small \textbf{Answer:} no\par
+\footnotesize \textbf{Also accepted:} no they were not; they are inherited cousins; inherited cousins
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/spanish/book/book.tex
+++ b/code/learning/human-languages/spanish/book/book.tex
@@ -130,5 +130,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/spanish/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/spanish/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,61 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 3
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 1}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-ES-C01-genero-gramatical-class-count}{\textbf{1.1}} \emph{Grammatical gender — the two noun classes behind \emph{el} and \emph{la}}\par
+\small How many grammatical noun classes does Spanish keep?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-ES-C01-practice-buenos-agreement}{\textbf{1.2}} \emph{Practice — hola and buenos días}\par
+\small Why does bueno become buenos in buenos días?
+\end{minipage}\par\medskip
+
+\section*{Chapter 4}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-ES-W03-question-span-roberto-outside}{\textbf{4.1}} \emph{Where does ¿ begin? — bracket the spoken span}\par
+\small In 'Roberto, ¿cómo estás?', is Roberto inside the question?
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 1}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-ES-C01-genero-gramatical-class-count}{\textbf{1.1}} \emph{Grammatical gender — the two noun classes behind \emph{el} and \emph{la}}\par
+\small \textbf{Answer:} two\par
+\footnotesize \textbf{Also accepted:} 2
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-ES-C01-practice-buenos-agreement}{\textbf{1.2}} \emph{Practice — hola and buenos días}\par
+\small \textbf{Answer:} it agrees with masculine plural días\par
+\footnotesize \textbf{Also accepted:} agreement with masculine plural días; días is masculine plural
+\end{minipage}\par\medskip
+
+\section*{Chapter 4}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-ES-W03-question-span-roberto-outside}{\textbf{4.1}} \emph{Where does ¿ begin? — bracket the spoken span}\par
+\small \textbf{Answer:} no\par
+\footnotesize \textbf{Also accepted:} no it is not; it is not
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/tamil/book/book.tex
+++ b/code/learning/human-languages/tamil/book/book.tex
@@ -131,5 +131,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/tamil/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/tamil/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,31 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 1
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 4}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-TA-W01-curves-va-ka-writing-surface}{\textbf{4.1}} \emph{Tamil's curves — the writing surface leaves a trace}\par
+\small What writing surface is usually linked to Tamil's rounded shapes?
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 4}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-TA-W01-curves-va-ka-writing-surface}{\textbf{4.1}} \emph{Tamil's curves — the writing surface leaves a trace}\par
+\small \textbf{Answer:} palm leaves\par
+\footnotesize \textbf{Also accepted:} palm leaf; leaves of palm
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/telugu/book/book.tex
+++ b/code/learning/human-languages/telugu/book/book.tex
@@ -123,5 +123,6 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \end{document}

--- a/code/learning/human-languages/telugu/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/telugu/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,31 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 1
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 31}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-TE-C31-subha-madhyahnam-register-source-scope}{\textbf{31.1}} \emph{\te{శుభ} \te{మధ్యాహ్నం} — register and evidence}\par
+\small Do both sources claim subha madhyahnam is less common?
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 31}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-TE-C31-subha-madhyahnam-register-source-scope}{\textbf{31.1}} \emph{\te{శుభ} \te{మధ్యాహ్నం} — register and evidence}\par
+\small \textbf{Answer:} no\par
+\footnotesize \textbf{Also accepted:} no they do not; only one source does
+\end{minipage}\par\medskip

--- a/code/learning/human-languages/urdu/book/book.tex
+++ b/code/learning/human-languages/urdu/book/book.tex
@@ -89,6 +89,7 @@ Released under CC~BY-SA~4.0 --- share it, adapt it, teach from it.
 
 \input{chapters/appendix-pronunciation}
 \input{chapters/appendix-glossary}
+\input{chapters/appendix-answer-key}
 
 \chapter*{A note on sources}
 \addcontentsline{toc}{chapter}{A note on sources}

--- a/code/learning/human-languages/urdu/book/chapters/appendix-answer-key.tex
+++ b/code/learning/human-languages/urdu/book/chapters/appendix-answer-key.tex
@@ -1,0 +1,379 @@
+% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.
+% canonical-activities: 25
+
+\chapter*{Review Questions}
+\addcontentsline{toc}{chapter}{Review Questions}
+\markboth{Review Questions}{Review Questions}
+
+Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.
+
+\section*{Chapter 2}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C02-mera-naam-sara}{\textbf{2.1}} \emph{\ur{میرا} \ur{نام} ... \ur{ہے} — my name is ...}\par
+\small Type the Urdu sentence 'My name is Sara.'
+\end{minipage}\par\medskip
+
+\section*{Chapter 3}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C03-aap-tum-tu-first-meeting}{\textbf{3.1}} \emph{\ur{آپ} / \ur{تم} / \ur{تو} — three relationships inside “you”}\par
+\small Type the Urdu 'you' safest in a first meeting.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C03-kya-what}{\textbf{3.2}} \emph{\ur{کیا} — what}\par
+\small Type Urdu for 'what'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C03-aap-ka-naam-kya-hai-question}{\textbf{3.3}} \emph{\ur{آپ} \ur{کا} \ur{نام} \ur{کیا} \ur{ہے؟} — ask a name respectfully}\par
+\small Type the respectful Urdu question 'What is your name?'
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C03-khushi-hui-close}{\textbf{3.4}} \emph{\ur{آپ} \ur{سے} \ur{مل} \ur{کر} \ur{خوشی} \ur{ہوئی} — pleased to meet you}\par
+\small Type the Urdu response 'Pleased to meet you.'
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C03-practice-next-line}{\textbf{3.5}} \emph{Practice — a complete Urdu name exchange}\par
+\small After someone asks \ur{آپ} \ur{کا} \ur{نام} \ur{کیا} \ur{ہے؟}, type the Urdu answer using Sara.
+\end{minipage}\par\medskip
+
+\section*{Chapter 4}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C04-kaise-kaisi-woman}{\textbf{4.1}} \emph{\ur{کیسے} / \ur{کیسی} — “how” follows the addressee}\par
+\small Type the Urdu 'how' form used when respectfully addressing a woman.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C04-aap-kaise-hain-man}{\textbf{4.2}} \emph{\ur{آپ} \ur{کیسے} \ur{ہیں؟} / \ur{آپ} \ur{کیسی} \ur{ہیں؟} — ask respectfully}\par
+\small Type the respectful Urdu question 'How are you?' addressed to a man.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C04-main-hun-frame}{\textbf{4.3}} \emph{\ur{میں} ... \ur{ہوں} — one frame for “I am ...”}\par
+\small Type the Urdu frame 'I am ...', leaving three dots for the state word.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C04-thik-well}{\textbf{4.4}} \emph{\ur{ٹھیک} — “fine,” “well,” and “correct”}\par
+\small Type the Urdu word meaning 'fine' or 'well'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C04-main-thik-hun-reply}{\textbf{4.5}} \emph{\ur{میں} \ur{ٹھیک} \ur{ہوں،} \ur{شکریہ} — “I am fine, thank you”}\par
+\small Reply in Urdu: 'I am fine, thank you.'
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C04-practice-next-line}{\textbf{4.6}} \emph{Practice — an Urdu wellbeing exchange}\par
+\small After \ur{آپ} \ur{کیسے} \ur{ہیں؟}, type the polite Urdu reply.
+\end{minipage}\par\medskip
+
+\section*{Chapter 5}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C05-khuda-meaning}{\textbf{5.1}} \emph{\ur{خدا} — the first half of an Urdu farewell}\par
+\small Type the Urdu word khudā, meaning 'God'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C05-hafiz-meaning}{\textbf{5.2}} \emph{\ur{حافظ} — “guardian” or “protector”}\par
+\small Type the Urdu word hāfiz, meaning 'guardian' or 'protector'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C05-khuda-hafiz-goodbye}{\textbf{5.3}} \emph{\ur{خدا} \ur{حافظ} — goodbye}\par
+\small Type the standard Urdu expression for 'goodbye'.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C05-practice-final-line}{\textbf{5.4}} \emph{Practice — open, check, and close}\par
+\small The short Urdu interaction is ending. Type the final expression.
+\end{minipage}\par\medskip
+
+\section*{Chapter 7}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C07-likhna-four-stems}{\textbf{7.1}} \emph{\ur{لکھنا} — “to write,” with nothing new left to decode}\par
+\small Type the Urdu verb meaning 'to write'.
+\end{minipage}\par\medskip
+
+\section*{Chapter 8}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C08-pasand-dative}{\textbf{8.1}} \emph{\ur{پسند} — Urdu does not like things; things please Urdu}\par
+\small Type the Urdu word for 'to me' — the form maiṅ takes when it cannot be the subject.
+\end{minipage}\par\medskip
+
+\section*{Chapter 9}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C09-bahan-agreement}{\textbf{9.1}} \emph{\ur{بہن} — \textquotedblleft{}sister,\textquotedblright{} and the word that makes \ur{میرا} move}\par
+\small Type the Urdu for 'my sister', choosing the correct form of my.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C09-khandan-sort}{\textbf{9.2}} \emph{\ur{خاندان} — \textquotedblleft{}family,\textquotedblright{} the word your three new nouns never needed}\par
+\small Type the Urdu word for 'family' — the loan that groups \ur{بھائی} and \ur{بہن} together.
+\end{minipage}\par\medskip
+
+\section*{Chapter 10}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C10-naak-reversal}{\textbf{10.1}} \emph{\ur{ناک} — \textquotedblleft{}nose,\textquotedblright{} the same three letters as \ur{کان}, backwards}\par
+\small Type the Urdu word for 'nose' — the same three letters as \ur{کان}, reversed.
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C10-munh-nun}{\textbf{10.2}} \emph{\ur{منہ} — \textquotedblleft{}mouth,\textquotedblright{} and the \ur{نون} \ur{آنکھ} already used without explaining}\par
+\small Which earlier body word in this chapter also used a plain \ur{نون} to mark a nasal vowel, unglossed at the time?
+\end{minipage}\par\medskip
+
+\section*{Chapter 11}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C11-dil-cousin}{\textbf{11.1}} \emph{\ur{دل} — \textquotedblleft{}heart,\textquotedblright{} Persian, and still a cousin of the English word}\par
+\small Is Urdu \ur{دل} related to Sanskrit hṛdaya, or is the resemblance a coincidence like \ur{پسند} and candēre?
+\end{minipage}\par\medskip
+
+\section*{Chapter 12}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C12-doodh-false-friend}{\textbf{12.1}} \emph{\ur{دودھ} — \textquotedblleft{}milk,\textquotedblright{} and a false friend worth naming before you fall for it}\par
+\small Which English word is the REAL cousin of \ur{دودھ} — dough, or doughty?
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hypertarget{review-UR-C12-roti-pasand}{\textbf{12.2}} \emph{\ur{روٹی} — \textquotedblleft{}bread,\textquotedblright{} and \ur{پسند} closes the chapter}\par
+\small Type the Urdu sentence 'I like bread.'
+\end{minipage}\par\medskip
+
+\chapter*{Answer Key}
+\addcontentsline{toc}{chapter}{Answer Key}
+\markboth{Answer Key}{Answer Key}
+
+The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.
+
+\section*{Chapter 2}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C02-mera-naam-sara}{\textbf{2.1}} \emph{\ur{میرا} \ur{نام} ... \ur{ہے} — my name is ...}\par
+\small \textbf{Answer:} \ur{میرا} \ur{نام} \ur{سارا} \ur{ہے}\par
+\footnotesize \textbf{Also accepted:} mera naam Sara hai; merā nām Sārā hai
+\end{minipage}\par\medskip
+
+\section*{Chapter 3}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C03-aap-tum-tu-first-meeting}{\textbf{3.1}} \emph{\ur{آپ} / \ur{تم} / \ur{تو} — three relationships inside “you”}\par
+\small \textbf{Answer:} \ur{آپ}\par
+\footnotesize \textbf{Also accepted:} aap; āp
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C03-kya-what}{\textbf{3.2}} \emph{\ur{کیا} — what}\par
+\small \textbf{Answer:} \ur{کیا}\par
+\footnotesize \textbf{Also accepted:} kya; kyā
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C03-aap-ka-naam-kya-hai-question}{\textbf{3.3}} \emph{\ur{آپ} \ur{کا} \ur{نام} \ur{کیا} \ur{ہے؟} — ask a name respectfully}\par
+\small \textbf{Answer:} \ur{آپ} \ur{کا} \ur{نام} \ur{کیا} \ur{ہے؟}\par
+\footnotesize \textbf{Also accepted:} \ur{آپ} \ur{کا} \ur{نام} \ur{کیا} \ur{ہے}; aap ka naam kya hai; āp kā nām kyā hai
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C03-khushi-hui-close}{\textbf{3.4}} \emph{\ur{آپ} \ur{سے} \ur{مل} \ur{کر} \ur{خوشی} \ur{ہوئی} — pleased to meet you}\par
+\small \textbf{Answer:} \ur{آپ} \ur{سے} \ur{مل} \ur{کر} \ur{خوشی} \ur{ہوئی}\par
+\footnotesize \textbf{Also accepted:} aap se mil kar khushi hui; āp se mil kar khushī huī
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C03-practice-next-line}{\textbf{3.5}} \emph{Practice — a complete Urdu name exchange}\par
+\small \textbf{Answer:} \ur{میرا} \ur{نام} \ur{سارا} \ur{ہے}\par
+\footnotesize \textbf{Also accepted:} mera naam Sara hai; merā nām Sārā hai
+\end{minipage}\par\medskip
+
+\section*{Chapter 4}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C04-kaise-kaisi-woman}{\textbf{4.1}} \emph{\ur{کیسے} / \ur{کیسی} — “how” follows the addressee}\par
+\small \textbf{Answer:} \ur{کیسی}\par
+\footnotesize \textbf{Also accepted:} kaisi; kaisī
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C04-aap-kaise-hain-man}{\textbf{4.2}} \emph{\ur{آپ} \ur{کیسے} \ur{ہیں؟} / \ur{آپ} \ur{کیسی} \ur{ہیں؟} — ask respectfully}\par
+\small \textbf{Answer:} \ur{آپ} \ur{کیسے} \ur{ہیں؟}\par
+\footnotesize \textbf{Also accepted:} \ur{آپ} \ur{کیسے} \ur{ہیں}; aap kaise hain; āp kaise haiṅ
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C04-main-hun-frame}{\textbf{4.3}} \emph{\ur{میں} ... \ur{ہوں} — one frame for “I am ...”}\par
+\small \textbf{Answer:} \ur{میں} ... \ur{ہوں}\par
+\footnotesize \textbf{Also accepted:} \ur{میں} \ur{۔۔۔} \ur{ہوں}; main ... hun; maiṅ ... hūṅ
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C04-thik-well}{\textbf{4.4}} \emph{\ur{ٹھیک} — “fine,” “well,” and “correct”}\par
+\small \textbf{Answer:} \ur{ٹھیک}\par
+\footnotesize \textbf{Also accepted:} thik; ṭhīk; theek
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C04-main-thik-hun-reply}{\textbf{4.5}} \emph{\ur{میں} \ur{ٹھیک} \ur{ہوں،} \ur{شکریہ} — “I am fine, thank you”}\par
+\small \textbf{Answer:} \ur{میں} \ur{ٹھیک} \ur{ہوں،} \ur{شکریہ}\par
+\footnotesize \textbf{Also accepted:} \ur{میں} \ur{ٹھیک} \ur{ہوں} \ur{شکریہ}; main thik hun shukriya; maiṅ ṭhīk hūṅ shukriyā
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C04-practice-next-line}{\textbf{4.6}} \emph{Practice — an Urdu wellbeing exchange}\par
+\small \textbf{Answer:} \ur{میں} \ur{ٹھیک} \ur{ہوں،} \ur{شکریہ}\par
+\footnotesize \textbf{Also accepted:} \ur{میں} \ur{ٹھیک} \ur{ہوں} \ur{شکریہ}; main thik hun shukriya; maiṅ ṭhīk hūṅ shukriyā
+\end{minipage}\par\medskip
+
+\section*{Chapter 5}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C05-khuda-meaning}{\textbf{5.1}} \emph{\ur{خدا} — the first half of an Urdu farewell}\par
+\small \textbf{Answer:} \ur{خدا}\par
+\footnotesize \textbf{Also accepted:} khuda; khudā; xuda; xudā
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C05-hafiz-meaning}{\textbf{5.2}} \emph{\ur{حافظ} — “guardian” or “protector”}\par
+\small \textbf{Answer:} \ur{حافظ}\par
+\footnotesize \textbf{Also accepted:} hafiz; hāfiz; haafiz; hafez
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C05-khuda-hafiz-goodbye}{\textbf{5.3}} \emph{\ur{خدا} \ur{حافظ} — goodbye}\par
+\small \textbf{Answer:} \ur{خدا} \ur{حافظ}\par
+\footnotesize \textbf{Also accepted:} khuda hafiz; khudā hāfiz; xuda hafiz; khudahafiz
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C05-practice-final-line}{\textbf{5.4}} \emph{Practice — open, check, and close}\par
+\small \textbf{Answer:} \ur{خدا} \ur{حافظ}\par
+\footnotesize \textbf{Also accepted:} khuda hafiz; khudā hāfiz; khudahafiz
+\end{minipage}\par\medskip
+
+\section*{Chapter 7}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C07-likhna-four-stems}{\textbf{7.1}} \emph{\ur{لکھنا} — “to write,” with nothing new left to decode}\par
+\small \textbf{Answer:} \ur{لکھنا}\par
+\footnotesize \textbf{Also accepted:} likhna; likhnā; likhnaa
+\end{minipage}\par\medskip
+
+\section*{Chapter 8}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C08-pasand-dative}{\textbf{8.1}} \emph{\ur{پسند} — Urdu does not like things; things please Urdu}\par
+\small \textbf{Answer:} \ur{مجھے}\par
+\footnotesize \textbf{Also accepted:} mujhe; mujhe.; mujhay
+\end{minipage}\par\medskip
+
+\section*{Chapter 9}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C09-bahan-agreement}{\textbf{9.1}} \emph{\ur{بہن} — \textquotedblleft{}sister,\textquotedblright{} and the word that makes \ur{میرا} move}\par
+\small \textbf{Answer:} \ur{میری} \ur{بہن}\par
+\footnotesize \textbf{Also accepted:} meri bahan; merī bahan
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C09-khandan-sort}{\textbf{9.2}} \emph{\ur{خاندان} — \textquotedblleft{}family,\textquotedblright{} the word your three new nouns never needed}\par
+\small \textbf{Answer:} \ur{خاندان}\par
+\footnotesize \textbf{Also accepted:} khandan; khāndān
+\end{minipage}\par\medskip
+
+\section*{Chapter 10}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C10-naak-reversal}{\textbf{10.1}} \emph{\ur{ناک} — \textquotedblleft{}nose,\textquotedblright{} the same three letters as \ur{کان}, backwards}\par
+\small \textbf{Answer:} \ur{ناک}\par
+\footnotesize \textbf{Also accepted:} naak; nāk
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C10-munh-nun}{\textbf{10.2}} \emph{\ur{منہ} — \textquotedblleft{}mouth,\textquotedblright{} and the \ur{نون} \ur{آنکھ} already used without explaining}\par
+\small \textbf{Answer:} \ur{آنکھ}\par
+\footnotesize \textbf{Also accepted:} aankh; āṅkh
+\end{minipage}\par\medskip
+
+\section*{Chapter 11}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C11-dil-cousin}{\textbf{11.1}} \emph{\ur{دل} — \textquotedblleft{}heart,\textquotedblright{} Persian, and still a cousin of the English word}\par
+\small \textbf{Answer:} related\par
+\footnotesize \textbf{Also accepted:} related, same root; same PIE root; cousins; yes, related
+\end{minipage}\par\medskip
+
+\section*{Chapter 12}
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C12-doodh-false-friend}{\textbf{12.1}} \emph{\ur{دودھ} — \textquotedblleft{}milk,\textquotedblright{} and a false friend worth naming before you fall for it}\par
+\small \textbf{Answer:} doughty\par
+\footnotesize \textbf{Also accepted:} doughty, not dough
+\end{minipage}\par\medskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\hyperlink{review-UR-C12-roti-pasand}{\textbf{12.2}} \emph{\ur{روٹی} — \textquotedblleft{}bread,\textquotedblright{} and \ur{پسند} closes the chapter}\par
+\small \textbf{Answer:} \ur{مجھے} \ur{روٹی} \ur{پسند} \ur{ہے}\par
+\footnotesize \textbf{Also accepted:} mujhe roti pasand hai; mujhe roṭī pasand hai
+\end{minipage}\par\medskip

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added - generated book review questions and answer keys
+
+- Render every executable `hl-activity` contract as a numbered review question
+  and answer-key entry, preserving the canonical display answer and all authored
+  accepted variants used by Language Ladder.
+- Byte-gate and include the generated back matter in all 22 books. French and
+  Bengali gain their first typed activity contracts so no volume ships an empty
+  key; legacy `[YOU ...]` delivery cues remain deliberately unscored.
+
 ### Added — generated book glossaries
 
 - Derive a compact glossary from every track's canonical word and phrase lessons,

--- a/code/packages/typescript/human-language-data/src/book-cli.ts
+++ b/code/packages/typescript/human-language-data/src/book-cli.ts
@@ -2,9 +2,11 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, normalize, relative as pathRelative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
+  renderBookAnswerKey,
   renderBookChapter,
   renderBookGlossary,
   renderReferenceAppendix,
+  type BookAnswerKeyTarget,
   type BookGenerationTarget,
   type BookGlossaryTarget,
   type BookReferenceAppendixTarget,
@@ -23,6 +25,11 @@ interface ConfiguredReferenceAppendixTarget extends BookReferenceAppendixTarget 
 }
 
 interface ConfiguredBookGlossaryTarget extends BookGlossaryTarget {
+  /** Named reusable mapping from the config's scriptSets table. */
+  scriptSet?: string;
+}
+
+interface ConfiguredBookAnswerKeyTarget extends BookAnswerKeyTarget {
   /** Named reusable mapping from the config's scriptSets table. */
   scriptSet?: string;
 }
@@ -64,6 +71,8 @@ interface BookGenerationConfig {
   referenceAppendices?: ConfiguredReferenceAppendixTarget[];
   /** Canonical word and phrase lessons rendered into book glossaries. */
   glossaries?: ConfiguredBookGlossaryTarget[];
+  /** Executable lesson activities rendered as review questions and answer keys. */
+  answerKeys?: ConfiguredBookAnswerKeyTarget[];
   /** Never rendered. See {@link HandwrittenBookChapter}. */
   handwritten?: HandwrittenBookChapter[];
 }
@@ -251,6 +260,31 @@ export function generatedBookOutputs(root = defaultCurriculumRoot()): Map<string
       throw new Error(`${glossary.output}: duplicate generated book output`);
     }
     outputs.set(glossary.output, renderBookGlossary(glossary, lessons));
+  }
+  for (const configuredAnswerKey of config.answerKeys ?? []) {
+    const { scriptSet, ...plainAnswerKey } = configuredAnswerKey;
+    let answerKey: BookAnswerKeyTarget = { ...plainAnswerKey };
+    if (scriptSet !== undefined) {
+      if (
+        answerKey.inlineScripts !== undefined ||
+        answerKey.unicodeScript !== undefined ||
+        answerKey.scriptCommand !== undefined
+      ) {
+        throw new Error(
+          `${answerKey.language} answer key: scriptSet cannot be combined with inline script options`,
+        );
+      }
+      const inlineScripts = config.scriptSets?.[scriptSet];
+      if (!inlineScripts) {
+        throw new Error(`${answerKey.language} answer key: unknown scriptSet '${scriptSet}'`);
+      }
+      answerKey = { ...answerKey, inlineScripts };
+    }
+    safeOutput(root, answerKey.output);
+    if (outputs.has(answerKey.output)) {
+      throw new Error(`${answerKey.output}: duplicate generated book output`);
+    }
+    outputs.set(answerKey.output, renderBookAnswerKey(answerKey, lessons));
   }
   manifest.chapters.sort(
     (left, right) => left.language.localeCompare(right.language) || left.chapter - right.chapter,

--- a/code/packages/typescript/human-language-data/src/book.ts
+++ b/code/packages/typescript/human-language-data/src/book.ts
@@ -1,6 +1,11 @@
 import { canonicalChapterHash } from "./hash.js";
 import { CONTENT_TYPES, hasOwn } from "./constants.js";
-import type { LessonBodyBlock, ChapterCapability } from "./types.js";
+import { compileLessonActivities } from "./activity.js";
+import type {
+  LessonBodyBlock,
+  ChapterCapability,
+  CompiledLessonActivity,
+} from "./types.js";
 import type { ParsedLesson } from "./parse.js";
 
 export interface BookGenerationTarget {
@@ -33,6 +38,18 @@ export interface BookReferenceAppendixTarget {
 
 /** A generated book glossary derived from canonical word and phrase lessons. */
 export interface BookGlossaryTarget {
+  language: string;
+  output: string;
+  /** Unicode Script property whose runs need the book's dedicated font command. */
+  unicodeScript?: string;
+  /** LaTeX command name, without the leading backslash, used for those runs. */
+  scriptCommand?: string;
+  /** Multiple script/font mappings for entries that compare writing systems inline. */
+  inlineScripts?: InlineRenderOptions[];
+}
+
+/** Generated review questions and answers sourced from executable lesson activities. */
+export interface BookAnswerKeyTarget {
   language: string;
   output: string;
   /** Unicode Script property whose runs need the book's dedicated font command. */
@@ -1118,6 +1135,126 @@ export function renderBookGlossary(
       `\\textbf{${headword}}${romanization}\\par`,
       `\\small ${gloss}\\par`,
       `\\footnotesize Introduced in ${chapterList(entry.chapters.sort((a, b) => a - b))}.`,
+      "\\end{minipage}\\par\\medskip",
+      "",
+    );
+  }
+  return `${output.join("\n").trimEnd()}\n`;
+}
+
+interface BookAnswerKeyEntry {
+  activity: CompiledLessonActivity;
+  chapter: number;
+  number: string;
+  lessonTitle: string;
+}
+
+/**
+ * Render the same executable retrieval contracts used by Language Ladder as
+ * printable end-of-book review questions and a separate answer key.
+ *
+ * The prompt is repeated in the review section because some canonical lessons
+ * still sit inside handwritten LaTeX chapters. Scraping those chapters or the
+ * legacy `[YOU ...]` delivery cues would create a second, untyped definition of
+ * correctness. Compiled activities are the only answer-bearing source.
+ */
+export function renderBookAnswerKey(
+  target: BookAnswerKeyTarget,
+  allLessons: ParsedLesson[],
+): string {
+  const renderOptions = targetRenderOptions(target, `${target.language} answer key`);
+  const lessons = allLessons
+    .filter((lesson) => lesson.language === target.language)
+    .sort(
+      (left, right) =>
+        left.realization.chapter - right.realization.chapter ||
+        lessonSequence(left) - lessonSequence(right) ||
+        left.realization.lessonId.localeCompare(right.realization.lessonId),
+    );
+  const chapterCounts = new Map<number, number>();
+  const activityIds = new Set<string>();
+  const entries: BookAnswerKeyEntry[] = [];
+
+  for (const lesson of lessons) {
+    const chapter = lesson.realization.chapter;
+    if (!Number.isInteger(chapter) || chapter < 1) {
+      throw new Error(`${lesson.realization.lessonId}: answer-key entries require a chapter`);
+    }
+    for (const activity of compileLessonActivities(lesson.blocks)) {
+      if (activityIds.has(activity.id)) {
+        throw new Error(`${target.language} answer key: duplicate activity id '${activity.id}'`);
+      }
+      activityIds.add(activity.id);
+      const inChapter = (chapterCounts.get(chapter) ?? 0) + 1;
+      chapterCounts.set(chapter, inChapter);
+      entries.push({
+        activity,
+        chapter,
+        number: `${chapter}.${inChapter}`,
+        lessonTitle: lessonTitle(lesson),
+      });
+    }
+  }
+  if (entries.length === 0) {
+    throw new Error(`${target.language} answer key: no compiled lesson activities`);
+  }
+
+  const output = [
+    "% GENERATED FILE. Edit canonical hl-activity contracts, then run npm run generate:books.",
+    `% canonical-activities: ${entries.length}`,
+    "",
+    "\\chapter*{Review Questions}",
+    "\\addcontentsline{toc}{chapter}{Review Questions}",
+    "\\markboth{Review Questions}{Review Questions}",
+    "",
+    "Try these without looking ahead. Every prompt comes from the same canonical lesson data as its chapter. Answers begin in the next section.",
+    "",
+  ];
+  let currentChapter: number | undefined;
+  for (const entry of entries) {
+    if (entry.chapter !== currentChapter) {
+      currentChapter = entry.chapter;
+      output.push(`\\section*{Chapter ${entry.chapter}}`, "");
+    }
+    const prompt = renderInlineMarkdown(entry.activity.prompt, renderOptions);
+    const title = renderInlineMarkdown(entry.lessonTitle, renderOptions);
+    output.push(
+      "\\noindent\\begin{minipage}[t]{\\linewidth}",
+      "\\raggedright",
+      `\\hypertarget{review-${entry.activity.id}}{\\textbf{${entry.number}}} \\emph{${title}}\\par`,
+      `\\small ${prompt}`,
+      "\\end{minipage}\\par\\medskip",
+      "",
+    );
+  }
+
+  output.push(
+    "\\chapter*{Answer Key}",
+    "\\addcontentsline{toc}{chapter}{Answer Key}",
+    "\\markboth{Answer Key}{Answer Key}",
+    "",
+    "The first response is the canonical display answer. When a question accepts other authored forms, they appear underneath.",
+    "",
+  );
+  currentChapter = undefined;
+  for (const entry of entries) {
+    if (entry.chapter !== currentChapter) {
+      currentChapter = entry.chapter;
+      output.push(`\\section*{Chapter ${entry.chapter}}`, "");
+    }
+    const answer = renderInlineMarkdown(entry.activity.answer, renderOptions);
+    const title = renderInlineMarkdown(entry.lessonTitle, renderOptions);
+    const accepted = entry.activity.accepted.map((variant) =>
+      renderInlineMarkdown(variant, renderOptions),
+    );
+    output.push(
+      "\\noindent\\begin{minipage}[t]{\\linewidth}",
+      "\\raggedright",
+      `\\hyperlink{review-${entry.activity.id}}{\\textbf{${entry.number}}} \\emph{${title}}\\par`,
+      `\\small \\textbf{Answer:} ${answer}\\par`,
+      ...(accepted.length > 0
+        ? [`\\footnotesize \\textbf{Also accepted:} ${accepted.join("; ")}`]
+        : []),
       "\\end{minipage}\\par\\medskip",
       "",
     );

--- a/code/packages/typescript/human-language-data/src/index.ts
+++ b/code/packages/typescript/human-language-data/src/index.ts
@@ -28,11 +28,13 @@ export {
 } from "./hash.js";
 export {
   renderInlineMarkdown,
+  renderBookAnswerKey,
   renderBookChapter,
   renderBookGlossary,
   renderReferenceAppendix,
   bookVoice,
   bookBlockTitle,
+  type BookAnswerKeyTarget,
   type BookGenerationTarget,
   type BookGlossaryTarget,
   type BookReferenceAppendixTarget,

--- a/code/packages/typescript/human-language-data/tests/book-cli.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book-cli.test.ts
@@ -199,6 +199,50 @@ describe("canonical book generator filesystem shell", () => {
     );
   });
 
+  it("writes and byte-checks configured canonical answer keys", () => {
+    const root = fixture();
+    const lessonPath = join(root, "test", "lessons", "hello.md");
+    writeFileSync(
+      lessonPath,
+      readFileSync(lessonPath, "utf8").replace(
+        "## Wrap-up Recall\n\nRead",
+        `## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TEST-HELLO] -->
+<!-- hl-activity: {"id":"TEST-C01-hello-recall","kind":"text","assesses":["TEST-HELLO"],"prompt":"Type the greeting.","answer":"hello","accepted":["hi"],"feedback":{"correct":"Right.","incorrect":"Try again."},"response_seconds":8} -->
+
+Read`,
+      ),
+    );
+    const configPath = join(root, "core", "book-generation.json");
+    const config = JSON.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
+    writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        ...config,
+        answerKeys: [{
+          language: "test",
+          output: "test/book/chapters/appendix-answer-key.tex",
+        }],
+      })}\n`,
+    );
+
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    expect(runBookGeneration(["--write"], root)).toBe(0);
+    const answerKey = join(root, "test", "book", "chapters", "appendix-answer-key.tex");
+    const generated = readFileSync(answerKey, "utf8");
+    expect(generated).toContain("\\chapter*{Review Questions}");
+    expect(generated).toContain("Type the greeting.");
+    expect(generated).toContain("\\textbf{Answer:} hello");
+    expect(runBookGeneration(["--check"], root)).toBe(0);
+
+    writeFileSync(answerKey, "stale\n");
+    expect(runBookGeneration(["--check"], root)).toBe(1);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      "test/book/chapters/appendix-answer-key.tex: generated output is missing or stale\n",
+    );
+  });
+
   it("rejects reference sources outside the curriculum root", () => {
     const root = fixture();
     const configPath = join(root, "core", "book-generation.json");
@@ -436,6 +480,29 @@ describe("glossary coverage", () => {
       expect(existsSync(join(root, relative)), `${id} glossary`).toBe(true);
       expect(readFileSync(join(root, id, "book", "book.tex"), "utf8"), `${id} book input`).toContain(
         "\\input{chapters/appendix-glossary}",
+      );
+    }
+  });
+});
+
+describe("answer-key coverage", () => {
+  const root = defaultCurriculumRoot();
+
+  it("generates, byte-gates, and includes a nonempty answer key in every registered book", () => {
+    const registry = JSON.parse(
+      readFileSync(join(root, "core", "languages.json"), "utf8"),
+    ) as { languages: Array<{ id: string }> };
+    const outputs = generatedBookOutputs(root);
+    expect(registry.languages.length).toBeGreaterThan(0);
+    for (const { id } of registry.languages) {
+      const relative = `${id}/book/chapters/appendix-answer-key.tex`;
+      expect(outputs.get(relative), relative).toMatch(/^% GENERATED FILE\./);
+      expect(outputs.get(relative), `${id} canonical activities`).toMatch(
+        /% canonical-activities: [1-9]\d*/,
+      );
+      expect(existsSync(join(root, relative)), `${id} answer key`).toBe(true);
+      expect(readFileSync(join(root, id, "book", "book.tex"), "utf8"), `${id} book input`).toContain(
+        "\\input{chapters/appendix-answer-key}",
       );
     }
   });

--- a/code/packages/typescript/human-language-data/tests/book.test.ts
+++ b/code/packages/typescript/human-language-data/tests/book.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   bookBlockTitle,
   bookVoice,
+  renderBookAnswerKey,
   renderBookChapter,
   renderBookGlossary,
   renderInlineMarkdown,
@@ -200,6 +201,97 @@ A [repository note](../data/script.json) and an [external source](https://exampl
         [lesson],
       ),
     ).toThrow(/require a chapter/);
+  });
+
+  it("renders compiled activities as linked review questions and answers", () => {
+    const withActivity = (
+      id: string,
+      sequence: number,
+      word: string,
+      activityId: string,
+      answer: string,
+    ) =>
+      parseLesson(
+        source(id, sequence, word).replace(
+          `## Wrap-up Recall\n\nSay *${word}*.`,
+          `## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TEST-RECALL] -->
+<!-- hl-activity: {"id":"${activityId}","kind":"text","assesses":["TEST-RECALL"],"prompt":"Type ${word}.","answer":"${answer}","accepted":["${word}-variant"],"feedback":{"correct":"Right.","incorrect":"Try again."},"response_seconds":8} -->
+
+Say *${word}*.`,
+        ),
+        "test",
+      );
+    const later = withActivity("B", 20, "bye", "TEST-bye", "goodbye");
+    const earlier = withActivity("A", 10, "hello", "TEST-hello", "hello");
+    const generated = renderBookAnswerKey(
+      { language: "test", output: "test/book/chapters/appendix-answer-key.tex" },
+      [later, earlier],
+    );
+
+    expect(generated).toContain("% canonical-activities: 2");
+    expect(generated).toContain("\\chapter*{Review Questions}");
+    expect(generated).toContain("\\hypertarget{review-TEST-hello}{\\textbf{1.1}}");
+    expect(generated).toContain("\\hypertarget{review-TEST-bye}{\\textbf{1.2}}");
+    expect(generated.indexOf("Type hello.")).toBeLessThan(generated.indexOf("Type bye."));
+    expect(generated).toContain("\\chapter*{Answer Key}");
+    expect(generated).toContain("\\hyperlink{review-TEST-hello}{\\textbf{1.1}}");
+    expect(generated).toContain("\\textbf{Answer:} hello");
+    expect(generated).toContain("\\textbf{Also accepted:} hello-variant");
+  });
+
+  it("uses the configured book font for target-script prompts and answers", () => {
+    const lesson = parseLesson(
+      source("A", 10, "namaste").replace(
+        "## Wrap-up Recall\n\nSay *namaste*.",
+        `## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TEST-RECALL] -->
+<!-- hl-activity: {"id":"TEST-namaste","kind":"text","assesses":["TEST-RECALL"],"prompt":"Type नमस्ते.","answer":"नमस्ते","accepted":["namaste"],"feedback":{"correct":"Right.","incorrect":"Try again."},"response_seconds":8} -->
+
+Say namaste.`,
+      ),
+      "test",
+      "devanagari",
+    );
+    const generated = renderBookAnswerKey(
+      {
+        language: "test",
+        output: "test/book/chapters/appendix-answer-key.tex",
+        unicodeScript: "Devanagari",
+        scriptCommand: "dv",
+      },
+      [lesson],
+    );
+    expect(generated).toContain("Type \\dv{नमस्ते}.");
+    expect(generated).toContain("\\textbf{Answer:} \\dv{नमस्ते}");
+  });
+
+  it("rejects empty answer keys and duplicate activity ids", () => {
+    const plain = parseLesson(source("A", 10, "hello"), "test");
+    const answerTarget = {
+      language: "test",
+      output: "test/book/chapters/appendix-answer-key.tex",
+    };
+    expect(() => renderBookAnswerKey(answerTarget, [plain])).toThrow(
+      /no compiled lesson activities/,
+    );
+
+    const activity = source("A", 10, "hello").replace(
+      "## Wrap-up Recall\n\nSay *hello*.",
+      `## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TEST-RECALL] -->
+<!-- hl-activity: {"id":"TEST-same","kind":"text","assesses":["TEST-RECALL"],"prompt":"Type hello.","answer":"hello","accepted":[],"feedback":{"correct":"Right.","incorrect":"Try again."},"response_seconds":8} -->
+
+Say hello.`,
+    );
+    const first = parseLesson(activity, "test");
+    const second = parseLesson(
+      activity.replace("id: A", "id: B").replace("sequence: 10", "sequence: 20"),
+      "test",
+    );
+    expect(() => renderBookAnswerKey(answerTarget, [first, second])).toThrow(
+      /duplicate activity id 'TEST-same'/,
+    );
   });
 
   it("keeps indented Markdown quote continuations in one LaTeX quote", () => {

--- a/code/packages/typescript/human-language-data/tests/integration.test.ts
+++ b/code/packages/typescript/human-language-data/tests/integration.test.ts
@@ -166,6 +166,7 @@ describe("real curriculum", () => {
     const activities = lessons.flatMap((lesson) => compileLessonActivities(lesson.blocks));
     expect(activities.map((activity) => activity.id).sort()).toEqual([
       "AR-W07-hook-family-ha-kha-dot-position",
+      "BN-C10-jol-water",
       "ES-C01-genero-gramatical-class-count",
       "ES-C01-practice-buenos-agreement",
       "ES-W03-question-span-roberto-outside",
@@ -198,6 +199,7 @@ describe("real curriculum", () => {
       "FA-C08-gereftan-stem",
       "FA-C08-komak-kardan-verb",
       "FA-C08-porsidan-stem",
+      "FR-C18-oui-negative",
       "GE-C17-kopf-haupt-compound-word",
       "GU-C06-number-histories-be-source",
       "HI-W01-shirorekha-na-ma-drawing-order",


### PR DESCRIPTION
## What changed

- generate standalone **Review Questions** and **Answer Key** back matter for all 22 human-language books from canonical schema-v2 `hl-activity` contracts
- preserve authored question order, source chapter and lesson context, canonical display answers, accepted variants, script fonts, and stable PDF hyperlinks
- byte-gate all 22 generated appendices through the shared book generator and consolidated all-books workflow
- backfill the first typed activity in French and Bengali, bringing the executable corpus to 115 activities across all 22 tracks
- explicitly ignore 5,255 legacy `[YOU ...]` delivery cues rather than guessing scoreable answers

## Why

The books need to work as complete standalone learning artifacts while sharing the same canonical curriculum and scoring contracts as Language Ladder. Generating this material keeps books and app practice aligned without duplicating or scraping prose.

## Validation

- `bash BUILD` — 26 files / 430 tests passing; 94.57% statements, 85.05% branches, 98.56% functions, 95.38% lines
- `npm run check:books` — all generated chapters and appendices byte-exact
- XeLaTeX compiled all 22 complete books successfully
- appendix-tail scan — no overfull/underfull boxes, missing glyphs, LaTeX warnings, hyperref warnings, or font warnings across all tracks
- rendered and visually inspected all 89 Review Questions / Answer Key pages, including representative Arabic, Bengali, Chinese, Cyrillic, Devanagari, Gurmukhi, Japanese, Persian, and Urdu pages