### PR TITLE
Authenticate typed Chief host launch bindings

### DIFF
--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Compose a fail-closed host launch-binding provider until durable pipeline
+  wiring is connected; hosts cannot start with ambient or invented bindings.
+
 ## 0.1.0 - 2026-08-03
 
 - Add the concrete cross-platform Chief daemon executable.

--- a/code/packages/rust/chief-of-staff-daemon/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon/src/lib.rs
@@ -11,8 +11,8 @@ use chief_of_staff_daemon_policy::{DenyChannelWiring, LocalAuthError, LocalBeare
 use chief_of_staff_daemon_runtime::{ChiefDaemonRuntime, DaemonRuntimeError, ReconcileSchedule};
 use chief_of_staff_orchestrator_core::OrchestratorCore;
 use chief_of_staff_process_supervisor::{
-    HostProgram, ProcessSupervisorConfig, ProcessSupervisorError, SystemMonotonicClock,
-    UuidV7SessionIdSource,
+    DenyHostLaunchBindings, HostProgram, ProcessSupervisorConfig, ProcessSupervisorError,
+    SystemMonotonicClock, UuidV7SessionIdSource,
 };
 use chief_of_staff_service_reconciler::{ConfigError as ReconcileConfigError, ReconcileConfig};
 use coding_adventures_storage_fs::FsStorageBackend;
@@ -256,6 +256,7 @@ pub fn run(config: ChiefConfig, home: &Path) -> Result<(), ChiefDaemonError> {
         backend,
         process_config,
         keyring,
+        Arc::new(DenyHostLaunchBindings),
         Arc::new(generate_identity_keypair()),
         clock,
         Box::new(UuidV7SessionIdSource),

--- a/code/packages/rust/chief-of-staff-host-control-protocol/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add an exactly-once pre-ready `LaunchBindings` record with canonical bounded
+  channel name-to-UUID mappings and optional bounded Level 1 model settings.
 - Add a bounded authenticated `PackageTrust` record that must be delivered
   exactly once before a child can announce independently verified readiness.
 - Add authenticated channel receive, publish, and acknowledge requests plus

--- a/code/packages/rust/chief-of-staff-host-control-protocol/README.md
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/README.md
@@ -4,14 +4,17 @@
 bounded data-plane conversation between the D18 orchestrator and one spawned
 host. After the secure handshake, the orchestrator authenticates the exact
 relevant public package key, trust class, and tier to the child. The child builds
-its own verification keyring, independently verifies its signed package, sends
-`Ready(package_hash)`, then sends heartbeats and serialized channel or
+its own verification keyring and independently verifies its signed package. The
+orchestrator then authenticates pipeline-authorized signed-name-to-UUID channel
+bindings and, for Level 1, bounded model settings. Only after matching those
+bindings to signed policy does the child send `Ready(package_hash)`, heartbeats,
+and serialized channel or
 provider-neutral completion requests. The orchestrator sends exact correlated
 responses or `Terminate`.
 
 The wrapper runs over `chief-of-staff-secure-host-channel`, enforces role and
 lifecycle ordering, and fails closed after malformed, unauthenticated,
-wrong-direction, replayed, duplicate/missing package trust, or package-mismatched
+wrong-direction, replayed, duplicate/missing package trust or launch bindings, or package-mismatched
 peer input. Heartbeats carry no child-selected timestamp: the orchestrator attaches
 its trusted monotonic receive time after authentication. The data plane permits one
 request in flight, uses

--- a/code/packages/rust/chief-of-staff-host-control-protocol/src/launch.rs
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/src/launch.rs
@@ -1,0 +1,393 @@
+//! Typed, bounded launch bindings delivered before child readiness.
+
+use std::collections::BTreeSet;
+
+use crate::ControlError;
+
+/// Maximum authorized channel bindings delivered to one child.
+pub const MAX_LAUNCH_CHANNEL_BINDINGS: usize = 128;
+/// Maximum UTF-8 bytes in one signed channel name.
+pub const MAX_LAUNCH_CHANNEL_NAME_BYTES: usize = 128;
+/// Maximum UTF-8 bytes in one provider-specific model selector.
+pub const MAX_LAUNCH_MODEL_BYTES: usize = 200;
+/// Maximum output-token cap accepted by the Level 1 launch contract.
+pub const MAX_LAUNCH_COMPLETION_TOKENS: u32 = 1_000_000;
+
+/// Authorized operation for one signed channel name.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ChannelBindingAccess {
+    /// The child may receive and acknowledge messages from this channel.
+    Read,
+    /// The child may publish messages to this channel.
+    Write,
+}
+
+/// One signed channel name resolved to an authorized durable UUID.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChannelBinding {
+    name: String,
+    access: ChannelBindingAccess,
+    channel_id: [u8; 16],
+}
+
+impl ChannelBinding {
+    /// Validate a signed channel name, access direction, and canonical UUID-v7 identity.
+    pub fn new(
+        name: impl Into<String>,
+        access: ChannelBindingAccess,
+        channel_id: [u8; 16],
+    ) -> Result<Self, ControlError> {
+        let name = name.into();
+        if !valid_channel_name(&name) || !valid_uuid_v7(&channel_id) {
+            return Err(ControlError::InvalidLaunchBindings);
+        }
+        Ok(Self {
+            name,
+            access,
+            channel_id,
+        })
+    }
+
+    /// Return the signed channel name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Return the authorized access direction.
+    pub fn access(&self) -> ChannelBindingAccess {
+        self.access
+    }
+
+    /// Return the canonical durable channel UUID.
+    pub fn channel_id(&self) -> [u8; 16] {
+        self.channel_id
+    }
+}
+
+/// Bounded model settings selected for one Level 1 child launch.
+#[derive(Clone, Debug, PartialEq)]
+pub struct LevelOneModelBinding {
+    model: String,
+    temperature: f32,
+    max_tokens: u32,
+}
+
+impl LevelOneModelBinding {
+    /// Validate one provider-specific model selector and bounded generation settings.
+    pub fn new(
+        model: impl Into<String>,
+        temperature: f32,
+        max_tokens: u32,
+    ) -> Result<Self, ControlError> {
+        let model = model.into();
+        if model.trim().is_empty()
+            || model.len() > MAX_LAUNCH_MODEL_BYTES
+            || !temperature.is_finite()
+            || !(0.0..=2.0).contains(&temperature)
+            || max_tokens == 0
+            || max_tokens > MAX_LAUNCH_COMPLETION_TOKENS
+        {
+            return Err(ControlError::InvalidLaunchBindings);
+        }
+        Ok(Self {
+            model,
+            temperature,
+            max_tokens,
+        })
+    }
+
+    /// Return the provider-specific model selector.
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    /// Return the finite sampling temperature.
+    pub fn temperature(&self) -> f32 {
+        self.temperature
+    }
+
+    /// Return the non-zero output-token cap.
+    pub fn max_tokens(&self) -> u32 {
+        self.max_tokens
+    }
+}
+
+/// Complete pipeline-authorized launch bindings for one child.
+#[derive(Clone, Debug, PartialEq)]
+pub struct LaunchBindings {
+    channels: Vec<ChannelBinding>,
+    level_one_model: Option<LevelOneModelBinding>,
+}
+
+impl LaunchBindings {
+    /// Validate, canonicalize, and own one launch's channel and model bindings.
+    pub fn new(
+        mut channels: Vec<ChannelBinding>,
+        level_one_model: Option<LevelOneModelBinding>,
+    ) -> Result<Self, ControlError> {
+        if channels.len() > MAX_LAUNCH_CHANNEL_BINDINGS {
+            return Err(ControlError::InvalidLaunchBindings);
+        }
+        channels.sort_by(|left, right| left.name.cmp(&right.name));
+        let mut names = BTreeSet::new();
+        let mut channel_ids = BTreeSet::new();
+        for binding in &channels {
+            if !names.insert(binding.name.clone()) || !channel_ids.insert(binding.channel_id) {
+                return Err(ControlError::InvalidLaunchBindings);
+            }
+        }
+        Ok(Self {
+            channels,
+            level_one_model,
+        })
+    }
+
+    /// Borrow canonical channel bindings sorted by signed name.
+    pub fn channels(&self) -> &[ChannelBinding] {
+        &self.channels
+    }
+
+    /// Borrow Level 1 model settings when this package runtime requires them.
+    pub fn level_one_model(&self) -> Option<&LevelOneModelBinding> {
+        self.level_one_model.as_ref()
+    }
+}
+
+pub(crate) fn encode_launch_bindings(bindings: &LaunchBindings) -> Vec<u8> {
+    let mut output = Vec::new();
+    output.extend_from_slice(&(bindings.channels.len() as u16).to_be_bytes());
+    for binding in &bindings.channels {
+        output.push(match binding.access {
+            ChannelBindingAccess::Read => 1,
+            ChannelBindingAccess::Write => 2,
+        });
+        output.push(binding.name.len() as u8);
+        output.extend_from_slice(binding.name.as_bytes());
+        output.extend_from_slice(&binding.channel_id);
+    }
+    match &bindings.level_one_model {
+        None => output.push(0),
+        Some(model) => {
+            output.push(1);
+            output.extend_from_slice(&(model.model.len() as u16).to_be_bytes());
+            output.extend_from_slice(model.model.as_bytes());
+            output.extend_from_slice(&model.temperature.to_bits().to_be_bytes());
+            output.extend_from_slice(&model.max_tokens.to_be_bytes());
+        }
+    }
+    output
+}
+
+pub(crate) fn decode_launch_bindings(body: &[u8]) -> Result<LaunchBindings, ControlError> {
+    let mut decoder = Decoder::new(body);
+    let count = decoder.u16()? as usize;
+    if count > MAX_LAUNCH_CHANNEL_BINDINGS {
+        return Err(ControlError::InvalidLaunchBindings);
+    }
+    let mut channels = Vec::with_capacity(count);
+    for _ in 0..count {
+        let access = match decoder.u8()? {
+            1 => ChannelBindingAccess::Read,
+            2 => ChannelBindingAccess::Write,
+            _ => return Err(ControlError::InvalidLaunchBindings),
+        };
+        let name_length = decoder.u8()? as usize;
+        if name_length == 0 || name_length > MAX_LAUNCH_CHANNEL_NAME_BYTES {
+            return Err(ControlError::InvalidLaunchBindings);
+        }
+        let name = std::str::from_utf8(decoder.take(name_length)?)
+            .map_err(|_| ControlError::InvalidLaunchBindings)?;
+        let channel_id = decoder
+            .take(16)?
+            .try_into()
+            .map_err(|_| ControlError::InvalidLaunchBindings)?;
+        channels.push(ChannelBinding::new(name, access, channel_id)?);
+    }
+    let level_one_model = match decoder.u8()? {
+        0 => None,
+        1 => {
+            let model_length = decoder.u16()? as usize;
+            if model_length == 0 || model_length > MAX_LAUNCH_MODEL_BYTES {
+                return Err(ControlError::InvalidLaunchBindings);
+            }
+            let model = std::str::from_utf8(decoder.take(model_length)?)
+                .map_err(|_| ControlError::InvalidLaunchBindings)?;
+            let temperature = f32::from_bits(decoder.u32()?);
+            let max_tokens = decoder.u32()?;
+            Some(LevelOneModelBinding::new(model, temperature, max_tokens)?)
+        }
+        _ => return Err(ControlError::InvalidLaunchBindings),
+    };
+    if !decoder.remaining().is_empty() {
+        return Err(ControlError::InvalidLaunchBindings);
+    }
+    LaunchBindings::new(channels, level_one_model)
+}
+
+fn valid_channel_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_LAUNCH_CHANNEL_NAME_BYTES
+        && value
+            .bytes()
+            .next()
+            .is_some_and(|byte| byte.is_ascii_lowercase())
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
+fn valid_uuid_v7(bytes: &[u8; 16]) -> bool {
+    bytes[6] >> 4 == 7 && bytes[8] & 0xc0 == 0x80
+}
+
+struct Decoder<'a> {
+    remaining: &'a [u8],
+}
+
+impl<'a> Decoder<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { remaining: bytes }
+    }
+
+    fn remaining(&self) -> &'a [u8] {
+        self.remaining
+    }
+
+    fn take(&mut self, length: usize) -> Result<&'a [u8], ControlError> {
+        let (value, remaining) = self
+            .remaining
+            .split_at_checked(length)
+            .ok_or(ControlError::InvalidLaunchBindings)?;
+        self.remaining = remaining;
+        Ok(value)
+    }
+
+    fn u8(&mut self) -> Result<u8, ControlError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, ControlError> {
+        Ok(u16::from_be_bytes(
+            self.take(2)?
+                .try_into()
+                .map_err(|_| ControlError::InvalidLaunchBindings)?,
+        ))
+    }
+
+    fn u32(&mut self) -> Result<u32, ControlError> {
+        Ok(u32::from_be_bytes(
+            self.take(4)?
+                .try_into()
+                .map_err(|_| ControlError::InvalidLaunchBindings)?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uuid_v7(byte: u8) -> [u8; 16] {
+        let mut bytes = [0; 16];
+        bytes[6] = 0x70;
+        bytes[8] = 0x80;
+        bytes[15] = byte;
+        bytes
+    }
+
+    fn bindings() -> LaunchBindings {
+        LaunchBindings::new(
+            vec![
+                ChannelBinding::new("weather-reports", ChannelBindingAccess::Write, uuid_v7(2))
+                    .unwrap(),
+                ChannelBinding::new("weather-requests", ChannelBindingAccess::Read, uuid_v7(1))
+                    .unwrap(),
+            ],
+            Some(LevelOneModelBinding::new("test-model", 0.25, 256).unwrap()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn exact_codec_round_trips_canonical_bindings() {
+        let bindings = bindings();
+        assert_eq!(bindings.channels()[0].name(), "weather-reports");
+        assert_eq!(bindings.channels()[1].name(), "weather-requests");
+        let bytes = encode_launch_bindings(&bindings);
+        assert_eq!(decode_launch_bindings(&bytes), Ok(bindings));
+    }
+
+    #[test]
+    fn constructors_reject_invalid_names_ids_models_and_duplicates() {
+        for name in ["", "Bad", "bad_name", &"x".repeat(129)] {
+            assert_eq!(
+                ChannelBinding::new(name, ChannelBindingAccess::Read, uuid_v7(1)),
+                Err(ControlError::InvalidLaunchBindings)
+            );
+        }
+        assert_eq!(
+            ChannelBinding::new("valid", ChannelBindingAccess::Read, [0; 16]),
+            Err(ControlError::InvalidLaunchBindings)
+        );
+        for model in ["", "   ", &"x".repeat(201)] {
+            assert_eq!(
+                LevelOneModelBinding::new(model, 0.0, 1),
+                Err(ControlError::InvalidLaunchBindings)
+            );
+        }
+        for temperature in [f32::NAN, -0.1, 2.1] {
+            assert_eq!(
+                LevelOneModelBinding::new("model", temperature, 1),
+                Err(ControlError::InvalidLaunchBindings)
+            );
+        }
+        assert_eq!(
+            LevelOneModelBinding::new("model", 0.0, 0),
+            Err(ControlError::InvalidLaunchBindings)
+        );
+        let first = ChannelBinding::new("first", ChannelBindingAccess::Read, uuid_v7(1)).unwrap();
+        let duplicate_name =
+            ChannelBinding::new("first", ChannelBindingAccess::Write, uuid_v7(2)).unwrap();
+        assert_eq!(
+            LaunchBindings::new(vec![first.clone(), duplicate_name], None),
+            Err(ControlError::InvalidLaunchBindings)
+        );
+        let duplicate_id =
+            ChannelBinding::new("second", ChannelBindingAccess::Write, uuid_v7(1)).unwrap();
+        assert_eq!(
+            LaunchBindings::new(vec![first, duplicate_id], None),
+            Err(ControlError::InvalidLaunchBindings)
+        );
+    }
+
+    #[test]
+    fn decoder_rejects_every_truncation_trailing_bytes_and_discriminants() {
+        let bytes = encode_launch_bindings(&bindings());
+        for length in 0..bytes.len() {
+            assert_eq!(
+                decode_launch_bindings(&bytes[..length]),
+                Err(ControlError::InvalidLaunchBindings),
+                "accepted truncation at {length}"
+            );
+        }
+        let mut trailing = bytes.clone();
+        trailing.push(0);
+        assert_eq!(
+            decode_launch_bindings(&trailing),
+            Err(ControlError::InvalidLaunchBindings)
+        );
+        let mut invalid_access = bytes.clone();
+        invalid_access[2] = 99;
+        assert_eq!(
+            decode_launch_bindings(&invalid_access),
+            Err(ControlError::InvalidLaunchBindings)
+        );
+        let mut invalid_model_presence =
+            encode_launch_bindings(&LaunchBindings::new(Vec::new(), None).expect("empty bindings"));
+        invalid_model_presence[2] = 2;
+        assert_eq!(
+            decode_launch_bindings(&invalid_model_presence),
+            Err(ControlError::InvalidLaunchBindings)
+        );
+    }
+}

--- a/code/packages/rust/chief-of-staff-host-control-protocol/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/src/lib.rs
@@ -11,6 +11,7 @@ use chief_of_staff_secure_host_channel::{ChannelError, ChannelRole, SecureHostCh
 use core::fmt::{self, Display, Formatter};
 
 mod data_plane;
+mod launch;
 
 pub use data_plane::{
     CompletionCall, CompletionFinishReason, CompletionProvider, CompletionResult, CompletionUsage,
@@ -23,6 +24,12 @@ use data_plane::{
     COMPLETED_RESPONSE_TAG, COMPLETE_REQUEST_TAG, FAILED_RESPONSE_TAG, PUBLISHED_RESPONSE_TAG,
     PUBLISH_REQUEST_TAG, RECEIVED_RESPONSE_TAG, RECEIVE_REQUEST_TAG,
 };
+use launch::{decode_launch_bindings, encode_launch_bindings};
+pub use launch::{
+    ChannelBinding, ChannelBindingAccess, LaunchBindings, LevelOneModelBinding,
+    MAX_LAUNCH_CHANNEL_BINDINGS, MAX_LAUNCH_CHANNEL_NAME_BYTES, MAX_LAUNCH_COMPLETION_TOKENS,
+    MAX_LAUNCH_MODEL_BYTES,
+};
 
 const MAGIC: &[u8; 4] = b"D18C";
 const VERSION: u8 = 1;
@@ -30,6 +37,7 @@ const READY_TAG: u8 = 1;
 const HEARTBEAT_TAG: u8 = 2;
 const TERMINATE_TAG: u8 = 3;
 const PACKAGE_TRUST_TAG: u8 = 4;
+const LAUNCH_BINDINGS_TAG: u8 = 5;
 const HEADER_BYTES: usize = 6;
 const READY_BYTES: usize = HEADER_BYTES + 32;
 const MAX_PACKAGE_KEY_ID_BYTES: usize = 128;
@@ -68,10 +76,12 @@ pub enum ChildEvent {
 }
 
 /// Authenticated orchestrator event accepted by a child.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum OrchestratorEvent {
     /// The exact package-signing trust selected by the supervising parent.
     PackageTrust(PackageTrust),
+    /// Pipeline-authorized channel UUIDs and optional Level 1 model settings.
+    LaunchBindings(LaunchBindings),
     /// Begin graceful host shutdown.
     Terminate,
     /// One exactly correlated response to the child's pending request.
@@ -95,6 +105,8 @@ pub enum ControlError {
     InvalidDataPlaneRecord,
     /// Package-signing trust violated its closed key, tier, or identifier contract.
     InvalidPackageTrust,
+    /// Launch bindings violated their name, UUID, model, uniqueness, or size contract.
+    InvalidLaunchBindings,
     /// The peer sent a valid message kind owned by the opposite direction.
     WrongMessageDirection,
     /// The operation violates readiness or termination ordering.
@@ -121,6 +133,7 @@ impl Display for ControlError {
             Self::UnknownMessageKind => "host-control: unknown message kind",
             Self::InvalidDataPlaneRecord => "host-control: invalid data-plane record",
             Self::InvalidPackageTrust => "host-control: invalid package trust",
+            Self::InvalidLaunchBindings => "host-control: invalid launch bindings",
             Self::WrongMessageDirection => "host-control: wrong message direction",
             Self::InvalidState => "host-control: invalid lifecycle state",
             Self::PackageMismatch => "host-control: package identity mismatch",
@@ -208,6 +221,7 @@ pub struct OrchestratorControl {
     expected_package_hash: [u8; 32],
     state: ControlState,
     trust_sent: bool,
+    launch_bindings_sent: bool,
     last_request_id: u64,
     pending_request: Option<(RequestId, DataPlaneOperation)>,
 }
@@ -226,6 +240,7 @@ impl OrchestratorControl {
             expected_package_hash,
             state: ControlState::AwaitingReady,
             trust_sent: false,
+            launch_bindings_sent: false,
             last_request_id: 0,
             pending_request: None,
         })
@@ -251,7 +266,7 @@ impl OrchestratorControl {
         };
         match (self.state, record) {
             (ControlState::AwaitingReady, ControlRecord::Ready(package_hash))
-                if self.trust_sent =>
+                if self.trust_sent && self.launch_bindings_sent =>
             {
                 if package_hash != self.expected_package_hash {
                     return Err(self.close(ControlError::PackageMismatch));
@@ -280,6 +295,7 @@ impl OrchestratorControl {
             (
                 _,
                 ControlRecord::PackageTrust(_)
+                | ControlRecord::LaunchBindings(_)
                 | ControlRecord::Terminate
                 | ControlRecord::Response(_),
             ) => Err(self.close(ControlError::WrongMessageDirection)),
@@ -301,6 +317,29 @@ impl OrchestratorControl {
             Err(error) => return Err(self.close(ControlError::Channel(error))),
         };
         self.trust_sent = true;
+        Ok(frame)
+    }
+
+    /// Authenticate pipeline-authorized launch bindings after package trust and before readiness.
+    pub fn provide_launch_bindings(
+        &mut self,
+        bindings: LaunchBindings,
+    ) -> Result<Vec<u8>, ControlError> {
+        if self.state == ControlState::Closed {
+            return Err(ControlError::Closed);
+        }
+        if self.state != ControlState::AwaitingReady
+            || !self.trust_sent
+            || self.launch_bindings_sent
+        {
+            return Err(ControlError::InvalidState);
+        }
+        let plaintext = encode_record(ControlRecord::LaunchBindings(bindings))?;
+        let frame = match self.channel.send(&plaintext) {
+            Ok(frame) => frame,
+            Err(error) => return Err(self.close(ControlError::Channel(error))),
+        };
+        self.launch_bindings_sent = true;
         Ok(frame)
     }
 
@@ -381,6 +420,7 @@ pub struct ChildControl {
     channel: SecureHostChannel,
     state: ControlState,
     trust_received: bool,
+    launch_bindings_received: bool,
     next_request_id: Option<u64>,
     pending_request: Option<(RequestId, DataPlaneOperation)>,
 }
@@ -395,6 +435,7 @@ impl ChildControl {
             channel,
             state: ControlState::AwaitingReady,
             trust_received: false,
+            launch_bindings_received: false,
             next_request_id: Some(1),
             pending_request: None,
         })
@@ -405,7 +446,10 @@ impl ChildControl {
         if self.state == ControlState::Closed {
             return Err(ControlError::Closed);
         }
-        if self.state != ControlState::AwaitingReady || !self.trust_received {
+        if self.state != ControlState::AwaitingReady
+            || !self.trust_received
+            || !self.launch_bindings_received
+        {
             return Err(ControlError::InvalidState);
         }
         let plaintext = encode_record(ControlRecord::Ready(package_hash))?;
@@ -502,11 +546,24 @@ impl ChildControl {
         };
         match record {
             ControlRecord::PackageTrust(trust) => {
-                if self.state != ControlState::AwaitingReady || self.trust_received {
+                if self.state != ControlState::AwaitingReady
+                    || self.trust_received
+                    || self.launch_bindings_received
+                {
                     return Err(self.close(ControlError::InvalidState));
                 }
                 self.trust_received = true;
                 Ok(OrchestratorEvent::PackageTrust(trust))
+            }
+            ControlRecord::LaunchBindings(bindings) => {
+                if self.state != ControlState::AwaitingReady
+                    || !self.trust_received
+                    || self.launch_bindings_received
+                {
+                    return Err(self.close(ControlError::InvalidState));
+                }
+                self.launch_bindings_received = true;
+                Ok(OrchestratorEvent::LaunchBindings(bindings))
             }
             ControlRecord::Terminate => {
                 self.state = ControlState::Terminating;
@@ -591,6 +648,7 @@ enum ControlRecord {
     Heartbeat,
     Terminate,
     PackageTrust(PackageTrust),
+    LaunchBindings(LaunchBindings),
     Request(DataPlaneRequest),
     Response(DataPlaneResponse),
 }
@@ -601,6 +659,9 @@ fn encode_record(record: ControlRecord) -> Result<Vec<u8>, ControlError> {
         ControlRecord::Heartbeat | ControlRecord::Terminate => HEADER_BYTES,
         ControlRecord::PackageTrust(trust) => {
             HEADER_BYTES + 1 + trust.key_id.len() + PACKAGE_TRUST_FIXED_BYTES
+        }
+        ControlRecord::LaunchBindings(bindings) => {
+            HEADER_BYTES + encode_launch_bindings(bindings).len()
         }
         ControlRecord::Request(_) | ControlRecord::Response(_) => HEADER_BYTES + 128,
     });
@@ -624,6 +685,10 @@ fn encode_record(record: ControlRecord) -> Result<Vec<u8>, ControlError> {
             });
             output.push(trust.maximum_tier);
             output.extend_from_slice(&trust.public_key);
+        }
+        ControlRecord::LaunchBindings(bindings) => {
+            output.push(LAUNCH_BINDINGS_TAG);
+            output.extend_from_slice(&encode_launch_bindings(&bindings));
         }
         ControlRecord::Request(request) => {
             let (tag, body) = data_plane::encode(&DataRecord::Request(request))?;
@@ -701,6 +766,9 @@ fn decode_record(bytes: &[u8]) -> Result<ControlRecord, ControlError> {
                 maximum_tier,
             )?))
         }
+        LAUNCH_BINDINGS_TAG => Ok(ControlRecord::LaunchBindings(decode_launch_bindings(
+            &bytes[HEADER_BYTES..],
+        )?)),
         RECEIVE_REQUEST_TAG
         | PUBLISH_REQUEST_TAG
         | ACKNOWLEDGE_REQUEST_TAG
@@ -805,6 +873,19 @@ mod tests {
         PackageTrust::new("prod-test", PackageTrustType::Production, [17; 32], 3).unwrap()
     }
 
+    fn launch_bindings() -> LaunchBindings {
+        LaunchBindings::new(
+            vec![
+                ChannelBinding::new("weather-requests", ChannelBindingAccess::Read, uuid_v7(1))
+                    .unwrap(),
+                ChannelBinding::new("weather-reports", ChannelBindingAccess::Write, uuid_v7(2))
+                    .unwrap(),
+            ],
+            Some(LevelOneModelBinding::new("test-model", 0.0, 128).unwrap()),
+        )
+        .unwrap()
+    }
+
     fn trusted_pair(hash: [u8; 32]) -> (OrchestratorControl, ChildControl) {
         let (mut orchestrator, mut child) = control_pair(hash);
         let trust = package_trust();
@@ -812,6 +893,14 @@ mod tests {
         assert_eq!(
             child.receive_orchestrator(&frame).unwrap(),
             OrchestratorEvent::PackageTrust(trust)
+        );
+        let bindings = launch_bindings();
+        let frame = orchestrator
+            .provide_launch_bindings(bindings.clone())
+            .unwrap();
+        assert_eq!(
+            child.receive_orchestrator(&frame).unwrap(),
+            OrchestratorEvent::LaunchBindings(bindings)
         );
         (orchestrator, child)
     }
@@ -1115,6 +1204,11 @@ mod tests {
         assert_eq!(child.state(), ControlState::AwaitingReady);
         let trust = orchestrator.provide_package_trust(package_trust()).unwrap();
         child.receive_orchestrator(&trust).unwrap();
+        assert_eq!(child.ready([3u8; 32]), Err(ControlError::InvalidState));
+        let bindings = orchestrator
+            .provide_launch_bindings(launch_bindings())
+            .unwrap();
+        child.receive_orchestrator(&bindings).unwrap();
         child.ready([3u8; 32]).unwrap();
         assert_eq!(child.ready([3u8; 32]), Err(ControlError::InvalidState));
         assert_eq!(child.state(), ControlState::Running);
@@ -1339,6 +1433,14 @@ mod tests {
             child.receive_orchestrator(&frame),
             Ok(OrchestratorEvent::PackageTrust(trust))
         );
+        assert_eq!(child.ready(hash), Err(ControlError::InvalidState));
+        let bindings = orchestrator
+            .provide_launch_bindings(launch_bindings())
+            .unwrap();
+        assert!(matches!(
+            child.receive_orchestrator(&bindings),
+            Ok(OrchestratorEvent::LaunchBindings(_))
+        ));
         assert!(child.ready(hash).is_ok());
 
         let (orchestrator_channel, mut child_channel) = raw_pair(43);
@@ -1364,6 +1466,53 @@ mod tests {
             Err(ControlError::InvalidState)
         );
         assert_eq!(child.state(), ControlState::Closed);
+    }
+
+    #[test]
+    fn launch_bindings_are_exactly_once_after_trust_and_before_ready() {
+        let hash = [32; 32];
+        let (mut orchestrator, mut child) = control_pair(hash);
+        assert_eq!(
+            orchestrator.provide_launch_bindings(launch_bindings()),
+            Err(ControlError::InvalidState)
+        );
+        let trust = orchestrator.provide_package_trust(package_trust()).unwrap();
+        child.receive_orchestrator(&trust).unwrap();
+        let bindings = launch_bindings();
+        let frame = orchestrator
+            .provide_launch_bindings(bindings.clone())
+            .unwrap();
+        assert_eq!(
+            orchestrator.provide_launch_bindings(bindings.clone()),
+            Err(ControlError::InvalidState)
+        );
+        assert_eq!(
+            child.receive_orchestrator(&frame),
+            Ok(OrchestratorEvent::LaunchBindings(bindings.clone()))
+        );
+
+        let duplicate = orchestrator
+            .channel
+            .send(&encode_record(ControlRecord::LaunchBindings(bindings)).unwrap())
+            .unwrap();
+        assert_eq!(
+            child.receive_orchestrator(&duplicate),
+            Err(ControlError::InvalidState)
+        );
+        assert_eq!(child.state(), ControlState::Closed);
+
+        let (orchestrator_channel, mut child_channel) = raw_pair(44);
+        let mut orchestrator = OrchestratorControl::new(orchestrator_channel, hash).unwrap();
+        let trust = orchestrator.provide_package_trust(package_trust()).unwrap();
+        child_channel.receive(&trust).unwrap();
+        let premature_ready = child_channel
+            .send(&encode_record(ControlRecord::Ready(hash)).unwrap())
+            .unwrap();
+        assert_eq!(
+            orchestrator.receive_child(&premature_ready, 1),
+            Err(ControlError::InvalidState)
+        );
+        assert_eq!(orchestrator.state(), ControlState::Closed);
     }
 
     #[test]

--- a/code/packages/rust/chief-of-staff-orchestrator-core/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Require the production process composition to inject a manifest-blind host
+  launch-binding authority alongside package trust and process identity.
 - Add safe package reload for stopped hosts with absent or exited supervisor authority.
 - Atomically write replacement identity and post-reload desired state before reconciliation.
 

--- a/code/packages/rust/chief-of-staff-orchestrator-core/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/src/lib.rs
@@ -12,7 +12,8 @@ use chief_of_staff_channel_endpoints::{
 };
 use chief_of_staff_host_runtime::PackageKeyring;
 use chief_of_staff_process_supervisor::{
-    MonotonicClock, ProcessHostSupervisor, ProcessSupervisorConfig, SessionIdSource,
+    HostLaunchBindingProvider, MonotonicClock, ProcessHostSupervisor, ProcessSupervisorConfig,
+    SessionIdSource,
 };
 use chief_of_staff_service_reconciler::{
     HostSupervisor, ReconcileConfig, ReconcileError, ReconcileReport, ServiceReconciler,
@@ -418,6 +419,7 @@ impl<A> OrchestratorCore<ProcessHostSupervisor, A> {
         backend: Arc<dyn StorageBackend>,
         process_config: ProcessSupervisorConfig,
         keyring: Arc<PackageKeyring>,
+        launch_bindings: Arc<dyn HostLaunchBindingProvider>,
         identity: Arc<IdentityKeyPair>,
         clock: Arc<dyn MonotonicClock>,
         sessions: Box<dyn SessionIdSource>,
@@ -427,6 +429,7 @@ impl<A> OrchestratorCore<ProcessHostSupervisor, A> {
         let supervisor = ProcessHostSupervisor::new(
             process_config,
             keyring,
+            launch_bindings,
             identity,
             Arc::clone(&clock),
             sessions,
@@ -442,7 +445,9 @@ mod tests {
     use chief_of_staff_channel_endpoints::{
         AgentId, ChannelLifecycle, OriginatorIdentity, ReceiverIdentity,
     };
-    use chief_of_staff_process_supervisor::{HostProgram, UuidV7SessionIdSource};
+    use chief_of_staff_process_supervisor::{
+        DenyHostLaunchBindings, HostProgram, UuidV7SessionIdSource,
+    };
     use chief_of_staff_service_reconciler::{ReconcileAction, SupervisorOperation};
     use chief_of_staff_service_registry::{PackagePath, RestartPolicy};
     use coding_adventures_x3dh::generate_identity_keypair;
@@ -1199,6 +1204,7 @@ mod tests {
             backend,
             config,
             keyring,
+            Arc::new(DenyHostLaunchBindings),
             identity,
             clock,
             Box::<UuidV7SessionIdSource>::default(),

--- a/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Require an injected manifest-blind launch-binding provider, authenticate its
+  channel UUID and Level 1 model bindings before readiness, and fail closed when
+  bindings are unavailable or incompatible with the verified package runtime.
 - Deliver the exact relevant public package key, trust class, and tier over the
   fresh child session, removing the test child's hard-coded verification key.
 - Pass the authenticated package runtime to the single configured host program

--- a/code/packages/rust/chief-of-staff-process-supervisor/README.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/README.md
@@ -4,8 +4,9 @@
 D18 Chief hosts. It re-verifies a registered signed package immediately before
 each spawn, owns and reaps the child, bootstraps a fresh UUID-v7 secure channel,
 delivers the exact relevant public package trust over that authenticated channel,
-and reports readiness and heartbeat only after the child independently verifies
-the package with that trust.
+obtains launch bindings from an injected manifest-blind pipeline authority, and
+reports readiness and heartbeat only after the child receives both inputs and
+independently verifies the package with that trust.
 The single configured host executable receives a final reserved
 `--package-runtime deno|skill` pair derived from that verified package snapshot,
 giving the production host a fail-closed runtime-dispatch seam without ambient
@@ -25,7 +26,9 @@ threaded control plane without copying secret key material.
 The crate implements the dependency-light service reconciler's
 `HostSupervisor` interface. It deliberately leaves durable restart policy,
 scheduling, backoff, and registry updates to the reconciler and runnable
-orchestrator. Channel endpoint and LLM service implementations remain injected by
+orchestrator. A fail-closed binding provider is available to compositions that do
+not yet have durable pipeline wiring; such a composition cannot launch a host.
+Channel endpoint and LLM service implementations remain injected by
 the concrete host/daemon composition rather than entering this process-authority
 crate.
 

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/bin/process_supervisor_test_child.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/bin/process_supervisor_test_child.rs
@@ -1,5 +1,5 @@
 use chief_of_staff_host_control_protocol::{
-    CompletionCall, DataPlaneResponse, PromptMessage, PromptRole,
+    ChannelBindingAccess, CompletionCall, DataPlaneResponse, PromptMessage, PromptRole,
 };
 use chief_of_staff_host_runtime::{verify_agent_package, AgentPackageRuntime, PackageKeyring};
 use chief_of_staff_process_supervisor::ChildProcessControl;
@@ -80,9 +80,19 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let mut keyring = PackageKeyring::new();
     keyring.trust(control.receive_package_trust()?)?;
     let package = verify_agent_package(Path::new("."), &keyring)?;
+    let launch_bindings = control.receive_launch_bindings()?;
+    if launch_bindings.channels().len() != 2
+        || launch_bindings.channels()[0].name() != "weather-reports"
+        || launch_bindings.channels()[0].access() != ChannelBindingAccess::Write
+        || launch_bindings.channels()[1].name() != "weather-requests"
+        || launch_bindings.channels()[1].access() != ChannelBindingAccess::Read
+    {
+        return Err("unexpected authorized channel bindings".into());
+    }
     let expected_runtime = match package.runtime() {
-        AgentPackageRuntime::Deno => "deno",
-        AgentPackageRuntime::Skill => "skill",
+        AgentPackageRuntime::Deno if launch_bindings.level_one_model().is_none() => "deno",
+        AgentPackageRuntime::Skill if launch_bindings.level_one_model().is_some() => "skill",
+        _ => return Err("launch model settings do not match package runtime".into()),
     };
     if arguments != ["--package-runtime", expected_runtime] {
         return Err("package runtime launch argument mismatch".into());

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
@@ -9,7 +9,7 @@
 
 use chief_of_staff_channel_crypto::ChannelId;
 use chief_of_staff_host_control_protocol::{
-    ChildControl, ChildEvent, CompletionCall, DataPlaneRequest, DataPlaneResponse,
+    ChildControl, ChildEvent, CompletionCall, DataPlaneRequest, DataPlaneResponse, LaunchBindings,
     OrchestratorControl, OrchestratorEvent, PackageTrust, PackageTrustType,
 };
 use chief_of_staff_host_runtime::{
@@ -62,6 +62,8 @@ pub enum ProcessSupervisorError {
     Framing,
     /// Authenticated host-control processing failed closed.
     Control,
+    /// Pipeline launch bindings were absent, invalid, or incompatible with the package runtime.
+    LaunchBindings,
     /// A different package is already active under this host name.
     ActivePackageMismatch,
     /// No supervised process exists under the requested host name.
@@ -81,6 +83,7 @@ impl Display for ProcessSupervisorError {
             Self::BootstrapTimeout => "process-supervisor: bootstrap timed out",
             Self::Framing => "process-supervisor: invalid framed record",
             Self::Control => "process-supervisor: host-control failure",
+            Self::LaunchBindings => "process-supervisor: launch bindings unavailable",
             Self::ActivePackageMismatch => "process-supervisor: active package identity mismatch",
             Self::HostNotFound => "process-supervisor: host not found",
         })
@@ -88,6 +91,46 @@ impl Display for ProcessSupervisorError {
 }
 
 impl std::error::Error for ProcessSupervisorError {}
+
+/// Redacted failure returned by a manifest-blind launch-binding authority.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct LaunchBindingProviderError;
+
+impl Display for LaunchBindingProviderError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("host launch bindings unavailable")
+    }
+}
+
+impl std::error::Error for LaunchBindingProviderError {}
+
+/// Injected manifest-blind authority for one registered host's launch bindings.
+///
+/// Implementations are expected to resolve durable pipeline wiring by immutable
+/// host and package identity. The independently verifying child remains
+/// responsible for matching returned names to its signed manifest.
+pub trait HostLaunchBindingProvider: Send + Sync {
+    /// Return the exact authorized bindings for this registered package launch.
+    fn launch_bindings(
+        &self,
+        registration: &HostRegistration,
+        runtime: AgentPackageRuntime,
+    ) -> Result<LaunchBindings, LaunchBindingProviderError>;
+}
+
+/// Fail-closed launch-binding provider for compositions without pipeline wiring.
+#[derive(Default)]
+pub struct DenyHostLaunchBindings;
+
+impl HostLaunchBindingProvider for DenyHostLaunchBindings {
+    fn launch_bindings(
+        &self,
+        _registration: &HostRegistration,
+        _runtime: AgentPackageRuntime,
+    ) -> Result<LaunchBindings, LaunchBindingProviderError> {
+        Err(LaunchBindingProviderError)
+    }
+}
 
 /// One shell-free executable plus bounded fixed arguments used for every host.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -378,6 +421,7 @@ impl OwnedInstance {
 pub struct ProcessHostSupervisor {
     config: ProcessSupervisorConfig,
     keyring: Arc<PackageKeyring>,
+    launch_bindings: Arc<dyn HostLaunchBindingProvider>,
     identity: Arc<IdentityKeyPair>,
     clock: Arc<dyn MonotonicClock>,
     sessions: Box<dyn SessionIdSource>,
@@ -389,6 +433,7 @@ impl ProcessHostSupervisor {
     pub fn new(
         config: ProcessSupervisorConfig,
         keyring: Arc<PackageKeyring>,
+        launch_bindings: Arc<dyn HostLaunchBindingProvider>,
         identity: Arc<IdentityKeyPair>,
         clock: Arc<dyn MonotonicClock>,
         sessions: Box<dyn SessionIdSource>,
@@ -396,6 +441,7 @@ impl ProcessHostSupervisor {
         Self {
             config,
             keyring,
+            launch_bindings,
             identity,
             clock,
             sessions,
@@ -418,6 +464,11 @@ impl ProcessHostSupervisor {
             .trusted_key(package.key_id())
             .ok_or(ProcessSupervisorError::PackageVerification)
             .and_then(package_trust_record)?;
+        let launch_bindings = self
+            .launch_bindings
+            .launch_bindings(registration, package.runtime())
+            .map_err(|_| ProcessSupervisorError::LaunchBindings)?;
+        validate_runtime_bindings(package.runtime(), &launch_bindings)?;
 
         let session = self.sessions.next_session()?;
         let host = HostId::new(registration.host_name().as_str().to_owned())
@@ -507,6 +558,10 @@ impl ProcessHostSupervisor {
                 .provide_package_trust(package_trust)
                 .map_err(|_| ProcessSupervisorError::Control)?;
             write_record(&mut stdin, &trust)?;
+            let bindings = control
+                .provide_launch_bindings(launch_bindings)
+                .map_err(|_| ProcessSupervisorError::Control)?;
+            write_record(&mut stdin, &bindings)?;
             Ok(control)
         })();
 
@@ -717,9 +772,24 @@ impl<R: Read, W: Write> ChildProcessControl<R, W> {
             .map_err(|_| ProcessSupervisorError::Control)?
         {
             OrchestratorEvent::PackageTrust(trust) => trusted_package_key(trust),
-            OrchestratorEvent::Terminate | OrchestratorEvent::Response(_) => {
-                Err(ProcessSupervisorError::Control)
-            }
+            OrchestratorEvent::LaunchBindings(_)
+            | OrchestratorEvent::Terminate
+            | OrchestratorEvent::Response(_) => Err(ProcessSupervisorError::Control),
+        }
+    }
+
+    /// Receive pipeline-authorized channel UUIDs and optional Level 1 model settings.
+    pub fn receive_launch_bindings(&mut self) -> Result<LaunchBindings, ProcessSupervisorError> {
+        let frame = read_record(&mut self.reader)?;
+        match self
+            .control
+            .receive_orchestrator(&frame)
+            .map_err(|_| ProcessSupervisorError::Control)?
+        {
+            OrchestratorEvent::LaunchBindings(bindings) => Ok(bindings),
+            OrchestratorEvent::PackageTrust(_)
+            | OrchestratorEvent::Terminate
+            | OrchestratorEvent::Response(_) => Err(ProcessSupervisorError::Control),
         }
     }
 
@@ -802,9 +872,9 @@ impl<R: Read, W: Write> ChildProcessControl<R, W> {
             .map_err(|_| ProcessSupervisorError::Control)?
         {
             OrchestratorEvent::Terminate => Ok(()),
-            OrchestratorEvent::PackageTrust(_) | OrchestratorEvent::Response(_) => {
-                Err(ProcessSupervisorError::Control)
-            }
+            OrchestratorEvent::PackageTrust(_)
+            | OrchestratorEvent::LaunchBindings(_)
+            | OrchestratorEvent::Response(_) => Err(ProcessSupervisorError::Control),
         }
     }
 
@@ -825,9 +895,9 @@ impl<R: Read, W: Write> ChildProcessControl<R, W> {
             .map_err(|_| ProcessSupervisorError::Control)?
         {
             OrchestratorEvent::Response(response) => Ok(response),
-            OrchestratorEvent::PackageTrust(_) | OrchestratorEvent::Terminate => {
-                Err(ProcessSupervisorError::Control)
-            }
+            OrchestratorEvent::PackageTrust(_)
+            | OrchestratorEvent::LaunchBindings(_)
+            | OrchestratorEvent::Terminate => Err(ProcessSupervisorError::Control),
         }
     }
 }
@@ -870,6 +940,16 @@ fn privilege_tier_number(tier: PrivilegeTier) -> u8 {
         PrivilegeTier::Tier1 => 1,
         PrivilegeTier::Tier2 => 2,
         PrivilegeTier::Tier3 => 3,
+    }
+}
+
+fn validate_runtime_bindings(
+    runtime: AgentPackageRuntime,
+    bindings: &LaunchBindings,
+) -> Result<(), ProcessSupervisorError> {
+    match (runtime, bindings.level_one_model()) {
+        (AgentPackageRuntime::Skill, Some(_)) | (AgentPackageRuntime::Deno, None) => Ok(()),
+        _ => Err(ProcessSupervisorError::LaunchBindings),
     }
 }
 
@@ -1132,6 +1212,10 @@ mod tests {
             let trust = control.receive_package_trust().unwrap();
             assert_eq!(trust.key_id, "prod-memory");
             assert_eq!(trust.public_key, [19; 32]);
+            assert_eq!(
+                control.receive_launch_bindings().unwrap(),
+                LaunchBindings::new(Vec::new(), None).unwrap()
+            );
             control.ready(package_hash).unwrap();
             control.heartbeat().unwrap();
             control.receive_terminate().unwrap();
@@ -1148,6 +1232,10 @@ mod tests {
             )
             .unwrap();
         write_record(&mut parent_writer, &trust).unwrap();
+        let bindings = control
+            .provide_launch_bindings(LaunchBindings::new(Vec::new(), None).unwrap())
+            .unwrap();
+        write_record(&mut parent_writer, &bindings).unwrap();
         let ready = read_record(&mut parent_reader).unwrap();
         assert!(matches!(
             control.receive_child(&ready, 10).unwrap(),

--- a/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
@@ -1,12 +1,14 @@
 use chief_of_staff_host_control_protocol::{
-    DataPlaneFailure, DataPlaneRequest, DataPlaneResponse, RequestId,
+    ChannelBinding, ChannelBindingAccess, DataPlaneFailure, DataPlaneRequest, DataPlaneResponse,
+    LaunchBindings, LevelOneModelBinding, RequestId,
 };
 use chief_of_staff_host_runtime::{
-    DenoLaunchPlan, PackageKeyType, PackageKeyring, TrustedPackageKey,
+    AgentPackageRuntime, DenoLaunchPlan, PackageKeyType, PackageKeyring, TrustedPackageKey,
 };
 use chief_of_staff_process_supervisor::{
-    HostProgram, MonotonicClock, ProcessHostSupervisor, ProcessSupervisorConfig,
-    ProcessSupervisorError, SessionIdSource,
+    DenyHostLaunchBindings, HostLaunchBindingProvider, HostProgram, LaunchBindingProviderError,
+    MonotonicClock, ProcessHostSupervisor, ProcessSupervisorConfig, ProcessSupervisorError,
+    SessionIdSource,
 };
 use chief_of_staff_secure_host_channel::SessionId;
 use chief_of_staff_service_reconciler::{HostSupervisor, SupervisorObservation, SupervisorPhase};
@@ -199,8 +201,48 @@ impl SessionIdSource for TestSessions {
     }
 }
 
+struct TestLaunchBindings;
+
+impl HostLaunchBindingProvider for TestLaunchBindings {
+    fn launch_bindings(
+        &self,
+        _registration: &HostRegistration,
+        runtime: AgentPackageRuntime,
+    ) -> Result<LaunchBindings, LaunchBindingProviderError> {
+        let channels = vec![
+            ChannelBinding::new("weather-requests", ChannelBindingAccess::Read, uuid_v7(1))
+                .unwrap(),
+            ChannelBinding::new("weather-reports", ChannelBindingAccess::Write, uuid_v7(2))
+                .unwrap(),
+        ];
+        let model = match runtime {
+            AgentPackageRuntime::Skill => {
+                Some(LevelOneModelBinding::new("test-model", 0.0, 128).unwrap())
+            }
+            AgentPackageRuntime::Deno => None,
+        };
+        LaunchBindings::new(channels, model).map_err(|_| LaunchBindingProviderError)
+    }
+}
+
 fn new_supervisor(
     keyring: Arc<PackageKeyring>,
+    identity: Arc<coding_adventures_x3dh::IdentityKeyPair>,
+    bootstrap_timeout: Duration,
+    graceful_timeout: Duration,
+) -> ProcessHostSupervisor {
+    new_supervisor_with_bindings(
+        keyring,
+        Arc::new(TestLaunchBindings),
+        identity,
+        bootstrap_timeout,
+        graceful_timeout,
+    )
+}
+
+fn new_supervisor_with_bindings(
+    keyring: Arc<PackageKeyring>,
+    launch_bindings: Arc<dyn HostLaunchBindingProvider>,
     identity: Arc<coding_adventures_x3dh::IdentityKeyPair>,
     bootstrap_timeout: Duration,
     graceful_timeout: Duration,
@@ -215,6 +257,7 @@ fn new_supervisor(
     ProcessHostSupervisor::new(
         config,
         keyring,
+        launch_bindings,
         identity,
         Arc::new(TestClock::default()),
         Box::new(TestSessions(0)),
@@ -548,5 +591,26 @@ fn invalid_package_fails_before_process_creation() {
     assert_eq!(
         supervisor.start(&registration),
         Err(ProcessSupervisorError::PackageVerification)
+    );
+}
+
+#[test]
+fn unavailable_launch_bindings_fail_before_process_creation() {
+    let package = TestPackage::new("missing-bindings", None);
+    let registration = package.registration("unbound-host");
+    let mut supervisor = new_supervisor_with_bindings(
+        Arc::new(keyring()),
+        Arc::new(DenyHostLaunchBindings),
+        Arc::new(generate_identity_keypair()),
+        Duration::from_secs(1),
+        Duration::from_secs(1),
+    );
+    assert_eq!(
+        supervisor.start(&registration),
+        Err(ProcessSupervisorError::LaunchBindings)
+    );
+    assert_eq!(
+        supervisor.inspect(&registration),
+        Ok(SupervisorObservation::Absent)
     );
 }

--- a/code/packages/rust/chief-of-staff-skill-runtime/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-skill-runtime/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bind authenticated channel UUIDs and bounded model settings to an independently
+  verified Level 1 package, rejecting missing, extra, or wrong-direction names.
 - Construct Level 1 runtimes directly from authenticated, policy-matched sealed
   SKILL packages.
 

--- a/code/packages/rust/chief-of-staff-skill-runtime/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-skill-runtime/Cargo.toml
@@ -11,6 +11,7 @@ chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints
 chief-of-staff-skill-parser = { path = "../chief-of-staff-skill-parser" }
 chief-of-staff-skill-package = { path = "../chief-of-staff-skill-package" }
 chief-of-staff-host-runtime = { path = "../chief-of-staff-host-runtime" }
+chief-of-staff-host-control-protocol = { path = "../chief-of-staff-host-control-protocol" }
 llm-gateway = { path = "../llm-gateway" }
 
 [dev-dependencies]

--- a/code/packages/rust/chief-of-staff-skill-runtime/README.md
+++ b/code/packages/rust/chief-of-staff-skill-runtime/README.md
@@ -10,6 +10,11 @@ retained by sealed-package verification. Loading rejects non-Skill runtimes and
 packages whose signed manifest differs from the policy derived from the signed
 `SKILL.md`.
 
+`LevelOneLaunchPlan::from_verified_package` additionally requires the exact set
+and read/write direction of pipeline-authorized channel names to match that
+signed policy. It retains only their canonical UUIDs and converts the bounded
+authenticated model binding into the existing provider-neutral runtime config.
+
 The package performs no operating-system access. Channel endpoints and the LLM
 provider are injected, so tests remain deterministic and deployments can swap
 storage, transport, crypto, and model implementations independently.

--- a/code/packages/rust/chief-of-staff-skill-runtime/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-skill-runtime/src/lib.rs
@@ -3,12 +3,15 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::{self, Display, Formatter};
 
 use chief_of_staff_channel_crypto::Sequence;
 use chief_of_staff_channel_endpoints::{
     ChannelEndpointError, MessageId, Originator, PublishedMessage, Receiver,
+};
+use chief_of_staff_host_control_protocol::{
+    ChannelBindingAccess, LaunchBindings, LevelOneModelBinding,
 };
 use chief_of_staff_host_runtime::VerifiedAgentPackage;
 use chief_of_staff_skill_package::{load_verified_skill, SkillPackageError};
@@ -40,6 +43,21 @@ impl LevelOneRuntimeConfig {
             temperature: 0.0,
             max_tokens: 1_024,
         }
+    }
+
+    /// Return the provider-specific model selector.
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    /// Return the finite sampling temperature.
+    pub fn temperature(&self) -> f32 {
+        self.temperature
+    }
+
+    /// Return the non-zero output-token cap.
+    pub fn max_tokens(&self) -> usize {
+        self.max_tokens
     }
 
     fn validate(&self) -> Result<(), LevelOneRuntimeError> {
@@ -102,6 +120,8 @@ pub enum LevelOneRunOutcome {
 pub enum LevelOneRuntimeError {
     /// Static runtime settings are outside the bounded Level 1 contract.
     InvalidConfig(&'static str),
+    /// Authorized launch bindings do not exactly match the signed Level 1 manifest.
+    InvalidLaunchBindings,
     /// A verified channel payload was not UTF-8 text.
     NonUtf8Input,
     /// The provider returned an empty or whitespace-only response.
@@ -118,6 +138,9 @@ impl Display for LevelOneRuntimeError {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidConfig(message) => write!(formatter, "invalid Level 1 runtime: {message}"),
+            Self::InvalidLaunchBindings => {
+                formatter.write_str("Level 1 launch bindings do not match signed policy")
+            }
             Self::NonUtf8Input => formatter.write_str("Level 1 input payload is not UTF-8 text"),
             Self::EmptyResponse => formatter.write_str("Level 1 model response is empty"),
             Self::Llm(error) => write!(formatter, "Level 1 model call failed: {error}"),
@@ -145,6 +168,113 @@ impl From<SkillPackageError> for LevelOneRuntimeError {
     fn from(error: SkillPackageError) -> Self {
         Self::Package(Box::new(error))
     }
+}
+
+/// Independently verified Level 1 policy bound to pipeline-authorized runtime inputs.
+#[derive(Clone, Debug, PartialEq)]
+pub struct LevelOneLaunchPlan {
+    skill: ParsedSkill,
+    config: LevelOneRuntimeConfig,
+    read_channels: BTreeMap<String, [u8; 16]>,
+    write_channels: BTreeMap<String, [u8; 16]>,
+}
+
+impl LevelOneLaunchPlan {
+    /// Require exact channel names, directions, and model settings for a signed package.
+    pub fn from_verified_package(
+        package: &VerifiedAgentPackage,
+        bindings: &LaunchBindings,
+    ) -> Result<Self, LevelOneRuntimeError> {
+        let skill = load_verified_skill(package)?;
+        let model = bindings
+            .level_one_model()
+            .ok_or(LevelOneRuntimeError::InvalidLaunchBindings)?;
+        let config = runtime_config(model)?;
+        let mut read_channels = BTreeMap::new();
+        let mut write_channels = BTreeMap::new();
+        for binding in bindings.channels() {
+            let target = match binding.access() {
+                ChannelBindingAccess::Read => &mut read_channels,
+                ChannelBindingAccess::Write => &mut write_channels,
+            };
+            if target
+                .insert(binding.name().to_string(), binding.channel_id())
+                .is_some()
+            {
+                return Err(LevelOneRuntimeError::InvalidLaunchBindings);
+            }
+        }
+        if read_channels.keys().map(String::as_str).collect::<Vec<_>>()
+            != skill
+                .manifest
+                .channels
+                .reads
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+            || write_channels
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                != skill
+                    .manifest
+                    .channels
+                    .writes
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+        {
+            return Err(LevelOneRuntimeError::InvalidLaunchBindings);
+        }
+        Ok(Self {
+            skill,
+            config,
+            read_channels,
+            write_channels,
+        })
+    }
+
+    /// Borrow the authenticated parsed skill.
+    pub fn skill(&self) -> &ParsedSkill {
+        &self.skill
+    }
+
+    /// Borrow the bounded model settings delivered for this launch.
+    pub fn config(&self) -> &LevelOneRuntimeConfig {
+        &self.config
+    }
+
+    /// Resolve one signed read-channel name to its authorized UUID.
+    pub fn read_channel_id(&self, name: &str) -> Option<[u8; 16]> {
+        self.read_channels.get(name).copied()
+    }
+
+    /// Resolve one signed write-channel name to its authorized UUID.
+    pub fn write_channel_id(&self, name: &str) -> Option<[u8; 16]> {
+        self.write_channels.get(name).copied()
+    }
+
+    /// Bind this verified plan to one provider-neutral model client.
+    pub fn runtime<'a>(
+        &self,
+        client: &'a dyn LlmClient,
+    ) -> Result<LevelOneSkillRuntime<'a>, LevelOneRuntimeError> {
+        LevelOneSkillRuntime::new(self.skill.clone(), client, self.config.clone())
+    }
+}
+
+fn runtime_config(
+    model: &LevelOneModelBinding,
+) -> Result<LevelOneRuntimeConfig, LevelOneRuntimeError> {
+    let max_tokens = usize::try_from(model.max_tokens())
+        .map_err(|_| LevelOneRuntimeError::InvalidLaunchBindings)?;
+    let config = LevelOneRuntimeConfig {
+        model: model.model().to_string(),
+        temperature: model.temperature(),
+        max_tokens,
+    };
+    config.validate()?;
+    Ok(config)
 }
 
 /// Parsed Level 1 skill bound to one injected LLM provider.
@@ -258,6 +388,7 @@ mod tests {
     use super::*;
     use chief_of_staff_channel_crypto::{ChannelId, Sequence};
     use chief_of_staff_channel_endpoints::{AgentId, ReceivedMessage};
+    use chief_of_staff_host_control_protocol::ChannelBinding;
     use chief_of_staff_host_runtime::{
         verify_agent_package, PackageKeyType, PackageKeyring, TrustedPackageKey,
     };
@@ -271,6 +402,7 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     const SKILL: &str = "# Weather Reporter\n\nYou are a friendly weather reporting agent.\n\n## Capabilities needed\n- none\n\n## Output format\nKeep the forecast brief.\n";
+    const WIRED_SKILL: &str = "---\nagent: weather-reporter\ndescription: Reports friendly forecasts for requested cities.\nprivilege_tier: 0\nreads: [weather-requests]\nwrites: [weather-reports]\nmessage_schema_versions: [weather-requests=1, weather-reports=1]\n---\n# Weather Reporter\n\nYou are a friendly weather reporting agent.\n\n## Capabilities needed\n- none\n";
     const MODEL: &str = "test-model";
 
     fn message_id(byte: u8) -> MessageId {
@@ -278,6 +410,27 @@ mod tests {
         bytes[6] = 0x70;
         bytes[8] = 0x80;
         MessageId::from_uuid_v7(bytes).unwrap()
+    }
+
+    fn uuid_v7(byte: u8) -> [u8; 16] {
+        let mut bytes = [0; 16];
+        bytes[6] = 0x70;
+        bytes[8] = 0x80;
+        bytes[15] = byte;
+        bytes
+    }
+
+    fn wired_bindings() -> LaunchBindings {
+        LaunchBindings::new(
+            vec![
+                ChannelBinding::new("weather-requests", ChannelBindingAccess::Read, uuid_v7(1))
+                    .unwrap(),
+                ChannelBinding::new("weather-reports", ChannelBindingAccess::Write, uuid_v7(2))
+                    .unwrap(),
+            ],
+            Some(LevelOneModelBinding::new(MODEL, 0.25, 256).unwrap()),
+        )
+        .unwrap()
     }
 
     fn response_provider() -> ProviderIdentity {
@@ -466,6 +619,52 @@ mod tests {
             runtime.respond("Seattle", "text/plain").unwrap().text,
             "Clear skies."
         );
+        std::fs::remove_dir_all(path).unwrap();
+    }
+
+    #[test]
+    fn verified_launch_plan_requires_exact_signed_channels_and_model_settings() {
+        let path = package_dir("wired-launch");
+        let (public_key, secret_key) = generate_keypair(&[63; 32]);
+        build_signed_skill_package(&path, WIRED_SKILL, "dev-wired", &secret_key).unwrap();
+        let mut keyring = PackageKeyring::new();
+        keyring
+            .trust(
+                TrustedPackageKey::new(
+                    "dev-wired",
+                    PackageKeyType::Developer,
+                    public_key,
+                    PrivilegeTier::Tier1,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        let package = verify_agent_package(&path, &keyring).unwrap();
+        let bindings = wired_bindings();
+        let plan = LevelOneLaunchPlan::from_verified_package(&package, &bindings).unwrap();
+        assert_eq!(plan.read_channel_id("weather-requests"), Some(uuid_v7(1)));
+        assert_eq!(plan.write_channel_id("weather-reports"), Some(uuid_v7(2)));
+        assert_eq!(plan.config().model(), MODEL);
+        assert_eq!(plan.config().temperature(), 0.25);
+        assert_eq!(plan.config().max_tokens(), 256);
+
+        let missing = LaunchBindings::new(
+            vec![
+                ChannelBinding::new("weather-requests", ChannelBindingAccess::Read, uuid_v7(1))
+                    .unwrap(),
+            ],
+            Some(LevelOneModelBinding::new(MODEL, 0.0, 128).unwrap()),
+        )
+        .unwrap();
+        assert!(matches!(
+            LevelOneLaunchPlan::from_verified_package(&package, &missing),
+            Err(LevelOneRuntimeError::InvalidLaunchBindings)
+        ));
+        let no_model = LaunchBindings::new(bindings.channels().to_vec(), None).unwrap();
+        assert!(matches!(
+            LevelOneLaunchPlan::from_verified_package(&package, &no_model),
+            Err(LevelOneRuntimeError::InvalidLaunchBindings)
+        ));
         std::fs::remove_dir_all(path).unwrap();
     }
 

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -196,7 +196,11 @@ and output channel endpoints. For each verified UTF-8 message it sends the full
 skill body as model instructions, sends the message as the user turn, publishes
 the non-empty text response, and only then acknowledges the input. Model and
 publication failures leave the channel cursor unchanged so recovery can replay
-the message.
+the message. Before readiness, the host receives a bounded authenticated launch
+record from manifest-blind pipeline wiring. It requires the exact signed channel
+name and read/write sets, resolves them to canonical UUID-v7 endpoints, and binds
+the supplied model selector, temperature, and token cap. Missing, extra,
+wrong-direction, or runtime-incompatible bindings fail closed.
 
 ### Level 4 any-language stdio contract
 
@@ -491,11 +495,14 @@ by the security escort (host process), not the Chief of Staff.
 4. Orchestrator records: host PID, agent name, "starting" status
 5. Orchestrator sends the exact relevant public package trust over the fresh
    authenticated child session.
-6. Host independently re-reads and verifies the package with that trust and sends
+6. Orchestrator sends authorized named-channel UUID mappings and bounded Level 1
+   model settings from pipeline wiring without reading the package manifest.
+7. Host independently re-reads and verifies the package, matches the bindings to
+   its signed policy, and sends
    authenticated Ready(package_hash) over its per-spawn control channel.
-7. Orchestrator marks Running only when that hash matches the registration.
-8. Orchestrator monitors authenticated heartbeats using trusted receipt time.
-9. Done. Orchestrator does NOT:
+8. Orchestrator marks Running only when that hash matches the registration.
+9. Orchestrator monitors authenticated heartbeats using trusted receipt time.
+10. Done. Orchestrator does NOT:
    • read manifest.json
    • know what capabilities the agent has
    • know what Deno flags are used

--- a/code/specs/host-control-protocol.md
+++ b/code/specs/host-control-protocol.md
@@ -24,7 +24,8 @@ channel, or call a model provider.
 
 Every control session has exactly two roles inherited from the secure channel:
 
-- the orchestrator sends one pre-ready `PackageTrust`, `Terminate`, and responses;
+- the orchestrator sends one pre-ready `PackageTrust`, one pre-ready
+  `LaunchBindings`, `Terminate`, and responses;
 - the child host sends `Ready`, `Heartbeat`, and requests.
 
 The orchestrator control endpoint is constructed with the immutable package hash
@@ -38,6 +39,15 @@ during its own package verification. The child must authenticate this record, bu
 its own one-key verification keyring, and independently re-read and verify the package.
 The record contains no private key and is bound to the fresh encrypted session. A
 missing, duplicate, malformed, or post-ready trust record is rejected.
+
+After package trust and before readiness, the orchestrator sends the exact
+manifest-blind output of authorized pipeline wiring. Each binding maps one
+signed channel name and read/write direction to one canonical UUID-v7 channel.
+An optional Level 1 model binding carries only a bounded model selector,
+temperature, and output-token cap. Names and UUIDs are unique. The independently
+verified child must require the exact signed name and direction sets and must
+reject missing, extra, or wrong-direction bindings before readiness. The parent
+never learns the signed manifest from this comparison.
 
 The timestamp attached to a received child event is not sent by the child. It is a
 caller-supplied monotonic receipt time sampled by the supervising process after the
@@ -57,27 +67,30 @@ contract matches the Level 1 runtime and avoids an unbounded correlation table.
 
 The orchestrator endpoint begins in `AwaitingReady`:
 
-1. It sends exactly one `PackageTrust` before accepting readiness.
-2. The first authenticated child message must be `Ready(expected_package_hash)`.
-3. A matching `Ready` transitions the endpoint to `Running` and yields authoritative
+1. It sends exactly one `PackageTrust`.
+2. It sends exactly one `LaunchBindings` after trust and before accepting readiness.
+3. The first authenticated child message must be `Ready(expected_package_hash)`.
+4. A matching `Ready` transitions the endpoint to `Running` and yields authoritative
    package, session, and receipt-time evidence.
-4. `Heartbeat` is accepted only in `Running` and refreshes the authoritative
+5. `Heartbeat` is accepted only in `Running` and refreshes the authoritative
    receipt time.
-5. One data-plane request is accepted only in `Running`; no second request is
+6. One data-plane request is accepted only in `Running`; no second request is
    accepted until the orchestrator sends its exact correlated response.
-6. `Terminate` may be sent while awaiting readiness or running, and transitions the
+7. `Terminate` may be sent while awaiting readiness or running, and transitions the
    endpoint to `Terminating`.
-7. No further application message is accepted or emitted after termination begins.
+8. No further application message is accepted or emitted after termination begins.
 
 The child endpoint begins in `AwaitingReady`:
 
 1. It accepts exactly one authenticated `PackageTrust` record.
-2. It must independently verify the package with that trust before sending
+2. It accepts exactly one authenticated `LaunchBindings` record after trust.
+3. It must independently verify the package and require the exact signed channel
+   names/directions plus runtime-compatible model presence before sending
    `Ready(package_hash)`.
-3. It may send `Heartbeat` only after readiness.
-4. It may send one bounded data-plane request after readiness and must wait for the
+4. It may send `Heartbeat` only after readiness.
+5. It may send one bounded data-plane request after readiness and must wait for the
    exactly correlated response before sending another.
-5. It accepts only correlated responses or `Terminate` from the orchestrator and
+6. It accepts only correlated responses or `Terminate` from the orchestrator and
    enters `Terminating` on the latter.
 
 Duplicate readiness, heartbeat-before-ready, child-sent terminate,
@@ -108,6 +121,7 @@ Kinds are:
 | 2   | child -> orchestrator | `Heartbeat` | empty                    |
 | 3   | orchestrator -> child | `Terminate` | empty                    |
 | 4   | orchestrator -> child | `PackageTrust` | key ID, key type, maximum tier, Ed25519 public key |
+| 5   | orchestrator -> child | `LaunchBindings` | named channel UUIDs and optional Level 1 model settings |
 | 10  | child -> orchestrator | `Receive` | request ID, channel UUID-v7, limit |
 | 11  | child -> orchestrator | `Publish` | request ID, channel UUID-v7, content type, payload |
 | 12  | child -> orchestrator | `Acknowledge` | request ID, channel and message UUID-v7 |
@@ -118,7 +132,7 @@ Kinds are:
 | 23  | orchestrator -> child | `Completed` | request ID and provider-neutral completion result |
 | 24  | orchestrator -> child | `Failed` | request ID and redacted stable failure code |
 
-All multi-byte integers are big-endian. The package key ID uses a bounded `u8`
+All multi-byte integers are big-endian. The package key ID and channel names use bounded `u8`
 length; data-plane variable bytes and UTF-8 strings use a `u32` length; vectors
 use their specified `u8` or `u16` count. UUID fields must be canonical
 UUID-v7 values. Data-plane bodies are capped at 768 KiB, a single channel payload
@@ -145,6 +159,7 @@ pub enum ChildEvent {
 
 pub enum OrchestratorEvent {
     PackageTrust(PackageTrust),
+    LaunchBindings(LaunchBindings),
     Terminate,
     Response(DataPlaneResponse),
 }
@@ -158,6 +173,8 @@ impl OrchestratorControl {
     pub fn receive_child(&mut self, frame: &[u8], received_at_ns: u64)
         -> Result<ChildEvent, ControlError>;
     pub fn provide_package_trust(&mut self, trust: PackageTrust)
+        -> Result<Vec<u8>, ControlError>;
+    pub fn provide_launch_bindings(&mut self, bindings: LaunchBindings)
         -> Result<Vec<u8>, ControlError>;
     pub fn terminate(&mut self) -> Result<Vec<u8>, ControlError>;
     pub fn respond(&mut self, response: DataPlaneResponse)
@@ -209,6 +226,8 @@ The package must cover:
 
 - matching readiness followed by multiple heartbeats;
 - authenticated bounded package trust required exactly once before readiness;
+- authenticated bounded launch bindings required exactly once after trust and
+  before readiness, including canonicalization and malformed/duplicate rejection;
 - authenticated round trips for receive, publish, acknowledge, completion, and
   redacted failure;
 - one-in-flight ordering, monotonic request IDs, exact response correlation, and

--- a/code/specs/host-runtime-rust.md
+++ b/code/specs/host-runtime-rust.md
@@ -186,11 +186,16 @@ Before reading the agent's manifest, the host:
    key, trust class, and maximum tier selected by the orchestrator. The host has
    no ambient key-file or vault access and rejects readiness if this record is
    absent, malformed, or duplicated.
-3. Computes the SHA-256 hash of the rest of the package using the
+3. Accepts exactly one authenticated `LaunchBindings` record after trust. Once
+   verification succeeds, the Level 1 host requires its channel names and
+   directions to match the signed manifest exactly and requires bounded model
+   settings; missing, extra, wrong-direction, or runtime-incompatible bindings
+   prevent readiness.
+4. Computes the SHA-256 hash of the rest of the package using the
    same deterministic file-set ordering D18 specifies.
-4. Verifies the package's Ed25519 SIGNATURE against the hash with
+5. Verifies the package's Ed25519 SIGNATURE against the hash with
    the trusted public key.
-5. On failure → exit 2 with a structured error sent to the
+6. On failure → exit 2 with a structured error sent to the
    orchestrator over the channel before exit (so the orchestrator
    logs the reason).
 

--- a/code/specs/process-host-supervisor.md
+++ b/code/specs/process-host-supervisor.md
@@ -52,9 +52,12 @@ After spawning, the parent writes one `BootstrapOffer` and waits for one
 secure channel is wrapped in `OrchestratorControl`. Subsequent framed records
 are encrypted host-control frames. Before accepting readiness, the parent sends
 the exact relevant package-signing public trust selected by its verified package
-snapshot. The child-side helper performs the inverse bootstrap over any `Read`
-and `Write`, receives that authenticated trust, then exposes readiness, heartbeat,
-termination, and data-plane operations.
+snapshot. It then asks an injected manifest-blind `HostLaunchBindingProvider` for
+the exact registered host/package/runtime identity and sends the returned channel
+UUID and optional Level 1 model bindings. A provider failure or runtime/model
+mismatch fails before process creation. The child-side helper performs the inverse
+bootstrap over any `Read` and `Write`, receives both authenticated inputs, then
+exposes readiness, heartbeat, termination, and data-plane operations.
 
 ## Package and Identity Safety
 
@@ -131,6 +134,8 @@ The package exposes:
 
 - validated `ProcessSupervisorConfig` and `HostProgram` values;
 - `MonotonicClock` and `SessionIdSource` interfaces plus production adapters;
+- `HostLaunchBindingProvider` plus a fail-closed provider for compositions that
+  have not connected durable pipeline wiring;
 - owned, movable `ProcessHostSupervisor`, implementing the reconciler
   `HostSupervisor` trait;
 - `ChildProcessControl<R, W>` for lifecycle plus serialized authenticated


### PR DESCRIPTION
## Summary
- authenticate one canonical bounded channel name-to-UUID and optional Level 1 model binding record after package trust and before Ready
- require manifest-blind provider lookup before spawn and fail closed on absent or runtime-incompatible bindings
- make LevelOneLaunchPlan require exact signed read/write names and convert authenticated model settings into runtime config

## Validation
- 68 focused protocol, supervisor, skill, orchestrator, and daemon tests
- strict Clippy, rustdoc, rustfmt, and diff checks
- dependency-closed planner: all 76 affected, prerequisite, and dependent packages

## Follow-up
The audit exposed missing durable pipeline name-to-UUID and model persistence. That is the next P0 before concrete host composition.

Progresses #128
Progresses #138