### PR TITLE
Validate MOS CGDO model cards

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate finite, non-negative MOS Level-1 model-card `CGDO` values.
 - Validate finite, non-negative MOS Level-1 model-card `CGSO` values.
 - Validate and lower BJT model-card `XCJC` base-collector capacitance fraction.
 - Validate and lower BJT model-card `IRB` base-resistance half-current.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -2525,6 +2525,10 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(params["CGSO"]) or params["CGSO"] < 0.0
         ):
             raise NetlistParseError("MOSFET CGSO must be finite and non-negative")
+        if "CGDO" in params and (
+            not math.isfinite(params["CGDO"]) or params["CGDO"] < 0.0
+        ):
+            raise NetlistParseError("MOSFET CGDO must be finite and non-negative")
         for parameter_name, canonical in (
             ("CBS", "CBS"),
             ("CJS", "CBS"),

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -3527,6 +3527,33 @@ def test_lowers_valid_mosfet_model_gate_source_overlap_capacitance(
     assert isclose(mosfet.model.model.params.CGSO, expected)
 
 
+@pytest.mark.parametrize("gate_drain_overlap", ["-1p", "1e999"])
+def test_rejects_invalid_mosfet_model_gate_drain_overlap_capacitance(
+    gate_drain_overlap: str,
+) -> None:
+    with pytest.raises(
+        NetlistParseError,
+        match="MOSFET CGDO must be finite and non-negative",
+    ):
+        parse_netlist(
+            f".model nfast NMOS(CGDO={gate_drain_overlap})\nM1 d g s b nfast\n"
+        )
+
+
+@pytest.mark.parametrize(
+    ("gate_drain_overlap", "expected"), [("0", 0.0), ("4p", 4.0e-12)]
+)
+def test_lowers_valid_mosfet_model_gate_drain_overlap_capacitance(
+    gate_drain_overlap: str, expected: float
+) -> None:
+    parsed = parse_netlist(
+        f".model nfast NMOS(CGDO={gate_drain_overlap})\nM1 d g s b nfast\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.CGDO, expected)
+
+
 @pytest.mark.parametrize("junction_current", ["-1p", "1e999"])
 def test_rejects_invalid_mosfet_model_junction_current(
     junction_current: str,

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate finite, non-negative MOS Level-1 model-card `CGDO` values.
 - Validate finite, non-negative MOS Level-1 model-card `CGSO` values.
 - Validate and lower BJT model-card `XCJC` base-collector capacitance fraction.
 - Validate and lower BJT model-card `IRB` base-resistance half-current.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1949,6 +1949,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("MOSFET CGSO must be finite and non-negative");
   }
+  const gateDrainOverlapCapacitance = params.get("CGDO");
+  if (
+    (kind === "NMOS" || kind === "PMOS") &&
+    gateDrainOverlapCapacitance !== undefined &&
+    (!Number.isFinite(gateDrainOverlapCapacitance) || gateDrainOverlapCapacitance < 0.0)
+  ) {
+    throw new NetlistParseError("MOSFET CGDO must be finite and non-negative");
+  }
   for (const [name, canonical] of [
     ["CBS", "CBS"],
     ["CJS", "CBS"],

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -3507,6 +3507,25 @@ Xright c d load
     expect(element.params.CGSO).toBeCloseTo(expected, 15);
   });
 
+  it.each(["-1p", "1e999"])("rejects invalid MOSFET model CGDO=%s", (overlap) => {
+    expect(() =>
+      parseNetlist(`.model nfast NMOS(CGDO=${overlap})\nM1 d g s b nfast\n`),
+    ).toThrow("MOSFET CGDO must be finite and non-negative");
+  });
+
+  it.each([
+    ["0", 0.0],
+    ["4p", 4.0e-12],
+  ])("lowers valid MOSFET model CGDO=%s", (overlap, expected) => {
+    const parsed = parseNetlist(
+      `.model nfast NMOS(CGDO=${overlap})\nM1 d g s b nfast\n`,
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.CGDO).toBeCloseTo(expected, 15);
+  });
+
   it.each(["-1p", "1e999"])("rejects invalid MOSFET model JS=%s", (junctionCurrent) => {
     expect(() =>
       parseNetlist(`.model nfast NMOS(JS=${junctionCurrent})\nM1 d g s b nfast\n`),

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4706,9 +4706,14 @@ the Rust, Python, and TypeScript surfaces together.
    - This completes the audited direct BJT engine-field lowering set.
 
 473. Python and TypeScript Berkeley SPICE MOS Level-1 gate-source-overlap validation parity.
-   - Status: implemented in this MOS CGSO validation parity slice.
+   - Status: completed in PR 10149.
    - Both parser facades validate finite, non-negative `CGSO` values before
      lowering them into the existing MOS Level-1 gate-source overlap field.
+
+474. Python and TypeScript Berkeley SPICE MOS Level-1 gate-drain-overlap validation parity.
+   - Status: implemented in this MOS CGDO validation parity slice.
+   - Both parser facades validate finite, non-negative `CGDO` values before
+     lowering them into the existing MOS Level-1 gate-drain overlap field.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- validate finite, non-negative MOS Level-1 model-card `CGDO` values in both parser facades
- preserve the existing lowering into the gate-drain overlap capacitance field
- cover zero, positive, negative, and non-finite values and update the SPICE plan

## Testing
- Python parser `bash BUILD` (630 passed, 90.51% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (615 passed)
- TypeScript parser `npx vitest run --coverage` (88.24% lines)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
