### PR TITLE
Normalize PCH model cards

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize the `PCH` model type alias to canonical `PMOS` cards.
 - Normalize the `NCH` model type alias to canonical `NMOS` cards.
 - Normalize the `PJ` model type alias to canonical `PJF` cards.
 - Normalize the `PJFET` model type alias to canonical `PJF` cards.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1994,6 +1994,8 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         kind = "PJF"
     elif kind == "NCH":
         kind = "NMOS"
+    elif kind == "PCH":
+        kind = "PMOS"
     params = _parse_model_params(params_text)
     if kind == "D":
         saturation_current = params.get("IS", params.get("JS"))

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2636,6 +2636,19 @@ def test_parse_nch_model_type_alias() -> None:
     assert isclose(mosfet.model.model.params.KP, 200.0e-6)
 
 
+def test_parse_pch_model_type_alias() -> None:
+    parsed = parse_netlist(
+        ".model pfast PCH(VTO=0.4 KP=120u)\nM1 d g s b pfast"
+    )
+
+    assert parsed.models["pfast"].kind == "PMOS"
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.model.type == MosfetType.PMOS
+    assert isinstance(mosfet.model.model, Level1Model)
+    assert isclose(mosfet.model.model.params.KP, 120.0e-6)
+
+
 def test_parse_pmos_mosfet_model() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize the `PCH` model type alias to canonical `PMOS` cards.
 - Normalize the `NCH` model type alias to canonical `NMOS` cards.
 - Normalize the `PJ` model type alias to canonical `PJF` cards.
 - Normalize the `PJFET` model type alias to canonical `PJF` cards.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1158,6 +1158,8 @@ function parseModelCard(fields: readonly string[]): ModelCard {
     kind = "PJF";
   } else if (rawKind === "NCH") {
     kind = "NMOS";
+  } else if (rawKind === "PCH") {
+    kind = "PMOS";
   }
   const params = parseModelParams(paramsText);
   const diodeSaturationCurrent = params.get("IS") ?? params.get("JS");

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2747,6 +2747,22 @@ M1 out gate 0 0 nfast W=2u L=180n
     expect(element.params.KP).toBeCloseTo(200.0e-6, 12);
   });
 
+  it("parses the PCH model type alias", () => {
+    const parsed = parseNetlist(".model pfast PCH(VTO=0.4 KP=120u)\nM1 d g s b pfast");
+
+    expect(parsed.models.get("pfast")?.kind).toBe("PMOS");
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "mosfet",
+      type: "PMOS",
+    });
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") {
+      throw new Error("unexpected element kind");
+    }
+    expect(element.params.KP).toBeCloseTo(120.0e-6, 12);
+  });
+
   it("parses PMOS MOSFET aliases", () => {
     const parsed = parseNetlist(`
 .model pfast PMOS(VTO=0.4 KP=120u NSUB=1.2)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4754,10 +4754,18 @@ the Rust, Python, and TypeScript surfaces together.
      model-type alias set.
 
 481. Python and TypeScript Berkeley SPICE N-channel MOS model-type alias parity.
-   - Status: implemented in this NCH model-type normalization slice.
+   - Status: completed in PR 10166.
    - Both parser facades normalize the engine-supported `NCH` model type alias
      to canonical `NMOS`, preserving MOS Level-1 validation and instance
      lowering.
+
+482. Python and TypeScript Berkeley SPICE P-channel MOS model-type alias parity.
+   - Status: implemented in this PCH model-type normalization slice.
+   - Both parser facades normalize the engine-supported `PCH` model type alias
+     to canonical `PMOS`, preserving MOS Level-1 validation and instance
+     lowering.
+   - This completes the audited engine-advertised `DIODE`, `NJFET`, `NJ`,
+     `PJFET`, `PJ`, `NCH`, and `PCH` model-type alias set.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- normalize engine-supported `PCH` model cards to canonical `PMOS` in both parser facades
- verify canonical model storage and PMOS Level-1 instance lowering end to end
- reconcile the SPICE plan and record completion of the advertised model-type alias audit

## Verification

- Python parser `bash BUILD` (`641 passed`, 90.59% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (`626 passed`)
- TypeScript parser `npx vitest run --coverage` (88.37% line coverage)
- TypeScript engine `bash BUILD` (`448 passed`)
- `git diff --check`
- BUILD and dependency manifest audit (no changes required)
