### PR TITLE
Normalize PJ model cards

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize the `PJ` model type alias to canonical `PJF` cards.
 - Normalize the `PJFET` model type alias to canonical `PJF` cards.
 - Normalize the `NJ` model type alias to canonical `NJF` cards.
 - Normalize the `NJFET` model type alias to canonical `NJF` cards.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1990,7 +1990,7 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         kind = "D"
     elif kind in {"NJFET", "NJ"}:
         kind = "NJF"
-    elif kind == "PJFET":
+    elif kind in {"PJFET", "PJ"}:
         kind = "PJF"
     params = _parse_model_params(params_text)
     if kind == "D":

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2131,6 +2131,16 @@ def test_parse_pjfet_model_type_alias() -> None:
     assert jfet.beta == 2.0e-3
 
 
+def test_parse_pj_model_type_alias() -> None:
+    parsed = parse_netlist(".model fast PJ(BETA=2m)\nJ1 drain gate source fast")
+
+    assert parsed.models["fast"].kind == "PJF"
+    jfet = parsed.circuit.elements[0]
+    assert isinstance(jfet, JFET)
+    assert jfet.polarity == "PJF"
+    assert jfet.beta == 2.0e-3
+
+
 @pytest.mark.parametrize("parameter", ["CGS", "CGS0"])
 def test_parse_jfet_gate_source_capacitance_aliases(parameter: str) -> None:
     parsed = parse_netlist(

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize the `PJ` model type alias to canonical `PJF` cards.
 - Normalize the `PJFET` model type alias to canonical `PJF` cards.
 - Normalize the `NJ` model type alias to canonical `NJF` cards.
 - Normalize the `NJFET` model type alias to canonical `NJF` cards.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1154,7 +1154,7 @@ function parseModelCard(fields: readonly string[]): ModelCard {
     kind = "D";
   } else if (rawKind === "NJFET" || rawKind === "NJ") {
     kind = "NJF";
-  } else if (rawKind === "PJFET") {
+  } else if (rawKind === "PJFET" || rawKind === "PJ") {
     kind = "PJF";
   }
   const params = parseModelParams(paramsText);

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2208,6 +2208,17 @@ J1 drain gate source fast
     });
   });
 
+  it("parses the PJ model type alias", () => {
+    const parsed = parseNetlist(".model fast PJ(BETA=2m)\nJ1 drain gate source fast");
+
+    expect(parsed.models.get("fast")?.kind).toBe("PJF");
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      polarity: "PJF",
+      beta: 2.0e-3,
+    });
+  });
+
   it.each(["CGS", "CGS0"])(
     "parses the JFET %s gate-source capacitance alias",
     (parameter) => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4740,10 +4740,18 @@ the Rust, Python, and TypeScript surfaces together.
      without changing the unresolved `B` parameter policy.
 
 479. Python and TypeScript Berkeley SPICE P-channel JFET model-type alias parity.
-   - Status: implemented in this PJFET model-type normalization slice.
+   - Status: completed in PR 10162.
    - Both parser facades normalize the engine-supported `PJFET` model type
      alias to canonical `PJF`, preserving JFET validation and instance lowering
      without changing the unresolved `B` parameter policy.
+
+480. Python and TypeScript Berkeley SPICE short P-channel JFET model-type alias parity.
+   - Status: implemented in this PJ model-type normalization slice.
+   - Both parser facades normalize the engine-supported `PJ` model type alias
+     to canonical `PJF`, preserving JFET validation and instance lowering
+     without changing the unresolved `B` parameter policy.
+   - This completes the audited `DIODE`, `NJFET`, `NJ`, `PJFET`, and `PJ`
+     model-type alias set.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- normalize the engine-supported `PJ` model type alias to canonical `PJF` in both parser facades
- verify canonical model storage and P-channel JFET instance lowering in Python and TypeScript
- complete the audited diode and JFET model-type alias set while preserving the unresolved JFET `B` parameter policy

## Verification

- Python parser `bash BUILD` (`639 passed`, 90.56% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (`624 passed`)
- TypeScript parser `npx vitest run --coverage` (88.33% lines)
- TypeScript engine `bash BUILD` (`448 passed`)
- `git diff --check`
- BUILD dependency audit: no BUILD files or dependency edges changed
