### PR TITLE
Add BJT NC parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `NC` base-collector leakage emission
+  coefficient.
 - Validate and lower BJT model-card `ISC` base-collector leakage saturation
   current with `C4 * IS` fallback semantics.
 - Validate and lower BJT model-card `NE` base-emitter leakage emission

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1336,6 +1336,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Ise=base_emitter_leakage_current,
             Ne=model.params.get("NE", 1.0),
             Isc=base_collector_leakage_current,
+            Nc=model.params.get("NC", 2.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2215,6 +2216,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or base_collector_leakage_current < 0.0
         ):
             raise NetlistParseError("BJT ISC must be finite and non-negative")
+        base_collector_leakage_emission_coefficient = params.get("NC")
+        if base_collector_leakage_emission_coefficient is not None and (
+            not math.isfinite(base_collector_leakage_emission_coefficient)
+            or base_collector_leakage_emission_coefficient <= 0.0
+        ):
+            raise NetlistParseError("BJT NC must be finite and positive")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1718,6 +1718,25 @@ def test_rejects_non_finite_bjt_c4_derived_leakage_current() -> None:
         parse_netlist(".model fast NPN(IS=1e308 C4=2)")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0.5", 0.5), ("2", 2.0)])
+def test_parse_bjt_base_collector_leakage_emission_coefficient(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model fast NPN(NC={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Nc == expected
+
+
+@pytest.mark.parametrize("value", ["0", "-0.1", "1e999"])
+def test_rejects_invalid_bjt_base_collector_leakage_emission_coefficient(
+    value: str,
+) -> None:
+    with pytest.raises(NetlistParseError, match="BJT NC must be finite and positive"):
+        parse_netlist(f".model fast NPN(NC={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `NC` base-collector leakage emission
+  coefficient.
 - Validate and lower BJT model-card `ISC` base-collector leakage saturation
   current with `C4 * IS` fallback semantics.
 - Validate and lower BJT model-card `NE` base-emitter leakage emission

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1482,6 +1482,15 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT ISC must be finite and non-negative");
   }
+  const bjtBaseCollectorLeakageEmissionCoefficient = params.get("NC");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtBaseCollectorLeakageEmissionCoefficient !== undefined &&
+    (!Number.isFinite(bjtBaseCollectorLeakageEmissionCoefficient) ||
+      bjtBaseCollectorLeakageEmissionCoefficient <= 0.0)
+  ) {
+    throw new NetlistParseError("BJT NC must be finite and positive");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2213,6 +2222,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       baseEmitterLeakageCurrent,
       model.params.get("NE") ?? 1.0,
       baseCollectorLeakageCurrent,
+      model.params.get("NC") ?? 2.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1781,6 +1781,27 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0.5", 0.5],
+    ["2", 2.0],
+  ])("parses BJT base-collector leakage emission coefficient NC=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(NC=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseCollectorLeakageEmissionCoefficient: expected,
+    });
+  });
+
+  it.each(["0", "-0.1", "1e999"])(
+    "rejects invalid BJT base-collector leakage emission coefficient NC=%s",
+    (value) => {
+      expect(() => parseNetlist(`.model fast NPN(NC=${value})`)).toThrow(
+        "BJT NC must be finite and positive",
+      );
+    },
+  );
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4610,10 +4610,15 @@ the Rust, Python, and TypeScript surfaces together.
      into the shared engine base-emitter-leakage-emission-coefficient field.
 
 455. Python and TypeScript Berkeley SPICE BJT base-collector-leakage parity.
-   - Status: implemented in this BJT ISC parity slice.
+   - Status: completed in PR 10121.
    - Both parser facades validate finite, non-negative `ISC` currents and `C4`
      ratios, prefer canonical `ISC`, preserve the engine's `C4 * IS` fallback,
      and reject non-finite derived currents before lowering.
+
+456. Python and TypeScript Berkeley SPICE BJT base-collector-leakage-emission parity.
+   - Status: implemented in this BJT NC parity slice.
+   - Both parser facades validate positive finite `NC` values and lower them
+     into the shared engine base-collector-leakage-emission-coefficient field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate positive finite BJT `NC` values in the Python and TypeScript parser facades
- lower `NC` into the shared engine base-collector leakage emission coefficient while preserving the engine default
- add parity tests, changelogs, and SPICE plan item 456

## Validation
- Python parser `bash BUILD`: 545 passed, 90.14% coverage
- Python parser `.venv/bin/ruff check .`: passed
- TypeScript parser `bash BUILD`: 530 passed
- TypeScript parser `npx vitest run --coverage`: 87.67% line coverage
- TypeScript engine `bash BUILD`: 448 passed
- `git diff --check`: passed
- BUILD/runtime dependency audit: existing engine dependencies present; no manifest changes