### PR TITLE
Add BJT AF parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `AF` flicker-noise exponent.
 - Validate and lower BJT model-card `KF` flicker-noise coefficient.
 - Validate and lower BJT model-card `TNOM` / `T_NOM` nominal temperature.
 - Validate and lower BJT model-card `IKR` reverse beta roll-off current.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1345,6 +1345,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
                 nominal_temperature + 273.15 if nominal_temperature is not None else None
             ),
             Kf=model.params.get("KF", 0.0),
+            Af=model.params.get("AF", 1.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2257,6 +2258,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or flicker_noise_coefficient < 0.0
         ):
             raise NetlistParseError("BJT KF must be finite and non-negative")
+        flicker_noise_exponent = params.get("AF")
+        if flicker_noise_exponent is not None and (
+            not math.isfinite(flicker_noise_exponent)
+            or flicker_noise_exponent < 0.0
+        ):
+            raise NetlistParseError("BJT AF must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1847,6 +1847,23 @@ def test_rejects_invalid_bjt_flicker_noise_coefficient(value: str) -> None:
         parse_netlist(f".model fast NPN(KF={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("1.5", 1.5)])
+def test_parse_bjt_flicker_noise_exponent(value: str, expected: float) -> None:
+    parsed = parse_netlist(f".model fast NPN(AF={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Af == expected
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1e999"])
+def test_rejects_invalid_bjt_flicker_noise_exponent(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT AF must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN(AF={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `AF` flicker-noise exponent.
 - Validate and lower BJT model-card `KF` flicker-noise coefficient.
 - Validate and lower BJT model-card `TNOM` / `T_NOM` nominal temperature.
 - Validate and lower BJT model-card `IKR` reverse beta roll-off current.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1531,6 +1531,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT KF must be finite and non-negative");
   }
+  const bjtFlickerNoiseExponent = params.get("AF");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtFlickerNoiseExponent !== undefined &&
+    (!Number.isFinite(bjtFlickerNoiseExponent) || bjtFlickerNoiseExponent < 0.0)
+  ) {
+    throw new NetlistParseError("BJT AF must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2269,6 +2277,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("IKR") ?? 0.0,
       nominalTemperature !== undefined ? nominalTemperature + 273.15 : undefined,
       model.params.get("KF") ?? 0.0,
+      model.params.get("AF") ?? 1.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1921,6 +1921,24 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["1.5", 1.5],
+  ])("parses BJT flicker-noise exponent AF=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(AF=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      flickerNoiseExponent: expected,
+    });
+  });
+
+  it.each(["-0.1", "1e999"])("rejects invalid BJT AF=%s", (value) => {
+    expect(() => parseNetlist(`.model fast NPN(AF=${value})`)).toThrow(
+      "BJT AF must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4643,9 +4643,14 @@ the Rust, Python, and TypeScript surfaces together.
      result into the shared engine nominal-temperature field.
 
 461. Python and TypeScript Berkeley SPICE BJT flicker-noise-coefficient parity.
-   - Status: implemented in this BJT KF parity slice.
+   - Status: completed in PR 10129.
    - Both parser facades validate finite, non-negative `KF` values and lower
      them into the shared engine flicker-noise-coefficient field.
+
+462. Python and TypeScript Berkeley SPICE BJT flicker-noise-exponent parity.
+   - Status: implemented in this BJT AF parity slice.
+   - Both parser facades validate finite, non-negative `AF` values and lower
+     them into the shared engine flicker-noise-exponent field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite, non-negative BJT model-card `AF` values in both parser facades
- lower `AF` into the shared engine flicker-noise exponent field
- cover zero, positive, negative, and non-finite values and update the SPICE plan

## Testing
- Python parser `bash BUILD` (578 passed, 90.27% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (563 passed)
- TypeScript parser `npx vitest run --coverage` (87.87% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
