### PR TITLE
Add BJT ITF parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `ITF` forward transit-time current.
 - Validate and lower BJT model-card `XTF` forward transit-time bias
   coefficient.
 - Validate and lower BJT model-card `PTF` forward excess phase.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1348,6 +1348,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Af=model.params.get("AF", 1.0),
             Ptf=model.params.get("PTF", 0.0),
             Xtf=model.params.get("XTF", 0.0),
+            Itf=model.params.get("ITF", 0.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2277,6 +2278,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or forward_transit_time_bias_coefficient < 0.0
         ):
             raise NetlistParseError("BJT XTF must be finite and non-negative")
+        forward_transit_time_current = params.get("ITF")
+        if forward_transit_time_current is not None and (
+            not math.isfinite(forward_transit_time_current)
+            or forward_transit_time_current < 0.0
+        ):
+            raise NetlistParseError("BJT ITF must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1902,6 +1902,25 @@ def test_rejects_invalid_bjt_forward_transit_time_bias_coefficient(
         parse_netlist(f".model fast NPN(XTF={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("2m", 2e-3)])
+def test_parse_bjt_forward_transit_time_current(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model fast NPN(ITF={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Itf == expected
+
+
+@pytest.mark.parametrize("value", ["-1m", "1e999"])
+def test_rejects_invalid_bjt_forward_transit_time_current(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT ITF must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN(ITF={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `ITF` forward transit-time current.
 - Validate and lower BJT model-card `XTF` forward transit-time bias
   coefficient.
 - Validate and lower BJT model-card `PTF` forward excess phase.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1556,6 +1556,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT XTF must be finite and non-negative");
   }
+  const bjtForwardTransitTimeCurrent = params.get("ITF");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtForwardTransitTimeCurrent !== undefined &&
+    (!Number.isFinite(bjtForwardTransitTimeCurrent) || bjtForwardTransitTimeCurrent < 0.0)
+  ) {
+    throw new NetlistParseError("BJT ITF must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2297,6 +2305,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("AF") ?? 1.0,
       model.params.get("PTF") ?? 0.0,
       model.params.get("XTF") ?? 0.0,
+      model.params.get("ITF") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1975,6 +1975,24 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["2m", 2.0e-3],
+  ])("parses BJT forward transit-time current ITF=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(ITF=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      forwardTransitTimeCurrent: expected,
+    });
+  });
+
+  it.each(["-1m", "1e999"])("rejects invalid BJT ITF=%s", (value) => {
+    expect(() => parseNetlist(`.model fast NPN(ITF=${value})`)).toThrow(
+      "BJT ITF must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4658,9 +4658,14 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine forward-excess-phase field in degrees.
 
 464. Python and TypeScript Berkeley SPICE BJT transit-time-bias parity.
-   - Status: implemented in this BJT XTF parity slice.
+   - Status: completed in PR 10133.
    - Both parser facades validate finite, non-negative `XTF` values and lower
      them into the shared engine forward-transit-time-bias-coefficient field.
+
+465. Python and TypeScript Berkeley SPICE BJT transit-time-current parity.
+   - Status: implemented in this BJT ITF parity slice.
+   - Both parser facades validate finite, non-negative `ITF` values and lower
+     them into the shared engine forward-transit-time-current field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite, non-negative BJT model-card `ITF` values in both parser facades
- lower `ITF` into the shared engine forward transit-time current field
- cover zero, positive, negative, and non-finite values and update the SPICE plan

## Testing
- Python parser `bash BUILD` (590 passed, 90.34% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (575 passed)
- TypeScript parser `npx vitest run --coverage` (87.96% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
