### PR TITLE
Add BJT VTF parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `VTF` forward transit-time voltage scale.
 - Validate and lower BJT model-card `ITF` forward transit-time current.
 - Validate and lower BJT model-card `XTF` forward transit-time bias
   coefficient.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1349,6 +1349,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Ptf=model.params.get("PTF", 0.0),
             Xtf=model.params.get("XTF", 0.0),
             Itf=model.params.get("ITF", 0.0),
+            Vtf=model.params.get("VTF", 0.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2284,6 +2285,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or forward_transit_time_current < 0.0
         ):
             raise NetlistParseError("BJT ITF must be finite and non-negative")
+        forward_transit_time_voltage = params.get("VTF")
+        if forward_transit_time_voltage is not None and (
+            not math.isfinite(forward_transit_time_voltage)
+            or forward_transit_time_voltage < 0.0
+        ):
+            raise NetlistParseError("BJT VTF must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1921,6 +1921,25 @@ def test_rejects_invalid_bjt_forward_transit_time_current(value: str) -> None:
         parse_netlist(f".model fast NPN(ITF={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("600m", 0.6)])
+def test_parse_bjt_forward_transit_time_voltage(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model fast NPN(VTF={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Vtf == expected
+
+
+@pytest.mark.parametrize("value", ["-1m", "1e999"])
+def test_rejects_invalid_bjt_forward_transit_time_voltage(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT VTF must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN(VTF={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `VTF` forward transit-time voltage scale.
 - Validate and lower BJT model-card `ITF` forward transit-time current.
 - Validate and lower BJT model-card `XTF` forward transit-time bias
   coefficient.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1564,6 +1564,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT ITF must be finite and non-negative");
   }
+  const bjtForwardTransitTimeVoltage = params.get("VTF");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtForwardTransitTimeVoltage !== undefined &&
+    (!Number.isFinite(bjtForwardTransitTimeVoltage) || bjtForwardTransitTimeVoltage < 0.0)
+  ) {
+    throw new NetlistParseError("BJT VTF must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2306,6 +2314,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("PTF") ?? 0.0,
       model.params.get("XTF") ?? 0.0,
       model.params.get("ITF") ?? 0.0,
+      model.params.get("VTF") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1993,6 +1993,24 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["600m", 0.6],
+  ])("parses BJT forward transit-time voltage VTF=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(VTF=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      forwardTransitTimeVoltage: expected,
+    });
+  });
+
+  it.each(["-1m", "1e999"])("rejects invalid BJT VTF=%s", (value) => {
+    expect(() => parseNetlist(`.model fast NPN(VTF=${value})`)).toThrow(
+      "BJT VTF must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4663,9 +4663,14 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine forward-transit-time-bias-coefficient field.
 
 465. Python and TypeScript Berkeley SPICE BJT transit-time-current parity.
-   - Status: implemented in this BJT ITF parity slice.
+   - Status: completed in PR 10134.
    - Both parser facades validate finite, non-negative `ITF` values and lower
      them into the shared engine forward-transit-time-current field.
+
+466. Python and TypeScript Berkeley SPICE BJT transit-time-voltage parity.
+   - Status: implemented in this BJT VTF parity slice.
+   - Both parser facades validate finite, non-negative `VTF` values and lower
+     them into the shared engine forward-transit-time-voltage-scale field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite, non-negative BJT model-card `VTF` values in both parser facades
- lower `VTF` into the shared engine forward transit-time voltage-scale field
- cover zero, positive, negative, and non-finite values and update the SPICE plan

## Testing
- Python parser `bash BUILD` (594 passed, 90.36% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (579 passed)
- TypeScript parser `npx vitest run --coverage` (88% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
