### PR TITLE
Normalize model parameter separators

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize hyphens in supported model-card parameter aliases.
 - Normalize hyphen and underscore separators in supported model type aliases.
 - Normalize the `PCH` model type alias to canonical `PMOS` cards.
 - Normalize the `NCH` model type alias to canonical `NMOS` cards.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -2598,8 +2598,9 @@ def _parse_model_params(params_text: str) -> dict[str, float]:
         return {}
     params: dict[str, float] = {}
     spans: list[tuple[int, int]] = []
-    for match in re.finditer(r"([A-Za-z][A-Za-z0-9_]*)\s*=\s*([^,\s)]+)", params_text):
-        params[match.group(1).upper()] = parse_value(match.group(2))
+    for match in re.finditer(r"([A-Za-z][A-Za-z0-9_-]*)\s*=\s*([^,\s)]+)", params_text):
+        key = match.group(1).upper().replace("-", "_")
+        params[key] = parse_value(match.group(2))
         spans.append(match.span())
     cursor = 0
     for start, end in spans:

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2666,6 +2666,23 @@ def test_parse_separator_normalized_model_type_aliases() -> None:
     assert mosfet.model.type == MosfetType.PMOS
 
 
+def test_parse_hyphen_normalized_model_parameter_aliases() -> None:
+    parsed = parse_netlist(
+        ".model qfast NPN(BETA-F=125)\n"
+        ".model mfast NMOS(T-NOM=325 KP=120u)\n"
+        "Q1 collector base emitter qfast\n"
+        "M1 d g s b mfast"
+    )
+
+    assert parsed.models["qfast"].params["BETA_F"] == 125.0
+    assert parsed.models["mfast"].params["T_NOM"] == 325.0
+    bjt, mosfet = parsed.circuit.elements
+    assert isinstance(bjt, BJT)
+    assert bjt.beta_f == 125.0
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.model.model.params.T_NOM == 325.0
+
+
 def test_parse_pmos_mosfet_model() -> None:
     parsed = parse_netlist(
         """

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Normalize hyphens in supported model-card parameter aliases.
 - Normalize hyphen and underscore separators in supported model type aliases.
 - Normalize the `PCH` model type alias to canonical `PMOS` cards.
 - Normalize the `NCH` model type alias to canonical `NMOS` cards.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -2071,10 +2071,10 @@ function parseModelParams(paramsText: string): ReadonlyMap<string, number> {
   if (paramsText.trim().length === 0) {
     return params;
   }
-  const pattern = /([A-Za-z][A-Za-z0-9_]*)\s*=\s*([^,\s)]+)/g;
+  const pattern = /([A-Za-z][A-Za-z0-9_-]*)\s*=\s*([^,\s)]+)/g;
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(paramsText)) !== null) {
-    params.set(match[1].toUpperCase(), parseValue(match[2]));
+    params.set(match[1].toUpperCase().replace(/-/g, "_"), parseValue(match[2]));
   }
   const leftover = paramsText.replace(pattern, "").replace(/[,\s]/g, "");
   if (leftover.length > 0 || params.size === 0) {

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2783,6 +2783,26 @@ M1 out gate 0 0 nfast W=2u L=180n
     });
   });
 
+  it("normalizes model parameter alias hyphens", () => {
+    const parsed = parseNetlist(
+      ".model qfast NPN(BETA-F=125)\n" +
+        ".model mfast NMOS(T-NOM=325 KP=120u)\n" +
+        "Q1 collector base emitter qfast\n" +
+        "M1 d g s b mfast",
+    );
+
+    expect(parsed.models.get("qfast")?.params.get("BETA_F")).toBe(125.0);
+    expect(parsed.models.get("mfast")?.params.get("T_NOM")).toBe(325.0);
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "bjt",
+      forwardBeta: 125.0,
+    });
+    expect(parsed.circuit.elements()[1]).toMatchObject({
+      kind: "mosfet",
+      params: { T_NOM: 325.0 },
+    });
+  });
+
   it("parses PMOS MOSFET aliases", () => {
     const parsed = parseNetlist(`
 .model pfast PMOS(VTO=0.4 KP=120u NSUB=1.2)

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4768,10 +4768,17 @@ the Rust, Python, and TypeScript surfaces together.
      `PJFET`, `PJ`, `NCH`, and `PCH` model-type alias set.
 
 483. Python and TypeScript Berkeley SPICE model-type separator normalization parity.
-   - Status: implemented in this model-type separator normalization slice.
+   - Status: completed in PR 10168.
    - Both parser facades mirror the engine type-key contract for supported
      aliases by ignoring hyphen and underscore separators, including the
      engine-tested `n-jfet` spelling, while preserving unknown model kinds.
+
+484. Python and TypeScript Berkeley SPICE model-parameter separator normalization parity.
+   - Status: implemented in this model-parameter separator normalization slice.
+   - Both parser facades mirror the engine parameter-key contract by converting
+     hyphens to underscores in `.model` parameter names, preserving existing
+     validation, alias precedence, and lowering for spellings such as
+     `BETA-F` and `T-NOM`.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- mirror the engine model-card parameter key contract by converting hyphens to underscores
- verify `BETA-F` and `T-NOM` validation and lowering through BJT and MOS instances in both parser facades
- reconcile the completed model-type separator slice in the SPICE plan

## Verification

- Python parser `bash BUILD` (`643 passed`, 90.60% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (`628 passed`)
- TypeScript parser `npx vitest run --coverage` (88.38% line coverage)
- TypeScript engine `bash BUILD` (`448 passed`)
- `git diff --check`
- BUILD and dependency manifest audit (no changes required)
