### PR TITLE
Add BJT RC parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `RC` collector resistance.
 - Validate and lower BJT model-card `RE` emitter resistance.
 - Validate and lower BJT model-card `VTF` forward transit-time voltage scale.
 - Validate and lower BJT model-card `ITF` forward transit-time current.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1351,6 +1351,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Itf=model.params.get("ITF", 0.0),
             Vtf=model.params.get("VTF", 0.0),
             Re=model.params.get("RE", 0.0),
+            Rc=model.params.get("RC", 0.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2297,6 +2298,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(emitter_resistance) or emitter_resistance < 0.0
         ):
             raise NetlistParseError("BJT RE must be finite and non-negative")
+        collector_resistance = params.get("RC")
+        if collector_resistance is not None and (
+            not math.isfinite(collector_resistance) or collector_resistance < 0.0
+        ):
+            raise NetlistParseError("BJT RC must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1957,6 +1957,23 @@ def test_rejects_invalid_bjt_emitter_resistance(value: str) -> None:
         parse_netlist(f".model fast NPN(RE={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("13.5", 13.5)])
+def test_parse_bjt_collector_resistance(value: str, expected: float) -> None:
+    parsed = parse_netlist(f".model fast NPN(RC={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Rc == expected
+
+
+@pytest.mark.parametrize("value", ["-1", "1e999"])
+def test_rejects_invalid_bjt_collector_resistance(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT RC must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN(RC={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `RC` collector resistance.
 - Validate and lower BJT model-card `RE` emitter resistance.
 - Validate and lower BJT model-card `VTF` forward transit-time voltage scale.
 - Validate and lower BJT model-card `ITF` forward transit-time current.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1580,6 +1580,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT RE must be finite and non-negative");
   }
+  const bjtCollectorResistance = params.get("RC");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtCollectorResistance !== undefined &&
+    (!Number.isFinite(bjtCollectorResistance) || bjtCollectorResistance < 0.0)
+  ) {
+    throw new NetlistParseError("BJT RC must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2324,6 +2332,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("ITF") ?? 0.0,
       model.params.get("VTF") ?? 0.0,
       model.params.get("RE") ?? 0.0,
+      model.params.get("RC") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2029,6 +2029,24 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["13.5", 13.5],
+  ])("parses BJT collector resistance RC=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(RC=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      collectorResistance: expected,
+    });
+  });
+
+  it.each(["-1", "1e999"])("rejects invalid BJT RC=%s", (value) => {
+    expect(() => parseNetlist(`.model fast NPN(RC=${value})`)).toThrow(
+      "BJT RC must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4673,9 +4673,14 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine forward-transit-time-voltage-scale field.
 
 467. Python and TypeScript Berkeley SPICE BJT emitter-resistance parity.
-   - Status: implemented in this BJT RE parity slice.
+   - Status: completed in PR 10138.
    - Both parser facades validate finite, non-negative `RE` values and lower
      them into the shared engine emitter-resistance field.
+
+468. Python and TypeScript Berkeley SPICE BJT collector-resistance parity.
+   - Status: implemented in this BJT RC parity slice.
+   - Both parser facades validate finite, non-negative `RC` values and lower
+     them into the shared engine collector-resistance field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite, non-negative BJT model-card `RC` values in both parser facades
- lower `RC` into the shared engine collector-resistance field
- cover zero, positive, negative, and non-finite values and update the SPICE plan

## Testing
- Python parser `bash BUILD` (602 passed, 90.40% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (587 passed)
- TypeScript parser `npx vitest run --coverage` (88.06% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
