### PR TITLE
Add BJT XCJC parser parity

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `XCJC` base-collector capacitance fraction.
 - Validate and lower BJT model-card `IRB` base-resistance half-current.
 - Validate and lower optional BJT model-card `RBM` minimum base resistance.
 - Validate and lower BJT model-card `RB` base resistance.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1355,6 +1355,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             Rb=model.params.get("RB", 0.0),
             Rbm=model.params.get("RBM"),
             Irb=model.params.get("IRB", 0.0),
+            Xcjc=model.params.get("XCJC", 1.0),
         )
     if prefix == "J":
         _require_fields(fields, 5, "JFET")
@@ -2323,6 +2324,12 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or base_resistance_half_current < 0.0
         ):
             raise NetlistParseError("BJT IRB must be finite and non-negative")
+        base_collector_capacitance_fraction = params.get("XCJC")
+        if base_collector_capacitance_fraction is not None and (
+            not math.isfinite(base_collector_capacitance_fraction)
+            or not 0.0 <= base_collector_capacitance_fraction <= 1.0
+        ):
+            raise NetlistParseError("BJT XCJC must be finite and between zero and one")
     if kind in {"NJF", "PJF"}:
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2035,6 +2035,33 @@ def test_rejects_invalid_bjt_base_resistance_half_current(value: str) -> None:
         parse_netlist(f".model fast NPN(IRB={value})")
 
 
+@pytest.mark.parametrize(("value", "expected"), [("0", 0.0), ("0.4", 0.4), ("1", 1.0)])
+def test_parse_bjt_base_collector_capacitance_fraction(
+    value: str, expected: float
+) -> None:
+    parsed = parse_netlist(f".model fast NPN(XCJC={value})\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Xcjc == expected
+
+
+def test_bjt_omitted_base_collector_capacitance_fraction_defaults_to_one() -> None:
+    parsed = parse_netlist(".model fast NPN\nQ1 col base emit fast")
+
+    transistor = parsed.circuit.elements[0]
+    assert isinstance(transistor, BJT)
+    assert transistor.Xcjc == 1.0
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1.1", "1e999"])
+def test_rejects_invalid_bjt_base_collector_capacitance_fraction(value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="BJT XCJC must be finite and between zero and one"
+    ):
+        parse_netlist(f".model fast NPN(XCJC={value})")
+
+
 def test_parse_jfet_model_into_operating_point_circuit() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate and lower BJT model-card `XCJC` base-collector capacitance fraction.
 - Validate and lower BJT model-card `IRB` base-resistance half-current.
 - Validate and lower optional BJT model-card `RBM` minimum base resistance.
 - Validate and lower BJT model-card `RB` base resistance.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1612,6 +1612,16 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT IRB must be finite and non-negative");
   }
+  const bjtBaseCollectorCapacitanceFraction = params.get("XCJC");
+  if (
+    (kind === "NPN" || kind === "PNP") &&
+    bjtBaseCollectorCapacitanceFraction !== undefined &&
+    (!Number.isFinite(bjtBaseCollectorCapacitanceFraction) ||
+      bjtBaseCollectorCapacitanceFraction < 0.0 ||
+      bjtBaseCollectorCapacitanceFraction > 1.0)
+  ) {
+    throw new NetlistParseError("BJT XCJC must be finite and between zero and one");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&
@@ -2360,6 +2370,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       model.params.get("RB") ?? 0.0,
       model.params.get("RBM"),
       model.params.get("IRB") ?? 0.0,
+      model.params.get("XCJC") ?? 1.0,
     );
   }
   if (prefix === "J") {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2109,6 +2109,34 @@ Q1 col base emit fast
     );
   });
 
+  it.each([
+    ["0", 0.0],
+    ["0.4", 0.4],
+    ["1", 1.0],
+  ])("parses BJT base-collector capacitance fraction XCJC=%s", (value, expected) => {
+    const parsed = parseNetlist(`.model fast NPN(XCJC=${value})\nQ1 col base emit fast`);
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseCollectorCapacitanceFraction: expected,
+    });
+  });
+
+  it("defaults omitted BJT XCJC to one", () => {
+    const parsed = parseNetlist(".model fast NPN\nQ1 col base emit fast");
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      baseCollectorCapacitanceFraction: 1.0,
+    });
+  });
+
+  it.each(["-0.1", "1.1", "1e999"])("rejects invalid BJT XCJC=%s", (value) => {
+    expect(() => parseNetlist(`.model fast NPN(XCJC=${value})`)).toThrow(
+      "BJT XCJC must be finite and between zero and one",
+    );
+  });
+
   it("parses JFET models into operating-point circuits", () => {
     const parsed = parseNetlist(`
 .model fast NJF(BETA=2m VTO=-3 LAMBDA=0.02)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4694,9 +4694,15 @@ the Rust, Python, and TypeScript surfaces together.
      preserving omitted `None`/`undefined` fallback-to-`RB` semantics.
 
 471. Python and TypeScript Berkeley SPICE BJT base-resistance-half-current parity.
-   - Status: implemented in this BJT IRB parity slice.
+   - Status: completed in PR 10147.
    - Both parser facades validate finite, non-negative `IRB` values and lower
      them into the shared engine base-resistance-half-current field.
+
+472. Python and TypeScript Berkeley SPICE BJT base-collector-capacitance-fraction parity.
+   - Status: implemented in this BJT XCJC parity slice.
+   - Both parser facades validate finite `XCJC` values in the closed interval
+     `[0, 1]` and lower them into the shared engine base-collector capacitance
+     fraction field while preserving the engine default of `1.0` when omitted.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite BJT model-card `XCJC` values in the closed interval `[0, 1]` in both parser facades
- lower `XCJC` into the shared engine base-collector capacitance-fraction field while preserving the `1.0` default
- cover both boundaries, an interior value, omission, and invalid values and update the SPICE plan

## Testing
- Python parser `bash BUILD` (622 passed, 90.48% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (607 passed)
- TypeScript parser `npx vitest run --coverage` (88.18% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
