### PR TITLE
Complete handwritten chapter capabilities

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -5,12 +5,22 @@ and Language Ladder. Reprioritize it after every merged work item. Add newly
 discovered work here before starting it so the repository, rather than an agent
 session, remains the source of truth.
 
-Last prioritized: 2026-08-08, after HL-C50D entered #10124. With all 22
-downloadable books now carrying pronunciation, glossary, review-question,
-answer-key, and English-first index back matter, HL-C50 is complete. HL-C63 is
-the next priority: fill the capability ledger for the 98 handwritten chapters
-the index audit found outside `chapters.json` without changing which chapters
-remain protected from generation.
+Last prioritized: 2026-08-08, after HL-C63 and HL-C64 entered #10128.
+With all 22 downloadable books now carrying pronunciation, glossary,
+review-question, answer-key, and English-first index back matter, HL-C50 is
+complete. The HL-C63 audit confirmed that all 98 missing handwritten chapters
+already have canonical lesson sources; 47 lessons across 11 of those chapters
+were additionally absent from their shared-spine paths. Validation then exposed
+two more Spanish prerequisite lessons and showed that each added segment needed
+an explicit language-local extension classification. HL-C63 is therefore one
+coherent tranche: author every missing capability, place the 49 lessons in
+prerequisite-safe paths, classify local support, keep legacy schema-v1 `assesses`
+lists honestly empty until atom migration, and leave handwritten/generation
+status unchanged. HL-C64 was discovered and fixed inside that tranche because
+the nested-brace parser made title agreement impossible for four Spanish chapters.
+HL-C10 is next: capability coverage is complete, while the shared spine remains
+the binding structural ceiling on the owner's pre-A1-to-C2 direction. Its first
+slice must update the now-22-track realization contract before adding breadth.
 The index audit found **2,070** canonical candidates across the corpus: **1,430**
 word and phrase lessons for English-first lookup, **127** dedicated grammar,
 writing, etymology, culture, and pronunciation lessons, **415** chapter
@@ -18,7 +28,7 @@ capabilities, and **98** additional handwritten chapter declarations. Practice
 drills stay out of the index; the checked title/label manifest provides durable
 navigation even where the authored capability ledger is still missing.
 Current generated baseline: **22** registered tracks, **1,669** canonical lessons,
-**1,521** mapped lessons, and **22** downloadable LaTeX books spanning **513**
+**1,570** mapped lessons, and **22** downloadable LaTeX books spanning **513**
 chapters, **408** of them generated from the canonical lesson AST. Twenty-five mapped
 non-lexical lessons across 18 tracks now carry
 compiled objective activities; 94 mapped non-lexical lessons remain explicit
@@ -190,7 +200,8 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C50B | Complete (#10116) | Generate a compact glossary for every book from canonical word and phrase lessons. | All 22 books carry byte-gated glossary back matter with headword, non-redundant romanization, gloss, and introduction chapter; duplicate realizations merge without losing distinct senses, every script uses the book's configured font, and all PDFs compile without warning regressions. |
 | HL-C50C | Complete (#10120) | Generate review questions and an answer key for every book from the same compiled `hl-activity` contracts Language Ladder scores. Backfill one schema-v2 activity in French and Bengali, the two tracks with zero contracts; never infer an answer from a legacy `[YOU ...]` cue. | Every track has nonempty, byte-gated review-question and answer-key back matter; each entry identifies its source chapter and lesson and resolves to the authored canonical answer plus accepted variants from the typed AST; all 22 PDFs compile without warning regressions. |
 | HL-C50D | Complete (#10124) | Generate a compact subject index for every book from English meanings, dedicated topic lessons, and the checked generated/handwritten chapter manifest; exclude practice drills and never scrape prose for guessed keywords. | All 22 books carry nonempty, byte-gated index back matter; entries are alphabetized, target-script forms use each book's configured font, facets identify explicitly typed grammar/script/etymology/culture/pronunciation coverage, and every reference links to a checked chapter label and page without PDF warning regressions. |
-| HL-C63 | Queued | Author capability-ledger entries for the 98 handwritten chapters that the index audit found outside `chapters.json`; keep chapter generation status independent from capability coverage. | All 513 declared chapters have an authored `canDo`, spine-node mapping, and representative payoff in their track's `chapters.json`; the 98 handwritten `.tex` files remain protected from generation, and the capability and book manifests agree on chapter number, title, and label. |
+| HL-C63 | Complete (#10128) | Author capability-ledger entries for the 98 handwritten chapters that the index audit found outside `chapters.json`; map the 47 canonical lessons across 11 of those chapters plus two required Spanish prerequisites, classify each new language-local segment, and keep chapter generation status independent from capability coverage. | All 513 declared chapters have an authored `canDo`, spine-node mapping, and representative payoff in their track's `chapters.json`; legacy schema-v1 payoffs name no invented atoms, all 49 newly placed lessons are reachable through prerequisite-safe `curriculum.json` paths and explicit extensions, the 98 handwritten `.tex` files remain protected from generation, and the capability and book manifests agree on chapter number, title, and label. |
+| HL-C64 | Complete (#10128) | Parse nested LaTeX commands inside `\\chapter{...}` titles without truncating at the first formatting brace. | `loadBookCorpus` returns the complete title for chapters containing nested `\\emph{...}` commands, a focused regression test pins the behavior, and chapter-title drift remains zero after handwritten capabilities become checkable. |
 | HL-C19 | Queued | Verify every prose `strokeOrder` against an authored ductus, so no letter's step list implies a pen lift nothing has checked. | All 190 prose stroke orders across the nine scripts (`arabic` 21, `chinese` 24, `cyrillic` 33, `devanagari` 28, `gujarati` 29, `hebrew` 22, `perso-arabic` 9, `tamil` 10, `urdu-nastaliq` 13) either carry a font-checked pen path with `penLifts` + `strokeOrderSource`, or are worded so they claim part order only. Today exactly one letter — Tamil ம — is verified; the audit that found it is written up in [`data/scripts/README.md`](data/scripts/README.md). Follows HL-C09, which authors the paths this check consumes. |
 | HL-C30 | Closed — no move is both legal and useful | Recover Arabic's drivable prefix by moving the writing lessons that open Chapters 3 and 4 later in their chapters. | Measured and answered: zero. Both chapters are prefix-0 under **every** legal ordering because neither has a `voice` lesson without an in-chapter prerequisite, and all 18 of Arabic's `sight` lessons are tables, not script. Corpus-wide only 2 chapters (`portuguese ch2`, `italian ch2`, +4 lessons) can be improved by reordering at all; 116 of the 123 zero-prefix chapters are table-blocked at the root and belong to HL-C17. See *Findings from HL-C30*. |
 | HL-C24 | Complete (#9979) | Pilot real chapter payoff lessons on the weakest Latin chapters. | Latin chapters 19, 21, 33, and 36 each own a dedicated terminal consolidation lesson built only from already-taught material, and `chapters.json` points their `payoff.lesson` at it. |
@@ -2501,11 +2512,35 @@ problem.
   generated review questions and answer keys are recorded complete in #10120,
   and HL-C50D's generated subject indexes are recorded complete in #10124.
   Together with the five merged link and cross-volume cleanup slices, those
-  artifacts complete HL-C50. HL-C63 is next: author capability-ledger entries
-  for the 98 handwritten chapters the index audit exposed.
+  artifacts complete HL-C50. HL-C63 and its blocking parser repair, HL-C64, enter
+  #10128; HL-C10 is next because the shared spine remains the structural ceiling.
 - A completed row must name at least one merge PR, an ID may occur only once,
   and `this PR` is not a durable status. HL-I06 was kept `In progress` until its
   own PR number existed so the repair did not violate the rule while making it.
+
+## Findings from HL-C63
+
+- The 98 missing capability entries were not missing lessons: every handwritten
+  chapter already had canonical lesson sources. Authoring their ledgers therefore
+  closes chapter intent without changing the 98-file handwritten protection list.
+- Schema-v1 chapters still declare no typed knowledge atoms. Their payoffs point to
+  real canonical closing lessons and keep `assesses: []`; the representativeness
+  gate remains intentionally unscored rather than being made green with invented ids.
+- Forty-seven lessons across eleven chapters were absent from the shared path.
+  Executable placement also required two earlier Spanish prerequisites and explicit
+  local-extension classification, taking mapped coverage from 1,521 to 1,570 lessons.
+- The narration export is capability-driven. Closing the ledger gap consequently
+  brings all 98 handwritten chapters into the checked app/audio projection while
+  leaving book generation ownership unchanged.
+
+## Findings from HL-C64
+
+- The original `\\chapter` regex stopped at the first closing brace, so four Spanish
+  titles containing nested `\\emph{...}` commands became newly visible title-drift
+  failures as soon as HL-C63 authored their capability entries.
+- A balanced-brace reader now returns the complete outer argument, preserves escaped
+  literal braces, and falls back to the filename slug when the command is malformed.
+  The focused regression test and the 513-chapter gate both pin the repair.
 
 ## Completed foundations
 

--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -108,10 +108,10 @@ enter cross-language review only after focused retrieval.
 <!-- BEGIN GENERATED TRACK PROGRESS -->
 | Language | Family / script | Canonical lessons | Mapped lessons | Book progress |
 |---|---|---:|---:|---|
-| [Spanish](./spanish/README.md) | Romance / Latin | 177 | 139 | 41 chapters; through Ch. 41; 29 generated |
+| [Spanish](./spanish/README.md) | Romance / Latin | 177 | 164 | 41 chapters; through Ch. 41; 29 generated |
 | [Latin](./latin/README.md) | Italic / Latin | 88 | 88 | 43 chapters; through Ch. 43; 42 generated |
-| [French](./french/README.md) | Romance / Latin | 105 | 89 | 31 chapters; through Ch. 31; 15 generated |
-| [German](./german/README.md) | Germanic / Latin | 106 | 89 | 31 chapters; through Ch. 31; 15 generated |
+| [French](./french/README.md) | Romance / Latin | 105 | 91 | 31 chapters; through Ch. 31; 15 generated |
+| [German](./german/README.md) | Germanic / Latin | 106 | 91 | 31 chapters; through Ch. 31; 15 generated |
 | [Arabic](./arabic/README.md) | Semitic / Arabic | 100 | 98 | 36 chapters; through Ch. 36; 34 generated |
 | [Hindi](./hindi/README.md) | Indo-Aryan / Devanagari | 109 | 103 | 39 chapters; through Ch. 39; 34 generated |
 | [Tamil](./tamil/README.md) | Dravidian / Tamil | 118 | 114 | 38 chapters; through Ch. 38; 33 generated |
@@ -120,12 +120,12 @@ enter cross-language review only after focused retrieval.
 | [Malayalam](./malayalam/README.md) | Dravidian / Malayalam | 78 | 74 | 34 chapters; through Ch. 34; 29 generated |
 | [Italian](./italian/README.md) | Romance / Latin | 88 | 87 | 25 chapters; through Ch. 25; 24 generated |
 | [Portuguese](./portuguese/README.md) | Romance / Latin | 96 | 95 | 26 chapters; through Ch. 26; 25 generated |
-| [Marathi](./marathi/README.md) | Indo-Aryan / Devanagari | 62 | 52 | 13 chapters; through Ch. 13; 8 generated |
+| [Marathi](./marathi/README.md) | Indo-Aryan / Devanagari | 62 | 57 | 13 chapters; through Ch. 13; 8 generated |
 | [Punjabi](./punjabi/README.md) | Indo-Aryan / Gurmukhi | 61 | 54 | 13 chapters; through Ch. 13; 8 generated |
-| [Bengali](./bengali/README.md) | Indo-Aryan / Bengali | 57 | 48 | 12 chapters; through Ch. 12; 7 generated |
-| [Gujarati](./gujarati/README.md) | Indo-Aryan / Gujarati | 59 | 50 | 12 chapters; through Ch. 12; 7 generated |
+| [Bengali](./bengali/README.md) | Indo-Aryan / Bengali | 57 | 53 | 12 chapters; through Ch. 12; 7 generated |
+| [Gujarati](./gujarati/README.md) | Indo-Aryan / Gujarati | 59 | 55 | 12 chapters; through Ch. 12; 7 generated |
 | [Russian](./russian/README.md) | Slavic / Cyrillic | 50 | 42 | 10 chapters; through Ch. 10; 8 generated |
-| [Sanskrit](./sanskrit/README.md) | Indo-Aryan / Devanagari | 59 | 51 | 13 chapters; through Ch. 13; 8 generated |
+| [Sanskrit](./sanskrit/README.md) | Indo-Aryan / Devanagari | 59 | 56 | 13 chapters; through Ch. 13; 8 generated |
 | [Persian](./persian/README.md) | Iranian / Perso-Arabic | 33 | 33 | 8 chapters; through Ch. 8; 6 generated |
 | [Urdu](./urdu/README.md) | Indo-Aryan / Urdu-Nastaliq | 46 | 46 | 12 chapters; through Ch. 12; 10 generated |
 | [Mandarin Chinese](./chinese/README.md) | Sinitic / Chinese | 7 | 7 | 1 chapter; through Ch. 1; 1 generated |

--- a/code/learning/human-languages/arabic/chapters.json
+++ b/code/learning/human-languages/arabic/chapters.json
@@ -1,8 +1,45 @@
 {
   "version": 1,
   "language": "arabic",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 1-2 are deliberately absent -- their terminal practice lessons (AR-C01-practice, AR-C02-practice) are still schema v1 with no practises.knowledge, so no payoff can name atoms without inventing them. That absence is real, measurable debt and must not be papered over with placeholders.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet someone in Arabic, recognize the reply, and choose an appropriate response.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-DEFINITE-REFERENCE",
+        "SPINE-TIME-OF-DAY",
+        "SPINE-COURTESY-THANK",
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "AR-C01-practice",
+        "kind": "task",
+        "summary": "Complete AR-C01-practice, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in Arabic, recognize the reply, and choose an appropriate response.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 2,
+      "title": "Introducing Yourself",
+      "label": "ch:introductions",
+      "canDo": "I can introduce myself in Arabic, give my name, and understand the other person's name.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES",
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "AR-C02-practice",
+        "kind": "task",
+        "summary": "Complete AR-C02-practice, the canonical closing checkpoint, and demonstrate the chapter promise: introduce myself in Arabic, give my name, and understand the other person's name.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 3,
       "title": "How Are You?",

--- a/code/learning/human-languages/arabic/narration/ch01.json
+++ b/code/learning/human-languages/arabic/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "arabic",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:644087df44cb504a",
   "lessons": [

--- a/code/learning/human-languages/arabic/narration/ch01.txt
+++ b/code/learning/human-languages/arabic/narration/ch01.txt
@@ -1,4 +1,4 @@
-Arabic, chapter 1: Chapter 1.
+Arabic, chapter 1: Greetings.
 14 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/arabic/narration/ch02.json
+++ b/code/learning/human-languages/arabic/narration/ch02.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "arabic",
   "chapter": 2,
-  "title": "Chapter 2",
+  "title": "Introducing Yourself",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:1078ff046e54595b",
   "lessons": [

--- a/code/learning/human-languages/arabic/narration/ch02.txt
+++ b/code/learning/human-languages/arabic/narration/ch02.txt
@@ -1,4 +1,4 @@
-Arabic, chapter 2: Chapter 2.
+Arabic, chapter 2: Introducing Yourself.
 12 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/bengali/chapters.json
+++ b/code/learning/human-languages/bengali/chapters.json
@@ -1,8 +1,93 @@
 {
   "version": 1,
   "language": "bengali",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only chapter 6 is authorable today. Chapters 1-5 are entirely schema-v1 (no introduces/practises knowledge atoms), so no payoff there can name atoms a lesson actually practises; they are deliberately absent rather than stubbed, and that absence is real, measurable debt.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet someone in Bengali, recognize the reply, and choose an appropriate response.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-COURTESY-THANK",
+        "SPINE-RESPOND-BASIC",
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "BN-C01-practice",
+        "kind": "task",
+        "summary": "Complete BN-C01-practice, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in Bengali, recognize the reply, and choose an appropriate response.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 2,
+      "title": "Introducing Yourself",
+      "label": "ch:introductions",
+      "canDo": "I can introduce myself in Bengali, give my name, and understand the other person's name.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "BN-C02-practice",
+        "kind": "task",
+        "summary": "Complete BN-C02-practice, the canonical closing checkpoint, and demonstrate the chapter promise: introduce myself in Bengali, give my name, and understand the other person's name.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "How Are You?",
+      "label": "ch:responding",
+      "canDo": "I can ask how someone is in Bengali, answer naturally, and return the question.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES",
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-COURTESY-THANK"
+      ],
+      "payoff": {
+        "lesson": "BN-C03-practice",
+        "kind": "task",
+        "summary": "Complete BN-C03-practice, the canonical closing checkpoint, and demonstrate the chapter promise: ask how someone is in Bengali, answer naturally, and return the question.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "Farewells",
+      "label": "ch:farewells",
+      "canDo": "I can end a Bengali conversation politely and choose a farewell that fits the situation.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "BN-C04-practice",
+        "kind": "task",
+        "summary": "Complete BN-C04-practice, the canonical closing checkpoint, and demonstrate the chapter promise: end a Bengali conversation politely and choose a farewell that fits the situation.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "The First Verbs",
+      "label": "ch:first-verbs",
+      "canDo": "I can build short present-tense Bengali sentences with the chapter's first verbs.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "BN-C05-practice",
+        "kind": "task",
+        "summary": "Complete BN-C05-practice, the canonical closing checkpoint, and demonstrate the chapter promise: build short present-tense Bengali sentences with the chapter's first verbs.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 6,
       "title": "Numbers One to Five",

--- a/code/learning/human-languages/bengali/curriculum.json
+++ b/code/learning/human-languages/bengali/curriculum.json
@@ -109,6 +109,22 @@
       "after": []
     },
     {
+      "id": "BN-PATH-017",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "BN-C05-bola",
+        "BN-C05-ami-bangla-boli",
+        "BN-C05-kaj-kora",
+        "BN-C05-thaka",
+        "BN-C05-practice"
+      ],
+      "before": [],
+      "inline": [
+        "BN-EXT-017-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
       "id": "BN-PATH-010",
       "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
       "lessons": [
@@ -330,6 +346,7 @@
     },
     "SPINE-SAY-WHAT-I-DO": {
       "segments": [
+        "BN-PATH-017",
         "BN-PATH-011",
         "BN-PATH-012",
         "BN-PATH-013"
@@ -671,6 +688,21 @@
         "BN-C11-poribar",
         "BN-C11-bhai",
         "BN-C11-bon"
+      ]
+    },
+    {
+      "id": "BN-EXT-017-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the Bengali-specific vocabulary and grammar that support this shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "BN-C05-bola",
+        "BN-C05-ami-bangla-boli",
+        "BN-C05-kaj-kora",
+        "BN-C05-thaka",
+        "BN-C05-practice"
       ]
     },
     {

--- a/code/learning/human-languages/bengali/narration/ch01.json
+++ b/code/learning/human-languages/bengali/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "bengali",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:fee72d60309a5ae8",
   "lessons": [

--- a/code/learning/human-languages/bengali/narration/ch01.txt
+++ b/code/learning/human-languages/bengali/narration/ch01.txt
@@ -1,4 +1,4 @@
-Bengali, chapter 1: Chapter 1.
+Bengali, chapter 1: Greetings.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/bengali/narration/ch02.json
+++ b/code/learning/human-languages/bengali/narration/ch02.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "bengali",
   "chapter": 2,
-  "title": "Chapter 2",
+  "title": "Introducing Yourself",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:c7df8cff9c52ce8d",
   "lessons": [

--- a/code/learning/human-languages/bengali/narration/ch02.txt
+++ b/code/learning/human-languages/bengali/narration/ch02.txt
@@ -1,4 +1,4 @@
-Bengali, chapter 2: Chapter 2.
+Bengali, chapter 2: Introducing Yourself.
 8 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/bengali/narration/ch03.json
+++ b/code/learning/human-languages/bengali/narration/ch03.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "bengali",
   "chapter": 3,
-  "title": "Chapter 3",
+  "title": "How Are You?",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:c879efbcfdf4fccb",
   "lessons": [

--- a/code/learning/human-languages/bengali/narration/ch03.txt
+++ b/code/learning/human-languages/bengali/narration/ch03.txt
@@ -1,4 +1,4 @@
-Bengali, chapter 3: Chapter 3.
+Bengali, chapter 3: How Are You?.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/bengali/narration/ch04.json
+++ b/code/learning/human-languages/bengali/narration/ch04.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "bengali",
   "chapter": 4,
-  "title": "Chapter 4",
+  "title": "Farewells",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:28db9f1b151935e5",
   "lessons": [

--- a/code/learning/human-languages/bengali/narration/ch04.txt
+++ b/code/learning/human-languages/bengali/narration/ch04.txt
@@ -1,4 +1,4 @@
-Bengali, chapter 4: Chapter 4.
+Bengali, chapter 4: Farewells.
 5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/bengali/narration/ch05.json
+++ b/code/learning/human-languages/bengali/narration/ch05.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "bengali",
   "chapter": 5,
-  "title": "Chapter 5",
+  "title": "The First Verbs",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:79852e715c7e5696",
   "lessons": [

--- a/code/learning/human-languages/bengali/narration/ch05.txt
+++ b/code/learning/human-languages/bengali/narration/ch05.txt
@@ -1,4 +1,4 @@
-Bengali, chapter 5: Chapter 5.
+Bengali, chapter 5: The First Verbs.
 5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -27,8 +27,8 @@
       "drivablePrefix": 0,
       "text": "arabic/narration/ch01.txt",
       "json": "arabic/narration/ch01.json",
-      "textHash": "fnv1a64:37835c10448c2a89",
-      "jsonHash": "fnv1a64:cb3b1950ed04bfa5"
+      "textHash": "fnv1a64:1229c7fcf26749db",
+      "jsonHash": "fnv1a64:3d151ecd6de5dccf"
     },
     {
       "language": "arabic",
@@ -52,8 +52,8 @@
       "drivablePrefix": 0,
       "text": "arabic/narration/ch02.txt",
       "json": "arabic/narration/ch02.json",
-      "textHash": "fnv1a64:eee465a78e2aa46e",
-      "jsonHash": "fnv1a64:0710899da140f119"
+      "textHash": "fnv1a64:bc53263f2913748e",
+      "jsonHash": "fnv1a64:e20d10d131cd4921"
     },
     {
       "language": "arabic",
@@ -587,8 +587,8 @@
       "drivablePrefix": 0,
       "text": "bengali/narration/ch01.txt",
       "json": "bengali/narration/ch01.json",
-      "textHash": "fnv1a64:b143d3c7b94c3829",
-      "jsonHash": "fnv1a64:e71005bba0a07e06"
+      "textHash": "fnv1a64:9aa5edafb30d9023",
+      "jsonHash": "fnv1a64:aaf07ba1e4f957f0"
     },
     {
       "language": "bengali",
@@ -608,8 +608,8 @@
       "drivablePrefix": 0,
       "text": "bengali/narration/ch02.txt",
       "json": "bengali/narration/ch02.json",
-      "textHash": "fnv1a64:2167b6feaadbd20d",
-      "jsonHash": "fnv1a64:f9a1c8e1930a908b"
+      "textHash": "fnv1a64:47013f15d37ee7ad",
+      "jsonHash": "fnv1a64:bafad7bfd0865b6b"
     },
     {
       "language": "bengali",
@@ -627,8 +627,8 @@
       "drivablePrefix": 0,
       "text": "bengali/narration/ch03.txt",
       "json": "bengali/narration/ch03.json",
-      "textHash": "fnv1a64:1c9e27f3a7145dc4",
-      "jsonHash": "fnv1a64:4e3b7141ca534b73"
+      "textHash": "fnv1a64:22cdfc2bfe05ea3a",
+      "jsonHash": "fnv1a64:a5dd43bdbc01ecd1"
     },
     {
       "language": "bengali",
@@ -645,8 +645,8 @@
       "drivablePrefix": 0,
       "text": "bengali/narration/ch04.txt",
       "json": "bengali/narration/ch04.json",
-      "textHash": "fnv1a64:820011f601dcb4a5",
-      "jsonHash": "fnv1a64:1b719b7c55665791"
+      "textHash": "fnv1a64:894c1e0cd24a4cb9",
+      "jsonHash": "fnv1a64:0fc4eb4732eafb4d"
     },
     {
       "language": "bengali",
@@ -663,8 +663,8 @@
       "drivablePrefix": 0,
       "text": "bengali/narration/ch05.txt",
       "json": "bengali/narration/ch05.json",
-      "textHash": "fnv1a64:6c63213edab024f5",
-      "jsonHash": "fnv1a64:4bf4c1e5b386d26c"
+      "textHash": "fnv1a64:385884742aefda7e",
+      "jsonHash": "fnv1a64:ca63ba0db928462f"
     },
     {
       "language": "bengali",
@@ -825,8 +825,8 @@
       "drivablePrefix": 7,
       "text": "french/narration/ch01.txt",
       "json": "french/narration/ch01.json",
-      "textHash": "fnv1a64:383e4b458a3c4195",
-      "jsonHash": "fnv1a64:2113a092fa9d46d9"
+      "textHash": "fnv1a64:7634ef9e32d05a0f",
+      "jsonHash": "fnv1a64:d220ace98be4c407"
     },
     {
       "language": "french",
@@ -847,8 +847,8 @@
       "drivablePrefix": 4,
       "text": "french/narration/ch02.txt",
       "json": "french/narration/ch02.json",
-      "textHash": "fnv1a64:0f308a3eea52897c",
-      "jsonHash": "fnv1a64:4cc5e17ee7a0df52"
+      "textHash": "fnv1a64:ebe80ac9567ace54",
+      "jsonHash": "fnv1a64:3b242daf063ad4ba"
     },
     {
       "language": "french",
@@ -867,8 +867,8 @@
       "drivablePrefix": 0,
       "text": "french/narration/ch03.txt",
       "json": "french/narration/ch03.json",
-      "textHash": "fnv1a64:d9d1aac98698224d",
-      "jsonHash": "fnv1a64:fa6ddcbae07f11a0"
+      "textHash": "fnv1a64:b1786bfb7f1c1667",
+      "jsonHash": "fnv1a64:983995d8d295d216"
     },
     {
       "language": "french",
@@ -888,8 +888,8 @@
       "drivablePrefix": 5,
       "text": "french/narration/ch04.txt",
       "json": "french/narration/ch04.json",
-      "textHash": "fnv1a64:5617c3684584e134",
-      "jsonHash": "fnv1a64:2553dad4623b131d"
+      "textHash": "fnv1a64:b7aab45591b81e48",
+      "jsonHash": "fnv1a64:7a310938e7e933d1"
     },
     {
       "language": "french",
@@ -906,8 +906,8 @@
       "drivablePrefix": 2,
       "text": "french/narration/ch05.txt",
       "json": "french/narration/ch05.json",
-      "textHash": "fnv1a64:1593c8b35c764439",
-      "jsonHash": "fnv1a64:39a85f17fd2c0aee"
+      "textHash": "fnv1a64:51f91084fe1f94d4",
+      "jsonHash": "fnv1a64:70785937d63a9f35"
     },
     {
       "language": "french",
@@ -921,8 +921,8 @@
       "drivablePrefix": 0,
       "text": "french/narration/ch06.txt",
       "json": "french/narration/ch06.json",
-      "textHash": "fnv1a64:6c5bf2528e360745",
-      "jsonHash": "fnv1a64:e6d7526a9e0772ad"
+      "textHash": "fnv1a64:55dd85d4f40913cc",
+      "jsonHash": "fnv1a64:15073b5791b4c34c"
     },
     {
       "language": "french",
@@ -936,8 +936,8 @@
       "drivablePrefix": 0,
       "text": "french/narration/ch07.txt",
       "json": "french/narration/ch07.json",
-      "textHash": "fnv1a64:0a1a3535e52bf777",
-      "jsonHash": "fnv1a64:8edb914f0d19c1ea"
+      "textHash": "fnv1a64:9e5a5270e9d9b801",
+      "jsonHash": "fnv1a64:23a95c61dec4bb74"
     },
     {
       "language": "french",
@@ -951,8 +951,8 @@
       "drivablePrefix": 2,
       "text": "french/narration/ch08.txt",
       "json": "french/narration/ch08.json",
-      "textHash": "fnv1a64:127baf754f4b3465",
-      "jsonHash": "fnv1a64:a1577a6c4e864d00"
+      "textHash": "fnv1a64:abb25242190f022f",
+      "jsonHash": "fnv1a64:dd9552e5f9d0a93a"
     },
     {
       "language": "french",
@@ -966,8 +966,8 @@
       "drivablePrefix": 2,
       "text": "french/narration/ch09.txt",
       "json": "french/narration/ch09.json",
-      "textHash": "fnv1a64:ac2900787fbd9497",
-      "jsonHash": "fnv1a64:8eabc55ef7428bd9"
+      "textHash": "fnv1a64:554d3cc3486706e3",
+      "jsonHash": "fnv1a64:db7ee143271fd9ad"
     },
     {
       "language": "french",
@@ -981,8 +981,8 @@
       "drivablePrefix": 2,
       "text": "french/narration/ch10.txt",
       "json": "french/narration/ch10.json",
-      "textHash": "fnv1a64:e28168362c9b7f6f",
-      "jsonHash": "fnv1a64:8efd7be14a2448a1"
+      "textHash": "fnv1a64:6a36d292e653e74d",
+      "jsonHash": "fnv1a64:c464c1297a575673"
     },
     {
       "language": "french",
@@ -996,8 +996,8 @@
       "drivablePrefix": 2,
       "text": "french/narration/ch11.txt",
       "json": "french/narration/ch11.json",
-      "textHash": "fnv1a64:356706b756fa20c4",
-      "jsonHash": "fnv1a64:2a35f000d3d262c4"
+      "textHash": "fnv1a64:77054f8bf6cbf8d7",
+      "jsonHash": "fnv1a64:a8a178e4429fa8bf"
     },
     {
       "language": "french",
@@ -1011,8 +1011,8 @@
       "drivablePrefix": 0,
       "text": "french/narration/ch12.txt",
       "json": "french/narration/ch12.json",
-      "textHash": "fnv1a64:a4014bb80df089de",
-      "jsonHash": "fnv1a64:1a141b462d7567e0"
+      "textHash": "fnv1a64:ba25cd8c811e667f",
+      "jsonHash": "fnv1a64:5d780500d40b39d7"
     },
     {
       "language": "french",
@@ -1026,8 +1026,8 @@
       "drivablePrefix": 2,
       "text": "french/narration/ch13.txt",
       "json": "french/narration/ch13.json",
-      "textHash": "fnv1a64:f9e04908d1da7de2",
-      "jsonHash": "fnv1a64:40259c96b3ea7659"
+      "textHash": "fnv1a64:d1689b83301e3678",
+      "jsonHash": "fnv1a64:dd810a1420bacae7"
     },
     {
       "language": "french",
@@ -1041,8 +1041,8 @@
       "drivablePrefix": 1,
       "text": "french/narration/ch14.txt",
       "json": "french/narration/ch14.json",
-      "textHash": "fnv1a64:c9ff51f24ddbbef0",
-      "jsonHash": "fnv1a64:44af7bbdb01e0f60"
+      "textHash": "fnv1a64:5f21133dbb676f2a",
+      "jsonHash": "fnv1a64:1eb920adfa33ad72"
     },
     {
       "language": "french",
@@ -1056,8 +1056,8 @@
       "drivablePrefix": 2,
       "text": "french/narration/ch15.txt",
       "json": "french/narration/ch15.json",
-      "textHash": "fnv1a64:ec15a0f126814c51",
-      "jsonHash": "fnv1a64:9d81fc2aeed0a1f9"
+      "textHash": "fnv1a64:d4e5a0c4a5a468ee",
+      "jsonHash": "fnv1a64:65cb84df7dc43392"
     },
     {
       "language": "french",
@@ -1073,8 +1073,8 @@
       "drivablePrefix": 4,
       "text": "french/narration/ch16.txt",
       "json": "french/narration/ch16.json",
-      "textHash": "fnv1a64:71ce25815506d603",
-      "jsonHash": "fnv1a64:4be9f083d6aa429c"
+      "textHash": "fnv1a64:13b47fb3a41c58d7",
+      "jsonHash": "fnv1a64:f2b3f1b830e60f90"
     },
     {
       "language": "french",
@@ -1334,8 +1334,8 @@
       "drivablePrefix": 6,
       "text": "german/narration/ch01.txt",
       "json": "german/narration/ch01.json",
-      "textHash": "fnv1a64:392afbb0702f9ce7",
-      "jsonHash": "fnv1a64:3372d1eac3989093"
+      "textHash": "fnv1a64:5589d3f2cb04026d",
+      "jsonHash": "fnv1a64:a63f0611061a6369"
     },
     {
       "language": "german",
@@ -1355,8 +1355,8 @@
       "drivablePrefix": 8,
       "text": "german/narration/ch02.txt",
       "json": "german/narration/ch02.json",
-      "textHash": "fnv1a64:701c88484ef7b167",
-      "jsonHash": "fnv1a64:35cbc9fe49464b39"
+      "textHash": "fnv1a64:eed5280ec22719df",
+      "jsonHash": "fnv1a64:fcbeb1aab28b1359"
     },
     {
       "language": "german",
@@ -1376,8 +1376,8 @@
       "drivablePrefix": 8,
       "text": "german/narration/ch03.txt",
       "json": "german/narration/ch03.json",
-      "textHash": "fnv1a64:a42137aea498ce7f",
-      "jsonHash": "fnv1a64:cf42b33ece08daa6"
+      "textHash": "fnv1a64:2830b5913f72a8fd",
+      "jsonHash": "fnv1a64:9a77cd803bcd5dd8"
     },
     {
       "language": "german",
@@ -1398,8 +1398,8 @@
       "drivablePrefix": 6,
       "text": "german/narration/ch04.txt",
       "json": "german/narration/ch04.json",
-      "textHash": "fnv1a64:a5c90daad58f70f0",
-      "jsonHash": "fnv1a64:7ca600e0e6e19fba"
+      "textHash": "fnv1a64:fb452c2cccc4b0fc",
+      "jsonHash": "fnv1a64:b37c5fbc2f515e7e"
     },
     {
       "language": "german",
@@ -1416,8 +1416,8 @@
       "drivablePrefix": 5,
       "text": "german/narration/ch05.txt",
       "json": "german/narration/ch05.json",
-      "textHash": "fnv1a64:ad10bc73a7f1fd68",
-      "jsonHash": "fnv1a64:6e97996fa3f9e4dc"
+      "textHash": "fnv1a64:90354236a83d9fbf",
+      "jsonHash": "fnv1a64:437388c6cf3dcdb7"
     },
     {
       "language": "german",
@@ -1431,8 +1431,8 @@
       "drivablePrefix": 0,
       "text": "german/narration/ch06.txt",
       "json": "german/narration/ch06.json",
-      "textHash": "fnv1a64:d4ccd11644ad0ed9",
-      "jsonHash": "fnv1a64:e7a2e18f342224fe"
+      "textHash": "fnv1a64:44ef522197d162f6",
+      "jsonHash": "fnv1a64:17abfdc8a93461f3"
     },
     {
       "language": "german",
@@ -1446,8 +1446,8 @@
       "drivablePrefix": 0,
       "text": "german/narration/ch07.txt",
       "json": "german/narration/ch07.json",
-      "textHash": "fnv1a64:6d1554ef08c046f8",
-      "jsonHash": "fnv1a64:6b727b56728d2e85"
+      "textHash": "fnv1a64:7c84327897fedd56",
+      "jsonHash": "fnv1a64:05da2007496f62ab"
     },
     {
       "language": "german",
@@ -1461,8 +1461,8 @@
       "drivablePrefix": 2,
       "text": "german/narration/ch08.txt",
       "json": "german/narration/ch08.json",
-      "textHash": "fnv1a64:5c3c63af96513668",
-      "jsonHash": "fnv1a64:ab97df8574f61566"
+      "textHash": "fnv1a64:0508806296a72456",
+      "jsonHash": "fnv1a64:d63c1b00d34e81e0"
     },
     {
       "language": "german",
@@ -1476,8 +1476,8 @@
       "drivablePrefix": 2,
       "text": "german/narration/ch09.txt",
       "json": "german/narration/ch09.json",
-      "textHash": "fnv1a64:c0520eddc0c2b771",
-      "jsonHash": "fnv1a64:53fe7b675ba9d5c0"
+      "textHash": "fnv1a64:790bd373f40b877d",
+      "jsonHash": "fnv1a64:a4b9351676778aec"
     },
     {
       "language": "german",
@@ -1491,8 +1491,8 @@
       "drivablePrefix": 2,
       "text": "german/narration/ch10.txt",
       "json": "german/narration/ch10.json",
-      "textHash": "fnv1a64:3b174dbfef11d81e",
-      "jsonHash": "fnv1a64:eb314e44a063fe2a"
+      "textHash": "fnv1a64:ad4198d51fe8049c",
+      "jsonHash": "fnv1a64:e8d1ebf2aae28e58"
     },
     {
       "language": "german",
@@ -1506,8 +1506,8 @@
       "drivablePrefix": 2,
       "text": "german/narration/ch11.txt",
       "json": "german/narration/ch11.json",
-      "textHash": "fnv1a64:a6956d8e2c207762",
-      "jsonHash": "fnv1a64:f3a324792de2853b"
+      "textHash": "fnv1a64:2f185347f13e9e41",
+      "jsonHash": "fnv1a64:a6fe5d5fd0726d9c"
     },
     {
       "language": "german",
@@ -1521,8 +1521,8 @@
       "drivablePrefix": 1,
       "text": "german/narration/ch12.txt",
       "json": "german/narration/ch12.json",
-      "textHash": "fnv1a64:3b1db63d11b7103c",
-      "jsonHash": "fnv1a64:f1ecf54ad60c51e4"
+      "textHash": "fnv1a64:ad93e46ef5dcda71",
+      "jsonHash": "fnv1a64:8e9c54f77c48993f"
     },
     {
       "language": "german",
@@ -1536,8 +1536,8 @@
       "drivablePrefix": 2,
       "text": "german/narration/ch13.txt",
       "json": "german/narration/ch13.json",
-      "textHash": "fnv1a64:52c4579e591d935a",
-      "jsonHash": "fnv1a64:02eae8c8d50a086f"
+      "textHash": "fnv1a64:13c3a91f666144ec",
+      "jsonHash": "fnv1a64:79191328a0916669"
     },
     {
       "language": "german",
@@ -1551,8 +1551,8 @@
       "drivablePrefix": 1,
       "text": "german/narration/ch14.txt",
       "json": "german/narration/ch14.json",
-      "textHash": "fnv1a64:c34f17faca0df62b",
-      "jsonHash": "fnv1a64:7a565d3d6288daea"
+      "textHash": "fnv1a64:d01cdf8101898e8d",
+      "jsonHash": "fnv1a64:b2e8b1500f401e4c"
     },
     {
       "language": "german",
@@ -1567,8 +1567,8 @@
       "drivablePrefix": 3,
       "text": "german/narration/ch15.txt",
       "json": "german/narration/ch15.json",
-      "textHash": "fnv1a64:6c1e0e841c6f4a75",
-      "jsonHash": "fnv1a64:0c1b00f0f7032ff2"
+      "textHash": "fnv1a64:64dd876a3ef08855",
+      "jsonHash": "fnv1a64:4ea969dc78a5a59e"
     },
     {
       "language": "german",
@@ -1583,8 +1583,8 @@
       "drivablePrefix": 2,
       "text": "german/narration/ch16.txt",
       "json": "german/narration/ch16.json",
-      "textHash": "fnv1a64:1b80ab6302fd25f7",
-      "jsonHash": "fnv1a64:0d4c53726c5d82e4"
+      "textHash": "fnv1a64:edefce3b7e316e23",
+      "jsonHash": "fnv1a64:283bd2ed7a6148e8"
     },
     {
       "language": "german",
@@ -1837,8 +1837,8 @@
       "drivablePrefix": 0,
       "text": "gujarati/narration/ch01.txt",
       "json": "gujarati/narration/ch01.json",
-      "textHash": "fnv1a64:0686ef65a8cb5ed7",
-      "jsonHash": "fnv1a64:c64fa78feceb63b4"
+      "textHash": "fnv1a64:11eeebe50b2b4871",
+      "jsonHash": "fnv1a64:3b084a58ef790bae"
     },
     {
       "language": "gujarati",
@@ -1859,8 +1859,8 @@
       "drivablePrefix": 0,
       "text": "gujarati/narration/ch02.txt",
       "json": "gujarati/narration/ch02.json",
-      "textHash": "fnv1a64:7e44531359f0154f",
-      "jsonHash": "fnv1a64:5e97674043dc6a4b"
+      "textHash": "fnv1a64:d26a9d8a6bfb2ca1",
+      "jsonHash": "fnv1a64:63e667473fe07be1"
     },
     {
       "language": "gujarati",
@@ -1878,8 +1878,8 @@
       "drivablePrefix": 0,
       "text": "gujarati/narration/ch03.txt",
       "json": "gujarati/narration/ch03.json",
-      "textHash": "fnv1a64:f8d37af0dc391627",
-      "jsonHash": "fnv1a64:3665369c829b462e"
+      "textHash": "fnv1a64:8ed231e80843803b",
+      "jsonHash": "fnv1a64:4bbb9340a3330ba6"
     },
     {
       "language": "gujarati",
@@ -1896,8 +1896,8 @@
       "drivablePrefix": 0,
       "text": "gujarati/narration/ch04.txt",
       "json": "gujarati/narration/ch04.json",
-      "textHash": "fnv1a64:e9eaa5d1fbca8eb2",
-      "jsonHash": "fnv1a64:b4c1a5c208550fff"
+      "textHash": "fnv1a64:86d513f5209fb31e",
+      "jsonHash": "fnv1a64:20345aac0ac86963"
     },
     {
       "language": "gujarati",
@@ -1914,8 +1914,8 @@
       "drivablePrefix": 0,
       "text": "gujarati/narration/ch05.txt",
       "json": "gujarati/narration/ch05.json",
-      "textHash": "fnv1a64:cc87d04fdb1f32f0",
-      "jsonHash": "fnv1a64:b0592938137ca239"
+      "textHash": "fnv1a64:a13e2b30c7c79bc9",
+      "jsonHash": "fnv1a64:c5e89c796ee37c62"
     },
     {
       "language": "gujarati",
@@ -2105,8 +2105,8 @@
       "drivablePrefix": 0,
       "text": "hindi/narration/ch03.txt",
       "json": "hindi/narration/ch03.json",
-      "textHash": "fnv1a64:803330c192a25015",
-      "jsonHash": "fnv1a64:4bd43ac154c6f105"
+      "textHash": "fnv1a64:71ca3e6d4fb54a87",
+      "jsonHash": "fnv1a64:42ea86775f79643f"
     },
     {
       "language": "hindi",
@@ -2124,8 +2124,8 @@
       "drivablePrefix": 0,
       "text": "hindi/narration/ch04.txt",
       "json": "hindi/narration/ch04.json",
-      "textHash": "fnv1a64:b0ecb8645ea480c2",
-      "jsonHash": "fnv1a64:6ebb1c7e35e21b1e"
+      "textHash": "fnv1a64:56c36706455460f6",
+      "jsonHash": "fnv1a64:f82d5971a6ea56a2"
     },
     {
       "language": "hindi",
@@ -2143,8 +2143,8 @@
       "drivablePrefix": 0,
       "text": "hindi/narration/ch05.txt",
       "json": "hindi/narration/ch05.json",
-      "textHash": "fnv1a64:c2eb01af7a2b59a0",
-      "jsonHash": "fnv1a64:ce7962c9228078a9"
+      "textHash": "fnv1a64:5e7eda22c5fd612b",
+      "jsonHash": "fnv1a64:5201643b92776ea4"
     },
     {
       "language": "hindi",
@@ -2671,8 +2671,8 @@
       "drivablePrefix": 6,
       "text": "italian/narration/ch01.txt",
       "json": "italian/narration/ch01.json",
-      "textHash": "fnv1a64:90492dfb57bbfe30",
-      "jsonHash": "fnv1a64:78caf0610e2a4c64"
+      "textHash": "fnv1a64:24a5f6350baebaf6",
+      "jsonHash": "fnv1a64:b943cd38ac54e50e"
     },
     {
       "language": "italian",
@@ -3102,8 +3102,8 @@
       "drivablePrefix": 0,
       "text": "kannada/narration/ch01.txt",
       "json": "kannada/narration/ch01.json",
-      "textHash": "fnv1a64:684d0316f036aa55",
-      "jsonHash": "fnv1a64:cd3608bba7deaf90"
+      "textHash": "fnv1a64:a1d053c33720e8bf",
+      "jsonHash": "fnv1a64:98c2fb0364247702"
     },
     {
       "language": "kannada",
@@ -3123,8 +3123,8 @@
       "drivablePrefix": 0,
       "text": "kannada/narration/ch02.txt",
       "json": "kannada/narration/ch02.json",
-      "textHash": "fnv1a64:7a269a9597177b7b",
-      "jsonHash": "fnv1a64:ceb9a56ef9b33c90"
+      "textHash": "fnv1a64:6da1898ea821443b",
+      "jsonHash": "fnv1a64:1b247366d2f9b730"
     },
     {
       "language": "kannada",
@@ -3142,8 +3142,8 @@
       "drivablePrefix": 0,
       "text": "kannada/narration/ch03.txt",
       "json": "kannada/narration/ch03.json",
-      "textHash": "fnv1a64:5325f64d955b958e",
-      "jsonHash": "fnv1a64:c51c8e63e746d68a"
+      "textHash": "fnv1a64:6fd66d6af67847b4",
+      "jsonHash": "fnv1a64:3cc6696307a08708"
     },
     {
       "language": "kannada",
@@ -3160,8 +3160,8 @@
       "drivablePrefix": 0,
       "text": "kannada/narration/ch04.txt",
       "json": "kannada/narration/ch04.json",
-      "textHash": "fnv1a64:ecfeb15eabc11fea",
-      "jsonHash": "fnv1a64:ea56172059a2e047"
+      "textHash": "fnv1a64:ae24b81ba9e035b6",
+      "jsonHash": "fnv1a64:ae4b14f3dc6a587b"
     },
     {
       "language": "kannada",
@@ -3178,8 +3178,8 @@
       "drivablePrefix": 0,
       "text": "kannada/narration/ch05.txt",
       "json": "kannada/narration/ch05.json",
-      "textHash": "fnv1a64:31c113e0e09b6d34",
-      "jsonHash": "fnv1a64:74346b3f73558e04"
+      "textHash": "fnv1a64:da255a4908bf4f59",
+      "jsonHash": "fnv1a64:91a40e98bb2ebe91"
     },
     {
       "language": "kannada",
@@ -4357,8 +4357,8 @@
       "drivablePrefix": 0,
       "text": "malayalam/narration/ch01.txt",
       "json": "malayalam/narration/ch01.json",
-      "textHash": "fnv1a64:5dbfca2ca18343e9",
-      "jsonHash": "fnv1a64:79eb1cbac161ec25"
+      "textHash": "fnv1a64:a643b6d92f12030f",
+      "jsonHash": "fnv1a64:b536392e530ab05f"
     },
     {
       "language": "malayalam",
@@ -4379,8 +4379,8 @@
       "drivablePrefix": 0,
       "text": "malayalam/narration/ch02.txt",
       "json": "malayalam/narration/ch02.json",
-      "textHash": "fnv1a64:a763fd2681c81ae2",
-      "jsonHash": "fnv1a64:b7b021556ead3fda"
+      "textHash": "fnv1a64:5659c1b5e9d6f374",
+      "jsonHash": "fnv1a64:4d1633db14f461f8"
     },
     {
       "language": "malayalam",
@@ -4398,8 +4398,8 @@
       "drivablePrefix": 0,
       "text": "malayalam/narration/ch03.txt",
       "json": "malayalam/narration/ch03.json",
-      "textHash": "fnv1a64:21bfdb993efccf41",
-      "jsonHash": "fnv1a64:7406581d718632e9"
+      "textHash": "fnv1a64:173afc8b9620ad19",
+      "jsonHash": "fnv1a64:e122ae9f5b683e95"
     },
     {
       "language": "malayalam",
@@ -4416,8 +4416,8 @@
       "drivablePrefix": 0,
       "text": "malayalam/narration/ch04.txt",
       "json": "malayalam/narration/ch04.json",
-      "textHash": "fnv1a64:72dd8f6f768ab094",
-      "jsonHash": "fnv1a64:1c024b5b6534e475"
+      "textHash": "fnv1a64:897d0ba59fc97e10",
+      "jsonHash": "fnv1a64:e08fb026a3d046d1"
     },
     {
       "language": "malayalam",
@@ -4434,8 +4434,8 @@
       "drivablePrefix": 0,
       "text": "malayalam/narration/ch05.txt",
       "json": "malayalam/narration/ch05.json",
-      "textHash": "fnv1a64:b5872e69e79d7819",
-      "jsonHash": "fnv1a64:1fd09d83af2da8ac"
+      "textHash": "fnv1a64:cd37929eeb9cdaae",
+      "jsonHash": "fnv1a64:10fe5762387e0afb"
     },
     {
       "language": "malayalam",
@@ -4878,8 +4878,8 @@
       "drivablePrefix": 0,
       "text": "marathi/narration/ch01.txt",
       "json": "marathi/narration/ch01.json",
-      "textHash": "fnv1a64:49f0cb079d15c5b1",
-      "jsonHash": "fnv1a64:70ba4fd397e7104b"
+      "textHash": "fnv1a64:9476e91360aac283",
+      "jsonHash": "fnv1a64:da1cf780ed95e451"
     },
     {
       "language": "marathi",
@@ -4900,8 +4900,8 @@
       "drivablePrefix": 0,
       "text": "marathi/narration/ch02.txt",
       "json": "marathi/narration/ch02.json",
-      "textHash": "fnv1a64:997f52a3ec21ea1e",
-      "jsonHash": "fnv1a64:f3c421e9870c7e9d"
+      "textHash": "fnv1a64:08018d4e9bd10e1e",
+      "jsonHash": "fnv1a64:25cc1db27e3617dd"
     },
     {
       "language": "marathi",
@@ -4919,8 +4919,8 @@
       "drivablePrefix": 1,
       "text": "marathi/narration/ch03.txt",
       "json": "marathi/narration/ch03.json",
-      "textHash": "fnv1a64:b3924db40016bddf",
-      "jsonHash": "fnv1a64:dd3baa3f168ccbab"
+      "textHash": "fnv1a64:cbc91fa67dbc5d81",
+      "jsonHash": "fnv1a64:126295a7b9159325"
     },
     {
       "language": "marathi",
@@ -4938,8 +4938,8 @@
       "drivablePrefix": 0,
       "text": "marathi/narration/ch04.txt",
       "json": "marathi/narration/ch04.json",
-      "textHash": "fnv1a64:aa70c216d026b9c3",
-      "jsonHash": "fnv1a64:9039a6a2b6096a25"
+      "textHash": "fnv1a64:243a6bf3be8eb0df",
+      "jsonHash": "fnv1a64:7330b409ed42ae39"
     },
     {
       "language": "marathi",
@@ -4956,8 +4956,8 @@
       "drivablePrefix": 0,
       "text": "marathi/narration/ch05.txt",
       "json": "marathi/narration/ch05.json",
-      "textHash": "fnv1a64:02fa10401fbe1fbb",
-      "jsonHash": "fnv1a64:7f0704071b792bb0"
+      "textHash": "fnv1a64:a0c31a7d46cfe4b0",
+      "jsonHash": "fnv1a64:80b8a75cfe0cd05f"
     },
     {
       "language": "marathi",
@@ -5106,8 +5106,8 @@
       "drivablePrefix": 4,
       "text": "persian/narration/ch01.txt",
       "json": "persian/narration/ch01.json",
-      "textHash": "fnv1a64:e0d6d4d4adb7a6ed",
-      "jsonHash": "fnv1a64:fc201b83cde92eb7"
+      "textHash": "fnv1a64:2ab896ea64610c90",
+      "jsonHash": "fnv1a64:f9b79a6243393058"
     },
     {
       "language": "persian",
@@ -5248,8 +5248,8 @@
       "drivablePrefix": 3,
       "text": "portuguese/narration/ch01.txt",
       "json": "portuguese/narration/ch01.json",
-      "textHash": "fnv1a64:9ad4e1111e02e003",
-      "jsonHash": "fnv1a64:111b501f138054fd"
+      "textHash": "fnv1a64:652565ec968b9a75",
+      "jsonHash": "fnv1a64:8d2ea3bbf1df7637"
     },
     {
       "language": "portuguese",
@@ -5679,8 +5679,8 @@
       "drivablePrefix": 0,
       "text": "punjabi/narration/ch01.txt",
       "json": "punjabi/narration/ch01.json",
-      "textHash": "fnv1a64:ca04bdb476231635",
-      "jsonHash": "fnv1a64:06bec4dc9f7d757a"
+      "textHash": "fnv1a64:94e5319d5b71b1c7",
+      "jsonHash": "fnv1a64:282ee8756e122f80"
     },
     {
       "language": "punjabi",
@@ -5701,8 +5701,8 @@
       "drivablePrefix": 0,
       "text": "punjabi/narration/ch02.txt",
       "json": "punjabi/narration/ch02.json",
-      "textHash": "fnv1a64:9ca222c6683223de",
-      "jsonHash": "fnv1a64:775483b872a02354"
+      "textHash": "fnv1a64:6330cfc194f24614",
+      "jsonHash": "fnv1a64:46ed7ee2aebacc82"
     },
     {
       "language": "punjabi",
@@ -5720,8 +5720,8 @@
       "drivablePrefix": 0,
       "text": "punjabi/narration/ch03.txt",
       "json": "punjabi/narration/ch03.json",
-      "textHash": "fnv1a64:e7f2a6e1df2ff084",
-      "jsonHash": "fnv1a64:6d4f79d9202f6d79"
+      "textHash": "fnv1a64:ff9062c543f1735c",
+      "jsonHash": "fnv1a64:1320848cba23d07d"
     },
     {
       "language": "punjabi",
@@ -5738,8 +5738,8 @@
       "drivablePrefix": 0,
       "text": "punjabi/narration/ch04.txt",
       "json": "punjabi/narration/ch04.json",
-      "textHash": "fnv1a64:53d46cf108b37c8e",
-      "jsonHash": "fnv1a64:ddafe0e9978ca1ec"
+      "textHash": "fnv1a64:2bb728a28c79d9d2",
+      "jsonHash": "fnv1a64:0d522268748bd870"
     },
     {
       "language": "punjabi",
@@ -5756,8 +5756,8 @@
       "drivablePrefix": 0,
       "text": "punjabi/narration/ch05.txt",
       "json": "punjabi/narration/ch05.json",
-      "textHash": "fnv1a64:879875ffd9f259ce",
-      "jsonHash": "fnv1a64:00f7fb68488dd023"
+      "textHash": "fnv1a64:e53129825bed02cb",
+      "jsonHash": "fnv1a64:f68149eaf0637766"
     },
     {
       "language": "punjabi",
@@ -5915,8 +5915,8 @@
       "drivablePrefix": 0,
       "text": "russian/narration/ch01.txt",
       "json": "russian/narration/ch01.json",
-      "textHash": "fnv1a64:48b836859ea2b1c0",
-      "jsonHash": "fnv1a64:c186e34a4c1dcac4"
+      "textHash": "fnv1a64:4d22cd074e8b4cb3",
+      "jsonHash": "fnv1a64:1cae78d2bee09d23"
     },
     {
       "language": "russian",
@@ -6089,8 +6089,8 @@
       "drivablePrefix": 0,
       "text": "sanskrit/narration/ch01.txt",
       "json": "sanskrit/narration/ch01.json",
-      "textHash": "fnv1a64:2500e0daf1b1caf8",
-      "jsonHash": "fnv1a64:71da3568320a6e16"
+      "textHash": "fnv1a64:271709c733eb5d06",
+      "jsonHash": "fnv1a64:84e617a68c1e2c28"
     },
     {
       "language": "sanskrit",
@@ -6110,8 +6110,8 @@
       "drivablePrefix": 0,
       "text": "sanskrit/narration/ch02.txt",
       "json": "sanskrit/narration/ch02.json",
-      "textHash": "fnv1a64:e2a1835d5ba8f515",
-      "jsonHash": "fnv1a64:a10b16c718be4dfe"
+      "textHash": "fnv1a64:d880705182bceafb",
+      "jsonHash": "fnv1a64:e7cea384b797a2a8"
     },
     {
       "language": "sanskrit",
@@ -6129,8 +6129,8 @@
       "drivablePrefix": 0,
       "text": "sanskrit/narration/ch03.txt",
       "json": "sanskrit/narration/ch03.json",
-      "textHash": "fnv1a64:4da71758ebc41fd6",
-      "jsonHash": "fnv1a64:f8f50ab61a926054"
+      "textHash": "fnv1a64:c509a4aaae88753a",
+      "jsonHash": "fnv1a64:bdad0e51dcbec2cc"
     },
     {
       "language": "sanskrit",
@@ -6147,8 +6147,8 @@
       "drivablePrefix": 0,
       "text": "sanskrit/narration/ch04.txt",
       "json": "sanskrit/narration/ch04.json",
-      "textHash": "fnv1a64:cb447311705e58b3",
-      "jsonHash": "fnv1a64:cbaf16911820298c"
+      "textHash": "fnv1a64:7faef6222baf27cf",
+      "jsonHash": "fnv1a64:fbdd1d12c072a7c8"
     },
     {
       "language": "sanskrit",
@@ -6165,8 +6165,8 @@
       "drivablePrefix": 0,
       "text": "sanskrit/narration/ch05.txt",
       "json": "sanskrit/narration/ch05.json",
-      "textHash": "fnv1a64:fa29930d26e809d9",
-      "jsonHash": "fnv1a64:44ef6007c7bd840d"
+      "textHash": "fnv1a64:4e9663137ffcabfe",
+      "jsonHash": "fnv1a64:019be05334898ab6"
     },
     {
       "language": "sanskrit",
@@ -6452,8 +6452,8 @@
       "drivablePrefix": 1,
       "text": "spanish/narration/ch07.txt",
       "json": "spanish/narration/ch07.json",
-      "textHash": "fnv1a64:1aeca19c2dfb0dfa",
-      "jsonHash": "fnv1a64:1a9142822ddfe851"
+      "textHash": "fnv1a64:83d9f545f7c1d05e",
+      "jsonHash": "fnv1a64:77f829dbacddb53b"
     },
     {
       "language": "spanish",
@@ -6470,8 +6470,8 @@
       "drivablePrefix": 5,
       "text": "spanish/narration/ch08.txt",
       "json": "spanish/narration/ch08.json",
-      "textHash": "fnv1a64:ece3418c7e272d33",
-      "jsonHash": "fnv1a64:5001c1540a854594"
+      "textHash": "fnv1a64:3dce48d5bca7202f",
+      "jsonHash": "fnv1a64:8c48c706fa1706d4"
     },
     {
       "language": "spanish",
@@ -6488,8 +6488,8 @@
       "drivablePrefix": 1,
       "text": "spanish/narration/ch09.txt",
       "json": "spanish/narration/ch09.json",
-      "textHash": "fnv1a64:04f0dba79a2d6484",
-      "jsonHash": "fnv1a64:4cd102dabf9ae5c8"
+      "textHash": "fnv1a64:87339f23ab01f15d",
+      "jsonHash": "fnv1a64:1e7a3bf85373fd5d"
     },
     {
       "language": "spanish",
@@ -6505,8 +6505,8 @@
       "drivablePrefix": 2,
       "text": "spanish/narration/ch10.txt",
       "json": "spanish/narration/ch10.json",
-      "textHash": "fnv1a64:854da3840e0ff935",
-      "jsonHash": "fnv1a64:811b7682e6660b2f"
+      "textHash": "fnv1a64:3a5b0d329f2f8ea8",
+      "jsonHash": "fnv1a64:fbcbe6812617370a"
     },
     {
       "language": "spanish",
@@ -6523,8 +6523,8 @@
       "drivablePrefix": 5,
       "text": "spanish/narration/ch11.txt",
       "json": "spanish/narration/ch11.json",
-      "textHash": "fnv1a64:07885328e44c13a2",
-      "jsonHash": "fnv1a64:b97317b34fd0651f"
+      "textHash": "fnv1a64:4e84a2e1e26f118c",
+      "jsonHash": "fnv1a64:a06be9aaf44e4b6d"
     },
     {
       "language": "spanish",
@@ -6540,8 +6540,8 @@
       "drivablePrefix": 2,
       "text": "spanish/narration/ch12.txt",
       "json": "spanish/narration/ch12.json",
-      "textHash": "fnv1a64:a5d51f2b6d65e588",
-      "jsonHash": "fnv1a64:7095f6c76900e946"
+      "textHash": "fnv1a64:a42b135aad54fbf6",
+      "jsonHash": "fnv1a64:6d4545dddf731948"
     },
     {
       "language": "spanish",
@@ -6557,8 +6557,8 @@
       "drivablePrefix": 0,
       "text": "spanish/narration/ch13.txt",
       "json": "spanish/narration/ch13.json",
-      "textHash": "fnv1a64:06cdf215fd3994c6",
-      "jsonHash": "fnv1a64:7f2cfcef656d8694"
+      "textHash": "fnv1a64:1338be47b159cfbd",
+      "jsonHash": "fnv1a64:d15d6e67c2d879bf"
     },
     {
       "language": "spanish",
@@ -6573,8 +6573,8 @@
       "drivablePrefix": 3,
       "text": "spanish/narration/ch14.txt",
       "json": "spanish/narration/ch14.json",
-      "textHash": "fnv1a64:3802e2dbe99973ae",
-      "jsonHash": "fnv1a64:3766b4c736751669"
+      "textHash": "fnv1a64:6e9633a2986b8c1c",
+      "jsonHash": "fnv1a64:3de52a74c7509a9f"
     },
     {
       "language": "spanish",
@@ -6589,8 +6589,8 @@
       "drivablePrefix": 1,
       "text": "spanish/narration/ch15.txt",
       "json": "spanish/narration/ch15.json",
-      "textHash": "fnv1a64:5cb5f5dcfab199e1",
-      "jsonHash": "fnv1a64:638a91584525e000"
+      "textHash": "fnv1a64:de3802a0f97ee1d8",
+      "jsonHash": "fnv1a64:1c22ab0a156ae489"
     },
     {
       "language": "spanish",
@@ -6605,8 +6605,8 @@
       "drivablePrefix": 1,
       "text": "spanish/narration/ch16.txt",
       "json": "spanish/narration/ch16.json",
-      "textHash": "fnv1a64:1aff743d44d8e988",
-      "jsonHash": "fnv1a64:8d75afe5fb51fb7f"
+      "textHash": "fnv1a64:3311f2181b943b81",
+      "jsonHash": "fnv1a64:06f4ec5541138812"
     },
     {
       "language": "spanish",
@@ -6622,8 +6622,8 @@
       "drivablePrefix": 2,
       "text": "spanish/narration/ch17.txt",
       "json": "spanish/narration/ch17.json",
-      "textHash": "fnv1a64:892ec53d74d0c99f",
-      "jsonHash": "fnv1a64:413aa32d9b925357"
+      "textHash": "fnv1a64:fe0c352e8a1fffd1",
+      "jsonHash": "fnv1a64:44107b161c5920c9"
     },
     {
       "language": "spanish",
@@ -6645,8 +6645,8 @@
       "drivablePrefix": 0,
       "text": "spanish/narration/ch18.txt",
       "json": "spanish/narration/ch18.json",
-      "textHash": "fnv1a64:03ab81aeb4513484",
-      "jsonHash": "fnv1a64:b0408cff584385b6"
+      "textHash": "fnv1a64:5bc4ef4684295d63",
+      "jsonHash": "fnv1a64:e0f01109fd77bb2d"
     },
     {
       "language": "spanish",
@@ -7051,8 +7051,8 @@
       "drivablePrefix": 2,
       "text": "tamil/narration/ch02.txt",
       "json": "tamil/narration/ch02.json",
-      "textHash": "fnv1a64:15a4ea890299aca6",
-      "jsonHash": "fnv1a64:5102266a57d3d2f9"
+      "textHash": "fnv1a64:244586946331121c",
+      "jsonHash": "fnv1a64:7f95b059a49e4b1f"
     },
     {
       "language": "tamil",
@@ -7070,8 +7070,8 @@
       "drivablePrefix": 0,
       "text": "tamil/narration/ch03.txt",
       "json": "tamil/narration/ch03.json",
-      "textHash": "fnv1a64:ea7853c6d4277b9a",
-      "jsonHash": "fnv1a64:5da5d3c37a951d6d"
+      "textHash": "fnv1a64:20361f0a27ab7832",
+      "jsonHash": "fnv1a64:2ec39197c5e28e81"
     },
     {
       "language": "tamil",
@@ -7089,8 +7089,8 @@
       "drivablePrefix": 0,
       "text": "tamil/narration/ch04.txt",
       "json": "tamil/narration/ch04.json",
-      "textHash": "fnv1a64:1b171aacaedb487f",
-      "jsonHash": "fnv1a64:48f48916a78ef3be"
+      "textHash": "fnv1a64:e5095270ae59ea43",
+      "jsonHash": "fnv1a64:4fdf4e9833823a52"
     },
     {
       "language": "tamil",
@@ -7108,8 +7108,8 @@
       "drivablePrefix": 0,
       "text": "tamil/narration/ch05.txt",
       "json": "tamil/narration/ch05.json",
-      "textHash": "fnv1a64:2ead7f41ba4f39f3",
-      "jsonHash": "fnv1a64:b1f272e50a261bd1"
+      "textHash": "fnv1a64:75cb0e6472b4e312",
+      "jsonHash": "fnv1a64:d069e67cf6116dd0"
     },
     {
       "language": "tamil",
@@ -7639,8 +7639,8 @@
       "drivablePrefix": 0,
       "text": "telugu/narration/ch01.txt",
       "json": "telugu/narration/ch01.json",
-      "textHash": "fnv1a64:6d31db1827067185",
-      "jsonHash": "fnv1a64:a64ba2a32e9ae899"
+      "textHash": "fnv1a64:c8695a7c8a61485f",
+      "jsonHash": "fnv1a64:365ddbcba951be9f"
     },
     {
       "language": "telugu",
@@ -7660,8 +7660,8 @@
       "drivablePrefix": 0,
       "text": "telugu/narration/ch02.txt",
       "json": "telugu/narration/ch02.json",
-      "textHash": "fnv1a64:4047544b5bf36dc6",
-      "jsonHash": "fnv1a64:dc1a241df86c0bc5"
+      "textHash": "fnv1a64:448792033c5c8446",
+      "jsonHash": "fnv1a64:a2b65907261c92bd"
     },
     {
       "language": "telugu",
@@ -7679,8 +7679,8 @@
       "drivablePrefix": 0,
       "text": "telugu/narration/ch03.txt",
       "json": "telugu/narration/ch03.json",
-      "textHash": "fnv1a64:19d5b8b6c39cbb04",
-      "jsonHash": "fnv1a64:1ac00673abdf1166"
+      "textHash": "fnv1a64:e5d42ff71eb0a026",
+      "jsonHash": "fnv1a64:73d91b01c8eab1b8"
     },
     {
       "language": "telugu",
@@ -7697,8 +7697,8 @@
       "drivablePrefix": 0,
       "text": "telugu/narration/ch04.txt",
       "json": "telugu/narration/ch04.json",
-      "textHash": "fnv1a64:bf3dfbc4ec5455af",
-      "jsonHash": "fnv1a64:a6377b88277ba168"
+      "textHash": "fnv1a64:3af99b7a49675223",
+      "jsonHash": "fnv1a64:e13b198aa1cfeb34"
     },
     {
       "language": "telugu",
@@ -7715,8 +7715,8 @@
       "drivablePrefix": 0,
       "text": "telugu/narration/ch05.txt",
       "json": "telugu/narration/ch05.json",
-      "textHash": "fnv1a64:832b54fc12af5997",
-      "jsonHash": "fnv1a64:42cc5d3cd8309241"
+      "textHash": "fnv1a64:c9468e54c71868ea",
+      "jsonHash": "fnv1a64:8cca837f3474fd26"
     },
     {
       "language": "telugu",
@@ -8153,8 +8153,8 @@
       "drivablePrefix": 4,
       "text": "urdu/narration/ch01.txt",
       "json": "urdu/narration/ch01.json",
-      "textHash": "fnv1a64:ec99ebef94e2242e",
-      "jsonHash": "fnv1a64:6d03bbc173e2cf37"
+      "textHash": "fnv1a64:1eb4183348befa5d",
+      "jsonHash": "fnv1a64:2403ebd0c5fbf756"
     },
     {
       "language": "urdu",

--- a/code/learning/human-languages/french/chapters.json
+++ b/code/learning/human-languages/french/chapters.json
@@ -1,8 +1,271 @@
 {
   "version": 1,
   "language": "french",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only Chapters 17-27 are authored — they are the French chapters whose lessons have been migrated to schema version 2 and therefore declare real knowledge atoms. Chapters 1-16 are still schema v1: their lessons carry no practises.knowledge, so any payoff written for them would assess invented atoms. Their absence here is real, measurable debt and must not be papered over with placeholders. Chapter 17's payoff sits exactly at the 0.5 representativeness floor and Chapters 17-18 have no terminal practice lesson at all; both facts are recorded per chapter below rather than hidden by padding assesses. Chapters 24 through 27 likewise have no terminal practice-mix, so their payoff is the chapter's last lesson by sequence — which is where the recombination and wrap-up recall actually live, and where each of the two reaches back past its own chapter to re-practise atoms taught earlier in the track (HL09 §7).",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet someone in French, recognize the reply, and choose an appropriate response.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-DEFINITE-REFERENCE",
+        "SPINE-TIME-OF-DAY",
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "FR-C01-practice",
+        "kind": "task",
+        "summary": "Complete FR-C01-practice, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in French, recognize the reply, and choose an appropriate response.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 2,
+      "title": "Introducing Yourself",
+      "label": "ch:introductions",
+      "canDo": "I can introduce myself in French, give my name, and understand the other person's name.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES",
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "FR-C02-practice",
+        "kind": "task",
+        "summary": "Complete FR-C02-practice, the canonical closing checkpoint, and demonstrate the chapter promise: introduce myself in French, give my name, and understand the other person's name.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "How Are You?",
+      "label": "ch:how-are-you",
+      "canDo": "I can ask how someone is in French, answer naturally, and return the question.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO",
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-COURTESY-THANK"
+      ],
+      "payoff": {
+        "lesson": "FR-C03-practice",
+        "kind": "task",
+        "summary": "Complete FR-C03-practice, the canonical closing checkpoint, and demonstrate the chapter promise: ask how someone is in French, answer naturally, and return the question.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "Farewells",
+      "label": "ch:farewells",
+      "canDo": "I can end a French conversation politely and choose a farewell that fits the situation.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "FR-C04-practice",
+        "kind": "task",
+        "summary": "Complete FR-C04-practice, the canonical closing checkpoint, and demonstrate the chapter promise: end a French conversation politely and choose a farewell that fits the situation.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "The First Verbs",
+      "label": "ch:first-verbs",
+      "canDo": "I can build short present-tense French sentences with the chapter's first verbs.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "FR-C05-practice",
+        "kind": "task",
+        "summary": "Complete FR-C05-practice, the canonical closing checkpoint, and demonstrate the chapter promise: build short present-tense French sentences with the chapter's first verbs.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 6,
+      "title": "Numbers One to Ten",
+      "label": "ch:numbers-1-10",
+      "canDo": "I can count from one to ten in French and use the numbers in a short exchange.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "FR-C06-nombres-6-10",
+        "kind": "task",
+        "summary": "Complete FR-C06-nombres-6-10, the canonical closing checkpoint, and demonstrate the chapter promise: count from one to ten in French and use the numbers in a short exchange.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 7,
+      "title": "The Days of the Week",
+      "label": "ch:days",
+      "canDo": "I can name the days of the week in French and use them in simple plans.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "FR-C07-jours-2",
+        "kind": "task",
+        "summary": "Complete FR-C07-jours-2, the canonical closing checkpoint, and demonstrate the chapter promise: name the days of the week in French and use them in simple plans.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 8,
+      "title": "Telling the Time",
+      "label": "ch:time",
+      "canDo": "I can ask for and tell the time in French.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "FR-C08-midi-minuit",
+        "kind": "task",
+        "summary": "Complete FR-C08-midi-minuit, the canonical closing checkpoint, and demonstrate the chapter promise: ask for and tell the time in French.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 9,
+      "title": "Months and Seasons",
+      "label": "ch:months-seasons",
+      "canDo": "I can name the months and seasons in French and say when something happens.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "FR-C09-saisons",
+        "kind": "task",
+        "summary": "Complete FR-C09-saisons, the canonical closing checkpoint, and demonstrate the chapter promise: name the months and seasons in French and say when something happens.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 10,
+      "title": "Family",
+      "label": "ch:family",
+      "canDo": "I can identify close family members in French and say who someone is.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "FR-C10-freres-soeurs",
+        "kind": "task",
+        "summary": "Complete FR-C10-freres-soeurs, the canonical closing checkpoint, and demonstrate the chapter promise: identify close family members in French and say who someone is.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 11,
+      "title": "Bread, Water, Wine",
+      "label": "ch:food",
+      "canDo": "I can name and request bread, water, and wine in French.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "FR-C11-eau-vin",
+        "kind": "task",
+        "summary": "Complete FR-C11-eau-vin, the canonical closing checkpoint, and demonstrate the chapter promise: name and request bread, water, and wine in French.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 12,
+      "title": "Numbers Eleven to Twenty",
+      "label": "ch:numbers-11-20",
+      "canDo": "I can count from eleven to twenty in French and recognize how the number forms are built.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "FR-C12-nombres-17-20",
+        "kind": "task",
+        "summary": "Complete FR-C12-nombres-17-20, the canonical closing checkpoint, and demonstrate the chapter promise: count from eleven to twenty in French and recognize how the number forms are built.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 13,
+      "title": "Colours",
+      "label": "ch:colours",
+      "canDo": "I can name basic colours in French and use them to describe something.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "FR-C13-rouge-bleu",
+        "kind": "task",
+        "summary": "Complete FR-C13-rouge-bleu, the canonical closing checkpoint, and demonstrate the chapter promise: name basic colours in French and use them to describe something.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 14,
+      "title": "To Have, and How Old You Are",
+      "label": "ch:avoir-age",
+      "canDo": "I can use the French verb for “to have” to talk about possession and age.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "FR-C14-age",
+        "kind": "task",
+        "summary": "Complete FR-C14-age, the canonical closing checkpoint, and demonstrate the chapter promise: use the French verb for “to have” to talk about possession and age.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 15,
+      "title": "The Compound Past",
+      "label": "ch:passe-compose",
+      "canDo": "I can build the chapter's conversational past tense in French and say what happened.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "FR-C15-passe-simple",
+        "kind": "task",
+        "summary": "Complete FR-C15-passe-simple, the canonical closing checkpoint, and demonstrate the chapter promise: build the chapter's conversational past tense in French and say what happened.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 16,
+      "title": "To Be, and the Past That Takes It",
+      "label": "ch:etre",
+      "canDo": "I can use the French verb for “to be” and form the past of verbs that select it.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "FR-C16-pronominal-past",
+        "kind": "task",
+        "summary": "Complete FR-C16-pronominal-past, the canonical closing checkpoint, and demonstrate the chapter promise: use the French verb for “to be” and form the past of verbs that select it.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 17,
       "title": "Head and Hand",

--- a/code/learning/human-languages/french/curriculum.json
+++ b/code/learning/human-languages/french/curriculum.json
@@ -185,6 +185,19 @@
       "after": []
     },
     {
+      "id": "FR-PATH-029",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "FR-C08-heure",
+        "FR-C08-midi-minuit"
+      ],
+      "before": [],
+      "inline": [
+        "FR-EXT-029-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
       "id": "FR-PATH-016",
       "spine_node": "SPINE-SAY-WHAT-I-DO",
       "lessons": [
@@ -446,6 +459,7 @@
         "FR-PATH-004",
         "FR-PATH-006",
         "FR-PATH-015",
+        "FR-PATH-029",
         "FR-PATH-021"
       ],
       "omits": [
@@ -844,6 +858,18 @@
         "FR-C30-beurre",
         "FR-C30-sel",
         "FR-C30-oeuf"
+      ]
+    },
+    {
+      "id": "FR-EXT-029-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the French-specific vocabulary and grammar that support this shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "FR-C08-heure",
+        "FR-C08-midi-minuit"
       ]
     },
     {

--- a/code/learning/human-languages/french/narration/ch01.json
+++ b/code/learning/human-languages/french/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings",
   "drivablePrefix": 7,
   "sourceHash": "fnv1a64:b9a7455b1f549b7d",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch01.txt
+++ b/code/learning/human-languages/french/narration/ch01.txt
@@ -1,4 +1,4 @@
-French, chapter 1: Chapter 1.
+French, chapter 1: Greetings.
 11 lessons. You can do the first 7 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/french/narration/ch02.json
+++ b/code/learning/human-languages/french/narration/ch02.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 2,
-  "title": "Chapter 2",
+  "title": "Introducing Yourself",
   "drivablePrefix": 4,
   "sourceHash": "fnv1a64:e3cb86d5fd9a61c0",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch02.txt
+++ b/code/learning/human-languages/french/narration/ch02.txt
@@ -1,4 +1,4 @@
-French, chapter 2: Chapter 2.
+French, chapter 2: Introducing Yourself.
 9 lessons. You can do the first 4 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/french/narration/ch03.json
+++ b/code/learning/human-languages/french/narration/ch03.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 3,
-  "title": "Chapter 3",
+  "title": "How Are You?",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:db59db21d0da9d56",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch03.txt
+++ b/code/learning/human-languages/french/narration/ch03.txt
@@ -1,4 +1,4 @@
-French, chapter 3: Chapter 3.
+French, chapter 3: How Are You?.
 7 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/french/narration/ch04.json
+++ b/code/learning/human-languages/french/narration/ch04.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 4,
-  "title": "Chapter 4",
+  "title": "Farewells",
   "drivablePrefix": 5,
   "sourceHash": "fnv1a64:eaff6c8fad389e25",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch04.txt
+++ b/code/learning/human-languages/french/narration/ch04.txt
@@ -1,4 +1,4 @@
-French, chapter 4: Chapter 4.
+French, chapter 4: Farewells.
 8 lessons. You can do the first 5 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/french/narration/ch05.json
+++ b/code/learning/human-languages/french/narration/ch05.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 5,
-  "title": "Chapter 5",
+  "title": "The First Verbs",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:1ac542fc6064f48f",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch05.txt
+++ b/code/learning/human-languages/french/narration/ch05.txt
@@ -1,4 +1,4 @@
-French, chapter 5: Chapter 5.
+French, chapter 5: The First Verbs.
 5 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/french/narration/ch06.json
+++ b/code/learning/human-languages/french/narration/ch06.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 6,
-  "title": "Chapter 6",
+  "title": "Numbers One to Ten",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:25abe4ad2f43a9c8",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch06.txt
+++ b/code/learning/human-languages/french/narration/ch06.txt
@@ -1,4 +1,4 @@
-French, chapter 6: Chapter 6.
+French, chapter 6: Numbers One to Ten.
 2 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/french/narration/ch07.json
+++ b/code/learning/human-languages/french/narration/ch07.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 7,
-  "title": "Chapter 7",
+  "title": "The Days of the Week",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:5ec84f262f3c7a49",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch07.txt
+++ b/code/learning/human-languages/french/narration/ch07.txt
@@ -1,4 +1,4 @@
-French, chapter 7: Chapter 7.
+French, chapter 7: The Days of the Week.
 2 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/french/narration/ch08.json
+++ b/code/learning/human-languages/french/narration/ch08.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 8,
-  "title": "Chapter 8",
+  "title": "Telling the Time",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:82538ce167e89fcb",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch08.txt
+++ b/code/learning/human-languages/french/narration/ch08.txt
@@ -1,4 +1,4 @@
-French, chapter 8: Chapter 8.
+French, chapter 8: Telling the Time.
 2 lessons. All 2 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/french/narration/ch09.json
+++ b/code/learning/human-languages/french/narration/ch09.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 9,
-  "title": "Chapter 9",
+  "title": "Months and Seasons",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:8841e970ee25edfd",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch09.txt
+++ b/code/learning/human-languages/french/narration/ch09.txt
@@ -1,4 +1,4 @@
-French, chapter 9: Chapter 9.
+French, chapter 9: Months and Seasons.
 2 lessons. All 2 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/french/narration/ch10.json
+++ b/code/learning/human-languages/french/narration/ch10.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 10,
-  "title": "Chapter 10",
+  "title": "Family",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:310363476cb5df5c",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch10.txt
+++ b/code/learning/human-languages/french/narration/ch10.txt
@@ -1,4 +1,4 @@
-French, chapter 10: Chapter 10.
+French, chapter 10: Family.
 2 lessons. All 2 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/french/narration/ch11.json
+++ b/code/learning/human-languages/french/narration/ch11.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 11,
-  "title": "Chapter 11",
+  "title": "Bread, Water, Wine",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:9b1a16bd909e6a7a",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch11.txt
+++ b/code/learning/human-languages/french/narration/ch11.txt
@@ -1,4 +1,4 @@
-French, chapter 11: Chapter 11.
+French, chapter 11: Bread, Water, Wine.
 2 lessons. All 2 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/french/narration/ch12.json
+++ b/code/learning/human-languages/french/narration/ch12.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 12,
-  "title": "Chapter 12",
+  "title": "Numbers Eleven to Twenty",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:61f59b165c29bd13",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch12.txt
+++ b/code/learning/human-languages/french/narration/ch12.txt
@@ -1,4 +1,4 @@
-French, chapter 12: Chapter 12.
+French, chapter 12: Numbers Eleven to Twenty.
 2 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/french/narration/ch13.json
+++ b/code/learning/human-languages/french/narration/ch13.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 13,
-  "title": "Chapter 13",
+  "title": "Colours",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:4a24fc14ce11546c",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch13.txt
+++ b/code/learning/human-languages/french/narration/ch13.txt
@@ -1,4 +1,4 @@
-French, chapter 13: Chapter 13.
+French, chapter 13: Colours.
 2 lessons. All 2 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/french/narration/ch14.json
+++ b/code/learning/human-languages/french/narration/ch14.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 14,
-  "title": "Chapter 14",
+  "title": "To Have, and How Old You Are",
   "drivablePrefix": 1,
   "sourceHash": "fnv1a64:a60c4c85228a0399",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch14.txt
+++ b/code/learning/human-languages/french/narration/ch14.txt
@@ -1,4 +1,4 @@
-French, chapter 14: Chapter 14.
+French, chapter 14: To Have, and How Old You Are.
 2 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/french/narration/ch15.json
+++ b/code/learning/human-languages/french/narration/ch15.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 15,
-  "title": "Chapter 15",
+  "title": "The Compound Past",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:671e0691db37e94a",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch15.txt
+++ b/code/learning/human-languages/french/narration/ch15.txt
@@ -1,4 +1,4 @@
-French, chapter 15: Chapter 15.
+French, chapter 15: The Compound Past.
 2 lessons. All 2 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/french/narration/ch16.json
+++ b/code/learning/human-languages/french/narration/ch16.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "french",
   "chapter": 16,
-  "title": "Chapter 16",
+  "title": "To Be, and the Past That Takes It",
   "drivablePrefix": 4,
   "sourceHash": "fnv1a64:d8315d6d2e9e3429",
   "lessons": [

--- a/code/learning/human-languages/french/narration/ch16.txt
+++ b/code/learning/human-languages/french/narration/ch16.txt
@@ -1,4 +1,4 @@
-French, chapter 16: Chapter 16.
+French, chapter 16: To Be, and the Past That Takes It.
 4 lessons. All 4 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/german/chapters.json
+++ b/code/learning/human-languages/german/chapters.json
@@ -1,8 +1,272 @@
 {
   "version": 1,
   "language": "german",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only Chapters 17-25 are authored — they are the nine German chapters whose lessons have been migrated to schema version 2 and therefore declare real knowledge atoms. Chapters 1-16 are still schema v1: their lessons carry no practises.knowledge, so any payoff written for them would assess invented atoms. Their absence here is real, measurable debt and must not be papered over with placeholders. Chapter 17 is the one authored chapter that FAILS the 0.5 representativeness floor (4 of 12 introduced atoms, 0.33): it is three word lessons deep with no terminal consolidation lesson, so its payoff can only reach the last of the three. That is recorded here rather than hidden by padding assesses — the fix is a real Kopf/Haupt/Hand practice lesson, not a longer list. Chapters 24 and 25 follow HL09 section 7: each payoff closes over all of its own chapter's atoms AND names atoms from earlier chapters it genuinely re-practises, so the reach-back is measurable rather than decorative.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet someone in German, recognize the reply, and choose an appropriate response.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-DEFINITE-REFERENCE",
+        "SPINE-TIME-OF-DAY",
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "GE-C01-practice",
+        "kind": "task",
+        "summary": "Complete GE-C01-practice, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in German, recognize the reply, and choose an appropriate response.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 2,
+      "title": "Introducing Yourself",
+      "label": "ch:introductions",
+      "canDo": "I can introduce myself in German, give my name, and understand the other person's name.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES",
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "GE-C02-practice",
+        "kind": "task",
+        "summary": "Complete GE-C02-practice, the canonical closing checkpoint, and demonstrate the chapter promise: introduce myself in German, give my name, and understand the other person's name.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "How Are You?",
+      "label": "ch:how-are-you",
+      "canDo": "I can ask how someone is in German, answer naturally, and return the question.",
+      "spineNodes": [
+        "SPINE-COURTESY-THANK",
+        "SPINE-SAY-WHAT-I-DO",
+        "SPINE-CHECK-WELLBEING"
+      ],
+      "payoff": {
+        "lesson": "GE-C03-formal-practice",
+        "kind": "task",
+        "summary": "Complete GE-C03-formal-practice, the canonical closing checkpoint, and demonstrate the chapter promise: ask how someone is in German, answer naturally, and return the question.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "Farewells",
+      "label": "ch:farewells",
+      "canDo": "I can end a German conversation politely and choose a farewell that fits the situation.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "GE-C04-practice",
+        "kind": "task",
+        "summary": "Complete GE-C04-practice, the canonical closing checkpoint, and demonstrate the chapter promise: end a German conversation politely and choose a farewell that fits the situation.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "The First Verbs",
+      "label": "ch:first-verbs",
+      "canDo": "I can build short present-tense German sentences with the chapter's first verbs.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "GE-C05-practice",
+        "kind": "task",
+        "summary": "Complete GE-C05-practice, the canonical closing checkpoint, and demonstrate the chapter promise: build short present-tense German sentences with the chapter's first verbs.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 6,
+      "title": "Numbers One to Ten",
+      "label": "ch:numbers-1-10",
+      "canDo": "I can count from one to ten in German and use the numbers in a short exchange.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "GE-C06-zahlen-6-10",
+        "kind": "task",
+        "summary": "Complete GE-C06-zahlen-6-10, the canonical closing checkpoint, and demonstrate the chapter promise: count from one to ten in German and use the numbers in a short exchange.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 7,
+      "title": "The Days of the Week",
+      "label": "ch:days",
+      "canDo": "I can name the days of the week in German and use them in simple plans.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "GE-C07-wochentage-2",
+        "kind": "task",
+        "summary": "Complete GE-C07-wochentage-2, the canonical closing checkpoint, and demonstrate the chapter promise: name the days of the week in German and use them in simple plans.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 8,
+      "title": "Telling the Time",
+      "label": "ch:time",
+      "canDo": "I can ask for and tell the time in German.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "GE-C08-mittag-mitternacht",
+        "kind": "task",
+        "summary": "Complete GE-C08-mittag-mitternacht, the canonical closing checkpoint, and demonstrate the chapter promise: ask for and tell the time in German.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 9,
+      "title": "Months and Seasons",
+      "label": "ch:months-seasons",
+      "canDo": "I can name the months and seasons in German and say when something happens.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "GE-C09-jahreszeiten",
+        "kind": "task",
+        "summary": "Complete GE-C09-jahreszeiten, the canonical closing checkpoint, and demonstrate the chapter promise: name the months and seasons in German and say when something happens.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 10,
+      "title": "Family",
+      "label": "ch:family",
+      "canDo": "I can identify close family members in German and say who someone is.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "GE-C10-geschwister",
+        "kind": "task",
+        "summary": "Complete GE-C10-geschwister, the canonical closing checkpoint, and demonstrate the chapter promise: identify close family members in German and say who someone is.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 11,
+      "title": "Bread, Water, Wine",
+      "label": "ch:food",
+      "canDo": "I can name and request bread, water, and wine in German.",
+      "spineNodes": [
+        "SPINE-POLITE-REQUEST-REPAIR"
+      ],
+      "payoff": {
+        "lesson": "GE-C11-wasser-wein",
+        "kind": "task",
+        "summary": "Complete GE-C11-wasser-wein, the canonical closing checkpoint, and demonstrate the chapter promise: name and request bread, water, and wine in German.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 12,
+      "title": "Numbers Eleven to Twenty",
+      "label": "ch:numbers-11-20",
+      "canDo": "I can count from eleven to twenty in German and recognize how the number forms are built.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "GE-C12-zahlen-13-20",
+        "kind": "task",
+        "summary": "Complete GE-C12-zahlen-13-20, the canonical closing checkpoint, and demonstrate the chapter promise: count from eleven to twenty in German and recognize how the number forms are built.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 13,
+      "title": "Colours",
+      "label": "ch:colours",
+      "canDo": "I can name basic colours in German and use them to describe something.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "GE-C13-rot-blau",
+        "kind": "task",
+        "summary": "Complete GE-C13-rot-blau, the canonical closing checkpoint, and demonstrate the chapter promise: name basic colours in German and use them to describe something.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 14,
+      "title": "To Have, and How Old You Are",
+      "label": "ch:haben-alter",
+      "canDo": "I can use the German verb for “to have” to talk about possession and age.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO",
+        "SPINE-TIME-OF-DAY"
+      ],
+      "payoff": {
+        "lesson": "GE-C14-alter",
+        "kind": "task",
+        "summary": "Complete GE-C14-alter, the canonical closing checkpoint, and demonstrate the chapter promise: use the German verb for “to have” to talk about possession and age.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 15,
+      "title": "The Two Past Tenses",
+      "label": "ch:perfekt",
+      "canDo": "I can build the chapter's conversational past tense in German and say what happened.",
+      "spineNodes": [
+        "SPINE-TALK-ABOUT-PAST"
+      ],
+      "payoff": {
+        "lesson": "GE-C15-praeteritum-map",
+        "kind": "task",
+        "summary": "Complete GE-C15-praeteritum-map, the canonical closing checkpoint, and demonstrate the chapter promise: build the chapter's conversational past tense in German and say what happened.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 16,
+      "title": "To Be, and the Past That Takes It",
+      "label": "ch:sein",
+      "canDo": "I can use the German verb for “to be” and form the past of verbs that select it.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "GE-C16-perfekt-sein-agreement",
+        "kind": "task",
+        "summary": "Complete GE-C16-perfekt-sein-agreement, the canonical closing checkpoint, and demonstrate the chapter promise: use the German verb for “to be” and form the past of verbs that select it.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 17,
       "title": "Head and Hand",

--- a/code/learning/human-languages/german/curriculum.json
+++ b/code/learning/human-languages/german/curriculum.json
@@ -175,6 +175,19 @@
       "after": []
     },
     {
+      "id": "GE-PATH-035",
+      "spine_node": "SPINE-TIME-OF-DAY",
+      "lessons": [
+        "GE-C07-wochentage-1",
+        "GE-C07-wochentage-2"
+      ],
+      "before": [],
+      "inline": [
+        "GE-EXT-035-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
       "id": "GE-PATH-016",
       "spine_node": "SPINE-POLITE-REQUEST-REPAIR",
       "lessons": [
@@ -507,6 +520,7 @@
         "GE-PATH-004",
         "GE-PATH-006",
         "GE-PATH-015",
+        "GE-PATH-035",
         "GE-PATH-017",
         "GE-PATH-019",
         "GE-PATH-025"
@@ -938,6 +952,18 @@
         "GE-C30-ohr",
         "GE-C30-mund",
         "GE-C30-nase"
+      ]
+    },
+    {
+      "id": "GE-EXT-035-LANGUAGE-SPECIFIC",
+      "stage": "A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the German-specific vocabulary and grammar that support this shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "GE-C07-wochentage-1",
+        "GE-C07-wochentage-2"
       ]
     },
     {

--- a/code/learning/human-languages/german/narration/ch01.json
+++ b/code/learning/human-languages/german/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings",
   "drivablePrefix": 6,
   "sourceHash": "fnv1a64:3eb0a576892fbc9e",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch01.txt
+++ b/code/learning/human-languages/german/narration/ch01.txt
@@ -1,4 +1,4 @@
-German, chapter 1: Chapter 1.
+German, chapter 1: Greetings.
 12 lessons. You can do the first 6 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/german/narration/ch02.json
+++ b/code/learning/human-languages/german/narration/ch02.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 2,
-  "title": "Chapter 2",
+  "title": "Introducing Yourself",
   "drivablePrefix": 8,
   "sourceHash": "fnv1a64:a3ce192e57bc4fbf",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch02.txt
+++ b/code/learning/human-languages/german/narration/ch02.txt
@@ -1,4 +1,4 @@
-German, chapter 2: Chapter 2.
+German, chapter 2: Introducing Yourself.
 8 lessons. All 8 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/german/narration/ch03.json
+++ b/code/learning/human-languages/german/narration/ch03.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 3,
-  "title": "Chapter 3",
+  "title": "How Are You?",
   "drivablePrefix": 8,
   "sourceHash": "fnv1a64:9c052e4af0dd40f4",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch03.txt
+++ b/code/learning/human-languages/german/narration/ch03.txt
@@ -1,4 +1,4 @@
-German, chapter 3: Chapter 3.
+German, chapter 3: How Are You?.
 8 lessons. All 8 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/german/narration/ch04.json
+++ b/code/learning/human-languages/german/narration/ch04.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 4,
-  "title": "Chapter 4",
+  "title": "Farewells",
   "drivablePrefix": 6,
   "sourceHash": "fnv1a64:911ace96428ac7d3",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch04.txt
+++ b/code/learning/human-languages/german/narration/ch04.txt
@@ -1,4 +1,4 @@
-German, chapter 4: Chapter 4.
+German, chapter 4: Farewells.
 9 lessons. You can do the first 6 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/german/narration/ch05.json
+++ b/code/learning/human-languages/german/narration/ch05.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 5,
-  "title": "Chapter 5",
+  "title": "The First Verbs",
   "drivablePrefix": 5,
   "sourceHash": "fnv1a64:fa85693f7e833aff",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch05.txt
+++ b/code/learning/human-languages/german/narration/ch05.txt
@@ -1,4 +1,4 @@
-German, chapter 5: Chapter 5.
+German, chapter 5: The First Verbs.
 5 lessons. All 5 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/german/narration/ch06.json
+++ b/code/learning/human-languages/german/narration/ch06.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 6,
-  "title": "Chapter 6",
+  "title": "Numbers One to Ten",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:7e9dfcbdcfad6638",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch06.txt
+++ b/code/learning/human-languages/german/narration/ch06.txt
@@ -1,4 +1,4 @@
-German, chapter 6: Chapter 6.
+German, chapter 6: Numbers One to Ten.
 2 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/german/narration/ch07.json
+++ b/code/learning/human-languages/german/narration/ch07.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 7,
-  "title": "Chapter 7",
+  "title": "The Days of the Week",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:df41328f5c217864",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch07.txt
+++ b/code/learning/human-languages/german/narration/ch07.txt
@@ -1,4 +1,4 @@
-German, chapter 7: Chapter 7.
+German, chapter 7: The Days of the Week.
 2 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/german/narration/ch08.json
+++ b/code/learning/human-languages/german/narration/ch08.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 8,
-  "title": "Chapter 8",
+  "title": "Telling the Time",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:6d770a78d187c917",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch08.txt
+++ b/code/learning/human-languages/german/narration/ch08.txt
@@ -1,4 +1,4 @@
-German, chapter 8: Chapter 8.
+German, chapter 8: Telling the Time.
 2 lessons. All 2 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/german/narration/ch09.json
+++ b/code/learning/human-languages/german/narration/ch09.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 9,
-  "title": "Chapter 9",
+  "title": "Months and Seasons",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:8432842e6258ad15",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch09.txt
+++ b/code/learning/human-languages/german/narration/ch09.txt
@@ -1,4 +1,4 @@
-German, chapter 9: Chapter 9.
+German, chapter 9: Months and Seasons.
 2 lessons. All 2 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/german/narration/ch10.json
+++ b/code/learning/human-languages/german/narration/ch10.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 10,
-  "title": "Chapter 10",
+  "title": "Family",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:0dab0076a84ba89e",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch10.txt
+++ b/code/learning/human-languages/german/narration/ch10.txt
@@ -1,4 +1,4 @@
-German, chapter 10: Chapter 10.
+German, chapter 10: Family.
 2 lessons. All 2 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/german/narration/ch11.json
+++ b/code/learning/human-languages/german/narration/ch11.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 11,
-  "title": "Chapter 11",
+  "title": "Bread, Water, Wine",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:c73ea28012642ca1",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch11.txt
+++ b/code/learning/human-languages/german/narration/ch11.txt
@@ -1,4 +1,4 @@
-German, chapter 11: Chapter 11.
+German, chapter 11: Bread, Water, Wine.
 2 lessons. All 2 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/german/narration/ch12.json
+++ b/code/learning/human-languages/german/narration/ch12.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 12,
-  "title": "Chapter 12",
+  "title": "Numbers Eleven to Twenty",
   "drivablePrefix": 1,
   "sourceHash": "fnv1a64:67b1d99f86f090c2",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch12.txt
+++ b/code/learning/human-languages/german/narration/ch12.txt
@@ -1,4 +1,4 @@
-German, chapter 12: Chapter 12.
+German, chapter 12: Numbers Eleven to Twenty.
 2 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/german/narration/ch13.json
+++ b/code/learning/human-languages/german/narration/ch13.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 13,
-  "title": "Chapter 13",
+  "title": "Colours",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:0903bc711593d695",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch13.txt
+++ b/code/learning/human-languages/german/narration/ch13.txt
@@ -1,4 +1,4 @@
-German, chapter 13: Chapter 13.
+German, chapter 13: Colours.
 2 lessons. All 2 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/german/narration/ch14.json
+++ b/code/learning/human-languages/german/narration/ch14.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 14,
-  "title": "Chapter 14",
+  "title": "To Have, and How Old You Are",
   "drivablePrefix": 1,
   "sourceHash": "fnv1a64:5e1bd195a055b413",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch14.txt
+++ b/code/learning/human-languages/german/narration/ch14.txt
@@ -1,4 +1,4 @@
-German, chapter 14: Chapter 14.
+German, chapter 14: To Have, and How Old You Are.
 2 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/german/narration/ch15.json
+++ b/code/learning/human-languages/german/narration/ch15.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 15,
-  "title": "Chapter 15",
+  "title": "The Two Past Tenses",
   "drivablePrefix": 3,
   "sourceHash": "fnv1a64:c9f90e9658f9d3f2",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch15.txt
+++ b/code/learning/human-languages/german/narration/ch15.txt
@@ -1,4 +1,4 @@
-German, chapter 15: Chapter 15.
+German, chapter 15: The Two Past Tenses.
 3 lessons. All 3 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/german/narration/ch16.json
+++ b/code/learning/human-languages/german/narration/ch16.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "german",
   "chapter": 16,
-  "title": "Chapter 16",
+  "title": "To Be, and the Past That Takes It",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:830f5bd79326d776",
   "lessons": [

--- a/code/learning/human-languages/german/narration/ch16.txt
+++ b/code/learning/human-languages/german/narration/ch16.txt
@@ -1,4 +1,4 @@
-German, chapter 16: Chapter 16.
+German, chapter 16: To Be, and the Past That Takes It.
 3 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/gujarati/chapters.json
+++ b/code/learning/human-languages/gujarati/chapters.json
@@ -1,8 +1,93 @@
 {
   "version": 1,
   "language": "gujarati",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 6 through 9 are authorable today. Chapters 1-5 are entirely schema-v1 (no introduces/practises knowledge atoms), so no payoff there can name atoms a lesson actually practises; they are deliberately absent rather than stubbed, and that absence is real, measurable debt.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet someone in Gujarati, recognize the reply, and choose an appropriate response.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-COURTESY-THANK",
+        "SPINE-TAKE-LEAVE",
+        "SPINE-RESPOND-BASIC"
+      ],
+      "payoff": {
+        "lesson": "GU-C01-practice",
+        "kind": "task",
+        "summary": "Complete GU-C01-practice, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in Gujarati, recognize the reply, and choose an appropriate response.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 2,
+      "title": "Introducing Yourself",
+      "label": "ch:introductions",
+      "canDo": "I can introduce myself in Gujarati, give my name, and understand the other person's name.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "GU-C02-practice",
+        "kind": "task",
+        "summary": "Complete GU-C02-practice, the canonical closing checkpoint, and demonstrate the chapter promise: introduce myself in Gujarati, give my name, and understand the other person's name.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "How Are You?",
+      "label": "ch:responding",
+      "canDo": "I can ask how someone is in Gujarati, answer naturally, and return the question.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES",
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-COURTESY-THANK"
+      ],
+      "payoff": {
+        "lesson": "GU-C03-practice",
+        "kind": "task",
+        "summary": "Complete GU-C03-practice, the canonical closing checkpoint, and demonstrate the chapter promise: ask how someone is in Gujarati, answer naturally, and return the question.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "Farewells",
+      "label": "ch:farewells",
+      "canDo": "I can end a Gujarati conversation politely and choose a farewell that fits the situation.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "GU-C04-practice",
+        "kind": "task",
+        "summary": "Complete GU-C04-practice, the canonical closing checkpoint, and demonstrate the chapter promise: end a Gujarati conversation politely and choose a farewell that fits the situation.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "The First Verbs",
+      "label": "ch:first-verbs",
+      "canDo": "I can build short present-tense Gujarati sentences with the chapter's first verbs.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "GU-C05-practice",
+        "kind": "task",
+        "summary": "Complete GU-C05-practice, the canonical closing checkpoint, and demonstrate the chapter promise: build short present-tense Gujarati sentences with the chapter's first verbs.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 6,
       "title": "Numbers One to Five",

--- a/code/learning/human-languages/gujarati/curriculum.json
+++ b/code/learning/human-languages/gujarati/curriculum.json
@@ -101,6 +101,22 @@
       "after": []
     },
     {
+      "id": "GU-PATH-016",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "GU-C05-bolvun",
+        "GU-C05-hun-gujarati-bolun-chhun",
+        "GU-C05-kaam-karvun",
+        "GU-C05-rahevun",
+        "GU-C05-practice"
+      ],
+      "before": [],
+      "inline": [
+        "GU-EXT-016-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
       "id": "GU-PATH-009",
       "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
       "lessons": [
@@ -316,6 +332,7 @@
     },
     "SPINE-SAY-WHAT-I-DO": {
       "segments": [
+        "GU-PATH-016",
         "GU-PATH-010",
         "GU-PATH-011",
         "GU-PATH-012"
@@ -624,6 +641,21 @@
         "GU-C11-kutumb",
         "GU-C11-bhai",
         "GU-C11-bahen"
+      ]
+    },
+    {
+      "id": "GU-EXT-016-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the Gujarati-specific vocabulary and grammar that support this shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "GU-C05-bolvun",
+        "GU-C05-hun-gujarati-bolun-chhun",
+        "GU-C05-kaam-karvun",
+        "GU-C05-rahevun",
+        "GU-C05-practice"
       ]
     },
     {

--- a/code/learning/human-languages/gujarati/narration/ch01.json
+++ b/code/learning/human-languages/gujarati/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "gujarati",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:08fb66dea407c28f",
   "lessons": [

--- a/code/learning/human-languages/gujarati/narration/ch01.txt
+++ b/code/learning/human-languages/gujarati/narration/ch01.txt
@@ -1,4 +1,4 @@
-Gujarati, chapter 1: Chapter 1.
+Gujarati, chapter 1: Greetings.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/gujarati/narration/ch02.json
+++ b/code/learning/human-languages/gujarati/narration/ch02.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "gujarati",
   "chapter": 2,
-  "title": "Chapter 2",
+  "title": "Introducing Yourself",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:b40428346fb84ab2",
   "lessons": [

--- a/code/learning/human-languages/gujarati/narration/ch02.txt
+++ b/code/learning/human-languages/gujarati/narration/ch02.txt
@@ -1,4 +1,4 @@
-Gujarati, chapter 2: Chapter 2.
+Gujarati, chapter 2: Introducing Yourself.
 9 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/gujarati/narration/ch03.json
+++ b/code/learning/human-languages/gujarati/narration/ch03.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "gujarati",
   "chapter": 3,
-  "title": "Chapter 3",
+  "title": "How Are You?",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:abfa845dbcbdcdb7",
   "lessons": [

--- a/code/learning/human-languages/gujarati/narration/ch03.txt
+++ b/code/learning/human-languages/gujarati/narration/ch03.txt
@@ -1,4 +1,4 @@
-Gujarati, chapter 3: Chapter 3.
+Gujarati, chapter 3: How Are You?.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/gujarati/narration/ch04.json
+++ b/code/learning/human-languages/gujarati/narration/ch04.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "gujarati",
   "chapter": 4,
-  "title": "Chapter 4",
+  "title": "Farewells",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:a7cb2a54ee279339",
   "lessons": [

--- a/code/learning/human-languages/gujarati/narration/ch04.txt
+++ b/code/learning/human-languages/gujarati/narration/ch04.txt
@@ -1,4 +1,4 @@
-Gujarati, chapter 4: Chapter 4.
+Gujarati, chapter 4: Farewells.
 5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/gujarati/narration/ch05.json
+++ b/code/learning/human-languages/gujarati/narration/ch05.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "gujarati",
   "chapter": 5,
-  "title": "Chapter 5",
+  "title": "The First Verbs",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:21df006e01581a7f",
   "lessons": [

--- a/code/learning/human-languages/gujarati/narration/ch05.txt
+++ b/code/learning/human-languages/gujarati/narration/ch05.txt
@@ -1,4 +1,4 @@
-Gujarati, chapter 5: Chapter 5.
+Gujarati, chapter 5: The First Verbs.
 5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/hindi/chapters.json
+++ b/code/learning/human-languages/hindi/chapters.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "language": "hindi",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 3, 4 and 5 are deliberately absent — every lesson in them is still schema v1 with no practises.knowledge, so no payoff could name a real atom, and a stub would destroy the very signal the gap report exists to carry. Chapters 34 and 35 are the second verb tranche and are schema v2 throughout, so their payoffs name real atoms. Chapters 1 and 2 have no schema-v2 terminal consolidation lesson either: their HI-C01/HI-C02 practice lessons are schema v1, so the payoff falls back to the chapter's last lesson by sequence, which in both cases is a Devanagari writing lesson. Those are recorded as kind 'task' and described as hand-writing work rather than dressed up as spoken dialogue. Chapters 36 to 39 are the pre-A1 noun tranche: four chapters of four word lessons each, every lesson carrying its noun's grammatical gender as part of the atom, and each payoff reaching back past its own chapter to atoms the ledger showed were never revisited.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
     {
       "chapter": 1,
@@ -40,6 +40,57 @@
           "HI-CONCEPT-W05-WRITE-NAMASTE-01",
           "HI-CONCEPT-W05-WRITE-NAMASTE-02"
         ]
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "How Are You?",
+      "label": "ch:responding",
+      "canDo": "I can ask how someone is in Hindi, answer naturally, and return the question.",
+      "spineNodes": [
+        "SPINE-COURTESY-THANK",
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-EXCHANGE-NAMES",
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "HI-C03-practice",
+        "kind": "task",
+        "summary": "Complete HI-C03-practice, the canonical closing checkpoint, and demonstrate the chapter promise: ask how someone is in Hindi, answer naturally, and return the question.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "Farewells",
+      "label": "ch:farewells",
+      "canDo": "I can end a Hindi conversation politely and choose a farewell that fits the situation.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "HI-C04-practice",
+        "kind": "task",
+        "summary": "Complete HI-C04-practice, the canonical closing checkpoint, and demonstrate the chapter promise: end a Hindi conversation politely and choose a farewell that fits the situation.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "The First Verbs",
+      "label": "ch:first-verbs",
+      "canDo": "I can build short present-tense Hindi sentences with the chapter's first verbs.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "HI-C05-practice",
+        "kind": "task",
+        "summary": "Complete HI-C05-practice, the canonical closing checkpoint, and demonstrate the chapter promise: build short present-tense Hindi sentences with the chapter's first verbs.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
       }
     },
     {

--- a/code/learning/human-languages/hindi/narration/ch03.json
+++ b/code/learning/human-languages/hindi/narration/ch03.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "hindi",
   "chapter": 3,
-  "title": "Chapter 3",
+  "title": "How Are You?",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:3214a53668c2fb82",
   "lessons": [

--- a/code/learning/human-languages/hindi/narration/ch03.txt
+++ b/code/learning/human-languages/hindi/narration/ch03.txt
@@ -1,4 +1,4 @@
-Hindi, chapter 3: Chapter 3.
+Hindi, chapter 3: How Are You?.
 7 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/hindi/narration/ch04.json
+++ b/code/learning/human-languages/hindi/narration/ch04.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "hindi",
   "chapter": 4,
-  "title": "Chapter 4",
+  "title": "Farewells",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:2abf2f1a1a306578",
   "lessons": [

--- a/code/learning/human-languages/hindi/narration/ch04.txt
+++ b/code/learning/human-languages/hindi/narration/ch04.txt
@@ -1,4 +1,4 @@
-Hindi, chapter 4: Chapter 4.
+Hindi, chapter 4: Farewells.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/hindi/narration/ch05.json
+++ b/code/learning/human-languages/hindi/narration/ch05.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "hindi",
   "chapter": 5,
-  "title": "Chapter 5",
+  "title": "The First Verbs",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:20f1ec1638063c5d",
   "lessons": [

--- a/code/learning/human-languages/hindi/narration/ch05.txt
+++ b/code/learning/human-languages/hindi/narration/ch05.txt
@@ -1,4 +1,4 @@
-Hindi, chapter 5: Chapter 5.
+Hindi, chapter 5: The First Verbs.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/italian/chapters.json
+++ b/code/learning/human-languages/italian/chapters.json
@@ -1,8 +1,29 @@
 {
   "version": 1,
   "language": "italian",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 2-19 are authored here. Chapter 1 is deliberately absent: its lessons are still schema_version 1 with no practises.knowledge, so no payoff can be claimed for it honestly, and it owns no core/book-generation.json target either. Chapters 2-5 have a terminal practice-mix; chapters 6-19 have none, so their payoff is the chapter's last lesson by sequence, which is where the recombination and wrap-up recall actually live. Chapters 18 and 19 additionally assess atoms from EARLIER chapters (HL09 section 7): 18 reaches back to parlare, the passato prossimo, the -ct- to -tt- law of the numbers, and mano; 19 reaches back to piacere and mi chiamo from Chapter 3, the seasons, the wine, and Chapter 18 itself.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet someone in Italian, recognize the reply, and choose an appropriate response.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-COURTESY-THANK",
+        "SPINE-DEFINITE-REFERENCE",
+        "SPINE-TIME-OF-DAY",
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "IT-C01-practice",
+        "kind": "task",
+        "summary": "Complete IT-C01-practice, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in Italian, recognize the reply, and choose an appropriate response.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 2,
       "title": "How Are You?",

--- a/code/learning/human-languages/italian/narration/ch01.json
+++ b/code/learning/human-languages/italian/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "italian",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings",
   "drivablePrefix": 6,
   "sourceHash": "fnv1a64:3e905f2b1c3dd36b",
   "lessons": [

--- a/code/learning/human-languages/italian/narration/ch01.txt
+++ b/code/learning/human-languages/italian/narration/ch01.txt
@@ -1,4 +1,4 @@
-Italian, chapter 1: Chapter 1.
+Italian, chapter 1: Greetings.
 9 lessons. You can do the first 6 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/kannada/chapters.json
+++ b/code/learning/human-languages/kannada/chapters.json
@@ -1,8 +1,92 @@
 {
   "version": 1,
   "language": "kannada",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 1-5 are absent on purpose — their lessons are still schema v1, carry no practises.knowledge, and have no core/book-generation.json target, so any payoff written for them would be invented rather than derived. That absence is real, measurable debt and must not be papered over with placeholders. No chapter from 6 on has a terminal practice/practice-mix lesson, so each payoff is the chapter's last lesson by sequence.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet someone in Kannada, recognize the reply, and choose an appropriate response.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-COURTESY-THANK",
+        "SPINE-RESPOND-BASIC"
+      ],
+      "payoff": {
+        "lesson": "KA-C01-practice",
+        "kind": "task",
+        "summary": "Complete KA-C01-practice, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in Kannada, recognize the reply, and choose an appropriate response.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 2,
+      "title": "Introducing Yourself",
+      "label": "ch:introductions",
+      "canDo": "I can introduce myself in Kannada, give my name, and understand the other person's name.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "KA-C02-practice",
+        "kind": "task",
+        "summary": "Complete KA-C02-practice, the canonical closing checkpoint, and demonstrate the chapter promise: introduce myself in Kannada, give my name, and understand the other person's name.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "How Are You?",
+      "label": "ch:responding",
+      "canDo": "I can ask how someone is in Kannada, answer naturally, and return the question.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-EXCHANGE-NAMES",
+        "SPINE-COURTESY-THANK"
+      ],
+      "payoff": {
+        "lesson": "KA-C03-practice",
+        "kind": "task",
+        "summary": "Complete KA-C03-practice, the canonical closing checkpoint, and demonstrate the chapter promise: ask how someone is in Kannada, answer naturally, and return the question.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "Farewells",
+      "label": "ch:farewells",
+      "canDo": "I can end a Kannada conversation politely and choose a farewell that fits the situation.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "KA-C04-practice",
+        "kind": "task",
+        "summary": "Complete KA-C04-practice, the canonical closing checkpoint, and demonstrate the chapter promise: end a Kannada conversation politely and choose a farewell that fits the situation.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "The First Verbs",
+      "label": "ch:first-verbs",
+      "canDo": "I can build short present-tense Kannada sentences with the chapter's first verbs.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "KA-C05-practice",
+        "kind": "task",
+        "summary": "Complete KA-C05-practice, the canonical closing checkpoint, and demonstrate the chapter promise: build short present-tense Kannada sentences with the chapter's first verbs.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 6,
       "title": "Case Endings and Dative Subjects",

--- a/code/learning/human-languages/kannada/narration/ch01.json
+++ b/code/learning/human-languages/kannada/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "kannada",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:d9491d4801d7b49f",
   "lessons": [

--- a/code/learning/human-languages/kannada/narration/ch01.txt
+++ b/code/learning/human-languages/kannada/narration/ch01.txt
@@ -1,4 +1,4 @@
-Kannada, chapter 1: Chapter 1.
+Kannada, chapter 1: Greetings.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/kannada/narration/ch02.json
+++ b/code/learning/human-languages/kannada/narration/ch02.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "kannada",
   "chapter": 2,
-  "title": "Chapter 2",
+  "title": "Introducing Yourself",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:ebb799b08b06b8f8",
   "lessons": [

--- a/code/learning/human-languages/kannada/narration/ch02.txt
+++ b/code/learning/human-languages/kannada/narration/ch02.txt
@@ -1,4 +1,4 @@
-Kannada, chapter 2: Chapter 2.
+Kannada, chapter 2: Introducing Yourself.
 8 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/kannada/narration/ch03.json
+++ b/code/learning/human-languages/kannada/narration/ch03.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "kannada",
   "chapter": 3,
-  "title": "Chapter 3",
+  "title": "How Are You?",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:cd9c763fa849439d",
   "lessons": [

--- a/code/learning/human-languages/kannada/narration/ch03.txt
+++ b/code/learning/human-languages/kannada/narration/ch03.txt
@@ -1,4 +1,4 @@
-Kannada, chapter 3: Chapter 3.
+Kannada, chapter 3: How Are You?.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/kannada/narration/ch04.json
+++ b/code/learning/human-languages/kannada/narration/ch04.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "kannada",
   "chapter": 4,
-  "title": "Chapter 4",
+  "title": "Farewells",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:e08a7fd2e7d9d6f8",
   "lessons": [

--- a/code/learning/human-languages/kannada/narration/ch04.txt
+++ b/code/learning/human-languages/kannada/narration/ch04.txt
@@ -1,4 +1,4 @@
-Kannada, chapter 4: Chapter 4.
+Kannada, chapter 4: Farewells.
 5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/kannada/narration/ch05.json
+++ b/code/learning/human-languages/kannada/narration/ch05.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "kannada",
   "chapter": 5,
-  "title": "Chapter 5",
+  "title": "The First Verbs",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:c43a92e2750d8991",
   "lessons": [

--- a/code/learning/human-languages/kannada/narration/ch05.txt
+++ b/code/learning/human-languages/kannada/narration/ch05.txt
@@ -1,4 +1,4 @@
-Kannada, chapter 5: Chapter 5.
+Kannada, chapter 5: The First Verbs.
 5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/malayalam/chapters.json
+++ b/code/learning/human-languages/malayalam/chapters.json
@@ -1,8 +1,92 @@
 {
   "version": 1,
   "language": "malayalam",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 1-5 are deliberately absent -- their terminal practice lessons (ML-C01-practice through ML-C05-practice) are still schema v1 with no practises.knowledge, so no payoff can name atoms without inventing them. That absence is real, measurable debt and must not be papered over with placeholders.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet someone in Malayalam, recognize the reply, and choose an appropriate response.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-RESPOND-BASIC",
+        "SPINE-COURTESY-THANK"
+      ],
+      "payoff": {
+        "lesson": "ML-C01-practice",
+        "kind": "task",
+        "summary": "Complete ML-C01-practice, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in Malayalam, recognize the reply, and choose an appropriate response.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 2,
+      "title": "Introducing Yourself",
+      "label": "ch:introductions",
+      "canDo": "I can introduce myself in Malayalam, give my name, and understand the other person's name.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "ML-C02-practice",
+        "kind": "task",
+        "summary": "Complete ML-C02-practice, the canonical closing checkpoint, and demonstrate the chapter promise: introduce myself in Malayalam, give my name, and understand the other person's name.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "How Are You?",
+      "label": "ch:responding",
+      "canDo": "I can ask how someone is in Malayalam, answer naturally, and return the question.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-EXCHANGE-NAMES",
+        "SPINE-COURTESY-THANK"
+      ],
+      "payoff": {
+        "lesson": "ML-C03-practice",
+        "kind": "task",
+        "summary": "Complete ML-C03-practice, the canonical closing checkpoint, and demonstrate the chapter promise: ask how someone is in Malayalam, answer naturally, and return the question.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "Farewells",
+      "label": "ch:farewells",
+      "canDo": "I can end a Malayalam conversation politely and choose a farewell that fits the situation.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "ML-C04-practice",
+        "kind": "task",
+        "summary": "Complete ML-C04-practice, the canonical closing checkpoint, and demonstrate the chapter promise: end a Malayalam conversation politely and choose a farewell that fits the situation.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "The First Verbs",
+      "label": "ch:first-verbs",
+      "canDo": "I can build short present-tense Malayalam sentences with the chapter's first verbs.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "ML-C05-practice",
+        "kind": "task",
+        "summary": "Complete ML-C05-practice, the canonical closing checkpoint, and demonstrate the chapter promise: build short present-tense Malayalam sentences with the chapter's first verbs.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 6,
       "title": "Case Endings and Dative Subjects",

--- a/code/learning/human-languages/malayalam/narration/ch01.json
+++ b/code/learning/human-languages/malayalam/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "malayalam",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:b228867e095b9ba0",
   "lessons": [

--- a/code/learning/human-languages/malayalam/narration/ch01.txt
+++ b/code/learning/human-languages/malayalam/narration/ch01.txt
@@ -1,4 +1,4 @@
-Malayalam, chapter 1: Chapter 1.
+Malayalam, chapter 1: Greetings.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/malayalam/narration/ch02.json
+++ b/code/learning/human-languages/malayalam/narration/ch02.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "malayalam",
   "chapter": 2,
-  "title": "Chapter 2",
+  "title": "Introducing Yourself",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:ac6aa6db065a34b3",
   "lessons": [

--- a/code/learning/human-languages/malayalam/narration/ch02.txt
+++ b/code/learning/human-languages/malayalam/narration/ch02.txt
@@ -1,4 +1,4 @@
-Malayalam, chapter 2: Chapter 2.
+Malayalam, chapter 2: Introducing Yourself.
 9 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/malayalam/narration/ch03.json
+++ b/code/learning/human-languages/malayalam/narration/ch03.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "malayalam",
   "chapter": 3,
-  "title": "Chapter 3",
+  "title": "How Are You?",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:a828ffb52fb5052d",
   "lessons": [

--- a/code/learning/human-languages/malayalam/narration/ch03.txt
+++ b/code/learning/human-languages/malayalam/narration/ch03.txt
@@ -1,4 +1,4 @@
-Malayalam, chapter 3: Chapter 3.
+Malayalam, chapter 3: How Are You?.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/malayalam/narration/ch04.json
+++ b/code/learning/human-languages/malayalam/narration/ch04.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "malayalam",
   "chapter": 4,
-  "title": "Chapter 4",
+  "title": "Farewells",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:f1c85116657207db",
   "lessons": [

--- a/code/learning/human-languages/malayalam/narration/ch04.txt
+++ b/code/learning/human-languages/malayalam/narration/ch04.txt
@@ -1,4 +1,4 @@
-Malayalam, chapter 4: Chapter 4.
+Malayalam, chapter 4: Farewells.
 5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/malayalam/narration/ch05.json
+++ b/code/learning/human-languages/malayalam/narration/ch05.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "malayalam",
   "chapter": 5,
-  "title": "Chapter 5",
+  "title": "The First Verbs",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:0bd13d76a6d2d33f",
   "lessons": [

--- a/code/learning/human-languages/malayalam/narration/ch05.txt
+++ b/code/learning/human-languages/malayalam/narration/ch05.txt
@@ -1,4 +1,4 @@
-Malayalam, chapter 5: Chapter 5.
+Malayalam, chapter 5: The First Verbs.
 5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/marathi/chapters.json
+++ b/code/learning/human-languages/marathi/chapters.json
@@ -1,8 +1,93 @@
 {
   "version": 1,
   "language": "marathi",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only chapters 6 and 7 are authorable today. Chapters 1-5 are entirely schema-v1 (no introduces/practises knowledge atoms), so no payoff there can name atoms a lesson actually practises; they are deliberately absent rather than stubbed, and that absence is real, measurable debt.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet someone in Marathi, recognize the reply, and choose an appropriate response.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-COURTESY-THANK",
+        "SPINE-RESPOND-BASIC",
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "MR-C01-practice",
+        "kind": "task",
+        "summary": "Complete MR-C01-practice, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in Marathi, recognize the reply, and choose an appropriate response.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 2,
+      "title": "Introducing Yourself",
+      "label": "ch:introductions",
+      "canDo": "I can introduce myself in Marathi, give my name, and understand the other person's name.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "MR-C02-practice",
+        "kind": "task",
+        "summary": "Complete MR-C02-practice, the canonical closing checkpoint, and demonstrate the chapter promise: introduce myself in Marathi, give my name, and understand the other person's name.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "How Are You?",
+      "label": "ch:responding",
+      "canDo": "I can ask how someone is in Marathi, answer naturally, and return the question.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-EXCHANGE-NAMES",
+        "SPINE-COURTESY-THANK"
+      ],
+      "payoff": {
+        "lesson": "MR-C03-practice",
+        "kind": "task",
+        "summary": "Complete MR-C03-practice, the canonical closing checkpoint, and demonstrate the chapter promise: ask how someone is in Marathi, answer naturally, and return the question.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "Farewells",
+      "label": "ch:farewells",
+      "canDo": "I can end a Marathi conversation politely and choose a farewell that fits the situation.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "MR-C04-practice",
+        "kind": "task",
+        "summary": "Complete MR-C04-practice, the canonical closing checkpoint, and demonstrate the chapter promise: end a Marathi conversation politely and choose a farewell that fits the situation.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "The First Verbs",
+      "label": "ch:first-verbs",
+      "canDo": "I can build short present-tense Marathi sentences with the chapter's first verbs.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "MR-C05-practice",
+        "kind": "task",
+        "summary": "Complete MR-C05-practice, the canonical closing checkpoint, and demonstrate the chapter promise: build short present-tense Marathi sentences with the chapter's first verbs.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 6,
       "title": "Numbers One to Five",

--- a/code/learning/human-languages/marathi/curriculum.json
+++ b/code/learning/human-languages/marathi/curriculum.json
@@ -120,6 +120,22 @@
       "after": []
     },
     {
+      "id": "MR-PATH-019",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "MR-C05-bolne",
+        "MR-C05-mi-marathi-bolto",
+        "MR-C05-rahne",
+        "MR-C05-kaam-karne",
+        "MR-C05-practice"
+      ],
+      "before": [],
+      "inline": [
+        "MR-EXT-019-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
       "id": "MR-PATH-011",
       "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
       "lessons": [
@@ -355,6 +371,7 @@
     },
     "SPINE-SAY-WHAT-I-DO": {
       "segments": [
+        "MR-PATH-019",
         "MR-PATH-012",
         "MR-PATH-013",
         "MR-PATH-014"
@@ -721,6 +738,21 @@
         "MR-C12-kaan",
         "MR-C12-tond",
         "MR-C12-naak"
+      ]
+    },
+    {
+      "id": "MR-EXT-019-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the Marathi-specific vocabulary and grammar that support this shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "MR-C05-bolne",
+        "MR-C05-mi-marathi-bolto",
+        "MR-C05-rahne",
+        "MR-C05-kaam-karne",
+        "MR-C05-practice"
       ]
     },
     {

--- a/code/learning/human-languages/marathi/narration/ch01.json
+++ b/code/learning/human-languages/marathi/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "marathi",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:07798362d454a9f2",
   "lessons": [

--- a/code/learning/human-languages/marathi/narration/ch01.txt
+++ b/code/learning/human-languages/marathi/narration/ch01.txt
@@ -1,4 +1,4 @@
-Marathi, chapter 1: Chapter 1.
+Marathi, chapter 1: Greetings.
 7 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/marathi/narration/ch02.json
+++ b/code/learning/human-languages/marathi/narration/ch02.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "marathi",
   "chapter": 2,
-  "title": "Chapter 2",
+  "title": "Introducing Yourself",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:d7d34ac586baf0bb",
   "lessons": [

--- a/code/learning/human-languages/marathi/narration/ch02.txt
+++ b/code/learning/human-languages/marathi/narration/ch02.txt
@@ -1,4 +1,4 @@
-Marathi, chapter 2: Chapter 2.
+Marathi, chapter 2: Introducing Yourself.
 9 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/marathi/narration/ch03.json
+++ b/code/learning/human-languages/marathi/narration/ch03.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "marathi",
   "chapter": 3,
-  "title": "Chapter 3",
+  "title": "How Are You?",
   "drivablePrefix": 1,
   "sourceHash": "fnv1a64:4698352cdd6ad6ca",
   "lessons": [

--- a/code/learning/human-languages/marathi/narration/ch03.txt
+++ b/code/learning/human-languages/marathi/narration/ch03.txt
@@ -1,4 +1,4 @@
-Marathi, chapter 3: Chapter 3.
+Marathi, chapter 3: How Are You?.
 6 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/marathi/narration/ch04.json
+++ b/code/learning/human-languages/marathi/narration/ch04.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "marathi",
   "chapter": 4,
-  "title": "Chapter 4",
+  "title": "Farewells",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:698a7e2e82e9ad58",
   "lessons": [

--- a/code/learning/human-languages/marathi/narration/ch04.txt
+++ b/code/learning/human-languages/marathi/narration/ch04.txt
@@ -1,4 +1,4 @@
-Marathi, chapter 4: Chapter 4.
+Marathi, chapter 4: Farewells.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/marathi/narration/ch05.json
+++ b/code/learning/human-languages/marathi/narration/ch05.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "marathi",
   "chapter": 5,
-  "title": "Chapter 5",
+  "title": "The First Verbs",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:03f79a98594f4da1",
   "lessons": [

--- a/code/learning/human-languages/marathi/narration/ch05.txt
+++ b/code/learning/human-languages/marathi/narration/ch05.txt
@@ -1,4 +1,4 @@
-Marathi, chapter 5: Chapter 5.
+Marathi, chapter 5: The First Verbs.
 5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/persian/chapters.json
+++ b/code/learning/human-languages/persian/chapters.json
@@ -1,8 +1,26 @@
 {
   "version": 1,
   "language": "persian",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapter 1 is deliberately absent — all four of its lessons are still schema v1 with no declared knowledge atoms, so any payoff written for it would be invented rather than derived. That absence is real, measurable debt and must not be papered over with a placeholder.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings and responses",
+      "label": "ch:persian-greetings",
+      "canDo": "I can greet someone in Persian, respond courteously, and close the exchange naturally.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-COURTESY-THANK",
+        "SPINE-RESPOND-BASIC"
+      ],
+      "payoff": {
+        "lesson": "FA-C01-na",
+        "kind": "task",
+        "summary": "Complete FA-C01-na, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in Persian, respond courteously, and close the exchange naturally.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 2,
       "title": "Give your name",

--- a/code/learning/human-languages/persian/narration/ch01.json
+++ b/code/learning/human-languages/persian/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "persian",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings and responses",
   "drivablePrefix": 4,
   "sourceHash": "fnv1a64:7c2f7fb0cadec8f6",
   "lessons": [

--- a/code/learning/human-languages/persian/narration/ch01.txt
+++ b/code/learning/human-languages/persian/narration/ch01.txt
@@ -1,4 +1,4 @@
-Persian, chapter 1: Chapter 1.
+Persian, chapter 1: Greetings and responses.
 4 lessons. All 4 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/portuguese/chapters.json
+++ b/code/learning/human-languages/portuguese/chapters.json
@@ -1,8 +1,29 @@
 {
   "version": 1,
   "language": "portuguese",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 2-26 are authored here. Chapter 1 is deliberately absent: its lessons are still schema_version 1 with no practises.knowledge, so no payoff can be claimed for it honestly, and it owns no core/book-generation.json target either. Chapters 2-5 have a terminal practice-mix; chapters 6-26 have none, so their payoff is the chapter's last lesson by sequence, which is where the recombination and wrap-up recall actually live. Chapter 2 carries two practice-mix lessons; the terminal one, PT-C02-formal-practice, is the payoff.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet someone in Portuguese, recognize the reply, and choose an appropriate response.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-DEFINITE-REFERENCE",
+        "SPINE-TIME-OF-DAY",
+        "SPINE-COURTESY-THANK",
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "PT-C01-practice",
+        "kind": "task",
+        "summary": "Complete PT-C01-practice, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in Portuguese, recognize the reply, and choose an appropriate response.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 2,
       "title": "How Are You?",

--- a/code/learning/human-languages/portuguese/narration/ch01.json
+++ b/code/learning/human-languages/portuguese/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "portuguese",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings",
   "drivablePrefix": 3,
   "sourceHash": "fnv1a64:eeea38606ef36d23",
   "lessons": [

--- a/code/learning/human-languages/portuguese/narration/ch01.txt
+++ b/code/learning/human-languages/portuguese/narration/ch01.txt
@@ -1,4 +1,4 @@
-Portuguese, chapter 1: Chapter 1.
+Portuguese, chapter 1: Greetings.
 9 lessons. You can do the first 3 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/punjabi/chapters.json
+++ b/code/learning/human-languages/punjabi/chapters.json
@@ -1,8 +1,92 @@
 {
   "version": 1,
   "language": "punjabi",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 6-9 are authorable. Chapters 1-5 are entirely schema-v1 (no introduces/practises knowledge atoms), so no payoff there can name atoms a lesson actually practises; they are deliberately absent rather than stubbed, and that absence is real, measurable debt.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet someone in Punjabi, recognize the reply, and choose an appropriate response.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-COURTESY-THANK",
+        "SPINE-RESPOND-BASIC"
+      ],
+      "payoff": {
+        "lesson": "PA-C01-practice",
+        "kind": "task",
+        "summary": "Complete PA-C01-practice, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in Punjabi, recognize the reply, and choose an appropriate response.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 2,
+      "title": "Introducing Yourself",
+      "label": "ch:introductions",
+      "canDo": "I can introduce myself in Punjabi, give my name, and understand the other person's name.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "PA-C02-practice",
+        "kind": "task",
+        "summary": "Complete PA-C02-practice, the canonical closing checkpoint, and demonstrate the chapter promise: introduce myself in Punjabi, give my name, and understand the other person's name.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "How Are You?",
+      "label": "ch:responding",
+      "canDo": "I can ask how someone is in Punjabi, answer naturally, and return the question.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-COURTESY-THANK",
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "PA-C03-practice",
+        "kind": "task",
+        "summary": "Complete PA-C03-practice, the canonical closing checkpoint, and demonstrate the chapter promise: ask how someone is in Punjabi, answer naturally, and return the question.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "Farewells",
+      "label": "ch:farewells",
+      "canDo": "I can end a Punjabi conversation politely and choose a farewell that fits the situation.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "PA-C04-practice",
+        "kind": "task",
+        "summary": "Complete PA-C04-practice, the canonical closing checkpoint, and demonstrate the chapter promise: end a Punjabi conversation politely and choose a farewell that fits the situation.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "The First Verbs",
+      "label": "ch:first-verbs",
+      "canDo": "I can build short present-tense Punjabi sentences with the chapter's first verbs.",
+      "spineNodes": [
+        "SPINE-COUNT-ONE-TO-FIVE"
+      ],
+      "payoff": {
+        "lesson": "PA-C05-practice",
+        "kind": "task",
+        "summary": "Complete PA-C05-practice, the canonical closing checkpoint, and demonstrate the chapter promise: build short present-tense Punjabi sentences with the chapter's first verbs.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 6,
       "title": "Numbers One to Five",

--- a/code/learning/human-languages/punjabi/narration/ch01.json
+++ b/code/learning/human-languages/punjabi/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "punjabi",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:03685e752baf67fe",
   "lessons": [

--- a/code/learning/human-languages/punjabi/narration/ch01.txt
+++ b/code/learning/human-languages/punjabi/narration/ch01.txt
@@ -1,4 +1,4 @@
-Punjabi, chapter 1: Chapter 1.
+Punjabi, chapter 1: Greetings.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/punjabi/narration/ch02.json
+++ b/code/learning/human-languages/punjabi/narration/ch02.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "punjabi",
   "chapter": 2,
-  "title": "Chapter 2",
+  "title": "Introducing Yourself",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:3fcfc2e95caa5978",
   "lessons": [

--- a/code/learning/human-languages/punjabi/narration/ch02.txt
+++ b/code/learning/human-languages/punjabi/narration/ch02.txt
@@ -1,4 +1,4 @@
-Punjabi, chapter 2: Chapter 2.
+Punjabi, chapter 2: Introducing Yourself.
 9 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/punjabi/narration/ch03.json
+++ b/code/learning/human-languages/punjabi/narration/ch03.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "punjabi",
   "chapter": 3,
-  "title": "Chapter 3",
+  "title": "How Are You?",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:653a3e23669dcad9",
   "lessons": [

--- a/code/learning/human-languages/punjabi/narration/ch03.txt
+++ b/code/learning/human-languages/punjabi/narration/ch03.txt
@@ -1,4 +1,4 @@
-Punjabi, chapter 3: Chapter 3.
+Punjabi, chapter 3: How Are You?.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/punjabi/narration/ch04.json
+++ b/code/learning/human-languages/punjabi/narration/ch04.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "punjabi",
   "chapter": 4,
-  "title": "Chapter 4",
+  "title": "Farewells",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:9d2ba0448ca47532",
   "lessons": [

--- a/code/learning/human-languages/punjabi/narration/ch04.txt
+++ b/code/learning/human-languages/punjabi/narration/ch04.txt
@@ -1,4 +1,4 @@
-Punjabi, chapter 4: Chapter 4.
+Punjabi, chapter 4: Farewells.
 5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/punjabi/narration/ch05.json
+++ b/code/learning/human-languages/punjabi/narration/ch05.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "punjabi",
   "chapter": 5,
-  "title": "Chapter 5",
+  "title": "The First Verbs",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:25a70d4ed764c8eb",
   "lessons": [

--- a/code/learning/human-languages/punjabi/narration/ch05.txt
+++ b/code/learning/human-languages/punjabi/narration/ch05.txt
@@ -1,4 +1,4 @@
-Punjabi, chapter 5: Chapter 5.
+Punjabi, chapter 5: The First Verbs.
 5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/russian/chapters.json
+++ b/code/learning/human-languages/russian/chapters.json
@@ -1,8 +1,27 @@
 {
   "version": 1,
   "language": "russian",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only chapter 2 is authorable today. Chapter 1 is entirely schema-v1 (no introduces/practises knowledge atoms), so it has no assessable payoff to point at and is deliberately absent rather than stubbed — its absence is real, measurable debt. Chapter 2 has no core/book-generation.json target either; its title and label are taken from russian/book/chapters/ch02-introducing-yourself.tex, the only other place they are written down. The payoff points at RU-C02-practice, the chapter's consolidation lesson, which HL-C32 migrated to schema v2 for exactly this reason; before that migration the only schema-v2 candidate was the cross-language etymology lesson RU-C02-kak-cross-language, whose three atoms gave a representativeness of 0.20 against a 0.50 floor. Chapters 4 and 5 (HL-C44) are authorable from the start: both are schema-v2 throughout and each closes on a payoff that assesses every atom its own chapter introduced. Chapter 3 is still absent for a different reason from chapter 1 — it is schema v2, but it has no consolidation lesson, so the only candidate payoff (RU-C03-idti) covers 5 of the chapter's 19 atoms, a representativeness of 0.26 against the 0.50 floor. Its ledger entry is withheld rather than written to fail, and it now shows up as a book chapter without an HL05 capability, which is the honest shape of that debt.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings and courtesy",
+      "label": "ch:russian-greetings",
+      "canDo": "I can greet someone in Russian, respond courteously, and close the exchange naturally.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-COURTESY-THANK",
+        "SPINE-POLITE-REQUEST-REPAIR",
+        "SPINE-RESPOND-BASIC"
+      ],
+      "payoff": {
+        "lesson": "RU-C01-practice",
+        "kind": "task",
+        "summary": "Complete RU-C01-practice, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in Russian, respond courteously, and close the exchange naturally.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 2,
       "title": "Introducing yourself",

--- a/code/learning/human-languages/russian/narration/ch01.json
+++ b/code/learning/human-languages/russian/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "russian",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings and courtesy",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:666276e1d698f4d5",
   "lessons": [

--- a/code/learning/human-languages/russian/narration/ch01.txt
+++ b/code/learning/human-languages/russian/narration/ch01.txt
@@ -1,4 +1,4 @@
-Russian, chapter 1: Chapter 1.
+Russian, chapter 1: Greetings and courtesy.
 12 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/sanskrit/chapters.json
+++ b/code/learning/human-languages/sanskrit/chapters.json
@@ -1,8 +1,92 @@
 {
   "version": 1,
   "language": "sanskrit",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Only chapters 6 and 7 are authorable today. Chapters 1-5 are entirely schema-v1 (no introduces/practises knowledge atoms), so no payoff there can name atoms a lesson actually practises; they are deliberately absent rather than stubbed, and that absence is real, measurable debt.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet someone in Sanskrit, recognize the reply, and choose an appropriate response.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-COURTESY-THANK",
+        "SPINE-RESPOND-BASIC"
+      ],
+      "payoff": {
+        "lesson": "SA-C01-practice",
+        "kind": "task",
+        "summary": "Complete SA-C01-practice, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in Sanskrit, recognize the reply, and choose an appropriate response.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 2,
+      "title": "Introducing Yourself",
+      "label": "ch:introductions",
+      "canDo": "I can introduce myself in Sanskrit, give my name, and understand the other person's name.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "SA-C02-tava-nama-kim",
+        "kind": "task",
+        "summary": "Complete SA-C02-tava-nama-kim, the canonical closing checkpoint, and demonstrate the chapter promise: introduce myself in Sanskrit, give my name, and understand the other person's name.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "How Are You?",
+      "label": "ch:responding",
+      "canDo": "I can ask how someone is in Sanskrit, answer naturally, and return the question.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES",
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-COURTESY-THANK"
+      ],
+      "payoff": {
+        "lesson": "SA-C03-practice",
+        "kind": "task",
+        "summary": "Complete SA-C03-practice, the canonical closing checkpoint, and demonstrate the chapter promise: ask how someone is in Sanskrit, answer naturally, and return the question.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "Farewells",
+      "label": "ch:farewells",
+      "canDo": "I can end a Sanskrit conversation politely and choose a farewell that fits the situation.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "SA-C04-practice",
+        "kind": "task",
+        "summary": "Complete SA-C04-practice, the canonical closing checkpoint, and demonstrate the chapter promise: end a Sanskrit conversation politely and choose a farewell that fits the situation.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "The First Verbs",
+      "label": "ch:first-verbs",
+      "canDo": "I can build short present-tense Sanskrit sentences with the chapter's first verbs.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "SA-C05-practice",
+        "kind": "task",
+        "summary": "Complete SA-C05-practice, the canonical closing checkpoint, and demonstrate the chapter promise: build short present-tense Sanskrit sentences with the chapter's first verbs.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 6,
       "title": "Numbers One to Five",

--- a/code/learning/human-languages/sanskrit/curriculum.json
+++ b/code/learning/human-languages/sanskrit/curriculum.json
@@ -101,6 +101,22 @@
       "after": []
     },
     {
+      "id": "SA-PATH-017",
+      "spine_node": "SPINE-SAY-WHAT-I-DO",
+      "lessons": [
+        "SA-C05-vadami",
+        "SA-C05-aham-samskritam-vadami",
+        "SA-C05-karomi",
+        "SA-C05-vasami",
+        "SA-C05-practice"
+      ],
+      "before": [],
+      "inline": [
+        "SA-EXT-017-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
       "id": "SA-PATH-009",
       "spine_node": "SPINE-COUNT-ONE-TO-FIVE",
       "lessons": [
@@ -328,6 +344,7 @@
     },
     "SPINE-SAY-WHAT-I-DO": {
       "segments": [
+        "SA-PATH-017",
         "SA-PATH-010",
         "SA-PATH-011",
         "SA-PATH-012"
@@ -648,6 +665,21 @@
         "SA-C12-akshi",
         "SA-C12-karnah",
         "SA-C12-mukham"
+      ]
+    },
+    {
+      "id": "SA-EXT-017-LANGUAGE-SPECIFIC",
+      "stage": "pre-A1",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the Sanskrit-specific vocabulary and grammar that support this shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "SA-C05-vadami",
+        "SA-C05-aham-samskritam-vadami",
+        "SA-C05-karomi",
+        "SA-C05-vasami",
+        "SA-C05-practice"
       ]
     },
     {

--- a/code/learning/human-languages/sanskrit/narration/ch01.json
+++ b/code/learning/human-languages/sanskrit/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "sanskrit",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:281f1ccd090a19c1",
   "lessons": [

--- a/code/learning/human-languages/sanskrit/narration/ch01.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch01.txt
@@ -1,4 +1,4 @@
-Sanskrit, chapter 1: Chapter 1.
+Sanskrit, chapter 1: Greetings.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/sanskrit/narration/ch02.json
+++ b/code/learning/human-languages/sanskrit/narration/ch02.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "sanskrit",
   "chapter": 2,
-  "title": "Chapter 2",
+  "title": "Introducing Yourself",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:bb5a242c96a6f6d0",
   "lessons": [

--- a/code/learning/human-languages/sanskrit/narration/ch02.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch02.txt
@@ -1,4 +1,4 @@
-Sanskrit, chapter 2: Chapter 2.
+Sanskrit, chapter 2: Introducing Yourself.
 8 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/sanskrit/narration/ch03.json
+++ b/code/learning/human-languages/sanskrit/narration/ch03.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "sanskrit",
   "chapter": 3,
-  "title": "Chapter 3",
+  "title": "How Are You?",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:dcf6cb6bc6f91b5c",
   "lessons": [

--- a/code/learning/human-languages/sanskrit/narration/ch03.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch03.txt
@@ -1,4 +1,4 @@
-Sanskrit, chapter 3: Chapter 3.
+Sanskrit, chapter 3: How Are You?.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/sanskrit/narration/ch04.json
+++ b/code/learning/human-languages/sanskrit/narration/ch04.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "sanskrit",
   "chapter": 4,
-  "title": "Chapter 4",
+  "title": "Farewells",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:f28a789d74943117",
   "lessons": [

--- a/code/learning/human-languages/sanskrit/narration/ch04.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch04.txt
@@ -1,4 +1,4 @@
-Sanskrit, chapter 4: Chapter 4.
+Sanskrit, chapter 4: Farewells.
 5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/sanskrit/narration/ch05.json
+++ b/code/learning/human-languages/sanskrit/narration/ch05.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "sanskrit",
   "chapter": 5,
-  "title": "Chapter 5",
+  "title": "The First Verbs",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:299477aef2c2aa1c",
   "lessons": [

--- a/code/learning/human-languages/sanskrit/narration/ch05.txt
+++ b/code/learning/human-languages/sanskrit/narration/ch05.txt
@@ -1,4 +1,4 @@
-Sanskrit, chapter 5: Chapter 5.
+Sanskrit, chapter 5: The First Verbs.
 5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/spanish/chapters.json
+++ b/code/learning/human-languages/spanish/chapters.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "language": "spanish",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 1-6 and 19-39 are authored here — every Spanish chapter that owns a core/book-generation.json target. Chapters 7-18 are deliberately absent: their lessons are still schema_version 1 with no practises.knowledge, so no payoff can be claimed for them honestly. That absence is real, measurable debt and must not be papered over with placeholders. Chapters 1-6 end in a terminal practice-mix; chapters 19-39 have none, so their payoff is the chapter's last lesson by sequence, which is where the recombination and wrap-up recall actually live.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
     {
       "chapter": 1,
@@ -151,6 +151,201 @@
           "ES-LEX-GRACIAS",
           "ES-LEX-DE-NADA"
         ]
+      }
+    },
+    {
+      "chapter": 7,
+      "title": "Eating, Drinking, Living --- the \\emph{-er} and \\emph{-ir} Verbs",
+      "label": "ch:er-ir-verbs",
+      "canDo": "I can conjugate regular Spanish -er and -ir verbs and say what I eat, drink, and where I live.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO",
+        "SPINE-EXCHANGE-NAMES",
+        "SPINE-ASK-LOCATION"
+      ],
+      "payoff": {
+        "lesson": "ES-C07-practice",
+        "kind": "task",
+        "summary": "Complete ES-C07-practice, the canonical closing checkpoint, and demonstrate the chapter promise: conjugate regular Spanish -er and -ir verbs and say what I eat, drink, and where I live.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 8,
+      "title": "Numbers, and How Old You Are",
+      "label": "ch:numbers-and-age",
+      "canDo": "I can use Spanish numbers in context and say how old I am.",
+      "spineNodes": [
+        "SPINE-TIME-OF-DAY",
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "ES-C08-practice",
+        "kind": "task",
+        "summary": "Complete ES-C08-practice, the canonical closing checkpoint, and demonstrate the chapter promise: use Spanish numbers in context and say how old I am.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 9,
+      "title": "\\emph{Ser} and \\emph{Estar} --- Two Ways to Be",
+      "label": "ch:ser-y-estar",
+      "canDo": "I can choose between ser and estar for simple descriptions, identities, states, and locations.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "ES-C09-practice",
+        "kind": "task",
+        "summary": "Complete ES-C09-practice, the canonical closing checkpoint, and demonstrate the chapter promise: choose between ser and estar for simple descriptions, identities, states, and locations.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 10,
+      "title": "Going, and the Future You Can Already Say",
+      "label": "ch:ir-y-futuro",
+      "canDo": "I can use ir to say where I am going and what I am going to do.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "ES-C10-practice",
+        "kind": "task",
+        "summary": "Complete ES-C10-practice, the canonical closing checkpoint, and demonstrate the chapter promise: use ir to say where I am going and what I am going to do.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 11,
+      "title": "Verbs That Break in the Middle --- the Stem Changers",
+      "label": "ch:stem-changes",
+      "canDo": "I can recognize and conjugate common Spanish stem-changing verbs in the present tense.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "ES-C11-practice",
+        "kind": "task",
+        "summary": "Complete ES-C11-practice, the canonical closing checkpoint, and demonstrate the chapter promise: recognize and conjugate common Spanish stem-changing verbs in the present tense.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 12,
+      "title": "\\emph{Hacer}, \\emph{Decir}, and the \\emph{-go} Verb Club",
+      "label": "ch:yo-go-verbs",
+      "canDo": "I can use hacer and decir and recognize the first members of the Spanish -go verb pattern.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "ES-C12-practice",
+        "kind": "task",
+        "summary": "Complete ES-C12-practice, the canonical closing checkpoint, and demonstrate the chapter promise: use hacer and decir and recognize the first members of the Spanish -go verb pattern.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 13,
+      "title": "\\emph{Poner}, \\emph{Salir}, \\emph{Venir} --- Completing the \\emph{-go} Club",
+      "label": "ch:completing-go-club",
+      "canDo": "I can use poner, salir, and venir and complete the practical Spanish -go verb family.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-DO"
+      ],
+      "payoff": {
+        "lesson": "ES-C13-practice",
+        "kind": "task",
+        "summary": "Complete ES-C13-practice, the canonical closing checkpoint, and demonstrate the chapter promise: use poner, salir, and venir and complete the practical Spanish -go verb family.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 14,
+      "title": "The Preterite --- Your First Past Tense",
+      "label": "ch:preterite",
+      "canDo": "I can form the regular Spanish preterite and say what happened in a completed past event.",
+      "spineNodes": [
+        "SPINE-TALK-ABOUT-PAST"
+      ],
+      "payoff": {
+        "lesson": "ES-C14-practice",
+        "kind": "task",
+        "summary": "Complete ES-C14-practice, the canonical closing checkpoint, and demonstrate the chapter promise: form the regular Spanish preterite and say what happened in a completed past event.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 15,
+      "title": "Completing the Preterite --- Three Families, One Question",
+      "label": "ch:completing-preterite",
+      "canDo": "I can choose and form the principal irregular Spanish preterite families.",
+      "spineNodes": [
+        "SPINE-TALK-ABOUT-PAST"
+      ],
+      "payoff": {
+        "lesson": "ES-C15-practice",
+        "kind": "task",
+        "summary": "Complete ES-C15-practice, the canonical closing checkpoint, and demonstrate the chapter promise: choose and form the principal irregular Spanish preterite families.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 16,
+      "title": "The Imperfect --- the Past That Kept Going",
+      "label": "ch:imperfect",
+      "canDo": "I can use the Spanish imperfect for past habits, background, and actions in progress.",
+      "spineNodes": [
+        "SPINE-TALK-ABOUT-PAST"
+      ],
+      "payoff": {
+        "lesson": "ES-C16-practice",
+        "kind": "task",
+        "summary": "Complete ES-C16-practice, the canonical closing checkpoint, and demonstrate the chapter promise: use the Spanish imperfect for past habits, background, and actions in progress.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 17,
+      "title": "The Future and the Conditional --- One Weld, Twice",
+      "label": "ch:future-conditional",
+      "canDo": "I can form the Spanish future and conditional from the infinitive and use each for its core meaning.",
+      "spineNodes": [
+        "SPINE-TALK-ABOUT-FUTURE"
+      ],
+      "payoff": {
+        "lesson": "ES-C17-practice",
+        "kind": "task",
+        "summary": "Complete ES-C17-practice, the canonical closing checkpoint, and demonstrate the chapter promise: form the Spanish future and conditional from the infinitive and use each for its core meaning.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 18,
+      "title": "The Subjunctive --- the Mood of the Not-Yet-Real",
+      "label": "ch:subjunctive",
+      "canDo": "I can form the present Spanish subjunctive and use it after a small set of wishes, doubts, and not-yet-real prompts.",
+      "spineNodes": [
+        "SPINE-SAY-WHAT-I-WANT"
+      ],
+      "payoff": {
+        "lesson": "ES-C18-practice-mood",
+        "kind": "task",
+        "summary": "Complete ES-C18-practice-mood, the canonical closing checkpoint, and demonstrate the chapter promise: form the present Spanish subjunctive and use it after a small set of wishes, doubts, and not-yet-real prompts.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
       }
     },
     {

--- a/code/learning/human-languages/spanish/curriculum.json
+++ b/code/learning/human-languages/spanish/curriculum.json
@@ -289,6 +289,86 @@
       "after": []
     },
     {
+      "id": "ES-PATH-038",
+      "spine_node": "SPINE-TALK-ABOUT-PAST",
+      "lessons": [
+        "ES-C14-ser-ir-preterite",
+        "ES-C14-hablar-preterite",
+        "ES-C14-practice"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-038-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-039",
+      "spine_node": "SPINE-TALK-ABOUT-PAST",
+      "lessons": [
+        "ES-C15-comer-vivir-preterite",
+        "ES-C15-preterite-fuertes",
+        "ES-C15-practice"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-039-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-040",
+      "spine_node": "SPINE-TALK-ABOUT-PAST",
+      "lessons": [
+        "ES-C16-imperfecto",
+        "ES-C16-tres-irregulares",
+        "ES-C16-practice"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-040-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-041",
+      "spine_node": "SPINE-TALK-ABOUT-FUTURE",
+      "lessons": [
+        "ES-C10-ir-a-futuro",
+        "ES-C17-futuro",
+        "ES-C17-condicional",
+        "ES-C17-practice",
+        "ES-C17-future-guessing"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-041-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
+      "id": "ES-PATH-042",
+      "spine_node": "SPINE-SAY-WHAT-I-WANT",
+      "lessons": [
+        "ES-C11-stem-changes",
+        "ES-C18-subjuntivo",
+        "ES-C18-inherited-subjunctive-stems",
+        "ES-C18-subjunctive-outliers",
+        "ES-C18-subjunctive-name",
+        "ES-C18-quiero-que",
+        "ES-C18-wanting-clause-trap",
+        "ES-C18-ojala",
+        "ES-C18-practice",
+        "ES-C18-practice-subjects",
+        "ES-C18-practice-mood"
+      ],
+      "before": [],
+      "inline": [
+        "ES-EXT-042-LANGUAGE-SPECIFIC"
+      ],
+      "after": []
+    },
+    {
       "id": "ES-PATH-017",
       "spine_node": "SPINE-RESPOND-BASIC",
       "lessons": [
@@ -689,21 +769,29 @@
       "relocates": {}
     },
     "SPINE-SAY-WHAT-I-WANT": {
-      "segments": [],
+      "segments": [
+        "ES-PATH-042"
+      ],
       "omits": [
         "VERB-WANT"
       ],
       "relocates": {}
     },
     "SPINE-TALK-ABOUT-PAST": {
-      "segments": [],
+      "segments": [
+        "ES-PATH-038",
+        "ES-PATH-039",
+        "ES-PATH-040"
+      ],
       "omits": [
         "VERB-PAST"
       ],
       "relocates": {}
     },
     "SPINE-TALK-ABOUT-FUTURE": {
-      "segments": [],
+      "segments": [
+        "ES-PATH-041"
+      ],
       "omits": [
         "VERB-FUTURE"
       ],
@@ -1259,6 +1347,81 @@
         "ES-C32-perro",
         "ES-C33-verde",
         "ES-C33-amarillo"
+      ]
+    },
+    {
+      "id": "ES-EXT-038-LANGUAGE-SPECIFIC",
+      "stage": "A2",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the Spanish-specific vocabulary and grammar that support this shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C14-ser-ir-preterite",
+        "ES-C14-hablar-preterite",
+        "ES-C14-practice"
+      ]
+    },
+    {
+      "id": "ES-EXT-039-LANGUAGE-SPECIFIC",
+      "stage": "A2",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the Spanish-specific vocabulary and grammar that support this shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C15-comer-vivir-preterite",
+        "ES-C15-preterite-fuertes",
+        "ES-C15-practice"
+      ]
+    },
+    {
+      "id": "ES-EXT-040-LANGUAGE-SPECIFIC",
+      "stage": "A2",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the Spanish-specific vocabulary and grammar that support this shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C16-imperfecto",
+        "ES-C16-tres-irregulares",
+        "ES-C16-practice"
+      ]
+    },
+    {
+      "id": "ES-EXT-041-LANGUAGE-SPECIFIC",
+      "stage": "A2",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the Spanish-specific vocabulary and grammar that support this shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C10-ir-a-futuro",
+        "ES-C17-futuro",
+        "ES-C17-condicional",
+        "ES-C17-practice",
+        "ES-C17-future-guessing"
+      ]
+    },
+    {
+      "id": "ES-EXT-042-LANGUAGE-SPECIFIC",
+      "stage": "A2",
+      "kind": "required",
+      "category": "language-specific",
+      "canDo": "I can use the Spanish-specific vocabulary and grammar that support this shared ability.",
+      "prerequisites": [],
+      "lessons": [
+        "ES-C11-stem-changes",
+        "ES-C18-subjuntivo",
+        "ES-C18-inherited-subjunctive-stems",
+        "ES-C18-subjunctive-outliers",
+        "ES-C18-subjunctive-name",
+        "ES-C18-quiero-que",
+        "ES-C18-wanting-clause-trap",
+        "ES-C18-ojala",
+        "ES-C18-practice",
+        "ES-C18-practice-subjects",
+        "ES-C18-practice-mood"
       ]
     },
     {

--- a/code/learning/human-languages/spanish/narration/ch07.json
+++ b/code/learning/human-languages/spanish/narration/ch07.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "spanish",
   "chapter": 7,
-  "title": "Chapter 7",
+  "title": "Eating, Drinking, Living --- the \\emph{-er} and \\emph{-ir} Verbs",
   "drivablePrefix": 1,
   "sourceHash": "fnv1a64:4158219fe9416bef",
   "lessons": [

--- a/code/learning/human-languages/spanish/narration/ch07.txt
+++ b/code/learning/human-languages/spanish/narration/ch07.txt
@@ -1,4 +1,4 @@
-Spanish, chapter 7: Chapter 7.
+Spanish, chapter 7: Eating, Drinking, Living --- the \emph{-er} and \emph{-ir} Verbs.
 6 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/spanish/narration/ch08.json
+++ b/code/learning/human-languages/spanish/narration/ch08.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "spanish",
   "chapter": 8,
-  "title": "Chapter 8",
+  "title": "Numbers, and How Old You Are",
   "drivablePrefix": 5,
   "sourceHash": "fnv1a64:04ed5b71dcd6ef10",
   "lessons": [

--- a/code/learning/human-languages/spanish/narration/ch08.txt
+++ b/code/learning/human-languages/spanish/narration/ch08.txt
@@ -1,4 +1,4 @@
-Spanish, chapter 8: Chapter 8.
+Spanish, chapter 8: Numbers, and How Old You Are.
 5 lessons. All 5 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/spanish/narration/ch09.json
+++ b/code/learning/human-languages/spanish/narration/ch09.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "spanish",
   "chapter": 9,
-  "title": "Chapter 9",
+  "title": "\\emph{Ser} and \\emph{Estar} --- Two Ways to Be",
   "drivablePrefix": 1,
   "sourceHash": "fnv1a64:31ecfffb1213f2bb",
   "lessons": [

--- a/code/learning/human-languages/spanish/narration/ch09.txt
+++ b/code/learning/human-languages/spanish/narration/ch09.txt
@@ -1,4 +1,4 @@
-Spanish, chapter 9: Chapter 9.
+Spanish, chapter 9: \emph{Ser} and \emph{Estar} --- Two Ways to Be.
 5 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/spanish/narration/ch10.json
+++ b/code/learning/human-languages/spanish/narration/ch10.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "spanish",
   "chapter": 10,
-  "title": "Chapter 10",
+  "title": "Going, and the Future You Can Already Say",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:ea6580c734b4662b",
   "lessons": [

--- a/code/learning/human-languages/spanish/narration/ch10.txt
+++ b/code/learning/human-languages/spanish/narration/ch10.txt
@@ -1,4 +1,4 @@
-Spanish, chapter 10: Chapter 10.
+Spanish, chapter 10: Going, and the Future You Can Already Say.
 4 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/spanish/narration/ch11.json
+++ b/code/learning/human-languages/spanish/narration/ch11.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "spanish",
   "chapter": 11,
-  "title": "Chapter 11",
+  "title": "Verbs That Break in the Middle --- the Stem Changers",
   "drivablePrefix": 5,
   "sourceHash": "fnv1a64:68f9ddd8f459cb18",
   "lessons": [

--- a/code/learning/human-languages/spanish/narration/ch11.txt
+++ b/code/learning/human-languages/spanish/narration/ch11.txt
@@ -1,4 +1,4 @@
-Spanish, chapter 11: Chapter 11.
+Spanish, chapter 11: Verbs That Break in the Middle --- the Stem Changers.
 5 lessons. All 5 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/spanish/narration/ch12.json
+++ b/code/learning/human-languages/spanish/narration/ch12.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "spanish",
   "chapter": 12,
-  "title": "Chapter 12",
+  "title": "\\emph{Hacer}, \\emph{Decir}, and the \\emph{-go} Verb Club",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:ab04c43bed11cbe9",
   "lessons": [

--- a/code/learning/human-languages/spanish/narration/ch12.txt
+++ b/code/learning/human-languages/spanish/narration/ch12.txt
@@ -1,4 +1,4 @@
-Spanish, chapter 12: Chapter 12.
+Spanish, chapter 12: \emph{Hacer}, \emph{Decir}, and the \emph{-go} Verb Club.
 4 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/spanish/narration/ch13.json
+++ b/code/learning/human-languages/spanish/narration/ch13.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "spanish",
   "chapter": 13,
-  "title": "Chapter 13",
+  "title": "\\emph{Poner}, \\emph{Salir}, \\emph{Venir} --- Completing the \\emph{-go} Club",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:9012955fa6cf35df",
   "lessons": [

--- a/code/learning/human-languages/spanish/narration/ch13.txt
+++ b/code/learning/human-languages/spanish/narration/ch13.txt
@@ -1,4 +1,4 @@
-Spanish, chapter 13: Chapter 13.
+Spanish, chapter 13: \emph{Poner}, \emph{Salir}, \emph{Venir} --- Completing the \emph{-go} Club.
 4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/spanish/narration/ch14.json
+++ b/code/learning/human-languages/spanish/narration/ch14.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "spanish",
   "chapter": 14,
-  "title": "Chapter 14",
+  "title": "The Preterite --- Your First Past Tense",
   "drivablePrefix": 3,
   "sourceHash": "fnv1a64:f23019fb92985626",
   "lessons": [

--- a/code/learning/human-languages/spanish/narration/ch14.txt
+++ b/code/learning/human-languages/spanish/narration/ch14.txt
@@ -1,4 +1,4 @@
-Spanish, chapter 14: Chapter 14.
+Spanish, chapter 14: The Preterite --- Your First Past Tense.
 3 lessons. All 3 can be done entirely by ear.
 
 

--- a/code/learning/human-languages/spanish/narration/ch15.json
+++ b/code/learning/human-languages/spanish/narration/ch15.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "spanish",
   "chapter": 15,
-  "title": "Chapter 15",
+  "title": "Completing the Preterite --- Three Families, One Question",
   "drivablePrefix": 1,
   "sourceHash": "fnv1a64:6a0d0566d7c228af",
   "lessons": [

--- a/code/learning/human-languages/spanish/narration/ch15.txt
+++ b/code/learning/human-languages/spanish/narration/ch15.txt
@@ -1,4 +1,4 @@
-Spanish, chapter 15: Chapter 15.
+Spanish, chapter 15: Completing the Preterite --- Three Families, One Question.
 3 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/spanish/narration/ch16.json
+++ b/code/learning/human-languages/spanish/narration/ch16.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "spanish",
   "chapter": 16,
-  "title": "Chapter 16",
+  "title": "The Imperfect --- the Past That Kept Going",
   "drivablePrefix": 1,
   "sourceHash": "fnv1a64:82ec9c67f1912a73",
   "lessons": [

--- a/code/learning/human-languages/spanish/narration/ch16.txt
+++ b/code/learning/human-languages/spanish/narration/ch16.txt
@@ -1,4 +1,4 @@
-Spanish, chapter 16: Chapter 16.
+Spanish, chapter 16: The Imperfect --- the Past That Kept Going.
 3 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/spanish/narration/ch17.json
+++ b/code/learning/human-languages/spanish/narration/ch17.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "spanish",
   "chapter": 17,
-  "title": "Chapter 17",
+  "title": "The Future and the Conditional --- One Weld, Twice",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:987d104372c450ad",
   "lessons": [

--- a/code/learning/human-languages/spanish/narration/ch17.txt
+++ b/code/learning/human-languages/spanish/narration/ch17.txt
@@ -1,4 +1,4 @@
-Spanish, chapter 17: Chapter 17.
+Spanish, chapter 17: The Future and the Conditional --- One Weld, Twice.
 4 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/spanish/narration/ch18.json
+++ b/code/learning/human-languages/spanish/narration/ch18.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "spanish",
   "chapter": 18,
-  "title": "Chapter 18",
+  "title": "The Subjunctive --- the Mood of the Not-Yet-Real",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:611f103a3f18023d",
   "lessons": [

--- a/code/learning/human-languages/spanish/narration/ch18.txt
+++ b/code/learning/human-languages/spanish/narration/ch18.txt
@@ -1,4 +1,4 @@
-Spanish, chapter 18: Chapter 18.
+Spanish, chapter 18: The Subjunctive --- the Mood of the Not-Yet-Real.
 10 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/tamil/chapters.json
+++ b/code/learning/human-languages/tamil/chapters.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "language": "tamil",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 2-5 are deliberately absent — every lesson in them is still schema v1 with no practises.knowledge, so no payoff could name a real atom. That absence is measurable debt and must not be papered over with placeholders. No Tamil chapter has a terminal practice/practice-mix lesson under schema v2 either, so every payoff below is the chapter's last lesson by sequence.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
     {
       "chapter": 1,
@@ -19,6 +19,74 @@
         "summary": "Hold the whole exchange out loud — greet, answer ஆம் or இல்லை, thank, and close with சரி — using only the ear.",
         "assesses": [],
         "note": "Chapter 1 holds no writing lesson and introduces no knowledge atoms at all, because its nine lessons are schema v1 and declare none. `assesses` is therefore empty as a matter of fact, and `payoffsNotClosed` is unaffected by it. Be clear about what that costs: chapters.ts guards the representativeness check with `introduced.size > 0`, so this payoff is not measured rather than passing — the gate that used to report tamil:1 at 5/24 now says nothing about it, and the corpus total holds at 25 only because tamil:13 took its place when TA-W04-i-sign-write-nandri moved there. Modelling spoken atoms is HL-C25 work. The writing strand starts in chapter 4."
+      }
+    },
+    {
+      "chapter": 2,
+      "title": "Introducing Yourself",
+      "label": "ch:introductions",
+      "canDo": "I can introduce myself in Tamil, give my name, and understand the other person's name.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "TA-C02-practice",
+        "kind": "task",
+        "summary": "Complete TA-C02-practice, the canonical closing checkpoint, and demonstrate the chapter promise: introduce myself in Tamil, give my name, and understand the other person's name.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "How Are You?",
+      "label": "ch:responding",
+      "canDo": "I can ask how someone is in Tamil, answer naturally, and return the question.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-EXCHANGE-NAMES",
+        "SPINE-COURTESY-THANK"
+      ],
+      "payoff": {
+        "lesson": "TA-C03-practice",
+        "kind": "task",
+        "summary": "Complete TA-C03-practice, the canonical closing checkpoint, and demonstrate the chapter promise: ask how someone is in Tamil, answer naturally, and return the question.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "Farewells",
+      "label": "ch:farewells",
+      "canDo": "I can end a Tamil conversation politely and choose a farewell that fits the situation.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "TA-C04-practice",
+        "kind": "task",
+        "summary": "Complete TA-C04-practice, the canonical closing checkpoint, and demonstrate the chapter promise: end a Tamil conversation politely and choose a farewell that fits the situation.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "The First Verbs",
+      "label": "ch:first-verbs",
+      "canDo": "I can build short present-tense Tamil sentences with the chapter's first verbs.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "TA-C05-practice",
+        "kind": "task",
+        "summary": "Complete TA-C05-practice, the canonical closing checkpoint, and demonstrate the chapter promise: build short present-tense Tamil sentences with the chapter's first verbs.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
       }
     },
     {

--- a/code/learning/human-languages/tamil/narration/ch02.json
+++ b/code/learning/human-languages/tamil/narration/ch02.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "tamil",
   "chapter": 2,
-  "title": "Chapter 2",
+  "title": "Introducing Yourself",
   "drivablePrefix": 2,
   "sourceHash": "fnv1a64:8d5757d04fc5050e",
   "lessons": [

--- a/code/learning/human-languages/tamil/narration/ch02.txt
+++ b/code/learning/human-languages/tamil/narration/ch02.txt
@@ -1,4 +1,4 @@
-Tamil, chapter 2: Chapter 2.
+Tamil, chapter 2: Introducing Yourself.
 8 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
 
 

--- a/code/learning/human-languages/tamil/narration/ch03.json
+++ b/code/learning/human-languages/tamil/narration/ch03.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "tamil",
   "chapter": 3,
-  "title": "Chapter 3",
+  "title": "How Are You?",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:1c736a85ee572d92",
   "lessons": [

--- a/code/learning/human-languages/tamil/narration/ch03.txt
+++ b/code/learning/human-languages/tamil/narration/ch03.txt
@@ -1,4 +1,4 @@
-Tamil, chapter 3: Chapter 3.
+Tamil, chapter 3: How Are You?.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/tamil/narration/ch04.json
+++ b/code/learning/human-languages/tamil/narration/ch04.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "tamil",
   "chapter": 4,
-  "title": "Chapter 4",
+  "title": "Farewells",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:ac8d1a3a89c18c13",
   "lessons": [

--- a/code/learning/human-languages/tamil/narration/ch04.txt
+++ b/code/learning/human-languages/tamil/narration/ch04.txt
@@ -1,4 +1,4 @@
-Tamil, chapter 4: Chapter 4.
+Tamil, chapter 4: Farewells.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/tamil/narration/ch05.json
+++ b/code/learning/human-languages/tamil/narration/ch05.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "tamil",
   "chapter": 5,
-  "title": "Chapter 5",
+  "title": "The First Verbs",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:0718a395630b7532",
   "lessons": [

--- a/code/learning/human-languages/tamil/narration/ch05.txt
+++ b/code/learning/human-languages/tamil/narration/ch05.txt
@@ -1,4 +1,4 @@
-Tamil, chapter 5: Chapter 5.
+Tamil, chapter 5: The First Verbs.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/telugu/chapters.json
+++ b/code/learning/human-languages/telugu/chapters.json
@@ -1,8 +1,92 @@
 {
   "version": 1,
   "language": "telugu",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapters 1-5 are absent on purpose — their lessons are still schema v1, carry no practises.knowledge, and have no core/book-generation.json target, so any payoff written for them would be invented rather than derived. That absence is real, measurable debt and must not be papered over with placeholders. No chapter from 6 on has a terminal practice/practice-mix lesson, so each payoff is the chapter's last lesson by sequence.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings",
+      "label": "ch:greetings",
+      "canDo": "I can greet someone in Telugu, recognize the reply, and choose an appropriate response.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-RESPOND-BASIC",
+        "SPINE-COURTESY-THANK"
+      ],
+      "payoff": {
+        "lesson": "TE-C01-practice",
+        "kind": "task",
+        "summary": "Complete TE-C01-practice, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in Telugu, recognize the reply, and choose an appropriate response.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 2,
+      "title": "Introducing Yourself",
+      "label": "ch:introductions",
+      "canDo": "I can introduce myself in Telugu, give my name, and understand the other person's name.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "TE-C02-practice",
+        "kind": "task",
+        "summary": "Complete TE-C02-practice, the canonical closing checkpoint, and demonstrate the chapter promise: introduce myself in Telugu, give my name, and understand the other person's name.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 3,
+      "title": "How Are You?",
+      "label": "ch:responding",
+      "canDo": "I can ask how someone is in Telugu, answer naturally, and return the question.",
+      "spineNodes": [
+        "SPINE-CHECK-WELLBEING",
+        "SPINE-EXCHANGE-NAMES",
+        "SPINE-COURTESY-THANK"
+      ],
+      "payoff": {
+        "lesson": "TE-C03-practice",
+        "kind": "task",
+        "summary": "Complete TE-C03-practice, the canonical closing checkpoint, and demonstrate the chapter promise: ask how someone is in Telugu, answer naturally, and return the question.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 4,
+      "title": "Farewells",
+      "label": "ch:farewells",
+      "canDo": "I can end a Telugu conversation politely and choose a farewell that fits the situation.",
+      "spineNodes": [
+        "SPINE-TAKE-LEAVE"
+      ],
+      "payoff": {
+        "lesson": "TE-C04-practice",
+        "kind": "task",
+        "summary": "Complete TE-C04-practice, the canonical closing checkpoint, and demonstrate the chapter promise: end a Telugu conversation politely and choose a farewell that fits the situation.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
+    {
+      "chapter": 5,
+      "title": "The First Verbs",
+      "label": "ch:first-verbs",
+      "canDo": "I can build short present-tense Telugu sentences with the chapter's first verbs.",
+      "spineNodes": [
+        "SPINE-EXCHANGE-NAMES"
+      ],
+      "payoff": {
+        "lesson": "TE-C05-practice",
+        "kind": "task",
+        "summary": "Complete TE-C05-practice, the canonical closing checkpoint, and demonstrate the chapter promise: build short present-tense Telugu sentences with the chapter's first verbs.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 6,
       "title": "Case Endings and Dative Subjects",

--- a/code/learning/human-languages/telugu/narration/ch01.json
+++ b/code/learning/human-languages/telugu/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "telugu",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:1e014704b06c6363",
   "lessons": [

--- a/code/learning/human-languages/telugu/narration/ch01.txt
+++ b/code/learning/human-languages/telugu/narration/ch01.txt
@@ -1,4 +1,4 @@
-Telugu, chapter 1: Chapter 1.
+Telugu, chapter 1: Greetings.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/telugu/narration/ch02.json
+++ b/code/learning/human-languages/telugu/narration/ch02.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "telugu",
   "chapter": 2,
-  "title": "Chapter 2",
+  "title": "Introducing Yourself",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:1cf5973cc83511a8",
   "lessons": [

--- a/code/learning/human-languages/telugu/narration/ch02.txt
+++ b/code/learning/human-languages/telugu/narration/ch02.txt
@@ -1,4 +1,4 @@
-Telugu, chapter 2: Chapter 2.
+Telugu, chapter 2: Introducing Yourself.
 8 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/telugu/narration/ch03.json
+++ b/code/learning/human-languages/telugu/narration/ch03.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "telugu",
   "chapter": 3,
-  "title": "Chapter 3",
+  "title": "How Are You?",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:4ce874054fee9743",
   "lessons": [

--- a/code/learning/human-languages/telugu/narration/ch03.txt
+++ b/code/learning/human-languages/telugu/narration/ch03.txt
@@ -1,4 +1,4 @@
-Telugu, chapter 3: Chapter 3.
+Telugu, chapter 3: How Are You?.
 6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/telugu/narration/ch04.json
+++ b/code/learning/human-languages/telugu/narration/ch04.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "telugu",
   "chapter": 4,
-  "title": "Chapter 4",
+  "title": "Farewells",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:e4153a7d2fa6af5d",
   "lessons": [

--- a/code/learning/human-languages/telugu/narration/ch04.txt
+++ b/code/learning/human-languages/telugu/narration/ch04.txt
@@ -1,4 +1,4 @@
-Telugu, chapter 4: Chapter 4.
+Telugu, chapter 4: Farewells.
 5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/telugu/narration/ch05.json
+++ b/code/learning/human-languages/telugu/narration/ch05.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "telugu",
   "chapter": 5,
-  "title": "Chapter 5",
+  "title": "The First Verbs",
   "drivablePrefix": 0,
   "sourceHash": "fnv1a64:e585e84796aea7f4",
   "lessons": [

--- a/code/learning/human-languages/telugu/narration/ch05.txt
+++ b/code/learning/human-languages/telugu/narration/ch05.txt
@@ -1,4 +1,4 @@
-Telugu, chapter 5: Chapter 5.
+Telugu, chapter 5: The First Verbs.
 5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 

--- a/code/learning/human-languages/urdu/chapters.json
+++ b/code/learning/human-languages/urdu/chapters.json
@@ -1,8 +1,26 @@
 {
   "version": 1,
   "language": "urdu",
-  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Chapter 1 is deliberately absent — all four of its lessons are still schema v1 with no declared knowledge atoms, so any payoff written for it would be invented rather than derived. That absence is real, measurable debt and must not be papered over with a placeholder.",
+  "note": "HL05 chapter capability ledger. Authored intent, not a derived cache: no validator may rewrite this file. Every declared book chapter now has an authored capability. Legacy schema-v1 entries anchor their payoff to real canonical lesson content but intentionally keep assesses empty until typed knowledge atoms exist, preserving measurable debt without inventing atoms. Chapter generation status remains independently controlled by core/book-generation.json.",
   "chapters": [
+    {
+      "chapter": 1,
+      "title": "Greetings and responses",
+      "label": "ch:urdu-greetings",
+      "canDo": "I can greet someone in Urdu, respond courteously, and close the exchange naturally.",
+      "spineNodes": [
+        "SPINE-MEET-GREET",
+        "SPINE-COURTESY-THANK",
+        "SPINE-RESPOND-BASIC"
+      ],
+      "payoff": {
+        "lesson": "UR-C01-nahin",
+        "kind": "task",
+        "summary": "Complete UR-C01-nahin, the canonical closing checkpoint, and demonstrate the chapter promise: greet someone in Urdu, respond courteously, and close the exchange naturally.",
+        "assesses": [],
+        "note": "This legacy schema-v1 chapter has no typed knowledge atoms yet. The payoff is anchored to real canonical lesson content, but its representativeness remains authored rather than atom-scored until migration."
+      }
+    },
     {
       "chapter": 2,
       "title": "Give your name",

--- a/code/learning/human-languages/urdu/narration/ch01.json
+++ b/code/learning/human-languages/urdu/narration/ch01.json
@@ -2,7 +2,7 @@
   "version": 1,
   "language": "urdu",
   "chapter": 1,
-  "title": "Chapter 1",
+  "title": "Greetings and responses",
   "drivablePrefix": 4,
   "sourceHash": "fnv1a64:6f9688165869e235",
   "lessons": [

--- a/code/learning/human-languages/urdu/narration/ch01.txt
+++ b/code/learning/human-languages/urdu/narration/ch01.txt
@@ -1,4 +1,4 @@
-Urdu, chapter 1: Chapter 1.
+Urdu, chapter 1: Greetings and responses.
 4 lessons. All 4 can be done entirely by ear.
 
 

--- a/code/packages/typescript/human-language-data/src/loader.ts
+++ b/code/packages/typescript/human-language-data/src/loader.ts
@@ -123,6 +123,24 @@ export function loadChapterPolicy(root = defaultCurriculumRoot()): ChapterPolicy
   return policy;
 }
 
+/** Read a braced LaTeX command argument without truncating nested formatting commands. */
+export function chapterTitleFromTex(tex: string, fallback: string): string {
+  const command = /\\chapter(?:\s*\[[^\]]*\])?\s*\{/.exec(tex);
+  if (!command) return fallback;
+  const openingBrace = command.index + command[0].lastIndexOf("{");
+  let depth = 1;
+  for (let index = openingBrace + 1; index < tex.length; index += 1) {
+    const character = tex[index];
+    const escaped = index > 0 && tex[index - 1] === "\\";
+    if (!escaped && character === "{") depth += 1;
+    if (!escaped && character === "}") {
+      depth -= 1;
+      if (depth === 0) return tex.slice(openingBrace + 1, index);
+    }
+  }
+  return fallback;
+}
+
 /**
  * Load the existing authored LaTeX books losslessly. The short Markdown lessons
  * remain the smallest teaching units; chapters are the narrative and sequencing
@@ -143,7 +161,7 @@ export function loadBookCorpus(root = defaultCurriculumRoot()): BookCorpus {
       const match = /^ch(\d+)-(.+)\.tex$/.exec(file);
       if (!match) continue;
       const tex = readFileSync(join(chaptersDir, file), "utf8");
-      const title = /\\chapter(?:\[[^\]]*\])?\{([^}]*)\}/.exec(tex)?.[1] ?? match[2];
+      const title = chapterTitleFromTex(tex, match[2]);
       chapters.push({
         language: track.name,
         chapter: Number(match[1]),

--- a/code/packages/typescript/human-language-data/tests/chapters.test.ts
+++ b/code/packages/typescript/human-language-data/tests/chapters.test.ts
@@ -5,7 +5,12 @@
 // always fires". The corpus block at the bottom pins the first published snapshot.
 
 import { describe, expect, it } from "vitest";
-import { loadChapterPolicy, loadEverything, loadTrackChapters } from "../src/loader.js";
+import {
+  chapterTitleFromTex,
+  loadChapterPolicy,
+  loadEverything,
+  loadTrackChapters,
+} from "../src/loader.js";
 import { CHAPTER_GATE_CODES, runChapterGates } from "../src/chapters.js";
 import { parseLesson } from "../src/parse.js";
 import type { BookCorpus, ChapterPolicy, TrackChapters } from "../src/types.js";
@@ -17,6 +22,11 @@ const POLICY: ChapterPolicy = {
   maxNewAtomsPerChapter: 12,
   maxLinearisableTableColumns: 3,
 };
+
+it("reads complete LaTeX chapter titles that contain nested formatting commands", () => {
+  expect(chapterTitleFromTex("\\chapter{\\emph{Ser} and \\emph{Estar} --- Two Ways to Be}", "fallback"))
+    .toBe("\\emph{Ser} and \\emph{Estar} --- Two Ways to Be");
+});
 
 /** A lesson that introduces the given atoms via its block directive. */
 function lesson(id: string, chapter: number, introduces: string[] = []) {
@@ -220,17 +230,14 @@ describe("corpus snapshot", () => {
       trackChapters: loadTrackChapters(),
       policy: loadChapterPolicy(),
     });
-    // Vocabulary wave 4 (Marathi, Punjabi, Sanskrit, Urdu) added 16 new chapters, four
-    // per track, and every one shipped with its own capability ledger entry and payoff,
-    // so bookChapters and declaredChapters both move by 16 and the debt count does not:
-    // 497 -> 513, 399 -> 415, chaptersWithoutCapability holds at 98. A new chapter that
-    // shipped without a `canDo`/`payoff` would have pushed the debt past 98, which is
-    // exactly what this trio is here to catch.
+    // HL-C63 authored the 98 capabilities that had lagged behind already published,
+    // handwritten chapters. The book total therefore stays at 513 while the declared
+    // capability total catches up from 415 to 513 and the missing-capability debt falls
+    // from 98 to zero. A future chapter without a `canDo`/`payoff` will move these totals
+    // apart again, which is exactly what this trio is here to catch.
     expect(report.summary.bookChapters).toBe(513); // +16: vocabulary wave 4, 4 tracks x 4 chapters
-    // Declared chapters keep pace with book chapters this wave -- every new chapter
-    // shipped a capability entry, unlike russian chapter 3 which lagged by one earlier.
-    expect(report.summary.declaredChapters).toBe(415); // +16: vocabulary wave 4
-    expect(report.summary.chaptersWithoutCapability).toBe(98);
+    expect(report.summary.declaredChapters).toBe(513); // +98: handwritten capability closure
+    expect(report.summary.chaptersWithoutCapability).toBe(0);
     expect(report.summary.payoffsNotClosed).toBe(0);
     expect(report.summary.unknownPayoffLessons).toBe(0);
     expect(report.summary.titleDrift).toBe(0);
@@ -245,7 +252,9 @@ describe("corpus snapshot", () => {
     // entirely rather than passing it), and tamil:13 joined at 1/4 — it gained
     // TA-W04-i-sign-write-nandri when the writing strand was spread out and its payoff
     // was not widened. Both are recorded in tamil/chapters.json's own notes.
-    expect(report.summary.payoffsNotRepresentative).toBe(25);
+    // Empty `assesses` lists on schema-v1 chapters remain unscored rather than pretending
+    // to pass. The current typed-atom corpus still exposes 27 genuinely thin payoffs.
+    expect(report.summary.payoffsNotRepresentative).toBe(27);
   });
 
   it("names the tracks whose chapter debt is already zero", () => {
@@ -256,11 +265,21 @@ describe("corpus snapshot", () => {
       trackChapters: loadTrackChapters(),
       policy: loadChapterPolicy(),
     });
-    // These three may flip to hard errors today; the rest flip as their debt clears.
+    // Capability closure makes nine more tracks clean. Tracks omitted from this list
+    // still carry typed-atom payoff debt, even though none lacks a chapter capability.
     expect(report.tracks.filter((t) => t.clean).map((t) => t.language).sort()).toEqual([
+      "bengali",
       "chinese",
+      "french",
+      "gujarati",
+      "italian",
       "japanese",
+      "kannada",
       "latin",
+      "marathi",
+      "portuguese",
+      "punjabi",
+      "telugu",
     ]);
   });
 

--- a/code/packages/typescript/human-language-data/tests/levels.test.ts
+++ b/code/packages/typescript/human-language-data/tests/levels.test.ts
@@ -219,8 +219,8 @@ describe("corpus snapshot", () => {
 
     // +2: TA-W08-read-en and TA-W09-read-peyar.
     expect(summary.byLevel["pre-A1"]).toBe(866); // +52: vocabulary wave 4 (marathi/punjabi/sanskrit/urdu)
-    expect(summary.byLevel.A1).toBe(297);
-    expect(summary.byLevel.A2).toBe(350);
+    expect(summary.byLevel.A1).toBe(301); // +4: French/German time and weekday chapters
+    expect(summary.byLevel.A2).toBe(395); // +25: Spanish chapters 14-18 plus prerequisite closure
     // 8, not 0: Spanish chapters 38 and 41 realize SPINE-NARRATE-EVENTS and
     // SPINE-GIVE-REASONS, four lessons each — the only B1 nodes any track has touched.
     // B2-C2 remain authored-but-unrealized, in every track.
@@ -229,10 +229,10 @@ describe("corpus snapshot", () => {
     expect(summary.byLevel.C1).toBe(0);
     expect(summary.byLevel.C2).toBe(0);
 
-    // 170 lessons sit in no realization-path segment, all of them schema-v1. They are the
-    // reason `mappedPercent` is not 100, and mapping them is migration work, not a gate.
-    expect(summary.unmapped).toBe(148);
-    expect(summary.mappedPercent).toBe(91);
+    // HL-C63 places 47 orphan chapter lessons and two Spanish prerequisites. The
+    // remaining 99 unmapped lessons are still explicit migration debt, not hidden data.
+    expect(summary.unmapped).toBe(99);
+    expect(summary.mappedPercent).toBe(94);
   });
 
   it("shows twenty tracks have reached A2, and only two have not reached A1", () => {
@@ -280,7 +280,7 @@ describe("corpus snapshot", () => {
     const { lessons, curricula: paths, spine } = loadEverything();
     const ramp = lessonsUpToLevel(lessons, paths, spine, "A1");
     // The whole point: this is a FILTER over the one corpus, not a second corpus.
-    expect(ramp).toHaveLength(1163); // +52: vocabulary wave 4, all of it pre-A1
+    expect(ramp).toHaveLength(1167); // +4: mapped French/German A1 lessons
     expect(ramp.length).toBeLessThan(lessons.length);
   });
 });


### PR DESCRIPTION
## What changed

- author capability entries and canonical narration for the 98 handwritten chapters that were missing from `chapters.json`
- keep legacy schema-v1 payoffs honest with real closing lessons and empty atom assessments until those lessons are migrated
- place 47 orphan chapter lessons plus two required Spanish prerequisites in prerequisite-safe shared-spine segments, with explicit language-local extension classifications
- refresh the generated progress table, narration exports, hashes, and corpus snapshots
- fix `loadBookCorpus` so nested LaTeX commands such as `\\emph{...}` do not truncate chapter titles

## Why

The book manifest declared 513 chapters, but only 415 had authored HL05 capabilities. That kept published handwritten material outside the app-facing chapter model and narration export. Closing the gap also exposed missing path placement and a nested-brace title parser defect.

## Impact

All 513 book chapters now have a checkable capability and payoff. The shared path places 1,570 of 1,669 lessons (94%), narration covers the newly modeled handwritten chapters, and handwritten/generation ownership remains unchanged.

## Validation

- `bash code/scripts/verify-human-languages.sh --fast`
- `bash BUILD` in `code/packages/typescript/human-language-data` — 435 tests with coverage
- `npm run check:books`
- `npm run check:modality`
- `npm run check:narration`
- `npm run check:progress`
- `npm run validate`
- `git diff --check`