### PR TITLE
Normalize NCH model cards

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize the `NCH` model type alias to canonical `NMOS` cards.
 - Normalize the `PJ` model type alias to canonical `PJF` cards.
 - Normalize the `PJFET` model type alias to canonical `PJF` cards.
 - Normalize the `NJ` model type alias to canonical `NJF` cards.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1992,6 +1992,8 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         kind = "NJF"
     elif kind in {"PJFET", "PJ"}:
         kind = "PJF"
+    elif kind == "NCH":
+        kind = "NMOS"
     params = _parse_model_params(params_text)
     if kind == "D":
         saturation_current = params.get("IS", params.get("JS"))

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2623,6 +2623,19 @@ M1 out gate 0 0 nfast W=2u L=180n
     assert 0.0 <= result.node_voltages["out"] < 1.8
 
 
+def test_parse_nch_model_type_alias() -> None:
+    parsed = parse_netlist(
+        ".model nfast NCH(VTO=0.45 KP=200u)\nM1 d g s b nfast"
+    )
+
+    assert parsed.models["nfast"].kind == "NMOS"
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.model.type == MosfetType.NMOS
+    assert isinstance(mosfet.model.model, Level1Model)
+    assert isclose(mosfet.model.model.params.KP, 200.0e-6)
+
+
 def test_parse_pmos_mosfet_model() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize the `NCH` model type alias to canonical `NMOS` cards.
 - Normalize the `PJ` model type alias to canonical `PJF` cards.
 - Normalize the `PJFET` model type alias to canonical `PJF` cards.
 - Normalize the `NJ` model type alias to canonical `NJF` cards.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1156,6 +1156,8 @@ function parseModelCard(fields: readonly string[]): ModelCard {
     kind = "NJF";
   } else if (rawKind === "PJFET" || rawKind === "PJ") {
     kind = "PJF";
+  } else if (rawKind === "NCH") {
+    kind = "NMOS";
   }
   const params = parseModelParams(paramsText);
   const diodeSaturationCurrent = params.get("IS") ?? params.get("JS");

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2731,6 +2731,22 @@ M1 out gate 0 0 nfast W=2u L=180n
     expect(result.voltage("out")).toBeLessThan(1.8);
   });
 
+  it("parses the NCH model type alias", () => {
+    const parsed = parseNetlist(".model nfast NCH(VTO=0.45 KP=200u)\nM1 d g s b nfast");
+
+    expect(parsed.models.get("nfast")?.kind).toBe("NMOS");
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "mosfet",
+      type: "NMOS",
+    });
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") {
+      throw new Error("unexpected element kind");
+    }
+    expect(element.params.KP).toBeCloseTo(200.0e-6, 12);
+  });
+
   it("parses PMOS MOSFET aliases", () => {
     const parsed = parseNetlist(`
 .model pfast PMOS(VTO=0.4 KP=120u NSUB=1.2)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4746,12 +4746,18 @@ the Rust, Python, and TypeScript surfaces together.
      without changing the unresolved `B` parameter policy.
 
 480. Python and TypeScript Berkeley SPICE short P-channel JFET model-type alias parity.
-   - Status: implemented in this PJ model-type normalization slice.
+   - Status: completed in PR 10165.
    - Both parser facades normalize the engine-supported `PJ` model type alias
      to canonical `PJF`, preserving JFET validation and instance lowering
      without changing the unresolved `B` parameter policy.
    - This completes the audited `DIODE`, `NJFET`, `NJ`, `PJFET`, and `PJ`
      model-type alias set.
+
+481. Python and TypeScript Berkeley SPICE N-channel MOS model-type alias parity.
+   - Status: implemented in this NCH model-type normalization slice.
+   - Both parser facades normalize the engine-supported `NCH` model type alias
+     to canonical `NMOS`, preserving MOS Level-1 validation and instance
+     lowering.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- normalize the engine-supported `NCH` model type alias to canonical `NMOS` in both parser facades
- verify canonical model storage and NMOS Level-1 instance lowering in Python and TypeScript
- record completion of the audited diode and JFET model-type alias set

## Verification

- Python parser `bash BUILD` (`640 passed`, 90.57% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (`625 passed`)
- TypeScript parser `npx vitest run --coverage` (88.35% lines)
- TypeScript engine `bash BUILD` (`448 passed`)
- `git diff --check`
- BUILD dependency audit: no BUILD files or dependency edges changed
