### PR TITLE
Normalize DIODE model cards

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize the `DIODE` model type alias to canonical `D` cards.
 - Validate finite, non-negative MOS Level-1 model-card `CGBO` values.
 - Validate finite, non-negative MOS Level-1 model-card `CGDO` values.
 - Validate finite, non-negative MOS Level-1 model-card `CGSO` values.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1986,6 +1986,8 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         params_text = " ".join(fields[3:]).strip()
         if params_text.startswith("(") and params_text.endswith(")"):
             params_text = params_text[1:-1]
+    if kind == "DIODE":
+        kind = "D"
     params = _parse_model_params(params_text)
     if kind == "D":
         saturation_current = params.get("IS", params.get("JS"))

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -798,6 +798,15 @@ Rload out 0 1k
     assert 0.0 < result.node_voltages["out"] < 0.7
 
 
+def test_parse_diode_model_type_alias() -> None:
+    parsed = parse_netlist(".model clamp DIODE(IS=2p)\nD1 in out clamp")
+
+    assert parsed.models["clamp"].kind == "D"
+    diode = parsed.circuit.elements[0]
+    assert isinstance(diode, Diode)
+    assert diode.Is == 2.0e-12
+
+
 def test_parse_diode_saturation_current_alias() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize the `DIODE` model type alias to canonical `D` cards.
 - Validate finite, non-negative MOS Level-1 model-card `CGBO` values.
 - Validate finite, non-negative MOS Level-1 model-card `CGDO` values.
 - Validate finite, non-negative MOS Level-1 model-card `CGSO` values.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1148,7 +1148,8 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   if (paramsText.startsWith("(") && paramsText.endsWith(")")) {
     paramsText = paramsText.slice(1, -1);
   }
-  const kind = match[1].toUpperCase();
+  const rawKind = match[1].toUpperCase();
+  const kind = rawKind === "DIODE" ? "D" : rawKind;
   const params = parseModelParams(paramsText);
   const diodeSaturationCurrent = params.get("IS") ?? params.get("JS");
   if (

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -777,6 +777,16 @@ Rload out 0 1k
     expect(result.voltage("out")).toBeLessThan(0.7);
   });
 
+  it("parses the DIODE model type alias", () => {
+    const parsed = parseNetlist(".model clamp DIODE(IS=2p)\nD1 in out clamp");
+
+    expect(parsed.models.get("clamp")?.kind).toBe("D");
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "diode",
+      saturationCurrent: 2.0e-12,
+    });
+  });
+
   it("parses the diode JS saturation-current alias", () => {
     const parsed = parseNetlist(`
 .model clamp D(JS=2p)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4716,9 +4716,16 @@ the Rust, Python, and TypeScript surfaces together.
      lowering them into the existing MOS Level-1 gate-drain overlap field.
 
 475. Python and TypeScript Berkeley SPICE MOS Level-1 gate-body-overlap validation parity.
-   - Status: implemented in this MOS CGBO validation parity slice.
+   - Status: completed in PR 10152.
    - Both parser facades validate finite, non-negative `CGBO` values before
      lowering them into the existing MOS Level-1 gate-body overlap field.
+   - This completes the audited MOS Level-1 `CGSO` / `CGDO` / `CGBO`
+     overlap-capacitance validation set.
+
+476. Python and TypeScript Berkeley SPICE diode model-type alias parity.
+   - Status: implemented in this model-type normalization slice.
+   - Both parser facades normalize the engine-supported `DIODE` model type
+     alias to canonical `D`, preserving diode validation and instance lowering.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- normalize the engine-supported `DIODE` model type alias to canonical `D` in both parser facades
- verify canonical model storage and diode instance lowering in Python and TypeScript
- record completion of the MOS overlap-capacitance validation audit and this next parity slice

## Verification

- Python parser `bash BUILD` (`635 passed`, 90.53% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (`620 passed`)
- TypeScript parser `npx vitest run --coverage` (88.27% lines)
- TypeScript engine `bash BUILD` (`448 passed`)
- `git diff --check`
- BUILD dependency audit: no BUILD files or dependency edges changed
