### PR TITLE
Add BJT BR parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `BR` / `BETA_R` reverse beta.
 - Validate and lower BJT model-card `XTB` forward-beta temperature exponent.
 - Validate and lower BJT model-card `NC` base-collector leakage emission
   coefficient.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1338,6 +1338,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Isc=base_collector_leakage_current,
             Nc=model.params.get("NC", 2.0),
             Xtb=model.params.get("XTB", 0.0),
+            beta_r=model.params.get("BR", model.params.get("BETA_R", 1.0)),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2228,6 +2229,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             forward_beta_temperature_exponent
         ):
             raise NetlistParseError("BJT XTB must be finite")
+        reverse_beta = params.get("BR", params.get("BETA_R"))
+        if reverse_beta is not None and (
+            not math.isfinite(reverse_beta) or reverse_beta <= 0.0
+        ):
+            raise NetlistParseError("BJT BR must be finite and positive")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1753,6 +1753,34 @@ def test_rejects_non_finite_bjt_forward_beta_temperature_exponent() -> None:
         parse_netlist(".model fast NPN(XTB=1e999)")
 
 
+@pytest.mark.parametrize("alias", ["BR", "BETA_R"])
+def test_parse_bjt_reverse_beta(alias: str) -> None:
+    parsed = parse_netlist(
+        f".model fast NPN({alias}=25)\nQ1 col base emit fast"
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.beta_r == 25.0
+
+
+def test_bjt_br_takes_precedence_over_beta_r() -> None:
+    parsed = parse_netlist(
+        ".model fast NPN(BETA_R=-1 BR=30)\nQ1 col base emit fast"
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.beta_r == 30.0
+
+
+@pytest.mark.parametrize("alias", ["BR", "BETA_R"])
+@pytest.mark.parametrize("value", ["0", "-1", "1e999"])
+def test_rejects_invalid_bjt_reverse_beta(alias: str, value: str) -> None:
+    with pytest.raises(NetlistParseError, match="BJT BR must be finite and positive"):
+        parse_netlist(f".model fast NPN({alias}={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `BR` / `BETA_R` reverse beta.
 - Validate and lower BJT model-card `XTB` forward-beta temperature exponent.
 - Validate and lower BJT model-card `NC` base-collector leakage emission
   coefficient.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1499,6 +1499,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT XTB must be finite");
   }
+  const bjtReverseBeta = params.get("BR") ?? params.get("BETA_R");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtReverseBeta !== undefined &&
+    (!Number.isFinite(bjtReverseBeta) || bjtReverseBeta <= 0.0)
+  ) {
+    throw new NetlistParseError("BJT BR must be finite and positive");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2232,6 +2240,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       baseCollectorLeakageCurrent,
       model.params.get("NC") ?? 2.0,
       model.params.get("XTB") ?? 0.0,
+      model.params.get("BR") ?? model.params.get("BETA_R") ?? 1.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1820,6 +1820,37 @@ Q1 col base emit fast
     );
   });
 
+  it.each(["BR", "BETA_R"])("parses BJT reverse beta %s", (alias) => {
+    const parsed = parseNetlist(`.model fast NPN(${alias}=25)\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      reverseBeta: 25.0,
+    });
+  });
+
+  it("gives BJT BR precedence over BETA_R", () => {
+    const parsed = parseNetlist(`.model fast NPN(BETA_R=-1 BR=30)\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      reverseBeta: 30.0,
+    });
+  });
+
+  it.each([
+    ["BR", "0"],
+    ["BR", "-1"],
+    ["BR", "1e999"],
+    ["BETA_R", "0"],
+    ["BETA_R", "-1"],
+    ["BETA_R", "1e999"],
+  ])("rejects invalid BJT reverse beta %s=%s", (alias, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${alias}=${value})`)).toThrow(
+      "BJT BR must be finite and positive",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4621,9 +4621,15 @@ the Rust, Python, and TypeScript surfaces together.
      into the shared engine base-collector-leakage-emission-coefficient field.
 
 457. Python and TypeScript Berkeley SPICE BJT forward-beta-temperature parity.
-   - Status: implemented in this BJT XTB parity slice.
+   - Status: completed in PR 10123.
    - Both parser facades validate finite `XTB` values and lower them into the
      shared engine forward-beta-temperature-exponent field.
+
+458. Python and TypeScript Berkeley SPICE BJT reverse-beta parity.
+   - Status: implemented in this BJT BR parity slice.
+   - Both parser facades validate positive finite `BR` / `BETA_R` values,
+     prefer canonical `BR`, and lower the result into the shared engine
+     reverse-beta field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate positive finite BJT `BR` / `BETA_R` values in the Python and TypeScript parser facades
- preserve canonical `BR` precedence and lower the result into the shared engine reverse-beta field
- add alias, precedence, rejection, changelog, and SPICE plan coverage

## Validation
- Python parser `bash BUILD`: 557 passed, 90.18% coverage
- Python parser `.venv/bin/ruff check .`: passed
- TypeScript parser `bash BUILD`: 542 passed
- TypeScript parser `npx vitest run --coverage`: 87.73% line coverage
- TypeScript engine `bash BUILD`: 448 passed
- `git diff --check`: passed
- BUILD/runtime dependency audit: existing engine dependencies present; no manifest changes