### PR TITLE
Validate MOS CGSO model cards

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate finite, non-negative MOS Level-1 model-card `CGSO` values.
 - Validate and lower BJT model-card `XCJC` base-collector capacitance fraction.
 - Validate and lower BJT model-card `IRB` base-resistance half-current.
 - Validate and lower optional BJT model-card `RBM` minimum base resistance.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -2521,6 +2521,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["CJSW"]) or params["CJSW"] < 0.0
         ):
             raise NetlistParseError("MOSFET CJSW must be finite and non-negative")
+        if "CGSO" in params and (
+            not math.isfinite(params["CGSO"]) or params["CGSO"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET CGSO must be finite and non-negative")
         for parameter_name, canonical in (
             ("CBS", "CBS"),
             ("CJS", "CBS"),

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -3500,6 +3500,33 @@ def test_lowers_valid_mosfet_model_sidewall_capacitance(
     assert isclose(mosfet.model.model.params.CJSW, expected)
 
 
+@pytest.mark.parametrize("gate_source_overlap", ["-1p", "1e999"])
+def test_rejects_invalid_mosfet_model_gate_source_overlap_capacitance(
+    gate_source_overlap: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET CGSO must be finite and non-negative",
+    ):
+        parse_netlist(
+            f".model nfast NMOS(CGSO={gate_source_overlap})\nM1 d g s b nfast\n"
+        )
+
+
+@pytest.mark.parametrize(
+    ("gate_source_overlap", "expected"), [("0", 0.0), ("3p", 3.0e-12)]
+)
+def test_lowers_valid_mosfet_model_gate_source_overlap_capacitance(
+    gate_source_overlap: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS(CGSO={gate_source_overlap})\nM1 d g s b nfast\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.CGSO, expected)
+
+
 @pytest.mark.parametrize("junction_current", ["-1p", "1e999"])
 def test_rejects_invalid_mosfet_model_junction_current(
     junction_current: str,

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate finite, non-negative MOS Level-1 model-card `CGSO` values.
 - Validate and lower BJT model-card `XCJC` base-collector capacitance fraction.
 - Validate and lower BJT model-card `IRB` base-resistance half-current.
 - Validate and lower optional BJT model-card `RBM` minimum base resistance.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1941,6 +1941,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET CJSW must be finite and non-negative");
   }
+  const gateSourceOverlapCapacitance = params.get("CGSO");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    gateSourceOverlapCapacitance !== undefined &&
+    (!Number.isFinite(gateSourceOverlapCapacitance) || gateSourceOverlapCapacitance < 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET CGSO must be finite and non-negative");
+  }
   for (const [name, canonical] of [
     ["CBS", "CBS"],
     ["CJS", "CBS"],

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -3488,6 +3488,25 @@ Xright c d load
     expect(element.params.CJSW).toBeCloseTo(expected, 15);
   });
 
+  it.each(["-1p", "1e999"])("rejects invalid MOSFET model CGSO=%s", (overlap) => {
+    expect(() =>
+      parseNetlist(`.model nfast NMOS(CGSO=${overlap})\nM1 d g s b nfast\n`),
+    ).toThrow("MOSFET CGSO must be finite and non-negative");
+  });
+
+  it.each([
+    ["0", 0.0],
+    ["3p", 3.0e-12],
+  ])("lowers valid MOSFET model CGSO=%s", (overlap, expected) => {
+    const parsed = parseNetlist(
+      `.model nfast NMOS(CGSO=${overlap})\nM1 d g s b nfast\n`,
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.CGSO).toBeCloseTo(expected, 15);
+  });
+
   it.each(["-1p", "1e999"])("rejects invalid MOSFET model JS=%s", (junctionCurrent) => {
     expect(() =>
       parseNetlist(`.model nfast NMOS(JS=${junctionCurrent})\nM1 d g s b nfast\n`),

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4699,10 +4699,16 @@ the Rust, Python, and TypeScript surfaces together.
      them into the shared engine base-resistance-half-current field.
 
 472. Python and TypeScript Berkeley SPICE BJT base-collector-capacitance-fraction parity.
-   - Status: implemented in this BJT XCJC parity slice.
+   - Status: completed in PR 10148.
    - Both parser facades validate finite `XCJC` values in the closed interval
      `[0, 1]` and lower them into the shared engine base-collector capacitance
      fraction field while preserving the engine default of `1.0` when omitted.
+   - This completes the audited direct BJT engine-field lowering set.
+
+473. Python and TypeScript Berkeley SPICE MOS Level-1 gate-source-overlap validation parity.
+   - Status: implemented in this MOS CGSO validation parity slice.
+   - Both parser facades validate finite, non-negative `CGSO` values before
+     lowering them into the existing MOS Level-1 gate-source overlap field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite, non-negative MOS Level-1 model-card `CGSO` values in both parser facades
- preserve the existing lowering into the gate-source overlap capacitance field
- cover zero, positive, negative, and non-finite values and update the SPICE plan

## Testing
- Python parser `bash BUILD` (626 passed, 90.49% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (611 passed)
- TypeScript parser `npx vitest run --coverage` (88.21% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
