### PR TITLE
Build the grammar-first Mermaid compatibility pipeline

### DIFF
--- a/code/grammars/mermaid/compatibility.json
+++ b/code/grammars/mermaid/compatibility.json
@@ -44,7 +44,7 @@
     {
       "id": "er",
       "headers": ["erDiagram"],
-      "status": "detected",
+      "status": "partial",
       "ir": "structural",
       "smoke_source": "erDiagram\nCUSTOMER ||--o{ ORDER : places"
     },

--- a/code/grammars/mermaid/compatibility.json
+++ b/code/grammars/mermaid/compatibility.json
@@ -1,0 +1,242 @@
+{
+  "schema_version": 1,
+  "upstream": {
+    "package": "mermaid",
+    "version": "11.16.1",
+    "tag": "mermaid@11.16.1",
+    "commit": "7ecca0cd7f1658ef74f4e7e91f925724ef403bbf",
+    "syntax_reference": "https://mermaid.js.org/intro/syntax-reference.html"
+  },
+  "levels": {
+    "detected": "The diagram header is recognized and reported by family.",
+    "partial": "A documented subset parses, lowers, lays out, and renders through PaintScene.",
+    "full": "The family passes the pinned upstream syntax corpus and native render fixtures."
+  },
+  "families": [
+    {
+      "id": "flowchart",
+      "headers": ["flowchart", "graph", "flowchart-elk"],
+      "status": "partial",
+      "ir": "graph",
+      "smoke_source": "flowchart LR\nA[Start] --> B{Done?}"
+    },
+    {
+      "id": "sequence",
+      "headers": ["sequenceDiagram"],
+      "status": "detected",
+      "ir": "sequence",
+      "smoke_source": "sequenceDiagram\nAlice->>Bob: Hello"
+    },
+    {
+      "id": "class",
+      "headers": ["classDiagram", "classDiagram-v2"],
+      "status": "partial",
+      "ir": "structural",
+      "smoke_source": "classDiagram\nclass Animal\nclass Dog\nAnimal <|-- Dog"
+    },
+    {
+      "id": "state",
+      "headers": ["stateDiagram", "stateDiagram-v2"],
+      "status": "detected",
+      "ir": "state",
+      "smoke_source": "stateDiagram-v2\n[*] --> Ready"
+    },
+    {
+      "id": "er",
+      "headers": ["erDiagram"],
+      "status": "detected",
+      "ir": "structural",
+      "smoke_source": "erDiagram\nCUSTOMER ||--o{ ORDER : places"
+    },
+    {
+      "id": "journey",
+      "headers": ["journey"],
+      "status": "detected",
+      "ir": "journey",
+      "smoke_source": "journey\ntitle My day\nsection Work\nTask: 5: Me"
+    },
+    {
+      "id": "gantt",
+      "headers": ["gantt"],
+      "status": "partial",
+      "ir": "temporal",
+      "smoke_source": "gantt\ndateFormat YYYY-MM-DD\nsection Build\nTask :t1, 2026-01-01, 1d"
+    },
+    {
+      "id": "pie",
+      "headers": ["pie"],
+      "status": "partial",
+      "ir": "chart",
+      "smoke_source": "pie showData\n\"Dogs\" : 60\n\"Cats\" : 40"
+    },
+    {
+      "id": "quadrant",
+      "headers": ["quadrantChart"],
+      "status": "detected",
+      "ir": "chart",
+      "smoke_source": "quadrantChart\nx-axis Low --> High\ny-axis Low --> High\nA: [0.5, 0.5]"
+    },
+    {
+      "id": "requirement",
+      "headers": ["requirement", "requirementDiagram"],
+      "status": "detected",
+      "ir": "structural",
+      "smoke_source": "requirementDiagram\nrequirement test_req {\nid: 1\ntext: Test\nrisk: low\nverifymethod: test\n}"
+    },
+    {
+      "id": "gitgraph",
+      "headers": ["gitGraph", "gitGraph:"],
+      "status": "detected",
+      "ir": "temporal",
+      "smoke_source": "gitGraph\ncommit\nbranch develop\ncheckout develop\ncommit"
+    },
+    {
+      "id": "c4",
+      "headers": ["C4Context", "C4Container", "C4Component", "C4Dynamic", "C4Deployment"],
+      "status": "detected",
+      "ir": "structural",
+      "smoke_source": "C4Context\nPerson(user, \"User\")"
+    },
+    {
+      "id": "mindmap",
+      "headers": ["mindmap"],
+      "status": "detected",
+      "ir": "tree",
+      "smoke_source": "mindmap\nroot((mindmap))\n  Topic"
+    },
+    {
+      "id": "timeline",
+      "headers": ["timeline"],
+      "status": "detected",
+      "ir": "temporal",
+      "smoke_source": "timeline\n2026 : Started"
+    },
+    {
+      "id": "sankey",
+      "headers": ["sankey", "sankey-beta"],
+      "status": "detected",
+      "ir": "chart",
+      "smoke_source": "sankey\nA,B,10"
+    },
+    {
+      "id": "xychart",
+      "headers": ["xychart", "xychart-beta"],
+      "status": "partial",
+      "ir": "chart",
+      "smoke_source": "xychart-beta\nx-axis [A, B]\ny-axis 0 --> 10\nbar [3, 7]"
+    },
+    {
+      "id": "block",
+      "headers": ["block", "block-beta"],
+      "status": "detected",
+      "ir": "grid",
+      "smoke_source": "block-beta\ncolumns 2\nA B"
+    },
+    {
+      "id": "packet",
+      "headers": ["packet", "packet-beta"],
+      "status": "detected",
+      "ir": "packet",
+      "smoke_source": "packet-beta\n0-7: \"Header\""
+    },
+    {
+      "id": "kanban",
+      "headers": ["kanban"],
+      "status": "detected",
+      "ir": "board",
+      "smoke_source": "kanban\nTodo\n  task1[Task]"
+    },
+    {
+      "id": "architecture",
+      "headers": ["architecture", "architecture-beta"],
+      "status": "detected",
+      "ir": "architecture",
+      "smoke_source": "architecture-beta\nservice api(server)[API]"
+    },
+    {
+      "id": "radar",
+      "headers": ["radar-beta"],
+      "status": "detected",
+      "ir": "chart",
+      "smoke_source": "radar-beta\naxis A, B, C\ncurve x{1, 2, 3}"
+    },
+    {
+      "id": "eventmodeling",
+      "headers": ["eventmodeling"],
+      "status": "detected",
+      "ir": "event-model",
+      "smoke_source": "eventmodeling\nCustomer : actor"
+    },
+    {
+      "id": "treemap",
+      "headers": ["treemap"],
+      "status": "detected",
+      "ir": "hierarchy",
+      "smoke_source": "treemap\n\"Root\"\n  \"Child\": 10"
+    },
+    {
+      "id": "venn",
+      "headers": ["venn-beta"],
+      "status": "detected",
+      "ir": "set",
+      "smoke_source": "venn-beta\nset A\nset B"
+    },
+    {
+      "id": "ishikawa",
+      "headers": ["ishikawa", "ishikawa-beta"],
+      "status": "detected",
+      "ir": "causal",
+      "smoke_source": "ishikawa-beta\nProblem\n  Cause"
+    },
+    {
+      "id": "wardley",
+      "headers": ["wardley-beta"],
+      "status": "detected",
+      "ir": "wardley",
+      "smoke_source": "wardley-beta\ncomponent User [0.9, 0.5]"
+    },
+    {
+      "id": "cynefin",
+      "headers": ["cynefin-beta"],
+      "status": "detected",
+      "ir": "domain-map",
+      "smoke_source": "cynefin-beta\nClear:\n  Practice"
+    },
+    {
+      "id": "treeview",
+      "headers": ["treeView-beta"],
+      "status": "detected",
+      "ir": "tree",
+      "smoke_source": "treeView-beta\nroot\n  child"
+    },
+    {
+      "id": "swimlane",
+      "headers": ["swimlane-beta"],
+      "status": "detected",
+      "ir": "swimlane",
+      "smoke_source": "swimlane-beta\nlane A\n  Task"
+    },
+    {
+      "id": "railroad",
+      "headers": ["railroad-beta", "railroad-ebnf-beta", "railroad-abnf-beta", "railroad-peg-beta"],
+      "status": "detected",
+      "ir": "railroad",
+      "smoke_source": "railroad-beta\nexpression ::= term"
+    },
+    {
+      "id": "info",
+      "headers": ["info"],
+      "status": "detected",
+      "ir": "info",
+      "smoke_source": "info"
+    },
+    {
+      "id": "zenuml",
+      "headers": ["zenuml"],
+      "status": "detected",
+      "ir": "sequence",
+      "external": true,
+      "smoke_source": "zenuml\nAlice->Bob: Hello"
+    }
+  ]
+}

--- a/code/grammars/mermaid/compatibility.json
+++ b/code/grammars/mermaid/compatibility.json
@@ -86,7 +86,7 @@
     {
       "id": "gitgraph",
       "headers": ["gitGraph", "gitGraph:"],
-      "status": "detected",
+      "status": "partial",
       "ir": "temporal",
       "smoke_source": "gitGraph\ncommit\nbranch develop\ncheckout develop\ncommit"
     },
@@ -114,7 +114,7 @@
     {
       "id": "sankey",
       "headers": ["sankey", "sankey-beta"],
-      "status": "detected",
+      "status": "partial",
       "ir": "chart",
       "smoke_source": "sankey\nA,B,10"
     },

--- a/code/grammars/mermaid/er.grammar
+++ b/code/grammars/mermaid/er.grammar
@@ -1,0 +1,30 @@
+# @version 1
+#
+# Mermaid 11.16.1 entity-relationship parser grammar.
+
+document = { NEWLINE } HEADER { NEWLINE | statement } EOF ;
+statement = relationship | entity_decl | direction_stmt | title_stmt | classdef_stmt | class_stmt | style_stmt ;
+
+relationship = entity_name [ class_suffix ] cardinality relation_type cardinality entity_name [ class_suffix ] COLON role ;
+entity_decl = entity_name [ alias ] [ class_suffix ] [ attribute_block ] ;
+alias = LBRACKET entity_name RBRACKET ;
+class_suffix = STYLE_SEPARATOR id_list ;
+
+attribute_block = LBRACE { NEWLINE } { attribute { NEWLINE } } RBRACE ;
+attribute = attribute_type attribute_name [ key_list ] [ STRING ] ;
+attribute_type = entity_name [ LBRACKET RBRACKET ] [ QUESTION ] ;
+attribute_name = entity_name ;
+key_list = ATTRIBUTE_KEY { COMMA ATTRIBUTE_KEY } ;
+
+cardinality = ZERO_OR_ONE | ZERO_OR_MORE | ONE_OR_MORE | ONLY_ONE | MD_PARENT ;
+relation_type = NON_IDENTIFYING | IDENTIFYING ;
+role = STRING | entity_name { entity_name } ;
+entity_name = IDENTIFIER | NUMBER | ATTRIBUTE_KEY | MD_PARENT ;
+
+direction_stmt = "direction" ( "TB" | "BT" | "LR" | "RL" ) ;
+title_stmt = "title" role ;
+classdef_stmt = "classDef" id_list { style_atom } ;
+class_stmt = "class" id_list id_list ;
+style_stmt = "style" id_list { style_atom } ;
+id_list = entity_name { COMMA entity_name } ;
+style_atom = entity_name | NUMBER | COLON | COMMA | STYLE_VALUE ;

--- a/code/grammars/mermaid/er.tokens
+++ b/code/grammars/mermaid/er.tokens
@@ -1,0 +1,42 @@
+# @version 1
+#
+# Mermaid 11.16.1 entity-relationship token grammar.
+# Derived from packages/mermaid/src/diagrams/er/parser/erDiagram.jison.
+
+skip:
+  WHITESPACE        = /[ \t]+/
+  COMMENT           = /%%[^\r\n]*/
+
+NEWLINE             = /\r?\n/
+HEADER              = "erDiagram"
+STYLE_SEPARATOR     = ":::"
+LBRACE              = "{"
+RBRACE              = "}"
+LBRACKET            = "["
+RBRACKET            = "]"
+COMMA               = ","
+COLON               = ":"
+QUESTION            = "?"
+STRING              = /"([^"\\]|\\.)*"/
+ZERO_OR_ONE         = /\|o|o\||zero[ \t]+or[ \t]+one|one[ \t]+or[ \t]+zero/
+ZERO_OR_MORE        = /o\{|\}o|0\+|many\(0\)|zero[ \t]+or[ \t]+(?:more|many)|many/
+ONE_OR_MORE         = /\|\{|\}\||1\+|many\(1\)|one[ \t]+or[ \t]+(?:more|many)/
+ONLY_ONE            = /\|\||only[ \t]+one|one/
+MD_PARENT           = "u"
+NON_IDENTIFYING     = /\.\.|\.\-|-\.|optionally[ \t]+to/
+IDENTIFYING         = /--|to/
+ATTRIBUTE_KEY       = /PK|FK|UK/
+NUMBER              = /[0-9]+(?:\.[0-9]+)?/
+IDENTIFIER          = /[\p{L}_*][\p{L}\p{N}_.()*~-]*/
+STYLE_VALUE         = /#[0-9A-Fa-f]+|[0-9]+%|;|-/
+
+keywords:
+  direction
+  title
+  classDef
+  class
+  style
+  TB
+  BT
+  LR
+  RL

--- a/code/grammars/mermaid/gitgraph.grammar
+++ b/code/grammars/mermaid/gitgraph.grammar
@@ -1,0 +1,18 @@
+# @version 1
+#
+# Mermaid 11.16.1 GitGraph parser grammar.
+
+document = { NEWLINE } HEADER [ DIRECTION [ COLON ] ] { NEWLINE | statement } EOF ;
+statement = commit_stmt | branch_stmt | merge_stmt | checkout_stmt | cherry_pick_stmt ;
+
+commit_stmt = "commit" { commit_attr } ;
+commit_attr = ID_ATTR STRING | [ MSG_ATTR ] STRING | TAG_ATTR STRING | TYPE_ATTR COMMIT_TYPE ;
+
+branch_stmt = "branch" reference [ ORDER_ATTR INT ] ;
+merge_stmt = "merge" reference { merge_attr } ;
+merge_attr = ID_ATTR STRING | TAG_ATTR STRING | TYPE_ATTR COMMIT_TYPE ;
+checkout_stmt = ( "checkout" | "switch" ) reference ;
+cherry_pick_stmt = CHERRY_PICK { cherry_pick_attr } ;
+cherry_pick_attr = ID_ATTR STRING | TAG_ATTR STRING | PARENT_ATTR STRING ;
+
+reference = REFERENCE | STRING ;

--- a/code/grammars/mermaid/gitgraph.tokens
+++ b/code/grammars/mermaid/gitgraph.tokens
@@ -1,0 +1,33 @@
+# @version 1
+#
+# Mermaid 11.16.1 GitGraph token grammar.
+#
+# Upstream grammar:
+# https://github.com/mermaid-js/mermaid/blob/mermaid%4011.16.1/packages/parser/src/language/gitGraph/gitGraph.langium
+
+skip:
+  WHITESPACE      = /[ \t]+/
+  COMMENT         = /%%[^\r\n]*/
+
+NEWLINE           = /\r?\n/
+HEADER            = /gitGraph:?/
+CHERRY_PICK       = "cherry-pick"
+ID_ATTR           = "id:"
+MSG_ATTR          = "msg:"
+TAG_ATTR          = "tag:"
+TYPE_ATTR         = "type:"
+ORDER_ATTR        = "order:"
+PARENT_ATTR       = "parent:"
+COLON             = ":"
+STRING            = /"([^"\\]|\\.)*"|'([^'\\]|\\.)*'/
+INT               = /0|[1-9][0-9]*/
+DIRECTION         = /LR|TB|BT/
+COMMIT_TYPE       = /NORMAL|REVERSE|HIGHLIGHT/
+REFERENCE         = /[A-Za-z0-9_](?:[-.\/A-Za-z0-9_]*[A-Za-z0-9_])?/
+
+keywords:
+  commit
+  branch
+  merge
+  checkout
+  switch

--- a/code/grammars/mermaid/pie.grammar
+++ b/code/grammars/mermaid/pie.grammar
@@ -1,0 +1,9 @@
+# @version 1
+#
+# Mermaid 11.16.1 pie-chart parser grammar.
+#
+# This first compatibility slice covers the semantic syntax needed by the
+# shared ChartDiagram IR: the pie header, showData, and labelled numeric slices.
+
+document = { NEWLINE } "pie" [ "showData" ] { NEWLINE | section } EOF ;
+section = STRING COLON NUMBER ;

--- a/code/grammars/mermaid/pie.tokens
+++ b/code/grammars/mermaid/pie.tokens
@@ -1,0 +1,20 @@
+# @version 1
+#
+# Mermaid 11.16.1 pie-chart token grammar.
+#
+# Upstream grammar:
+# https://github.com/mermaid-js/mermaid/blob/mermaid%4011.16.1/packages/parser/src/language/pie/pie.langium
+
+skip:
+  WHITESPACE      = /[ \t]+/
+  COMMENT         = /%%[^\r\n]*/
+
+NEWLINE           = /\r?\n/
+COLON             = ":"
+NUMBER            = /-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?/
+STRING            = /"([^"\\]|\\.)*"/
+NAME              = /[A-Za-z_][A-Za-z0-9_]*/
+
+keywords:
+  pie
+  showData

--- a/code/grammars/mermaid/sankey.grammar
+++ b/code/grammars/mermaid/sankey.grammar
@@ -1,0 +1,7 @@
+# @version 1
+#
+# Mermaid 11.16.1 Sankey parser grammar.
+
+document = { NEWLINE } HEADER { NEWLINE | row } EOF ;
+row = field COMMA field COMMA NUMBER ;
+field = STRING | BARE_FIELD | NUMBER ;

--- a/code/grammars/mermaid/sankey.tokens
+++ b/code/grammars/mermaid/sankey.tokens
@@ -1,0 +1,17 @@
+# @version 1
+#
+# Mermaid 11.16.1 Sankey token grammar.
+#
+# Sankey rows follow an RFC 4180-like three-column CSV dialect. Quoted fields
+# use doubled quotes, while empty lines and Mermaid comments are allowed.
+
+skip:
+  WHITESPACE      = /[ \t]+/
+  COMMENT         = /%%[^\r\n]*/
+
+NEWLINE           = /\r?\n/
+HEADER            = /sankey(?:-beta)?/
+COMMA             = ","
+NUMBER            = /-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?/
+STRING            = /"(?:[^"]|"")*"/
+BARE_FIELD        = /[^,\r\n" \t][^,\r\n"]*/

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -200,13 +200,18 @@ pub struct GanttSection { pub label: Option<String>, pub tasks: Vec<GanttTask> }
 pub struct GanttDiagram { pub date_format: String, pub sections: Vec<GanttSection> }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GitBranch { pub name: String }
+pub struct GitBranch { pub name: String, pub order: Option<i64> }
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub enum GitCommitType { #[default]
+Normal, Reverse, Highlight }
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum GitEvent {
-    Commit { id: Option<String>, message: Option<String>, tag: Option<String>, branch: String },
+    Commit { id: Option<String>, message: Option<String>, tag: Option<String>, branch: String, type_: GitCommitType },
     Checkout { branch: String },
-    Merge { from: String, id: Option<String>, tag: Option<String> },
+    Merge { from: String, id: Option<String>, tag: Option<String>, type_: GitCommitType },
+    CherryPick { id: String, tag: Option<String>, parent: Option<String>, branch: String },
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/code/packages/rust/diagram-layout-temporal/src/lib.rs
+++ b/code/packages/rust/diagram-layout-temporal/src/lib.rs
@@ -195,7 +195,7 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
 
     for event in &diagram.events {
         match event {
-            GitEvent::Commit { id, message, tag, branch } => {
+            GitEvent::Commit { id, message, tag, branch, .. } => {
                 let lane = *branch_lanes.entry(branch.clone()).or_insert_with(|| {
                     let l = next_lane; next_lane += 1; l
                 });
@@ -218,7 +218,7 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
                     let l = next_lane; next_lane += 1; l
                 });
             }
-            GitEvent::Merge { from, id, tag } => {
+            GitEvent::Merge { from, id, tag, .. } => {
                 let from_lane = *branch_lanes.get(from).unwrap_or(&0);
                 let to_lane   = *branch_lanes.get(&current_branch).unwrap_or(&0);
                 let from_y    = lane_y(from_lane);
@@ -233,6 +233,23 @@ fn layout_git(diagram: &GitDiagram, cw: f64) -> LayoutedTemporalDiagram {
                     x: x_cursor, y: to_y,
                     id: commit_id,
                     message: Some(format!("merge {from}")),
+                    tag: tag.clone(),
+                });
+                x_cursor += COMMIT_SPACING;
+            }
+            GitEvent::CherryPick { id, tag, parent, branch } => {
+                let lane = *branch_lanes.entry(branch.clone()).or_insert_with(|| {
+                    let l = next_lane; next_lane += 1; l
+                });
+                let cy = lane_y(lane);
+                commit_x.insert(id.clone(), (x_cursor, cy));
+                items.push(LayoutedTemporalItem::CommitNode {
+                    x: x_cursor, y: cy,
+                    id: id.clone(),
+                    message: Some(match parent {
+                        Some(parent) => format!("cherry-pick {id} from {parent}"),
+                        None => format!("cherry-pick {id}"),
+                    }),
                     tag: tag.clone(),
                 });
                 x_cursor += COMMIT_SPACING;
@@ -286,15 +303,15 @@ mod tests {
             title: None,
             body: TemporalBody::Git(GitDiagram {
                 direction: DiagramDirection::Lr,
-                branches: vec![GitBranch { name: "main".into() }],
+                branches: vec![GitBranch { name: "main".into(), order: None }],
                 events: vec![
                     GitEvent::Commit {
                         id: Some("a1".into()), message: Some("init".into()),
-                        tag: None, branch: "main".into(),
+                        tag: None, branch: "main".into(), type_: GitCommitType::Normal,
                     },
                     GitEvent::Commit {
                         id: Some("a2".into()), message: Some("feature".into()),
-                        tag: None, branch: "main".into(),
+                        tag: None, branch: "main".into(), type_: GitCommitType::Normal,
                     },
                 ],
             }),

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — diagram-to-paint
 
+## Unreleased
+
+- Added a Mermaid Pie -> chart layout -> PaintScene -> Metal PNG example and
+  Apple end-to-end test.
+
 ## 0.1.2 — Fix text coordinate-space mismatch (text now inside nodes)
 
 ### Fixed

--- a/code/packages/rust/diagram-to-paint/examples/mermaid_pie.rs
+++ b/code/packages/rust/diagram-to-paint/examples/mermaid_pie.rs
@@ -1,0 +1,67 @@
+//! End-to-end example: Mermaid pie -> PaintScene -> Metal -> PNG.
+//!
+//! Run with:
+//!   cargo run --example mermaid_pie -p diagram-to-paint
+//!
+//! Output: /tmp/mermaid_pie.png
+
+#[cfg(target_vendor = "apple")]
+fn main() {
+    use diagram_layout_chart::layout_chart_diagram;
+    use diagram_to_paint::{diagram_to_paint_chart, DiagramToPaintOptions};
+    use layout_ir::font_spec;
+    use mermaid_parser::parse_pie;
+    use paint_codec_png::write_png;
+    use paint_metal::render;
+    use text_native_coretext::{CoreTextMetrics, CoreTextResolver, CoreTextShaper};
+
+    let source = r#"pie showData
+  "Flowchart" : 40
+  "Class" : 20
+  "Gantt" : 20
+  "XY Chart" : 10
+  "Pie" : 10"#;
+
+    let diagram = parse_pie(source).expect("Mermaid pie parse failed");
+    let layout = layout_chart_diagram(&diagram, 640.0, 480.0);
+    let shaper = CoreTextShaper;
+    let metrics = CoreTextMetrics;
+    let resolver = CoreTextResolver::new();
+
+    let scene = diagram_to_paint_chart(
+        &layout,
+        &DiagramToPaintOptions {
+            background: layout_ir::Color {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 255,
+            },
+            device_pixel_ratio: 2.0,
+            label_font: font_spec("Helvetica", 12.0),
+            title_font: {
+                let mut font = font_spec("Helvetica", 16.0);
+                font.weight = 700;
+                font
+            },
+            shaper: &shaper,
+            metrics: &metrics,
+            resolver: &resolver,
+        },
+    );
+
+    let path = "/tmp/mermaid_pie.png";
+    write_png(&render(&scene), path).expect("PNG write failed");
+    println!("Rendered Mermaid pie to {path}");
+    println!(
+        "Scene: {}x{} px, {} chart items",
+        scene.width,
+        scene.height,
+        layout.items.len()
+    );
+}
+
+#[cfg(not(target_vendor = "apple"))]
+fn main() {
+    panic!("mermaid_pie example requires an Apple target (paint-metal)");
+}

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -629,6 +629,27 @@ where
                 lf.clone(), Color { r: 55, g: 65, b: 81, a: 255 },
             ));
         }
+        if rel.points.len() >= 2 {
+            let start = &rel.points[0];
+            let end = &rel.points[rel.points.len() - 1];
+            let dx = end.x - start.x;
+            let dy = end.y - start.y;
+            let len = (dx * dx + dy * dy).sqrt().max(1.0);
+            let ux = dx / len;
+            let uy = dy / len;
+            if let Some(ref multiplicity) = rel.from_mult {
+                text_children.push(text_node(
+                    multiplicity, start.x + ux * 18.0 - 20.0, start.y + uy * 18.0 + 4.0,
+                    40.0, ls * 1.2, lf.clone(), Color { r: 55, g: 65, b: 81, a: 255 },
+                ));
+            }
+            if let Some(ref multiplicity) = rel.to_mult {
+                text_children.push(text_node(
+                    multiplicity, end.x - ux * 18.0 - 20.0, end.y - uy * 18.0 + 4.0,
+                    40.0, ls * 1.2, lf.clone(), Color { r: 55, g: 65, b: 81, a: 255 },
+                ));
+            }
+        }
     }
 
     // ── Node boxes ───────────────────────────────────────────────────────────

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -226,7 +226,7 @@ mod apple {
     #[test]
     fn render_mermaid_gitgraph_to_png() {
         let git = parse_gitgraph(
-            "gitGraph LR:\ncommit id: \"root\"\nbranch feature\ncheckout feature\ncommit id: \"work\" msg: \"Build parser\"\ncheckout main\nmerge feature tag: \"v1\"",
+            "gitGraph LR:\ncommit id: \"root\"\nbranch feature\ncheckout feature\ncommit id: \"work\" msg: \"Build parser\"\ncherry-pick id: \"root\" parent: \"work\"\ncheckout main\nmerge feature tag: \"v1\"",
         )
         .expect("Mermaid GitGraph parse failed");
         let temporal = diagram_ir::TemporalDiagram {

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -11,10 +11,15 @@
 mod apple {
     use diagram_layout_chart::layout_chart_diagram;
     use diagram_layout_graph::layout_graph_diagram;
-    use diagram_to_paint::{diagram_to_paint, diagram_to_paint_chart, DiagramToPaintOptions};
+    use diagram_layout_temporal::layout_temporal_diagram;
+    use diagram_to_paint::{
+        diagram_to_paint, diagram_to_paint_chart, diagram_to_paint_temporal, DiagramToPaintOptions,
+    };
     use dot_parser::parse_to_diagram;
     use layout_ir::font_spec;
-    use mermaid_parser::{parse_pie, parse_to_diagram as parse_mermaid_to_diagram};
+    use mermaid_parser::{
+        parse_gitgraph, parse_pie, parse_sankey, parse_to_diagram as parse_mermaid_to_diagram,
+    };
     use paint_codec_png::write_png;
     use paint_metal::render;
     use text_native_coretext::{CoreTextMetrics, CoreTextResolver, CoreTextShaper};
@@ -177,6 +182,83 @@ mod apple {
         let path = "/tmp/mermaid_pie_e2e.png";
         write_png(&pixels, path).expect("PNG write failed");
 
+        assert!(pixels.width > 0);
+        assert!(pixels.height > 0);
+        assert!(!scene.instructions.is_empty());
+    }
+
+    #[test]
+    fn render_mermaid_sankey_to_png() {
+        let diagram = parse_sankey(
+            "sankey-beta\nElectricity,Heating,45\nElectricity,Lighting,30\nHeating,Losses,8",
+        )
+        .expect("Mermaid Sankey parse failed");
+        let layout = layout_chart_diagram(&diagram, 700.0, 460.0);
+
+        let shaper = CoreTextShaper;
+        let metrics = CoreTextMetrics;
+        let resolver = CoreTextResolver::new();
+        let scene = diagram_to_paint_chart(
+            &layout,
+            &DiagramToPaintOptions {
+                background: layout_ir::Color {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                },
+                device_pixel_ratio: 2.0,
+                label_font: font_spec("Helvetica", 12.0),
+                title_font: font_spec("Helvetica", 16.0),
+                shaper: &shaper,
+                metrics: &metrics,
+                resolver: &resolver,
+            },
+        );
+
+        let pixels = render(&scene);
+        write_png(&pixels, "/tmp/mermaid_sankey_e2e.png").expect("PNG write failed");
+        assert!(pixels.width > 0);
+        assert!(pixels.height > 0);
+        assert!(!scene.instructions.is_empty());
+    }
+
+    #[test]
+    fn render_mermaid_gitgraph_to_png() {
+        let git = parse_gitgraph(
+            "gitGraph LR:\ncommit id: \"root\"\nbranch feature\ncheckout feature\ncommit id: \"work\" msg: \"Build parser\"\ncheckout main\nmerge feature tag: \"v1\"",
+        )
+        .expect("Mermaid GitGraph parse failed");
+        let temporal = diagram_ir::TemporalDiagram {
+            kind: diagram_ir::TemporalKind::Git,
+            title: Some("GitGraph pipeline".to_string()),
+            body: diagram_ir::TemporalBody::Git(git),
+        };
+        let layout = layout_temporal_diagram(&temporal, 800.0);
+
+        let shaper = CoreTextShaper;
+        let metrics = CoreTextMetrics;
+        let resolver = CoreTextResolver::new();
+        let scene = diagram_to_paint_temporal(
+            &layout,
+            &DiagramToPaintOptions {
+                background: layout_ir::Color {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                },
+                device_pixel_ratio: 2.0,
+                label_font: font_spec("Helvetica", 12.0),
+                title_font: font_spec("Helvetica", 16.0),
+                shaper: &shaper,
+                metrics: &metrics,
+                resolver: &resolver,
+            },
+        );
+
+        let pixels = render(&scene);
+        write_png(&pixels, "/tmp/mermaid_gitgraph_e2e.png").expect("PNG write failed");
         assert!(pixels.width > 0);
         assert!(pixels.height > 0);
         assert!(!scene.instructions.is_empty());

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -11,14 +11,17 @@
 mod apple {
     use diagram_layout_chart::layout_chart_diagram;
     use diagram_layout_graph::layout_graph_diagram;
+    use diagram_layout_structural::layout_structural_diagram;
     use diagram_layout_temporal::layout_temporal_diagram;
     use diagram_to_paint::{
-        diagram_to_paint, diagram_to_paint_chart, diagram_to_paint_temporal, DiagramToPaintOptions,
+        diagram_to_paint, diagram_to_paint_chart, diagram_to_paint_structural,
+        diagram_to_paint_temporal, DiagramToPaintOptions,
     };
     use dot_parser::parse_to_diagram;
     use layout_ir::font_spec;
     use mermaid_parser::{
-        parse_gitgraph, parse_pie, parse_sankey, parse_to_diagram as parse_mermaid_to_diagram,
+        parse_er_diagram, parse_gitgraph, parse_pie, parse_sankey,
+        parse_to_diagram as parse_mermaid_to_diagram,
     };
     use paint_codec_png::write_png;
     use paint_metal::render;
@@ -259,6 +262,42 @@ mod apple {
 
         let pixels = render(&scene);
         write_png(&pixels, "/tmp/mermaid_gitgraph_e2e.png").expect("PNG write failed");
+        assert!(pixels.width > 0);
+        assert!(pixels.height > 0);
+        assert!(!scene.instructions.is_empty());
+    }
+
+    #[test]
+    fn render_mermaid_er_to_png() {
+        let diagram = parse_er_diagram(
+            "erDiagram\nCUSTOMER ||--o{ ORDER : places\nCUSTOMER {\nstring name PK\nstring email UK\n}\nORDER {\nint id PK\n}",
+        )
+        .expect("Mermaid ER parse failed");
+        let layout = layout_structural_diagram(&diagram);
+
+        let shaper = CoreTextShaper;
+        let metrics = CoreTextMetrics;
+        let resolver = CoreTextResolver::new();
+        let scene = diagram_to_paint_structural(
+            &layout,
+            &DiagramToPaintOptions {
+                background: layout_ir::Color {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                },
+                device_pixel_ratio: 2.0,
+                label_font: font_spec("Helvetica", 12.0),
+                title_font: font_spec("Helvetica", 16.0),
+                shaper: &shaper,
+                metrics: &metrics,
+                resolver: &resolver,
+            },
+        );
+
+        let pixels = render(&scene);
+        write_png(&pixels, "/tmp/mermaid_er_e2e.png").expect("PNG write failed");
         assert!(pixels.width > 0);
         assert!(pixels.height > 0);
         assert!(!scene.instructions.is_empty());

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -9,11 +9,12 @@
 
 #[cfg(target_vendor = "apple")]
 mod apple {
+    use diagram_layout_chart::layout_chart_diagram;
     use diagram_layout_graph::layout_graph_diagram;
-    use diagram_to_paint::{diagram_to_paint, DiagramToPaintOptions};
+    use diagram_to_paint::{diagram_to_paint, diagram_to_paint_chart, DiagramToPaintOptions};
     use dot_parser::parse_to_diagram;
     use layout_ir::font_spec;
-    use mermaid_parser::parse_to_diagram as parse_mermaid_to_diagram;
+    use mermaid_parser::{parse_pie, parse_to_diagram as parse_mermaid_to_diagram};
     use paint_codec_png::write_png;
     use paint_metal::render;
     use text_native_coretext::{CoreTextMetrics, CoreTextResolver, CoreTextShaper};
@@ -140,5 +141,44 @@ mod apple {
             glyph_runs > 0,
             "expected at least one PaintGlyphRun from shaping pipeline"
         );
+    }
+
+    #[test]
+    fn render_mermaid_pie_to_png() {
+        let diagram = parse_pie(
+            r#"pie showData
+                "Graph" : 50
+                "Chart" : 30
+                "Temporal" : 20"#,
+        )
+        .expect("Mermaid pie parse failed");
+        let layout = layout_chart_diagram(&diagram, 640.0, 480.0);
+
+        let shaper = CoreTextShaper;
+        let metrics = CoreTextMetrics;
+        let resolver = CoreTextResolver::new();
+        let opts = DiagramToPaintOptions {
+            background: layout_ir::Color {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 255,
+            },
+            device_pixel_ratio: 2.0,
+            label_font: font_spec("Helvetica", 12.0),
+            title_font: font_spec("Helvetica", 16.0),
+            shaper: &shaper,
+            metrics: &metrics,
+            resolver: &resolver,
+        };
+
+        let scene = diagram_to_paint_chart(&layout, &opts);
+        let pixels = render(&scene);
+        let path = "/tmp/mermaid_pie_e2e.png";
+        write_png(&pixels, path).expect("PNG write failed");
+
+        assert!(pixels.width > 0);
+        assert!(pixels.height > 0);
+        assert!(!scene.instructions.is_empty());
     }
 }

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+- Added the shared Mermaid 11.16.0 pie-chart token grammar and lexer entrypoint.
+
 ## 0.1.0
 
 - Added a grammar-driven Mermaid flowchart lexer backed by `code/grammars/mermaid.tokens`.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "mermaid-lexer"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "Grammar-driven lexer for a focused Mermaid flowchart subset"
+description = "Grammar-driven lexers for Mermaid diagram families"
 
 [dependencies]
 grammar-tools = { path = "../grammar-tools" }

--- a/code/packages/rust/mermaid-lexer/README.md
+++ b/code/packages/rust/mermaid-lexer/README.md
@@ -1,19 +1,19 @@
 # mermaid-lexer
 
-Grammar-driven Rust lexer for the shared `code/grammars/mermaid.tokens`
-definition.
+Grammar-driven Rust lexers for the shared Mermaid family grammars under
+`code/grammars/mermaid/`.
 
-This package tokenizes a focused Mermaid flowchart subset that is meant to feed
-the native diagram pipeline:
+The current entrypoints tokenize flowchart and Pie syntax for the native
+diagram pipeline:
 
 ```text
 Mermaid source
   -> mermaid-lexer
   -> mermaid-parser
-  -> GraphDiagram
+  -> family Diagram IR
 ```
 
-Supported lexical constructs in v1:
+The flowchart lexer supports:
 
 - `flowchart` / `graph`
 - directions: `TB`, `TD`, `BT`, `LR`, `RL`
@@ -22,4 +22,11 @@ Supported lexical constructs in v1:
 - edge operators: `-->`, `---`
 - edge labels: `|label|`
 - statement separators: newline or `;`
+- `%%` comments
+
+The Pie lexer supports:
+
+- `pie` and `showData`
+- quoted labels
+- numeric slice values
 - `%%` comments

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -8,6 +8,10 @@ use lexer::token::Token;
 
 const TOKEN_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/mermaid.tokens");
 const PIE_TOKEN_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/pie.tokens");
+const SANKEY_TOKEN_GRAMMAR_SOURCE: &str =
+    include_str!("../../../../grammars/mermaid/sankey.tokens");
+const GITGRAPH_TOKEN_GRAMMAR_SOURCE: &str =
+    include_str!("../../../../grammars/mermaid/gitgraph.tokens");
 
 fn create_lexer<'a>(source: &'a str, grammar_source: &str, grammar_name: &str) -> GrammarLexer<'a> {
     let grammar = parse_token_grammar(grammar_source)
@@ -23,6 +27,14 @@ pub fn create_mermaid_pie_lexer(source: &str) -> GrammarLexer<'_> {
     create_lexer(source, PIE_TOKEN_GRAMMAR_SOURCE, "pie.tokens")
 }
 
+pub fn create_mermaid_sankey_lexer(source: &str) -> GrammarLexer<'_> {
+    create_lexer(source, SANKEY_TOKEN_GRAMMAR_SOURCE, "sankey.tokens")
+}
+
+pub fn create_mermaid_gitgraph_lexer(source: &str) -> GrammarLexer<'_> {
+    create_lexer(source, GITGRAPH_TOKEN_GRAMMAR_SOURCE, "gitgraph.tokens")
+}
+
 pub fn tokenize_mermaid(source: &str) -> Vec<Token> {
     let mut lexer = create_mermaid_lexer(source);
     lexer
@@ -35,6 +47,20 @@ pub fn tokenize_mermaid_pie(source: &str) -> Vec<Token> {
     lexer
         .tokenize()
         .unwrap_or_else(|e| panic!("Mermaid pie tokenization failed: {e}"))
+}
+
+pub fn tokenize_mermaid_sankey(source: &str) -> Vec<Token> {
+    let mut lexer = create_mermaid_sankey_lexer(source);
+    lexer
+        .tokenize()
+        .unwrap_or_else(|e| panic!("Mermaid Sankey tokenization failed: {e}"))
+}
+
+pub fn tokenize_mermaid_gitgraph(source: &str) -> Vec<Token> {
+    let mut lexer = create_mermaid_gitgraph_lexer(source);
+    lexer
+        .tokenize()
+        .unwrap_or_else(|e| panic!("Mermaid GitGraph tokenization failed: {e}"))
 }
 
 #[cfg(test)]
@@ -126,5 +152,55 @@ mod tests {
             values,
             vec!["pie", "showData", "\\n", "Dogs", ":", "60", "\\n", "Cats", ":", "40.5", "\\n"]
         );
+    }
+
+    #[test]
+    fn tokenizes_sankey_csv_rows() {
+        let tokens = tokenize_mermaid_sankey(
+            "sankey-beta\nGrid,\"Heating, homes\",113.726\nGrid,Losses,56\n",
+        );
+        let values: Vec<&str> = tokens
+            .iter()
+            .filter(|token| token.type_ != TokenType::Eof)
+            .map(|token| token.value.as_str())
+            .collect();
+
+        assert_eq!(
+            values,
+            vec![
+                "sankey-beta",
+                "\\n",
+                "Grid",
+                ",",
+                "Heating, homes",
+                ",",
+                "113.726",
+                "\\n",
+                "Grid",
+                ",",
+                "Losses",
+                ",",
+                "56",
+                "\\n"
+            ]
+        );
+    }
+
+    #[test]
+    fn tokenizes_gitgraph_commands_and_attributes() {
+        let tokens = tokenize_mermaid_gitgraph(
+            "gitGraph LR:\ncommit id: \"c1\" msg: \"Start\"\nbranch develop\ncheckout develop\n",
+        );
+        let values: Vec<&str> = tokens
+            .iter()
+            .filter(|token| token.type_ != TokenType::Eof)
+            .map(|token| token.value.as_str())
+            .collect();
+
+        assert_eq!(values[0], "gitGraph");
+        assert!(values.contains(&"LR"));
+        assert!(values.contains(&"commit"));
+        assert!(values.contains(&"c1"));
+        assert!(values.contains(&"develop"));
     }
 }

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,17 +1,26 @@
-//! Grammar-driven lexer for a focused Mermaid flowchart subset.
+//! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
 use lexer::token::Token;
 
 const TOKEN_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/mermaid.tokens");
+const PIE_TOKEN_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/pie.tokens");
+
+fn create_lexer<'a>(source: &'a str, grammar_source: &str, grammar_name: &str) -> GrammarLexer<'a> {
+    let grammar = parse_token_grammar(grammar_source)
+        .unwrap_or_else(|e| panic!("Failed to parse {grammar_name}: {e}"));
+    GrammarLexer::new(source, &grammar)
+}
 
 pub fn create_mermaid_lexer(source: &str) -> GrammarLexer<'_> {
-    let grammar = parse_token_grammar(TOKEN_GRAMMAR_SOURCE)
-        .unwrap_or_else(|e| panic!("Failed to parse mermaid.tokens: {e}"));
-    GrammarLexer::new(source, &grammar)
+    create_lexer(source, TOKEN_GRAMMAR_SOURCE, "mermaid.tokens")
+}
+
+pub fn create_mermaid_pie_lexer(source: &str) -> GrammarLexer<'_> {
+    create_lexer(source, PIE_TOKEN_GRAMMAR_SOURCE, "pie.tokens")
 }
 
 pub fn tokenize_mermaid(source: &str) -> Vec<Token> {
@@ -19,6 +28,13 @@ pub fn tokenize_mermaid(source: &str) -> Vec<Token> {
     lexer
         .tokenize()
         .unwrap_or_else(|e| panic!("Mermaid tokenization failed: {e}"))
+}
+
+pub fn tokenize_mermaid_pie(source: &str) -> Vec<Token> {
+    let mut lexer = create_mermaid_pie_lexer(source);
+    lexer
+        .tokenize()
+        .unwrap_or_else(|e| panic!("Mermaid pie tokenization failed: {e}"))
 }
 
 #[cfg(test)]
@@ -32,7 +48,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.1.0");
+        assert_eq!(VERSION, "0.2.0");
     }
 
     #[test]
@@ -95,5 +111,20 @@ mod tests {
         assert!(custom_tokens.contains(&("RECT", "[Rect]")));
         assert!(custom_tokens.contains(&("DIAMOND", "{Decision}")));
         assert_eq!(semicolon_count, 3);
+    }
+
+    #[test]
+    fn tokenizes_pie_sections() {
+        let tokens = tokenize_mermaid_pie("pie showData\n\"Dogs\" : 60\n\"Cats\" : 40.5\n");
+        let values: Vec<&str> = tokens
+            .iter()
+            .filter(|token| token.type_ != TokenType::Eof)
+            .map(|token| token.value.as_str())
+            .collect();
+
+        assert_eq!(
+            values,
+            vec!["pie", "showData", "\\n", "Dogs", ":", "60", "\\n", "Cats", ":", "40.5", "\\n"]
+        );
     }
 }

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -12,6 +12,7 @@ const SANKEY_TOKEN_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/sankey.tokens");
 const GITGRAPH_TOKEN_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/gitgraph.tokens");
+const ER_TOKEN_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/er.tokens");
 
 fn create_lexer<'a>(source: &'a str, grammar_source: &str, grammar_name: &str) -> GrammarLexer<'a> {
     let grammar = parse_token_grammar(grammar_source)
@@ -33,6 +34,10 @@ pub fn create_mermaid_sankey_lexer(source: &str) -> GrammarLexer<'_> {
 
 pub fn create_mermaid_gitgraph_lexer(source: &str) -> GrammarLexer<'_> {
     create_lexer(source, GITGRAPH_TOKEN_GRAMMAR_SOURCE, "gitgraph.tokens")
+}
+
+pub fn create_mermaid_er_lexer(source: &str) -> GrammarLexer<'_> {
+    create_lexer(source, ER_TOKEN_GRAMMAR_SOURCE, "er.tokens")
 }
 
 pub fn tokenize_mermaid(source: &str) -> Vec<Token> {
@@ -61,6 +66,13 @@ pub fn tokenize_mermaid_gitgraph(source: &str) -> Vec<Token> {
     lexer
         .tokenize()
         .unwrap_or_else(|e| panic!("Mermaid GitGraph tokenization failed: {e}"))
+}
+
+pub fn tokenize_mermaid_er(source: &str) -> Vec<Token> {
+    let mut lexer = create_mermaid_er_lexer(source);
+    lexer
+        .tokenize()
+        .unwrap_or_else(|e| panic!("Mermaid ER tokenization failed: {e}"))
 }
 
 #[cfg(test)]
@@ -202,5 +214,23 @@ mod tests {
         assert!(values.contains(&"commit"));
         assert!(values.contains(&"c1"));
         assert!(values.contains(&"develop"));
+    }
+
+    #[test]
+    fn tokenizes_er_relationships_and_attributes() {
+        let tokens = tokenize_mermaid_er(
+            "erDiagram\nCUSTOMER ||--o{ ORDER : places\nCUSTOMER {\nstring name PK\n}\n",
+        );
+        let values: Vec<&str> = tokens
+            .iter()
+            .filter(|token| token.type_ != TokenType::Eof)
+            .map(|token| token.value.as_str())
+            .collect();
+
+        assert!(values.contains(&"erDiagram"));
+        assert!(values.contains(&"||"));
+        assert!(values.contains(&"--"));
+        assert!(values.contains(&"o{"));
+        assert!(values.contains(&"PK"));
     }
 }

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.0
+
+- Pinned the compatibility target to Mermaid 11.16.1.
+- Added detection for every documented core diagram family and the external
+  ZenUML family.
+- Added grammar-backed Pie parsing into the shared chart IR.
+- Added a machine-readable compatibility manifest and conformance tests.
+
 ## 0.1.0
 
 - Added a grammar-driven Mermaid flowchart parser that lowers into `diagram-ir::GraphDiagram`.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "mermaid-parser"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "Grammar-driven parser for a focused Mermaid flowchart subset that lowers to diagram-ir GraphDiagram"
+description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 
 [dependencies]
 diagram-ir = { path = "../diagram-ir" }
@@ -10,3 +10,6 @@ grammar-tools = { path = "../grammar-tools" }
 lexer = { path = "../lexer" }
 mermaid-lexer = { path = "../mermaid-lexer" }
 parser = { path = "../parser" }
+
+[dev-dependencies]
+serde_json = "1"

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -1,22 +1,33 @@
 # mermaid-parser
 
-Grammar-driven Rust parser for the shared Mermaid flowchart grammar.
+Versioned Mermaid compatibility dispatcher and grammar-driven Rust parsers.
 
-The parser reads `code/grammars/mermaid.tokens` and
-`code/grammars/mermaid.grammar`, validates the source with the generic lexer
-and parser infrastructure, then lowers the result into `diagram-ir::GraphDiagram`.
+Compatibility is pinned to Mermaid 11.16.1 in
+`code/grammars/mermaid/compatibility.json`. The manifest distinguishes family
+detection from syntax and native-render compatibility so progress can be
+measured without treating a recognized header as a completed implementation.
 
-The first supported subset is intentionally small but useful:
+The current native pipeline supports documented subsets of:
 
 - `flowchart` / `graph`
-- directions: `TB`, `TD`, `BT`, `LR`, `RL`
-- node declarations
-- edge chains
-- edge labels
-- inline Mermaid node shapes: `[]`, `()`, `(())`, `{}`
+- `classDiagram`
+- `gantt`
+- `pie`
+- `xychart`
 
-That is enough to prove:
+Each supported family lowers into the shared Diagram IR and can continue
+through its family layout package:
 
 ```text
-Mermaid -> GraphDiagram -> diagram-layout-graph -> diagram-to-paint -> paint-metal -> PNG
+Mermaid
+  -> family grammar and parser
+  -> Diagram IR
+  -> family layout
+  -> diagram-to-paint
+  -> PaintScene
+  -> Metal / SVG / Direct2D / other Paint VM backends
 ```
+
+All other Mermaid 11.16.1 family headers are recognized and return an explicit
+`recognized but not implemented` error until their grammar, lowering, layout,
+and native render fixtures are complete.

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -1,4 +1,4 @@
-//! Grammar-driven parser for a focused Mermaid flowchart subset.
+//! Grammar-driven parser and compatibility dispatcher for Mermaid diagrams.
 
 // This file hand-parses many `starts_with(...)` / slice-index prefix strips
 // where the prefix and the stripped remainder need slightly different handling;
@@ -6,7 +6,8 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.2.0";
+pub const VERSION: &str = "0.3.0";
+pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
 
@@ -15,10 +16,11 @@ use diagram_ir::{
 };
 use grammar_tools::parser_grammar::parse_parser_grammar;
 use lexer::token::{Token, TokenType};
-use mermaid_lexer::tokenize_mermaid;
+use mermaid_lexer::{tokenize_mermaid, tokenize_mermaid_pie};
 use parser::grammar_parser::{GrammarASTNode, GrammarParser, DEFAULT_MAX_RULE_DEPTH};
 
 const PARSER_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/mermaid.grammar");
+const PIE_PARSER_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/pie.grammar");
 
 /// Recursion-depth cap for the Mermaid [`GrammarParser`] — see
 /// [`GrammarParser::with_max_depth`] for why this guard exists at all (deep
@@ -168,6 +170,18 @@ pub fn create_mermaid_parser(source: &str) -> GrammarParser {
 
 pub fn parse_mermaid_ast(source: &str) -> Result<GrammarASTNode, ParseError> {
     let mut parser = create_mermaid_parser(source);
+    parser.parse().map_err(|e| ParseError {
+        message: e.message,
+        line: e.token.line,
+        col: e.token.column,
+    })
+}
+
+pub fn parse_mermaid_pie_ast(source: &str) -> Result<GrammarASTNode, ParseError> {
+    let tokens = tokenize_mermaid_pie(source);
+    let grammar = parse_parser_grammar(PIE_PARSER_GRAMMAR_SOURCE)
+        .unwrap_or_else(|e| panic!("Failed to parse pie.grammar: {e}"));
+    let mut parser = GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH);
     parser.parse().map_err(|e| ParseError {
         message: e.message,
         line: e.token.line,
@@ -332,31 +346,111 @@ fn is_edge_operator(token: &Token) -> bool {
 }
 
 fn token_name(token: &Token) -> &str {
-    token
-        .type_name
-        .as_deref()
-        .unwrap_or(match token.type_ {
-            TokenType::Name => "NAME",
-            TokenType::Keyword => "KEYWORD",
-            TokenType::Newline => "NEWLINE",
-            TokenType::Semicolon => "SEMICOLON",
-            TokenType::Eof => "EOF",
-            _ => "TOKEN",
-        })
+    token.type_name.as_deref().unwrap_or(match token.type_ {
+        TokenType::Name => "NAME",
+        TokenType::Number => "NUMBER",
+        TokenType::String => "STRING",
+        TokenType::Keyword => "KEYWORD",
+        TokenType::Colon => "COLON",
+        TokenType::Newline => "NEWLINE",
+        TokenType::Semicolon => "SEMICOLON",
+        TokenType::Eof => "EOF",
+        _ => "TOKEN",
+    })
 }
-
 
 // ============================================================================
 // DG04 — Extended Mermaid parsers for Chart, Structural, and Temporal families
 // ============================================================================
 
 use diagram_ir::{
-    Axis, AxisKind, ChartDiagram, ChartKind, ChartOrientation, ChartSeries,
-    Compartment, CompartmentKind, GanttDiagram, GanttSection, GanttTask, RelKind,
-    SeriesKind, StructuralDiagram, StructuralKind, StructuralNode,
-    StructuralNodeKind, StructuralRelationship, TaskStart, TaskStatus,
-    TemporalBody, TemporalDiagram, TemporalKind,
+    Axis, AxisKind, ChartDiagram, ChartKind, ChartOrientation, ChartSeries, Compartment,
+    CompartmentKind, GanttDiagram, GanttSection, GanttTask, PieSlice, RelKind, SeriesKind,
+    StructuralDiagram, StructuralKind, StructuralNode, StructuralNodeKind, StructuralRelationship,
+    TaskStart, TaskStatus, TemporalBody, TemporalDiagram, TemporalKind,
 };
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MermaidDiagramType {
+    Flowchart,
+    Sequence,
+    Class,
+    State,
+    Er,
+    Journey,
+    Gantt,
+    Pie,
+    Quadrant,
+    Requirement,
+    GitGraph,
+    C4,
+    Mindmap,
+    Timeline,
+    Sankey,
+    XyChart,
+    Block,
+    Packet,
+    Kanban,
+    Architecture,
+    Radar,
+    EventModeling,
+    Treemap,
+    Venn,
+    Ishikawa,
+    Wardley,
+    Cynefin,
+    TreeView,
+    Swimlane,
+    Railroad,
+    Info,
+    ZenUml,
+}
+
+impl MermaidDiagramType {
+    pub fn canonical_id(self) -> &'static str {
+        match self {
+            Self::Flowchart => "flowchart",
+            Self::Sequence => "sequence",
+            Self::Class => "class",
+            Self::State => "state",
+            Self::Er => "er",
+            Self::Journey => "journey",
+            Self::Gantt => "gantt",
+            Self::Pie => "pie",
+            Self::Quadrant => "quadrant",
+            Self::Requirement => "requirement",
+            Self::GitGraph => "gitgraph",
+            Self::C4 => "c4",
+            Self::Mindmap => "mindmap",
+            Self::Timeline => "timeline",
+            Self::Sankey => "sankey",
+            Self::XyChart => "xychart",
+            Self::Block => "block",
+            Self::Packet => "packet",
+            Self::Kanban => "kanban",
+            Self::Architecture => "architecture",
+            Self::Radar => "radar",
+            Self::EventModeling => "eventmodeling",
+            Self::Treemap => "treemap",
+            Self::Venn => "venn",
+            Self::Ishikawa => "ishikawa",
+            Self::Wardley => "wardley",
+            Self::Cynefin => "cynefin",
+            Self::TreeView => "treeview",
+            Self::Swimlane => "swimlane",
+            Self::Railroad => "railroad",
+            Self::Info => "info",
+            Self::ZenUml => "zenuml",
+        }
+    }
+
+    pub fn has_native_pipeline(self) -> bool {
+        matches!(
+            self,
+            Self::Flowchart | Self::Class | Self::Gantt | Self::Pie | Self::XyChart
+        )
+    }
+}
 
 /// Union of all Mermaid diagram variants that `parse_any_mermaid` can return.
 pub enum MermaidDiagram {
@@ -366,33 +460,133 @@ pub enum MermaidDiagram {
     Temporal(TemporalDiagram),
 }
 
-/// Dispatch to the correct sub-parser based on the first keyword line.
+/// Detect a Mermaid 11.16.1 diagram family from its header.
 ///
-/// Supported diagram types:
-/// - `flowchart`/`graph` → `GraphDiagram`
-/// - `classDiagram` → `StructuralDiagram`
-/// - `xychart-beta`/`xychart` → `ChartDiagram`
-/// - `gantt` → `TemporalDiagram` (Gantt body)
-pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
+/// Detection also skips leading YAML front matter, Mermaid directives,
+/// comments, and blank lines. A recognized family may still be reported as
+/// unsupported by [`parse_any_mermaid`] while its semantic IR is implemented.
+pub fn detect_mermaid_type(source: &str) -> Result<MermaidDiagramType, ParseError> {
     let first = first_keyword(source);
-    match first.as_str() {
-        "flowchart" | "graph" => parse_to_diagram(source).map(MermaidDiagram::Graph),
-        "classDiagram" => parse_class_diagram(source).map(MermaidDiagram::Structural),
-        "xychart-beta" | "xychart" => parse_xychart(source).map(MermaidDiagram::Chart),
-        "gantt" => parse_gantt(source).map(|g| MermaidDiagram::Temporal(TemporalDiagram {
-            kind: TemporalKind::Gantt,
-            title: None,
-            body: TemporalBody::Gantt(g),
-        })),
-        other => Err(ParseError { message: format!("Unknown diagram type: {other:?}"), line: 0, col: 0 }),
+    let diagram_type = match first.as_str() {
+        "flowchart" | "graph" | "flowchart-elk" => MermaidDiagramType::Flowchart,
+        "sequenceDiagram" => MermaidDiagramType::Sequence,
+        "classDiagram" | "classDiagram-v2" => MermaidDiagramType::Class,
+        "stateDiagram" | "stateDiagram-v2" => MermaidDiagramType::State,
+        "erDiagram" => MermaidDiagramType::Er,
+        "journey" => MermaidDiagramType::Journey,
+        "gantt" => MermaidDiagramType::Gantt,
+        "pie" => MermaidDiagramType::Pie,
+        "quadrantChart" => MermaidDiagramType::Quadrant,
+        "requirement" | "requirementDiagram" => MermaidDiagramType::Requirement,
+        "gitGraph" => MermaidDiagramType::GitGraph,
+        "C4Context" | "C4Container" | "C4Component" | "C4Dynamic" | "C4Deployment" => {
+            MermaidDiagramType::C4
+        }
+        "mindmap" => MermaidDiagramType::Mindmap,
+        "timeline" => MermaidDiagramType::Timeline,
+        "sankey" | "sankey-beta" => MermaidDiagramType::Sankey,
+        "xychart" | "xychart-beta" => MermaidDiagramType::XyChart,
+        "block" | "block-beta" => MermaidDiagramType::Block,
+        "packet" | "packet-beta" => MermaidDiagramType::Packet,
+        "kanban" => MermaidDiagramType::Kanban,
+        "architecture" | "architecture-beta" => MermaidDiagramType::Architecture,
+        "radar-beta" => MermaidDiagramType::Radar,
+        "eventmodeling" => MermaidDiagramType::EventModeling,
+        "treemap" => MermaidDiagramType::Treemap,
+        "venn-beta" => MermaidDiagramType::Venn,
+        "ishikawa" | "ishikawa-beta" => MermaidDiagramType::Ishikawa,
+        "wardley-beta" => MermaidDiagramType::Wardley,
+        "cynefin-beta" => MermaidDiagramType::Cynefin,
+        "treeView-beta" => MermaidDiagramType::TreeView,
+        "swimlane-beta" => MermaidDiagramType::Swimlane,
+        "railroad-beta" | "railroad-ebnf-beta" | "railroad-abnf-beta" | "railroad-peg-beta" => {
+            MermaidDiagramType::Railroad
+        }
+        "info" => MermaidDiagramType::Info,
+        "zenuml" => MermaidDiagramType::ZenUml,
+        other => {
+            return Err(ParseError {
+                message: format!("Unknown Mermaid diagram type: {other:?}"),
+                line: 1,
+                col: 1,
+            });
+        }
+    };
+
+    Ok(diagram_type)
+}
+
+/// Dispatch a recognized Mermaid family to its semantic parser.
+pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
+    let diagram_type = detect_mermaid_type(source)?;
+    match diagram_type {
+        MermaidDiagramType::Flowchart => parse_to_diagram(source).map(MermaidDiagram::Graph),
+        MermaidDiagramType::Class => parse_class_diagram(source).map(MermaidDiagram::Structural),
+        MermaidDiagramType::XyChart => parse_xychart(source).map(MermaidDiagram::Chart),
+        MermaidDiagramType::Pie => parse_pie(source).map(MermaidDiagram::Chart),
+        MermaidDiagramType::Gantt => parse_gantt(source).map(|g| {
+            MermaidDiagram::Temporal(TemporalDiagram {
+                kind: TemporalKind::Gantt,
+                title: None,
+                body: TemporalBody::Gantt(g),
+            })
+        }),
+        unsupported => Err(ParseError {
+            message: format!(
+                "Mermaid {} diagram family {:?} is recognized but not implemented",
+                MERMAID_COMPATIBILITY_BASELINE,
+                unsupported.canonical_id()
+            ),
+            line: 1,
+            col: 1,
+        }),
     }
 }
 
 fn first_keyword(source: &str) -> String {
+    let mut in_front_matter = false;
+    let mut can_start_front_matter = true;
+    let mut in_directive = false;
+
     for line in source.lines() {
         let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with("%%") { continue; }
-        return trimmed.split_whitespace().next().unwrap_or("").to_string();
+
+        if can_start_front_matter && trimmed.is_empty() {
+            continue;
+        }
+        if can_start_front_matter && trimmed == "---" {
+            in_front_matter = true;
+            can_start_front_matter = false;
+            continue;
+        }
+        if in_front_matter {
+            if trimmed == "---" {
+                in_front_matter = false;
+            }
+            continue;
+        }
+
+        can_start_front_matter = false;
+        if in_directive {
+            if trimmed.contains("}%%") {
+                in_directive = false;
+            }
+            continue;
+        }
+        if trimmed.starts_with("%%{") {
+            in_directive = !trimmed.contains("}%%");
+            continue;
+        }
+        if trimmed.is_empty() || trimmed.starts_with("%%") {
+            continue;
+        }
+
+        return trimmed
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+            .trim_end_matches(':')
+            .to_string();
     }
     String::new()
 }
@@ -418,8 +612,12 @@ pub fn parse_class_diagram(source: &str) -> Result<StructuralDiagram, ParseError
     // Skip the `classDiagram` header line.
     for line in lines.by_ref() {
         let t = line.trim();
-        if t == "classDiagram" { break; }
-        if t.starts_with("%%") || t.is_empty() { continue; }
+        if t == "classDiagram" {
+            break;
+        }
+        if t.starts_with("%%") || t.is_empty() {
+            continue;
+        }
         if t.starts_with("title") {
             title = Some(t.trim_start_matches("title").trim().to_string());
         }
@@ -427,12 +625,17 @@ pub fn parse_class_diagram(source: &str) -> Result<StructuralDiagram, ParseError
 
     for line in lines {
         let t = line.trim();
-        if t.is_empty() || t.starts_with("%%") { continue; }
+        if t.is_empty() || t.starts_with("%%") {
+            continue;
+        }
 
         if t.starts_with("class ") {
             let rest = t[6..].trim();
             let (id_str, body_str): (String, Option<String>) = if let Some(pos) = rest.find('{') {
-                (rest[..pos].trim().to_string(), Some(rest[pos+1..].trim_end_matches('}').to_string()))
+                (
+                    rest[..pos].trim().to_string(),
+                    Some(rest[pos + 1..].trim_end_matches('}').to_string()),
+                )
             } else {
                 (rest.to_string(), None)
             };
@@ -440,35 +643,47 @@ pub fn parse_class_diagram(source: &str) -> Result<StructuralDiagram, ParseError
 
             let mut compartments: Vec<Compartment> = Vec::new();
             if let Some(body) = body_str.as_deref() {
-                let entries: Vec<String> = body.split(';')
+                let entries: Vec<String> = body
+                    .split(';')
                     .map(|e| e.trim().to_string())
                     .filter(|e| !e.is_empty())
                     .collect();
                 if !entries.is_empty() {
                     // Heuristic: entries with `()` are methods, otherwise fields.
-                    let fields: Vec<String> = entries.iter()
+                    let fields: Vec<String> = entries
+                        .iter()
                         .filter(|e| !e.contains('('))
                         .map(|e| strip_visibility(e))
                         .collect();
-                    let methods: Vec<String> = entries.iter()
+                    let methods: Vec<String> = entries
+                        .iter()
                         .filter(|e| e.contains('('))
                         .map(|e| strip_visibility(e))
                         .collect();
                     if !fields.is_empty() {
-                        compartments.push(Compartment { kind: CompartmentKind::Fields, entries: fields });
+                        compartments.push(Compartment {
+                            kind: CompartmentKind::Fields,
+                            entries: fields,
+                        });
                     }
                     if !methods.is_empty() {
-                        compartments.push(Compartment { kind: CompartmentKind::Methods, entries: methods });
+                        compartments.push(Compartment {
+                            kind: CompartmentKind::Methods,
+                            entries: methods,
+                        });
                     }
                 }
             }
 
             // Update existing node or create a new one.
             if let Some(existing) = nodes.iter_mut().find(|n| n.id == id) {
-                if !compartments.is_empty() { existing.compartments = compartments; }
+                if !compartments.is_empty() {
+                    existing.compartments = compartments;
+                }
             } else {
                 nodes.push(StructuralNode {
-                    id: id.clone(), label: id,
+                    id: id.clone(),
+                    label: id,
                     stereotype: None,
                     node_kind: StructuralNodeKind::Class,
                     compartments,
@@ -479,7 +694,8 @@ pub fn parse_class_diagram(source: &str) -> Result<StructuralDiagram, ParseError
             for id in [&rel.from, &rel.to] {
                 if !nodes.iter().any(|n| &n.id == id) {
                     nodes.push(StructuralNode {
-                        id: id.clone(), label: id.clone(),
+                        id: id.clone(),
+                        label: id.clone(),
                         stereotype: None,
                         node_kind: StructuralNodeKind::Class,
                         compartments: vec![],
@@ -490,7 +706,12 @@ pub fn parse_class_diagram(source: &str) -> Result<StructuralDiagram, ParseError
         }
     }
 
-    Ok(StructuralDiagram { kind: StructuralKind::Class, title, nodes, relationships })
+    Ok(StructuralDiagram {
+        kind: StructuralKind::Class,
+        title,
+        nodes,
+        relationships,
+    })
 }
 
 fn strip_visibility(s: &str) -> String {
@@ -514,25 +735,32 @@ fn parse_class_relationship(line: &str) -> Option<StructuralRelationship> {
     let arrows: &[(&str, RelKind)] = &[
         ("<|--", RelKind::Inheritance),
         ("<|..", RelKind::Realization),
-        ("*--",  RelKind::Composition),
-        ("o--",  RelKind::Aggregation),
-        ("-->",  RelKind::Association),
-        ("..",   RelKind::Dependency),
-        ("--",   RelKind::Link),
+        ("*--", RelKind::Composition),
+        ("o--", RelKind::Aggregation),
+        ("-->", RelKind::Association),
+        ("..", RelKind::Dependency),
+        ("--", RelKind::Link),
     ];
     for (arrow, kind) in arrows {
         if let Some(pos) = line.find(arrow) {
-            let from  = line[..pos].trim().to_string();
+            let from = line[..pos].trim().to_string();
             let after = line[pos + arrow.len()..].trim();
             let (to, label) = if let Some(colon) = after.find(':') {
-                (after[..colon].trim().to_string(), Some(after[colon+1..].trim().to_string()))
+                (
+                    after[..colon].trim().to_string(),
+                    Some(after[colon + 1..].trim().to_string()),
+                )
             } else {
                 (after.to_string(), None)
             };
             if !from.is_empty() && !to.is_empty() {
                 return Some(StructuralRelationship {
-                    from, to, kind: kind.clone(),
-                    from_mult: None, to_mult: None, label,
+                    from,
+                    to,
+                    kind: kind.clone(),
+                    from_mult: None,
+                    to_mult: None,
+                    label,
                 });
             }
         }
@@ -563,9 +791,13 @@ pub fn parse_xychart(source: &str) -> Result<ChartDiagram, ParseError> {
     let mut past_header = false;
     for line in source.lines() {
         let t = line.trim();
-        if t.is_empty() || t.starts_with("%%") { continue; }
+        if t.is_empty() || t.starts_with("%%") {
+            continue;
+        }
         if !past_header {
-            if t.starts_with("xychart") { past_header = true; }
+            if t.starts_with("xychart") {
+                past_header = true;
+            }
             continue;
         }
         if t.starts_with("title") {
@@ -577,34 +809,70 @@ pub fn parse_xychart(source: &str) -> Result<ChartDiagram, ParseError> {
             // Strip optional quoted label before numbers.
             let rest = if rest.starts_with('"') {
                 if let Some(end) = rest[1..].find('"') {
-                    rest[end+2..].trim()
-                } else { rest }
-            } else { rest };
-            let nums: Vec<f64> = rest.split_whitespace()
-                .filter(|s| s.chars().all(|c| c.is_ascii_digit() || c == '-' || c == '.'))
+                    rest[end + 2..].trim()
+                } else {
+                    rest
+                }
+            } else {
+                rest
+            };
+            let nums: Vec<f64> = rest
+                .split_whitespace()
+                .filter(|s| {
+                    s.chars()
+                        .all(|c| c.is_ascii_digit() || c == '-' || c == '.')
+                })
                 .filter_map(|s| s.parse().ok())
                 .collect();
-            if nums.len() >= 2 { y_min = nums[0]; y_max = nums[nums.len()-1]; }
+            if nums.len() >= 2 {
+                y_min = nums[0];
+                y_max = nums[nums.len() - 1];
+            }
         } else if t.starts_with("bar") {
             let data = parse_data_list(&t[3..]);
-            series.push(ChartSeries { kind: SeriesKind::Bar, label: Some("bar".into()), data });
+            series.push(ChartSeries {
+                kind: SeriesKind::Bar,
+                label: Some("bar".into()),
+                data,
+            });
         } else if t.starts_with("line") {
             let data = parse_data_list(&t[4..]);
-            series.push(ChartSeries { kind: SeriesKind::Line, label: Some("line".into()), data });
+            series.push(ChartSeries {
+                kind: SeriesKind::Line,
+                label: Some("line".into()),
+                data,
+            });
         }
     }
 
     let x_axis = if !x_cats.is_empty() {
-        Some(Axis { kind: AxisKind::Categorical, title: None, categories: x_cats, min: 0.0, max: 0.0 })
-    } else { None };
+        Some(Axis {
+            kind: AxisKind::Categorical,
+            title: None,
+            categories: x_cats,
+            min: 0.0,
+            max: 0.0,
+        })
+    } else {
+        None
+    };
     let y_axis = Some(Axis {
-        kind: AxisKind::Numeric, title: None, categories: vec![], min: y_min, max: y_max,
+        kind: AxisKind::Numeric,
+        title: None,
+        categories: vec![],
+        min: y_min,
+        max: y_max,
     });
 
     Ok(ChartDiagram {
-        title, kind: ChartKind::Xy,
-        x_axis, y_axis, series,
-        slices: vec![], sankey_nodes: vec![], flows: vec![],
+        title,
+        kind: ChartKind::Xy,
+        x_axis,
+        y_axis,
+        series,
+        slices: vec![],
+        sankey_nodes: vec![],
+        flows: vec![],
         orientation: ChartOrientation::Vertical,
     })
 }
@@ -612,18 +880,112 @@ pub fn parse_xychart(source: &str) -> Result<ChartDiagram, ParseError> {
 fn parse_bracket_list(s: &str) -> Vec<String> {
     let s = s.trim();
     let inner = if let (Some(l), Some(r)) = (s.find('['), s.rfind(']')) {
-        &s[l+1..r]
-    } else { s };
-    inner.split(',').map(|x| x.trim().trim_matches('"').to_string())
-        .filter(|x| !x.is_empty()).collect()
+        &s[l + 1..r]
+    } else {
+        s
+    };
+    inner
+        .split(',')
+        .map(|x| x.trim().trim_matches('"').to_string())
+        .filter(|x| !x.is_empty())
+        .collect()
 }
 
 fn parse_data_list(s: &str) -> Vec<f64> {
     let s = s.trim();
     let inner = if let (Some(l), Some(r)) = (s.find('['), s.rfind(']')) {
-        &s[l+1..r]
-    } else { s };
-    inner.split(',').filter_map(|x| x.trim().parse().ok()).collect()
+        &s[l + 1..r]
+    } else {
+        s
+    };
+    inner
+        .split(',')
+        .filter_map(|x| x.trim().parse().ok())
+        .collect()
+}
+
+// ── pie parser ───────────────────────────────────────────────────────────
+
+/// Parse the grammar-backed Mermaid `pie` family into a `ChartDiagram`.
+///
+/// The first compatibility slice supports `showData` and quoted numeric
+/// sections, which are the semantic inputs needed by `diagram-layout-chart`.
+pub fn parse_pie(source: &str) -> Result<ChartDiagram, ParseError> {
+    parse_mermaid_pie_ast(source)?;
+
+    let mut cursor = TokenCursor::new(tokenize_mermaid_pie(source));
+    cursor.skip_terminators();
+    cursor.expect_keyword("pie")?;
+
+    if cursor.current().type_ == TokenType::Keyword && cursor.current().value == "showData" {
+        cursor.advance();
+    }
+    cursor.skip_terminators();
+
+    let mut slices = Vec::new();
+    while !cursor.at_eof() {
+        let label_token = cursor
+            .consume_if("STRING")
+            .ok_or_else(|| token_error(cursor.current(), "expected quoted pie slice label"))?;
+        cursor
+            .consume_if("COLON")
+            .ok_or_else(|| token_error(cursor.current(), "expected ':' after pie slice label"))?;
+        let value_token = cursor
+            .consume_if("NUMBER")
+            .ok_or_else(|| token_error(cursor.current(), "expected numeric pie slice value"))?;
+        let value = value_token.value.parse::<f64>().map_err(|_| {
+            token_error(
+                &value_token,
+                format!("invalid pie slice value {:?}", value_token.value),
+            )
+        })?;
+
+        slices.push(PieSlice {
+            label: unquote_mermaid_string(&label_token.value),
+            value,
+        });
+        cursor.skip_terminators();
+    }
+
+    Ok(ChartDiagram {
+        title: None,
+        kind: ChartKind::Pie,
+        x_axis: None,
+        y_axis: None,
+        series: vec![],
+        slices,
+        sankey_nodes: vec![],
+        flows: vec![],
+        orientation: ChartOrientation::Vertical,
+    })
+}
+
+fn unquote_mermaid_string(raw: &str) -> String {
+    let inner = raw
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .unwrap_or(raw);
+    let mut result = String::with_capacity(inner.len());
+    let mut chars = inner.chars();
+
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            result.push(ch);
+            continue;
+        }
+
+        match chars.next() {
+            Some('n') => result.push('\n'),
+            Some('r') => result.push('\r'),
+            Some('t') => result.push('\t'),
+            Some('"') => result.push('"'),
+            Some('\\') => result.push('\\'),
+            Some(other) => result.push(other),
+            None => result.push('\\'),
+        }
+    }
+
+    result
 }
 
 // ── gantt parser ──────────────────────────────────────────────────────────
@@ -647,9 +1009,13 @@ pub fn parse_gantt(source: &str) -> Result<GanttDiagram, ParseError> {
     let mut past_header = false;
     for line in source.lines() {
         let t = line.trim();
-        if t.is_empty() || t.starts_with("%%") { continue; }
+        if t.is_empty() || t.starts_with("%%") {
+            continue;
+        }
         if !past_header {
-            if t == "gantt" { past_header = true; }
+            if t == "gantt" {
+                past_header = true;
+            }
             continue;
         }
         if t.starts_with("title") {
@@ -658,7 +1024,9 @@ pub fn parse_gantt(source: &str) -> Result<GanttDiagram, ParseError> {
         } else if t.starts_with("dateFormat") {
             date_format = t[10..].trim().to_string();
         } else if t.starts_with("section") {
-            if let Some(sec) = current_section.take() { sections.push(sec); }
+            if let Some(sec) = current_section.take() {
+                sections.push(sec);
+            }
             current_section = Some(GanttSection {
                 label: Some(t[7..].trim().to_string()),
                 tasks: vec![],
@@ -666,15 +1034,21 @@ pub fn parse_gantt(source: &str) -> Result<GanttDiagram, ParseError> {
         } else if t.contains(':') {
             if let Some(task) = parse_gantt_task(t) {
                 let sec = current_section.get_or_insert_with(|| GanttSection {
-                    label: None, tasks: vec![],
+                    label: None,
+                    tasks: vec![],
                 });
                 sec.tasks.push(task);
             }
         }
     }
-    if let Some(sec) = current_section { sections.push(sec); }
+    if let Some(sec) = current_section {
+        sections.push(sec);
+    }
 
-    Ok(GanttDiagram { date_format, sections })
+    Ok(GanttDiagram {
+        date_format,
+        sections,
+    })
 }
 
 /// Parse a single Gantt task line.
@@ -684,10 +1058,12 @@ pub fn parse_gantt(source: &str) -> Result<GanttDiagram, ParseError> {
 fn parse_gantt_task(line: &str) -> Option<GanttTask> {
     let colon = line.find(':')?;
     let label = line[..colon].trim().to_string();
-    let rest  = line[colon+1..].trim();
+    let rest = line[colon + 1..].trim();
 
     let parts: Vec<&str> = rest.splitn(4, ',').map(str::trim).collect();
-    if parts.is_empty() { return None; }
+    if parts.is_empty() {
+        return None;
+    }
 
     // Detect status keywords in the first part.
     let status_keywords = ["done", "active", "crit", "milestone"];
@@ -698,8 +1074,10 @@ fn parse_gantt_task(line: &str) -> Option<GanttTask> {
         (TaskStatus::Normal, &parts[..])
     };
 
-    if remaining.is_empty() { return None; }
-    let id    = remaining[0].to_string();
+    if remaining.is_empty() {
+        return None;
+    }
+    let id = remaining[0].to_string();
     let start = if remaining.len() > 1 {
         let s = remaining[1];
         if s.starts_with("after ") {
@@ -712,18 +1090,27 @@ fn parse_gantt_task(line: &str) -> Option<GanttTask> {
     };
     let duration_days = if remaining.len() > 2 {
         parse_duration(remaining[2]).unwrap_or(1.0)
-    } else { 1.0 };
+    } else {
+        1.0
+    };
 
-    Some(GanttTask { id, label, start, duration_days, status, dependencies: vec![] })
+    Some(GanttTask {
+        id,
+        label,
+        start,
+        duration_days,
+        status,
+        dependencies: vec![],
+    })
 }
 
 fn parse_task_status(s: &str) -> TaskStatus {
     match s {
-        "done"      => TaskStatus::Done,
-        "active"    => TaskStatus::Active,
-        "crit"      => TaskStatus::Crit,
+        "done" => TaskStatus::Done,
+        "active" => TaskStatus::Active,
+        "crit" => TaskStatus::Crit,
         "milestone" => TaskStatus::Milestone,
-        _           => TaskStatus::Normal,
+        _ => TaskStatus::Normal,
     }
 }
 
@@ -745,7 +1132,6 @@ fn parse_duration(s: &str) -> Option<f64> {
 #[cfg(test)]
 mod tests_dg04 {
     use super::*;
-    
 
     const CLASS_SRC: &str = "classDiagram
   class Animal { +name: String; +speak() void }
@@ -765,6 +1151,10 @@ mod tests_dg04 {
   section Phase 1
     Design :done, t1, 2026-01-01, 5d
     Build :t2, after t1, 3d";
+
+    const PIE_SRC: &str = "pie showData
+  \"Dogs\" : 60
+  \"Cats\" : 40";
 
     #[test]
     fn class_diagram_parses_nodes() {
@@ -837,10 +1227,19 @@ mod tests_dg04 {
     }
 
     #[test]
+    fn pie_parses_slices() {
+        let d = parse_pie(PIE_SRC).unwrap();
+        assert_eq!(d.kind, ChartKind::Pie);
+        assert_eq!(d.slices.len(), 2);
+        assert_eq!(d.slices[0].label, "Dogs");
+        assert_eq!(d.slices[0].value, 60.0);
+    }
+
+    #[test]
     fn dispatch_flowchart() {
         let src = "flowchart LR\n  A --> B";
         match parse_any_mermaid(src).unwrap() {
-            MermaidDiagram::Graph(_) => {},
+            MermaidDiagram::Graph(_) => {}
             _ => panic!("expected Graph"),
         }
     }
@@ -849,7 +1248,7 @@ mod tests_dg04 {
     fn dispatch_class_diagram() {
         let src = "classDiagram\n  class Foo";
         match parse_any_mermaid(src).unwrap() {
-            MermaidDiagram::Structural(_) => {},
+            MermaidDiagram::Structural(_) => {}
             _ => panic!("expected Structural"),
         }
     }
@@ -858,7 +1257,7 @@ mod tests_dg04 {
     fn dispatch_xychart() {
         let src = "xychart-beta\n  bar [1,2,3]";
         match parse_any_mermaid(src).unwrap() {
-            MermaidDiagram::Chart(_) => {},
+            MermaidDiagram::Chart(_) => {}
             _ => panic!("expected Chart"),
         }
     }
@@ -867,8 +1266,16 @@ mod tests_dg04 {
     fn dispatch_gantt() {
         let src = "gantt\n  dateFormat YYYY-MM-DD";
         match parse_any_mermaid(src).unwrap() {
-            MermaidDiagram::Temporal(_) => {},
+            MermaidDiagram::Temporal(_) => {}
             _ => panic!("expected Temporal"),
+        }
+    }
+
+    #[test]
+    fn dispatch_pie() {
+        match parse_any_mermaid(PIE_SRC).unwrap() {
+            MermaidDiagram::Chart(chart) => assert_eq!(chart.kind, ChartKind::Pie),
+            _ => panic!("expected Chart"),
         }
     }
 }
@@ -887,7 +1294,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.2.0");
+        assert_eq!(crate::VERSION, "0.3.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -17,7 +17,8 @@ use diagram_ir::{
 use grammar_tools::parser_grammar::parse_parser_grammar;
 use lexer::token::{Token, TokenType};
 use mermaid_lexer::{
-    tokenize_mermaid, tokenize_mermaid_gitgraph, tokenize_mermaid_pie, tokenize_mermaid_sankey,
+    tokenize_mermaid, tokenize_mermaid_er, tokenize_mermaid_gitgraph, tokenize_mermaid_pie,
+    tokenize_mermaid_sankey,
 };
 use parser::grammar_parser::{GrammarASTNode, GrammarParser, DEFAULT_MAX_RULE_DEPTH};
 
@@ -27,6 +28,7 @@ const SANKEY_PARSER_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/sankey.grammar");
 const GITGRAPH_PARSER_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/gitgraph.grammar");
+const ER_PARSER_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/er.grammar");
 
 /// Recursion-depth cap for the Mermaid [`GrammarParser`] — see
 /// [`GrammarParser::with_max_depth`] for why this guard exists at all (deep
@@ -219,6 +221,18 @@ pub fn parse_mermaid_gitgraph_ast(source: &str) -> Result<GrammarASTNode, ParseE
     })
 }
 
+pub fn parse_mermaid_er_ast(source: &str) -> Result<GrammarASTNode, ParseError> {
+    let tokens = tokenize_mermaid_er(source);
+    let grammar = parse_parser_grammar(ER_PARSER_GRAMMAR_SOURCE)
+        .unwrap_or_else(|e| panic!("Failed to parse er.grammar: {e}"));
+    let mut parser = GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH);
+    parser.parse().map_err(|e| ParseError {
+        message: e.message,
+        line: e.token.line,
+        col: e.token.column,
+    })
+}
+
 pub fn parse_to_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     let mut cursor = TokenCursor::new(tokenize_mermaid(source));
     cursor.skip_terminators();
@@ -383,6 +397,10 @@ fn token_name(token: &Token) -> &str {
         TokenType::Keyword => "KEYWORD",
         TokenType::Colon => "COLON",
         TokenType::Comma => "COMMA",
+        TokenType::LBrace => "LBRACE",
+        TokenType::RBrace => "RBRACE",
+        TokenType::LBracket => "LBRACKET",
+        TokenType::RBracket => "RBRACKET",
         TokenType::Newline => "NEWLINE",
         TokenType::Semicolon => "SEMICOLON",
         TokenType::Eof => "EOF",
@@ -481,6 +499,7 @@ impl MermaidDiagramType {
             self,
             Self::Flowchart
                 | Self::Class
+                | Self::Er
                 | Self::Gantt
                 | Self::GitGraph
                 | Self::Pie
@@ -560,6 +579,7 @@ pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
     match diagram_type {
         MermaidDiagramType::Flowchart => parse_to_diagram(source).map(MermaidDiagram::Graph),
         MermaidDiagramType::Class => parse_class_diagram(source).map(MermaidDiagram::Structural),
+        MermaidDiagramType::Er => parse_er_diagram(source).map(MermaidDiagram::Structural),
         MermaidDiagramType::XyChart => parse_xychart(source).map(MermaidDiagram::Chart),
         MermaidDiagramType::Pie => parse_pie(source).map(MermaidDiagram::Chart),
         MermaidDiagramType::Sankey => parse_sankey(source).map(MermaidDiagram::Chart),
@@ -1338,6 +1358,231 @@ fn expect_gitgraph_token(
         .ok_or_else(|| token_error(cursor.current(), format!("expected GitGraph {description}")))
 }
 
+// ── Entity-relationship parser ───────────────────────────────────────────
+
+/// Parse Mermaid ER syntax into the shared structural IR.
+pub fn parse_er_diagram(source: &str) -> Result<StructuralDiagram, ParseError> {
+    parse_mermaid_er_ast(source)?;
+
+    let mut cursor = TokenCursor::new(tokenize_mermaid_er(source));
+    cursor.skip_terminators();
+    cursor
+        .consume_if("HEADER")
+        .ok_or_else(|| token_error(cursor.current(), "expected erDiagram header"))?;
+    cursor.skip_terminators();
+
+    let mut title = None;
+    let mut nodes: Vec<StructuralNode> = Vec::new();
+    let mut node_indices: HashMap<String, usize> = HashMap::new();
+    let mut relationships = Vec::new();
+
+    while !cursor.at_eof() {
+        if cursor.current().type_ == TokenType::Keyword {
+            match cursor.current().value.as_str() {
+                "title" => {
+                    cursor.advance();
+                    title = Some(parse_er_line_text(&mut cursor));
+                }
+                "direction" | "classDef" | "class" | "style" => {
+                    while !cursor.at_eof() && token_name(cursor.current()) != "NEWLINE" {
+                        cursor.advance();
+                    }
+                }
+                _ => return Err(token_error(cursor.current(), "unsupported ER statement")),
+            }
+            cursor.skip_terminators();
+            continue;
+        }
+
+        let entity_id = parse_er_name(&mut cursor)?;
+        let mut entity_label = entity_id.clone();
+        if cursor.consume_if("LBRACKET").is_some() {
+            entity_label = parse_er_name(&mut cursor)?;
+            cursor
+                .consume_if("RBRACKET")
+                .ok_or_else(|| token_error(cursor.current(), "expected ']' after ER alias"))?;
+        }
+        consume_er_class_suffix(&mut cursor)?;
+
+        if is_er_cardinality(cursor.current()) {
+            let from_mult = parse_er_cardinality(&mut cursor)?;
+            let relation_token = cursor.current().clone();
+            if !matches!(
+                token_name(&relation_token),
+                "IDENTIFYING" | "NON_IDENTIFYING"
+            ) {
+                return Err(token_error(&relation_token, "expected ER relationship type"));
+            }
+            cursor.advance();
+            let to_mult = parse_er_cardinality(&mut cursor)?;
+            let target_id = parse_er_name(&mut cursor)?;
+            consume_er_class_suffix(&mut cursor)?;
+            cursor.consume_if("COLON").ok_or_else(|| {
+                token_error(cursor.current(), "expected ':' before ER relationship role")
+            })?;
+            let label = parse_er_line_text(&mut cursor);
+
+            upsert_er_node(
+                &mut nodes,
+                &mut node_indices,
+                entity_id.clone(),
+                entity_label,
+            );
+            upsert_er_node(
+                &mut nodes,
+                &mut node_indices,
+                target_id.clone(),
+                target_id.clone(),
+            );
+            relationships.push(StructuralRelationship {
+                from: entity_id,
+                to: target_id,
+                kind: if token_name(&relation_token) == "IDENTIFYING" {
+                    RelKind::Association
+                } else {
+                    RelKind::Dependency
+                },
+                from_mult: Some(from_mult),
+                to_mult: Some(to_mult),
+                label: (!label.is_empty()).then_some(label),
+            });
+        } else {
+            let mut fields = Vec::new();
+            if cursor.consume_if("LBRACE").is_some() {
+                cursor.skip_terminators();
+                while cursor.consume_if("RBRACE").is_none() {
+                    if cursor.at_eof() {
+                        return Err(token_error(cursor.current(), "unterminated ER attribute block"));
+                    }
+                    let mut attribute_type = parse_er_name(&mut cursor)?;
+                    if cursor.consume_if("LBRACKET").is_some() {
+                        cursor.consume_if("RBRACKET").ok_or_else(|| {
+                            token_error(cursor.current(), "expected ']' in ER attribute type")
+                        })?;
+                        attribute_type.push_str("[]");
+                    }
+                    if cursor.consume_if("QUESTION").is_some() {
+                        attribute_type.push('?');
+                    }
+                    let attribute_name = parse_er_name(&mut cursor)?;
+                    let mut keys = Vec::new();
+                    while token_name(cursor.current()) == "ATTRIBUTE_KEY" {
+                        keys.push(cursor.advance().value.clone());
+                        if cursor.consume_if("COMMA").is_none() {
+                            break;
+                        }
+                    }
+                    let comment = cursor.consume_if("STRING").map(|token| token.value);
+                    let mut field = format!("{attribute_name}: {attribute_type}");
+                    if !keys.is_empty() {
+                        field.push_str(&format!(" [{}]", keys.join(", ")));
+                    }
+                    if let Some(comment) = comment {
+                        field.push_str(&format!(" - {comment}"));
+                    }
+                    fields.push(field);
+                    cursor.skip_terminators();
+                }
+            }
+            let index = upsert_er_node(
+                &mut nodes,
+                &mut node_indices,
+                entity_id,
+                entity_label,
+            );
+            if !fields.is_empty() {
+                nodes[index].compartments.push(Compartment {
+                    kind: CompartmentKind::Fields,
+                    entries: fields,
+                });
+            }
+        }
+        cursor.skip_terminators();
+    }
+
+    Ok(StructuralDiagram {
+        kind: StructuralKind::Er,
+        title,
+        nodes,
+        relationships,
+    })
+}
+
+fn parse_er_name(cursor: &mut TokenCursor) -> Result<String, ParseError> {
+    let token = cursor.current().clone();
+    if !matches!(
+        token_name(&token),
+        "IDENTIFIER" | "NUMBER" | "ATTRIBUTE_KEY" | "MD_PARENT" | "STRING"
+    ) {
+        return Err(token_error(&token, "expected ER name"));
+    }
+    Ok(cursor.advance().value.clone())
+}
+
+fn consume_er_class_suffix(cursor: &mut TokenCursor) -> Result<(), ParseError> {
+    if cursor.consume_if("STYLE_SEPARATOR").is_none() {
+        return Ok(());
+    }
+    parse_er_name(cursor)?;
+    while cursor.consume_if("COMMA").is_some() {
+        parse_er_name(cursor)?;
+    }
+    Ok(())
+}
+
+fn is_er_cardinality(token: &Token) -> bool {
+    matches!(
+        token_name(token),
+        "ZERO_OR_ONE" | "ZERO_OR_MORE" | "ONE_OR_MORE" | "ONLY_ONE" | "MD_PARENT"
+    )
+}
+
+fn parse_er_cardinality(cursor: &mut TokenCursor) -> Result<String, ParseError> {
+    let token = cursor.current().clone();
+    let normalized = match token_name(&token) {
+        "ZERO_OR_ONE" => "0..1",
+        "ZERO_OR_MORE" => "0..*",
+        "ONE_OR_MORE" => "1..*",
+        "ONLY_ONE" => "1",
+        "MD_PARENT" => "parent",
+        _ => return Err(token_error(&token, "expected ER cardinality")),
+    };
+    cursor.advance();
+    Ok(normalized.to_string())
+}
+
+fn parse_er_line_text(cursor: &mut TokenCursor) -> String {
+    let mut words = Vec::new();
+    while !cursor.at_eof() && token_name(cursor.current()) != "NEWLINE" {
+        words.push(cursor.advance().value.clone());
+    }
+    words.join(" ")
+}
+
+fn upsert_er_node(
+    nodes: &mut Vec<StructuralNode>,
+    indices: &mut HashMap<String, usize>,
+    id: String,
+    label: String,
+) -> usize {
+    if let Some(index) = indices.get(&id).copied() {
+        if label != id {
+            nodes[index].label = label;
+        }
+        return index;
+    }
+    let index = nodes.len();
+    indices.insert(id.clone(), index);
+    nodes.push(StructuralNode {
+        id,
+        label,
+        stereotype: Some("entity".to_string()),
+        node_kind: StructuralNodeKind::Entity,
+        compartments: Vec::new(),
+    });
+    index
+}
+
 // ── gantt parser ──────────────────────────────────────────────────────────
 
 /// Parse a Mermaid `gantt` block into a `GanttDiagram`.
@@ -1518,6 +1763,16 @@ commit id: \"feature\" tag: \"v1\"
 checkout main
 merge develop id: \"merge-1\"";
 
+    const ER_SRC: &str = "erDiagram
+CUSTOMER ||--o{ ORDER : places
+CUSTOMER {
+string name PK \"display name\"
+string email UK
+}
+ORDER[Purchase] {
+int id PK
+}";
+
     #[test]
     fn class_diagram_parses_nodes() {
         let d = parse_class_diagram(CLASS_SRC).unwrap();
@@ -1640,6 +1895,23 @@ merge develop id: \"merge-1\"";
     }
 
     #[test]
+    fn er_parses_entities_attributes_and_cardinalities() {
+        let d = parse_er_diagram(ER_SRC).unwrap();
+        assert_eq!(d.kind, StructuralKind::Er);
+        assert_eq!(
+            d.nodes.iter().map(|node| node.id.as_str()).collect::<Vec<_>>(),
+            vec!["CUSTOMER", "ORDER"]
+        );
+        assert_eq!(d.relationships.len(), 1);
+        assert_eq!(d.relationships[0].from_mult.as_deref(), Some("1"));
+        assert_eq!(d.relationships[0].to_mult.as_deref(), Some("0..*"));
+        let customer = d.nodes.iter().find(|node| node.id == "CUSTOMER").unwrap();
+        assert_eq!(customer.compartments[0].entries.len(), 2);
+        let order = d.nodes.iter().find(|node| node.id == "ORDER").unwrap();
+        assert_eq!(order.label, "Purchase");
+    }
+
+    #[test]
     fn dispatch_flowchart() {
         let src = "flowchart LR\n  A --> B";
         match parse_any_mermaid(src).unwrap() {
@@ -1696,6 +1968,14 @@ merge develop id: \"merge-1\"";
         match parse_any_mermaid(GITGRAPH_SRC).unwrap() {
             MermaidDiagram::Temporal(diagram) => assert_eq!(diagram.kind, TemporalKind::Git),
             _ => panic!("expected Temporal"),
+        }
+    }
+
+    #[test]
+    fn dispatch_er() {
+        match parse_any_mermaid(ER_SRC).unwrap() {
+            MermaidDiagram::Structural(diagram) => assert_eq!(diagram.kind, StructuralKind::Er),
+            _ => panic!("expected Structural"),
         }
     }
 }

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -16,11 +16,17 @@ use diagram_ir::{
 };
 use grammar_tools::parser_grammar::parse_parser_grammar;
 use lexer::token::{Token, TokenType};
-use mermaid_lexer::{tokenize_mermaid, tokenize_mermaid_pie};
+use mermaid_lexer::{
+    tokenize_mermaid, tokenize_mermaid_gitgraph, tokenize_mermaid_pie, tokenize_mermaid_sankey,
+};
 use parser::grammar_parser::{GrammarASTNode, GrammarParser, DEFAULT_MAX_RULE_DEPTH};
 
 const PARSER_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/mermaid.grammar");
 const PIE_PARSER_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/pie.grammar");
+const SANKEY_PARSER_GRAMMAR_SOURCE: &str =
+    include_str!("../../../../grammars/mermaid/sankey.grammar");
+const GITGRAPH_PARSER_GRAMMAR_SOURCE: &str =
+    include_str!("../../../../grammars/mermaid/gitgraph.grammar");
 
 /// Recursion-depth cap for the Mermaid [`GrammarParser`] — see
 /// [`GrammarParser::with_max_depth`] for why this guard exists at all (deep
@@ -181,6 +187,30 @@ pub fn parse_mermaid_pie_ast(source: &str) -> Result<GrammarASTNode, ParseError>
     let tokens = tokenize_mermaid_pie(source);
     let grammar = parse_parser_grammar(PIE_PARSER_GRAMMAR_SOURCE)
         .unwrap_or_else(|e| panic!("Failed to parse pie.grammar: {e}"));
+    let mut parser = GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH);
+    parser.parse().map_err(|e| ParseError {
+        message: e.message,
+        line: e.token.line,
+        col: e.token.column,
+    })
+}
+
+pub fn parse_mermaid_sankey_ast(source: &str) -> Result<GrammarASTNode, ParseError> {
+    let tokens = tokenize_mermaid_sankey(source);
+    let grammar = parse_parser_grammar(SANKEY_PARSER_GRAMMAR_SOURCE)
+        .unwrap_or_else(|e| panic!("Failed to parse sankey.grammar: {e}"));
+    let mut parser = GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH);
+    parser.parse().map_err(|e| ParseError {
+        message: e.message,
+        line: e.token.line,
+        col: e.token.column,
+    })
+}
+
+pub fn parse_mermaid_gitgraph_ast(source: &str) -> Result<GrammarASTNode, ParseError> {
+    let tokens = tokenize_mermaid_gitgraph(source);
+    let grammar = parse_parser_grammar(GITGRAPH_PARSER_GRAMMAR_SOURCE)
+        .unwrap_or_else(|e| panic!("Failed to parse gitgraph.grammar: {e}"));
     let mut parser = GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH);
     parser.parse().map_err(|e| ParseError {
         message: e.message,
@@ -352,6 +382,7 @@ fn token_name(token: &Token) -> &str {
         TokenType::String => "STRING",
         TokenType::Keyword => "KEYWORD",
         TokenType::Colon => "COLON",
+        TokenType::Comma => "COMMA",
         TokenType::Newline => "NEWLINE",
         TokenType::Semicolon => "SEMICOLON",
         TokenType::Eof => "EOF",
@@ -365,9 +396,10 @@ fn token_name(token: &Token) -> &str {
 
 use diagram_ir::{
     Axis, AxisKind, ChartDiagram, ChartKind, ChartOrientation, ChartSeries, Compartment,
-    CompartmentKind, GanttDiagram, GanttSection, GanttTask, PieSlice, RelKind, SeriesKind,
-    StructuralDiagram, StructuralKind, StructuralNode, StructuralNodeKind, StructuralRelationship,
-    TaskStart, TaskStatus, TemporalBody, TemporalDiagram, TemporalKind,
+    CompartmentKind, GanttDiagram, GanttSection, GanttTask, GitBranch, GitDiagram, GitEvent,
+    PieSlice, RelKind, SankeyFlow, SankeyNode, SeriesKind, StructuralDiagram, StructuralKind,
+    StructuralNode, StructuralNodeKind, StructuralRelationship, TaskStart, TaskStatus, TemporalBody,
+    TemporalDiagram, TemporalKind,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -447,7 +479,13 @@ impl MermaidDiagramType {
     pub fn has_native_pipeline(self) -> bool {
         matches!(
             self,
-            Self::Flowchart | Self::Class | Self::Gantt | Self::Pie | Self::XyChart
+            Self::Flowchart
+                | Self::Class
+                | Self::Gantt
+                | Self::GitGraph
+                | Self::Pie
+                | Self::Sankey
+                | Self::XyChart
         )
     }
 }
@@ -524,6 +562,14 @@ pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
         MermaidDiagramType::Class => parse_class_diagram(source).map(MermaidDiagram::Structural),
         MermaidDiagramType::XyChart => parse_xychart(source).map(MermaidDiagram::Chart),
         MermaidDiagramType::Pie => parse_pie(source).map(MermaidDiagram::Chart),
+        MermaidDiagramType::Sankey => parse_sankey(source).map(MermaidDiagram::Chart),
+        MermaidDiagramType::GitGraph => parse_gitgraph(source).map(|git| {
+            MermaidDiagram::Temporal(TemporalDiagram {
+                kind: TemporalKind::Git,
+                title: None,
+                body: TemporalBody::Git(git),
+            })
+        }),
         MermaidDiagramType::Gantt => parse_gantt(source).map(|g| {
             MermaidDiagram::Temporal(TemporalDiagram {
                 kind: TemporalKind::Gantt,
@@ -988,6 +1034,253 @@ fn unquote_mermaid_string(raw: &str) -> String {
     result
 }
 
+// ── Sankey parser ─────────────────────────────────────────────────────────
+
+/// Parse Mermaid's three-column Sankey CSV dialect into the shared chart IR.
+pub fn parse_sankey(source: &str) -> Result<ChartDiagram, ParseError> {
+    parse_mermaid_sankey_ast(source)?;
+
+    let mut cursor = TokenCursor::new(tokenize_mermaid_sankey(source));
+    cursor.skip_terminators();
+    cursor
+        .consume_if("HEADER")
+        .ok_or_else(|| token_error(cursor.current(), "expected Sankey header"))?;
+    cursor.skip_terminators();
+
+    let mut nodes: Vec<SankeyNode> = Vec::new();
+    let mut flows: Vec<SankeyFlow> = Vec::new();
+
+    while !cursor.at_eof() {
+        let source_id = parse_sankey_field(&mut cursor)?;
+        cursor
+            .consume_if("COMMA")
+            .ok_or_else(|| token_error(cursor.current(), "expected ',' after Sankey source"))?;
+        let target_id = parse_sankey_field(&mut cursor)?;
+        cursor
+            .consume_if("COMMA")
+            .ok_or_else(|| token_error(cursor.current(), "expected ',' after Sankey target"))?;
+        let weight_token = cursor
+            .consume_if("NUMBER")
+            .ok_or_else(|| token_error(cursor.current(), "expected Sankey flow weight"))?;
+        let weight = weight_token.value.parse::<f64>().map_err(|_| {
+            token_error(
+                &weight_token,
+                format!("invalid Sankey flow weight {:?}", weight_token.value),
+            )
+        })?;
+
+        for id in [&source_id, &target_id] {
+            if !nodes.iter().any(|node| node.id == *id) {
+                nodes.push(SankeyNode {
+                    id: id.clone(),
+                    label: Some(id.clone()),
+                });
+            }
+        }
+        flows.push(SankeyFlow {
+            source: source_id,
+            target: target_id,
+            weight,
+        });
+        cursor.skip_terminators();
+    }
+
+    Ok(ChartDiagram {
+        title: None,
+        kind: ChartKind::Sankey,
+        x_axis: None,
+        y_axis: None,
+        series: vec![],
+        slices: vec![],
+        sankey_nodes: nodes,
+        flows,
+        orientation: ChartOrientation::Horizontal,
+    })
+}
+
+fn parse_sankey_field(cursor: &mut TokenCursor) -> Result<String, ParseError> {
+    let token = cursor.current().clone();
+    if !matches!(token_name(&token), "STRING" | "BARE_FIELD" | "NUMBER") {
+        return Err(token_error(&token, "expected Sankey CSV field"));
+    }
+
+    let value = cursor.advance().value.trim().replace("\"\"", "\"");
+    if value.is_empty() {
+        return Err(token_error(&token, "Sankey CSV fields cannot be empty"));
+    }
+    Ok(value)
+}
+
+// ── GitGraph parser ───────────────────────────────────────────────────────
+
+/// Parse Mermaid GitGraph syntax into the shared temporal IR.
+///
+/// The grammar accepts Mermaid's complete command surface. Cherry-pick is
+/// rejected during lowering until the temporal IR can represent it without
+/// losing parent-commit semantics.
+pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
+    parse_mermaid_gitgraph_ast(source)?;
+
+    let mut cursor = TokenCursor::new(tokenize_mermaid_gitgraph(source));
+    cursor.skip_terminators();
+    cursor
+        .consume_if("HEADER")
+        .ok_or_else(|| token_error(cursor.current(), "expected GitGraph header"))?;
+
+    let direction = cursor
+        .consume_if("DIRECTION")
+        .map(|token| direction_from_token(&token))
+        .transpose()?
+        .unwrap_or(DiagramDirection::Lr);
+    cursor.consume_if("COLON");
+    cursor.skip_terminators();
+
+    let mut branches = vec![GitBranch {
+        name: "main".to_string(),
+    }];
+    let mut events = Vec::new();
+    let mut current_branch = "main".to_string();
+
+    while !cursor.at_eof() {
+        let command = cursor.current().clone();
+        match command.value.as_str() {
+            "commit" => {
+                cursor.advance();
+                let mut id = None;
+                let mut message = None;
+                let mut tag = None;
+                while !gitgraph_statement_ended(&cursor) {
+                    match token_name(cursor.current()) {
+                        "ID_ATTR" => {
+                            cursor.advance();
+                            id = Some(parse_gitgraph_string(&mut cursor, "commit id")?);
+                        }
+                        "MSG_ATTR" => {
+                            cursor.advance();
+                            message = Some(parse_gitgraph_string(&mut cursor, "commit message")?);
+                        }
+                        "TAG_ATTR" => {
+                            cursor.advance();
+                            tag = Some(parse_gitgraph_string(&mut cursor, "commit tag")?);
+                        }
+                        "TYPE_ATTR" => {
+                            cursor.advance();
+                            expect_gitgraph_token(&mut cursor, "COMMIT_TYPE", "commit type")?;
+                        }
+                        "STRING" => {
+                            message = Some(cursor.advance().value.clone());
+                        }
+                        _ => return Err(token_error(cursor.current(), "invalid commit attribute")),
+                    }
+                }
+                events.push(GitEvent::Commit {
+                    id,
+                    message,
+                    tag,
+                    branch: current_branch.clone(),
+                });
+            }
+            "branch" => {
+                cursor.advance();
+                let branch = parse_gitgraph_reference(&mut cursor)?;
+                if cursor.consume_if("ORDER_ATTR").is_some() {
+                    expect_gitgraph_token(&mut cursor, "INT", "branch order")?;
+                }
+                if !branches.iter().any(|candidate| candidate.name == branch) {
+                    branches.push(GitBranch { name: branch });
+                }
+            }
+            "checkout" | "switch" => {
+                cursor.advance();
+                let branch = parse_gitgraph_reference(&mut cursor)?;
+                if !branches.iter().any(|candidate| candidate.name == branch) {
+                    return Err(token_error(
+                        &command,
+                        format!("cannot checkout unknown GitGraph branch {branch:?}"),
+                    ));
+                }
+                current_branch = branch.clone();
+                events.push(GitEvent::Checkout { branch });
+            }
+            "merge" => {
+                cursor.advance();
+                let from = parse_gitgraph_reference(&mut cursor)?;
+                let mut id = None;
+                let mut tag = None;
+                while !gitgraph_statement_ended(&cursor) {
+                    match token_name(cursor.current()) {
+                        "ID_ATTR" => {
+                            cursor.advance();
+                            id = Some(parse_gitgraph_string(&mut cursor, "merge id")?);
+                        }
+                        "TAG_ATTR" => {
+                            cursor.advance();
+                            tag = Some(parse_gitgraph_string(&mut cursor, "merge tag")?);
+                        }
+                        "TYPE_ATTR" => {
+                            cursor.advance();
+                            expect_gitgraph_token(&mut cursor, "COMMIT_TYPE", "merge type")?;
+                        }
+                        _ => return Err(token_error(cursor.current(), "invalid merge attribute")),
+                    }
+                }
+                events.push(GitEvent::Merge { from, id, tag });
+            }
+            "cherry-pick" => {
+                return Err(token_error(
+                    &command,
+                    "GitGraph cherry-pick is recognized but requires a native temporal IR event",
+                ));
+            }
+            _ => {
+                return Err(token_error(
+                    &command,
+                    format!("unsupported GitGraph command {:?}", command.value),
+                ));
+            }
+        }
+        cursor.skip_terminators();
+    }
+
+    Ok(GitDiagram {
+        direction,
+        branches,
+        events,
+    })
+}
+
+fn gitgraph_statement_ended(cursor: &TokenCursor) -> bool {
+    cursor.at_eof() || token_name(cursor.current()) == "NEWLINE"
+}
+
+fn parse_gitgraph_reference(cursor: &mut TokenCursor) -> Result<String, ParseError> {
+    let token = cursor.current().clone();
+    if !matches!(token_name(&token), "REFERENCE" | "STRING") {
+        return Err(token_error(&token, "expected GitGraph reference"));
+    }
+    Ok(cursor.advance().value.clone())
+}
+
+fn parse_gitgraph_string(
+    cursor: &mut TokenCursor,
+    description: &str,
+) -> Result<String, ParseError> {
+    Ok(expect_gitgraph_token(cursor, "STRING", description)?.value)
+}
+
+fn expect_gitgraph_token(
+    cursor: &mut TokenCursor,
+    name: &str,
+    description: &str,
+) -> Result<Token, ParseError> {
+    cursor.consume_if(name).ok_or_else(|| {
+        token_error(
+            cursor.current(),
+            format!("expected GitGraph {description}"),
+        )
+    })
+}
+
 // ── gantt parser ──────────────────────────────────────────────────────────
 
 /// Parse a Mermaid `gantt` block into a `GanttDiagram`.
@@ -1156,6 +1449,18 @@ mod tests_dg04 {
   \"Dogs\" : 60
   \"Cats\" : 40";
 
+    const SANKEY_SRC: &str = "sankey
+Grid,\"Heating, homes\",113.726
+Grid,Losses,56";
+
+    const GITGRAPH_SRC: &str = "gitGraph LR:
+commit id: \"root\" msg: \"Initial commit\"
+branch develop order: 1
+checkout develop
+commit id: \"feature\" tag: \"v1\"
+checkout main
+merge develop id: \"merge-1\"";
+
     #[test]
     fn class_diagram_parses_nodes() {
         let d = parse_class_diagram(CLASS_SRC).unwrap();
@@ -1236,6 +1541,40 @@ mod tests_dg04 {
     }
 
     #[test]
+    fn sankey_parses_csv_flows_and_nodes() {
+        let d = parse_sankey(SANKEY_SRC).unwrap();
+        assert_eq!(d.kind, ChartKind::Sankey);
+        assert_eq!(d.flows.len(), 2);
+        assert_eq!(d.sankey_nodes.len(), 3);
+        assert_eq!(d.flows[0].target, "Heating, homes");
+        assert_eq!(d.flows[0].weight, 113.726);
+    }
+
+    #[test]
+    fn gitgraph_parses_branch_history() {
+        let d = parse_gitgraph(GITGRAPH_SRC).unwrap();
+        assert_eq!(d.direction, DiagramDirection::Lr);
+        assert_eq!(d.branches.len(), 2);
+        assert_eq!(d.events.len(), 5);
+        assert!(matches!(
+            &d.events[1],
+            GitEvent::Checkout { branch } if branch == "develop"
+        ));
+        assert!(matches!(
+            &d.events[4],
+            GitEvent::Merge { from, id, .. }
+                if from == "develop" && id.as_deref() == Some("merge-1")
+        ));
+    }
+
+    #[test]
+    fn gitgraph_reports_cherry_pick_ir_gap() {
+        let error = parse_gitgraph("gitGraph\ncherry-pick id: \"abc123\"").unwrap_err();
+        assert!(error.message.contains("cherry-pick"));
+        assert!(error.message.contains("temporal IR"));
+    }
+
+    #[test]
     fn dispatch_flowchart() {
         let src = "flowchart LR\n  A --> B";
         match parse_any_mermaid(src).unwrap() {
@@ -1276,6 +1615,22 @@ mod tests_dg04 {
         match parse_any_mermaid(PIE_SRC).unwrap() {
             MermaidDiagram::Chart(chart) => assert_eq!(chart.kind, ChartKind::Pie),
             _ => panic!("expected Chart"),
+        }
+    }
+
+    #[test]
+    fn dispatch_sankey() {
+        match parse_any_mermaid(SANKEY_SRC).unwrap() {
+            MermaidDiagram::Chart(chart) => assert_eq!(chart.kind, ChartKind::Sankey),
+            _ => panic!("expected Chart"),
+        }
+    }
+
+    #[test]
+    fn dispatch_gitgraph() {
+        match parse_any_mermaid(GITGRAPH_SRC).unwrap() {
+            MermaidDiagram::Temporal(diagram) => assert_eq!(diagram.kind, TemporalKind::Git),
+            _ => panic!("expected Temporal"),
         }
     }
 }

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -396,10 +396,10 @@ fn token_name(token: &Token) -> &str {
 
 use diagram_ir::{
     Axis, AxisKind, ChartDiagram, ChartKind, ChartOrientation, ChartSeries, Compartment,
-    CompartmentKind, GanttDiagram, GanttSection, GanttTask, GitBranch, GitDiagram, GitEvent,
-    PieSlice, RelKind, SankeyFlow, SankeyNode, SeriesKind, StructuralDiagram, StructuralKind,
-    StructuralNode, StructuralNodeKind, StructuralRelationship, TaskStart, TaskStatus, TemporalBody,
-    TemporalDiagram, TemporalKind,
+    CompartmentKind, GanttDiagram, GanttSection, GanttTask, GitBranch, GitCommitType, GitDiagram,
+    GitEvent, PieSlice, RelKind, SankeyFlow, SankeyNode, SeriesKind, StructuralDiagram,
+    StructuralKind, StructuralNode, StructuralNodeKind, StructuralRelationship, TaskStart,
+    TaskStatus, TemporalBody, TemporalDiagram, TemporalKind,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1115,9 +1115,8 @@ fn parse_sankey_field(cursor: &mut TokenCursor) -> Result<String, ParseError> {
 
 /// Parse Mermaid GitGraph syntax into the shared temporal IR.
 ///
-/// The grammar accepts Mermaid's complete command surface. Cherry-pick is
-/// rejected during lowering until the temporal IR can represent it without
-/// losing parent-commit semantics.
+/// The grammar and temporal IR preserve Mermaid's complete command surface,
+/// including branch order, commit types, and cherry-pick parent metadata.
 pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
     parse_mermaid_gitgraph_ast(source)?;
 
@@ -1137,6 +1136,7 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
 
     let mut branches = vec![GitBranch {
         name: "main".to_string(),
+        order: None,
     }];
     let mut events = Vec::new();
     let mut current_branch = "main".to_string();
@@ -1149,6 +1149,7 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                 let mut id = None;
                 let mut message = None;
                 let mut tag = None;
+                let mut type_ = GitCommitType::Normal;
                 while !gitgraph_statement_ended(&cursor) {
                     match token_name(cursor.current()) {
                         "ID_ATTR" => {
@@ -1165,7 +1166,7 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                         }
                         "TYPE_ATTR" => {
                             cursor.advance();
-                            expect_gitgraph_token(&mut cursor, "COMMIT_TYPE", "commit type")?;
+                            type_ = parse_gitgraph_commit_type(&mut cursor)?;
                         }
                         "STRING" => {
                             message = Some(cursor.advance().value.clone());
@@ -1178,16 +1179,24 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                     message,
                     tag,
                     branch: current_branch.clone(),
+                    type_,
                 });
             }
             "branch" => {
                 cursor.advance();
                 let branch = parse_gitgraph_reference(&mut cursor)?;
+                let mut order = None;
                 if cursor.consume_if("ORDER_ATTR").is_some() {
-                    expect_gitgraph_token(&mut cursor, "INT", "branch order")?;
+                    let token = expect_gitgraph_token(&mut cursor, "INT", "branch order")?;
+                    order = Some(token.value.parse::<i64>().map_err(|_| {
+                        token_error(&token, format!("invalid branch order {:?}", token.value))
+                    })?);
                 }
                 if !branches.iter().any(|candidate| candidate.name == branch) {
-                    branches.push(GitBranch { name: branch });
+                    branches.push(GitBranch {
+                        name: branch,
+                        order,
+                    });
                 }
             }
             "checkout" | "switch" => {
@@ -1207,6 +1216,7 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                 let from = parse_gitgraph_reference(&mut cursor)?;
                 let mut id = None;
                 let mut tag = None;
+                let mut type_ = GitCommitType::Normal;
                 while !gitgraph_statement_ended(&cursor) {
                     match token_name(cursor.current()) {
                         "ID_ATTR" => {
@@ -1219,18 +1229,55 @@ pub fn parse_gitgraph(source: &str) -> Result<GitDiagram, ParseError> {
                         }
                         "TYPE_ATTR" => {
                             cursor.advance();
-                            expect_gitgraph_token(&mut cursor, "COMMIT_TYPE", "merge type")?;
+                            type_ = parse_gitgraph_commit_type(&mut cursor)?;
                         }
                         _ => return Err(token_error(cursor.current(), "invalid merge attribute")),
                     }
                 }
-                events.push(GitEvent::Merge { from, id, tag });
+                events.push(GitEvent::Merge {
+                    from,
+                    id,
+                    tag,
+                    type_,
+                });
             }
             "cherry-pick" => {
-                return Err(token_error(
-                    &command,
-                    "GitGraph cherry-pick is recognized but requires a native temporal IR event",
-                ));
+                cursor.advance();
+                let mut id = None;
+                let mut tag = None;
+                let mut parent = None;
+                while !gitgraph_statement_ended(&cursor) {
+                    match token_name(cursor.current()) {
+                        "ID_ATTR" => {
+                            cursor.advance();
+                            id = Some(parse_gitgraph_string(&mut cursor, "cherry-pick id")?);
+                        }
+                        "TAG_ATTR" => {
+                            cursor.advance();
+                            tag = Some(parse_gitgraph_string(&mut cursor, "cherry-pick tag")?);
+                        }
+                        "PARENT_ATTR" => {
+                            cursor.advance();
+                            parent =
+                                Some(parse_gitgraph_string(&mut cursor, "cherry-pick parent")?);
+                        }
+                        _ => {
+                            return Err(token_error(
+                                cursor.current(),
+                                "invalid cherry-pick attribute",
+                            ));
+                        }
+                    }
+                }
+                let id = id.ok_or_else(|| {
+                    token_error(&command, "GitGraph cherry-pick requires an id attribute")
+                })?;
+                events.push(GitEvent::CherryPick {
+                    id,
+                    tag,
+                    parent,
+                    branch: current_branch.clone(),
+                });
             }
             _ => {
                 return Err(token_error(
@@ -1268,17 +1315,27 @@ fn parse_gitgraph_string(
     Ok(expect_gitgraph_token(cursor, "STRING", description)?.value)
 }
 
+fn parse_gitgraph_commit_type(cursor: &mut TokenCursor) -> Result<GitCommitType, ParseError> {
+    let token = expect_gitgraph_token(cursor, "COMMIT_TYPE", "commit type")?;
+    match token.value.as_str() {
+        "NORMAL" => Ok(GitCommitType::Normal),
+        "REVERSE" => Ok(GitCommitType::Reverse),
+        "HIGHLIGHT" => Ok(GitCommitType::Highlight),
+        _ => Err(token_error(
+            &token,
+            format!("invalid GitGraph commit type {:?}", token.value),
+        )),
+    }
+}
+
 fn expect_gitgraph_token(
     cursor: &mut TokenCursor,
     name: &str,
     description: &str,
 ) -> Result<Token, ParseError> {
-    cursor.consume_if(name).ok_or_else(|| {
-        token_error(
-            cursor.current(),
-            format!("expected GitGraph {description}"),
-        )
-    })
+    cursor
+        .consume_if(name)
+        .ok_or_else(|| token_error(cursor.current(), format!("expected GitGraph {description}")))
 }
 
 // ── gantt parser ──────────────────────────────────────────────────────────
@@ -1568,10 +1625,18 @@ merge develop id: \"merge-1\"";
     }
 
     #[test]
-    fn gitgraph_reports_cherry_pick_ir_gap() {
-        let error = parse_gitgraph("gitGraph\ncherry-pick id: \"abc123\"").unwrap_err();
-        assert!(error.message.contains("cherry-pick"));
-        assert!(error.message.contains("temporal IR"));
+    fn gitgraph_parses_cherry_pick_metadata() {
+        let d = parse_gitgraph(
+            "gitGraph\ncommit id: \"abc123\"\ncherry-pick id: \"abc123\" parent: \"root\"",
+        )
+        .unwrap();
+        assert!(matches!(
+            &d.events[1],
+            GitEvent::CherryPick { id, parent, branch, .. }
+                if id == "abc123"
+                    && parent.as_deref() == Some("root")
+                    && branch == "main"
+        ));
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/compatibility.rs
+++ b/code/packages/rust/mermaid-parser/tests/compatibility.rs
@@ -1,0 +1,65 @@
+use mermaid_parser::{detect_mermaid_type, parse_any_mermaid, MERMAID_COMPATIBILITY_BASELINE};
+use serde_json::Value;
+
+const COMPATIBILITY_MANIFEST: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../grammars/mermaid/compatibility.json"
+));
+
+#[test]
+fn compatibility_manifest_matches_detector_and_dispatch() {
+    let manifest: Value =
+        serde_json::from_str(COMPATIBILITY_MANIFEST).expect("compatibility manifest must be JSON");
+    assert_eq!(
+        manifest["upstream"]["version"].as_str(),
+        Some(MERMAID_COMPATIBILITY_BASELINE)
+    );
+
+    let families = manifest["families"]
+        .as_array()
+        .expect("families must be an array");
+    assert!(
+        families.len() >= 32,
+        "the Mermaid 11.16.1 baseline should enumerate every documented family"
+    );
+
+    for family in families {
+        let id = family["id"].as_str().expect("family id must be a string");
+        let smoke_source = family["smoke_source"]
+            .as_str()
+            .expect("family smoke_source must be a string");
+        let detected = detect_mermaid_type(smoke_source)
+            .unwrap_or_else(|error| panic!("failed to detect {id}: {error}"));
+        assert_eq!(detected.canonical_id(), id);
+
+        if family["status"].as_str() == Some("partial") {
+            parse_any_mermaid(smoke_source)
+                .unwrap_or_else(|error| panic!("partial family {id} must parse: {error}"));
+            assert!(detected.has_native_pipeline());
+        }
+    }
+}
+
+#[test]
+fn detection_skips_front_matter_directives_and_comments() {
+    let source = r#"---
+title: Example
+---
+%%{init: {"theme": "neutral"}}%%
+%% comment
+sequenceDiagram
+Alice->>Bob: Hello
+"#;
+
+    let detected = detect_mermaid_type(source).expect("sequence diagram should be detected");
+    assert_eq!(detected.canonical_id(), "sequence");
+}
+
+#[test]
+fn recognized_but_unimplemented_family_is_not_reported_as_unknown() {
+    let error = parse_any_mermaid("sequenceDiagram\nAlice->>Bob: Hello")
+        .err()
+        .expect("sequence support is not implemented yet");
+    assert!(error.message.contains("recognized but not implemented"));
+    assert!(error.message.contains(MERMAID_COMPATIBILITY_BASELINE));
+}

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -1,0 +1,201 @@
+# DG04 - Mermaid Compatibility Program
+
+> Status: Draft
+>
+> Baseline: Mermaid 11.16.1, tag `mermaid@11.16.1`, commit
+> `7ecca0cd7f1658ef74f4e7e91f925724ef403bbf`
+
+## Goal
+
+Reach practical compatibility with the full Mermaid language while preserving
+the native rendering pipeline:
+
+```text
+Mermaid source
+  -> shared family grammar
+  -> source AST
+  -> semantic Diagram IR
+  -> family layout
+  -> PaintScene / PaintInstructions
+  -> Metal / Direct2D / SVG / WGPU / other Paint VM backends
+```
+
+Compatibility is versioned. "Full Mermaid" means the pinned release, not the
+moving contents of Mermaid's development branch.
+
+The machine-readable baseline is
+`code/grammars/mermaid/compatibility.json`. Every language implementation and
+CI report should consume the same manifest.
+
+## Why This Is A Program, Not One Parser
+
+Mermaid is a dispatcher over many independent languages. Flowcharts, sequence
+diagrams, Gantt charts, packet diagrams, Sankey charts, and Wardley maps do not
+share one useful context-free grammar or one useful semantic model.
+
+The repository should therefore keep:
+
+- one detector that recognizes every Mermaid family and alias;
+- one shared token and parser grammar per family where a grammar is applicable;
+- one source AST per family;
+- a small set of reusable semantic IR families;
+- specialized IRs only where the semantics are genuinely different;
+- one common final lowering into PaintScene.
+
+A monolithic Mermaid grammar would couple unrelated syntaxes and make
+cross-language generation harder.
+
+## Compatibility Levels
+
+Each family advances independently through these levels:
+
+| Level | Name | Requirement |
+|---|---|---|
+| 0 | Detected | Header, aliases, front matter, directives, and comments are recognized. |
+| 1 | Parsed | The pinned syntax corpus produces a source AST with useful errors and locations. |
+| 2 | Lowered | All source semantics are represented without lossy paint-specific shortcuts. |
+| 3 | Layouted | The family layout package produces deterministic geometry. |
+| 4 | Native | The layout lowers to PaintScene and renders on the Tier 1 native backends. |
+| 5 | Compatible | Syntax fixtures and tolerant visual fixtures pass against the pinned release. |
+
+The word `partial` in the compatibility manifest currently means Levels 1
+through 4 exist for a documented subset. It does not mean full family
+compatibility.
+
+## Current Baseline
+
+The first native subsets are:
+
+- Flowchart and graph
+- Class diagram
+- Gantt
+- Pie
+- XY chart
+
+The existing IR already has useful downstream capacity for the next group:
+
+| Mermaid family | Existing semantic target | Existing layout and paint |
+|---|---|---|
+| Sankey | `ChartDiagram::Sankey` | Yes |
+| GitGraph | `TemporalDiagram::Git` | Yes |
+| ER | `StructuralDiagram::Er` | Yes |
+| C4 | `StructuralDiagram::C4` | Yes |
+
+These should be implemented before inventing new IR families.
+
+## Required New Semantic Families
+
+The remaining languages cluster into reusable domains:
+
+| Domain | Mermaid families |
+|---|---|
+| Sequence | Sequence Diagram, ZenUML |
+| State | State Diagram |
+| Hierarchy | Mindmap, Treemap, TreeView |
+| Board and lanes | Kanban, Swimlane, Block |
+| Quantitative chart | Quadrant, Radar, Venn |
+| Chronology | Timeline, Journey |
+| Systems modeling | Requirement, Architecture, Event Modeling |
+| Grammar | Railroad, EBNF, ABNF, PEG |
+| Specialized geometry | Packet, Sankey, Ishikawa, Wardley, Cynefin |
+
+Sharing a domain IR does not require sharing a source AST. For example,
+Sequence Diagram and ZenUML should have different parsers but may lower into
+the same participant/message/lifeline IR.
+
+## Grammar Source Of Truth
+
+Shared grammar files live under:
+
+```text
+code/grammars/mermaid/
+  compatibility.json
+  <family>.tokens
+  <family>.grammar
+```
+
+The grammar files are the portable syntax source for Rust, TypeScript, Go,
+Python, Ruby, and future implementations. Language packages may contain
+semantic AST builders and lowerers, but must not redefine the accepted syntax
+with an unrelated handwritten parser.
+
+Some Mermaid families use embedded encodings rather than ordinary grammars:
+
+- Sankey contains RFC 4180-like CSV rows.
+- Packet diagrams contain bit-range declarations.
+- Railroad variants embed grammar dialects.
+- Directives and YAML front matter are preprocessing layers.
+
+Those layers should use their existing shared parsers or dedicated portable
+grammars and then feed the family AST.
+
+## Conformance Corpus
+
+Each family needs three fixture tiers:
+
+1. `smoke`: one minimal source proving detection through native paint.
+2. `syntax`: focused fixtures for every documented production and alias.
+3. `visual`: representative diagrams compared with tolerant geometry or image
+   metrics rather than byte-identical PNGs.
+
+The upstream Mermaid package at the pinned tag is the behavioral oracle. CI may
+run it as a development-only oracle, but production rendering must not invoke
+Mermaid JavaScript or round-trip through SVG.
+
+Every upstream version bump must:
+
+1. update `compatibility.json`;
+2. report added and removed families, aliases, and productions;
+3. leave newly introduced behavior explicitly `detected` until implemented;
+4. never silently claim the previous compatibility level.
+
+## Cross-Cutting Mermaid Features
+
+Family syntax is only part of compatibility. The shared frontend also needs:
+
+- YAML front matter and Mermaid directives;
+- `title`, accessibility title, and accessibility description;
+- comments and Unicode text;
+- Markdown strings and entity decoding;
+- theme variables and class/style declarations;
+- links, callbacks, tooltips, and security-level policy;
+- icon and image references;
+- deterministic IDs and stable layout options.
+
+Interactive features should lower into scene metadata or document actions.
+They should not become backend-specific paint instructions.
+
+## Paint And Backend Policy
+
+New Mermaid concepts should become paint instructions only when they describe a
+general graphics primitive. Nodes, participants, tasks, commits, and domains
+remain in Diagram IR.
+
+Likely general-purpose paint needs include:
+
+- text decoration and multiline text metrics;
+- dashed and patterned strokes;
+- robust cubic and arc paths;
+- gradients;
+- image/icon drawing;
+- link and hit-test metadata;
+- clipping and nested transforms.
+
+Backend parity is tracked separately from parser compatibility. A family is not
+Level 4 until its representative scene renders without major degradation on
+the target backend.
+
+## Delivery Order
+
+1. Complete Flowchart syntax while retaining its current graph pipeline.
+2. Add Sankey, GitGraph, ER, and C4 parsers against existing IR capacity.
+3. Add Sequence IR, layout, paint lowering, and both Sequence/ZenUML frontends.
+4. Add State and hierarchy domains.
+5. Add chart, chronology, board, and systems-modeling families.
+6. Add specialized and beta families.
+7. Close cross-cutting configuration, styling, accessibility, interaction, and
+   visual-parity gaps.
+
+Full compatibility is achieved when every manifest family is Level 5 for the
+pinned Mermaid release and unsupported syntax fails explicitly rather than
+silently degrading.


### PR DESCRIPTION
## Summary

- pin Mermaid compatibility to 11.16.1 with a machine-readable 32-family manifest and delivery spec
- add portable token/parser grammars for Pie, Sankey, GitGraph, and ER
- dispatch grammar-backed diagrams into shared chart, temporal, and structural IRs
- preserve GitGraph branch order, commit types, merge metadata, and cherry-pick semantics
- render Pie, Sankey, GitGraph, and ER through layout, PaintScene/PaintInstructions, Metal, and PNG
- paint ER endpoint multiplicities through backend-neutral glyph instructions

## Why

Mermaid is a family dispatcher rather than one language. This establishes a versioned, grammar-first compatibility program that can generate lexers/parsers across supported implementation languages while keeping rendering native and backend-neutral.

The manifest deliberately marks implemented families as partial until syntax and tolerant visual corpora reach the pinned Mermaid release. Detection-only families continue to fail explicitly rather than silently degrading.

## Validation

- `cargo test -p mermaid-lexer -p mermaid-parser -- --nocapture`
- `cargo clippy -p mermaid-lexer -p mermaid-parser --all-targets -- -D warnings`
- `cargo test --lib` in `diagram-to-paint`
- `cargo test --test e2e_render -- --nocapture` on Apple: 6 Metal-to-PNG tests passed
- visual inspection of Pie, Sankey, GitGraph, and ER PNG output

## Follow-up scope

C4 is next because structural IR/layout/paint already exist. Sequence/ZenUML then require the first new shared semantic family. The compatibility manifest remains the source of truth for those follow-ups.