### PR TITLE
Add BJT RBM parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower optional BJT model-card `RBM` minimum base resistance.
 - Validate and lower BJT model-card `RB` base resistance.
 - Validate and lower BJT model-card `RC` collector resistance.
 - Validate and lower BJT model-card `RE` emitter resistance.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1353,6 +1353,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Re=model.params.get("RE", 0.0),
             Rc=model.params.get("RC", 0.0),
             Rb=model.params.get("RB", 0.0),
+            Rbm=model.params.get("RBM"),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2309,6 +2310,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(base_resistance) or base_resistance < 0.0
         ):
             raise NetlistParseError("BJT RB must be finite and non-negative")
+        minimum_base_resistance = params.get("RBM")
+        if minimum_base_resistance is not None and (
+            not math.isfinite(minimum_base_resistance)
+            or minimum_base_resistance < 0.0
+        ):
+            raise NetlistParseError("BJT RBM must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1991,6 +1991,31 @@ def test_rejects_invalid_bjt_base_resistance(value: str) -> None:
         parse_netlist(f".model fast NPN(RB={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("2.5", 2.5)])
+def test_parse_bjt_minimum_base_resistance(value: str, expected: float) -> None:
+    parsed = parse_netlist(f".model fast NPN(RBM={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Rbm == expected
+
+
+def test_bjt_omitted_minimum_base_resistance_preserves_fallback() -> None:
+    parsed = parse_netlist(".model fast NPN(RB=14)\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Rbm is None
+
+
+@pytest.mark.parametrize("value", ["-1", "1e999"])
+def test_rejects_invalid_bjt_minimum_base_resistance(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT RBM must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN(RBM={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower optional BJT model-card `RBM` minimum base resistance.
 - Validate and lower BJT model-card `RB` base resistance.
 - Validate and lower BJT model-card `RC` collector resistance.
 - Validate and lower BJT model-card `RE` emitter resistance.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1596,6 +1596,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT RB must be finite and non-negative");
   }
+  const bjtMinimumBaseResistance = params.get("RBM");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtMinimumBaseResistance !== undefined &&
+    (!Number.isFinite(bjtMinimumBaseResistance) || bjtMinimumBaseResistance < 0.0)
+  ) {
+    throw new NetlistParseError("BJT RBM must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2342,6 +2350,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("RE") ?? 0.0,
       model.params.get("RC") ?? 0.0,
       model.params.get("RB") ?? 0.0,
+      model.params.get("RBM"),
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2065,6 +2065,33 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["2.5", 2.5],
+  ])("parses BJT minimum base resistance RBM=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(RBM=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      minimumBaseResistance: expected,
+    });
+  });
+
+  it("preserves the fallback when BJT RBM is omitted", () => {
+    const parsed = parseNetlist(".model fast NPN(RB=14)\nQ1 col base emit fast");
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      minimumBaseResistance: undefined,
+    });
+  });
+
+  it.each(["-1", "1e999"])("rejects invalid BJT RBM=%s", (value) => {
+    expect(() => parseNetlist(`.model fast NPN(RBM=${value})`)).toThrow(
+      "BJT RBM must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4683,9 +4683,15 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine collector-resistance field.
 
 469. Python and TypeScript Berkeley SPICE BJT base-resistance parity.
-   - Status: implemented in this BJT RB parity slice.
+   - Status: completed in PR 10143.
    - Both parser facades validate finite, non-negative `RB` values and lower
      them into the shared engine base-resistance field.
+
+470. Python and TypeScript Berkeley SPICE BJT minimum-base-resistance parity.
+   - Status: implemented in this BJT RBM parity slice.
+   - Both parser facades validate finite, non-negative `RBM` values and lower
+     them into the shared engine optional minimum-base-resistance field while
+     preserving omitted `None`/`undefined` fallback-to-`RB` semantics.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite, non-negative optional BJT model-card `RBM` values in both parser facades
- lower `RBM` into the shared engine minimum-base-resistance field
- preserve omitted `None`/`undefined` fallback-to-`RB` semantics and update the SPICE plan

## Testing
- Python parser `bash BUILD` (611 passed, 90.44% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (596 passed)
- TypeScript parser `npx vitest run --coverage` (88.12% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
