### PR TITLE
Add BJT KF parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `KF` flicker-noise coefficient.
 - Validate and lower BJT model-card `TNOM` / `T_NOM` nominal temperature.
 - Validate and lower BJT model-card `IKR` reverse beta roll-off current.
 - Validate and lower BJT model-card `BR` / `BETA_R` reverse beta.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1344,6 +1344,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Tnom=(
                 nominal_temperature + 273.15 if nominal_temperature is not None else None
             ),
+            Kf=model.params.get("KF", 0.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2250,6 +2251,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0
         ):
             raise NetlistParseError("BJT TNOM must be finite and positive")
+        flicker_noise_coefficient = params.get("KF")
+        if flicker_noise_coefficient is not None and (
+            not math.isfinite(flicker_noise_coefficient)
+            or flicker_noise_coefficient < 0.0
+        ):
+            raise NetlistParseError("BJT KF must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1830,6 +1830,23 @@ def test_rejects_invalid_bjt_nominal_temperature(alias: str, value: str) -> None
         parse_netlist(f".model fast NPN({alias}={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("2e-18", 2e-18)])
+def test_parse_bjt_flicker_noise_coefficient(value: str, expected: float) -> None:
+    parsed = parse_netlist(f".model fast NPN(KF={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Kf == expected
+
+
+@pytest.mark.parametrize("value", ["-1e-18", "1e999"])
+def test_rejects_invalid_bjt_flicker_noise_coefficient(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT KF must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN(KF={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `KF` flicker-noise coefficient.
 - Validate and lower BJT model-card `TNOM` / `T_NOM` nominal temperature.
 - Validate and lower BJT model-card `IKR` reverse beta roll-off current.
 - Validate and lower BJT model-card `BR` / `BETA_R` reverse beta.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1523,6 +1523,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT TNOM must be finite and positive");
   }
+  const bjtFlickerNoiseCoefficient = params.get("KF");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtFlickerNoiseCoefficient !== undefined &&
+    (!Number.isFinite(bjtFlickerNoiseCoefficient) || bjtFlickerNoiseCoefficient < 0.0)
+  ) {
+    throw new NetlistParseError("BJT KF must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2260,6 +2268,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("BR") ?? model.params.get("BETA_R") ?? 1.0,
       model.params.get("IKR") ?? 0.0,
       nominalTemperature !== undefined ? nominalTemperature + 273.15 : undefined,
+      model.params.get("KF") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1903,6 +1903,24 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["2e-18", 2.0e-18],
+  ])("parses BJT flicker-noise coefficient KF=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(KF=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      flickerNoiseCoefficient: expected,
+    });
+  });
+
+  it.each(["-1e-18", "1e999"])("rejects invalid BJT KF=%s", (value) => {
+    expect(() => parseNetlist(`.model fast NPN(KF=${value})`)).toThrow(
+      "BJT KF must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4637,10 +4637,15 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine reverse-beta-roll-off-current field.
 
 460. Python and TypeScript Berkeley SPICE BJT nominal-temperature parity.
-   - Status: implemented in this BJT TNOM parity slice.
+   - Status: completed in PR 10127.
    - Both parser facades validate positive finite `TNOM` / `T_NOM` values,
      prefer `T_NOM`, convert Celsius model-card values to Kelvin, and lower the
      result into the shared engine nominal-temperature field.
+
+461. Python and TypeScript Berkeley SPICE BJT flicker-noise-coefficient parity.
+   - Status: implemented in this BJT KF parity slice.
+   - Both parser facades validate finite, non-negative `KF` values and lower
+     them into the shared engine flicker-noise-coefficient field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite, non-negative BJT model-card `KF` values in both parser facades
- lower `KF` into the shared engine flicker-noise coefficient field
- cover zero, positive, negative, and non-finite values and update the SPICE plan

## Testing
- Python parser `bash BUILD` (574 passed, 90.25% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (559 passed)
- TypeScript parser `npx vitest run --coverage` (87.84% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
