### PR TITLE
Normalize model type separators

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize hyphen and underscore separators in supported model type aliases.
 - Normalize the `PCH` model type alias to canonical `PMOS` cards.
 - Normalize the `NCH` model type alias to canonical `NMOS` cards.
 - Normalize the `PJ` model type alias to canonical `PJF` cards.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1977,7 +1977,7 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
     kind: str
     params_text: str
     joined_tail = " ".join(fields[2:]).strip()
-    inline = re.match(r"^([A-Za-z][A-Za-z0-9_]*)\s*(?:\((.*)\))?$", joined_tail)
+    inline = re.match(r"^([A-Za-z][A-Za-z0-9_-]*)\s*(?:\((.*)\))?$", joined_tail)
     if len(fields) == 3 and inline is not None:
         kind = inline.group(1).upper()
         params_text = inline.group(2) or ""
@@ -1986,15 +1986,16 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         params_text = " ".join(fields[3:]).strip()
         if params_text.startswith("(") and params_text.endswith(")"):
             params_text = params_text[1:-1]
-    if kind == "DIODE":
+    kind_key = kind.replace("-", "").replace("_", "")
+    if kind_key == "DIODE":
         kind = "D"
-    elif kind in {"NJFET", "NJ"}:
+    elif kind_key in {"NJFET", "NJ"}:
         kind = "NJF"
-    elif kind in {"PJFET", "PJ"}:
+    elif kind_key in {"PJFET", "PJ"}:
         kind = "PJF"
-    elif kind == "NCH":
+    elif kind_key == "NCH":
         kind = "NMOS"
-    elif kind == "PCH":
+    elif kind_key == "PCH":
         kind = "PMOS"
     params = _parse_model_params(params_text)
     if kind == "D":

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2649,6 +2649,23 @@ def test_parse_pch_model_type_alias() -> None:
     assert isclose(mosfet.model.model.params.KP, 120.0e-6)
 
 
+def test_parse_separator_normalized_model_type_aliases() -> None:
+    parsed = parse_netlist(
+        ".model jfast n-jfet(BETA=2m)\n"
+        ".model pfast p_ch(VTO=0.4 KP=120u)\n"
+        "J1 drain gate source jfast\n"
+        "M1 d g s b pfast"
+    )
+
+    assert parsed.models["jfast"].kind == "NJF"
+    assert parsed.models["pfast"].kind == "PMOS"
+    jfet, mosfet = parsed.circuit.elements
+    assert isinstance(jfet, JFET)
+    assert jfet.polarity == "NJF"
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.model.type == MosfetType.PMOS
+
+
 def test_parse_pmos_mosfet_model() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize hyphen and underscore separators in supported model type aliases.
 - Normalize the `PCH` model type alias to canonical `PMOS` cards.
 - Normalize the `NCH` model type alias to canonical `NMOS` cards.
 - Normalize the `PJ` model type alias to canonical `PJF` cards.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1140,7 +1140,7 @@ function toComplex(value: SelectedOutputValue): Complex {
 function parseModelCard(fields: readonly string[]): ModelCard {
   requireMinFields(fields, 3, ".model");
   const tail = fields.slice(2).join(" ").trim();
-  const match = /^([A-Za-z][A-Za-z0-9_]*)(?:\s*\((.*)\)|\s+(.*))?$/.exec(tail);
+  const match = /^([A-Za-z][A-Za-z0-9_-]*)(?:\s*\((.*)\)|\s+(.*))?$/.exec(tail);
   if (match === null) {
     throw new NetlistParseError(`invalid .model kind ${JSON.stringify(tail)}`);
   }
@@ -1149,16 +1149,17 @@ function parseModelCard(fields: readonly string[]): ModelCard {
     paramsText = paramsText.slice(1, -1);
   }
   const rawKind = match[1].toUpperCase();
+  const kindKey = rawKind.replace(/[-_]/g, "");
   let kind = rawKind;
-  if (rawKind === "DIODE") {
+  if (kindKey === "DIODE") {
     kind = "D";
-  } else if (rawKind === "NJFET" || rawKind === "NJ") {
+  } else if (kindKey === "NJFET" || kindKey === "NJ") {
     kind = "NJF";
-  } else if (rawKind === "PJFET" || rawKind === "PJ") {
+  } else if (kindKey === "PJFET" || kindKey === "PJ") {
     kind = "PJF";
-  } else if (rawKind === "NCH") {
+  } else if (kindKey === "NCH") {
     kind = "NMOS";
-  } else if (rawKind === "PCH") {
+  } else if (kindKey === "PCH") {
     kind = "PMOS";
   }
   const params = parseModelParams(paramsText);

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2763,6 +2763,26 @@ M1 out gate 0 0 nfast W=2u L=180n
     expect(element.params.KP).toBeCloseTo(120.0e-6, 12);
   });
 
+  it("normalizes model type alias separators", () => {
+    const parsed = parseNetlist(
+      ".model jfast n-jfet(BETA=2m)\n" +
+        ".model pfast p_ch(VTO=0.4 KP=120u)\n" +
+        "J1 drain gate source jfast\n" +
+        "M1 d g s b pfast",
+    );
+
+    expect(parsed.models.get("jfast")?.kind).toBe("NJF");
+    expect(parsed.models.get("pfast")?.kind).toBe("PMOS");
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      polarity: "NJF",
+    });
+    expect(parsed.circuit.elements()[1]).toMatchObject({
+      kind: "mosfet",
+      type: "PMOS",
+    });
+  });
+
   it("parses PMOS MOSFET aliases", () => {
     const parsed = parseNetlist(`
 .model pfast PMOS(VTO=0.4 KP=120u NSUB=1.2)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4760,12 +4760,18 @@ the Rust, Python, and TypeScript surfaces together.
      lowering.
 
 482. Python and TypeScript Berkeley SPICE P-channel MOS model-type alias parity.
-   - Status: implemented in this PCH model-type normalization slice.
+   - Status: completed in PR 10167.
    - Both parser facades normalize the engine-supported `PCH` model type alias
      to canonical `PMOS`, preserving MOS Level-1 validation and instance
      lowering.
    - This completes the audited engine-advertised `DIODE`, `NJFET`, `NJ`,
      `PJFET`, `PJ`, `NCH`, and `PCH` model-type alias set.
+
+483. Python and TypeScript Berkeley SPICE model-type separator normalization parity.
+   - Status: implemented in this model-type separator normalization slice.
+   - Both parser facades mirror the engine type-key contract for supported
+     aliases by ignoring hyphen and underscore separators, including the
+     engine-tested `n-jfet` spelling, while preserving unknown model kinds.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- mirror the engine model-type key contract by ignoring hyphen and underscore separators in supported aliases
- accept the engine-tested `n-jfet` spelling and lower both JFET and MOS separator variants end to end
- preserve unmatched model kinds and reconcile the completed PCH slice in the SPICE plan

## Verification

- Python parser `bash BUILD` (`642 passed`, 90.59% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (`627 passed`)
- TypeScript parser `npx vitest run --coverage` (88.38% line coverage)
- TypeScript engine `bash BUILD` (`448 passed`)
- `git diff --check`
- BUILD and dependency manifest audit (no changes required)
