### PR TITLE
Add BJT XTB parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `XTB` forward-beta temperature exponent.
 - Validate and lower BJT model-card `NC` base-collector leakage emission
   coefficient.
 - Validate and lower BJT model-card `ISC` base-collector leakage saturation

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1337,6 +1337,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Ne=model.params.get("NE", 1.0),
             Isc=base_collector_leakage_current,
             Nc=model.params.get("NC", 2.0),
+            Xtb=model.params.get("XTB", 0.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2222,6 +2223,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or base_collector_leakage_emission_coefficient <= 0.0
         ):
             raise NetlistParseError("BJT NC must be finite and positive")
+        forward_beta_temperature_exponent = params.get("XTB")
+        if forward_beta_temperature_exponent is not None and not math.isfinite(
+            forward_beta_temperature_exponent
+        ):
+            raise NetlistParseError("BJT XTB must be finite")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1737,6 +1737,22 @@ def test_rejects_invalid_bjt_base_collector_leakage_emission_coefficient(
         parse_netlist(f".model fast NPN(NC={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("-1", -1.0), ("2", 2.0)])
+def test_parse_bjt_forward_beta_temperature_exponent(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model fast NPN(XTB={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Xtb == expected
+
+
+def test_rejects_non_finite_bjt_forward_beta_temperature_exponent() -> None:
+    with pytest.raises(NetlistParseError, match="BJT XTB must be finite"):
+        parse_netlist(".model fast NPN(XTB=1e999)")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `XTB` forward-beta temperature exponent.
 - Validate and lower BJT model-card `NC` base-collector leakage emission
   coefficient.
 - Validate and lower BJT model-card `ISC` base-collector leakage saturation

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1491,6 +1491,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT NC must be finite and positive");
   }
+  const bjtForwardBetaTemperatureExponent = params.get("XTB");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtForwardBetaTemperatureExponent !== undefined &&
+    !Number.isFinite(bjtForwardBetaTemperatureExponent)
+  ) {
+    throw new NetlistParseError("BJT XTB must be finite");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2223,6 +2231,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("NE") ?? 1.0,
       baseCollectorLeakageCurrent,
       model.params.get("NC") ?? 2.0,
+      model.params.get("XTB") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1802,6 +1802,24 @@ Q1 col base emit fast
     },
   );
 
+  it.each([
+    ["-1", -1.0],
+    ["2", 2.0],
+  ])("parses BJT forward-beta temperature exponent XTB=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(XTB=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      forwardBetaTemperatureExponent: expected,
+    });
+  });
+
+  it("rejects a non-finite BJT forward-beta temperature exponent", () => {
+    expect(() => parseNetlist(`.model fast NPN(XTB=1e999)`)).toThrow(
+      "BJT XTB must be finite",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4616,9 +4616,14 @@ the Rust, Python, and TypeScript surfaces together.
      and reject non-finite derived currents before lowering.
 
 456. Python and TypeScript Berkeley SPICE BJT base-collector-leakage-emission parity.
-   - Status: implemented in this BJT NC parity slice.
+   - Status: completed in PR 10122.
    - Both parser facades validate positive finite `NC` values and lower them
      into the shared engine base-collector-leakage-emission-coefficient field.
+
+457. Python and TypeScript Berkeley SPICE BJT forward-beta-temperature parity.
+   - Status: implemented in this BJT XTB parity slice.
+   - Both parser facades validate finite `XTB` values and lower them into the
+     shared engine forward-beta-temperature-exponent field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite BJT `XTB` values in the Python and TypeScript parser facades
- lower `XTB` into the shared engine forward-beta temperature exponent while preserving the zero default
- add parity tests, changelogs, and SPICE plan item 457

## Validation
- Python parser `bash BUILD`: 548 passed, 90.16% coverage
- Python parser `.venv/bin/ruff check .`: passed
- TypeScript parser `bash BUILD`: 533 passed
- TypeScript parser `npx vitest run --coverage`: 87.70% line coverage
- TypeScript engine `bash BUILD`: 448 passed
- `git diff --check`: passed
- BUILD/runtime dependency audit: existing engine dependencies present; no manifest changes