### PR TITLE
Add BJT PTF parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `PTF` forward excess phase.
 - Validate and lower BJT model-card `AF` flicker-noise exponent.
 - Validate and lower BJT model-card `KF` flicker-noise coefficient.
 - Validate and lower BJT model-card `TNOM` / `T_NOM` nominal temperature.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1346,6 +1346,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             ),
             Kf=model.params.get("KF", 0.0),
             Af=model.params.get("AF", 1.0),
+            Ptf=model.params.get("PTF", 0.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2264,6 +2265,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or flicker_noise_exponent < 0.0
         ):
             raise NetlistParseError("BJT AF must be finite and non-negative")
+        forward_excess_phase = params.get("PTF")
+        if forward_excess_phase is not None and (
+            not math.isfinite(forward_excess_phase) or forward_excess_phase < 0.0
+        ):
+            raise NetlistParseError("BJT PTF must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1864,6 +1864,23 @@ def test_rejects_invalid_bjt_flicker_noise_exponent(value: str) -> None:
         parse_netlist(f".model fast NPN(AF={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("45", 45.0)])
+def test_parse_bjt_forward_excess_phase(value: str, expected: float) -> None:
+    parsed = parse_netlist(f".model fast NPN(PTF={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Ptf == expected
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1e999"])
+def test_rejects_invalid_bjt_forward_excess_phase(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT PTF must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN(PTF={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `PTF` forward excess phase.
 - Validate and lower BJT model-card `AF` flicker-noise exponent.
 - Validate and lower BJT model-card `KF` flicker-noise coefficient.
 - Validate and lower BJT model-card `TNOM` / `T_NOM` nominal temperature.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1539,6 +1539,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT AF must be finite and non-negative");
   }
+  const bjtForwardExcessPhase = params.get("PTF");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtForwardExcessPhase !== undefined &&
+    (!Number.isFinite(bjtForwardExcessPhase) || bjtForwardExcessPhase < 0.0)
+  ) {
+    throw new NetlistParseError("BJT PTF must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2278,6 +2286,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       nominalTemperature !== undefined ? nominalTemperature + 273.15 : undefined,
       model.params.get("KF") ?? 0.0,
       model.params.get("AF") ?? 1.0,
+      model.params.get("PTF") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1939,6 +1939,24 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["45", 45.0],
+  ])("parses BJT forward excess phase PTF=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(PTF=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      forwardExcessPhaseDegrees: expected,
+    });
+  });
+
+  it.each(["-0.1", "1e999"])("rejects invalid BJT PTF=%s", (value) => {
+    expect(() => parseNetlist(`.model fast NPN(PTF=${value})`)).toThrow(
+      "BJT PTF must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4648,9 +4648,14 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine flicker-noise-coefficient field.
 
 462. Python and TypeScript Berkeley SPICE BJT flicker-noise-exponent parity.
-   - Status: implemented in this BJT AF parity slice.
+   - Status: completed in PR 10130.
    - Both parser facades validate finite, non-negative `AF` values and lower
      them into the shared engine flicker-noise-exponent field.
+
+463. Python and TypeScript Berkeley SPICE BJT forward-excess-phase parity.
+   - Status: implemented in this BJT PTF parity slice.
+   - Both parser facades validate finite, non-negative `PTF` values and lower
+     them into the shared engine forward-excess-phase field in degrees.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite, non-negative BJT model-card `PTF` values in both parser facades
- lower `PTF` into the shared engine forward excess phase field in degrees
- cover zero, positive, negative, and non-finite values and update the SPICE plan

## Testing
- Python parser `bash BUILD` (582 passed, 90.29% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (567 passed)
- TypeScript parser `npx vitest run --coverage` (87.90% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
