### PR TITLE
Add BJT IRB parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `IRB` base-resistance half-current.
 - Validate and lower optional BJT model-card `RBM` minimum base resistance.
 - Validate and lower BJT model-card `RB` base resistance.
 - Validate and lower BJT model-card `RC` collector resistance.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1354,6 +1354,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Rc=model.params.get("RC", 0.0),
             Rb=model.params.get("RB", 0.0),
             Rbm=model.params.get("RBM"),
+            Irb=model.params.get("IRB", 0.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2316,6 +2317,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or minimum_base_resistance < 0.0
         ):
             raise NetlistParseError("BJT RBM must be finite and non-negative")
+        base_resistance_half_current = params.get("IRB")
+        if base_resistance_half_current is not None and (
+            not math.isfinite(base_resistance_half_current)
+            or base_resistance_half_current < 0.0
+        ):
+            raise NetlistParseError("BJT IRB must be finite and non-negative")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2016,6 +2016,25 @@ def test_rejects_invalid_bjt_minimum_base_resistance(value: str) -> None:
         parse_netlist(f".model fast NPN(RBM={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("5u", 5e-6)])
+def test_parse_bjt_base_resistance_half_current(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model fast NPN(IRB={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Irb == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("value", ["-1u", "1e999"])
+def test_rejects_invalid_bjt_base_resistance_half_current(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT IRB must be finite and non-negative"
+    ):
+        parse_netlist(f".model fast NPN(IRB={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `IRB` base-resistance half-current.
 - Validate and lower optional BJT model-card `RBM` minimum base resistance.
 - Validate and lower BJT model-card `RB` base resistance.
 - Validate and lower BJT model-card `RC` collector resistance.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1604,6 +1604,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT RBM must be finite and non-negative");
   }
+  const bjtBaseResistanceHalfCurrent = params.get("IRB");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtBaseResistanceHalfCurrent !== undefined &&
+    (!Number.isFinite(bjtBaseResistanceHalfCurrent) || bjtBaseResistanceHalfCurrent < 0.0)
+  ) {
+    throw new NetlistParseError("BJT IRB must be finite and non-negative");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2351,6 +2359,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("RC") ?? 0.0,
       model.params.get("RB") ?? 0.0,
       model.params.get("RBM"),
+      model.params.get("IRB") ?? 0.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2092,6 +2092,23 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["5u", 5.0e-6],
+  ])("parses BJT base-resistance half-current IRB=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(IRB=${value})\nQ1 col base emit fast`);
+
+    const transistor = parsed.circuit.elements()[0];
+    expect(transistor).toMatchObject({ kind: "bjt" });
+    expect(transistor.baseResistanceHalfCurrent).toBeCloseTo(expected);
+  });
+
+  it.each(["-1u", "1e999"])("rejects invalid BJT IRB=%s", (value) => {
+    expect(() => parseNetlist(`.model fast NPN(IRB=${value})`)).toThrow(
+      "BJT IRB must be finite and non-negative",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4688,10 +4688,15 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine base-resistance field.
 
 470. Python and TypeScript Berkeley SPICE BJT minimum-base-resistance parity.
-   - Status: implemented in this BJT RBM parity slice.
+   - Status: completed in PR 10144.
    - Both parser facades validate finite, non-negative `RBM` values and lower
      them into the shared engine optional minimum-base-resistance field while
      preserving omitted `None`/`undefined` fallback-to-`RB` semantics.
+
+471. Python and TypeScript Berkeley SPICE BJT base-resistance-half-current parity.
+   - Status: implemented in this BJT IRB parity slice.
+   - Both parser facades validate finite, non-negative `IRB` values and lower
+     them into the shared engine base-resistance-half-current field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite, non-negative BJT model-card `IRB` values in both parser facades
- lower `IRB` into the shared engine base-resistance-half-current field
- cover zero, positive, negative, and non-finite values and update the SPICE plan

## Testing
- Python parser `bash BUILD` (615 passed, 90.46% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (600 passed)
- TypeScript parser `npx vitest run --coverage` (88.15% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
