### PR TITLE
Authenticate package trust before Chief host readiness

### DIFF
--- a/code/packages/rust/chief-of-staff-host-control-protocol/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add a bounded authenticated `PackageTrust` record that must be delivered
+  exactly once before a child can announce independently verified readiness.
 - Add authenticated channel receive, publish, and acknowledge requests plus
   provider-neutral text completion requests and responses.
 - Enforce bounded binary fields, canonical UUID-v7 identities, one in-flight

--- a/code/packages/rust/chief-of-staff-host-control-protocol/README.md
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/README.md
@@ -2,16 +2,19 @@
 
 `chief-of-staff-host-control-protocol` defines the authenticated lifecycle and
 bounded data-plane conversation between the D18 orchestrator and one spawned
-host. A child independently verifies its signed package, sends
+host. After the secure handshake, the orchestrator authenticates the exact
+relevant public package key, trust class, and tier to the child. The child builds
+its own verification keyring, independently verifies its signed package, sends
 `Ready(package_hash)`, then sends heartbeats and serialized channel or
 provider-neutral completion requests. The orchestrator sends exact correlated
 responses or `Terminate`.
 
 The wrapper runs over `chief-of-staff-secure-host-channel`, enforces role and
 lifecycle ordering, and fails closed after malformed, unauthenticated,
-wrong-direction, replayed, or package-mismatched peer input. Heartbeats carry no
-child-selected timestamp: the orchestrator attaches its trusted monotonic receive
-time after authentication. The data plane permits one request in flight, uses
+wrong-direction, replayed, duplicate/missing package trust, or package-mismatched
+peer input. Heartbeats carry no child-selected timestamp: the orchestrator attaches
+its trusted monotonic receive time after authentication. The data plane permits one
+request in flight, uses
 strictly increasing non-zero IDs, and fails closed on skipped, duplicate,
 wrong-operation, or unsolicited responses. Receive, publish, acknowledge, and
 text completion records have explicit aggregate and field bounds below the

--- a/code/packages/rust/chief-of-staff-host-control-protocol/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/src/lib.rs
@@ -29,8 +29,11 @@ const VERSION: u8 = 1;
 const READY_TAG: u8 = 1;
 const HEARTBEAT_TAG: u8 = 2;
 const TERMINATE_TAG: u8 = 3;
+const PACKAGE_TRUST_TAG: u8 = 4;
 const HEADER_BYTES: usize = 6;
 const READY_BYTES: usize = HEADER_BYTES + 32;
+const MAX_PACKAGE_KEY_ID_BYTES: usize = 128;
+const PACKAGE_TRUST_FIXED_BYTES: usize = 1 + 1 + 32;
 
 /// Observable state of one authenticated control endpoint.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -67,6 +70,8 @@ pub enum ChildEvent {
 /// Authenticated orchestrator event accepted by a child.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum OrchestratorEvent {
+    /// The exact package-signing trust selected by the supervising parent.
+    PackageTrust(PackageTrust),
     /// Begin graceful host shutdown.
     Terminate,
     /// One exactly correlated response to the child's pending request.
@@ -88,6 +93,8 @@ pub enum ControlError {
     UnknownMessageKind,
     /// A data-plane body violated its static shape, UTF-8, UUID, or size bounds.
     InvalidDataPlaneRecord,
+    /// Package-signing trust violated its closed key, tier, or identifier contract.
+    InvalidPackageTrust,
     /// The peer sent a valid message kind owned by the opposite direction.
     WrongMessageDirection,
     /// The operation violates readiness or termination ordering.
@@ -113,6 +120,7 @@ impl Display for ControlError {
             Self::UnsupportedVersion => "host-control: unsupported version",
             Self::UnknownMessageKind => "host-control: unknown message kind",
             Self::InvalidDataPlaneRecord => "host-control: invalid data-plane record",
+            Self::InvalidPackageTrust => "host-control: invalid package trust",
             Self::WrongMessageDirection => "host-control: wrong message direction",
             Self::InvalidState => "host-control: invalid lifecycle state",
             Self::PackageMismatch => "host-control: package identity mismatch",
@@ -126,11 +134,80 @@ impl Display for ControlError {
 
 impl std::error::Error for ControlError {}
 
+/// Signing-key class carried to the child before package readiness.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PackageTrustType {
+    /// Operator-controlled production package key.
+    Production,
+    /// Local developer key, restricted to Tier 0 or Tier 1 packages.
+    Developer,
+    /// Independently operated third-party package key.
+    ThirdParty,
+}
+
+/// Exact public package trust authenticated to one child session.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PackageTrust {
+    key_id: String,
+    key_type: PackageTrustType,
+    public_key: [u8; 32],
+    maximum_tier: u8,
+}
+
+impl PackageTrust {
+    /// Validate one package-signing public key and its maximum privilege tier.
+    pub fn new(
+        key_id: impl Into<String>,
+        key_type: PackageTrustType,
+        public_key: [u8; 32],
+        maximum_tier: u8,
+    ) -> Result<Self, ControlError> {
+        let key_id = key_id.into();
+        if key_id.is_empty()
+            || key_id.len() > MAX_PACKAGE_KEY_ID_BYTES
+            || !key_id
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+            || maximum_tier > 3
+            || (key_type == PackageTrustType::Developer && maximum_tier > 1)
+        {
+            return Err(ControlError::InvalidPackageTrust);
+        }
+        Ok(Self {
+            key_id,
+            key_type,
+            public_key,
+            maximum_tier,
+        })
+    }
+
+    /// Return the stable package key identifier.
+    pub fn key_id(&self) -> &str {
+        &self.key_id
+    }
+
+    /// Return the authenticated package trust class.
+    pub fn key_type(&self) -> PackageTrustType {
+        self.key_type
+    }
+
+    /// Return the raw Ed25519 public verification key.
+    pub fn public_key(&self) -> [u8; 32] {
+        self.public_key
+    }
+
+    /// Return the maximum package privilege tier accepted for this key.
+    pub fn maximum_tier(&self) -> u8 {
+        self.maximum_tier
+    }
+}
+
 /// Orchestrator-side lifecycle wrapper around one secure host channel.
 pub struct OrchestratorControl {
     channel: SecureHostChannel,
     expected_package_hash: [u8; 32],
     state: ControlState,
+    trust_sent: bool,
     last_request_id: u64,
     pending_request: Option<(RequestId, DataPlaneOperation)>,
 }
@@ -148,6 +225,7 @@ impl OrchestratorControl {
             channel,
             expected_package_hash,
             state: ControlState::AwaitingReady,
+            trust_sent: false,
             last_request_id: 0,
             pending_request: None,
         })
@@ -172,7 +250,9 @@ impl OrchestratorControl {
             Err(error) => return Err(self.close(error)),
         };
         match (self.state, record) {
-            (ControlState::AwaitingReady, ControlRecord::Ready(package_hash)) => {
+            (ControlState::AwaitingReady, ControlRecord::Ready(package_hash))
+                if self.trust_sent =>
+            {
                 if package_hash != self.expected_package_hash {
                     return Err(self.close(ControlError::PackageMismatch));
                 }
@@ -197,11 +277,31 @@ impl OrchestratorControl {
                 self.pending_request = Some((request.id(), request.operation()));
                 Ok(ChildEvent::Request(request))
             }
-            (_, ControlRecord::Terminate | ControlRecord::Response(_)) => {
-                Err(self.close(ControlError::WrongMessageDirection))
-            }
+            (
+                _,
+                ControlRecord::PackageTrust(_)
+                | ControlRecord::Terminate
+                | ControlRecord::Response(_),
+            ) => Err(self.close(ControlError::WrongMessageDirection)),
             _ => Err(self.close(ControlError::InvalidState)),
         }
+    }
+
+    /// Authenticate the exact relevant package-signing trust before readiness.
+    pub fn provide_package_trust(&mut self, trust: PackageTrust) -> Result<Vec<u8>, ControlError> {
+        if self.state == ControlState::Closed {
+            return Err(ControlError::Closed);
+        }
+        if self.state != ControlState::AwaitingReady || self.trust_sent {
+            return Err(ControlError::InvalidState);
+        }
+        let plaintext = encode_record(ControlRecord::PackageTrust(trust))?;
+        let frame = match self.channel.send(&plaintext) {
+            Ok(frame) => frame,
+            Err(error) => return Err(self.close(ControlError::Channel(error))),
+        };
+        self.trust_sent = true;
+        Ok(frame)
     }
 
     /// Encrypt the response to the one pending child request.
@@ -280,6 +380,7 @@ impl OrchestratorControl {
 pub struct ChildControl {
     channel: SecureHostChannel,
     state: ControlState,
+    trust_received: bool,
     next_request_id: Option<u64>,
     pending_request: Option<(RequestId, DataPlaneOperation)>,
 }
@@ -293,6 +394,7 @@ impl ChildControl {
         Ok(Self {
             channel,
             state: ControlState::AwaitingReady,
+            trust_received: false,
             next_request_id: Some(1),
             pending_request: None,
         })
@@ -303,7 +405,7 @@ impl ChildControl {
         if self.state == ControlState::Closed {
             return Err(ControlError::Closed);
         }
-        if self.state != ControlState::AwaitingReady {
+        if self.state != ControlState::AwaitingReady || !self.trust_received {
             return Err(ControlError::InvalidState);
         }
         let plaintext = encode_record(ControlRecord::Ready(package_hash))?;
@@ -399,6 +501,13 @@ impl ChildControl {
             Err(error) => return Err(self.close(error)),
         };
         match record {
+            ControlRecord::PackageTrust(trust) => {
+                if self.state != ControlState::AwaitingReady || self.trust_received {
+                    return Err(self.close(ControlError::InvalidState));
+                }
+                self.trust_received = true;
+                Ok(OrchestratorEvent::PackageTrust(trust))
+            }
             ControlRecord::Terminate => {
                 self.state = ControlState::Terminating;
                 Ok(OrchestratorEvent::Terminate)
@@ -481,6 +590,7 @@ enum ControlRecord {
     Ready([u8; 32]),
     Heartbeat,
     Terminate,
+    PackageTrust(PackageTrust),
     Request(DataPlaneRequest),
     Response(DataPlaneResponse),
 }
@@ -489,6 +599,9 @@ fn encode_record(record: ControlRecord) -> Result<Vec<u8>, ControlError> {
     let mut output = Vec::with_capacity(match &record {
         ControlRecord::Ready(_) => READY_BYTES,
         ControlRecord::Heartbeat | ControlRecord::Terminate => HEADER_BYTES,
+        ControlRecord::PackageTrust(trust) => {
+            HEADER_BYTES + 1 + trust.key_id.len() + PACKAGE_TRUST_FIXED_BYTES
+        }
         ControlRecord::Request(_) | ControlRecord::Response(_) => HEADER_BYTES + 128,
     });
     output.extend_from_slice(MAGIC);
@@ -500,6 +613,18 @@ fn encode_record(record: ControlRecord) -> Result<Vec<u8>, ControlError> {
         }
         ControlRecord::Heartbeat => output.push(HEARTBEAT_TAG),
         ControlRecord::Terminate => output.push(TERMINATE_TAG),
+        ControlRecord::PackageTrust(trust) => {
+            output.push(PACKAGE_TRUST_TAG);
+            output.push(trust.key_id.len() as u8);
+            output.extend_from_slice(trust.key_id.as_bytes());
+            output.push(match trust.key_type {
+                PackageTrustType::Production => 1,
+                PackageTrustType::Developer => 2,
+                PackageTrustType::ThirdParty => 3,
+            });
+            output.push(trust.maximum_tier);
+            output.extend_from_slice(&trust.public_key);
+        }
         ControlRecord::Request(request) => {
             let (tag, body) = data_plane::encode(&DataRecord::Request(request))?;
             output.push(tag);
@@ -546,6 +671,35 @@ fn decode_record(bytes: &[u8]) -> Result<ControlRecord, ControlError> {
                 return Err(ControlError::MalformedRecord);
             }
             Ok(ControlRecord::Terminate)
+        }
+        PACKAGE_TRUST_TAG => {
+            let body = &bytes[HEADER_BYTES..];
+            let key_id_length = *body.first().ok_or(ControlError::InvalidPackageTrust)? as usize;
+            if key_id_length == 0 || key_id_length > MAX_PACKAGE_KEY_ID_BYTES {
+                return Err(ControlError::InvalidPackageTrust);
+            }
+            let expected_length = 1 + key_id_length + PACKAGE_TRUST_FIXED_BYTES;
+            if body.len() != expected_length {
+                return Err(ControlError::InvalidPackageTrust);
+            }
+            let key_id = std::str::from_utf8(&body[1..1 + key_id_length])
+                .map_err(|_| ControlError::InvalidPackageTrust)?;
+            let key_type = match body[1 + key_id_length] {
+                1 => PackageTrustType::Production,
+                2 => PackageTrustType::Developer,
+                3 => PackageTrustType::ThirdParty,
+                _ => return Err(ControlError::InvalidPackageTrust),
+            };
+            let maximum_tier = body[2 + key_id_length];
+            let public_key = body[3 + key_id_length..]
+                .try_into()
+                .map_err(|_| ControlError::InvalidPackageTrust)?;
+            Ok(ControlRecord::PackageTrust(PackageTrust::new(
+                key_id,
+                key_type,
+                public_key,
+                maximum_tier,
+            )?))
         }
         RECEIVE_REQUEST_TAG
         | PUBLISH_REQUEST_TAG
@@ -647,8 +801,23 @@ mod tests {
         }
     }
 
-    fn running_pair(hash: [u8; 32]) -> (OrchestratorControl, ChildControl) {
+    fn package_trust() -> PackageTrust {
+        PackageTrust::new("prod-test", PackageTrustType::Production, [17; 32], 3).unwrap()
+    }
+
+    fn trusted_pair(hash: [u8; 32]) -> (OrchestratorControl, ChildControl) {
         let (mut orchestrator, mut child) = control_pair(hash);
+        let trust = package_trust();
+        let frame = orchestrator.provide_package_trust(trust.clone()).unwrap();
+        assert_eq!(
+            child.receive_orchestrator(&frame).unwrap(),
+            OrchestratorEvent::PackageTrust(trust)
+        );
+        (orchestrator, child)
+    }
+
+    fn running_pair(hash: [u8; 32]) -> (OrchestratorControl, ChildControl) {
+        let (mut orchestrator, mut child) = trusted_pair(hash);
         let ready = child.ready(hash).unwrap();
         orchestrator.receive_child(&ready, 1).unwrap();
         (orchestrator, child)
@@ -657,7 +826,7 @@ mod tests {
     #[test]
     fn matching_ready_and_heartbeats_preserve_trusted_receipt_times() {
         let hash = [7u8; 32];
-        let (mut orchestrator, mut child) = control_pair(hash);
+        let (mut orchestrator, mut child) = trusted_pair(hash);
         let ready = child.ready(hash).unwrap();
         assert_eq!(
             orchestrator.receive_child(&ready, 100).unwrap(),
@@ -911,7 +1080,7 @@ mod tests {
 
     #[test]
     fn package_mismatch_fails_closed() {
-        let (mut orchestrator, mut child) = control_pair([1u8; 32]);
+        let (mut orchestrator, mut child) = trusted_pair([1u8; 32]);
         let ready = child.ready([2u8; 32]).unwrap();
         assert_eq!(
             orchestrator.receive_child(&ready, 10),
@@ -940,9 +1109,12 @@ mod tests {
 
     #[test]
     fn local_child_ordering_is_non_destructive() {
-        let (_, mut child) = control_pair([3u8; 32]);
+        let (mut orchestrator, mut child) = control_pair([3u8; 32]);
         assert_eq!(child.heartbeat(), Err(ControlError::InvalidState));
+        assert_eq!(child.ready([3u8; 32]), Err(ControlError::InvalidState));
         assert_eq!(child.state(), ControlState::AwaitingReady);
+        let trust = orchestrator.provide_package_trust(package_trust()).unwrap();
+        child.receive_orchestrator(&trust).unwrap();
         child.ready([3u8; 32]).unwrap();
         assert_eq!(child.ready([3u8; 32]), Err(ControlError::InvalidState));
         assert_eq!(child.state(), ControlState::Running);
@@ -961,9 +1133,7 @@ mod tests {
         );
         assert_eq!(orchestrator.state(), ControlState::Closed);
 
-        let (orchestrator_channel, child_channel) = raw_pair(4);
-        let mut orchestrator = OrchestratorControl::new(orchestrator_channel, [4; 32]).unwrap();
-        let mut child = ChildControl::new(child_channel).unwrap();
+        let (mut orchestrator, mut child) = trusted_pair([4; 32]);
         let first = child.ready([4; 32]).unwrap();
         orchestrator.receive_child(&first, 1).unwrap();
         let duplicate = child
@@ -1005,7 +1175,7 @@ mod tests {
         );
         assert_eq!(orchestrator.state(), ControlState::Closed);
 
-        let (mut orchestrator, mut child) = control_pair([6; 32]);
+        let (mut orchestrator, mut child) = trusted_pair([6; 32]);
         let ready = child.ready([6; 32]).unwrap();
         orchestrator.receive_child(&ready, 8).unwrap();
         let terminate = orchestrator.terminate().unwrap();
@@ -1048,7 +1218,7 @@ mod tests {
     #[test]
     fn secure_tampering_and_replay_fail_closed() {
         let hash = [8; 32];
-        let (mut orchestrator, mut child) = control_pair(hash);
+        let (mut orchestrator, mut child) = trusted_pair(hash);
         let mut ready = child.ready(hash).unwrap();
         *ready.last_mut().unwrap() ^= 1;
         assert!(matches!(
@@ -1057,7 +1227,7 @@ mod tests {
         ));
         assert_eq!(orchestrator.state(), ControlState::Closed);
 
-        let (mut orchestrator, mut child) = control_pair(hash);
+        let (mut orchestrator, mut child) = trusted_pair(hash);
         let ready = child.ready(hash).unwrap();
         orchestrator.receive_child(&ready, 1).unwrap();
         assert!(matches!(
@@ -1070,22 +1240,25 @@ mod tests {
     #[test]
     fn codec_is_strict_bounded_and_complete() {
         let records = [
-            ControlRecord::Ready([9; 32]),
-            ControlRecord::Heartbeat,
-            ControlRecord::Terminate,
+            (ControlRecord::Ready([9; 32]), ControlError::MalformedRecord),
+            (ControlRecord::Heartbeat, ControlError::MalformedRecord),
+            (ControlRecord::Terminate, ControlError::MalformedRecord),
+            (
+                ControlRecord::PackageTrust(package_trust()),
+                ControlError::InvalidPackageTrust,
+            ),
         ];
-        for record in records {
+        for (record, truncated_error) in records {
             let encoded = encode_record(record.clone()).unwrap();
             assert_eq!(decode_record(&encoded), Ok(record));
             for end in 0..encoded.len() {
-                assert_eq!(
-                    decode_record(&encoded[..end]),
-                    Err(ControlError::MalformedRecord)
-                );
+                let error = decode_record(&encoded[..end]).unwrap_err();
+                assert!(matches!(error, ControlError::MalformedRecord) || error == truncated_error);
             }
             let mut trailing = encoded;
             trailing.push(0);
-            assert_eq!(decode_record(&trailing), Err(ControlError::MalformedRecord));
+            let error = decode_record(&trailing).unwrap_err();
+            assert!(matches!(error, ControlError::MalformedRecord) || error == truncated_error);
         }
 
         let mut bad_magic = encode_record(ControlRecord::Heartbeat).unwrap();
@@ -1106,6 +1279,91 @@ mod tests {
             decode_record(&bad_tag),
             Err(ControlError::UnknownMessageKind)
         );
+    }
+
+    #[test]
+    fn package_trust_is_bounded_typed_and_required_before_ready() {
+        for invalid in ["", "bad key", "x/", &"x".repeat(129)] {
+            assert_eq!(
+                PackageTrust::new(invalid, PackageTrustType::Production, [1; 32], 3),
+                Err(ControlError::InvalidPackageTrust)
+            );
+        }
+        assert_eq!(
+            PackageTrust::new("dev", PackageTrustType::Developer, [1; 32], 2),
+            Err(ControlError::InvalidPackageTrust)
+        );
+        assert_eq!(
+            PackageTrust::new("prod", PackageTrustType::Production, [1; 32], 4),
+            Err(ControlError::InvalidPackageTrust)
+        );
+        for trust in [
+            PackageTrust::new("dev", PackageTrustType::Developer, [2; 32], 1).unwrap(),
+            PackageTrust::new("third", PackageTrustType::ThirdParty, [3; 32], 2).unwrap(),
+        ] {
+            let record = ControlRecord::PackageTrust(trust);
+            assert_eq!(
+                decode_record(&encode_record(record.clone()).unwrap()),
+                Ok(record)
+            );
+        }
+
+        let mut invalid_type = encode_record(ControlRecord::PackageTrust(package_trust())).unwrap();
+        let key_id_length = invalid_type[HEADER_BYTES] as usize;
+        invalid_type[HEADER_BYTES + 1 + key_id_length] = 99;
+        assert_eq!(
+            decode_record(&invalid_type),
+            Err(ControlError::InvalidPackageTrust)
+        );
+        let mut invalid_tier = encode_record(ControlRecord::PackageTrust(package_trust())).unwrap();
+        invalid_tier[HEADER_BYTES + 2 + key_id_length] = 4;
+        assert_eq!(
+            decode_record(&invalid_tier),
+            Err(ControlError::InvalidPackageTrust)
+        );
+
+        let hash = [31; 32];
+        let (mut orchestrator, mut child) = control_pair(hash);
+        assert_eq!(child.ready(hash), Err(ControlError::InvalidState));
+        let trust = package_trust();
+        assert_eq!(trust.key_id(), "prod-test");
+        assert_eq!(trust.key_type(), PackageTrustType::Production);
+        assert_eq!(trust.public_key(), [17; 32]);
+        assert_eq!(trust.maximum_tier(), 3);
+        let frame = orchestrator.provide_package_trust(trust.clone()).unwrap();
+        assert_eq!(
+            orchestrator.provide_package_trust(trust.clone()),
+            Err(ControlError::InvalidState)
+        );
+        assert_eq!(
+            child.receive_orchestrator(&frame),
+            Ok(OrchestratorEvent::PackageTrust(trust))
+        );
+        assert!(child.ready(hash).is_ok());
+
+        let (orchestrator_channel, mut child_channel) = raw_pair(43);
+        let mut orchestrator = OrchestratorControl::new(orchestrator_channel, hash).unwrap();
+        let premature_ready = child_channel
+            .send(&encode_record(ControlRecord::Ready(hash)).unwrap())
+            .unwrap();
+        assert_eq!(
+            orchestrator.receive_child(&premature_ready, 1),
+            Err(ControlError::InvalidState)
+        );
+        assert_eq!(orchestrator.state(), ControlState::Closed);
+
+        let (mut orchestrator, mut child) = control_pair(hash);
+        let first = orchestrator.provide_package_trust(package_trust()).unwrap();
+        child.receive_orchestrator(&first).unwrap();
+        let duplicate = orchestrator
+            .channel
+            .send(&encode_record(ControlRecord::PackageTrust(package_trust())).unwrap())
+            .unwrap();
+        assert_eq!(
+            child.receive_orchestrator(&duplicate),
+            Err(ControlError::InvalidState)
+        );
+        assert_eq!(child.state(), ControlState::Closed);
     }
 
     #[test]
@@ -1144,6 +1402,7 @@ mod tests {
             ControlError::UnsupportedVersion,
             ControlError::UnknownMessageKind,
             ControlError::InvalidDataPlaneRecord,
+            ControlError::InvalidPackageTrust,
             ControlError::WrongMessageDirection,
             ControlError::InvalidState,
             ControlError::PackageMismatch,

--- a/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Deliver the exact relevant public package key, trust class, and tier over the
+  fresh child session, removing the test child's hard-coded verification key.
 - Pass the authenticated package runtime to the single configured host program
   as the reserved final `--package-runtime deno|skill` argument pair.
 - Carry bounded correlated channel and completion exchanges over the established

--- a/code/packages/rust/chief-of-staff-process-supervisor/README.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/README.md
@@ -3,7 +3,9 @@
 `chief-of-staff-process-supervisor` is the concrete OS-process authority for
 D18 Chief hosts. It re-verifies a registered signed package immediately before
 each spawn, owns and reaps the child, bootstraps a fresh UUID-v7 secure channel,
-and reports readiness and heartbeat only after authenticated control messages.
+delivers the exact relevant public package trust over that authenticated channel,
+and reports readiness and heartbeat only after the child independently verifies
+the package with that trust.
 The single configured host executable receives a final reserved
 `--package-runtime deno|skill` pair derived from that verified package snapshot,
 giving the production host a fail-closed runtime-dispatch seam without ambient

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/bin/process_supervisor_test_child.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/bin/process_supervisor_test_child.rs
@@ -1,22 +1,14 @@
 use chief_of_staff_host_control_protocol::{
     CompletionCall, DataPlaneResponse, PromptMessage, PromptRole,
 };
-use chief_of_staff_host_runtime::{
-    verify_agent_package, AgentPackageRuntime, PackageKeyType, PackageKeyring, TrustedPackageKey,
-};
+use chief_of_staff_host_runtime::{verify_agent_package, AgentPackageRuntime, PackageKeyring};
 use chief_of_staff_process_supervisor::ChildProcessControl;
-use chief_of_staff_tool_api::PrivilegeTier;
 use std::collections::BTreeMap;
 use std::env;
 use std::io::{self, Write};
 use std::path::Path;
 use std::thread;
 use std::time::Duration;
-
-const TEST_PUBLIC_KEY: [u8; 32] = [
-    25, 127, 107, 35, 225, 108, 133, 50, 198, 171, 200, 56, 250, 205, 94, 167, 137, 190, 12, 118,
-    178, 146, 3, 52, 3, 155, 250, 139, 61, 54, 141, 97,
-];
 
 fn has_marker(name: &str) -> bool {
     Path::new(name).is_file()
@@ -81,15 +73,13 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let mut keyring = PackageKeyring::new();
-    keyring.trust(TrustedPackageKey::new(
-        "prod-test",
-        PackageKeyType::Production,
-        TEST_PUBLIC_KEY,
-        PrivilegeTier::Tier3,
-    )?)?;
-    let package = verify_agent_package(Path::new("."), &keyring)?;
     let arguments = env::args().skip(1).collect::<Vec<_>>();
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut control = ChildProcessControl::bootstrap(stdin.lock(), stdout.lock())?;
+    let mut keyring = PackageKeyring::new();
+    keyring.trust(control.receive_package_trust()?)?;
+    let package = verify_agent_package(Path::new("."), &keyring)?;
     let expected_runtime = match package.runtime() {
         AgentPackageRuntime::Deno => "deno",
         AgentPackageRuntime::Skill => "skill",
@@ -97,10 +87,6 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     if arguments != ["--package-runtime", expected_runtime] {
         return Err("package runtime launch argument mismatch".into());
     }
-    let stdin = io::stdin();
-    let stdout = io::stdout();
-    let mut control = ChildProcessControl::bootstrap(stdin.lock(), stdout.lock())?;
-
     if has_marker("EXIT_BEFORE_READY") {
         return Ok(());
     }

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
@@ -10,14 +10,17 @@
 use chief_of_staff_channel_crypto::ChannelId;
 use chief_of_staff_host_control_protocol::{
     ChildControl, ChildEvent, CompletionCall, DataPlaneRequest, DataPlaneResponse,
-    OrchestratorControl, OrchestratorEvent,
+    OrchestratorControl, OrchestratorEvent, PackageTrust, PackageTrustType,
 };
-use chief_of_staff_host_runtime::{verify_agent_package, AgentPackageRuntime, PackageKeyring};
+use chief_of_staff_host_runtime::{
+    verify_agent_package, AgentPackageRuntime, PackageKeyType, PackageKeyring, TrustedPackageKey,
+};
 use chief_of_staff_secure_host_channel::{
     BootstrapOffer, ChildBootstrap, ClientHello, HostId, OrchestratorBootstrap, SessionId,
 };
 use chief_of_staff_service_reconciler::{HostSupervisor, SupervisorObservation};
 use chief_of_staff_service_registry::{HostName, HostRegistration};
+use chief_of_staff_tool_api::PrivilegeTier;
 use coding_adventures_x3dh::IdentityKeyPair;
 use core::fmt::{self, Display, Formatter};
 use std::collections::BTreeMap;
@@ -410,6 +413,11 @@ impl ProcessHostSupervisor {
         if package.digest() != *registration.package_hash() {
             return Err(ProcessSupervisorError::PackageMismatch);
         }
+        let package_trust = self
+            .keyring
+            .trusted_key(package.key_id())
+            .ok_or(ProcessSupervisorError::PackageVerification)
+            .and_then(package_trust_record)?;
 
         let session = self.sessions.next_session()?;
         let host = HostId::new(registration.host_name().as_str().to_owned())
@@ -493,8 +501,13 @@ impl ProcessHostSupervisor {
             let channel = bootstrap
                 .accept(&hello)
                 .map_err(|_| ProcessSupervisorError::Bootstrap)?;
-            OrchestratorControl::new(channel, *registration.package_hash())
-                .map_err(|_| ProcessSupervisorError::Control)
+            let mut control = OrchestratorControl::new(channel, *registration.package_hash())
+                .map_err(|_| ProcessSupervisorError::Control)?;
+            let trust = control
+                .provide_package_trust(package_trust)
+                .map_err(|_| ProcessSupervisorError::Control)?;
+            write_record(&mut stdin, &trust)?;
+            Ok(control)
         })();
 
         match startup {
@@ -695,6 +708,21 @@ impl<R: Read, W: Write> ChildProcessControl<R, W> {
         })
     }
 
+    /// Receive the exact authenticated public trust required for package verification.
+    pub fn receive_package_trust(&mut self) -> Result<TrustedPackageKey, ProcessSupervisorError> {
+        let frame = read_record(&mut self.reader)?;
+        match self
+            .control
+            .receive_orchestrator(&frame)
+            .map_err(|_| ProcessSupervisorError::Control)?
+        {
+            OrchestratorEvent::PackageTrust(trust) => trusted_package_key(trust),
+            OrchestratorEvent::Terminate | OrchestratorEvent::Response(_) => {
+                Err(ProcessSupervisorError::Control)
+            }
+        }
+    }
+
     /// Send one authenticated readiness record with the independently verified hash.
     pub fn ready(&mut self, package_hash: [u8; 32]) -> Result<(), ProcessSupervisorError> {
         let frame = self
@@ -774,7 +802,9 @@ impl<R: Read, W: Write> ChildProcessControl<R, W> {
             .map_err(|_| ProcessSupervisorError::Control)?
         {
             OrchestratorEvent::Terminate => Ok(()),
-            OrchestratorEvent::Response(_) => Err(ProcessSupervisorError::Control),
+            OrchestratorEvent::PackageTrust(_) | OrchestratorEvent::Response(_) => {
+                Err(ProcessSupervisorError::Control)
+            }
         }
     }
 
@@ -795,8 +825,51 @@ impl<R: Read, W: Write> ChildProcessControl<R, W> {
             .map_err(|_| ProcessSupervisorError::Control)?
         {
             OrchestratorEvent::Response(response) => Ok(response),
-            OrchestratorEvent::Terminate => Err(ProcessSupervisorError::Control),
+            OrchestratorEvent::PackageTrust(_) | OrchestratorEvent::Terminate => {
+                Err(ProcessSupervisorError::Control)
+            }
         }
+    }
+}
+
+fn package_trust_record(key: &TrustedPackageKey) -> Result<PackageTrust, ProcessSupervisorError> {
+    let key_type = match key.key_type {
+        PackageKeyType::Production => PackageTrustType::Production,
+        PackageKeyType::Developer => PackageTrustType::Developer,
+        PackageKeyType::ThirdParty => PackageTrustType::ThirdParty,
+    };
+    PackageTrust::new(
+        &key.key_id,
+        key_type,
+        key.public_key,
+        privilege_tier_number(key.maximum_tier),
+    )
+    .map_err(|_| ProcessSupervisorError::PackageVerification)
+}
+
+fn trusted_package_key(trust: PackageTrust) -> Result<TrustedPackageKey, ProcessSupervisorError> {
+    let key_type = match trust.key_type() {
+        PackageTrustType::Production => PackageKeyType::Production,
+        PackageTrustType::Developer => PackageKeyType::Developer,
+        PackageTrustType::ThirdParty => PackageKeyType::ThirdParty,
+    };
+    let maximum_tier = match trust.maximum_tier() {
+        0 => PrivilegeTier::Tier0,
+        1 => PrivilegeTier::Tier1,
+        2 => PrivilegeTier::Tier2,
+        3 => PrivilegeTier::Tier3,
+        _ => return Err(ProcessSupervisorError::Control),
+    };
+    TrustedPackageKey::new(trust.key_id(), key_type, trust.public_key(), maximum_tier)
+        .map_err(|_| ProcessSupervisorError::Control)
+}
+
+fn privilege_tier_number(tier: PrivilegeTier) -> u8 {
+    match tier {
+        PrivilegeTier::Tier0 => 0,
+        PrivilegeTier::Tier1 => 1,
+        PrivilegeTier::Tier2 => 2,
+        PrivilegeTier::Tier3 => 3,
     }
 }
 
@@ -1056,6 +1129,9 @@ mod tests {
         let child = thread::spawn(move || {
             let mut control = ChildProcessControl::bootstrap(child_reader, child_writer).unwrap();
             assert_eq!(control.session_id(), session);
+            let trust = control.receive_package_trust().unwrap();
+            assert_eq!(trust.key_id, "prod-memory");
+            assert_eq!(trust.public_key, [19; 32]);
             control.ready(package_hash).unwrap();
             control.heartbeat().unwrap();
             control.receive_terminate().unwrap();
@@ -1065,6 +1141,13 @@ mod tests {
         let hello = ClientHello::from_bytes(&read_record(&mut parent_reader).unwrap()).unwrap();
         let channel = bootstrap.accept(&hello).unwrap();
         let mut control = OrchestratorControl::new(channel, package_hash).unwrap();
+        let trust = control
+            .provide_package_trust(
+                PackageTrust::new("prod-memory", PackageTrustType::Production, [19; 32], 3)
+                    .unwrap(),
+            )
+            .unwrap();
+        write_record(&mut parent_writer, &trust).unwrap();
         let ready = read_record(&mut parent_reader).unwrap();
         assert!(matches!(
             control.receive_child(&ready, 10).unwrap(),

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -489,11 +489,13 @@ by the security escort (host process), not the Chief of Staff.
 3. Orchestrator spawns: Host Actor process
    argument: path to the sealed package (./email-reader.agent/)
 4. Orchestrator records: host PID, agent name, "starting" status
-5. Host independently verifies the package and sends authenticated
-   Ready(package_hash) over its per-spawn control channel.
-6. Orchestrator marks Running only when that hash matches the registration.
-7. Orchestrator monitors authenticated heartbeats using trusted receipt time.
-8. Done. Orchestrator does NOT:
+5. Orchestrator sends the exact relevant public package trust over the fresh
+   authenticated child session.
+6. Host independently re-reads and verifies the package with that trust and sends
+   authenticated Ready(package_hash) over its per-spawn control channel.
+7. Orchestrator marks Running only when that hash matches the registration.
+8. Orchestrator monitors authenticated heartbeats using trusted receipt time.
+9. Done. Orchestrator does NOT:
    • read manifest.json
    • know what capabilities the agent has
    • know what Deno flags are used

--- a/code/specs/host-control-protocol.md
+++ b/code/specs/host-control-protocol.md
@@ -24,13 +24,20 @@ channel, or call a model provider.
 
 Every control session has exactly two roles inherited from the secure channel:
 
-- the orchestrator sends `Terminate` and responses;
+- the orchestrator sends one pre-ready `PackageTrust`, `Terminate`, and responses;
 - the child host sends `Ready`, `Heartbeat`, and requests.
 
 The orchestrator control endpoint is constructed with the immutable package hash
 from the service-registry registration. A `Ready` record carries the exact package
 hash independently reverified by the child. A mismatch is terminal and must never
 produce `Running` evidence.
+
+After the secure-channel handshake and before `Ready`, the orchestrator sends the
+exact relevant public package key, trust class, and maximum privilege tier selected
+during its own package verification. The child must authenticate this record, build
+its own one-key verification keyring, and independently re-read and verify the package.
+The record contains no private key and is bound to the fresh encrypted session. A
+missing, duplicate, malformed, or post-ready trust record is rejected.
 
 The timestamp attached to a received child event is not sent by the child. It is a
 caller-supplied monotonic receipt time sampled by the supervising process after the
@@ -50,24 +57,27 @@ contract matches the Level 1 runtime and avoids an unbounded correlation table.
 
 The orchestrator endpoint begins in `AwaitingReady`:
 
-1. The first authenticated child message must be `Ready(expected_package_hash)`.
-2. A matching `Ready` transitions the endpoint to `Running` and yields authoritative
+1. It sends exactly one `PackageTrust` before accepting readiness.
+2. The first authenticated child message must be `Ready(expected_package_hash)`.
+3. A matching `Ready` transitions the endpoint to `Running` and yields authoritative
    package, session, and receipt-time evidence.
-3. `Heartbeat` is accepted only in `Running` and refreshes the authoritative
+4. `Heartbeat` is accepted only in `Running` and refreshes the authoritative
    receipt time.
-4. One data-plane request is accepted only in `Running`; no second request is
+5. One data-plane request is accepted only in `Running`; no second request is
    accepted until the orchestrator sends its exact correlated response.
-5. `Terminate` may be sent while awaiting readiness or running, and transitions the
+6. `Terminate` may be sent while awaiting readiness or running, and transitions the
    endpoint to `Terminating`.
-6. No further application message is accepted or emitted after termination begins.
+7. No further application message is accepted or emitted after termination begins.
 
 The child endpoint begins in `AwaitingReady`:
 
-1. It must independently verify the package before sending `Ready(package_hash)`.
-2. It may send `Heartbeat` only after readiness.
-3. It may send one bounded data-plane request after readiness and must wait for the
+1. It accepts exactly one authenticated `PackageTrust` record.
+2. It must independently verify the package with that trust before sending
+   `Ready(package_hash)`.
+3. It may send `Heartbeat` only after readiness.
+4. It may send one bounded data-plane request after readiness and must wait for the
    exactly correlated response before sending another.
-4. It accepts only correlated responses or `Terminate` from the orchestrator and
+5. It accepts only correlated responses or `Terminate` from the orchestrator and
    enters `Terminating` on the latter.
 
 Duplicate readiness, heartbeat-before-ready, child-sent terminate,
@@ -97,6 +107,7 @@ Kinds are:
 | 1   | child -> orchestrator | `Ready`     | 32-byte package SHA-256 |
 | 2   | child -> orchestrator | `Heartbeat` | empty                    |
 | 3   | orchestrator -> child | `Terminate` | empty                    |
+| 4   | orchestrator -> child | `PackageTrust` | key ID, key type, maximum tier, Ed25519 public key |
 | 10  | child -> orchestrator | `Receive` | request ID, channel UUID-v7, limit |
 | 11  | child -> orchestrator | `Publish` | request ID, channel UUID-v7, content type, payload |
 | 12  | child -> orchestrator | `Acknowledge` | request ID, channel and message UUID-v7 |
@@ -107,8 +118,9 @@ Kinds are:
 | 23  | orchestrator -> child | `Completed` | request ID and provider-neutral completion result |
 | 24  | orchestrator -> child | `Failed` | request ID and redacted stable failure code |
 
-All integers are big-endian. Variable bytes and UTF-8 strings use a `u32` length;
-vectors use their specified `u8` or `u16` count. UUID fields must be canonical
+All multi-byte integers are big-endian. The package key ID uses a bounded `u8`
+length; data-plane variable bytes and UTF-8 strings use a `u32` length; vectors
+use their specified `u8` or `u16` count. UUID fields must be canonical
 UUID-v7 values. Data-plane bodies are capped at 768 KiB, a single channel payload
 or completion text at 512 KiB, a receive page and completion prompt at 64 items,
 and completion metadata at 32 unique canonically ordered keys. Completion calls
@@ -132,6 +144,7 @@ pub enum ChildEvent {
 }
 
 pub enum OrchestratorEvent {
+    PackageTrust(PackageTrust),
     Terminate,
     Response(DataPlaneResponse),
 }
@@ -144,6 +157,8 @@ impl OrchestratorControl {
         -> Result<Self, ControlError>;
     pub fn receive_child(&mut self, frame: &[u8], received_at_ns: u64)
         -> Result<ChildEvent, ControlError>;
+    pub fn provide_package_trust(&mut self, trust: PackageTrust)
+        -> Result<Vec<u8>, ControlError>;
     pub fn terminate(&mut self) -> Result<Vec<u8>, ControlError>;
     pub fn respond(&mut self, response: DataPlaneResponse)
         -> Result<Vec<u8>, ControlError>;
@@ -193,6 +208,7 @@ service dispatch, and hard-kill fallback belong to adapters specified in
 The package must cover:
 
 - matching readiness followed by multiple heartbeats;
+- authenticated bounded package trust required exactly once before readiness;
 - authenticated round trips for receive, publish, acknowledge, completion, and
   redacted failure;
 - one-in-flight ordering, monotonic request IDs, exact response correlation, and

--- a/code/specs/host-runtime-rust.md
+++ b/code/specs/host-runtime-rust.md
@@ -180,11 +180,12 @@ bootstrapped.
 
 Before reading the agent's manifest, the host:
 
-1. Reads `argv[1]/PUBKEY_ID`.
-2. Reads the trusted-keys file from a path the orchestrator gave it
-   in the bootstrap (the host has no vault access of its own; the
-   orchestrator passes the relevant trusted public keys as part of
-   the bootstrap blob, signed by the orchestrator's identity key).
+1. Reads `./PUBKEY_ID` from the package working directory.
+2. Completes the fresh secure-channel handshake and accepts exactly one
+   authenticated `PackageTrust` control record containing the relevant public
+   key, trust class, and maximum tier selected by the orchestrator. The host has
+   no ambient key-file or vault access and rejects readiness if this record is
+   absent, malformed, or duplicated.
 3. Computes the SHA-256 hash of the rest of the package using the
    same deterministic file-set ordering D18 specifies.
 4. Verifies the package's Ed25519 SIGNATURE against the hash with

--- a/code/specs/process-host-supervisor.md
+++ b/code/specs/process-host-supervisor.md
@@ -50,9 +50,11 @@ stream is terminal for that child.
 After spawning, the parent writes one `BootstrapOffer` and waits for one
 `ClientHello`. The wait has a non-zero configured real-time bound. The accepted
 secure channel is wrapped in `OrchestratorControl`. Subsequent framed records
-are encrypted host-control frames. The child-side helper performs the inverse
-bootstrap over any `Read` and `Write`, then exposes only `ready`, `heartbeat`,
-and `receive_terminate` operations.
+are encrypted host-control frames. Before accepting readiness, the parent sends
+the exact relevant package-signing public trust selected by its verified package
+snapshot. The child-side helper performs the inverse bootstrap over any `Read`
+and `Write`, receives that authenticated trust, then exposes readiness, heartbeat,
+termination, and data-plane operations.
 
 ## Package and Identity Safety
 
@@ -64,7 +66,8 @@ Before every actual spawn, including a restart, the adapter:
    `HostRegistration`; and
 3. refuses to launch on any verification or identity mismatch.
 
-The child independently verifies its package before sending
+The child constructs its own one-key `PackageKeyring` from the authenticated
+public trust, independently re-reads and verifies its package, and only then sends
 `Ready(package_hash)`. A mismatched authenticated readiness record closes the
 control endpoint and terminates the child.
 
@@ -150,7 +153,8 @@ The package must cover:
 - zero-length, oversized, truncated, and valid framed records;
 - invalid configuration and stable redacted diagnostics;
 - signature or registered-hash failure before process spawn;
-- real cross-platform child bootstrap, matching readiness, heartbeat, and
+- real cross-platform child bootstrap, authenticated public package trust,
+  independent package verification, matching readiness, heartbeat, and
   graceful termination;
 - real cross-platform child exchanges for every data-plane operation over the
   established secure process pipes;


### PR DESCRIPTION
## Summary
- send the exact relevant public package trust over the fresh authenticated host-control session before accepting Ready
- require package trust exactly once with strict type, tier, identifier, size, direction, and lifecycle validation
- let child runtimes build a TrustedPackageKey from the delivered trust and independently re-verify the package without a hard-coded key

## Validation
- 20 host-control protocol tests
- 6 process-supervisor unit tests
- 8 process-supervisor integration tests
- strict clippy, rustdoc, rustfmt, and diff checks
- dependency-closed planner: all 69 affected, prerequisite, and dependent packages built successfully

Named-channel UUID resolution and Level 1 model launch bindings remain the next prioritized slice.

Progresses #128
Progresses #138