### PR TITLE
Normalize NJFET model cards

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize the `NJFET` model type alias to canonical `NJF` cards.
 - Normalize the `DIODE` model type alias to canonical `D` cards.
 - Validate finite, non-negative MOS Level-1 model-card `CGBO` values.
 - Validate finite, non-negative MOS Level-1 model-card `CGDO` values.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1988,6 +1988,8 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             params_text = params_text[1:-1]
     if kind == "DIODE":
         kind = "D"
+    elif kind == "NJFET":
+        kind = "NJF"
     params = _parse_model_params(params_text)
     if kind == "D":
         saturation_current = params.get("IS", params.get("JS"))

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2097,6 +2097,18 @@ J1 drain gate source fast
     assert jfet.lambda_ == 0.02
 
 
+def test_parse_njfet_model_type_alias() -> None:
+    parsed = parse_netlist(
+        ".model fast NJFET(BETA=2m)\nJ1 drain gate source fast"
+    )
+
+    assert parsed.models["fast"].kind == "NJF"
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert jfet.polarity == "NJF"
+    assert jfet.beta == 2.0e-3
+
+
 @pytest.mark.parametrize("parameter", ["CGS", "CGS0"])
 def test_parse_jfet_gate_source_capacitance_aliases(parameter: str) -> None:
     parsed = parse_netlist(

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize the `NJFET` model type alias to canonical `NJF` cards.
 - Normalize the `DIODE` model type alias to canonical `D` cards.
 - Validate finite, non-negative MOS Level-1 model-card `CGBO` values.
 - Validate finite, non-negative MOS Level-1 model-card `CGDO` values.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1149,7 +1149,7 @@ function parseModelCard(fields: readonly string[]): ModelCard {
     paramsText = paramsText.slice(1, -1);
   }
   const rawKind = match[1].toUpperCase();
-  const kind = rawKind === "DIODE" ? "D" : rawKind;
+  const kind = rawKind === "DIODE" ? "D" : rawKind === "NJFET" ? "NJF" : rawKind;
   const params = parseModelParams(paramsText);
   const diodeSaturationCurrent = params.get("IS") ?? params.get("JS");
   if (

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2175,6 +2175,17 @@ J1 drain gate source fast
     });
   });
 
+  it("parses the NJFET model type alias", () => {
+    const parsed = parseNetlist(".model fast NJFET(BETA=2m)\nJ1 drain gate source fast");
+
+    expect(parsed.models.get("fast")?.kind).toBe("NJF");
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      polarity: "NJF",
+      beta: 2.0e-3,
+    });
+  });
+
   it.each(["CGS", "CGS0"])(
     "parses the JFET %s gate-source capacitance alias",
     (parameter) => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4723,9 +4723,15 @@ the Rust, Python, and TypeScript surfaces together.
      overlap-capacitance validation set.
 
 476. Python and TypeScript Berkeley SPICE diode model-type alias parity.
-   - Status: implemented in this model-type normalization slice.
+   - Status: completed in PR 10155.
    - Both parser facades normalize the engine-supported `DIODE` model type
      alias to canonical `D`, preserving diode validation and instance lowering.
+
+477. Python and TypeScript Berkeley SPICE N-channel JFET model-type alias parity.
+   - Status: implemented in this NJFET model-type normalization slice.
+   - Both parser facades normalize the engine-supported `NJFET` model type
+     alias to canonical `NJF`, preserving JFET validation and instance lowering
+     without changing the unresolved `B` parameter policy.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- normalize the engine-supported `NJFET` model type alias to canonical `NJF` in both parser facades
- verify canonical model storage and N-channel JFET instance lowering in Python and TypeScript
- preserve the documented JFET `B` parameter policy collision without changing parameter lowering

## Verification

- Python parser `bash BUILD` (`636 passed`, 90.55% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (`621 passed`)
- TypeScript parser `npx vitest run --coverage` (88.27% lines)
- TypeScript engine `bash BUILD` (`448 passed`)
- `git diff --check`
- BUILD dependency audit: no BUILD files or dependency edges changed
