### PR TITLE
Carry Chief host data over the authenticated session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added — Chief Host Authenticated Data Plane
+- The existing per-spawn secure host session now carries bounded, serialized
+  channel receive/publish/acknowledge and provider-neutral text completion
+  exchanges with monotonic request IDs and exact response correlation.
+- The process supervisor exposes real-pipe child exchange helpers and retains
+  authenticated pending requests for injected daemon service adapters, closing
+  the missing data-plane seam before the production Chief host composition.
+
 ### Fixed — Ruby Canonical Starlark BUILD Compatibility
 - Ruby's Starlark stack now closes indented files in the specified token order,
   preserves `r`/`b`-leading identifiers, binds mixed keyword calls, and keeps

--- a/code/packages/rust/chief-of-staff-host-control-protocol/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Add authenticated channel receive, publish, and acknowledge requests plus
+  provider-neutral text completion requests and responses.
+- Enforce bounded binary fields, canonical UUID-v7 identities, one in-flight
+  request, monotonic request IDs, exact correlation, response-kind matching,
+  and redacted stable failure codes.
+
 ## 0.1.0
 
 - Add strict bounded `D18C` readiness, heartbeat, and termination records.

--- a/code/packages/rust/chief-of-staff-host-control-protocol/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/Cargo.toml
@@ -2,7 +2,7 @@
 name = "chief-of-staff-host-control-protocol"
 version = "0.1.0"
 edition = "2021"
-description = "Authenticated readiness, heartbeat, and termination protocol for D18 Chief hosts"
+description = "Authenticated lifecycle and bounded data-plane protocol for D18 Chief hosts"
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/chief-of-staff-host-control-protocol/README.md
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/README.md
@@ -1,19 +1,26 @@
 # chief-of-staff-host-control-protocol
 
-`chief-of-staff-host-control-protocol` defines the minimum authenticated
-lifecycle conversation between the D18 orchestrator and one spawned host. A
-child independently verifies its signed package, sends `Ready(package_hash)`,
-then sends heartbeats. The orchestrator alone sends `Terminate`.
+`chief-of-staff-host-control-protocol` defines the authenticated lifecycle and
+bounded data-plane conversation between the D18 orchestrator and one spawned
+host. A child independently verifies its signed package, sends
+`Ready(package_hash)`, then sends heartbeats and serialized channel or
+provider-neutral completion requests. The orchestrator sends exact correlated
+responses or `Terminate`.
 
 The wrapper runs over `chief-of-staff-secure-host-channel`, enforces role and
 lifecycle ordering, and fails closed after malformed, unauthenticated,
 wrong-direction, replayed, or package-mismatched peer input. Heartbeats carry no
 child-selected timestamp: the orchestrator attaches its trusted monotonic receive
-time after authentication.
+time after authentication. The data plane permits one request in flight, uses
+strictly increasing non-zero IDs, and fails closed on skipped, duplicate,
+wrong-operation, or unsolicited responses. Receive, publish, acknowledge, and
+text completion records have explicit aggregate and field bounds below the
+secure channel's one-megabyte frame limit.
 
 The crate owns no clock, file descriptor, process, stream, filesystem, or network
-capability. A concrete process supervisor supplies complete encrypted frames and
-receipt times.
+channel-storage, model-provider, or authorization capability. A concrete process
+supervisor supplies complete encrypted frames and receipt times; later adapters
+execute authenticated requests against injected services.
 
 ## Validation
 

--- a/code/packages/rust/chief-of-staff-host-control-protocol/src/data_plane.rs
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/src/data_plane.rs
@@ -1,0 +1,1206 @@
+//! Strict bounded data-plane records carried by the authenticated host session.
+
+use std::collections::BTreeMap;
+
+use crate::ControlError;
+
+pub(crate) const RECEIVE_REQUEST_TAG: u8 = 10;
+pub(crate) const PUBLISH_REQUEST_TAG: u8 = 11;
+pub(crate) const ACKNOWLEDGE_REQUEST_TAG: u8 = 12;
+pub(crate) const COMPLETE_REQUEST_TAG: u8 = 13;
+pub(crate) const RECEIVED_RESPONSE_TAG: u8 = 20;
+pub(crate) const PUBLISHED_RESPONSE_TAG: u8 = 21;
+pub(crate) const ACKNOWLEDGED_RESPONSE_TAG: u8 = 22;
+pub(crate) const COMPLETED_RESPONSE_TAG: u8 = 23;
+pub(crate) const FAILED_RESPONSE_TAG: u8 = 24;
+
+/// Maximum plaintext bytes in one data-plane body before the six-byte control header.
+pub const MAX_DATA_PLANE_RECORD_BYTES: usize = 768 * 1024;
+/// Maximum verified channel payload or completion text in one v1 exchange.
+pub const MAX_DATA_PLANE_PAYLOAD_BYTES: usize = 512 * 1024;
+/// Maximum messages in one receive page.
+pub const MAX_DATA_PLANE_MESSAGES: usize = 64;
+const MAX_CONTENT_TYPE_BYTES: usize = 1_024;
+const MAX_MODEL_BYTES: usize = 200;
+const MAX_SYSTEM_BYTES: usize = 64 * 1024;
+const MAX_PROMPT_MESSAGES: usize = 64;
+const MAX_PROMPT_TEXT_BYTES: usize = 64 * 1024;
+const MAX_STOP_SEQUENCES: usize = 16;
+const MAX_STOP_SEQUENCE_BYTES: usize = 1_024;
+const MAX_METADATA_ENTRIES: usize = 32;
+const MAX_METADATA_KEY_BYTES: usize = 256;
+const MAX_METADATA_VALUE_BYTES: usize = 4 * 1024;
+const MAX_PROVIDER_FIELD_BYTES: usize = 512;
+const MAX_PROVIDER_ENDPOINT_BYTES: usize = 4 * 1024;
+const MAX_COMPLETION_TOKENS: u32 = 1_000_000;
+
+/// Non-zero request identity minted monotonically by the child endpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RequestId(u64);
+
+impl RequestId {
+    /// Validate a non-zero request identity.
+    pub fn new(value: u64) -> Result<Self, ControlError> {
+        if value == 0 {
+            return Err(ControlError::InvalidDataPlaneRecord);
+        }
+        Ok(Self(value))
+    }
+
+    /// Return the wire integer.
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Data-plane operation used to enforce response shape and correlation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DataPlaneOperation {
+    /// Read verified messages from one authorized channel.
+    Receive,
+    /// Publish plaintext to one authorized channel.
+    Publish,
+    /// Advance one authorized receiver cursor.
+    Acknowledge,
+    /// Execute one provider-neutral LLM completion.
+    Complete,
+}
+
+/// Text-only role accepted by the first production Level 1 data plane.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PromptRole {
+    /// System instruction inside the ordered prompt.
+    System,
+    /// User-authored input.
+    User,
+    /// Prior assistant output.
+    Assistant,
+}
+
+/// One bounded provider-neutral prompt message.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PromptMessage {
+    /// Conversation role.
+    pub role: PromptRole,
+    /// UTF-8 text content.
+    pub text: String,
+}
+
+/// Provider-neutral completion request used by a child host.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CompletionCall {
+    /// Provider-specific model selector.
+    pub model: String,
+    /// Optional top-level system instruction.
+    pub system: Option<String>,
+    /// Ordered text prompt.
+    pub messages: Vec<PromptMessage>,
+    /// Finite sampling temperature from zero through two.
+    pub temperature: f32,
+    /// Optional non-zero output-token cap.
+    pub max_tokens: Option<u32>,
+    /// Provider stop strings.
+    pub stop_sequences: Vec<String>,
+    /// Optional deterministic seed.
+    pub seed: Option<u64>,
+    /// Bounded audit metadata with canonical key order.
+    pub metadata: BTreeMap<String, String>,
+}
+
+/// Provider identity returned with every successful completion.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompletionProvider {
+    /// Provider vendor.
+    pub vendor: String,
+    /// Stable model family.
+    pub model_family: String,
+    /// Stable model version.
+    pub model_version: String,
+    /// Optional provider endpoint identity.
+    pub endpoint: Option<String>,
+}
+
+/// Provider-reported token accounting.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CompletionUsage {
+    /// Tokens consumed by the prompt.
+    pub input_tokens: u64,
+    /// Tokens emitted by the model.
+    pub output_tokens: u64,
+    /// Prompt tokens served from provider cache.
+    pub cached_tokens: u64,
+}
+
+/// Why a provider stopped generating.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CompletionFinishReason {
+    /// Natural end or stop sequence.
+    Stop,
+    /// Output-token cap reached.
+    MaxTokens,
+    /// Provider refused the request.
+    Refusal,
+    /// Provider-specific reason outside the stable taxonomy.
+    Other,
+}
+
+/// Successful provider-neutral completion result.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompletionResult {
+    /// Generated text.
+    pub text: String,
+    /// Provider-reported model.
+    pub model: String,
+    /// Provider audit identity.
+    pub provider: CompletionProvider,
+    /// Provider token accounting.
+    pub usage: CompletionUsage,
+    /// Provider stop reason.
+    pub finish_reason: CompletionFinishReason,
+    /// Provider-reported latency in milliseconds.
+    pub latency_ms: u64,
+}
+
+/// Verified plaintext channel message returned to the child host.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DataPlaneMessage {
+    /// Canonical UUID-v7 message identity.
+    pub message_id: [u8; 16],
+    /// Durable global channel sequence.
+    pub sequence: u64,
+    /// Authenticated originator timestamp.
+    pub timestamp_ns: u64,
+    /// Authenticated MIME content type.
+    pub content_type: String,
+    /// Verified plaintext payload.
+    pub payload: Vec<u8>,
+}
+
+/// Stable failure category returned without provider or payload diagnostics.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DataPlaneFailure {
+    /// Request shape or static bounds were rejected.
+    InvalidRequest,
+    /// The package is not authorized for the requested operation.
+    Unauthorized,
+    /// Channel receive, publish, or acknowledgement failed.
+    Channel,
+    /// Provider-neutral completion failed.
+    Completion,
+    /// A required service is temporarily unavailable.
+    Unavailable,
+    /// An internal adapter failed without a safe public detail.
+    Internal,
+}
+
+/// Authenticated child-to-orchestrator data-plane request.
+#[derive(Clone, Debug, PartialEq)]
+pub enum DataPlaneRequest {
+    /// Read a bounded page from one channel.
+    Receive {
+        /// Correlation identity.
+        id: RequestId,
+        /// Canonical UUID-v7 channel identity.
+        channel_id: [u8; 16],
+        /// Maximum messages, from one through 64.
+        limit: u16,
+    },
+    /// Publish one bounded payload.
+    Publish {
+        /// Correlation identity.
+        id: RequestId,
+        /// Canonical UUID-v7 channel identity.
+        channel_id: [u8; 16],
+        /// MIME content type.
+        content_type: String,
+        /// Plaintext payload.
+        payload: Vec<u8>,
+    },
+    /// Acknowledge one previously delivered message.
+    Acknowledge {
+        /// Correlation identity.
+        id: RequestId,
+        /// Canonical UUID-v7 channel identity.
+        channel_id: [u8; 16],
+        /// Canonical UUID-v7 delivered-message identity.
+        message_id: [u8; 16],
+    },
+    /// Execute one provider-neutral completion.
+    Complete {
+        /// Correlation identity.
+        id: RequestId,
+        /// Validated completion input.
+        call: CompletionCall,
+    },
+}
+
+impl DataPlaneRequest {
+    /// Return the correlation identity.
+    pub fn id(&self) -> RequestId {
+        match self {
+            Self::Receive { id, .. }
+            | Self::Publish { id, .. }
+            | Self::Acknowledge { id, .. }
+            | Self::Complete { id, .. } => *id,
+        }
+    }
+
+    /// Return the required response operation.
+    pub fn operation(&self) -> DataPlaneOperation {
+        match self {
+            Self::Receive { .. } => DataPlaneOperation::Receive,
+            Self::Publish { .. } => DataPlaneOperation::Publish,
+            Self::Acknowledge { .. } => DataPlaneOperation::Acknowledge,
+            Self::Complete { .. } => DataPlaneOperation::Complete,
+        }
+    }
+}
+
+/// Authenticated orchestrator-to-child data-plane response.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DataPlaneResponse {
+    /// Ordered verified messages, possibly empty.
+    Received {
+        /// Correlation identity.
+        id: RequestId,
+        /// At most 64 verified messages.
+        messages: Vec<DataPlaneMessage>,
+    },
+    /// Durable publication receipt.
+    Published {
+        /// Correlation identity.
+        id: RequestId,
+        /// Canonical UUID-v7 message identity.
+        message_id: [u8; 16],
+        /// Durable global channel sequence.
+        sequence: u64,
+        /// Authenticated publish timestamp.
+        timestamp_ns: u64,
+    },
+    /// Monotonic receiver cursor after acknowledgement.
+    Acknowledged {
+        /// Correlation identity.
+        id: RequestId,
+        /// Durable sequence acknowledged through.
+        sequence: u64,
+    },
+    /// Successful provider-neutral completion.
+    Completed {
+        /// Correlation identity.
+        id: RequestId,
+        /// Completion output and audit identity.
+        result: Box<CompletionResult>,
+    },
+    /// Redacted operation failure.
+    Failed {
+        /// Correlation identity.
+        id: RequestId,
+        /// Stable non-sensitive failure class.
+        failure: DataPlaneFailure,
+    },
+}
+
+impl DataPlaneResponse {
+    /// Return the correlation identity.
+    pub fn id(&self) -> RequestId {
+        match self {
+            Self::Received { id, .. }
+            | Self::Published { id, .. }
+            | Self::Acknowledged { id, .. }
+            | Self::Completed { id, .. }
+            | Self::Failed { id, .. } => *id,
+        }
+    }
+
+    /// Return the successful operation kind, or `None` for a generic failure.
+    pub fn operation(&self) -> Option<DataPlaneOperation> {
+        match self {
+            Self::Received { .. } => Some(DataPlaneOperation::Receive),
+            Self::Published { .. } => Some(DataPlaneOperation::Publish),
+            Self::Acknowledged { .. } => Some(DataPlaneOperation::Acknowledge),
+            Self::Completed { .. } => Some(DataPlaneOperation::Complete),
+            Self::Failed { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum DataRecord {
+    Request(DataPlaneRequest),
+    Response(DataPlaneResponse),
+}
+
+pub(crate) fn encode(record: &DataRecord) -> Result<(u8, Vec<u8>), ControlError> {
+    let mut encoder = Encoder::default();
+    let tag = match record {
+        DataRecord::Request(request) => {
+            encoder.u64(request.id().get());
+            match request {
+                DataPlaneRequest::Receive {
+                    channel_id, limit, ..
+                } => {
+                    validate_uuid_v7(channel_id)?;
+                    if !(1..=MAX_DATA_PLANE_MESSAGES as u16).contains(limit) {
+                        return Err(ControlError::InvalidDataPlaneRecord);
+                    }
+                    encoder.fixed(channel_id);
+                    encoder.u16(*limit);
+                    RECEIVE_REQUEST_TAG
+                }
+                DataPlaneRequest::Publish {
+                    channel_id,
+                    content_type,
+                    payload,
+                    ..
+                } => {
+                    validate_uuid_v7(channel_id)?;
+                    validate_string(content_type, 1, MAX_CONTENT_TYPE_BYTES)?;
+                    validate_bytes(payload, MAX_DATA_PLANE_PAYLOAD_BYTES)?;
+                    encoder.fixed(channel_id);
+                    encoder.string(content_type)?;
+                    encoder.bytes(payload)?;
+                    PUBLISH_REQUEST_TAG
+                }
+                DataPlaneRequest::Acknowledge {
+                    channel_id,
+                    message_id,
+                    ..
+                } => {
+                    validate_uuid_v7(channel_id)?;
+                    validate_uuid_v7(message_id)?;
+                    encoder.fixed(channel_id);
+                    encoder.fixed(message_id);
+                    ACKNOWLEDGE_REQUEST_TAG
+                }
+                DataPlaneRequest::Complete { call, .. } => {
+                    encode_completion_call(&mut encoder, call)?;
+                    COMPLETE_REQUEST_TAG
+                }
+            }
+        }
+        DataRecord::Response(response) => {
+            encoder.u64(response.id().get());
+            match response {
+                DataPlaneResponse::Received { messages, .. } => {
+                    if messages.len() > MAX_DATA_PLANE_MESSAGES {
+                        return Err(ControlError::InvalidDataPlaneRecord);
+                    }
+                    encoder.u16(messages.len() as u16);
+                    for message in messages {
+                        encode_message(&mut encoder, message)?;
+                        encoder.ensure_record_bound()?;
+                    }
+                    RECEIVED_RESPONSE_TAG
+                }
+                DataPlaneResponse::Published {
+                    message_id,
+                    sequence,
+                    timestamp_ns,
+                    ..
+                } => {
+                    validate_uuid_v7(message_id)?;
+                    encoder.fixed(message_id);
+                    encoder.u64(*sequence);
+                    encoder.u64(*timestamp_ns);
+                    PUBLISHED_RESPONSE_TAG
+                }
+                DataPlaneResponse::Acknowledged { sequence, .. } => {
+                    encoder.u64(*sequence);
+                    ACKNOWLEDGED_RESPONSE_TAG
+                }
+                DataPlaneResponse::Completed { result, .. } => {
+                    encode_completion_result(&mut encoder, result)?;
+                    COMPLETED_RESPONSE_TAG
+                }
+                DataPlaneResponse::Failed { failure, .. } => {
+                    encoder.u8(encode_failure(*failure));
+                    FAILED_RESPONSE_TAG
+                }
+            }
+        }
+    };
+    if encoder.bytes.len() > MAX_DATA_PLANE_RECORD_BYTES {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    Ok((tag, encoder.bytes))
+}
+
+pub(crate) fn decode(tag: u8, body: &[u8]) -> Result<DataRecord, ControlError> {
+    if body.len() > MAX_DATA_PLANE_RECORD_BYTES {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    let mut decoder = Decoder::new(body);
+    let id = RequestId::new(decoder.u64()?)?;
+    let record = match tag {
+        RECEIVE_REQUEST_TAG => DataRecord::Request(DataPlaneRequest::Receive {
+            id,
+            channel_id: decoder.uuid_v7()?,
+            limit: {
+                let limit = decoder.u16()?;
+                if !(1..=MAX_DATA_PLANE_MESSAGES as u16).contains(&limit) {
+                    return Err(ControlError::InvalidDataPlaneRecord);
+                }
+                limit
+            },
+        }),
+        PUBLISH_REQUEST_TAG => DataRecord::Request(DataPlaneRequest::Publish {
+            id,
+            channel_id: decoder.uuid_v7()?,
+            content_type: decoder.string(1, MAX_CONTENT_TYPE_BYTES)?,
+            payload: decoder.bytes(MAX_DATA_PLANE_PAYLOAD_BYTES)?,
+        }),
+        ACKNOWLEDGE_REQUEST_TAG => DataRecord::Request(DataPlaneRequest::Acknowledge {
+            id,
+            channel_id: decoder.uuid_v7()?,
+            message_id: decoder.uuid_v7()?,
+        }),
+        COMPLETE_REQUEST_TAG => DataRecord::Request(DataPlaneRequest::Complete {
+            id,
+            call: decode_completion_call(&mut decoder)?,
+        }),
+        RECEIVED_RESPONSE_TAG => {
+            let count = decoder.u16()? as usize;
+            if count > MAX_DATA_PLANE_MESSAGES {
+                return Err(ControlError::InvalidDataPlaneRecord);
+            }
+            let mut messages = Vec::with_capacity(count);
+            for _ in 0..count {
+                messages.push(decode_message(&mut decoder)?);
+            }
+            DataRecord::Response(DataPlaneResponse::Received { id, messages })
+        }
+        PUBLISHED_RESPONSE_TAG => DataRecord::Response(DataPlaneResponse::Published {
+            id,
+            message_id: decoder.uuid_v7()?,
+            sequence: decoder.u64()?,
+            timestamp_ns: decoder.u64()?,
+        }),
+        ACKNOWLEDGED_RESPONSE_TAG => DataRecord::Response(DataPlaneResponse::Acknowledged {
+            id,
+            sequence: decoder.u64()?,
+        }),
+        COMPLETED_RESPONSE_TAG => DataRecord::Response(DataPlaneResponse::Completed {
+            id,
+            result: Box::new(decode_completion_result(&mut decoder)?),
+        }),
+        FAILED_RESPONSE_TAG => DataRecord::Response(DataPlaneResponse::Failed {
+            id,
+            failure: decode_failure(decoder.u8()?)?,
+        }),
+        _ => return Err(ControlError::UnknownMessageKind),
+    };
+    decoder.finish()?;
+    Ok(record)
+}
+
+fn encode_message(encoder: &mut Encoder, message: &DataPlaneMessage) -> Result<(), ControlError> {
+    validate_uuid_v7(&message.message_id)?;
+    validate_string(&message.content_type, 1, MAX_CONTENT_TYPE_BYTES)?;
+    validate_bytes(&message.payload, MAX_DATA_PLANE_PAYLOAD_BYTES)?;
+    encoder.fixed(&message.message_id);
+    encoder.u64(message.sequence);
+    encoder.u64(message.timestamp_ns);
+    encoder.string(&message.content_type)?;
+    encoder.bytes(&message.payload)
+}
+
+fn decode_message(decoder: &mut Decoder<'_>) -> Result<DataPlaneMessage, ControlError> {
+    Ok(DataPlaneMessage {
+        message_id: decoder.uuid_v7()?,
+        sequence: decoder.u64()?,
+        timestamp_ns: decoder.u64()?,
+        content_type: decoder.string(1, MAX_CONTENT_TYPE_BYTES)?,
+        payload: decoder.bytes(MAX_DATA_PLANE_PAYLOAD_BYTES)?,
+    })
+}
+
+fn encode_completion_call(
+    encoder: &mut Encoder,
+    call: &CompletionCall,
+) -> Result<(), ControlError> {
+    validate_string(&call.model, 1, MAX_MODEL_BYTES)?;
+    if call.messages.is_empty() || call.messages.len() > MAX_PROMPT_MESSAGES {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    if !call.temperature.is_finite() || !(0.0..=2.0).contains(&call.temperature) {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    if call
+        .max_tokens
+        .is_some_and(|tokens| tokens == 0 || tokens > MAX_COMPLETION_TOKENS)
+        || call.stop_sequences.len() > MAX_STOP_SEQUENCES
+        || call.metadata.len() > MAX_METADATA_ENTRIES
+    {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    encoder.string(&call.model)?;
+    encoder.optional_string(call.system.as_deref(), MAX_SYSTEM_BYTES)?;
+    encoder.u16(call.messages.len() as u16);
+    for message in &call.messages {
+        validate_string(&message.text, 1, MAX_PROMPT_TEXT_BYTES)?;
+        encoder.u8(encode_role(message.role));
+        encoder.string(&message.text)?;
+        encoder.ensure_record_bound()?;
+    }
+    encoder.u32(call.temperature.to_bits());
+    encoder.optional_u32(call.max_tokens);
+    encoder.u8(call.stop_sequences.len() as u8);
+    for stop in &call.stop_sequences {
+        validate_string(stop, 1, MAX_STOP_SEQUENCE_BYTES)?;
+        encoder.string(stop)?;
+        encoder.ensure_record_bound()?;
+    }
+    encoder.optional_u64(call.seed);
+    encoder.u8(call.metadata.len() as u8);
+    for (key, value) in &call.metadata {
+        validate_string(key, 1, MAX_METADATA_KEY_BYTES)?;
+        validate_string(value, 0, MAX_METADATA_VALUE_BYTES)?;
+        encoder.string(key)?;
+        encoder.string(value)?;
+        encoder.ensure_record_bound()?;
+    }
+    Ok(())
+}
+
+fn decode_completion_call(decoder: &mut Decoder<'_>) -> Result<CompletionCall, ControlError> {
+    let model = decoder.string(1, MAX_MODEL_BYTES)?;
+    let system = decoder.optional_string(MAX_SYSTEM_BYTES)?;
+    let message_count = decoder.u16()? as usize;
+    if message_count == 0 || message_count > MAX_PROMPT_MESSAGES {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    let mut messages = Vec::with_capacity(message_count);
+    for _ in 0..message_count {
+        messages.push(PromptMessage {
+            role: decode_role(decoder.u8()?)?,
+            text: decoder.string(1, MAX_PROMPT_TEXT_BYTES)?,
+        });
+    }
+    let temperature = f32::from_bits(decoder.u32()?);
+    if !temperature.is_finite() || !(0.0..=2.0).contains(&temperature) {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    let max_tokens = decoder.optional_u32()?;
+    if max_tokens.is_some_and(|tokens| tokens == 0 || tokens > MAX_COMPLETION_TOKENS) {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    let stop_count = decoder.u8()? as usize;
+    if stop_count > MAX_STOP_SEQUENCES {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    let mut stop_sequences = Vec::with_capacity(stop_count);
+    for _ in 0..stop_count {
+        stop_sequences.push(decoder.string(1, MAX_STOP_SEQUENCE_BYTES)?);
+    }
+    let seed = decoder.optional_u64()?;
+    let metadata_count = decoder.u8()? as usize;
+    if metadata_count > MAX_METADATA_ENTRIES {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    let mut metadata = BTreeMap::new();
+    for _ in 0..metadata_count {
+        let key = decoder.string(1, MAX_METADATA_KEY_BYTES)?;
+        let value = decoder.string(0, MAX_METADATA_VALUE_BYTES)?;
+        if metadata.insert(key, value).is_some() {
+            return Err(ControlError::InvalidDataPlaneRecord);
+        }
+    }
+    Ok(CompletionCall {
+        model,
+        system,
+        messages,
+        temperature,
+        max_tokens,
+        stop_sequences,
+        seed,
+        metadata,
+    })
+}
+
+fn encode_completion_result(
+    encoder: &mut Encoder,
+    result: &CompletionResult,
+) -> Result<(), ControlError> {
+    validate_string(&result.text, 1, MAX_DATA_PLANE_PAYLOAD_BYTES)?;
+    validate_string(&result.model, 1, MAX_MODEL_BYTES)?;
+    validate_string(&result.provider.vendor, 1, MAX_PROVIDER_FIELD_BYTES)?;
+    validate_string(&result.provider.model_family, 1, MAX_PROVIDER_FIELD_BYTES)?;
+    validate_string(&result.provider.model_version, 1, MAX_PROVIDER_FIELD_BYTES)?;
+    encoder.string(&result.text)?;
+    encoder.string(&result.model)?;
+    encoder.string(&result.provider.vendor)?;
+    encoder.string(&result.provider.model_family)?;
+    encoder.string(&result.provider.model_version)?;
+    encoder.optional_string(
+        result.provider.endpoint.as_deref(),
+        MAX_PROVIDER_ENDPOINT_BYTES,
+    )?;
+    encoder.u64(result.usage.input_tokens);
+    encoder.u64(result.usage.output_tokens);
+    encoder.u64(result.usage.cached_tokens);
+    encoder.u8(encode_finish_reason(result.finish_reason));
+    encoder.u64(result.latency_ms);
+    Ok(())
+}
+
+fn decode_completion_result(decoder: &mut Decoder<'_>) -> Result<CompletionResult, ControlError> {
+    Ok(CompletionResult {
+        text: decoder.string(1, MAX_DATA_PLANE_PAYLOAD_BYTES)?,
+        model: decoder.string(1, MAX_MODEL_BYTES)?,
+        provider: CompletionProvider {
+            vendor: decoder.string(1, MAX_PROVIDER_FIELD_BYTES)?,
+            model_family: decoder.string(1, MAX_PROVIDER_FIELD_BYTES)?,
+            model_version: decoder.string(1, MAX_PROVIDER_FIELD_BYTES)?,
+            endpoint: decoder.optional_string(MAX_PROVIDER_ENDPOINT_BYTES)?,
+        },
+        usage: CompletionUsage {
+            input_tokens: decoder.u64()?,
+            output_tokens: decoder.u64()?,
+            cached_tokens: decoder.u64()?,
+        },
+        finish_reason: decode_finish_reason(decoder.u8()?)?,
+        latency_ms: decoder.u64()?,
+    })
+}
+
+fn validate_uuid_v7(bytes: &[u8; 16]) -> Result<(), ControlError> {
+    if bytes[6] >> 4 != 7 || bytes[8] & 0xc0 != 0x80 {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    Ok(())
+}
+
+fn validate_string(value: &str, minimum: usize, maximum: usize) -> Result<(), ControlError> {
+    if value.len() < minimum || value.len() > maximum || value.contains('\0') {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    Ok(())
+}
+
+fn validate_bytes(value: &[u8], maximum: usize) -> Result<(), ControlError> {
+    if value.len() > maximum {
+        return Err(ControlError::InvalidDataPlaneRecord);
+    }
+    Ok(())
+}
+
+fn encode_role(role: PromptRole) -> u8 {
+    match role {
+        PromptRole::System => 1,
+        PromptRole::User => 2,
+        PromptRole::Assistant => 3,
+    }
+}
+
+fn decode_role(value: u8) -> Result<PromptRole, ControlError> {
+    match value {
+        1 => Ok(PromptRole::System),
+        2 => Ok(PromptRole::User),
+        3 => Ok(PromptRole::Assistant),
+        _ => Err(ControlError::InvalidDataPlaneRecord),
+    }
+}
+
+fn encode_finish_reason(reason: CompletionFinishReason) -> u8 {
+    match reason {
+        CompletionFinishReason::Stop => 1,
+        CompletionFinishReason::MaxTokens => 2,
+        CompletionFinishReason::Refusal => 3,
+        CompletionFinishReason::Other => 4,
+    }
+}
+
+fn decode_finish_reason(value: u8) -> Result<CompletionFinishReason, ControlError> {
+    match value {
+        1 => Ok(CompletionFinishReason::Stop),
+        2 => Ok(CompletionFinishReason::MaxTokens),
+        3 => Ok(CompletionFinishReason::Refusal),
+        4 => Ok(CompletionFinishReason::Other),
+        _ => Err(ControlError::InvalidDataPlaneRecord),
+    }
+}
+
+fn encode_failure(failure: DataPlaneFailure) -> u8 {
+    match failure {
+        DataPlaneFailure::InvalidRequest => 1,
+        DataPlaneFailure::Unauthorized => 2,
+        DataPlaneFailure::Channel => 3,
+        DataPlaneFailure::Completion => 4,
+        DataPlaneFailure::Unavailable => 5,
+        DataPlaneFailure::Internal => 6,
+    }
+}
+
+fn decode_failure(value: u8) -> Result<DataPlaneFailure, ControlError> {
+    match value {
+        1 => Ok(DataPlaneFailure::InvalidRequest),
+        2 => Ok(DataPlaneFailure::Unauthorized),
+        3 => Ok(DataPlaneFailure::Channel),
+        4 => Ok(DataPlaneFailure::Completion),
+        5 => Ok(DataPlaneFailure::Unavailable),
+        6 => Ok(DataPlaneFailure::Internal),
+        _ => Err(ControlError::InvalidDataPlaneRecord),
+    }
+}
+
+#[derive(Default)]
+struct Encoder {
+    bytes: Vec<u8>,
+}
+
+impl Encoder {
+    fn ensure_record_bound(&self) -> Result<(), ControlError> {
+        if self.bytes.len() > MAX_DATA_PLANE_RECORD_BYTES {
+            Err(ControlError::InvalidDataPlaneRecord)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn u8(&mut self, value: u8) {
+        self.bytes.push(value);
+    }
+
+    fn u16(&mut self, value: u16) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn u32(&mut self, value: u32) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn u64(&mut self, value: u64) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn fixed(&mut self, value: &[u8]) {
+        self.bytes.extend_from_slice(value);
+    }
+
+    fn bytes(&mut self, value: &[u8]) -> Result<(), ControlError> {
+        let length =
+            u32::try_from(value.len()).map_err(|_| ControlError::InvalidDataPlaneRecord)?;
+        self.u32(length);
+        self.fixed(value);
+        Ok(())
+    }
+
+    fn string(&mut self, value: &str) -> Result<(), ControlError> {
+        self.bytes(value.as_bytes())
+    }
+
+    fn optional_string(&mut self, value: Option<&str>, maximum: usize) -> Result<(), ControlError> {
+        match value {
+            Some(value) => {
+                validate_string(value, 0, maximum)?;
+                self.u8(1);
+                self.string(value)
+            }
+            None => {
+                self.u8(0);
+                Ok(())
+            }
+        }
+    }
+
+    fn optional_u32(&mut self, value: Option<u32>) {
+        match value {
+            Some(value) => {
+                self.u8(1);
+                self.u32(value);
+            }
+            None => self.u8(0),
+        }
+    }
+
+    fn optional_u64(&mut self, value: Option<u64>) {
+        match value {
+            Some(value) => {
+                self.u8(1);
+                self.u64(value);
+            }
+            None => self.u8(0),
+        }
+    }
+}
+
+struct Decoder<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Decoder<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn take(&mut self, length: usize) -> Result<&'a [u8], ControlError> {
+        let end = self
+            .offset
+            .checked_add(length)
+            .ok_or(ControlError::InvalidDataPlaneRecord)?;
+        let result = self
+            .bytes
+            .get(self.offset..end)
+            .ok_or(ControlError::InvalidDataPlaneRecord)?;
+        self.offset = end;
+        Ok(result)
+    }
+
+    fn u8(&mut self) -> Result<u8, ControlError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, ControlError> {
+        let bytes = self
+            .take(2)?
+            .try_into()
+            .map_err(|_| ControlError::InvalidDataPlaneRecord)?;
+        Ok(u16::from_be_bytes(bytes))
+    }
+
+    fn u32(&mut self) -> Result<u32, ControlError> {
+        let bytes = self
+            .take(4)?
+            .try_into()
+            .map_err(|_| ControlError::InvalidDataPlaneRecord)?;
+        Ok(u32::from_be_bytes(bytes))
+    }
+
+    fn u64(&mut self) -> Result<u64, ControlError> {
+        let bytes = self
+            .take(8)?
+            .try_into()
+            .map_err(|_| ControlError::InvalidDataPlaneRecord)?;
+        Ok(u64::from_be_bytes(bytes))
+    }
+
+    fn bytes(&mut self, maximum: usize) -> Result<Vec<u8>, ControlError> {
+        let length = self.u32()? as usize;
+        if length > maximum {
+            return Err(ControlError::InvalidDataPlaneRecord);
+        }
+        Ok(self.take(length)?.to_vec())
+    }
+
+    fn string(&mut self, minimum: usize, maximum: usize) -> Result<String, ControlError> {
+        let bytes = self.bytes(maximum)?;
+        let value = String::from_utf8(bytes).map_err(|_| ControlError::InvalidDataPlaneRecord)?;
+        validate_string(&value, minimum, maximum)?;
+        Ok(value)
+    }
+
+    fn optional_string(&mut self, maximum: usize) -> Result<Option<String>, ControlError> {
+        match self.u8()? {
+            0 => Ok(None),
+            1 => Ok(Some(self.string(0, maximum)?)),
+            _ => Err(ControlError::InvalidDataPlaneRecord),
+        }
+    }
+
+    fn optional_u32(&mut self) -> Result<Option<u32>, ControlError> {
+        match self.u8()? {
+            0 => Ok(None),
+            1 => Ok(Some(self.u32()?)),
+            _ => Err(ControlError::InvalidDataPlaneRecord),
+        }
+    }
+
+    fn optional_u64(&mut self) -> Result<Option<u64>, ControlError> {
+        match self.u8()? {
+            0 => Ok(None),
+            1 => Ok(Some(self.u64()?)),
+            _ => Err(ControlError::InvalidDataPlaneRecord),
+        }
+    }
+
+    fn uuid_v7(&mut self) -> Result<[u8; 16], ControlError> {
+        let bytes: [u8; 16] = self
+            .take(16)?
+            .try_into()
+            .map_err(|_| ControlError::InvalidDataPlaneRecord)?;
+        validate_uuid_v7(&bytes)?;
+        Ok(bytes)
+    }
+
+    fn finish(self) -> Result<(), ControlError> {
+        if self.offset == self.bytes.len() {
+            Ok(())
+        } else {
+            Err(ControlError::InvalidDataPlaneRecord)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uuid_v7(last: u8) -> [u8; 16] {
+        let mut bytes = [0u8; 16];
+        bytes[6] = 0x70;
+        bytes[8] = 0x80;
+        bytes[15] = last;
+        bytes
+    }
+
+    fn call_with_all_roles() -> CompletionCall {
+        CompletionCall {
+            model: "model".to_string(),
+            system: None,
+            messages: vec![
+                PromptMessage {
+                    role: PromptRole::System,
+                    text: "system".to_string(),
+                },
+                PromptMessage {
+                    role: PromptRole::User,
+                    text: "user".to_string(),
+                },
+                PromptMessage {
+                    role: PromptRole::Assistant,
+                    text: "assistant".to_string(),
+                },
+            ],
+            temperature: 2.0,
+            max_tokens: None,
+            stop_sequences: Vec::new(),
+            seed: None,
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    fn result(reason: CompletionFinishReason) -> CompletionResult {
+        CompletionResult {
+            text: "result".to_string(),
+            model: "model".to_string(),
+            provider: CompletionProvider {
+                vendor: "vendor".to_string(),
+                model_family: "family".to_string(),
+                model_version: "version".to_string(),
+                endpoint: None,
+            },
+            usage: CompletionUsage {
+                input_tokens: 1,
+                output_tokens: 2,
+                cached_tokens: 3,
+            },
+            finish_reason: reason,
+            latency_ms: 4,
+        }
+    }
+
+    #[test]
+    fn every_enum_value_and_optional_absence_round_trips() {
+        let request = DataRecord::Request(DataPlaneRequest::Complete {
+            id: RequestId::new(1).unwrap(),
+            call: call_with_all_roles(),
+        });
+        let (tag, body) = encode(&request).unwrap();
+        assert_eq!(decode(tag, &body).unwrap(), request);
+
+        for reason in [
+            CompletionFinishReason::Stop,
+            CompletionFinishReason::MaxTokens,
+            CompletionFinishReason::Refusal,
+            CompletionFinishReason::Other,
+        ] {
+            let response = DataRecord::Response(DataPlaneResponse::Completed {
+                id: RequestId::new(2).unwrap(),
+                result: Box::new(result(reason)),
+            });
+            let (tag, body) = encode(&response).unwrap();
+            assert_eq!(decode(tag, &body).unwrap(), response);
+        }
+
+        for failure in [
+            DataPlaneFailure::InvalidRequest,
+            DataPlaneFailure::Unauthorized,
+            DataPlaneFailure::Channel,
+            DataPlaneFailure::Completion,
+            DataPlaneFailure::Unavailable,
+            DataPlaneFailure::Internal,
+        ] {
+            let response = DataRecord::Response(DataPlaneResponse::Failed {
+                id: RequestId::new(3).unwrap(),
+                failure,
+            });
+            let (tag, body) = encode(&response).unwrap();
+            assert_eq!(decode(tag, &body).unwrap(), response);
+        }
+    }
+
+    #[test]
+    fn primitive_decoders_reject_noncanonical_discriminants_and_input() {
+        assert_eq!(RequestId::new(0), Err(ControlError::InvalidDataPlaneRecord));
+        assert_eq!(decode_role(0), Err(ControlError::InvalidDataPlaneRecord));
+        assert_eq!(
+            decode_finish_reason(0),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
+        assert_eq!(decode_failure(0), Err(ControlError::InvalidDataPlaneRecord));
+        assert_eq!(
+            decode(99, &1u64.to_be_bytes()),
+            Err(ControlError::UnknownMessageKind)
+        );
+
+        let mut invalid_optional = Decoder::new(&[2]);
+        assert_eq!(
+            invalid_optional.optional_string(10),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
+        let mut invalid_optional = Decoder::new(&[2]);
+        assert_eq!(
+            invalid_optional.optional_u32(),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
+        let mut invalid_optional = Decoder::new(&[2]);
+        assert_eq!(
+            invalid_optional.optional_u64(),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
+        let mut invalid_utf8 = Decoder::new(&[0, 0, 0, 1, 0xff]);
+        assert_eq!(
+            invalid_utf8.string(0, 1),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
+        let mut truncated = Decoder::new(&[0]);
+        assert_eq!(truncated.u64(), Err(ControlError::InvalidDataPlaneRecord));
+    }
+
+    #[test]
+    fn static_bounds_reject_invalid_requests_and_responses() {
+        let id = RequestId::new(1).unwrap();
+        let invalid_requests = [
+            DataPlaneRequest::Receive {
+                id,
+                channel_id: uuid_v7(1),
+                limit: 0,
+            },
+            DataPlaneRequest::Receive {
+                id,
+                channel_id: [0; 16],
+                limit: 1,
+            },
+            DataPlaneRequest::Publish {
+                id,
+                channel_id: uuid_v7(1),
+                content_type: String::new(),
+                payload: Vec::new(),
+            },
+            DataPlaneRequest::Publish {
+                id,
+                channel_id: uuid_v7(1),
+                content_type: "text/plain".to_string(),
+                payload: vec![0; MAX_DATA_PLANE_PAYLOAD_BYTES + 1],
+            },
+            DataPlaneRequest::Acknowledge {
+                id,
+                channel_id: uuid_v7(1),
+                message_id: [0; 16],
+            },
+        ];
+        for request in invalid_requests {
+            assert_eq!(
+                encode(&DataRecord::Request(request)),
+                Err(ControlError::InvalidDataPlaneRecord)
+            );
+        }
+
+        let too_many_messages = DataPlaneResponse::Received {
+            id,
+            messages: (0..=MAX_DATA_PLANE_MESSAGES)
+                .map(|index| DataPlaneMessage {
+                    message_id: uuid_v7(index as u8),
+                    sequence: index as u64,
+                    timestamp_ns: 0,
+                    content_type: "text/plain".to_string(),
+                    payload: Vec::new(),
+                })
+                .collect(),
+        };
+        assert_eq!(
+            encode(&DataRecord::Response(too_many_messages)),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
+        let aggregate_too_large = DataPlaneResponse::Received {
+            id,
+            messages: [1, 2]
+                .into_iter()
+                .map(|last| DataPlaneMessage {
+                    message_id: uuid_v7(last),
+                    sequence: u64::from(last),
+                    timestamp_ns: 0,
+                    content_type: "application/octet-stream".to_string(),
+                    payload: vec![0; MAX_DATA_PLANE_PAYLOAD_BYTES],
+                })
+                .collect(),
+        };
+        assert_eq!(
+            encode(&DataRecord::Response(aggregate_too_large)),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
+        let invalid_published = DataPlaneResponse::Published {
+            id,
+            message_id: [0; 16],
+            sequence: 0,
+            timestamp_ns: 0,
+        };
+        assert_eq!(
+            encode(&DataRecord::Response(invalid_published)),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
+    }
+
+    #[test]
+    fn completion_bounds_fail_closed() {
+        let id = RequestId::new(1).unwrap();
+        let invalid_calls = [
+            CompletionCall {
+                model: String::new(),
+                ..call_with_all_roles()
+            },
+            CompletionCall {
+                messages: Vec::new(),
+                ..call_with_all_roles()
+            },
+            CompletionCall {
+                temperature: f32::NAN,
+                ..call_with_all_roles()
+            },
+            CompletionCall {
+                max_tokens: Some(0),
+                ..call_with_all_roles()
+            },
+            CompletionCall {
+                stop_sequences: vec!["x".to_string(); MAX_STOP_SEQUENCES + 1],
+                ..call_with_all_roles()
+            },
+            CompletionCall {
+                metadata: (0..=MAX_METADATA_ENTRIES)
+                    .map(|index| (format!("key-{index}"), String::new()))
+                    .collect(),
+                ..call_with_all_roles()
+            },
+        ];
+        for call in invalid_calls {
+            assert_eq!(
+                encode(&DataRecord::Request(DataPlaneRequest::Complete {
+                    id,
+                    call,
+                })),
+                Err(ControlError::InvalidDataPlaneRecord)
+            );
+        }
+
+        let mut invalid_result = result(CompletionFinishReason::Stop);
+        invalid_result.provider.vendor = String::new();
+        assert_eq!(
+            encode(&DataRecord::Response(DataPlaneResponse::Completed {
+                id,
+                result: Box::new(invalid_result),
+            })),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
+    }
+}

--- a/code/packages/rust/chief-of-staff-host-control-protocol/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/src/lib.rs
@@ -1,4 +1,4 @@
-//! Authenticated D18 host readiness, heartbeat, and termination protocol.
+//! Authenticated D18 host lifecycle and bounded data-plane protocol.
 //!
 //! The secure host channel provides opaque authenticated bytes. This crate adds
 //! the minimum lifecycle state machine required by process supervision without
@@ -9,6 +9,20 @@
 
 use chief_of_staff_secure_host_channel::{ChannelError, ChannelRole, SecureHostChannel, SessionId};
 use core::fmt::{self, Display, Formatter};
+
+mod data_plane;
+
+pub use data_plane::{
+    CompletionCall, CompletionFinishReason, CompletionProvider, CompletionResult, CompletionUsage,
+    DataPlaneFailure, DataPlaneMessage, DataPlaneOperation, DataPlaneRequest, DataPlaneResponse,
+    PromptMessage, PromptRole, RequestId, MAX_DATA_PLANE_MESSAGES, MAX_DATA_PLANE_PAYLOAD_BYTES,
+    MAX_DATA_PLANE_RECORD_BYTES,
+};
+use data_plane::{DataRecord, ACKNOWLEDGED_RESPONSE_TAG, ACKNOWLEDGE_REQUEST_TAG};
+use data_plane::{
+    COMPLETED_RESPONSE_TAG, COMPLETE_REQUEST_TAG, FAILED_RESPONSE_TAG, PUBLISHED_RESPONSE_TAG,
+    PUBLISH_REQUEST_TAG, RECEIVED_RESPONSE_TAG, RECEIVE_REQUEST_TAG,
+};
 
 const MAGIC: &[u8; 4] = b"D18C";
 const VERSION: u8 = 1;
@@ -32,7 +46,7 @@ pub enum ControlState {
 }
 
 /// Authenticated child event with a supervisor-trusted receipt time.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ChildEvent {
     /// The child independently verified and started the exact package hash.
     Ready {
@@ -46,13 +60,17 @@ pub enum ChildEvent {
         /// Monotonic time sampled by the supervising caller after receipt.
         received_at_ns: u64,
     },
+    /// One correlated data-plane request from a ready child.
+    Request(DataPlaneRequest),
 }
 
 /// Authenticated orchestrator event accepted by a child.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum OrchestratorEvent {
     /// Begin graceful host shutdown.
     Terminate,
+    /// One exactly correlated response to the child's pending request.
+    Response(DataPlaneResponse),
 }
 
 /// Bounded host-control failure with input-independent diagnostics.
@@ -68,12 +86,20 @@ pub enum ControlError {
     UnsupportedVersion,
     /// The plaintext control message tag is unknown.
     UnknownMessageKind,
+    /// A data-plane body violated its static shape, UTF-8, UUID, or size bounds.
+    InvalidDataPlaneRecord,
     /// The peer sent a valid message kind owned by the opposite direction.
     WrongMessageDirection,
     /// The operation violates readiness or termination ordering.
     InvalidState,
     /// The child's independently verified package differs from registration.
     PackageMismatch,
+    /// A response identity or successful response operation mismatched the request.
+    CorrelationMismatch,
+    /// The serialized protocol permits only one outstanding data-plane request.
+    RequestInFlight,
+    /// The endpoint exhausted the non-zero request identity space.
+    RequestIdExhausted,
     /// A prior terminal failure permanently closed this endpoint.
     Closed,
 }
@@ -86,9 +112,13 @@ impl Display for ControlError {
             Self::MalformedRecord => "host-control: malformed record",
             Self::UnsupportedVersion => "host-control: unsupported version",
             Self::UnknownMessageKind => "host-control: unknown message kind",
+            Self::InvalidDataPlaneRecord => "host-control: invalid data-plane record",
             Self::WrongMessageDirection => "host-control: wrong message direction",
             Self::InvalidState => "host-control: invalid lifecycle state",
             Self::PackageMismatch => "host-control: package identity mismatch",
+            Self::CorrelationMismatch => "host-control: data-plane correlation mismatch",
+            Self::RequestInFlight => "host-control: data-plane request already in flight",
+            Self::RequestIdExhausted => "host-control: request identity space exhausted",
             Self::Closed => "host-control: endpoint is closed",
         })
     }
@@ -101,6 +131,8 @@ pub struct OrchestratorControl {
     channel: SecureHostChannel,
     expected_package_hash: [u8; 32],
     state: ControlState,
+    last_request_id: u64,
+    pending_request: Option<(RequestId, DataPlaneOperation)>,
 }
 
 impl OrchestratorControl {
@@ -116,6 +148,8 @@ impl OrchestratorControl {
             channel,
             expected_package_hash,
             state: ControlState::AwaitingReady,
+            last_request_id: 0,
+            pending_request: None,
         })
     }
 
@@ -151,9 +185,55 @@ impl OrchestratorControl {
             (ControlState::Running, ControlRecord::Heartbeat) => {
                 Ok(ChildEvent::Heartbeat { received_at_ns })
             }
-            (_, ControlRecord::Terminate) => Err(self.close(ControlError::WrongMessageDirection)),
+            (ControlState::Running, ControlRecord::Request(request)) => {
+                let expected = self
+                    .last_request_id
+                    .checked_add(1)
+                    .ok_or_else(|| self.close(ControlError::CorrelationMismatch))?;
+                if self.pending_request.is_some() || request.id().get() != expected {
+                    return Err(self.close(ControlError::CorrelationMismatch));
+                }
+                self.last_request_id = request.id().get();
+                self.pending_request = Some((request.id(), request.operation()));
+                Ok(ChildEvent::Request(request))
+            }
+            (_, ControlRecord::Terminate | ControlRecord::Response(_)) => {
+                Err(self.close(ControlError::WrongMessageDirection))
+            }
             _ => Err(self.close(ControlError::InvalidState)),
         }
+    }
+
+    /// Encrypt the response to the one pending child request.
+    pub fn respond(&mut self, response: DataPlaneResponse) -> Result<Vec<u8>, ControlError> {
+        if self.state == ControlState::Closed {
+            return Err(ControlError::Closed);
+        }
+        if self.state != ControlState::Running {
+            return Err(ControlError::InvalidState);
+        }
+        let Some((expected_id, expected_operation)) = self.pending_request else {
+            return Err(ControlError::CorrelationMismatch);
+        };
+        if response.id() != expected_id
+            || response
+                .operation()
+                .is_some_and(|operation| operation != expected_operation)
+        {
+            return Err(ControlError::CorrelationMismatch);
+        }
+        let plaintext = encode_record(ControlRecord::Response(response))?;
+        let frame = match self.channel.send(&plaintext) {
+            Ok(frame) => frame,
+            Err(error) => return Err(self.close(ControlError::Channel(error))),
+        };
+        self.pending_request = None;
+        Ok(frame)
+    }
+
+    /// Borrow the one request awaiting an orchestrator response.
+    pub fn pending_request(&self) -> Option<(RequestId, DataPlaneOperation)> {
+        self.pending_request
     }
 
     /// Encrypt one graceful-termination request and stop accepting messages.
@@ -163,7 +243,8 @@ impl OrchestratorControl {
             ControlState::Closed => return Err(ControlError::Closed),
             ControlState::Terminating => return Err(ControlError::InvalidState),
         }
-        let frame = match self.channel.send(&encode_record(ControlRecord::Terminate)) {
+        let plaintext = encode_record(ControlRecord::Terminate)?;
+        let frame = match self.channel.send(&plaintext) {
             Ok(frame) => frame,
             Err(error) => return Err(self.close(ControlError::Channel(error))),
         };
@@ -199,6 +280,8 @@ impl OrchestratorControl {
 pub struct ChildControl {
     channel: SecureHostChannel,
     state: ControlState,
+    next_request_id: Option<u64>,
+    pending_request: Option<(RequestId, DataPlaneOperation)>,
 }
 
 impl ChildControl {
@@ -210,6 +293,8 @@ impl ChildControl {
         Ok(Self {
             channel,
             state: ControlState::AwaitingReady,
+            next_request_id: Some(1),
+            pending_request: None,
         })
     }
 
@@ -221,10 +306,8 @@ impl ChildControl {
         if self.state != ControlState::AwaitingReady {
             return Err(ControlError::InvalidState);
         }
-        let frame = match self
-            .channel
-            .send(&encode_record(ControlRecord::Ready(package_hash)))
-        {
+        let plaintext = encode_record(ControlRecord::Ready(package_hash))?;
+        let frame = match self.channel.send(&plaintext) {
             Ok(frame) => frame,
             Err(error) => return Err(self.close(ControlError::Channel(error))),
         };
@@ -240,10 +323,60 @@ impl ChildControl {
         if self.state != ControlState::Running {
             return Err(ControlError::InvalidState);
         }
-        match self.channel.send(&encode_record(ControlRecord::Heartbeat)) {
+        let plaintext = encode_record(ControlRecord::Heartbeat)?;
+        match self.channel.send(&plaintext) {
             Ok(frame) => Ok(frame),
             Err(error) => Err(self.close(ControlError::Channel(error))),
         }
+    }
+
+    /// Encrypt one bounded channel receive request.
+    pub fn request_receive(
+        &mut self,
+        channel_id: [u8; 16],
+        limit: u16,
+    ) -> Result<(RequestId, Vec<u8>), ControlError> {
+        self.send_request(|id| DataPlaneRequest::Receive {
+            id,
+            channel_id,
+            limit,
+        })
+    }
+
+    /// Encrypt one bounded channel publish request.
+    pub fn request_publish(
+        &mut self,
+        channel_id: [u8; 16],
+        content_type: String,
+        payload: Vec<u8>,
+    ) -> Result<(RequestId, Vec<u8>), ControlError> {
+        self.send_request(|id| DataPlaneRequest::Publish {
+            id,
+            channel_id,
+            content_type,
+            payload,
+        })
+    }
+
+    /// Encrypt one delivered-message acknowledgement request.
+    pub fn request_acknowledge(
+        &mut self,
+        channel_id: [u8; 16],
+        message_id: [u8; 16],
+    ) -> Result<(RequestId, Vec<u8>), ControlError> {
+        self.send_request(|id| DataPlaneRequest::Acknowledge {
+            id,
+            channel_id,
+            message_id,
+        })
+    }
+
+    /// Encrypt one provider-neutral completion request.
+    pub fn request_completion(
+        &mut self,
+        call: CompletionCall,
+    ) -> Result<(RequestId, Vec<u8>), ControlError> {
+        self.send_request(|id| DataPlaneRequest::Complete { id, call })
     }
 
     /// Authenticate and apply one exact next orchestrator record.
@@ -270,7 +403,24 @@ impl ChildControl {
                 self.state = ControlState::Terminating;
                 Ok(OrchestratorEvent::Terminate)
             }
-            ControlRecord::Ready(_) | ControlRecord::Heartbeat => {
+            ControlRecord::Response(response) => {
+                if self.state != ControlState::Running {
+                    return Err(self.close(ControlError::InvalidState));
+                }
+                let Some((expected_id, expected_operation)) = self.pending_request else {
+                    return Err(self.close(ControlError::CorrelationMismatch));
+                };
+                if response.id() != expected_id
+                    || response
+                        .operation()
+                        .is_some_and(|operation| operation != expected_operation)
+                {
+                    return Err(self.close(ControlError::CorrelationMismatch));
+                }
+                self.pending_request = None;
+                Ok(OrchestratorEvent::Response(response))
+            }
+            ControlRecord::Ready(_) | ControlRecord::Heartbeat | ControlRecord::Request(_) => {
                 Err(self.close(ControlError::WrongMessageDirection))
             }
         }
@@ -286,23 +436,60 @@ impl ChildControl {
         self.state
     }
 
+    /// Borrow the one request awaiting an orchestrator response.
+    pub fn pending_request(&self) -> Option<(RequestId, DataPlaneOperation)> {
+        self.pending_request
+    }
+
+    fn send_request(
+        &mut self,
+        build: impl FnOnce(RequestId) -> DataPlaneRequest,
+    ) -> Result<(RequestId, Vec<u8>), ControlError> {
+        if self.state == ControlState::Closed {
+            return Err(ControlError::Closed);
+        }
+        if self.state != ControlState::Running {
+            return Err(ControlError::InvalidState);
+        }
+        if self.pending_request.is_some() {
+            return Err(ControlError::RequestInFlight);
+        }
+        let value = self
+            .next_request_id
+            .ok_or(ControlError::RequestIdExhausted)?;
+        let id = RequestId::new(value)?;
+        let request = build(id);
+        let operation = request.operation();
+        let plaintext = encode_record(ControlRecord::Request(request))?;
+        let frame = match self.channel.send(&plaintext) {
+            Ok(frame) => frame,
+            Err(error) => return Err(self.close(ControlError::Channel(error))),
+        };
+        self.next_request_id = value.checked_add(1);
+        self.pending_request = Some((id, operation));
+        Ok((id, frame))
+    }
+
     fn close(&mut self, error: ControlError) -> ControlError {
         self.state = ControlState::Closed;
         error
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 enum ControlRecord {
     Ready([u8; 32]),
     Heartbeat,
     Terminate,
+    Request(DataPlaneRequest),
+    Response(DataPlaneResponse),
 }
 
-fn encode_record(record: ControlRecord) -> Vec<u8> {
-    let mut output = Vec::with_capacity(match record {
+fn encode_record(record: ControlRecord) -> Result<Vec<u8>, ControlError> {
+    let mut output = Vec::with_capacity(match &record {
         ControlRecord::Ready(_) => READY_BYTES,
         ControlRecord::Heartbeat | ControlRecord::Terminate => HEADER_BYTES,
+        ControlRecord::Request(_) | ControlRecord::Response(_) => HEADER_BYTES + 128,
     });
     output.extend_from_slice(MAGIC);
     output.push(VERSION);
@@ -313,8 +500,18 @@ fn encode_record(record: ControlRecord) -> Vec<u8> {
         }
         ControlRecord::Heartbeat => output.push(HEARTBEAT_TAG),
         ControlRecord::Terminate => output.push(TERMINATE_TAG),
+        ControlRecord::Request(request) => {
+            let (tag, body) = data_plane::encode(&DataRecord::Request(request))?;
+            output.push(tag);
+            output.extend_from_slice(&body);
+        }
+        ControlRecord::Response(response) => {
+            let (tag, body) = data_plane::encode(&DataRecord::Response(response))?;
+            output.push(tag);
+            output.extend_from_slice(&body);
+        }
     }
-    output
+    Ok(output)
 }
 
 fn decode_record(bytes: &[u8]) -> Result<ControlRecord, ControlError> {
@@ -350,6 +547,21 @@ fn decode_record(bytes: &[u8]) -> Result<ControlRecord, ControlError> {
             }
             Ok(ControlRecord::Terminate)
         }
+        RECEIVE_REQUEST_TAG
+        | PUBLISH_REQUEST_TAG
+        | ACKNOWLEDGE_REQUEST_TAG
+        | COMPLETE_REQUEST_TAG => match data_plane::decode(header[5], &bytes[HEADER_BYTES..])? {
+            DataRecord::Request(request) => Ok(ControlRecord::Request(request)),
+            DataRecord::Response(_) => Err(ControlError::InvalidDataPlaneRecord),
+        },
+        RECEIVED_RESPONSE_TAG
+        | PUBLISHED_RESPONSE_TAG
+        | ACKNOWLEDGED_RESPONSE_TAG
+        | COMPLETED_RESPONSE_TAG
+        | FAILED_RESPONSE_TAG => match data_plane::decode(header[5], &bytes[HEADER_BYTES..])? {
+            DataRecord::Response(response) => Ok(ControlRecord::Response(response)),
+            DataRecord::Request(_) => Err(ControlError::InvalidDataPlaneRecord),
+        },
         _ => Err(ControlError::UnknownMessageKind),
     }
 }
@@ -388,6 +600,60 @@ mod tests {
         )
     }
 
+    fn uuid_v7(last: u8) -> [u8; 16] {
+        let mut bytes = [0u8; 16];
+        bytes[..6].copy_from_slice(&[1, 2, 3, 4, 5, 6]);
+        bytes[6] = 0x70;
+        bytes[8] = 0x80;
+        bytes[15] = last;
+        bytes
+    }
+
+    fn completion_call() -> CompletionCall {
+        CompletionCall {
+            model: "test-model".to_string(),
+            system: Some("answer weather questions".to_string()),
+            messages: vec![PromptMessage {
+                role: PromptRole::User,
+                text: "weather in Seattle".to_string(),
+            }],
+            temperature: 0.0,
+            max_tokens: Some(128),
+            stop_sequences: vec!["END".to_string()],
+            seed: Some(7),
+            metadata: [("agent".to_string(), "weather".to_string())]
+                .into_iter()
+                .collect(),
+        }
+    }
+
+    fn completion_result() -> CompletionResult {
+        CompletionResult {
+            text: "Rain".to_string(),
+            model: "test-model-1".to_string(),
+            provider: CompletionProvider {
+                vendor: "test".to_string(),
+                model_family: "test-model".to_string(),
+                model_version: "1".to_string(),
+                endpoint: Some("local".to_string()),
+            },
+            usage: CompletionUsage {
+                input_tokens: 4,
+                output_tokens: 1,
+                cached_tokens: 0,
+            },
+            finish_reason: CompletionFinishReason::Stop,
+            latency_ms: 3,
+        }
+    }
+
+    fn running_pair(hash: [u8; 32]) -> (OrchestratorControl, ChildControl) {
+        let (mut orchestrator, mut child) = control_pair(hash);
+        let ready = child.ready(hash).unwrap();
+        orchestrator.receive_child(&ready, 1).unwrap();
+        (orchestrator, child)
+    }
+
     #[test]
     fn matching_ready_and_heartbeats_preserve_trusted_receipt_times() {
         let hash = [7u8; 32];
@@ -411,6 +677,236 @@ mod tests {
         }
         assert_eq!(orchestrator.state(), ControlState::Running);
         assert_eq!(child.state(), ControlState::Running);
+    }
+
+    #[test]
+    fn authenticated_data_plane_round_trips_every_operation() {
+        let (mut orchestrator, mut child) = running_pair([10; 32]);
+
+        let (receive_id, frame) = child.request_receive(uuid_v7(1), 2).unwrap();
+        assert_eq!(receive_id.get(), 1);
+        assert_eq!(
+            orchestrator.receive_child(&frame, 2).unwrap(),
+            ChildEvent::Request(DataPlaneRequest::Receive {
+                id: receive_id,
+                channel_id: uuid_v7(1),
+                limit: 2,
+            })
+        );
+        let received = DataPlaneResponse::Received {
+            id: receive_id,
+            messages: vec![DataPlaneMessage {
+                message_id: uuid_v7(2),
+                sequence: 9,
+                timestamp_ns: 11,
+                content_type: "text/plain".to_string(),
+                payload: b"Seattle".to_vec(),
+            }],
+        };
+        let frame = orchestrator.respond(received.clone()).unwrap();
+        assert_eq!(
+            child.receive_orchestrator(&frame).unwrap(),
+            OrchestratorEvent::Response(received)
+        );
+
+        let (publish_id, frame) = child
+            .request_publish(
+                uuid_v7(3),
+                "text/plain; charset=utf-8".to_string(),
+                b"Rain".to_vec(),
+            )
+            .unwrap();
+        assert_eq!(publish_id.get(), 2);
+        assert!(matches!(
+            orchestrator.receive_child(&frame, 3).unwrap(),
+            ChildEvent::Request(DataPlaneRequest::Publish { id, .. }) if id == publish_id
+        ));
+        let published = DataPlaneResponse::Published {
+            id: publish_id,
+            message_id: uuid_v7(4),
+            sequence: 10,
+            timestamp_ns: 12,
+        };
+        let frame = orchestrator.respond(published.clone()).unwrap();
+        assert_eq!(
+            child.receive_orchestrator(&frame).unwrap(),
+            OrchestratorEvent::Response(published)
+        );
+
+        let (ack_id, frame) = child.request_acknowledge(uuid_v7(1), uuid_v7(2)).unwrap();
+        assert_eq!(ack_id.get(), 3);
+        assert!(matches!(
+            orchestrator.receive_child(&frame, 4).unwrap(),
+            ChildEvent::Request(DataPlaneRequest::Acknowledge { id, .. }) if id == ack_id
+        ));
+        let acknowledged = DataPlaneResponse::Acknowledged {
+            id: ack_id,
+            sequence: 9,
+        };
+        let frame = orchestrator.respond(acknowledged.clone()).unwrap();
+        assert_eq!(
+            child.receive_orchestrator(&frame).unwrap(),
+            OrchestratorEvent::Response(acknowledged)
+        );
+
+        let call = completion_call();
+        let (completion_id, frame) = child.request_completion(call.clone()).unwrap();
+        assert_eq!(completion_id.get(), 4);
+        assert_eq!(
+            orchestrator.receive_child(&frame, 5).unwrap(),
+            ChildEvent::Request(DataPlaneRequest::Complete {
+                id: completion_id,
+                call,
+            })
+        );
+        let completed = DataPlaneResponse::Completed {
+            id: completion_id,
+            result: Box::new(completion_result()),
+        };
+        let frame = orchestrator.respond(completed.clone()).unwrap();
+        assert_eq!(
+            child.receive_orchestrator(&frame).unwrap(),
+            OrchestratorEvent::Response(completed)
+        );
+
+        let (failure_id, frame) = child.request_receive(uuid_v7(5), 1).unwrap();
+        orchestrator.receive_child(&frame, 6).unwrap();
+        let failed = DataPlaneResponse::Failed {
+            id: failure_id,
+            failure: DataPlaneFailure::Unavailable,
+        };
+        let frame = orchestrator.respond(failed.clone()).unwrap();
+        assert_eq!(
+            child.receive_orchestrator(&frame).unwrap(),
+            OrchestratorEvent::Response(failed)
+        );
+        assert_eq!(child.pending_request(), None);
+        assert_eq!(orchestrator.pending_request(), None);
+    }
+
+    #[test]
+    fn local_data_plane_misuse_is_rejected_without_consuming_correlation() {
+        let (_, mut awaiting_child) = control_pair([11; 32]);
+        assert_eq!(
+            awaiting_child.request_receive(uuid_v7(1), 1),
+            Err(ControlError::InvalidState)
+        );
+        assert_eq!(awaiting_child.state(), ControlState::AwaitingReady);
+
+        let (mut orchestrator, mut child) = running_pair([12; 32]);
+        assert_eq!(
+            child.request_receive([0; 16], 1),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
+        assert_eq!(child.pending_request(), None);
+
+        let (id, frame) = child.request_receive(uuid_v7(1), 1).unwrap();
+        assert_eq!(id.get(), 1);
+        assert_eq!(
+            child.request_receive(uuid_v7(1), 1),
+            Err(ControlError::RequestInFlight)
+        );
+        orchestrator.receive_child(&frame, 2).unwrap();
+        let wrong_shape = DataPlaneResponse::Acknowledged { id, sequence: 0 };
+        assert_eq!(
+            orchestrator.respond(wrong_shape),
+            Err(ControlError::CorrelationMismatch)
+        );
+        assert_eq!(
+            orchestrator.pending_request(),
+            Some((id, DataPlaneOperation::Receive))
+        );
+        let response = DataPlaneResponse::Received {
+            id,
+            messages: Vec::new(),
+        };
+        let frame = orchestrator.respond(response).unwrap();
+        child.receive_orchestrator(&frame).unwrap();
+
+        let (_, mut exhausted_child) = running_pair([15; 32]);
+        exhausted_child.next_request_id = None;
+        assert_eq!(
+            exhausted_child.request_receive(uuid_v7(1), 1),
+            Err(ControlError::RequestIdExhausted)
+        );
+    }
+
+    #[test]
+    fn peer_correlation_mismatch_fails_closed() {
+        let (mut orchestrator, mut child) = running_pair([13; 32]);
+        let (id, request) = child.request_receive(uuid_v7(1), 1).unwrap();
+        orchestrator.receive_child(&request, 2).unwrap();
+        let wrong_id = RequestId::new(id.get() + 1).unwrap();
+        let plaintext = encode_record(ControlRecord::Response(DataPlaneResponse::Received {
+            id: wrong_id,
+            messages: Vec::new(),
+        }))
+        .unwrap();
+        let frame = orchestrator.channel.send(&plaintext).unwrap();
+        assert_eq!(
+            child.receive_orchestrator(&frame),
+            Err(ControlError::CorrelationMismatch)
+        );
+        assert_eq!(child.state(), ControlState::Closed);
+
+        let (mut orchestrator, mut child) = running_pair([16; 32]);
+        child.next_request_id = Some(2);
+        let (_, skipped_request) = child.request_receive(uuid_v7(1), 1).unwrap();
+        assert_eq!(
+            orchestrator.receive_child(&skipped_request, 3),
+            Err(ControlError::CorrelationMismatch)
+        );
+        assert_eq!(orchestrator.state(), ControlState::Closed);
+    }
+
+    #[test]
+    fn data_plane_codec_rejects_truncation_trailing_bytes_and_limits() {
+        let request = ControlRecord::Request(DataPlaneRequest::Publish {
+            id: RequestId::new(1).unwrap(),
+            channel_id: uuid_v7(1),
+            content_type: "application/octet-stream".to_string(),
+            payload: vec![1, 2, 3],
+        });
+        let encoded = encode_record(request).unwrap();
+        assert!(matches!(
+            decode_record(&encoded),
+            Ok(ControlRecord::Request(DataPlaneRequest::Publish { .. }))
+        ));
+        for end in 0..encoded.len() {
+            assert!(decode_record(&encoded[..end]).is_err());
+        }
+        let mut trailing = encoded;
+        trailing.push(0);
+        assert_eq!(
+            decode_record(&trailing),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
+
+        let (mut orchestrator, mut child) = running_pair([14; 32]);
+        let mut oversized = completion_call();
+        oversized.model = "m".repeat(201);
+        assert_eq!(
+            child.request_completion(oversized),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
+        assert_eq!(child.pending_request(), None);
+
+        let (_, request) = child.request_receive(uuid_v7(1), 1).unwrap();
+        orchestrator.receive_child(&request, 2).unwrap();
+        let invalid_message = DataPlaneResponse::Received {
+            id: RequestId::new(1).unwrap(),
+            messages: vec![DataPlaneMessage {
+                message_id: [0; 16],
+                sequence: 0,
+                timestamp_ns: 0,
+                content_type: "text/plain".to_string(),
+                payload: Vec::new(),
+            }],
+        };
+        assert_eq!(
+            orchestrator.respond(invalid_message),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
     }
 
     #[test]
@@ -457,7 +953,7 @@ mod tests {
         let (orchestrator_channel, mut child_channel) = raw_pair(3);
         let mut orchestrator = OrchestratorControl::new(orchestrator_channel, [4; 32]).unwrap();
         let early_heartbeat = child_channel
-            .send(&encode_record(ControlRecord::Heartbeat))
+            .send(&encode_record(ControlRecord::Heartbeat).unwrap())
             .unwrap();
         assert_eq!(
             orchestrator.receive_child(&early_heartbeat, 1),
@@ -472,7 +968,7 @@ mod tests {
         orchestrator.receive_child(&first, 1).unwrap();
         let duplicate = child
             .channel
-            .send(&encode_record(ControlRecord::Ready([4; 32])))
+            .send(&encode_record(ControlRecord::Ready([4; 32])).unwrap())
             .unwrap();
         assert_eq!(
             orchestrator.receive_child(&duplicate, 2),
@@ -501,7 +997,7 @@ mod tests {
         assert_eq!(child.state(), ControlState::Closed);
         let post_terminate = child
             .channel
-            .send(&encode_record(ControlRecord::Heartbeat))
+            .send(&encode_record(ControlRecord::Heartbeat).unwrap())
             .unwrap();
         assert_eq!(
             orchestrator.receive_child(&post_terminate, 9),
@@ -524,7 +1020,7 @@ mod tests {
         let (orchestrator_channel, mut child_channel) = raw_pair(5);
         let mut orchestrator = OrchestratorControl::new(orchestrator_channel, [7; 32]).unwrap();
         let terminate = child_channel
-            .send(&encode_record(ControlRecord::Terminate))
+            .send(&encode_record(ControlRecord::Terminate).unwrap())
             .unwrap();
         assert_eq!(
             orchestrator.receive_child(&terminate, 1),
@@ -535,7 +1031,7 @@ mod tests {
         let (mut orchestrator_channel, child_channel) = raw_pair(6);
         let mut child = ChildControl::new(child_channel).unwrap();
         let ready = orchestrator_channel
-            .send(&encode_record(ControlRecord::Ready([7; 32])))
+            .send(&encode_record(ControlRecord::Ready([7; 32])).unwrap())
             .unwrap();
         assert_eq!(
             child.receive_orchestrator(&ready),
@@ -579,7 +1075,7 @@ mod tests {
             ControlRecord::Terminate,
         ];
         for record in records {
-            let encoded = encode_record(record);
+            let encoded = encode_record(record.clone()).unwrap();
             assert_eq!(decode_record(&encoded), Ok(record));
             for end in 0..encoded.len() {
                 assert_eq!(
@@ -592,19 +1088,19 @@ mod tests {
             assert_eq!(decode_record(&trailing), Err(ControlError::MalformedRecord));
         }
 
-        let mut bad_magic = encode_record(ControlRecord::Heartbeat);
+        let mut bad_magic = encode_record(ControlRecord::Heartbeat).unwrap();
         bad_magic[0] = b'X';
         assert_eq!(
             decode_record(&bad_magic),
             Err(ControlError::MalformedRecord)
         );
-        let mut bad_version = encode_record(ControlRecord::Heartbeat);
+        let mut bad_version = encode_record(ControlRecord::Heartbeat).unwrap();
         bad_version[4] = 2;
         assert_eq!(
             decode_record(&bad_version),
             Err(ControlError::UnsupportedVersion)
         );
-        let mut bad_tag = encode_record(ControlRecord::Heartbeat);
+        let mut bad_tag = encode_record(ControlRecord::Heartbeat).unwrap();
         bad_tag[5] = 99;
         assert_eq!(
             decode_record(&bad_tag),
@@ -647,9 +1143,13 @@ mod tests {
             ControlError::MalformedRecord,
             ControlError::UnsupportedVersion,
             ControlError::UnknownMessageKind,
+            ControlError::InvalidDataPlaneRecord,
             ControlError::WrongMessageDirection,
             ControlError::InvalidState,
             ControlError::PackageMismatch,
+            ControlError::CorrelationMismatch,
+            ControlError::RequestInFlight,
+            ControlError::RequestIdExhausted,
             ControlError::Closed,
         ];
         for error in errors {

--- a/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Pass the authenticated package runtime to the single configured host program
   as the reserved final `--package-runtime deno|skill` argument pair.
+- Carry bounded correlated channel and completion exchanges over the established
+  secure child pipe, with child request helpers and supervisor-side pending-request
+  and response hooks.
+- Exercise receive, publish, acknowledge, and completion failure through a real
+  signed-package child process on the platform-neutral integration path.
 
 ## 0.1.0
 

--- a/code/packages/rust/chief-of-staff-process-supervisor/README.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/README.md
@@ -9,6 +9,13 @@ The single configured host executable receives a final reserved
 giving the production host a fail-closed runtime-dispatch seam without ambient
 environment or registry input.
 
+The same authenticated session now carries the host data plane. Child-side
+helpers serialize bounded channel receive/publish/acknowledge and provider-neutral
+completion exchanges. The supervisor retains one authenticated request per host
+until an injected service adapter answers through `respond_data_plane`, preserving
+exact correlation across real cross-platform process pipes without adding an
+unauthenticated side channel.
+
 Its keyring and X3DH identity are shared through owned `Arc` handles, and its
 session source is `Send`, so the complete supervisor can move with the daemon's
 threaded control plane without copying secret key material.
@@ -16,7 +23,9 @@ threaded control plane without copying secret key material.
 The crate implements the dependency-light service reconciler's
 `HostSupervisor` interface. It deliberately leaves durable restart policy,
 scheduling, backoff, and registry updates to the reconciler and runnable
-orchestrator.
+orchestrator. Channel endpoint and LLM service implementations remain injected by
+the concrete host/daemon composition rather than entering this process-authority
+crate.
 
 ## Validation
 

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/bin/process_supervisor_test_child.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/bin/process_supervisor_test_child.rs
@@ -1,8 +1,12 @@
+use chief_of_staff_host_control_protocol::{
+    CompletionCall, DataPlaneResponse, PromptMessage, PromptRole,
+};
 use chief_of_staff_host_runtime::{
     verify_agent_package, AgentPackageRuntime, PackageKeyType, PackageKeyring, TrustedPackageKey,
 };
 use chief_of_staff_process_supervisor::ChildProcessControl;
 use chief_of_staff_tool_api::PrivilegeTier;
+use std::collections::BTreeMap;
 use std::env;
 use std::io::{self, Write};
 use std::path::Path;
@@ -16,6 +20,52 @@ const TEST_PUBLIC_KEY: [u8; 32] = [
 
 fn has_marker(name: &str) -> bool {
     Path::new(name).is_file()
+}
+
+fn uuid_v7(last: u8) -> [u8; 16] {
+    let mut bytes = [0u8; 16];
+    bytes[6] = 0x70;
+    bytes[8] = 0x80;
+    bytes[15] = last;
+    bytes
+}
+
+fn exercise_data_plane(
+    control: &mut ChildProcessControl<impl io::Read, impl Write>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let received = control.request_receive(uuid_v7(1), 1)?;
+    if !matches!(received, DataPlaneResponse::Received { messages, .. } if messages.is_empty()) {
+        return Err("unexpected receive response".into());
+    }
+    let published =
+        control.request_publish(uuid_v7(2), "text/plain".to_string(), b"weather".to_vec())?;
+    if !matches!(published, DataPlaneResponse::Published { sequence: 1, .. }) {
+        return Err("unexpected publish response".into());
+    }
+    let acknowledged = control.request_acknowledge(uuid_v7(1), uuid_v7(3))?;
+    if !matches!(
+        acknowledged,
+        DataPlaneResponse::Acknowledged { sequence: 2, .. }
+    ) {
+        return Err("unexpected acknowledge response".into());
+    }
+    let completed = control.request_completion(CompletionCall {
+        model: "test-model".to_string(),
+        system: Some("be concise".to_string()),
+        messages: vec![PromptMessage {
+            role: PromptRole::User,
+            text: "weather".to_string(),
+        }],
+        temperature: 0.0,
+        max_tokens: Some(32),
+        stop_sequences: Vec::new(),
+        seed: Some(0),
+        metadata: BTreeMap::new(),
+    })?;
+    if !matches!(completed, DataPlaneResponse::Failed { .. }) {
+        return Err("unexpected completion response".into());
+    }
+    Ok(())
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -61,6 +111,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     control.ready(digest)?;
     if !has_marker("NO_HEARTBEAT") {
         control.heartbeat()?;
+    }
+    if has_marker("DATA_PLANE") {
+        exercise_data_plane(&mut control)?;
     }
     control.receive_terminate()?;
     if has_marker("IGNORE_TERMINATE") {

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
@@ -9,7 +9,8 @@
 
 use chief_of_staff_channel_crypto::ChannelId;
 use chief_of_staff_host_control_protocol::{
-    ChildControl, ChildEvent, OrchestratorControl, OrchestratorEvent,
+    ChildControl, ChildEvent, CompletionCall, DataPlaneRequest, DataPlaneResponse,
+    OrchestratorControl, OrchestratorEvent,
 };
 use chief_of_staff_host_runtime::{verify_agent_package, AgentPackageRuntime, PackageKeyring};
 use chief_of_staff_secure_host_channel::{
@@ -60,6 +61,8 @@ pub enum ProcessSupervisorError {
     Control,
     /// A different package is already active under this host name.
     ActivePackageMismatch,
+    /// No supervised process exists under the requested host name.
+    HostNotFound,
 }
 
 impl Display for ProcessSupervisorError {
@@ -76,6 +79,7 @@ impl Display for ProcessSupervisorError {
             Self::Framing => "process-supervisor: invalid framed record",
             Self::Control => "process-supervisor: host-control failure",
             Self::ActivePackageMismatch => "process-supervisor: active package identity mismatch",
+            Self::HostNotFound => "process-supervisor: host not found",
         })
     }
 }
@@ -237,6 +241,7 @@ struct OwnedInstance {
     started_at_ns: u64,
     last_heartbeat_ns: Option<u64>,
     channel_id: ChannelId,
+    pending_data_plane_request: Option<DataPlaneRequest>,
 }
 
 impl OwnedInstance {
@@ -251,6 +256,7 @@ impl OwnedInstance {
             let _ = reader.join();
         }
         self.control.take();
+        self.pending_data_plane_request = None;
         self.phase = InstancePhase::Exited {
             exit_code: status.code(),
         };
@@ -301,6 +307,9 @@ impl OwnedInstance {
                         | Ok(ChildEvent::Heartbeat { received_at_ns }) => {
                             self.phase = InstancePhase::Running;
                             self.last_heartbeat_ns = Some(received_at_ns);
+                        }
+                        Ok(ChildEvent::Request(request)) => {
+                            self.pending_data_plane_request = Some(request);
                         }
                         Err(error) => {
                             let _ = self.hard_kill_and_reap();
@@ -496,6 +505,7 @@ impl ProcessHostSupervisor {
                 reader: Some(reader),
                 records,
                 channel_id: ChannelId(control.session_id().as_bytes()),
+                pending_data_plane_request: None,
                 control: Some(control),
                 phase: InstancePhase::Starting,
                 process_id,
@@ -517,6 +527,54 @@ fn package_runtime_label(runtime: AgentPackageRuntime) -> &'static str {
     match runtime {
         AgentPackageRuntime::Deno => "deno",
         AgentPackageRuntime::Skill => "skill",
+    }
+}
+
+impl ProcessHostSupervisor {
+    /// Return the one authenticated request awaiting service for a host.
+    ///
+    /// The request remains pending until [`Self::respond_data_plane`] succeeds,
+    /// so an adapter can retry its own service lookup without losing correlation.
+    pub fn pending_data_plane_request(
+        &mut self,
+        host_name: &HostName,
+    ) -> Result<Option<DataPlaneRequest>, ProcessSupervisorError> {
+        let instance = self
+            .instances
+            .get_mut(host_name.as_str())
+            .ok_or(ProcessSupervisorError::HostNotFound)?;
+        instance.refresh()?;
+        Ok(instance.pending_data_plane_request.clone())
+    }
+
+    /// Send the exact correlated response for a host's pending request.
+    pub fn respond_data_plane(
+        &mut self,
+        host_name: &HostName,
+        response: DataPlaneResponse,
+    ) -> Result<(), ProcessSupervisorError> {
+        let instance = self
+            .instances
+            .get_mut(host_name.as_str())
+            .ok_or(ProcessSupervisorError::HostNotFound)?;
+        instance.refresh()?;
+        let frame = instance
+            .control
+            .as_mut()
+            .ok_or(ProcessSupervisorError::Control)?
+            .respond(response)
+            .map_err(|_| ProcessSupervisorError::Control)?;
+        let result = instance
+            .stdin
+            .as_mut()
+            .ok_or(ProcessSupervisorError::ProcessIo)
+            .and_then(|stdin| write_record(stdin, &frame));
+        if let Err(error) = result {
+            let _ = instance.hard_kill_and_reap();
+            return Err(error);
+        }
+        instance.pending_data_plane_request = None;
+        Ok(())
     }
 }
 
@@ -655,6 +713,58 @@ impl<R: Read, W: Write> ChildProcessControl<R, W> {
         write_record(&mut self.writer, &frame)
     }
 
+    /// Request one bounded page from an authorized channel.
+    pub fn request_receive(
+        &mut self,
+        channel_id: [u8; 16],
+        limit: u16,
+    ) -> Result<DataPlaneResponse, ProcessSupervisorError> {
+        let (_, frame) = self
+            .control
+            .request_receive(channel_id, limit)
+            .map_err(|_| ProcessSupervisorError::Control)?;
+        self.exchange_data_plane(frame)
+    }
+
+    /// Request publication of one bounded plaintext channel payload.
+    pub fn request_publish(
+        &mut self,
+        channel_id: [u8; 16],
+        content_type: String,
+        payload: Vec<u8>,
+    ) -> Result<DataPlaneResponse, ProcessSupervisorError> {
+        let (_, frame) = self
+            .control
+            .request_publish(channel_id, content_type, payload)
+            .map_err(|_| ProcessSupervisorError::Control)?;
+        self.exchange_data_plane(frame)
+    }
+
+    /// Request acknowledgement of one previously delivered message.
+    pub fn request_acknowledge(
+        &mut self,
+        channel_id: [u8; 16],
+        message_id: [u8; 16],
+    ) -> Result<DataPlaneResponse, ProcessSupervisorError> {
+        let (_, frame) = self
+            .control
+            .request_acknowledge(channel_id, message_id)
+            .map_err(|_| ProcessSupervisorError::Control)?;
+        self.exchange_data_plane(frame)
+    }
+
+    /// Request one provider-neutral completion.
+    pub fn request_completion(
+        &mut self,
+        call: CompletionCall,
+    ) -> Result<DataPlaneResponse, ProcessSupervisorError> {
+        let (_, frame) = self
+            .control
+            .request_completion(call)
+            .map_err(|_| ProcessSupervisorError::Control)?;
+        self.exchange_data_plane(frame)
+    }
+
     /// Block for and authenticate the orchestrator's graceful termination request.
     pub fn receive_terminate(&mut self) -> Result<(), ProcessSupervisorError> {
         let frame = read_record(&mut self.reader)?;
@@ -664,12 +774,29 @@ impl<R: Read, W: Write> ChildProcessControl<R, W> {
             .map_err(|_| ProcessSupervisorError::Control)?
         {
             OrchestratorEvent::Terminate => Ok(()),
+            OrchestratorEvent::Response(_) => Err(ProcessSupervisorError::Control),
         }
     }
 
     /// Return this launch's UUID-v7 secure-session identity.
     pub fn session_id(&self) -> SessionId {
         self.control.session_id()
+    }
+
+    fn exchange_data_plane(
+        &mut self,
+        frame: Vec<u8>,
+    ) -> Result<DataPlaneResponse, ProcessSupervisorError> {
+        write_record(&mut self.writer, &frame)?;
+        let response = read_record(&mut self.reader)?;
+        match self
+            .control
+            .receive_orchestrator(&response)
+            .map_err(|_| ProcessSupervisorError::Control)?
+        {
+            OrchestratorEvent::Response(response) => Ok(response),
+            OrchestratorEvent::Terminate => Err(ProcessSupervisorError::Control),
+        }
     }
 }
 
@@ -895,6 +1022,7 @@ mod tests {
                 ProcessSupervisorError::ActivePackageMismatch,
                 "active package identity mismatch",
             ),
+            (ProcessSupervisorError::HostNotFound, "host not found"),
         ];
         for (error, suffix) in cases {
             let standard: &dyn std::error::Error = &error;

--- a/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
@@ -1,3 +1,6 @@
+use chief_of_staff_host_control_protocol::{
+    DataPlaneFailure, DataPlaneRequest, DataPlaneResponse, RequestId,
+};
 use chief_of_staff_host_runtime::{
     DenoLaunchPlan, PackageKeyType, PackageKeyring, TrustedPackageKey,
 };
@@ -124,6 +127,7 @@ fn package_digest(path: &Path) -> [u8; 32] {
         ]
     };
     for marker in [
+        "DATA_PLANE",
         "EXIT_BEFORE_READY",
         "IGNORE_TERMINATE",
         "NO_HEARTBEAT",
@@ -146,6 +150,14 @@ fn package_digest(path: &Path) -> [u8; 32] {
         hasher.update(&bytes);
     }
     hasher.digest()
+}
+
+fn uuid_v7(last: u8) -> [u8; 16] {
+    let mut bytes = [0u8; 16];
+    bytes[6] = 0x70;
+    bytes[8] = 0x80;
+    bytes[15] = last;
+    bytes
 }
 
 fn keyring() -> PackageKeyring {
@@ -265,6 +277,80 @@ fn real_child_reaches_running_and_stops_gracefully() {
     );
     assert_eq!(exited.process_id(), None);
     supervisor.stop(registration.host_name()).unwrap();
+}
+
+#[test]
+fn real_child_exchanges_all_authenticated_data_plane_operations() {
+    let package = TestPackage::new("data-plane", Some("DATA_PLANE"));
+    let registration = package.registration("data-plane-host");
+    let host_name = HostName::new("data-plane-host").unwrap();
+    let mut supervisor = new_supervisor(
+        Arc::new(keyring()),
+        Arc::new(generate_identity_keypair()),
+        Duration::from_secs(2),
+        Duration::from_secs(2),
+    );
+    assert_eq!(
+        supervisor.pending_data_plane_request(&host_name),
+        Err(ProcessSupervisorError::HostNotFound)
+    );
+    assert_eq!(
+        supervisor.respond_data_plane(
+            &host_name,
+            DataPlaneResponse::Failed {
+                id: RequestId::new(1).unwrap(),
+                failure: DataPlaneFailure::Unavailable,
+            },
+        ),
+        Err(ProcessSupervisorError::HostNotFound)
+    );
+    supervisor.start(&registration).unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut operations = Vec::new();
+    while operations.len() < 4 {
+        if let Some(request) = supervisor.pending_data_plane_request(&host_name).unwrap() {
+            let response = match request {
+                DataPlaneRequest::Receive { id, .. } => {
+                    operations.push("receive");
+                    DataPlaneResponse::Received {
+                        id,
+                        messages: Vec::new(),
+                    }
+                }
+                DataPlaneRequest::Publish { id, .. } => {
+                    operations.push("publish");
+                    DataPlaneResponse::Published {
+                        id,
+                        message_id: uuid_v7(4),
+                        sequence: 1,
+                        timestamp_ns: 10,
+                    }
+                }
+                DataPlaneRequest::Acknowledge { id, .. } => {
+                    operations.push("acknowledge");
+                    DataPlaneResponse::Acknowledged { id, sequence: 2 }
+                }
+                DataPlaneRequest::Complete { id, .. } => {
+                    operations.push("complete");
+                    DataPlaneResponse::Failed {
+                        id,
+                        failure: DataPlaneFailure::Unavailable,
+                    }
+                }
+            };
+            supervisor.respond_data_plane(&host_name, response).unwrap();
+        } else {
+            assert!(Instant::now() < deadline, "timed out waiting for request");
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+    assert_eq!(
+        operations,
+        ["receive", "publish", "acknowledge", "complete"]
+    );
+    supervisor.stop(&host_name).unwrap();
+    assert_eq!(supervisor.pending_data_plane_request(&host_name), Ok(None));
 }
 
 #[test]

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -503,6 +503,12 @@ by the security escort (host process), not the Chief of Staff.
 
 The strict readiness, heartbeat, and termination state machine is specified in
 [`host-control-protocol.md`](host-control-protocol.md).
+That same authenticated session carries a serialized, bounded channel and
+provider-neutral completion data plane after readiness. The protocol permits one
+request in flight with exact monotonic correlation; the orchestrator-side adapter
+authorizes and executes the operation without creating a second child pipe. The
+payload-blind orchestration core receives no request body; the process adapter
+hands it only to the separately injected channel/LLM authority.
 
 ```
 ┌────────────────────────────────────────────────────────────────┐

--- a/code/specs/host-control-protocol.md
+++ b/code/specs/host-control-protocol.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-This document specifies the authenticated lifecycle protocol carried inside one
-D18 secure host channel. The implementation package is
+This document specifies the authenticated lifecycle and bounded host data-plane
+protocol carried inside one D18 secure host channel. The implementation package is
 `chief-of-staff-host-control-protocol`.
 
 ## Purpose
@@ -14,17 +14,18 @@ bytes. The service reconciler requires stronger process evidence: a host is
 authenticated channel, and later health evidence must come from authenticated
 heartbeats rather than PID existence.
 
-This protocol is the stable seam between those packages. It defines the minimum
-control messages and lifecycle ordering needed by a concrete process supervisor.
-It does not spawn processes, poll clocks, schedule heartbeats, or interpret agent
-manifests.
+This protocol is the stable seam between those packages. It defines lifecycle
+ordering plus the channel and provider-neutral completion operations a concrete
+host needs without creating a second unauthenticated pipe. It does not spawn
+processes, poll clocks, schedule heartbeats, interpret agent manifests, operate a
+channel, or call a model provider.
 
 ## Roles and Authority
 
 Every control session has exactly two roles inherited from the secure channel:
 
-- the orchestrator sends `Terminate`;
-- the child host sends `Ready` and `Heartbeat`.
+- the orchestrator sends `Terminate` and responses;
+- the child host sends `Ready`, `Heartbeat`, and requests.
 
 The orchestrator control endpoint is constructed with the immutable package hash
 from the service-registry registration. A `Ready` record carries the exact package
@@ -37,6 +38,14 @@ encrypted frame is received. This prevents a compromised child from forging a
 fresh or future heartbeat. The later reconciliation tick still rejects receipt
 times later than its own trusted `now_ns`.
 
+After readiness, the child may have exactly one data-plane request in flight. It
+mints non-zero `u64` request IDs beginning at one. The orchestrator requires each
+ID to be the exact successor of the last request and returns the same ID. A
+successful response kind must match the pending operation; a redacted `Failed`
+response may complete any operation. Duplicate, skipped, unsolicited, or
+cross-operation responses close the peer endpoint. This deliberately serial
+contract matches the Level 1 runtime and avoids an unbounded correlation table.
+
 ## Lifecycle
 
 The orchestrator endpoint begins in `AwaitingReady`:
@@ -46,21 +55,29 @@ The orchestrator endpoint begins in `AwaitingReady`:
    package, session, and receipt-time evidence.
 3. `Heartbeat` is accepted only in `Running` and refreshes the authoritative
    receipt time.
-4. `Terminate` may be sent while awaiting readiness or running, and transitions the
+4. One data-plane request is accepted only in `Running`; no second request is
+   accepted until the orchestrator sends its exact correlated response.
+5. `Terminate` may be sent while awaiting readiness or running, and transitions the
    endpoint to `Terminating`.
-5. No further application message is accepted or emitted after termination begins.
+6. No further application message is accepted or emitted after termination begins.
 
 The child endpoint begins in `AwaitingReady`:
 
 1. It must independently verify the package before sending `Ready(package_hash)`.
 2. It may send `Heartbeat` only after readiness.
-3. It accepts only `Terminate` from the orchestrator and then enters `Terminating`.
+3. It may send one bounded data-plane request after readiness and must wait for the
+   exactly correlated response before sending another.
+4. It accepts only correlated responses or `Terminate` from the orchestrator and
+   enters `Terminating` on the latter.
 
 Duplicate readiness, heartbeat-before-ready, child-sent terminate,
-orchestrator-sent ready/heartbeat, and messages after termination are protocol
-violations. Authentication, decoding, package identity, role, or lifecycle failure
-permanently closes the control endpoint. Callers terminate the underlying process
-out of band after a terminal peer failure.
+orchestrator-sent ready/heartbeat/request, child-sent response/terminate, invalid
+correlation, and messages after termination are protocol violations.
+Authentication, decoding, package identity, role, correlation, or lifecycle
+failure permanently closes the control endpoint. Callers terminate the underlying
+process out of band after a terminal peer failure. Locally rejected construction
+(for example an oversized publish) does not consume a request ID or close the
+endpoint.
 
 ## Wire Format
 
@@ -80,11 +97,30 @@ Kinds are:
 | 1   | child -> orchestrator | `Ready`     | 32-byte package SHA-256 |
 | 2   | child -> orchestrator | `Heartbeat` | empty                    |
 | 3   | orchestrator -> child | `Terminate` | empty                    |
+| 10  | child -> orchestrator | `Receive` | request ID, channel UUID-v7, limit |
+| 11  | child -> orchestrator | `Publish` | request ID, channel UUID-v7, content type, payload |
+| 12  | child -> orchestrator | `Acknowledge` | request ID, channel and message UUID-v7 |
+| 13  | child -> orchestrator | `Complete` | request ID, provider-neutral completion call |
+| 20  | orchestrator -> child | `Received` | request ID and verified message page |
+| 21  | orchestrator -> child | `Published` | request ID, message UUID-v7, sequence, timestamp |
+| 22  | orchestrator -> child | `Acknowledged` | request ID and monotonic sequence |
+| 23  | orchestrator -> child | `Completed` | request ID and provider-neutral completion result |
+| 24  | orchestrator -> child | `Failed` | request ID and redacted stable failure code |
 
-Records are at most 38 bytes before secure-channel encryption. Unknown versions,
-unknown tags, truncation, trailing bytes, and bodies with the wrong exact length
-are rejected. Diagnostics identify only the failure class; they never include
-package bytes, keys, ciphertext, or plaintext.
+All integers are big-endian. Variable bytes and UTF-8 strings use a `u32` length;
+vectors use their specified `u8` or `u16` count. UUID fields must be canonical
+UUID-v7 values. Data-plane bodies are capped at 768 KiB, a single channel payload
+or completion text at 512 KiB, a receive page and completion prompt at 64 items,
+and completion metadata at 32 unique canonically ordered keys. Completion calls
+are provider-neutral, text-only in v1, and bound model, prompt, stop, temperature,
+token, seed, and metadata fields. Responses retain provider identity, usage,
+finish reason, and latency for audit.
+
+Unknown versions/tags/enum values, invalid UTF-8 or UUIDs, non-finite or out-of-range
+temperatures, duplicate metadata keys, truncation, trailing bytes, oversized
+fields, and bodies with the wrong exact length are rejected. Diagnostics identify
+only the failure class; they never include package bytes, keys, ciphertext,
+provider details, or plaintext.
 
 ## Public API
 
@@ -92,10 +128,12 @@ package bytes, keys, ciphertext, or plaintext.
 pub enum ChildEvent {
     Ready { package_hash: [u8; 32], received_at_ns: u64 },
     Heartbeat { received_at_ns: u64 },
+    Request(DataPlaneRequest),
 }
 
 pub enum OrchestratorEvent {
     Terminate,
+    Response(DataPlaneResponse),
 }
 
 pub struct OrchestratorControl { /* channel, expected hash, lifecycle */ }
@@ -107,6 +145,9 @@ impl OrchestratorControl {
     pub fn receive_child(&mut self, frame: &[u8], received_at_ns: u64)
         -> Result<ChildEvent, ControlError>;
     pub fn terminate(&mut self) -> Result<Vec<u8>, ControlError>;
+    pub fn respond(&mut self, response: DataPlaneResponse)
+        -> Result<Vec<u8>, ControlError>;
+    pub fn pending_request(&self) -> Option<(RequestId, DataPlaneOperation)>;
     pub fn session_id(&self) -> SessionId;
     pub fn state(&self) -> ControlState;
 }
@@ -116,6 +157,16 @@ impl ChildControl {
     pub fn ready(&mut self, package_hash: [u8; 32])
         -> Result<Vec<u8>, ControlError>;
     pub fn heartbeat(&mut self) -> Result<Vec<u8>, ControlError>;
+    pub fn request_receive(&mut self, channel_id: [u8; 16], limit: u16)
+        -> Result<(RequestId, Vec<u8>), ControlError>;
+    pub fn request_publish(&mut self, channel_id: [u8; 16],
+        content_type: String, payload: Vec<u8>)
+        -> Result<(RequestId, Vec<u8>), ControlError>;
+    pub fn request_acknowledge(&mut self, channel_id: [u8; 16],
+        message_id: [u8; 16])
+        -> Result<(RequestId, Vec<u8>), ControlError>;
+    pub fn request_completion(&mut self, call: CompletionCall)
+        -> Result<(RequestId, Vec<u8>), ControlError>;
     pub fn receive_orchestrator(&mut self, frame: &[u8])
         -> Result<OrchestratorEvent, ControlError>;
     pub fn session_id(&self) -> SessionId;
@@ -130,10 +181,11 @@ channel ID without minting a second identity.
 ## Boundaries
 
 The package has no direct filesystem, network, stream, environment, process, clock,
-or random capability. It receives complete encrypted frames and trusted receipt
-times from its caller. Length-prefix framing, pipe ownership, process launch/reap,
-heartbeat scheduling, time sampling, and hard-kill fallback belong to the concrete
-process-supervisor adapter specified in
+random, channel-storage, key-custody, or model-provider capability. It receives
+complete encrypted frames and trusted receipt times from its caller. It validates
+and authenticates requests but does not authorize or execute them. Length-prefix
+framing, pipe ownership, process launch/reap, heartbeat scheduling, time sampling,
+service dispatch, and hard-kill fallback belong to adapters specified in
 [`process-host-supervisor.md`](process-host-supervisor.md).
 
 ## Required Tests
@@ -141,6 +193,12 @@ process-supervisor adapter specified in
 The package must cover:
 
 - matching readiness followed by multiple heartbeats;
+- authenticated round trips for receive, publish, acknowledge, completion, and
+  redacted failure;
+- one-in-flight ordering, monotonic request IDs, exact response correlation, and
+  successful-response operation matching;
+- every data-plane variant, bound, invalid UTF-8/UUID/enum, duplicate metadata,
+  truncation, and trailing bytes;
 - package-hash mismatch failing closed;
 - role-mismatched secure-channel constructors;
 - heartbeat-before-ready and duplicate-ready rejection;

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -231,10 +231,14 @@ capability authenticated lifecycle protocol over complete secure-host-channel
 frames. `Ready`, `Heartbeat`, and `Terminate` records, role and direction
 enforcement, lifecycle ordering, replay and package-hash mismatch rejection,
 caller-supplied trusted receipt times, and terminal malformed-input behavior
-are portable fixture candidates. Clocks, descriptors, streams, processes,
-filesystems, networks, package verification, and supervisor effects remain
-injected or native. Its dedicated backlog owner depends on the secure-host-
-channel contract and therefore remains dependency-blocked.
+are portable fixture candidates. The later host-data-plane extension adds
+bounded receive/publish/acknowledge and provider-neutral completion records,
+monotonic one-in-flight request correlation, canonical UUID validation, and
+redacted failures to that same portable kernel. Clocks, descriptors, streams,
+processes, filesystems, networks, package verification, channel/LLM effects,
+and supervisor authority remain injected or native. Its dedicated backlog owner
+depends on the secure-host-channel contract and therefore remains dependency-
+blocked.
 
 The `9ad8105f` refresh added `chief-of-staff-process-supervisor`. This crate is
 the concrete native authority behind the portable reconciler and host-control

--- a/code/specs/process-host-supervisor.md
+++ b/code/specs/process-host-supervisor.md
@@ -130,7 +130,10 @@ The package exposes:
 - `MonotonicClock` and `SessionIdSource` interfaces plus production adapters;
 - owned, movable `ProcessHostSupervisor`, implementing the reconciler
   `HostSupervisor` trait;
-- `ChildProcessControl<R, W>` for host-runtime integration; and
+- `ChildProcessControl<R, W>` for lifecycle plus serialized authenticated
+  receive/publish/acknowledge/completion exchanges;
+- `pending_data_plane_request` and `respond_data_plane` hooks that retain one
+  correlated request until an injected service adapter answers; and
 - bounded, input-independent `ProcessSupervisorError` diagnostics.
 
 ## Capabilities
@@ -149,6 +152,9 @@ The package must cover:
 - signature or registered-hash failure before process spawn;
 - real cross-platform child bootstrap, matching readiness, heartbeat, and
   graceful termination;
+- real cross-platform child exchanges for every data-plane operation over the
+  established secure process pipes;
+- pending-request retention and exact response correlation;
 - idempotent same-hash start and refusal of an active different-hash launch;
 - compile-time `Send + 'static` production composition with shared trust and
   identity ownership;


### PR DESCRIPTION
## What changed

- extend the existing authenticated `D18C` host session with strict binary records for channel receive, publish, acknowledge, and provider-neutral text completion
- serialize child requests one at a time with monotonic non-zero IDs, exact response correlation, response-kind matching, and redacted stable failures
- enforce canonical UUID-v7 identities plus aggregate, payload, prompt, metadata, UTF-8, enum, temperature, and token bounds below the secure channel frame ceiling
- expose child-side typed exchanges and supervisor-side pending-request/response hooks over the real process pipes
- exercise all four operations through an independently verified signed-package child process
- update D18, protocol, supervisor, package, parity, and changelog documentation

## Why

The production supervisor previously carried only `Ready`, `Heartbeat`, and `Terminate`. A verified Level 1 `SKILL.md` package could be launched, but its host had no authenticated way to reach injected channel endpoints or the provider-neutral LLM service. Reusing the already authenticated per-spawn session closes that seam without adding a second pipe or transport trust boundary.

This is the protocol/process-authority prerequisite for the concrete `chief-of-staff-host` composition and the text-only weather package. The broader 64 MiB SDK payload contract remains an explicit follow-up because the secure host channel has a 1 MiB frame limit; this v1 protocol fails closed at 512 KiB rather than pretending those limits match.

## Security properties

- peer authentication, encryption, ordering, and replay rejection remain owned by `chief-of-staff-secure-host-channel`
- data-plane requests are accepted only after exact package readiness
- one in-flight request avoids an unbounded correlation table
- skipped, duplicate, unsolicited, wrong-direction, and wrong-operation records fail closed
- local construction failures do not consume request IDs or close a healthy session
- error records and public diagnostics contain no payload, provider, key, or ciphertext detail
- the protocol crate retains zero ambient filesystem, process, network, clock, random, channel, or provider authority

## Validation

- `cargo test -p chief-of-staff-host-control-protocol -p chief-of-staff-process-supervisor -- --nocapture` (33 tests)
- `cargo clippy -p chief-of-staff-host-control-protocol -p chief-of-staff-process-supervisor --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p chief-of-staff-host-control-protocol -p chief-of-staff-process-supervisor --no-deps`
- package-scoped `cargo fmt --check`
- dependency-closed repository planner: 2 changed packages, 69 affected prerequisites/dependents, all green with strict Clippy
- `git diff --check`

Advances #128 and #138.
