### PR TITLE
Normalize PJFET model cards

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize the `PJFET` model type alias to canonical `PJF` cards.
 - Normalize the `NJ` model type alias to canonical `NJF` cards.
 - Normalize the `NJFET` model type alias to canonical `NJF` cards.
 - Normalize the `DIODE` model type alias to canonical `D` cards.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1990,6 +1990,8 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         kind = "D"
     elif kind in {"NJFET", "NJ"}:
         kind = "NJF"
+    elif kind == "PJFET":
+        kind = "PJF"
     params = _parse_model_params(params_text)
     if kind == "D":
         saturation_current = params.get("IS", params.get("JS"))

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2119,6 +2119,18 @@ def test_parse_nj_model_type_alias() -> None:
     assert jfet.beta == 2.0e-3
 
 
+def test_parse_pjfet_model_type_alias() -> None:
+    parsed = parse_netlist(
+        ".model fast PJFET(BETA=2m)\nJ1 drain gate source fast"
+    )
+
+    assert parsed.models["fast"].kind == "PJF"
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert jfet.polarity == "PJF"
+    assert jfet.beta == 2.0e-3
+
+
 @pytest.mark.parametrize("parameter", ["CGS", "CGS0"])
 def test_parse_jfet_gate_source_capacitance_aliases(parameter: str) -> None:
     parsed = parse_netlist(

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize the `PJFET` model type alias to canonical `PJF` cards.
 - Normalize the `NJ` model type alias to canonical `NJF` cards.
 - Normalize the `NJFET` model type alias to canonical `NJF` cards.
 - Normalize the `DIODE` model type alias to canonical `D` cards.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1149,8 +1149,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
     paramsText = paramsText.slice(1, -1);
   }
   const rawKind = match[1].toUpperCase();
-  const kind =
-    rawKind === "DIODE" ? "D" : rawKind === "NJFET" || rawKind === "NJ" ? "NJF" : rawKind;
+  let kind = rawKind;
+  if (rawKind === "DIODE") {
+    kind = "D";
+  } else if (rawKind === "NJFET" || rawKind === "NJ") {
+    kind = "NJF";
+  } else if (rawKind === "PJFET") {
+    kind = "PJF";
+  }
   const params = parseModelParams(paramsText);
   const diodeSaturationCurrent = params.get("IS") ?? params.get("JS");
   if (

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2197,6 +2197,17 @@ J1 drain gate source fast
     });
   });
 
+  it("parses the PJFET model type alias", () => {
+    const parsed = parseNetlist(".model fast PJFET(BETA=2m)\nJ1 drain gate source fast");
+
+    expect(parsed.models.get("fast")?.kind).toBe("PJF");
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      polarity: "PJF",
+      beta: 2.0e-3,
+    });
+  });
+
   it.each(["CGS", "CGS0"])(
     "parses the JFET %s gate-source capacitance alias",
     (parameter) => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4734,9 +4734,15 @@ the Rust, Python, and TypeScript surfaces together.
      without changing the unresolved `B` parameter policy.
 
 478. Python and TypeScript Berkeley SPICE short N-channel JFET model-type alias parity.
-   - Status: implemented in this NJ model-type normalization slice.
+   - Status: completed in PR 10160.
    - Both parser facades normalize the engine-supported `NJ` model type alias
      to canonical `NJF`, preserving JFET validation and instance lowering
+     without changing the unresolved `B` parameter policy.
+
+479. Python and TypeScript Berkeley SPICE P-channel JFET model-type alias parity.
+   - Status: implemented in this PJFET model-type normalization slice.
+   - Both parser facades normalize the engine-supported `PJFET` model type
+     alias to canonical `PJF`, preserving JFET validation and instance lowering
      without changing the unresolved `B` parameter policy.
 
 ## Backlog


### PR DESCRIPTION
## Summary

- normalize the engine-supported `PJFET` model type alias to canonical `PJF` in both parser facades
- verify canonical model storage and P-channel JFET instance lowering in Python and TypeScript
- preserve the documented JFET `B` parameter policy collision without changing parameter lowering

## Verification

- Python parser `bash BUILD` (`638 passed`, 90.56% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (`623 passed`)
- TypeScript parser `npx vitest run --coverage` (88.33% lines)
- TypeScript engine `bash BUILD` (`448 passed`)
- `git diff --check`
- BUILD dependency audit: no BUILD files or dependency edges changed
