### PR TITLE
Add BJT RE parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `RE` emitter resistance.
 - Validate and lower BJT model-card `VTF` forward transit-time voltage scale.
 - Validate and lower BJT model-card `ITF` forward transit-time current.
 - Validate and lower BJT model-card `XTF` forward transit-time bias

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1350,6 +1350,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Xtf=model.params.get("XTF", 0.0),
             Itf=model.params.get("ITF", 0.0),
             Vtf=model.params.get("VTF", 0.0),
+            Re=model.params.get("RE", 0.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2291,6 +2292,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or forward_transit_time_voltage < 0.0
         ):
             raise NetlistParseError("BJT VTF must be finite and non-negative")
+        emitter_resistance = params.get("RE")
+        if emitter_resistance is not None and (
+            not math.isfinite(emitter_resistance) or emitter_resistance < 0.0
+        ):
+            raise NetlistParseError("BJT RE must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1940,6 +1940,23 @@ def test_rejects_invalid_bjt_forward_transit_time_voltage(value: str) -> None:
         parse_netlist(f".model fast NPN(VTF={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("12.5", 12.5)])
+def test_parse_bjt_emitter_resistance(value: str, expected: float) -> None:
+    parsed = parse_netlist(f".model fast NPN(RE={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Re == expected
+
+
+@pytest.mark.parametrize("value", ["-1", "1e999"])
+def test_rejects_invalid_bjt_emitter_resistance(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT RE must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN(RE={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `RE` emitter resistance.
 - Validate and lower BJT model-card `VTF` forward transit-time voltage scale.
 - Validate and lower BJT model-card `ITF` forward transit-time current.
 - Validate and lower BJT model-card `XTF` forward transit-time bias

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1572,6 +1572,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT VTF must be finite and non-negative");
   }
+  const bjtEmitterResistance = params.get("RE");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtEmitterResistance !== undefined &&
+    (!Number.isFinite(bjtEmitterResistance) || bjtEmitterResistance < 0.0)
+  ) {
+    throw new NetlistParseError("BJT RE must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2315,6 +2323,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("XTF") ?? 0.0,
       model.params.get("ITF") ?? 0.0,
       model.params.get("VTF") ?? 0.0,
+      model.params.get("RE") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2011,6 +2011,24 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["12.5", 12.5],
+  ])("parses BJT emitter resistance RE=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(RE=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      emitterResistance: expected,
+    });
+  });
+
+  it.each(["-1", "1e999"])("rejects invalid BJT RE=%s", (value) => {
+    expect(() => parseNetlist(`.model fast NPN(RE=${value})`)).toThrow(
+      "BJT RE must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4668,9 +4668,14 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine forward-transit-time-current field.
 
 466. Python and TypeScript Berkeley SPICE BJT transit-time-voltage parity.
-   - Status: implemented in this BJT VTF parity slice.
+   - Status: completed in PR 10136.
    - Both parser facades validate finite, non-negative `VTF` values and lower
      them into the shared engine forward-transit-time-voltage-scale field.
+
+467. Python and TypeScript Berkeley SPICE BJT emitter-resistance parity.
+   - Status: implemented in this BJT RE parity slice.
+   - Both parser facades validate finite, non-negative `RE` values and lower
+     them into the shared engine emitter-resistance field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite, non-negative BJT model-card `RE` values in both parser facades
- lower `RE` into the shared engine emitter-resistance field
- cover zero, positive, negative, and non-finite values and update the SPICE plan

## Testing
- Python parser `bash BUILD` (598 passed, 90.38% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (583 passed)
- TypeScript parser `npx vitest run --coverage` (88.03% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
