### PR TITLE
Add BJT IKR parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `IKR` reverse beta roll-off current.
 - Validate and lower BJT model-card `BR` / `BETA_R` reverse beta.
 - Validate and lower BJT model-card `XTB` forward-beta temperature exponent.
 - Validate and lower BJT model-card `NC` base-collector leakage emission

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1339,6 +1339,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Nc=model.params.get("NC", 2.0),
             Xtb=model.params.get("XTB", 0.0),
             beta_r=model.params.get("BR", model.params.get("BETA_R", 1.0)),
+            Ikr=model.params.get("IKR", 0.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2234,6 +2235,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(reverse_beta) or reverse_beta <= 0.0
         ):
             raise NetlistParseError("BJT BR must be finite and positive")
+        reverse_beta_rolloff_current = params.get("IKR")
+        if reverse_beta_rolloff_current is not None and (
+            not math.isfinite(reverse_beta_rolloff_current)
+            or reverse_beta_rolloff_current < 0.0
+        ):
+            raise NetlistParseError("BJT IKR must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1781,6 +1781,25 @@ def test_rejects_invalid_bjt_reverse_beta(alias: str, value: str) -> None:
         parse_netlist(f".model fast NPN({alias}={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("2m", 2e-3)])
+def test_parse_bjt_reverse_beta_rolloff_current(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model fast NPN(IKR={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Ikr == expected
+
+
+@pytest.mark.parametrize("value", ["-1m", "1e999"])
+def test_rejects_invalid_bjt_reverse_beta_rolloff_current(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT IKR must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN(IKR={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `IKR` reverse beta roll-off current.
 - Validate and lower BJT model-card `BR` / `BETA_R` reverse beta.
 - Validate and lower BJT model-card `XTB` forward-beta temperature exponent.
 - Validate and lower BJT model-card `NC` base-collector leakage emission

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1507,6 +1507,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT BR must be finite and positive");
   }
+  const bjtReverseBetaRolloffCurrent = params.get("IKR");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtReverseBetaRolloffCurrent !== undefined &&
+    (!Number.isFinite(bjtReverseBetaRolloffCurrent) || bjtReverseBetaRolloffCurrent < 0.0)
+  ) {
+    throw new NetlistParseError("BJT IKR must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2241,6 +2249,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("NC") ?? 2.0,
       model.params.get("XTB") ?? 0.0,
       model.params.get("BR") ?? model.params.get("BETA_R") ?? 1.0,
+      model.params.get("IKR") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1851,6 +1851,24 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["2m", 2.0e-3],
+  ])("parses BJT reverse-beta roll-off current IKR=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(IKR=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      reverseBetaRolloffCurrent: expected,
+    });
+  });
+
+  it.each(["-1m", "1e999"])("rejects invalid BJT IKR=%s", (value) => {
+    expect(() => parseNetlist(`.model fast NPN(IKR=${value})`)).toThrow(
+      "BJT IKR must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4626,10 +4626,15 @@ the Rust, Python, and TypeScript surfaces together.
      shared engine forward-beta-temperature-exponent field.
 
 458. Python and TypeScript Berkeley SPICE BJT reverse-beta parity.
-   - Status: implemented in this BJT BR parity slice.
+   - Status: completed in PR 10125.
    - Both parser facades validate positive finite `BR` / `BETA_R` values,
      prefer canonical `BR`, and lower the result into the shared engine
      reverse-beta field.
+
+459. Python and TypeScript Berkeley SPICE BJT reverse-beta-roll-off parity.
+   - Status: implemented in this BJT IKR parity slice.
+   - Both parser facades validate finite, non-negative `IKR` values and lower
+     them into the shared engine reverse-beta-roll-off-current field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite non-negative BJT `IKR` values in the Python and TypeScript parser facades
- lower `IKR` into the shared engine reverse-beta roll-off current while preserving zero-as-disabled semantics
- add parity tests, changelogs, and SPICE plan item 459

## Validation
- Python parser `bash BUILD`: 561 passed, 90.20% coverage
- Python parser `.venv/bin/ruff check .`: passed
- TypeScript parser `bash BUILD`: 546 passed
- TypeScript parser `npx vitest run --coverage`: 87.77% line coverage
- TypeScript engine `bash BUILD`: 448 passed
- `git diff --check`: passed
- BUILD/runtime dependency audit: existing engine dependencies present; no manifest changes