### PR TITLE
Add consent-gated AirGradient cloud controls

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -921,6 +921,7 @@ members = [
     "smart-home-capability-cage",
     "smart-home-discovery",
     "smart-home-discovery-service",
+    "smart-home-data-governance",
     "smart-home-event-streams",
     "smart-home-hue-pairing-service",
     "smart-home-local-http",

--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Expose stable country and cloud-upload command labels plus the reusable data
+  governance primitive label.
 - Expose the `camera_set_recording` D23 command label.
 - Expose labels for typed non-credential device-configuration commands.
 

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -90181,6 +90181,12 @@ fn parse_command_type(label: &str) -> Result<CommandType, ToolCallError> {
         "device_set_correction_profile" => Ok(CommandType::DeviceControl(
             DeviceControlCommandType::SetCorrectionProfile,
         )),
+        "device_set_country" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetCountry,
+        )),
+        "device_set_cloud_upload" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetCloudUpload,
+        )),
         "camera_set_recording" => Ok(CommandType::DeviceControl(
             DeviceControlCommandType::SetCameraRecording,
         )),
@@ -90423,6 +90429,7 @@ fn parse_primitive_family(label: &str) -> Result<PrimitiveFamily, ToolCallError>
         "calculated_state" => Ok(PrimitiveFamily::CalculatedState),
         "command_mapping" => Ok(PrimitiveFamily::CommandMapping),
         "capability_policy" => Ok(PrimitiveFamily::CapabilityPolicy),
+        "data_governance" => Ok(PrimitiveFamily::DataGovernance),
         "vault_lease" => Ok(PrimitiveFamily::VaultLease),
         "supervision" => Ok(PrimitiveFamily::Supervision),
         "test_simulator" => Ok(PrimitiveFamily::TestSimulator),
@@ -92598,6 +92605,10 @@ fn command_type_label(command_type: CommandType) -> &'static str {
         }
         CommandType::DeviceControl(DeviceControlCommandType::SetCorrectionProfile) => {
             "device_set_correction_profile"
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::SetCountry) => "device_set_country",
+        CommandType::DeviceControl(DeviceControlCommandType::SetCloudUpload) => {
+            "device_set_cloud_upload"
         }
         CommandType::DeviceControl(DeviceControlCommandType::SetCameraRecording) => {
             "camera_set_recording"
@@ -121555,6 +121566,11 @@ mod tests {
             (
                 "device_set_correction_profile",
                 DeviceControlCommandType::SetCorrectionProfile,
+            ),
+            ("device_set_country", DeviceControlCommandType::SetCountry),
+            (
+                "device_set_cloud_upload",
+                DeviceControlCommandType::SetCloudUpload,
             ),
             (
                 "camera_set_recording",

--- a/code/packages/rust/smart-home-airgradient-local-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-airgradient-local-integration/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.4.0
+
+- Add human-approved, readback-verified country and AirGradient cloud-upload
+  controls over the documented local `/config` contract.
+- Require exact host-owned data-use grants before country configuration or
+  vendor-cloud upload enablement can perform transport I/O; permit upload
+  shutdown without a consent grant.
+- Validate assigned ISO 3166 alpha-2 codes and keep the selected country out of
+  normalized state and debug output.
+
 ## 0.3.0
 
 - Add typed local temperature/PM display settings, ABC days, gas learning

--- a/code/packages/rust/smart-home-airgradient-local-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-airgradient-local-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smart-home-airgradient-local-integration"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "AirGradient local monitor telemetry and typed configuration integration for the smart-home runtime"
 license = "MIT"
@@ -10,6 +10,7 @@ http-core = { path = "../http-core" }
 http1 = { path = "../http1" }
 serde_json = "1"
 smart-home-core = { path = "../smart-home-core" }
+smart-home-data-governance = { path = "../smart-home-data-governance" }
 smart-home-discovery = { path = "../smart-home-discovery" }
 smart-home-local-http = { path = "../smart-home-local-http" }
 smart-home-runtime = { path = "../smart-home-runtime" }

--- a/code/packages/rust/smart-home-airgradient-local-integration/README.md
+++ b/code/packages/rust/smart-home-airgradient-local-integration/README.md
@@ -18,13 +18,21 @@ US AQI display, 0-200 day automatic CO2 baseline calibration, 0-720 hour VOC
 and NOx learning offsets, compensated display values, LED self-test, and
 sensor-specific correction profiles. Persistent settings are read back and
 verified against the monitor's native response.
+Country configuration accepts assigned ISO 3166 alpha-2 codes and requires an
+exact host-owned coarse-location consent grant. Enabling AirGradient vendor
+cloud upload requires a separate environmental-telemetry egress grant bound to
+`https://api.airgradient.com`; disabling upload remains privacy-protective and
+does not require a consent grant. Both commands still require D23 human
+approval, and every persistent change is verified through `/config` readback.
+Normalized state records only whether a country is configured, never the
+country value.
 Monitors with `configurationControl=cloud` reject local commands explicitly;
 `configurationControl=both` succeeds with a warning that a later cloud update
 may overwrite the local value.
 
 MQTT broker and custom HTTP destination settings remain excluded because they
 can carry credentials or redirect telemetry and therefore require Vault leases
-and destination policy.
+and destination policy beyond the exact AirGradient vendor-cloud grant.
 
 ```bash
 cargo run -p smart-home-airgradient-local-integration -- discover ecda3b1eaaaf

--- a/code/packages/rust/smart-home-airgradient-local-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-airgradient-local-integration/src/lib.rs
@@ -11,6 +11,10 @@ use smart_home_core::{
     EntityKind, Health, IntegrationId, Metadata, ProtocolFamily, ProtocolIdentifier, SmartHomeTool,
     StateConfidence, StateSnapshot, StateSource, Value, ValueKind,
 };
+use smart_home_data_governance::{
+    DataCategory, DataDestination, DataGovernanceDecision, DataGovernanceDenial,
+    DataGovernancePolicy, DataOperation, DataUseRequest,
+};
 use smart_home_discovery::{
     DiscoveryConfidence, DiscoveryRecord, DiscoverySource, PairingRequirement,
 };
@@ -33,6 +37,25 @@ pub const MEASUREMENT_PATH: &str = "/measures/current";
 pub const CONFIGURATION_PATH: &str = "/config";
 pub const DEFAULT_PORT: u16 = 80;
 pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
+pub const AIRGRADIENT_CLOUD_ORIGIN: &str = "https://api.airgradient.com";
+const ISO_3166_ALPHA_2_CODES: &[&str] = &[
+    "AD", "AE", "AF", "AG", "AI", "AL", "AM", "AO", "AQ", "AR", "AS", "AT", "AU", "AW", "AX", "AZ",
+    "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BL", "BM", "BN", "BO", "BQ", "BR", "BS",
+    "BT", "BV", "BW", "BY", "BZ", "CA", "CC", "CD", "CF", "CG", "CH", "CI", "CK", "CL", "CM", "CN",
+    "CO", "CR", "CU", "CV", "CW", "CX", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE",
+    "EG", "EH", "ER", "ES", "ET", "FI", "FJ", "FK", "FM", "FO", "FR", "GA", "GB", "GD", "GE", "GF",
+    "GG", "GH", "GI", "GL", "GM", "GN", "GP", "GQ", "GR", "GS", "GT", "GU", "GW", "GY", "HK", "HM",
+    "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IM", "IN", "IO", "IQ", "IR", "IS", "IT", "JE", "JM",
+    "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KP", "KR", "KW", "KY", "KZ", "LA", "LB", "LC",
+    "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MF", "MG", "MH", "MK",
+    "ML", "MM", "MN", "MO", "MP", "MQ", "MR", "MS", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA",
+    "NC", "NE", "NF", "NG", "NI", "NL", "NO", "NP", "NR", "NU", "NZ", "OM", "PA", "PE", "PF", "PG",
+    "PH", "PK", "PL", "PM", "PN", "PR", "PS", "PT", "PW", "PY", "QA", "RE", "RO", "RS", "RU", "RW",
+    "SA", "SB", "SC", "SD", "SE", "SG", "SH", "SI", "SJ", "SK", "SL", "SM", "SN", "SO", "SR", "SS",
+    "ST", "SV", "SX", "SY", "SZ", "TC", "TD", "TF", "TG", "TH", "TJ", "TK", "TL", "TM", "TN", "TO",
+    "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "UM", "US", "UY", "UZ", "VA", "VC", "VE", "VG", "VI",
+    "VN", "VU", "WF", "WS", "YE", "YT", "ZA", "ZM", "ZW",
+];
 
 #[derive(Debug)]
 pub enum AirGradientError {
@@ -59,6 +82,7 @@ pub enum AirGradientError {
         expected: &'static str,
     },
     CloudConfigurationConflict,
+    DataGovernanceDenied(DataGovernanceDenial),
     VerificationFailed(&'static str),
     Runtime(RuntimeError),
 }
@@ -106,6 +130,9 @@ impl fmt::Display for AirGradientError {
             Self::CloudConfigurationConflict => formatter.write_str(
                 "AirGradient configurationControl=cloud rejects local configuration; changing it to local requires a factory reset"
             ),
+            Self::DataGovernanceDenied(reason) => {
+                write!(formatter, "AirGradient data-governance policy denied the request: {reason:?}")
+            }
             Self::VerificationFailed(field) => {
                 write!(formatter, "AirGradient did not confirm updated {field}")
             }
@@ -292,6 +319,8 @@ pub struct AirGradientCorrectionProfile {
 #[derive(Debug, Clone, PartialEq)]
 pub struct AirGradientConfiguration {
     pub control: AirGradientConfigurationControl,
+    pub country: Option<AirGradientCountryCode>,
+    pub post_data_to_airgradient: Option<bool>,
     pub led_bar_mode: String,
     pub led_bar_brightness: u8,
     pub display_brightness: u8,
@@ -302,6 +331,34 @@ pub struct AirGradientConfiguration {
     pub nox_learning_offset: Option<u16>,
     pub monitor_display_compensated_values: Option<bool>,
     pub corrections: BTreeMap<String, AirGradientCorrectionProfile>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct AirGradientCountryCode(String);
+
+impl AirGradientCountryCode {
+    pub fn new(value: impl Into<String>) -> Result<Self, AirGradientError> {
+        let value = value.into().to_ascii_uppercase();
+        if ISO_3166_ALPHA_2_CODES
+            .binary_search(&value.as_str())
+            .is_err()
+        {
+            return Err(AirGradientError::Validation(
+                "country must be a two-letter ISO alpha-2 code".to_string(),
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for AirGradientCountryCode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AirGradientCountryCode([REDACTED])")
+    }
 }
 
 pub fn discovery_record(
@@ -467,6 +524,7 @@ pub struct InstalledAirGradientDevice {
 pub struct AirGradientRuntimeIntegration<T> {
     client: AirGradientClient<T>,
     command_targets: BTreeMap<EntityId, AirGradientCommandTarget>,
+    data_governance: DataGovernancePolicy,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -481,7 +539,13 @@ impl<T: AirGradientTransport> AirGradientRuntimeIntegration<T> {
         Self {
             client,
             command_targets: BTreeMap::new(),
+            data_governance: DataGovernancePolicy::default(),
         }
+    }
+
+    pub fn with_data_governance(mut self, data_governance: DataGovernancePolicy) -> Self {
+        self.data_governance = data_governance;
+        self
     }
 
     pub fn transport(&self) -> &T {
@@ -701,7 +765,16 @@ impl<T: AirGradientTransport> AirGradientRuntimeIntegration<T> {
     ) -> Result<CommandResult, AirGradientError> {
         let plan = airgradient_command_plan(&self.command_targets, &request)?;
         let target_entity_id = request.entity_id.clone();
-        let command = runtime.authorize_command_tool(principal_id, request, now_ms)?;
+        let command = runtime.authorize_command_tool(principal_id.clone(), request, now_ms)?;
+        if let Some(operation) = plan.governance {
+            authorize_data_use(
+                &self.data_governance,
+                &principal_id,
+                &target_entity_id,
+                operation,
+                now_ms,
+            )?;
+        }
         let configuration = self.client.configuration()?;
         if configuration.control == AirGradientConfigurationControl::Cloud {
             return Err(AirGradientError::CloudConfigurationConflict);
@@ -740,6 +813,13 @@ impl<T: AirGradientTransport> AirGradientRuntimeIntegration<T> {
 struct AirGradientCommandPlan {
     update: JsonValue,
     expected: Option<ExpectedConfiguration>,
+    governance: Option<GovernedAirGradientOperation>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GovernedAirGradientOperation {
+    ConfigureCountry,
+    SetCloudUpload(bool),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -759,6 +839,8 @@ enum ExpectedConfiguration {
         sensor: String,
         profile: AirGradientCorrectionProfile,
     },
+    Country(AirGradientCountryCode),
+    CloudUpload(bool),
 }
 
 impl ExpectedConfiguration {
@@ -800,6 +882,13 @@ impl ExpectedConfiguration {
                 configuration.corrections.get(sensor) == Some(profile),
                 "corrections",
             ),
+            Self::Country(expected) => {
+                (configuration.country.as_ref() == Some(expected), "country")
+            }
+            Self::CloudUpload(expected) => (
+                configuration.post_data_to_airgradient == Some(*expected),
+                "postDataToAirGradient",
+            ),
         };
         if matches {
             Ok(())
@@ -837,6 +926,7 @@ fn airgradient_command_plan(
             Ok(AirGradientCommandPlan {
                 update: configuration_update("ledBarMode", JsonValue::String(mode.clone())),
                 expected: Some(ExpectedConfiguration::IndicatorMode(mode)),
+                governance: None,
             })
         }
         CommandType::DeviceControl(DeviceControlCommandType::SetIndicatorBrightness)
@@ -848,6 +938,7 @@ fn airgradient_command_plan(
             Ok(AirGradientCommandPlan {
                 update: configuration_update("ledBarBrightness", JsonValue::from(brightness)),
                 expected: Some(ExpectedConfiguration::IndicatorBrightness(brightness)),
+                governance: None,
             })
         }
         CommandType::DeviceControl(DeviceControlCommandType::SetDisplayBrightness)
@@ -859,6 +950,7 @@ fn airgradient_command_plan(
             Ok(AirGradientCommandPlan {
                 update: configuration_update("displayBrightness", JsonValue::from(brightness)),
                 expected: Some(ExpectedConfiguration::DisplayBrightness(brightness)),
+                governance: None,
             })
         }
         CommandType::DeviceControl(DeviceControlCommandType::CalibrateSensor)
@@ -870,6 +962,7 @@ fn airgradient_command_plan(
             Ok(AirGradientCommandPlan {
                 update: configuration_update("co2CalibrationRequested", JsonValue::Bool(true)),
                 expected: None,
+                governance: None,
             })
         }
         CommandType::DeviceControl(DeviceControlCommandType::SetTemperatureUnit)
@@ -889,6 +982,7 @@ fn airgradient_command_plan(
                     JsonValue::String(unit.as_str().to_string()),
                 ),
                 expected: Some(ExpectedConfiguration::TemperatureUnit(unit)),
+                governance: None,
             })
         }
         CommandType::DeviceControl(DeviceControlCommandType::SetParticulateDisplayStandard)
@@ -908,6 +1002,7 @@ fn airgradient_command_plan(
                     JsonValue::String(standard.as_str().to_string()),
                 ),
                 expected: Some(ExpectedConfiguration::ParticulateDisplayStandard(standard)),
+                governance: None,
             })
         }
         CommandType::DeviceControl(DeviceControlCommandType::SetAutomaticCo2BaselineDays)
@@ -922,6 +1017,7 @@ fn airgradient_command_plan(
             Ok(AirGradientCommandPlan {
                 update: configuration_update("abcDays", JsonValue::from(days)),
                 expected: Some(ExpectedConfiguration::AutomaticCo2BaselineDays(days)),
+                governance: None,
             })
         }
         CommandType::DeviceControl(DeviceControlCommandType::SetGasLearningOffsets)
@@ -951,6 +1047,7 @@ fn airgradient_command_plan(
             Ok(AirGradientCommandPlan {
                 update: JsonValue::Object(update),
                 expected: Some(ExpectedConfiguration::GasLearningOffsets { tvoc, nox }),
+                governance: None,
             })
         }
         CommandType::DeviceControl(DeviceControlCommandType::SetCompensatedDisplay)
@@ -965,6 +1062,7 @@ fn airgradient_command_plan(
                     JsonValue::Bool(enabled),
                 ),
                 expected: Some(ExpectedConfiguration::CompensatedDisplay(enabled)),
+                governance: None,
             })
         }
         CommandType::DeviceControl(DeviceControlCommandType::TestIndicator)
@@ -976,6 +1074,7 @@ fn airgradient_command_plan(
             Ok(AirGradientCommandPlan {
                 update: configuration_update("ledBarTestRequested", JsonValue::Bool(true)),
                 expected: None,
+                governance: None,
             })
         }
         CommandType::DeviceControl(DeviceControlCommandType::SetCorrectionProfile)
@@ -985,6 +1084,38 @@ fn airgradient_command_plan(
             Ok(AirGradientCommandPlan {
                 update,
                 expected: Some(ExpectedConfiguration::CorrectionProfile { sensor, profile }),
+                governance: None,
+            })
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::SetCountry)
+            if target == AirGradientCommandTarget::Configuration =>
+        {
+            let Value::Text(country) = &request.arguments else {
+                return invalid_command_arguments(
+                    request.command_type,
+                    "a two-letter ISO alpha-2 country code",
+                );
+            };
+            let country = AirGradientCountryCode::new(country)?;
+            Ok(AirGradientCommandPlan {
+                update: configuration_update(
+                    "country",
+                    JsonValue::String(country.as_str().to_string()),
+                ),
+                expected: Some(ExpectedConfiguration::Country(country)),
+                governance: Some(GovernedAirGradientOperation::ConfigureCountry),
+            })
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::SetCloudUpload)
+            if target == AirGradientCommandTarget::Configuration =>
+        {
+            let Value::Bool(enabled) = request.arguments else {
+                return invalid_command_arguments(request.command_type, "a boolean");
+            };
+            Ok(AirGradientCommandPlan {
+                update: configuration_update("postDataToAirGradient", JsonValue::Bool(enabled)),
+                expected: Some(ExpectedConfiguration::CloudUpload(enabled)),
+                governance: Some(GovernedAirGradientOperation::SetCloudUpload(enabled)),
             })
         }
         CommandType::DeviceControl(_) => invalid_command_arguments(
@@ -1003,6 +1134,47 @@ fn invalid_command_arguments<T>(
         command_type,
         expected,
     })
+}
+
+fn authorize_data_use(
+    policy: &DataGovernancePolicy,
+    principal_id: &AgentId,
+    entity_id: &EntityId,
+    operation: GovernedAirGradientOperation,
+    now_ms: u64,
+) -> Result<(), AirGradientError> {
+    let (category, operation, destination) = match operation {
+        GovernedAirGradientOperation::ConfigureCountry => (
+            DataCategory::CoarseLocation,
+            DataOperation::Configure,
+            DataDestination::LocalDevice,
+        ),
+        GovernedAirGradientOperation::SetCloudUpload(true) => (
+            DataCategory::EnvironmentalTelemetry,
+            DataOperation::StartEgress,
+            DataDestination::https_origin(AIRGRADIENT_CLOUD_ORIGIN).map_err(|error| {
+                AirGradientError::Validation(format!("invalid AirGradient cloud origin: {error}"))
+            })?,
+        ),
+        GovernedAirGradientOperation::SetCloudUpload(false) => (
+            DataCategory::EnvironmentalTelemetry,
+            DataOperation::StopEgress,
+            DataDestination::https_origin(AIRGRADIENT_CLOUD_ORIGIN).map_err(|error| {
+                AirGradientError::Validation(format!("invalid AirGradient cloud origin: {error}"))
+            })?,
+        ),
+    };
+    match policy.decide(&DataUseRequest {
+        principal_id,
+        resource_id: entity_id.as_str(),
+        category,
+        operation,
+        destination,
+        now_ms,
+    }) {
+        DataGovernanceDecision::Allow(_) => Ok(()),
+        DataGovernanceDecision::Deny(reason) => Err(AirGradientError::DataGovernanceDenied(reason)),
+    }
 }
 
 fn value_object(value: &Value) -> Option<&[(String, Value)]> {
@@ -1177,6 +1349,12 @@ fn configuration_value(configuration: &AirGradientConfiguration) -> Value {
             Value::Text(unit.as_str().to_string()),
         ));
     }
+    if let Some(enabled) = configuration.post_data_to_airgradient {
+        fields.push(("cloud_upload_enabled".to_string(), Value::Bool(enabled)));
+    }
+    if configuration.country.is_some() {
+        fields.push(("country_configured".to_string(), Value::Bool(true)));
+    }
     if let Some(standard) = configuration.particulate_display_standard {
         fields.push((
             "particulate_display_standard".to_string(),
@@ -1279,6 +1457,8 @@ fn parse_configuration(data: &JsonValue) -> Result<AirGradientConfiguration, Air
     };
     Ok(AirGradientConfiguration {
         control,
+        country: optional_country(data)?,
+        post_data_to_airgradient: optional_bool(data, "postDataToAirGradient")?,
         led_bar_mode: required_string(data, "ledBarMode")?.to_ascii_lowercase(),
         led_bar_brightness: required_percentage(data, "ledBarBrightness")?,
         display_brightness: required_percentage(data, "displayBrightness")?,
@@ -1290,6 +1470,21 @@ fn parse_configuration(data: &JsonValue) -> Result<AirGradientConfiguration, Air
         monitor_display_compensated_values: optional_bool(data, "monitorDisplayCompensatedValues")?,
         corrections: parse_corrections(data)?,
     })
+}
+
+fn optional_country(
+    data: &JsonMap<String, JsonValue>,
+) -> Result<Option<AirGradientCountryCode>, AirGradientError> {
+    let Some(value) = data.get("country") else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let value = value
+        .as_str()
+        .ok_or_else(|| AirGradientError::Validation("country must be text".to_string()))?;
+    AirGradientCountryCode::new(value).map(Some)
 }
 
 fn optional_temperature_unit(
@@ -1765,6 +1960,7 @@ fn decode_chunked(input: &[u8], maximum: usize) -> Result<Vec<u8>, AirGradientEr
 mod tests {
     use super::*;
     use smart_home_core::{CapabilityGrant, CapabilityGrantId, PrivilegeTier};
+    use smart_home_data_governance::{ConsentReceiptRef, DataPurpose, DataUseGrant};
     use std::net::TcpListener;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
@@ -1776,6 +1972,9 @@ mod tests {
     const CONFIG_MODE_PM: &str = r#"{"configurationControl":"both","ledBarMode":"pm","ledBarBrightness":80,"displayBrightness":70}"#;
     const CONFIG_LED_35: &str = r#"{"configurationControl":"both","ledBarMode":"pm","ledBarBrightness":35,"displayBrightness":70}"#;
     const CONFIG_DISPLAY_25: &str = r#"{"configurationControl":"both","ledBarMode":"pm","ledBarBrightness":35,"displayBrightness":25}"#;
+    const CONFIG_GOVERNED_INITIAL: &str = r#"{"configurationControl":"both","country":"US","postDataToAirGradient":false,"ledBarMode":"co2","ledBarBrightness":80,"displayBrightness":70}"#;
+    const CONFIG_COUNTRY_CA: &str = r#"{"configurationControl":"both","country":"CA","postDataToAirGradient":false,"ledBarMode":"co2","ledBarBrightness":80,"displayBrightness":70}"#;
+    const CONFIG_UPLOAD_ENABLED: &str = r#"{"configurationControl":"both","country":"CA","postDataToAirGradient":true,"ledBarMode":"co2","ledBarBrightness":80,"displayBrightness":70}"#;
 
     fn advanced_config(
         temperature_unit: &str,
@@ -1866,6 +2065,43 @@ mod tests {
             )
             .with_expiry(20_000),
         );
+    }
+
+    fn governed_policy(principal: &AgentId, entity_id: &EntityId) -> DataGovernancePolicy {
+        let mut policy = DataGovernancePolicy::default();
+        policy
+            .add_grant(
+                DataUseGrant::new(
+                    principal.clone(),
+                    entity_id.as_str(),
+                    DataCategory::CoarseLocation,
+                    DataOperation::Configure,
+                    DataDestination::LocalDevice,
+                    DataPurpose::new("operator-selected monitor country").unwrap(),
+                    ConsentReceiptRef::new("consent://airgradient/country-1").unwrap(),
+                    1_000,
+                    20_000,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        policy
+            .add_grant(
+                DataUseGrant::new(
+                    principal.clone(),
+                    entity_id.as_str(),
+                    DataCategory::EnvironmentalTelemetry,
+                    DataOperation::StartEgress,
+                    DataDestination::https_origin(AIRGRADIENT_CLOUD_ORIGIN).unwrap(),
+                    DataPurpose::new("operator-selected AirGradient dashboard upload").unwrap(),
+                    ConsentReceiptRef::new("consent://airgradient/cloud-1").unwrap(),
+                    1_000,
+                    20_000,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        policy
     }
 
     #[test]
@@ -2080,6 +2316,170 @@ mod tests {
             Err(AirGradientError::Runtime(_))
         ));
         assert_eq!(integration.transport().calls, 2);
+    }
+
+    #[test]
+    fn governed_controls_without_consent_reach_no_additional_transport() {
+        let client = AirGradientClient::new(
+            AirGradientConfig::new(
+                BridgeId::trusted("airgradient.governance-denied"),
+                "http://127.0.0.1",
+            )
+            .unwrap(),
+            SequenceTransport::new(&[MEASUREMENTS, CONFIG_GOVERNED_INITIAL]),
+        )
+        .unwrap();
+        let mut integration = AirGradientRuntimeIntegration::new(client);
+        let principal = AgentId::trusted("agent:airgradient-governance-denied");
+        let mut runtime = SmartHomeRuntime::new();
+        grant(&mut runtime, &principal);
+        integration
+            .inspect_and_install_authorized(&mut runtime, principal.clone(), 5_000)
+            .unwrap();
+        for (command_type, arguments) in [
+            (
+                DeviceControlCommandType::SetCountry,
+                Value::Text("CA".to_string()),
+            ),
+            (DeviceControlCommandType::SetCloudUpload, Value::Bool(true)),
+        ] {
+            let request = RuntimeCommandToolRequest::new(
+                EntityId::trusted("airgradient:ecda3b1eaaaf:configuration"),
+                CommandType::DeviceControl(command_type),
+                arguments,
+            );
+            assert!(matches!(
+                integration.dispatch_command_authorized(
+                    &mut runtime,
+                    principal.clone(),
+                    request,
+                    6_000,
+                ),
+                Err(AirGradientError::DataGovernanceDenied(
+                    DataGovernanceDenial::NoMatchingConsent
+                ))
+            ));
+            assert_eq!(integration.transport().calls, 2);
+            assert_eq!(runtime.optimistic_state_count(), 0);
+        }
+    }
+
+    #[test]
+    fn governed_country_and_cloud_upload_controls_are_verified_over_real_tcp() {
+        let payloads = [
+            MEASUREMENTS,
+            CONFIG_GOVERNED_INITIAL,
+            CONFIG_GOVERNED_INITIAL,
+            "{}",
+            CONFIG_COUNTRY_CA,
+            CONFIG_COUNTRY_CA,
+            "{}",
+            CONFIG_UPLOAD_ENABLED,
+        ]
+        .into_iter()
+        .map(response)
+        .collect();
+        let (port, requests, handle) = start_server(payloads);
+        let client =
+            AirGradientClient::new(config(port), AirGradientLanTransport::default()).unwrap();
+        let principal = AgentId::trusted("agent:airgradient-governed");
+        let configuration = EntityId::trusted("airgradient:ecda3b1eaaaf:configuration");
+        let mut integration = AirGradientRuntimeIntegration::new(client)
+            .with_data_governance(governed_policy(&principal, &configuration));
+        let mut runtime = SmartHomeRuntime::new();
+        grant(&mut runtime, &principal);
+        integration
+            .inspect_and_install_authorized(&mut runtime, principal.clone(), 5_000)
+            .unwrap();
+
+        for (command_type, arguments) in [
+            (
+                DeviceControlCommandType::SetCountry,
+                Value::Text("ca".to_string()),
+            ),
+            (DeviceControlCommandType::SetCloudUpload, Value::Bool(true)),
+        ] {
+            integration
+                .dispatch_command_authorized(
+                    &mut runtime,
+                    principal.clone(),
+                    RuntimeCommandToolRequest::new(
+                        configuration.clone(),
+                        CommandType::DeviceControl(command_type),
+                        arguments,
+                    ),
+                    6_000,
+                )
+                .unwrap();
+        }
+
+        handle.join().unwrap();
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 8);
+        let put_requests = requests
+            .iter()
+            .filter(|request| request.starts_with(&format!("PUT {CONFIGURATION_PATH}")))
+            .collect::<Vec<_>>();
+        assert_eq!(put_requests.len(), 2);
+        assert!(put_requests[0].contains(r#"{"country":"CA"}"#));
+        assert!(put_requests[1].contains(r#"{"postDataToAirGradient":true}"#));
+        let state = runtime
+            .registry()
+            .entity(&configuration)
+            .unwrap()
+            .state
+            .as_ref()
+            .unwrap();
+        assert!(matches!(
+            &state.value,
+            Value::Object(fields)
+                if fields.contains(&("country_configured".to_string(), Value::Bool(true)))
+                    && fields.contains(&("cloud_upload_enabled".to_string(), Value::Bool(true)))
+                    && !format!("{fields:?}").contains("CA")
+        ));
+    }
+
+    #[test]
+    fn cloud_upload_shutdown_is_privacy_protective_without_a_consent_grant() {
+        let initial = CONFIG_UPLOAD_ENABLED.replace("\"country\":\"CA\"", "\"country\":\"US\"");
+        let disabled = CONFIG_GOVERNED_INITIAL;
+        let payloads = [
+            MEASUREMENTS.to_string(),
+            initial.clone(),
+            initial,
+            "{}".to_string(),
+            disabled.to_string(),
+        ]
+        .iter()
+        .map(|body| response(body))
+        .collect();
+        let (port, requests, handle) = start_server(payloads);
+        let client =
+            AirGradientClient::new(config(port), AirGradientLanTransport::default()).unwrap();
+        let mut integration = AirGradientRuntimeIntegration::new(client);
+        let principal = AgentId::trusted("agent:airgradient-disable-upload");
+        let mut runtime = SmartHomeRuntime::new();
+        grant(&mut runtime, &principal);
+        integration
+            .inspect_and_install_authorized(&mut runtime, principal.clone(), 5_000)
+            .unwrap();
+        integration
+            .dispatch_command_authorized(
+                &mut runtime,
+                principal,
+                RuntimeCommandToolRequest::new(
+                    EntityId::trusted("airgradient:ecda3b1eaaaf:configuration"),
+                    CommandType::DeviceControl(DeviceControlCommandType::SetCloudUpload),
+                    Value::Bool(false),
+                ),
+                6_000,
+            )
+            .unwrap();
+
+        handle.join().unwrap();
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 5);
+        assert!(requests[3].contains(r#"{"postDataToAirGradient":false}"#));
     }
 
     #[test]
@@ -2399,6 +2799,23 @@ mod tests {
         assert_eq!(configuration.led_bar_mode, "co2");
         assert_eq!(configuration.led_bar_brightness, 80);
         assert_eq!(configuration.display_brightness, 70);
+
+        let governed =
+            parse_configuration(&serde_json::from_str(CONFIG_UPLOAD_ENABLED).unwrap()).unwrap();
+        assert_eq!(
+            governed
+                .country
+                .as_ref()
+                .map(AirGradientCountryCode::as_str),
+            Some("CA")
+        );
+        assert_eq!(governed.post_data_to_airgradient, Some(true));
+        assert!(!format!("{governed:?}").contains("CA"));
+        assert!(AirGradientCountryCode::new("ZZ").is_err());
+        assert_eq!(ISO_3166_ALPHA_2_CODES.len(), 249);
+        assert!(ISO_3166_ALPHA_2_CODES
+            .windows(2)
+            .all(|pair| pair[0] < pair[1]));
 
         let advanced = advanced_config(
             "f",

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Add human-approved country and telemetry-upload device configuration commands
+  for integrations that enforce a separate host-owned data-governance policy.
 - Add a reusable `camera.ptz` capability plus typed preset-recall and bounded
   movement commands with a human-approval policy tier.
 - Add a reusable `camera.recording` capability and typed recording-control

--- a/code/packages/rust/smart-home-core/README.md
+++ b/code/packages/rust/smart-home-core/README.md
@@ -42,6 +42,8 @@ Current scope:
   command-capability and policy-tier mappings
 - typed non-credential device configuration operations for display standards,
   learning settings, self-tests, and correction profiles
+- typed country and telemetry-upload configuration operations with a human-
+  approval tier for integrations that enforce data-governance policy
 - typed camera recording control with an explicit human-approval boundary
 - typed camera PTZ preset and bounded-movement control with an explicit
   human-approval boundary

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1339,6 +1339,8 @@ pub enum DeviceControlCommandType {
     SetCompensatedDisplay,
     TestIndicator,
     SetCorrectionProfile,
+    SetCountry,
+    SetCloudUpload,
     SetCameraRecording,
     RecallCameraPtzPreset,
     MoveCameraPtz,
@@ -1390,7 +1392,9 @@ impl DeviceControlCommandType {
             | Self::SetAutomaticCo2BaselineDays
             | Self::SetGasLearningOffsets
             | Self::SetCompensatedDisplay
-            | Self::SetCorrectionProfile => CapabilityId::trusted("device.configuration"),
+            | Self::SetCorrectionProfile
+            | Self::SetCountry
+            | Self::SetCloudUpload => CapabilityId::trusted("device.configuration"),
             Self::SetCameraRecording => CapabilityId::trusted("camera.recording"),
             Self::RecallCameraPtzPreset | Self::MoveCameraPtz => {
                 CapabilityId::trusted("camera.ptz")
@@ -1456,6 +1460,8 @@ pub fn tier_for_command(command_type: CommandType) -> PrivilegeTier {
         | CommandType::DeviceControl(DeviceControlCommandType::SetAutomaticCo2BaselineDays)
         | CommandType::DeviceControl(DeviceControlCommandType::SetGasLearningOffsets)
         | CommandType::DeviceControl(DeviceControlCommandType::SetCorrectionProfile)
+        | CommandType::DeviceControl(DeviceControlCommandType::SetCountry)
+        | CommandType::DeviceControl(DeviceControlCommandType::SetCloudUpload)
         | CommandType::DeviceControl(DeviceControlCommandType::SetCameraRecording)
         | CommandType::DeviceControl(DeviceControlCommandType::RecallCameraPtzPreset)
         | CommandType::DeviceControl(DeviceControlCommandType::MoveCameraPtz) => {
@@ -4387,14 +4393,14 @@ mod tests {
             CommandType::DeviceControl(DeviceControlCommandType::SetDisplayBrightness),
             CommandType::DeviceControl(DeviceControlCommandType::CalibrateSensor),
             CommandType::DeviceControl(DeviceControlCommandType::SetTemperatureUnit),
-            CommandType::DeviceControl(
-                DeviceControlCommandType::SetParticulateDisplayStandard,
-            ),
+            CommandType::DeviceControl(DeviceControlCommandType::SetParticulateDisplayStandard),
             CommandType::DeviceControl(DeviceControlCommandType::SetAutomaticCo2BaselineDays),
             CommandType::DeviceControl(DeviceControlCommandType::SetGasLearningOffsets),
             CommandType::DeviceControl(DeviceControlCommandType::SetCompensatedDisplay),
             CommandType::DeviceControl(DeviceControlCommandType::TestIndicator),
             CommandType::DeviceControl(DeviceControlCommandType::SetCorrectionProfile),
+            CommandType::DeviceControl(DeviceControlCommandType::SetCountry),
+            CommandType::DeviceControl(DeviceControlCommandType::SetCloudUpload),
             CommandType::DeviceControl(DeviceControlCommandType::SetCameraRecording),
             CommandType::DeviceControl(DeviceControlCommandType::RecallCameraPtzPreset),
             CommandType::DeviceControl(DeviceControlCommandType::MoveCameraPtz),

--- a/code/packages/rust/smart-home-data-governance/BUILD
+++ b/code/packages/rust/smart-home-data-governance/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-data-governance -- --nocapture

--- a/code/packages/rust/smart-home-data-governance/CHANGELOG.md
+++ b/code/packages/rust/smart-home-data-governance/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.1.0
+
+- Add a bounded, deny-by-default data-governance policy for coarse-location
+  configuration and environmental-telemetry egress.
+- Bind explicit consent to one principal, resource, action, destination,
+  purpose, and validity window without exposing consent references in debug
+  output.
+- Permit telemetry shutdown as a privacy-protective action without requiring a
+  grant that could prevent an operator from stopping disclosure.

--- a/code/packages/rust/smart-home-data-governance/Cargo.toml
+++ b/code/packages/rust/smart-home-data-governance/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "smart-home-data-governance"
+version = "0.1.0"
+edition = "2021"
+description = "Bounded host-owned privacy, consent, and telemetry-egress policy for D23 smart-home integrations"
+license = "MIT"
+
+[dependencies]
+smart-home-core = { path = "../smart-home-core" }
+url-parser = { path = "../url-parser" }

--- a/code/packages/rust/smart-home-data-governance/README.md
+++ b/code/packages/rust/smart-home-data-governance/README.md
@@ -1,0 +1,24 @@
+# smart-home-data-governance
+
+Pure host-owned privacy, consent, and telemetry-egress policy for D23 smart-home
+integrations.
+
+The policy is deny-by-default. A trusted host may install a bounded grant that
+binds one authenticated principal and resource to a data category, operation,
+destination, declared purpose, consent receipt, and expiry. Integrations ask the
+policy for a decision before transport I/O; model-facing command arguments
+cannot create or widen grants.
+
+The initial categories cover coarse country configuration and environmental
+telemetry. Destinations are either the local device or an exact validated HTTPS
+origin. Telemetry shutdown is always allowed as a privacy-protective operation,
+but the ordinary D23 command authorization layer may still require human
+approval for the device mutation.
+
+Consent references and purpose text stay private to the policy and are redacted
+from `Debug`. Decision records expose only inert enums and whether a matching
+grant existed.
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/smart-home-data-governance/src/lib.rs
+++ b/code/packages/rust/smart-home-data-governance/src/lib.rs
@@ -1,0 +1,492 @@
+//! Bounded privacy, consent, and telemetry-egress policy for D23 integrations.
+
+#![forbid(unsafe_code)]
+
+use smart_home_core::AgentId;
+use std::fmt;
+use url_parser::Url;
+
+pub const DEFAULT_MAX_GRANTS: usize = 128;
+pub const MAX_RESOURCE_BYTES: usize = 256;
+pub const MAX_PURPOSE_BYTES: usize = 256;
+pub const MAX_CONSENT_REFERENCE_BYTES: usize = 512;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataCategory {
+    CoarseLocation,
+    EnvironmentalTelemetry,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataOperation {
+    Configure,
+    StartEgress,
+    StopEgress,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub enum DataDestination {
+    LocalDevice,
+    HttpsOrigin(String),
+}
+
+impl fmt::Debug for DataDestination {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LocalDevice => formatter.write_str("LocalDevice"),
+            Self::HttpsOrigin(_) => formatter.write_str("HttpsOrigin([REDACTED])"),
+        }
+    }
+}
+
+impl DataDestination {
+    pub fn https_origin(origin: impl Into<String>) -> Result<Self, DataGovernanceError> {
+        let origin = origin.into();
+        let parsed = Url::parse(&origin).map_err(|_| DataGovernanceError::InvalidDestination)?;
+        if parsed.scheme != "https"
+            || parsed.host.is_none()
+            || parsed.userinfo.is_some()
+            || parsed.query.is_some()
+            || parsed.fragment.is_some()
+            || !matches!(parsed.path.as_str(), "" | "/")
+            || has_unsafe_text(&origin)
+        {
+            return Err(DataGovernanceError::InvalidDestination);
+        }
+        Ok(Self::HttpsOrigin(origin.trim_end_matches('/').to_string()))
+    }
+
+    pub fn kind(&self) -> DataDestinationKind {
+        match self {
+            Self::LocalDevice => DataDestinationKind::LocalDevice,
+            Self::HttpsOrigin(_) => DataDestinationKind::HttpsOrigin,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataDestinationKind {
+    LocalDevice,
+    HttpsOrigin,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct ConsentReceiptRef(String);
+
+impl ConsentReceiptRef {
+    pub fn new(value: impl Into<String>) -> Result<Self, DataGovernanceError> {
+        let value = value.into();
+        if !value.starts_with("consent://")
+            || value.len() <= "consent://".len()
+            || value.len() > MAX_CONSENT_REFERENCE_BYTES
+            || has_unsafe_text(&value)
+        {
+            return Err(DataGovernanceError::InvalidConsentReference);
+        }
+        Ok(Self(value))
+    }
+}
+
+impl fmt::Debug for ConsentReceiptRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ConsentReceiptRef([REDACTED])")
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct DataPurpose(String);
+
+impl DataPurpose {
+    pub fn new(value: impl Into<String>) -> Result<Self, DataGovernanceError> {
+        let value = value.into();
+        if value.trim().is_empty() || value.len() > MAX_PURPOSE_BYTES || has_unsafe_text(&value) {
+            return Err(DataGovernanceError::InvalidPurpose);
+        }
+        Ok(Self(value))
+    }
+}
+
+impl fmt::Debug for DataPurpose {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("DataPurpose([REDACTED])")
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct DataUseGrant {
+    principal_id: AgentId,
+    resource_id: String,
+    category: DataCategory,
+    operation: DataOperation,
+    destination: DataDestination,
+    purpose: DataPurpose,
+    consent_ref: ConsentReceiptRef,
+    granted_at_ms: u64,
+    expires_at_ms: u64,
+}
+
+impl DataUseGrant {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        principal_id: AgentId,
+        resource_id: impl Into<String>,
+        category: DataCategory,
+        operation: DataOperation,
+        destination: DataDestination,
+        purpose: DataPurpose,
+        consent_ref: ConsentReceiptRef,
+        granted_at_ms: u64,
+        expires_at_ms: u64,
+    ) -> Result<Self, DataGovernanceError> {
+        let resource_id = resource_id.into();
+        if resource_id.trim().is_empty()
+            || resource_id.len() > MAX_RESOURCE_BYTES
+            || has_unsafe_text(&resource_id)
+        {
+            return Err(DataGovernanceError::InvalidResource);
+        }
+        if expires_at_ms <= granted_at_ms
+            || operation == DataOperation::StopEgress
+            || !operation_destination_is_valid(operation, &destination)
+        {
+            return Err(DataGovernanceError::InvalidGrant);
+        }
+        Ok(Self {
+            principal_id,
+            resource_id,
+            category,
+            operation,
+            destination,
+            purpose,
+            consent_ref,
+            granted_at_ms,
+            expires_at_ms,
+        })
+    }
+
+    fn matches(&self, request: &DataUseRequest<'_>) -> bool {
+        self.principal_id == *request.principal_id
+            && self.resource_id == request.resource_id
+            && self.category == request.category
+            && self.operation == request.operation
+            && self.destination == request.destination
+            && request.now_ms >= self.granted_at_ms
+            && request.now_ms < self.expires_at_ms
+    }
+}
+
+impl fmt::Debug for DataUseGrant {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DataUseGrant")
+            .field("principal_id", &"[REDACTED]")
+            .field("resource_id", &"[REDACTED]")
+            .field("category", &self.category)
+            .field("operation", &self.operation)
+            .field("destination_kind", &self.destination.kind())
+            .field("purpose", &self.purpose)
+            .field("consent_ref", &self.consent_ref)
+            .field("granted_at_ms", &self.granted_at_ms)
+            .field("expires_at_ms", &self.expires_at_ms)
+            .finish()
+    }
+}
+
+pub struct DataUseRequest<'a> {
+    pub principal_id: &'a AgentId,
+    pub resource_id: &'a str,
+    pub category: DataCategory,
+    pub operation: DataOperation,
+    pub destination: DataDestination,
+    pub now_ms: u64,
+}
+
+impl fmt::Debug for DataUseRequest<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DataUseRequest")
+            .field("principal_id", &"[REDACTED]")
+            .field("resource_id", &"[REDACTED]")
+            .field("category", &self.category)
+            .field("operation", &self.operation)
+            .field("destination_kind", &self.destination.kind())
+            .field("now_ms", &self.now_ms)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataGovernanceAllowance {
+    ExplicitConsent,
+    PrivacyProtective,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataGovernanceDenial {
+    NoMatchingConsent,
+    InvalidRequest,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataGovernanceDecision {
+    Allow(DataGovernanceAllowance),
+    Deny(DataGovernanceDenial),
+}
+
+impl DataGovernanceDecision {
+    pub fn is_allowed(self) -> bool {
+        matches!(self, Self::Allow(_))
+    }
+}
+
+pub struct DataGovernancePolicy {
+    grants: Vec<DataUseGrant>,
+    maximum_grants: usize,
+}
+
+impl Default for DataGovernancePolicy {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_GRANTS)
+    }
+}
+
+impl DataGovernancePolicy {
+    pub fn new(maximum_grants: usize) -> Self {
+        Self {
+            grants: Vec::new(),
+            maximum_grants: maximum_grants.max(1),
+        }
+    }
+
+    pub fn add_grant(&mut self, grant: DataUseGrant) -> Result<(), DataGovernanceError> {
+        if self.grants.len() >= self.maximum_grants {
+            return Err(DataGovernanceError::GrantCapacityExceeded);
+        }
+        self.grants.push(grant);
+        Ok(())
+    }
+
+    pub fn decide(&self, request: &DataUseRequest<'_>) -> DataGovernanceDecision {
+        if request.resource_id.trim().is_empty()
+            || request.resource_id.len() > MAX_RESOURCE_BYTES
+            || has_unsafe_text(request.resource_id)
+            || !operation_destination_is_valid(request.operation, &request.destination)
+        {
+            return DataGovernanceDecision::Deny(DataGovernanceDenial::InvalidRequest);
+        }
+        if request.operation == DataOperation::StopEgress {
+            return DataGovernanceDecision::Allow(DataGovernanceAllowance::PrivacyProtective);
+        }
+        if self.grants.iter().any(|grant| grant.matches(request)) {
+            DataGovernanceDecision::Allow(DataGovernanceAllowance::ExplicitConsent)
+        } else {
+            DataGovernanceDecision::Deny(DataGovernanceDenial::NoMatchingConsent)
+        }
+    }
+
+    pub fn grant_count(&self) -> usize {
+        self.grants.len()
+    }
+}
+
+impl fmt::Debug for DataGovernancePolicy {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DataGovernancePolicy")
+            .field("grant_count", &self.grants.len())
+            .field("maximum_grants", &self.maximum_grants)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataGovernanceError {
+    InvalidConsentReference,
+    InvalidDestination,
+    InvalidGrant,
+    InvalidPurpose,
+    InvalidResource,
+    GrantCapacityExceeded,
+}
+
+impl fmt::Display for DataGovernanceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidConsentReference => "invalid consent receipt reference",
+            Self::InvalidDestination => "invalid data destination",
+            Self::InvalidGrant => "invalid data-use grant",
+            Self::InvalidPurpose => "invalid data-use purpose",
+            Self::InvalidResource => "invalid governed resource",
+            Self::GrantCapacityExceeded => "data-governance grant capacity exceeded",
+        })
+    }
+}
+
+impl std::error::Error for DataGovernanceError {}
+
+fn has_unsafe_text(value: &str) -> bool {
+    value.chars().any(char::is_control)
+}
+
+fn operation_destination_is_valid(
+    operation: DataOperation,
+    destination: &DataDestination,
+) -> bool {
+    matches!(
+        (operation, destination),
+        (DataOperation::Configure, DataDestination::LocalDevice)
+            | (
+                DataOperation::StartEgress | DataOperation::StopEgress,
+                DataDestination::HttpsOrigin(_)
+            )
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn principal() -> AgentId {
+        AgentId::trusted("operator")
+    }
+
+    fn cloud() -> DataDestination {
+        DataDestination::https_origin("https://api.airgradient.com").unwrap()
+    }
+
+    fn grant() -> DataUseGrant {
+        DataUseGrant::new(
+            principal(),
+            "airgradient:monitor:configuration",
+            DataCategory::EnvironmentalTelemetry,
+            DataOperation::StartEgress,
+            cloud(),
+            DataPurpose::new("operator-requested vendor dashboard upload").unwrap(),
+            ConsentReceiptRef::new("consent://smart-home/receipt-1").unwrap(),
+            100,
+            200,
+        )
+        .unwrap()
+    }
+
+    fn request<'a>(principal: &'a AgentId, now_ms: u64) -> DataUseRequest<'a> {
+        DataUseRequest {
+            principal_id: principal,
+            resource_id: "airgradient:monitor:configuration",
+            category: DataCategory::EnvironmentalTelemetry,
+            operation: DataOperation::StartEgress,
+            destination: cloud(),
+            now_ms,
+        }
+    }
+
+    #[test]
+    fn policy_denies_without_exact_active_consent() {
+        let principal = principal();
+        let policy = DataGovernancePolicy::default();
+        assert_eq!(
+            policy.decide(&request(&principal, 150)),
+            DataGovernanceDecision::Deny(DataGovernanceDenial::NoMatchingConsent)
+        );
+    }
+
+    #[test]
+    fn policy_allows_only_exact_active_consent() {
+        let principal = principal();
+        let mut policy = DataGovernancePolicy::default();
+        policy.add_grant(grant()).unwrap();
+        assert_eq!(
+            policy.decide(&request(&principal, 150)),
+            DataGovernanceDecision::Allow(DataGovernanceAllowance::ExplicitConsent)
+        );
+        assert_eq!(
+            policy.decide(&request(&principal, 200)),
+            DataGovernanceDecision::Deny(DataGovernanceDenial::NoMatchingConsent)
+        );
+        let other = AgentId::trusted("other");
+        assert_eq!(
+            policy.decide(&request(&other, 150)),
+            DataGovernanceDecision::Deny(DataGovernanceDenial::NoMatchingConsent)
+        );
+    }
+
+    #[test]
+    fn stopping_egress_is_privacy_protective() {
+        let principal = principal();
+        let policy = DataGovernancePolicy::default();
+        let mut request = request(&principal, 150);
+        request.operation = DataOperation::StopEgress;
+        assert_eq!(
+            policy.decide(&request),
+            DataGovernanceDecision::Allow(DataGovernanceAllowance::PrivacyProtective)
+        );
+    }
+
+    #[test]
+    fn operation_and_destination_pairs_are_fail_closed() {
+        let principal = principal();
+        let policy = DataGovernancePolicy::default();
+        let request = DataUseRequest {
+            principal_id: &principal,
+            resource_id: "airgradient:monitor:configuration",
+            category: DataCategory::EnvironmentalTelemetry,
+            operation: DataOperation::StopEgress,
+            destination: DataDestination::LocalDevice,
+            now_ms: 150,
+        };
+        assert_eq!(
+            policy.decide(&request),
+            DataGovernanceDecision::Deny(DataGovernanceDenial::InvalidRequest)
+        );
+        assert_eq!(
+            DataUseGrant::new(
+                principal,
+                "airgradient:monitor:configuration",
+                DataCategory::CoarseLocation,
+                DataOperation::Configure,
+                cloud(),
+                DataPurpose::new("operator-selected monitor country").unwrap(),
+                ConsentReceiptRef::new("consent://smart-home/receipt-2").unwrap(),
+                100,
+                200,
+            ),
+            Err(DataGovernanceError::InvalidGrant)
+        );
+    }
+
+    #[test]
+    fn grant_capacity_is_bounded() {
+        let mut policy = DataGovernancePolicy::new(1);
+        policy.add_grant(grant()).unwrap();
+        assert_eq!(
+            policy.add_grant(grant()),
+            Err(DataGovernanceError::GrantCapacityExceeded)
+        );
+    }
+
+    #[test]
+    fn sensitive_text_is_redacted_from_debug() {
+        let debug = format!("{:?}", grant());
+        assert!(!debug.contains("receipt-1"));
+        assert!(!debug.contains("operator-requested"));
+        assert!(!debug.contains("airgradient:monitor"));
+        assert!(!debug.contains("operator"));
+        assert!(!format!("{:?}", cloud()).contains("airgradient"));
+    }
+
+    #[test]
+    fn destinations_and_consent_references_are_strict() {
+        assert_eq!(
+            DataDestination::https_origin("http://api.airgradient.com"),
+            Err(DataGovernanceError::InvalidDestination)
+        );
+        assert_eq!(
+            ConsentReceiptRef::new("receipt-1"),
+            Err(DataGovernanceError::InvalidConsentReference)
+        );
+        assert_eq!(
+            DataPurpose::new("line\tbreak"),
+            Err(DataGovernanceError::InvalidPurpose)
+        );
+    }
+}

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -35,6 +35,8 @@
 
 ## Unreleased
 
+- Add the reusable data-governance primitive family and require it for
+  AirGradient country and vendor-cloud upload controls.
 - Upgraded HEOS runtime coverage with D23-authorized local playback, volume,
   grouping, and queue controls over the existing TCP command host.
 - Upgraded HEOS CLI runtime coverage from polling-only inspection to local

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -143,6 +143,7 @@ pub enum PrimitiveFamily {
     CalculatedState,
     CommandMapping,
     CapabilityPolicy,
+    DataGovernance,
     VaultLease,
     Supervision,
     TestSimulator,
@@ -184,6 +185,7 @@ impl PrimitiveFamily {
             Self::CalculatedState => "calculated_state",
             Self::CommandMapping => "command_mapping",
             Self::CapabilityPolicy => "capability_policy",
+            Self::DataGovernance => "data_governance",
             Self::VaultLease => "vault_lease",
             Self::Supervision => "supervision",
             Self::TestSimulator => "test_simulator",
@@ -44778,6 +44780,10 @@ pub fn describe_primitive_family(primitive: PrimitiveFamily) -> PrimitiveFamilyD
             "Capability Policy",
             "Capability, privilege, and approval rules for tool execution.",
         ),
+        PrimitiveFamily::DataGovernance => (
+            "Data Governance",
+            "Purpose, consent, privacy, and exact-destination rules for data use and egress.",
+        ),
         PrimitiveFamily::VaultLease => ("Vault Lease", "Time-bounded secret access for workers."),
         PrimitiveFamily::Supervision => (
             "Supervision",
@@ -44831,6 +44837,7 @@ pub fn all_primitive_families() -> &'static [PrimitiveFamily] {
         PrimitiveFamily::CalculatedState,
         PrimitiveFamily::CommandMapping,
         PrimitiveFamily::CapabilityPolicy,
+        PrimitiveFamily::DataGovernance,
         PrimitiveFamily::VaultLease,
         PrimitiveFamily::Supervision,
         PrimitiveFamily::TestSimulator,
@@ -45579,11 +45586,13 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
             PrimitiveFamily::EnvironmentalTelemetry,
             PrimitiveFamily::CommandMapping,
             PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::DataGovernance,
             PrimitiveFamily::Supervision,
             PrimitiveFamily::TestSimulator,
         ])
         .with_notes(&[
             "Cloud-only configuration is rejected locally; dual local/cloud control returns an explicit overwrite warning.",
+            "Country and vendor-cloud upload controls require human approval; country and upload enablement also require an exact host-owned consent grant before transport I/O.",
             "Typed local settings validate documented ranges and sensor-specific correction algorithms before transport I/O.",
             "Credential-bearing MQTT and custom HTTP destinations remain blocked on Vault leasing and destination policy.",
         ]),
@@ -81683,6 +81692,7 @@ mod tests {
             PrimitiveFamily::EnvironmentalTelemetry,
             PrimitiveFamily::CommandMapping,
             PrimitiveFamily::CapabilityPolicy,
+            PrimitiveFamily::DataGovernance,
             PrimitiveFamily::TestSimulator,
         ] {
             assert!(airgradient.required_primitives.contains(&primitive));

--- a/code/packages/rust/smart-home-local-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-local-http/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- Redact request body bytes from `LocalHttpRequestPlan` debug output while
+  retaining the body length needed for diagnostics.
+
 ### Added
 
 - Deterministic retry policies with bounded backoff, transient status matching,

--- a/code/packages/rust/smart-home-local-http/src/lib.rs
+++ b/code/packages/rust/smart-home-local-http/src/lib.rs
@@ -657,7 +657,7 @@ impl LocalHttpRequestTemplate {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct LocalHttpRequestPlan {
     pub integration_id: IntegrationId,
     pub bridge_id: BridgeId,
@@ -670,6 +670,25 @@ pub struct LocalHttpRequestPlan {
     pub retry_policy: LocalHttpRetryPolicy,
     pub auth: LocalHttpAuth,
     pub metadata: Vec<Metadata>,
+}
+
+impl fmt::Debug for LocalHttpRequestPlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LocalHttpRequestPlan")
+            .field("integration_id", &self.integration_id)
+            .field("bridge_id", &self.bridge_id)
+            .field("method", &self.method)
+            .field("url", &self.url)
+            .field("headers", &self.headers)
+            .field("body_bytes", &self.body.len())
+            .field("timeout_ms", &self.timeout_ms)
+            .field("idempotent", &self.idempotent)
+            .field("retry_policy", &self.retry_policy)
+            .field("auth", &self.auth)
+            .field("metadata", &self.metadata)
+            .finish()
+    }
 }
 
 impl LocalHttpRequestPlan {
@@ -1243,6 +1262,9 @@ mod tests {
         assert!(plan
             .metadata
             .contains(&Metadata::new("operation", "set-light-on")));
+        let debug = format!("{plan:?}");
+        assert!(debug.contains(&format!("body_bytes: {}", plan.body.len())));
+        assert!(!debug.contains(&format!("{:?}", plan.body)));
     }
 
     #[test]

--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Add stable local API labels for country and cloud-upload configuration.
 - Add the stable `camera_set_recording` local API command label.
 - Add stable local API labels for typed device-configuration commands.
 

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -10302,6 +10302,10 @@ fn command_type_label(command_type: CommandType) -> &'static str {
         CommandType::DeviceControl(DeviceControlCommandType::SetCorrectionProfile) => {
             "device_set_correction_profile"
         }
+        CommandType::DeviceControl(DeviceControlCommandType::SetCountry) => "device_set_country",
+        CommandType::DeviceControl(DeviceControlCommandType::SetCloudUpload) => {
+            "device_set_cloud_upload"
+        }
         CommandType::DeviceControl(DeviceControlCommandType::SetCameraRecording) => {
             "camera_set_recording"
         }
@@ -10364,6 +10368,12 @@ fn command_type_from_label(command_type: &str) -> Result<CommandType, ApiError> 
         )),
         "device_set_correction_profile" => Ok(CommandType::DeviceControl(
             DeviceControlCommandType::SetCorrectionProfile,
+        )),
+        "device_set_country" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetCountry,
+        )),
+        "device_set_cloud_upload" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetCloudUpload,
         )),
         "camera_set_recording" => Ok(CommandType::DeviceControl(
             DeviceControlCommandType::SetCameraRecording,
@@ -13898,6 +13908,11 @@ mod tests {
             (
                 "device_set_correction_profile",
                 DeviceControlCommandType::SetCorrectionProfile,
+            ),
+            ("device_set_country", DeviceControlCommandType::SetCountry),
+            (
+                "device_set_cloud_upload",
+                DeviceControlCommandType::SetCloudUpload,
             ),
             (
                 "camera_set_recording",

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Keep country and cloud-upload configuration commands non-optimistic until a
+  native integration confirms device readback.
 - Keep camera recording changes non-optimistic until a native integration
   confirms device readback.
 - Keep typed device-configuration and self-test commands non-optimistic until

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -808,8 +808,7 @@ impl RuntimeEventDeliverySummary {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum RuntimeEventSort {
     #[default]
     SequenceAsc,
@@ -1807,7 +1806,8 @@ impl RuntimeSupervisor {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default)]
 pub struct RuntimeSupervisorSnapshot {
     pub generated_at_ms: u64,
     pub worker_count: usize,
@@ -6478,6 +6478,8 @@ fn optimistic_snapshot_for_command(command: &DeviceCommand, now_ms: u64) -> Opti
             | DeviceControlCommandType::SetCompensatedDisplay
             | DeviceControlCommandType::TestIndicator
             | DeviceControlCommandType::SetCorrectionProfile
+            | DeviceControlCommandType::SetCountry
+            | DeviceControlCommandType::SetCloudUpload
             | DeviceControlCommandType::SetCameraRecording
             | DeviceControlCommandType::RecallCameraPtzPreset
             | DeviceControlCommandType::MoveCameraPtz,

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1107,113 +1107,135 @@ existing Axis VAPIX production transport:
   count, and `stale=true` nonce refresh while production TLS remains
   certificate-verifying.
 
+## Current AirGradient Data Governance Slice
+
+This slice closes the privacy, telemetry-egress, and operator-consent
+prerequisite for AirGradient's documented country and vendor-cloud controls:
+
+- `smart-home-data-governance` adds a bounded, deny-by-default host policy that
+  binds one authenticated principal and governed resource to a data category,
+  operation, exact destination, declared purpose, consent receipt, and validity
+  window. Model-facing command arguments cannot create or widen grants.
+- D23 adds human-approved country and cloud-upload command types. The runtime
+  keeps both non-optimistic until native device readback.
+- AirGradient accepts only assigned ISO 3166 alpha-2 country codes and requires
+  an exact coarse-location configuration grant before any transport I/O.
+  Normalized state records only that a country is configured, never its value.
+- Enabling upload requires a separate environmental-telemetry egress grant
+  bound to `https://api.airgradient.com`. Disabling upload is
+  privacy-protective and does not require a consent grant, though D23 still
+  requires human approval for the mutation.
+- Both persistent controls use the documented local `PUT /config` contract and
+  exact `GET /config` readback. Real loopback tests prove wire shapes,
+  authorization ordering, consent denial before I/O, and verified shutdown.
+- Local HTTP request-plan debug output now reports only body length, preventing
+  country or future configuration bodies from leaking through derived debug.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
-1. Add AirGradient country and cloud-upload controls only after privacy,
-   telemetry-egress, and operator-consent policy are concrete.
-2. Add AirGradient MQTT broker and custom HTTP routing settings only after
+1. Add AirGradient MQTT broker and custom HTTP routing settings only after
    credential-bearing values use Vault leasing and destination validation.
-3. Add authenticated HEOS source browsing and queue insertion only after the
+2. Add authenticated HEOS source browsing and queue insertion only after the
    account/session and Vault-leasing prerequisites are concrete.
-4. Automate Enphase access-token acquisition or renewal only after Enphase
+3. Automate Enphase access-token acquisition or renewal only after Enphase
    account authentication, cloud-session handling, operator consent, and
    Vault-leased credential policy are concrete; the current host accepts a
    pre-generated token.
-5. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
+4. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
    stable LAN advertisement; the current production path uses explicit local
    HTTPS endpoint and gateway-serial configuration.
-6. Add Enphase per-inverter production inspection only after device-identifier
+5. Add Enphase per-inverter production inspection only after device-identifier
    privacy, purpose, and retention policy are concrete because the native
    response exposes every microinverter serial number.
-7. Add Enphase live battery, relay, generator, grid, and system-topology state
+6. Add Enphase live battery, relay, generator, grid, and system-topology state
    only after the normalized energy topology and retention semantics are
    concrete.
-8. Add Enphase relay, grid-services, or configuration controls only with
+7. Add Enphase relay, grid-services, or configuration controls only with
    operation-specific D23 contracts, explicit safety approval, bounded native
    semantics, and readable postcondition verification.
-9. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
+8. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
    supervised session lifecycle and Vault policy for refresh-token residency are
    concrete; the current isolated inspection drops both tokens after each read.
-10. Add ZoneMinder event push only after a concrete authenticated event host and
+9. Add ZoneMinder event push only after a concrete authenticated event host and
     supervised subscription lifecycle exist.
-11. Add ZoneMinder snapshots, streams, recordings, export, and playback only
+10. Add ZoneMinder snapshots, streams, recordings, export, and playback only
     through the camera-media lease and a concrete media executor.
-12. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
+11. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
     mutations only with operation-specific D23 contracts, least-privilege user
     checks, bounded semantics, and readable postcondition verification.
-13. Add UniFi Network connected-client inspection only after privacy, presence,
+12. Add UniFi Network connected-client inspection only after privacy, presence,
    identifier-retention, and operator-purpose policy are concrete.
-14. Add UniFi Network latest device statistics only after metrics schema,
+13. Add UniFi Network latest device statistics only after metrics schema,
    retention, and bounded polling-load policy are concrete.
-15. Add remote UniFi Site Manager inspection only after telemetry-egress,
+14. Add remote UniFi Site Manager inspection only after telemetry-egress,
    destination, and operator-consent policy are concrete; keep the current host
    local-only.
-16. Add UniFi Network push or change events only after a concrete authenticated
+15. Add UniFi Network push or change events only after a concrete authenticated
    event host and supervised subscription lifecycle exist.
-17. Add UniFi adoption, guest authorization, port actions, or configuration
+16. Add UniFi adoption, guest authorization, port actions, or configuration
    mutations only with operation-specific D23 contracts, least-privilege API
    keys, bounded semantics, and readable postcondition verification.
-18. Add Synology Surveillance Station OTP and remembered-device authentication
+17. Add Synology Surveillance Station OTP and remembered-device authentication
    only after an interactive challenge lifecycle and Vault-leased device-token
    policy are concrete.
-19. Add Synology Surveillance Station events only after a concrete authenticated
+18. Add Synology Surveillance Station events only after a concrete authenticated
    event host and supervised subscription lifecycle exist.
-20. Add Synology Surveillance Station snapshots, recordings, export, and
+19. Add Synology Surveillance Station snapshots, recordings, export, and
    playback only through the camera-media lease and a concrete executor.
-21. Add Synology Surveillance Station PTZ, external recording, or configuration
+20. Add Synology Surveillance Station PTZ, external recording, or configuration
    mutations only with operation-specific D23 contracts, least-privilege API
    checks, bounded semantics, and readable postcondition verification.
-22. Add Frigate event and review push only after a concrete authenticated event
+21. Add Frigate event and review push only after a concrete authenticated event
    or WebSocket host and supervised subscription lifecycle exist.
-23. Add Frigate snapshots, recordings, export, and playback only through the
+22. Add Frigate snapshots, recordings, export, and playback only through the
    camera-media lease and a concrete executor.
-24. Add Frigate commands or configuration mutations only with operation-specific
+23. Add Frigate commands or configuration mutations only with operation-specific
    D23 contracts, least-privilege role checks, and readable postcondition
    verification.
-25. Add Blue Iris snapshots, alert/clip search, export, and playback only through
+24. Add Blue Iris snapshots, alert/clip search, export, and playback only through
    the camera-media lease and a concrete media executor.
-26. Add broader Blue Iris `camconfig` or administrative mutations only with
+25. Add broader Blue Iris `camconfig` or administrative mutations only with
    operation-specific D23 contracts, least-privilege permissions, and readable
    postcondition verification; do not persist the license value returned at
    login.
-27. Add automatic Blue Iris discovery only if the server exposes a documented,
+26. Add automatic Blue Iris discovery only if the server exposes a documented,
    stable LAN advertisement; the current production path is explicit local
    HTTPS endpoint configuration.
-28. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
+27. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
    controls only when each operation has a specific native capability probe,
    bounded semantics, and readable verification where the device exposes it.
-29. Add Axis event streaming only after the existing WebSocket protocol core has
+28. Add Axis event streaming only after the existing WebSocket protocol core has
    a concrete authenticated host using the completed Digest primitive or a
    short-lived session token, plus subscription supervision.
-30. Add Axis snapshots and media transfer only through the camera-media lease and
+29. Add Axis snapshots and media transfer only through the camera-media lease and
    a concrete media executor.
-31. Enumerate Axis video sources/channels before extending PTZ beyond the current
+30. Enumerate Axis video sources/channels before extending PTZ beyond the current
    capability-probed VAPIX camera 1 boundary.
-32. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
+31. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
    only when each operation has a specific capability probe and readable state.
-33. Add Reolink snapshot, recording search/download, and playback operations only
+32. Add Reolink snapshot, recording search/download, and playback operations only
    through the existing camera-media lease and a concrete media executor.
-34. Add Reolink current-position, zoom, guard-point, or patrol controls only when
+33. Add Reolink current-position, zoom, guard-point, or patrol controls only when
    each operation has a capability-specific probe and the firmware exposes the
    native state needed to avoid invented orientation claims.
-35. Add Reolink push events only after a concrete webhook or event-stream host
+34. Add Reolink push events only after a concrete webhook or event-stream host
    and subscription lifecycle exist.
-36. Add authenticated KLAP/Tapo devices and other broader-device families only
+35. Add authenticated KLAP/Tapo devices and other broader-device families only
    after their authentication and session prerequisites are concrete.
-37. Add ONVIF PullPoint events once a concrete event host and subscription
+36. Add ONVIF PullPoint events once a concrete event host and subscription
    lifecycle exist.
-38. Add RTSP media transfer and recording once concrete media transfer and
+37. Add RTSP media transfer and recording once concrete media transfer and
    recorder host primitives exist.
-39. Add a production Matter commissioning, secure-session, and network host only
+38. Add a production Matter commissioning, secure-session, and network host only
    after certificate, fabric, Interaction Model encoding, subscription, and
    transport prerequisites exist.
-40. Add a Thread border-router host only after an actual host transport exists.
-41. Add a production Zigbee coordinator, join, and security host only after
+39. Add a Thread border-router host only after an actual host transport exists.
+40. Add a production Zigbee coordinator, join, and security host only after
    concrete coordinator transport and security primitives exist.
-42. Add production Z-Wave inclusion and S2 only after concrete host transport
+41. Add production Z-Wave inclusion and S2 only after concrete host transport
    and security primitives exist.
 
 ## End-To-End Definition

--- a/code/specs/D23A-smart-home-integration-catalog.md
+++ b/code/specs/D23A-smart-home-integration-catalog.md
@@ -601,6 +601,7 @@ These should be implemented before most vendor-specific adapters:
 | `smart-home-usb-serial` | Zigbee, Z-Wave, Thread, Modbus RTU |
 | `smart-home-camera-media` | ONVIF, RTSP, snapshots, privacy-sensitive state |
 | `smart-home-cloud-account` | OAuth/API-key cloud integrations and webhook registration |
+| `smart-home-data-governance` | purpose-bound consent, coarse-location configuration, and exact-destination telemetry egress |
 | `smart-home-testkit` | fake bridges, fake brokers, fake event streams, replay fixtures |
 
 ### Wave 2 - Standards
@@ -710,6 +711,18 @@ radio adapters, cloud APIs, webhook receivers, and sidecar processes into the
 generic `capability-cage` manifest taxonomy. It keeps D23 smart-home read and
 command capability hints separate from OS-level permissions so runtime hosts can
 review both before launching workers.
+
+### `smart-home-data-governance`
+
+Pure Rust host-owned privacy, consent, and data-egress policy.
+
+**Initial Rust implementation:** `code/packages/rust/smart-home-data-governance`
+now provides bounded, deny-by-default grants that bind one authenticated
+principal and governed resource to a data category, operation, exact local or
+HTTPS destination, declared purpose, consent receipt, and validity window.
+Privacy-protective egress shutdown remains grant-free, while D23 command policy
+continues to own human approval for the underlying device mutation. Sensitive
+grant fields and exact origins are redacted from debug output.
 
 ### `smart-home-integration-importer`
 


### PR DESCRIPTION
## Summary

- add a bounded, deny-by-default `smart-home-data-governance` primitive for exact principal, resource, purpose, consent receipt, validity window, and destination grants
- add human-approved AirGradient country and vendor-cloud upload controls over the documented local `/config` API with native readback verification
- allow privacy-protective cloud-upload shutdown without a consent grant while keeping D23 command approval intact
- keep country values out of normalized state and redact request bodies, consent details, and exact governed origins from debug output
- record the completed slice and reprioritize the remaining Smart Home inventory from 42 to 41 gated items

## Validation

- `bash smart-home-data-governance/BUILD`
- `bash smart-home-airgradient-local-integration/BUILD`
- `bash smart-home-core/BUILD`
- `bash smart-home-runtime/BUILD`
- `bash smart-home-local-http/BUILD`
- `bash smart-home-integration-catalog/BUILD` (334 tests)
- `bash chief-of-staff-smart-home-tools/BUILD`
- `bash smart-home-platform-http/BUILD`
- `bash matter-core/BUILD`
- strict Clippy across all touched packages and targets with `-D warnings`

## Protocol source

Implementation follows the AirGradient [local server API contract](https://github.com/Open-Air-Foundation/arduino/blob/master/docs/local-server.md) for `GET /config`, `PUT /config`, `country`, and `postDataToAirGradient`.