### PR TITLE
Add BJT RB parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `RB` base resistance.
 - Validate and lower BJT model-card `RC` collector resistance.
 - Validate and lower BJT model-card `RE` emitter resistance.
 - Validate and lower BJT model-card `VTF` forward transit-time voltage scale.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1352,6 +1352,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Vtf=model.params.get("VTF", 0.0),
             Re=model.params.get("RE", 0.0),
             Rc=model.params.get("RC", 0.0),
+            Rb=model.params.get("RB", 0.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2303,6 +2304,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(collector_resistance) or collector_resistance < 0.0
         ):
             raise NetlistParseError("BJT RC must be finite and non-negative")
+        base_resistance = params.get("RB")
+        if base_resistance is not None and (
+            not math.isfinite(base_resistance) or base_resistance < 0.0
+        ):
+            raise NetlistParseError("BJT RB must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1974,6 +1974,23 @@ def test_rejects_invalid_bjt_collector_resistance(value: str) -> None:
         parse_netlist(f".model fast NPN(RC={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("14.5", 14.5)])
+def test_parse_bjt_base_resistance(value: str, expected: float) -> None:
+    parsed = parse_netlist(f".model fast NPN(RB={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Rb == expected
+
+
+@pytest.mark.parametrize("value", ["-1", "1e999"])
+def test_rejects_invalid_bjt_base_resistance(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT RB must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN(RB={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `RB` base resistance.
 - Validate and lower BJT model-card `RC` collector resistance.
 - Validate and lower BJT model-card `RE` emitter resistance.
 - Validate and lower BJT model-card `VTF` forward transit-time voltage scale.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1588,6 +1588,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT RC must be finite and non-negative");
   }
+  const bjtBaseResistance = params.get("RB");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtBaseResistance !== undefined &&
+    (!Number.isFinite(bjtBaseResistance) || bjtBaseResistance < 0.0)
+  ) {
+    throw new NetlistParseError("BJT RB must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2333,6 +2341,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("VTF") ?? 0.0,
       model.params.get("RE") ?? 0.0,
       model.params.get("RC") ?? 0.0,
+      model.params.get("RB") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2047,6 +2047,24 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["14.5", 14.5],
+  ])("parses BJT base resistance RB=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(RB=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseResistance: expected,
+    });
+  });
+
+  it.each(["-1", "1e999"])("rejects invalid BJT RB=%s", (value) => {
+    expect(() => parseNetlist(`.model fast NPN(RB=${value})`)).toThrow(
+      "BJT RB must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4678,9 +4678,14 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine emitter-resistance field.
 
 468. Python and TypeScript Berkeley SPICE BJT collector-resistance parity.
-   - Status: implemented in this BJT RC parity slice.
+   - Status: completed in PR 10140.
    - Both parser facades validate finite, non-negative `RC` values and lower
      them into the shared engine collector-resistance field.
+
+469. Python and TypeScript Berkeley SPICE BJT base-resistance parity.
+   - Status: implemented in this BJT RB parity slice.
+   - Both parser facades validate finite, non-negative `RB` values and lower
+     them into the shared engine base-resistance field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite, non-negative BJT model-card `RB` values in both parser facades
- lower `RB` into the shared engine base-resistance field
- cover zero, positive, negative, and non-finite values and update the SPICE plan

## Testing
- Python parser `bash BUILD` (606 passed, 90.42% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (591 passed)
- TypeScript parser `npx vitest run --coverage` (88.09% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
