### PR TITLE
Add BJT TNOM parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `TNOM` / `T_NOM` nominal temperature.
 - Validate and lower BJT model-card `IKR` reverse beta roll-off current.
 - Validate and lower BJT model-card `BR` / `BETA_R` reverse beta.
 - Validate and lower BJT model-card `XTB` forward-beta temperature exponent.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1299,6 +1299,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
         base_collector_leakage_current = model.params.get(
             "ISC", model.params.get("C4", 0.0) * saturation_current
         )
+        nominal_temperature = model.params.get("T_NOM", model.params.get("TNOM"))
         return BJT(
             name,
             fields[1],
@@ -1340,6 +1341,9 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Xtb=model.params.get("XTB", 0.0),
             beta_r=model.params.get("BR", model.params.get("BETA_R", 1.0)),
             Ikr=model.params.get("IKR", 0.0),
+            Tnom=(
+                nominal_temperature + 273.15 if nominal_temperature is not None else None
+            ),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2241,6 +2245,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or reverse_beta_rolloff_current < 0.0
         ):
             raise NetlistParseError("BJT IKR must be finite and non-negative")
+        nominal_temperature = params.get("T_NOM", params.get("TNOM"))
+        if nominal_temperature is not None and (
+            not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0
+        ):
+            raise NetlistParseError("BJT TNOM must be finite and positive")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1800,6 +1800,36 @@ def test_rejects_invalid_bjt_reverse_beta_rolloff_current(value: str) -> None:
         parse_netlist(f".model fast NPN(IKR={value})")
 
 
+@pytest.mark.parametrize(("alias", "value"), [("TNOM", "50"), ("T_NOM", "75")])
+def test_parse_bjt_nominal_temperature(alias: str, value: str) -> None:
+    parsed = parse_netlist(
+        f".model fast NPN({alias}={value})\nQ1 col base emit fast"
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Tnom == pytest.approx(float(value) + 273.15)
+
+
+def test_bjt_t_nom_takes_precedence_over_tnom() -> None:
+    parsed = parse_netlist(
+        ".model fast NPN(TNOM=-1 T_NOM=50)\nQ1 col base emit fast"
+    )
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Tnom == pytest.approx(323.15)
+
+
+@pytest.mark.parametrize("alias", ["TNOM", "T_NOM"])
+@pytest.mark.parametrize("value", ["0", "-1", "1e999"])
+def test_rejects_invalid_bjt_nominal_temperature(alias: str, value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT TNOM must be finite and positive"
+    ):
+        parse_netlist(f".model fast NPN({alias}={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `TNOM` / `T_NOM` nominal temperature.
 - Validate and lower BJT model-card `IKR` reverse beta roll-off current.
 - Validate and lower BJT model-card `BR` / `BETA_R` reverse beta.
 - Validate and lower BJT model-card `XTB` forward-beta temperature exponent.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1515,6 +1515,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT IKR must be finite and non-negative");
   }
+  const bjtNominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtNominalTemperature !== undefined &&
+    (!Number.isFinite(bjtNominalTemperature) || bjtNominalTemperature <= 0.0)
+  ) {
+    throw new NetlistParseError("BJT TNOM must be finite and positive");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2208,6 +2216,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       (model.params.get("C2") ?? 0.0) * saturationCurrent;
     const baseCollectorLeakageCurrent = model.params.get("ISC") ??
       (model.params.get("C4") ?? 0.0) * saturationCurrent;
+    const nominalTemperature = model.params.get("T_NOM") ?? model.params.get("TNOM");
     return bjt(
       name,
       fields[1],
@@ -2250,6 +2259,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("XTB") ?? 0.0,
       model.params.get("BR") ?? model.params.get("BETA_R") ?? 1.0,
       model.params.get("IKR") ?? 0.0,
+      nominalTemperature !== undefined ? nominalTemperature + 273.15 : undefined,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1869,6 +1869,40 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["TNOM", "50"],
+    ["T_NOM", "75"],
+  ])("parses BJT nominal temperature %s=%s", (alias, value) => {
+    const parsed = parseNetlist(`.model fast NPN(${alias}=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      nominalTemperatureKelvin: Number(value) + 273.15,
+    });
+  });
+
+  it("gives BJT T_NOM precedence over TNOM", () => {
+    const parsed = parseNetlist(`.model fast NPN(TNOM=-1 T_NOM=50)\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      nominalTemperatureKelvin: 323.15,
+    });
+  });
+
+  it.each([
+    ["TNOM", "0"],
+    ["TNOM", "-1"],
+    ["TNOM", "1e999"],
+    ["T_NOM", "0"],
+    ["T_NOM", "-1"],
+    ["T_NOM", "1e999"],
+  ])("rejects invalid BJT nominal temperature %s=%s", (alias, value) => {
+    expect(() => parseNetlist(`.model fast NPN(${alias}=${value})`)).toThrow(
+      "BJT TNOM must be finite and positive",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4632,9 +4632,15 @@ the Rust, Python, and TypeScript surfaces together.
      reverse-beta field.
 
 459. Python and TypeScript Berkeley SPICE BJT reverse-beta-roll-off parity.
-   - Status: implemented in this BJT IKR parity slice.
+   - Status: completed in PR 10126.
    - Both parser facades validate finite, non-negative `IKR` values and lower
      them into the shared engine reverse-beta-roll-off-current field.
+
+460. Python and TypeScript Berkeley SPICE BJT nominal-temperature parity.
+   - Status: implemented in this BJT TNOM parity slice.
+   - Both parser facades validate positive finite `TNOM` / `T_NOM` values,
+     prefer `T_NOM`, convert Celsius model-card values to Kelvin, and lower the
+     result into the shared engine nominal-temperature field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate positive finite BJT `TNOM` / `T_NOM` values in the Python and TypeScript parser facades
- preserve `T_NOM` precedence and convert Celsius card values to Kelvin for the shared engine
- add alias, precedence, rejection, changelog, and SPICE plan coverage

## Validation
- Python parser `bash BUILD`: 570 passed, 90.23% coverage
- Python parser `.venv/bin/ruff check .`: passed
- TypeScript parser `bash BUILD`: 555 passed
- TypeScript parser `npx vitest run --coverage`: 87.81% line coverage
- TypeScript engine `bash BUILD`: 448 passed
- `git diff --check`: passed
- BUILD/runtime dependency audit: existing engine dependencies present; no manifest changes