### PR TITLE
Add BJT XTF parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `XTF` forward transit-time bias
+  coefficient.
 - Validate and lower BJT model-card `PTF` forward excess phase.
 - Validate and lower BJT model-card `AF` flicker-noise exponent.
 - Validate and lower BJT model-card `KF` flicker-noise coefficient.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1347,6 +1347,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Kf=model.params.get("KF", 0.0),
             Af=model.params.get("AF", 1.0),
             Ptf=model.params.get("PTF", 0.0),
+            Xtf=model.params.get("XTF", 0.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2270,6 +2271,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(forward_excess_phase) or forward_excess_phase < 0.0
         ):
             raise NetlistParseError("BJT PTF must be finite and non-negative")
+        forward_transit_time_bias_coefficient = params.get("XTF")
+        if forward_transit_time_bias_coefficient is not None and (
+            not math.isfinite(forward_transit_time_bias_coefficient)
+            or forward_transit_time_bias_coefficient < 0.0
+        ):
+            raise NetlistParseError("BJT XTF must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1881,6 +1881,27 @@ def test_rejects_invalid_bjt_forward_excess_phase(value: str) -> None:
         parse_netlist(f".model fast NPN(PTF={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("2.5", 2.5)])
+def test_parse_bjt_forward_transit_time_bias_coefficient(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model fast NPN(XTF={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Xtf == expected
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1e999"])
+def test_rejects_invalid_bjt_forward_transit_time_bias_coefficient(
+    value: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT XTF must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN(XTF={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `XTF` forward transit-time bias
+  coefficient.
 - Validate and lower BJT model-card `PTF` forward excess phase.
 - Validate and lower BJT model-card `AF` flicker-noise exponent.
 - Validate and lower BJT model-card `KF` flicker-noise coefficient.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1547,6 +1547,15 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT PTF must be finite and non-negative");
   }
+  const bjtForwardTransitTimeBiasCoefficient = params.get("XTF");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtForwardTransitTimeBiasCoefficient !== undefined &&
+    (!Number.isFinite(bjtForwardTransitTimeBiasCoefficient) ||
+      bjtForwardTransitTimeBiasCoefficient < 0.0)
+  ) {
+    throw new NetlistParseError("BJT XTF must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2287,6 +2296,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("KF") ?? 0.0,
       model.params.get("AF") ?? 1.0,
       model.params.get("PTF") ?? 0.0,
+      model.params.get("XTF") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1957,6 +1957,24 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["2.5", 2.5],
+  ])("parses BJT forward transit-time bias coefficient XTF=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(XTF=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      forwardTransitTimeBiasCoefficient: expected,
+    });
+  });
+
+  it.each(["-0.1", "1e999"])("rejects invalid BJT XTF=%s", (value) => {
+    expect(() => parseNetlist(`.model fast NPN(XTF=${value})`)).toThrow(
+      "BJT XTF must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4653,9 +4653,14 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine flicker-noise-exponent field.
 
 463. Python and TypeScript Berkeley SPICE BJT forward-excess-phase parity.
-   - Status: implemented in this BJT PTF parity slice.
+   - Status: completed in PR 10131.
    - Both parser facades validate finite, non-negative `PTF` values and lower
      them into the shared engine forward-excess-phase field in degrees.
+
+464. Python and TypeScript Berkeley SPICE BJT transit-time-bias parity.
+   - Status: implemented in this BJT XTF parity slice.
+   - Both parser facades validate finite, non-negative `XTF` values and lower
+     them into the shared engine forward-transit-time-bias-coefficient field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite, non-negative BJT model-card `XTF` values in both parser facades
- lower `XTF` into the shared engine forward transit-time bias coefficient field
- cover zero, positive, negative, and non-finite values and update the SPICE plan

## Testing
- Python parser `bash BUILD` (586 passed, 90.32% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (571 passed)
- TypeScript parser `npx vitest run --coverage` (87.93% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
