### PR TITLE
Add BJT ISC parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `ISC` base-collector leakage saturation
+  current with `C4 * IS` fallback semantics.
 - Validate and lower BJT model-card `NE` base-emitter leakage emission
   coefficient.
 - Validate and lower BJT model-card `ISE` base-emitter leakage saturation

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1296,6 +1296,9 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
         base_emitter_leakage_current = model.params.get(
             "ISE", model.params.get("C2", 0.0) * saturation_current
         )
+        base_collector_leakage_current = model.params.get(
+            "ISC", model.params.get("C4", 0.0) * saturation_current
+        )
         return BJT(
             name,
             fields[1],
@@ -1332,6 +1335,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Ikf=model.params.get("IKF", model.params.get("IK", 0.0)),
             Ise=base_emitter_leakage_current,
             Ne=model.params.get("NE", 1.0),
+            Isc=base_collector_leakage_current,
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2188,6 +2192,29 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or base_emitter_leakage_emission_coefficient <= 0.0
         ):
             raise NetlistParseError("BJT NE must be finite and positive")
+        base_collector_leakage_ratio = params.get("C4")
+        base_collector_leakage_current = params.get("ISC")
+        if (
+            base_collector_leakage_current is None
+            and base_collector_leakage_ratio is not None
+            and (
+                not math.isfinite(base_collector_leakage_ratio)
+                or base_collector_leakage_ratio < 0.0
+            )
+        ):
+            raise NetlistParseError("BJT C4 must be finite and non-negative")
+        if (
+            base_collector_leakage_current is None
+            and base_collector_leakage_ratio is not None
+        ):
+            base_collector_leakage_current = base_collector_leakage_ratio * params.get(
+                "IS", 1e-14
+            )
+        if base_collector_leakage_current is not None and (
+            not math.isfinite(base_collector_leakage_current)
+            or base_collector_leakage_current < 0.0
+        ):
+            raise NetlistParseError("BJT ISC must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1673,6 +1673,51 @@ def test_rejects_invalid_bjt_base_emitter_leakage_emission_coefficient(
         parse_netlist(f".model fast NPN(NE={value})")
 
 
+@pytest.mark.parametrize(
+    ("parameter", "value", "expected"),
+    [("ISC", "3p", 3e-12), ("C4", "2", 2e-14)],
+)
+def test_parse_bjt_base_collector_leakage_current(
+    parameter: str, value: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model fast NPN({parameter}={value})\nQ1 col base emit fast"
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Isc == expected
+
+
+def test_bjt_isc_takes_precedence_over_c4() -> None:
+    parsed = parse_netlist(
+        ".model fast NPN(IS=2p C4=-1 ISC=4p)\nQ1 col base emit fast"
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Isc == 4e-12
+
+
+@pytest.mark.parametrize("parameter", ["ISC", "C4"])
+@pytest.mark.parametrize("value", ["-1p", "1e999"])
+def test_rejects_invalid_bjt_base_collector_leakage_parameter(
+    parameter: str, value: str
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match=f"BJT {parameter} must be finite and non-negative",
+    ):
+        parse_netlist(f".model fast NPN({parameter}={value})")
+
+
+def test_rejects_non_finite_bjt_c4_derived_leakage_current() -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT ISC must be finite and non-negative"
+    ):
+        parse_netlist(".model fast NPN(IS=1e308 C4=2)")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `ISC` base-collector leakage saturation
+  current with `C4 * IS` fallback semantics.
 - Validate and lower BJT model-card `NE` base-emitter leakage emission
   coefficient.
 - Validate and lower BJT model-card `ISE` base-emitter leakage saturation

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1461,6 +1461,27 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT NE must be finite and positive");
   }
+  const bjtBaseCollectorLeakageRatio = params.get("C4");
+  const explicitBjtBaseCollectorLeakageCurrent = params.get("ISC");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    explicitBjtBaseCollectorLeakageCurrent === undefined &&
+    bjtBaseCollectorLeakageRatio !== undefined &&
+    (!Number.isFinite(bjtBaseCollectorLeakageRatio) || bjtBaseCollectorLeakageRatio < 0.0)
+  ) {
+    throw new NetlistParseError("BJT C4 must be finite and non-negative");
+  }
+  const bjtBaseCollectorLeakageCurrent = explicitBjtBaseCollectorLeakageCurrent ??
+    (bjtBaseCollectorLeakageRatio === undefined
+      ? undefined
+      : bjtBaseCollectorLeakageRatio * (params.get("IS") ?? 1.0e-14));
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtBaseCollectorLeakageCurrent !== undefined &&
+    (!Number.isFinite(bjtBaseCollectorLeakageCurrent) || bjtBaseCollectorLeakageCurrent < 0.0)
+  ) {
+    throw new NetlistParseError("BJT ISC must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2152,6 +2173,8 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
     const saturationCurrent = model.params.get("IS") ?? 1.0e-14;
     const baseEmitterLeakageCurrent = model.params.get("ISE") ??
       (model.params.get("C2") ?? 0.0) * saturationCurrent;
+    const baseCollectorLeakageCurrent = model.params.get("ISC") ??
+      (model.params.get("C4") ?? 0.0) * saturationCurrent;
     return bjt(
       name,
       fields[1],
@@ -2189,6 +2212,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("IKF") ?? model.params.get("IK") ?? 0.0,
       baseEmitterLeakageCurrent,
       model.params.get("NE") ?? 1.0,
+      baseCollectorLeakageCurrent,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1743,6 +1743,44 @@ Q1 col base emit fast
     },
   );
 
+  it.each([
+    ["ISC", "3p", 3.0e-12],
+    ["C4", "2", 2.0e-14],
+  ])("parses BJT base-collector leakage parameter %s=%s", (parameter, value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(${parameter}=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseCollectorLeakageSaturationCurrent: expected,
+    });
+  });
+
+  it("gives BJT ISC precedence over C4", () => {
+    const parsed = parseNetlist(`.model fast NPN(IS=2p C4=-1 ISC=4p)\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseCollectorLeakageSaturationCurrent: 4.0e-12,
+    });
+  });
+
+  it.each([
+    ["ISC", "-1p"],
+    ["ISC", "1e999"],
+    ["C4", "-1"],
+    ["C4", "1e999"],
+  ])("rejects invalid BJT base-collector leakage parameter %s=%s", (parameter, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${parameter}=${value})`)).toThrow(
+      `BJT ${parameter} must be finite and non-negative`,
+    );
+  });
+
+  it("rejects a non-finite BJT C4-derived leakage current", () => {
+    expect(() => parseNetlist(`.model fast NPN(IS=1e308 C4=2)`)).toThrow(
+      "BJT ISC must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4605,9 +4605,15 @@ the Rust, Python, and TypeScript surfaces together.
      and reject non-finite derived currents before lowering.
 
 454. Python and TypeScript Berkeley SPICE BJT base-emitter-leakage-emission parity.
-   - Status: implemented in this BJT NE parity slice.
+   - Status: completed in PR 10119.
    - Both parser facades validate positive finite `NE` values and lower them
      into the shared engine base-emitter-leakage-emission-coefficient field.
+
+455. Python and TypeScript Berkeley SPICE BJT base-collector-leakage parity.
+   - Status: implemented in this BJT ISC parity slice.
+   - Both parser facades validate finite, non-negative `ISC` currents and `C4`
+     ratios, prefer canonical `ISC`, preserve the engine's `C4 * IS` fallback,
+     and reject non-finite derived currents before lowering.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate and lower BJT `ISC` base-collector leakage saturation current in Python and TypeScript parser facades
- preserve canonical `ISC` precedence and the engine-compatible `C4 * IS` fallback, including derived-overflow rejection
- add parity tests, changelogs, and SPICE plan item 455

## Validation
- Python parser `bash BUILD`: 540 passed, 90.12% coverage
- Python parser `.venv/bin/ruff check .`: passed
- TypeScript parser `bash BUILD`: 525 passed
- TypeScript parser `npx vitest run --coverage`: 87.64% line coverage
- TypeScript engine `bash BUILD`: 448 passed
- `git diff --check`: passed
- BUILD/runtime dependency audit: existing engine dependencies present; no manifest changes