### PR TITLE
Add consent-bound AirGradient custom egress controls

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Expose stable MQTT-broker and custom-HTTP-domain command labels.
 - Expose stable country and cloud-upload command labels plus the reusable data
   governance primitive label.
 - Expose the `camera_set_recording` D23 command label.

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -90187,6 +90187,12 @@ fn parse_command_type(label: &str) -> Result<CommandType, ToolCallError> {
         "device_set_cloud_upload" => Ok(CommandType::DeviceControl(
             DeviceControlCommandType::SetCloudUpload,
         )),
+        "device_set_mqtt_broker" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetMqttBroker,
+        )),
+        "device_set_http_domain" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetHttpDomain,
+        )),
         "camera_set_recording" => Ok(CommandType::DeviceControl(
             DeviceControlCommandType::SetCameraRecording,
         )),
@@ -92609,6 +92615,12 @@ fn command_type_label(command_type: CommandType) -> &'static str {
         CommandType::DeviceControl(DeviceControlCommandType::SetCountry) => "device_set_country",
         CommandType::DeviceControl(DeviceControlCommandType::SetCloudUpload) => {
             "device_set_cloud_upload"
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::SetMqttBroker) => {
+            "device_set_mqtt_broker"
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::SetHttpDomain) => {
+            "device_set_http_domain"
         }
         CommandType::DeviceControl(DeviceControlCommandType::SetCameraRecording) => {
             "camera_set_recording"
@@ -121571,6 +121583,14 @@ mod tests {
             (
                 "device_set_cloud_upload",
                 DeviceControlCommandType::SetCloudUpload,
+            ),
+            (
+                "device_set_mqtt_broker",
+                DeviceControlCommandType::SetMqttBroker,
+            ),
+            (
+                "device_set_http_domain",
+                DeviceControlCommandType::SetHttpDomain,
             ),
             (
                 "camera_set_recording",

--- a/code/packages/rust/smart-home-airgradient-local-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-airgradient-local-integration/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.0
+
+- Add human-approved, readback-verified credential-free MQTT broker and custom
+  HTTPS-domain routing over the documented local `/config` contract.
+- Require exact destination-bound consent before enabling either telemetry
+  route while allowing privacy-protective shutdown without consent.
+- Redact configured destinations and any pre-existing MQTT userinfo from debug
+  and normalized state; reject credential-bearing command values because the
+  current upstream firmware logs parsed MQTT credentials.
+
 ## 0.4.0
 
 - Add human-approved, readback-verified country and AirGradient cloud-upload

--- a/code/packages/rust/smart-home-airgradient-local-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-airgradient-local-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smart-home-airgradient-local-integration"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "AirGradient local monitor telemetry and typed configuration integration for the smart-home runtime"
 license = "MIT"
@@ -15,3 +15,4 @@ smart-home-discovery = { path = "../smart-home-discovery" }
 smart-home-local-http = { path = "../smart-home-local-http" }
 smart-home-runtime = { path = "../smart-home-runtime" }
 url-parser = { path = "../url-parser" }
+coding_adventures_zeroize = { path = "../zeroize" }

--- a/code/packages/rust/smart-home-airgradient-local-integration/README.md
+++ b/code/packages/rust/smart-home-airgradient-local-integration/README.md
@@ -26,13 +26,24 @@ does not require a consent grant. Both commands still require D23 human
 approval, and every persistent change is verified through `/config` readback.
 Normalized state records only whether a country is configured, never the
 country value.
+Credential-free `mqtt://` and `mqtts://` broker routes require an explicit
+port and an exact environmental-telemetry egress grant. Custom HTTP routing
+accepts only a fully qualified DNS name and requires a grant for the matching
+HTTPS origin. AirGradient firmware applies that domain to telemetry, remote
+configuration, and OTA traffic together, so consent covers the coupled route.
+Both controls require D23 human approval before `PUT /config`, verify exact
+`GET /config` readback, and expose only configured/not-configured state.
+Disabling either route is privacy-protective and does not require a consent
+grant.
 Monitors with `configurationControl=cloud` reject local commands explicitly;
 `configurationControl=both` succeeds with a warning that a later cloud update
 may overwrite the local value.
 
-MQTT broker and custom HTTP destination settings remain excluded because they
-can carry credentials or redirect telemetry and therefore require Vault leases
-and destination policy beyond the exact AirGradient vendor-cloud grant.
+Credential-bearing MQTT command values are rejected. The current upstream
+firmware logs parsed MQTT usernames and passwords, so host-side Vault leasing
+cannot prevent a device-side disclosure; authenticated MQTT remains blocked
+until that firmware behavior is removed and one-shot credential injection can
+be proven without normalized-state or request-plan exposure.
 
 ```bash
 cargo run -p smart-home-airgradient-local-integration -- discover ecda3b1eaaaf

--- a/code/packages/rust/smart-home-airgradient-local-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-airgradient-local-integration/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![forbid(unsafe_code)]
 
+use coding_adventures_zeroize::Zeroizing;
 use http1::{parse_response_head, Http1ParseError};
 use http_core::BodyKind;
 use serde_json::{Map as JsonMap, Value as JsonValue};
@@ -30,7 +31,7 @@ use std::net::{TcpStream, ToSocketAddrs};
 use std::time::Duration;
 use url_parser::{Url, UrlError};
 
-pub const VERSION: &str = "0.3.0";
+pub const VERSION: &str = "0.5.0";
 pub const INTEGRATION_ID: &str = "airgradient";
 pub const PROTOCOL_ID: &str = "airgradient_local_api";
 pub const MEASUREMENT_PATH: &str = "/measures/current";
@@ -167,13 +168,26 @@ impl From<RuntimeError> for AirGradientError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct AirGradientConfig {
     pub bridge_id: BridgeId,
     pub base_url: String,
     pub display_name: String,
     pub expected_serial: Option<String>,
     pub timeout: Duration,
+}
+
+impl fmt::Debug for AirGradientConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AirGradientConfig")
+            .field("bridge_id", &self.bridge_id)
+            .field("base_url", &self.base_url)
+            .field("display_name", &self.display_name)
+            .field("expected_serial", &self.expected_serial)
+            .field("timeout", &self.timeout)
+            .finish()
+    }
 }
 
 impl AirGradientConfig {
@@ -321,6 +335,8 @@ pub struct AirGradientConfiguration {
     pub control: AirGradientConfigurationControl,
     pub country: Option<AirGradientCountryCode>,
     pub post_data_to_airgradient: Option<bool>,
+    pub mqtt_broker_uri: Option<AirGradientMqttBrokerUri>,
+    pub http_domain: Option<AirGradientHttpDomain>,
     pub led_bar_mode: String,
     pub led_bar_brightness: u8,
     pub display_brightness: u8,
@@ -358,6 +374,159 @@ impl AirGradientCountryCode {
 impl fmt::Debug for AirGradientCountryCode {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("AirGradientCountryCode([REDACTED])")
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct AirGradientMqttDestination(String);
+
+impl AirGradientMqttDestination {
+    pub fn new(value: impl Into<String>) -> Result<Self, AirGradientError> {
+        let value = value.into().trim_end_matches('/').to_string();
+        if value.len() > 255 {
+            return Err(AirGradientError::Validation(
+                "MQTT broker URI exceeds 255 bytes".to_string(),
+            ));
+        }
+        DataDestination::mqtt_broker(value.clone()).map_err(|error| {
+            AirGradientError::Validation(format!("invalid MQTT broker destination: {error}"))
+        })?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn governed_destination(&self) -> Result<DataDestination, AirGradientError> {
+        DataDestination::mqtt_broker(self.0.clone()).map_err(|error| {
+            AirGradientError::Validation(format!("invalid MQTT broker destination: {error}"))
+        })
+    }
+}
+
+impl fmt::Debug for AirGradientMqttDestination {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AirGradientMqttDestination([REDACTED])")
+    }
+}
+
+pub struct AirGradientMqttBrokerUri(Zeroizing<String>);
+
+impl Clone for AirGradientMqttBrokerUri {
+    fn clone(&self) -> Self {
+        Self(Zeroizing::new(self.0.to_string()))
+    }
+}
+
+impl PartialEq for AirGradientMqttBrokerUri {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for AirGradientMqttBrokerUri {}
+
+impl AirGradientMqttBrokerUri {
+    fn from_device(value: &str) -> Result<Self, AirGradientError> {
+        let parsed = Url::parse(value)?;
+        if !matches!(parsed.scheme.as_str(), "mqtt" | "mqtts")
+            || parsed.host.is_none()
+            || parsed.port.is_none()
+            || parsed.query.is_some()
+            || parsed.fragment.is_some()
+            || !matches!(parsed.path.as_str(), "" | "/")
+            || value.len() > 255
+            || has_unsafe_http_text(value)
+        {
+            return Err(AirGradientError::Validation(
+                "device returned an invalid MQTT broker URI".to_string(),
+            ));
+        }
+        Ok(Self(Zeroizing::new(
+            value.trim_end_matches('/').to_string(),
+        )))
+    }
+
+    pub fn is_configured(&self) -> bool {
+        !self.0.is_empty()
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn governed_destination(&self) -> Result<DataDestination, AirGradientError> {
+        let parsed = Url::parse(&self.0)?;
+        let host = parsed
+            .host
+            .as_deref()
+            .ok_or(AirGradientError::MissingField("MQTT broker host"))?;
+        let port = parsed
+            .port
+            .ok_or(AirGradientError::MissingField("MQTT broker port"))?;
+        let host = if host.contains(':') {
+            format!("[{host}]")
+        } else {
+            host.to_string()
+        };
+        DataDestination::mqtt_broker(format!("{}://{host}:{port}", parsed.scheme)).map_err(
+            |error| {
+                AirGradientError::Validation(format!(
+                    "invalid configured MQTT broker destination: {error}"
+                ))
+            },
+        )
+    }
+}
+
+impl fmt::Debug for AirGradientMqttBrokerUri {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AirGradientMqttBrokerUri([REDACTED])")
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct AirGradientHttpDomain(String);
+
+impl AirGradientHttpDomain {
+    pub fn new(value: impl Into<String>) -> Result<Self, AirGradientError> {
+        let value = value.into().to_ascii_lowercase();
+        let labels = value.split('.').collect::<Vec<_>>();
+        if value.is_empty()
+            || value.len() > 253
+            || labels.len() < 2
+            || labels.iter().any(|label| {
+                label.is_empty()
+                    || label.len() > 63
+                    || label.starts_with('-')
+                    || label.ends_with('-')
+                    || !label
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+            })
+        {
+            return Err(AirGradientError::Validation(
+                "HTTP domain must be a fully qualified DNS name".to_string(),
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn governed_destination(&self) -> Result<DataDestination, AirGradientError> {
+        DataDestination::https_origin(format!("https://{}", self.0)).map_err(|error| {
+            AirGradientError::Validation(format!("invalid custom HTTP destination: {error}"))
+        })
+    }
+}
+
+impl fmt::Debug for AirGradientHttpDomain {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AirGradientHttpDomain([REDACTED])")
     }
 }
 
@@ -425,7 +594,7 @@ impl AirGradientTransport for AirGradientLanTransport {
             .effective_port()
             .ok_or(AirGradientError::MissingField("URL port"))?;
         let timeout = Duration::from_millis(plan.timeout_ms.max(1));
-        let request = encode_http_request(&url, plan)?;
+        let request = encode_http_request(&url, plan, &plan.body)?;
         let mut stream = connect_tcp(host, port, timeout)?;
         stream
             .write_all(&request)
@@ -766,16 +935,35 @@ impl<T: AirGradientTransport> AirGradientRuntimeIntegration<T> {
         let plan = airgradient_command_plan(&self.command_targets, &request)?;
         let target_entity_id = request.entity_id.clone();
         let command = runtime.authorize_command_tool(principal_id.clone(), request, now_ms)?;
-        if let Some(operation) = plan.governance {
+        if let Some(operation) = plan
+            .governance
+            .as_ref()
+            .filter(|operation| !operation.requires_current_configuration())
+        {
             authorize_data_use(
                 &self.data_governance,
                 &principal_id,
                 &target_entity_id,
-                operation,
+                operation.resolve(None)?,
                 now_ms,
             )?;
         }
         let configuration = self.client.configuration()?;
+        if let Some(operation) = plan
+            .governance
+            .as_ref()
+            .filter(|operation| operation.requires_current_configuration())
+        {
+            if let Some(operation) = operation.resolve(Some(&configuration))? {
+                authorize_data_use(
+                    &self.data_governance,
+                    &principal_id,
+                    &target_entity_id,
+                    Some(operation),
+                    now_ms,
+                )?;
+            }
+        }
         if configuration.control == AirGradientConfigurationControl::Cloud {
             return Err(AirGradientError::CloudConfigurationConflict);
         }
@@ -816,10 +1004,86 @@ struct AirGradientCommandPlan {
     governance: Option<GovernedAirGradientOperation>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum GovernedAirGradientOperation {
     ConfigureCountry,
     SetCloudUpload(bool),
+    SetMqttBroker(Option<AirGradientMqttDestination>),
+    SetHttpDomain(Option<AirGradientHttpDomain>),
+}
+
+impl GovernedAirGradientOperation {
+    fn requires_current_configuration(&self) -> bool {
+        matches!(self, Self::SetMqttBroker(None) | Self::SetHttpDomain(None))
+    }
+
+    fn resolve(
+        &self,
+        configuration: Option<&AirGradientConfiguration>,
+    ) -> Result<Option<ResolvedDataOperation>, AirGradientError> {
+        match self {
+            Self::ConfigureCountry => Ok(Some(ResolvedDataOperation {
+                category: DataCategory::CoarseLocation,
+                operation: DataOperation::Configure,
+                destination: DataDestination::LocalDevice,
+            })),
+            Self::SetCloudUpload(enabled) => Ok(Some(ResolvedDataOperation {
+                category: DataCategory::EnvironmentalTelemetry,
+                operation: if *enabled {
+                    DataOperation::StartEgress
+                } else {
+                    DataOperation::StopEgress
+                },
+                destination: DataDestination::https_origin(AIRGRADIENT_CLOUD_ORIGIN).map_err(
+                    |error| {
+                        AirGradientError::Validation(format!(
+                            "invalid AirGradient cloud origin: {error}"
+                        ))
+                    },
+                )?,
+            })),
+            Self::SetMqttBroker(Some(destination)) => Ok(Some(ResolvedDataOperation {
+                category: DataCategory::EnvironmentalTelemetry,
+                operation: DataOperation::StartEgress,
+                destination: destination.governed_destination()?,
+            })),
+            Self::SetMqttBroker(None) => configuration
+                .ok_or(AirGradientError::MissingField("current configuration"))?
+                .mqtt_broker_uri
+                .as_ref()
+                .map(|destination| {
+                    Ok(ResolvedDataOperation {
+                        category: DataCategory::EnvironmentalTelemetry,
+                        operation: DataOperation::StopEgress,
+                        destination: destination.governed_destination()?,
+                    })
+                })
+                .transpose(),
+            Self::SetHttpDomain(Some(destination)) => Ok(Some(ResolvedDataOperation {
+                category: DataCategory::EnvironmentalTelemetry,
+                operation: DataOperation::StartEgress,
+                destination: destination.governed_destination()?,
+            })),
+            Self::SetHttpDomain(None) => configuration
+                .ok_or(AirGradientError::MissingField("current configuration"))?
+                .http_domain
+                .as_ref()
+                .map(|destination| {
+                    Ok(ResolvedDataOperation {
+                        category: DataCategory::EnvironmentalTelemetry,
+                        operation: DataOperation::StopEgress,
+                        destination: destination.governed_destination()?,
+                    })
+                })
+                .transpose(),
+        }
+    }
+}
+
+struct ResolvedDataOperation {
+    category: DataCategory,
+    operation: DataOperation,
+    destination: DataDestination,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -841,6 +1105,8 @@ enum ExpectedConfiguration {
     },
     Country(AirGradientCountryCode),
     CloudUpload(bool),
+    MqttBroker(Option<AirGradientMqttDestination>),
+    HttpDomain(Option<AirGradientHttpDomain>),
 }
 
 impl ExpectedConfiguration {
@@ -888,6 +1154,18 @@ impl ExpectedConfiguration {
             Self::CloudUpload(expected) => (
                 configuration.post_data_to_airgradient == Some(*expected),
                 "postDataToAirGradient",
+            ),
+            Self::MqttBroker(expected) => (
+                match (expected, configuration.mqtt_broker_uri.as_ref()) {
+                    (None, None) => true,
+                    (Some(expected), Some(actual)) => actual.as_str() == expected.as_str(),
+                    _ => false,
+                },
+                "mqttBrokerUrl",
+            ),
+            Self::HttpDomain(expected) => (
+                configuration.http_domain.as_ref() == expected.as_ref(),
+                "httpDomain",
             ),
         };
         if matches {
@@ -1118,6 +1396,57 @@ fn airgradient_command_plan(
                 governance: Some(GovernedAirGradientOperation::SetCloudUpload(enabled)),
             })
         }
+        CommandType::DeviceControl(DeviceControlCommandType::SetMqttBroker)
+            if target == AirGradientCommandTarget::Configuration =>
+        {
+            let destination = match &request.arguments {
+                Value::Null => None,
+                Value::Text(value) => Some(AirGradientMqttDestination::new(value)?),
+                _ => {
+                    return invalid_command_arguments(
+                        request.command_type,
+                        "a credential-free mqtt or mqtts broker URI with an explicit port, or null to disable",
+                    )
+                }
+            };
+            Ok(AirGradientCommandPlan {
+                update: configuration_update(
+                    "mqttBrokerUrl",
+                    JsonValue::String(
+                        destination
+                            .as_ref()
+                            .map_or_else(String::new, |value| value.as_str().to_string()),
+                    ),
+                ),
+                expected: Some(ExpectedConfiguration::MqttBroker(destination.clone())),
+                governance: Some(GovernedAirGradientOperation::SetMqttBroker(destination)),
+            })
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::SetHttpDomain)
+            if target == AirGradientCommandTarget::Configuration =>
+        {
+            let destination =
+                match &request.arguments {
+                    Value::Null => None,
+                    Value::Text(value) => Some(AirGradientHttpDomain::new(value)?),
+                    _ => return invalid_command_arguments(
+                        request.command_type,
+                        "a fully qualified DNS name, or null to restore the AirGradient default",
+                    ),
+                };
+            Ok(AirGradientCommandPlan {
+                update: configuration_update(
+                    "httpDomain",
+                    JsonValue::String(
+                        destination
+                            .as_ref()
+                            .map_or_else(String::new, |value| value.as_str().to_string()),
+                    ),
+                ),
+                expected: Some(ExpectedConfiguration::HttpDomain(destination.clone())),
+                governance: Some(GovernedAirGradientOperation::SetHttpDomain(destination)),
+            })
+        }
         CommandType::DeviceControl(_) => invalid_command_arguments(
             request.command_type,
             "an AirGradient entity that advertises the command capability",
@@ -1140,36 +1469,18 @@ fn authorize_data_use(
     policy: &DataGovernancePolicy,
     principal_id: &AgentId,
     entity_id: &EntityId,
-    operation: GovernedAirGradientOperation,
+    operation: Option<ResolvedDataOperation>,
     now_ms: u64,
 ) -> Result<(), AirGradientError> {
-    let (category, operation, destination) = match operation {
-        GovernedAirGradientOperation::ConfigureCountry => (
-            DataCategory::CoarseLocation,
-            DataOperation::Configure,
-            DataDestination::LocalDevice,
-        ),
-        GovernedAirGradientOperation::SetCloudUpload(true) => (
-            DataCategory::EnvironmentalTelemetry,
-            DataOperation::StartEgress,
-            DataDestination::https_origin(AIRGRADIENT_CLOUD_ORIGIN).map_err(|error| {
-                AirGradientError::Validation(format!("invalid AirGradient cloud origin: {error}"))
-            })?,
-        ),
-        GovernedAirGradientOperation::SetCloudUpload(false) => (
-            DataCategory::EnvironmentalTelemetry,
-            DataOperation::StopEgress,
-            DataDestination::https_origin(AIRGRADIENT_CLOUD_ORIGIN).map_err(|error| {
-                AirGradientError::Validation(format!("invalid AirGradient cloud origin: {error}"))
-            })?,
-        ),
+    let Some(operation) = operation else {
+        return Ok(());
     };
     match policy.decide(&DataUseRequest {
         principal_id,
         resource_id: entity_id.as_str(),
-        category,
-        operation,
-        destination,
+        category: operation.category,
+        operation: operation.operation,
+        destination: operation.destination,
         now_ms,
     }) {
         DataGovernanceDecision::Allow(_) => Ok(()),
@@ -1352,6 +1663,14 @@ fn configuration_value(configuration: &AirGradientConfiguration) -> Value {
     if let Some(enabled) = configuration.post_data_to_airgradient {
         fields.push(("cloud_upload_enabled".to_string(), Value::Bool(enabled)));
     }
+    fields.push((
+        "mqtt_broker_configured".to_string(),
+        Value::Bool(configuration.mqtt_broker_uri.is_some()),
+    ));
+    fields.push((
+        "custom_http_domain_configured".to_string(),
+        Value::Bool(configuration.http_domain.is_some()),
+    ));
     if configuration.country.is_some() {
         fields.push(("country_configured".to_string(), Value::Bool(true)));
     }
@@ -1459,6 +1778,8 @@ fn parse_configuration(data: &JsonValue) -> Result<AirGradientConfiguration, Air
         control,
         country: optional_country(data)?,
         post_data_to_airgradient: optional_bool(data, "postDataToAirGradient")?,
+        mqtt_broker_uri: optional_mqtt_broker_uri(data)?,
+        http_domain: optional_http_domain(data)?,
         led_bar_mode: required_string(data, "ledBarMode")?.to_ascii_lowercase(),
         led_bar_brightness: required_percentage(data, "ledBarBrightness")?,
         display_brightness: required_percentage(data, "displayBrightness")?,
@@ -1470,6 +1791,38 @@ fn parse_configuration(data: &JsonValue) -> Result<AirGradientConfiguration, Air
         monitor_display_compensated_values: optional_bool(data, "monitorDisplayCompensatedValues")?,
         corrections: parse_corrections(data)?,
     })
+}
+
+fn optional_mqtt_broker_uri(
+    data: &JsonMap<String, JsonValue>,
+) -> Result<Option<AirGradientMqttBrokerUri>, AirGradientError> {
+    let Some(value) = data.get("mqttBrokerUrl") else {
+        return Ok(None);
+    };
+    let value = value
+        .as_str()
+        .ok_or_else(|| AirGradientError::Validation("mqttBrokerUrl must be text".to_string()))?;
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        AirGradientMqttBrokerUri::from_device(value).map(Some)
+    }
+}
+
+fn optional_http_domain(
+    data: &JsonMap<String, JsonValue>,
+) -> Result<Option<AirGradientHttpDomain>, AirGradientError> {
+    let Some(value) = data.get("httpDomain") else {
+        return Ok(None);
+    };
+    let value = value
+        .as_str()
+        .ok_or_else(|| AirGradientError::Validation("httpDomain must be text".to_string()))?;
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        AirGradientHttpDomain::new(value).map(Some)
+    }
 }
 
 fn optional_country(
@@ -1797,7 +2150,8 @@ fn has_unsafe_http_text(value: &str) -> bool {
 fn encode_http_request(
     url: &Url,
     plan: &LocalHttpRequestPlan,
-) -> Result<Vec<u8>, AirGradientError> {
+    body: &[u8],
+) -> Result<Zeroizing<Vec<u8>>, AirGradientError> {
     let host = url
         .host
         .as_deref()
@@ -1822,11 +2176,13 @@ fn encode_http_request(
     } else {
         format!("{host}:{port}")
     };
-    let mut request = format!(
-        "{} {target} HTTP/1.1\r\nHost: {host_header}\r\nConnection: close\r\n",
-        plan.method.as_str()
-    )
-    .into_bytes();
+    let mut request = Zeroizing::new(
+        format!(
+            "{} {target} HTTP/1.1\r\nHost: {host_header}\r\nConnection: close\r\n",
+            plan.method.as_str()
+        )
+        .into_bytes(),
+    );
     let mut seen = BTreeSet::new();
     for header in &plan.headers {
         if has_unsafe_http_text(&header.name) || has_unsafe_http_text(&header.value) {
@@ -1838,10 +2194,10 @@ fn encode_http_request(
         request.extend_from_slice(format!("{}: {}\r\n", header.name, header.value).as_bytes());
     }
     if !seen.contains("content-length") {
-        request.extend_from_slice(format!("Content-Length: {}\r\n", plan.body.len()).as_bytes());
+        request.extend_from_slice(format!("Content-Length: {}\r\n", body.len()).as_bytes());
     }
     request.extend_from_slice(b"\r\n");
-    request.extend_from_slice(&plan.body);
+    request.extend_from_slice(body);
     Ok(request)
 }
 
@@ -1975,6 +2331,11 @@ mod tests {
     const CONFIG_GOVERNED_INITIAL: &str = r#"{"configurationControl":"both","country":"US","postDataToAirGradient":false,"ledBarMode":"co2","ledBarBrightness":80,"displayBrightness":70}"#;
     const CONFIG_COUNTRY_CA: &str = r#"{"configurationControl":"both","country":"CA","postDataToAirGradient":false,"ledBarMode":"co2","ledBarBrightness":80,"displayBrightness":70}"#;
     const CONFIG_UPLOAD_ENABLED: &str = r#"{"configurationControl":"both","country":"CA","postDataToAirGradient":true,"ledBarMode":"co2","ledBarBrightness":80,"displayBrightness":70}"#;
+    const CONFIG_CUSTOM_EGRESS_DISABLED: &str = r#"{"configurationControl":"both","mqttBrokerUrl":"","httpDomain":"","ledBarMode":"co2","ledBarBrightness":80,"displayBrightness":70}"#;
+    const CONFIG_MQTT_ENABLED: &str = r#"{"configurationControl":"both","mqttBrokerUrl":"mqtts://broker.example.test:8883","httpDomain":"","ledBarMode":"co2","ledBarBrightness":80,"displayBrightness":70}"#;
+    const CONFIG_CUSTOM_EGRESS_ENABLED: &str = r#"{"configurationControl":"both","mqttBrokerUrl":"mqtts://broker.example.test:8883","httpDomain":"telemetry.example.test","ledBarMode":"co2","ledBarBrightness":80,"displayBrightness":70}"#;
+    const CONFIG_EXISTING_CREDENTIALED_EGRESS: &str = r#"{"configurationControl":"both","mqttBrokerUrl":"mqtts://device-user:device-secret@broker.example.test:8883","httpDomain":"telemetry.example.test","ledBarMode":"co2","ledBarBrightness":80,"displayBrightness":70}"#;
+    const CONFIG_MQTT_DISABLED_HTTP_ENABLED: &str = r#"{"configurationControl":"both","mqttBrokerUrl":"","httpDomain":"telemetry.example.test","ledBarMode":"co2","ledBarBrightness":80,"displayBrightness":70}"#;
 
     fn advanced_config(
         temperature_unit: &str,
@@ -2101,6 +2462,40 @@ mod tests {
                 .unwrap(),
             )
             .unwrap();
+        policy
+    }
+
+    fn custom_egress_policy(principal: &AgentId, entity_id: &EntityId) -> DataGovernancePolicy {
+        let mut policy = DataGovernancePolicy::default();
+        for (destination, purpose, consent_ref) in [
+            (
+                DataDestination::mqtt_broker("mqtts://broker.example.test:8883").unwrap(),
+                "operator-selected AirGradient MQTT telemetry route",
+                "consent://airgradient/mqtt-1",
+            ),
+            (
+                DataDestination::https_origin("https://telemetry.example.test").unwrap(),
+                "operator-selected AirGradient HTTPS telemetry route",
+                "consent://airgradient/http-1",
+            ),
+        ] {
+            policy
+                .add_grant(
+                    DataUseGrant::new(
+                        principal.clone(),
+                        entity_id.as_str(),
+                        DataCategory::EnvironmentalTelemetry,
+                        DataOperation::StartEgress,
+                        destination,
+                        DataPurpose::new(purpose).unwrap(),
+                        ConsentReceiptRef::new(consent_ref).unwrap(),
+                        1_000,
+                        20_000,
+                    )
+                    .unwrap(),
+                )
+                .unwrap();
+        }
         policy
     }
 
@@ -2342,6 +2737,14 @@ mod tests {
                 Value::Text("CA".to_string()),
             ),
             (DeviceControlCommandType::SetCloudUpload, Value::Bool(true)),
+            (
+                DeviceControlCommandType::SetMqttBroker,
+                Value::Text("mqtts://broker.example.test:8883".to_string()),
+            ),
+            (
+                DeviceControlCommandType::SetHttpDomain,
+                Value::Text("telemetry.example.test".to_string()),
+            ),
         ] {
             let request = RuntimeCommandToolRequest::new(
                 EntityId::trusted("airgradient:ecda3b1eaaaf:configuration"),
@@ -2362,6 +2765,168 @@ mod tests {
             assert_eq!(integration.transport().calls, 2);
             assert_eq!(runtime.optimistic_state_count(), 0);
         }
+    }
+
+    #[test]
+    fn exact_custom_egress_destinations_are_consented_and_verified_over_real_tcp() {
+        let payloads = [
+            MEASUREMENTS,
+            CONFIG_CUSTOM_EGRESS_DISABLED,
+            CONFIG_CUSTOM_EGRESS_DISABLED,
+            "{}",
+            CONFIG_MQTT_ENABLED,
+            CONFIG_MQTT_ENABLED,
+            "{}",
+            CONFIG_CUSTOM_EGRESS_ENABLED,
+        ]
+        .into_iter()
+        .map(response)
+        .collect();
+        let (port, requests, handle) = start_server(payloads);
+        let client =
+            AirGradientClient::new(config(port), AirGradientLanTransport::default()).unwrap();
+        let principal = AgentId::trusted("agent:airgradient-custom-egress");
+        let configuration = EntityId::trusted("airgradient:ecda3b1eaaaf:configuration");
+        let mut integration = AirGradientRuntimeIntegration::new(client)
+            .with_data_governance(custom_egress_policy(&principal, &configuration));
+        let mut runtime = SmartHomeRuntime::new();
+        grant(&mut runtime, &principal);
+        integration
+            .inspect_and_install_authorized(&mut runtime, principal.clone(), 5_000)
+            .unwrap();
+
+        for (command_type, arguments) in [
+            (
+                DeviceControlCommandType::SetMqttBroker,
+                Value::Text("mqtts://broker.example.test:8883".to_string()),
+            ),
+            (
+                DeviceControlCommandType::SetHttpDomain,
+                Value::Text("telemetry.example.test".to_string()),
+            ),
+        ] {
+            integration
+                .dispatch_command_authorized(
+                    &mut runtime,
+                    principal.clone(),
+                    RuntimeCommandToolRequest::new(
+                        configuration.clone(),
+                        CommandType::DeviceControl(command_type),
+                        arguments,
+                    ),
+                    6_000,
+                )
+                .unwrap();
+        }
+
+        handle.join().unwrap();
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 8);
+        assert!(requests[3].contains(r#"{"mqttBrokerUrl":"mqtts://broker.example.test:8883"}"#));
+        assert!(requests[6].contains(r#"{"httpDomain":"telemetry.example.test"}"#));
+        let state = runtime
+            .registry()
+            .entity(&configuration)
+            .unwrap()
+            .state
+            .as_ref()
+            .unwrap();
+        assert!(matches!(
+            &state.value,
+            Value::Object(fields)
+                if fields.contains(&("mqtt_broker_configured".to_string(), Value::Bool(true)))
+                    && fields.contains(&("custom_http_domain_configured".to_string(), Value::Bool(true)))
+                    && !format!("{fields:?}").contains("broker.example.test")
+                    && !format!("{fields:?}").contains("telemetry.example.test")
+        ));
+    }
+
+    #[test]
+    fn custom_egress_shutdown_is_privacy_protective_and_redacts_existing_credentials() {
+        let payloads = [
+            MEASUREMENTS,
+            CONFIG_EXISTING_CREDENTIALED_EGRESS,
+            CONFIG_EXISTING_CREDENTIALED_EGRESS,
+            "{}",
+            CONFIG_MQTT_DISABLED_HTTP_ENABLED,
+            CONFIG_MQTT_DISABLED_HTTP_ENABLED,
+            "{}",
+            CONFIG_CUSTOM_EGRESS_DISABLED,
+        ]
+        .into_iter()
+        .map(response)
+        .collect();
+        let (port, requests, handle) = start_server(payloads);
+        let client =
+            AirGradientClient::new(config(port), AirGradientLanTransport::default()).unwrap();
+        let principal = AgentId::trusted("agent:airgradient-disable-custom-egress");
+        let configuration = EntityId::trusted("airgradient:ecda3b1eaaaf:configuration");
+        let mut integration = AirGradientRuntimeIntegration::new(client);
+        let mut runtime = SmartHomeRuntime::new();
+        grant(&mut runtime, &principal);
+        integration
+            .inspect_and_install_authorized(&mut runtime, principal.clone(), 5_000)
+            .unwrap();
+        let installed_state = runtime
+            .registry()
+            .entity(&configuration)
+            .unwrap()
+            .state
+            .as_ref()
+            .unwrap();
+        assert!(!format!("{installed_state:?}").contains("device-secret"));
+
+        for command_type in [
+            DeviceControlCommandType::SetMqttBroker,
+            DeviceControlCommandType::SetHttpDomain,
+        ] {
+            integration
+                .dispatch_command_authorized(
+                    &mut runtime,
+                    principal.clone(),
+                    RuntimeCommandToolRequest::new(
+                        configuration.clone(),
+                        CommandType::DeviceControl(command_type),
+                        Value::Null,
+                    ),
+                    6_000,
+                )
+                .unwrap();
+        }
+
+        handle.join().unwrap();
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 8);
+        assert!(requests[3].contains(r#"{"mqttBrokerUrl":""}"#));
+        assert!(requests[6].contains(r#"{"httpDomain":""}"#));
+        assert!(requests
+            .iter()
+            .all(|request| !request.contains("device-secret")));
+    }
+
+    #[test]
+    fn custom_egress_inputs_are_strict_and_credential_free() {
+        for destination in [
+            "mqtts://broker.example.test",
+            "mqtts://user:secret@broker.example.test:8883",
+            "mqtts://broker.example.test:8883/topic",
+            "https://broker.example.test:8883",
+        ] {
+            assert!(AirGradientMqttDestination::new(destination).is_err());
+        }
+        for domain in [
+            "localhost",
+            "https://telemetry.example.test",
+            "-bad.example",
+        ] {
+            assert!(AirGradientHttpDomain::new(domain).is_err());
+        }
+        let parsed = parse_configuration(
+            &serde_json::from_str::<JsonValue>(CONFIG_EXISTING_CREDENTIALED_EGRESS).unwrap(),
+        )
+        .unwrap();
+        assert!(parsed.mqtt_broker_uri.is_some());
+        assert!(!format!("{parsed:?}").contains("device-secret"));
     }
 
     #[test]

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Add human-approved MQTT-broker and custom-HTTP-domain device configuration
+  commands for integrations that enforce exact host-owned egress consent.
 - Add human-approved country and telemetry-upload device configuration commands
   for integrations that enforce a separate host-owned data-governance policy.
 - Add a reusable `camera.ptz` capability plus typed preset-recall and bounded

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1341,6 +1341,8 @@ pub enum DeviceControlCommandType {
     SetCorrectionProfile,
     SetCountry,
     SetCloudUpload,
+    SetMqttBroker,
+    SetHttpDomain,
     SetCameraRecording,
     RecallCameraPtzPreset,
     MoveCameraPtz,
@@ -1394,7 +1396,9 @@ impl DeviceControlCommandType {
             | Self::SetCompensatedDisplay
             | Self::SetCorrectionProfile
             | Self::SetCountry
-            | Self::SetCloudUpload => CapabilityId::trusted("device.configuration"),
+            | Self::SetCloudUpload
+            | Self::SetMqttBroker
+            | Self::SetHttpDomain => CapabilityId::trusted("device.configuration"),
             Self::SetCameraRecording => CapabilityId::trusted("camera.recording"),
             Self::RecallCameraPtzPreset | Self::MoveCameraPtz => {
                 CapabilityId::trusted("camera.ptz")
@@ -1462,6 +1466,8 @@ pub fn tier_for_command(command_type: CommandType) -> PrivilegeTier {
         | CommandType::DeviceControl(DeviceControlCommandType::SetCorrectionProfile)
         | CommandType::DeviceControl(DeviceControlCommandType::SetCountry)
         | CommandType::DeviceControl(DeviceControlCommandType::SetCloudUpload)
+        | CommandType::DeviceControl(DeviceControlCommandType::SetMqttBroker)
+        | CommandType::DeviceControl(DeviceControlCommandType::SetHttpDomain)
         | CommandType::DeviceControl(DeviceControlCommandType::SetCameraRecording)
         | CommandType::DeviceControl(DeviceControlCommandType::RecallCameraPtzPreset)
         | CommandType::DeviceControl(DeviceControlCommandType::MoveCameraPtz) => {

--- a/code/packages/rust/smart-home-data-governance/CHANGELOG.md
+++ b/code/packages/rust/smart-home-data-governance/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.0
+
+- Add exact credential-free MQTT broker destinations for telemetry start/stop
+  policy, requiring an explicit port and rejecting userinfo, paths, queries,
+  fragments, and unsupported schemes.
+- Redact MQTT broker identities from policy debug output and preserve
+  privacy-protective shutdown semantics.
+
 ## 0.1.0
 
 - Add a bounded, deny-by-default data-governance policy for coarse-location

--- a/code/packages/rust/smart-home-data-governance/Cargo.toml
+++ b/code/packages/rust/smart-home-data-governance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smart-home-data-governance"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Bounded host-owned privacy, consent, and telemetry-egress policy for D23 smart-home integrations"
 license = "MIT"

--- a/code/packages/rust/smart-home-data-governance/README.md
+++ b/code/packages/rust/smart-home-data-governance/README.md
@@ -10,14 +10,15 @@ policy for a decision before transport I/O; model-facing command arguments
 cannot create or widen grants.
 
 The initial categories cover coarse country configuration and environmental
-telemetry. Destinations are either the local device or an exact validated HTTPS
-origin. Telemetry shutdown is always allowed as a privacy-protective operation,
-but the ordinary D23 command authorization layer may still require human
-approval for the device mutation.
+telemetry. Destinations are the local device, an exact validated HTTPS origin,
+or a credential-free `mqtt://` or `mqtts://` broker URI with an explicit port.
+Telemetry shutdown is always allowed as a privacy-protective operation, but the
+ordinary D23 command authorization layer may still require human approval for
+the device mutation.
 
-Consent references and purpose text stay private to the policy and are redacted
-from `Debug`. Decision records expose only inert enums and whether a matching
-grant existed.
+Consent references, purpose text, HTTPS origins, and MQTT broker identities stay
+private to the policy and are redacted from `Debug`. Decision records expose
+only inert enums and whether a matching grant existed.
 
 ```bash
 bash BUILD

--- a/code/packages/rust/smart-home-data-governance/src/lib.rs
+++ b/code/packages/rust/smart-home-data-governance/src/lib.rs
@@ -28,6 +28,7 @@ pub enum DataOperation {
 pub enum DataDestination {
     LocalDevice,
     HttpsOrigin(String),
+    MqttBroker(String),
 }
 
 impl fmt::Debug for DataDestination {
@@ -35,6 +36,7 @@ impl fmt::Debug for DataDestination {
         match self {
             Self::LocalDevice => formatter.write_str("LocalDevice"),
             Self::HttpsOrigin(_) => formatter.write_str("HttpsOrigin([REDACTED])"),
+            Self::MqttBroker(_) => formatter.write_str("MqttBroker([REDACTED])"),
         }
     }
 }
@@ -56,10 +58,28 @@ impl DataDestination {
         Ok(Self::HttpsOrigin(origin.trim_end_matches('/').to_string()))
     }
 
+    pub fn mqtt_broker(uri: impl Into<String>) -> Result<Self, DataGovernanceError> {
+        let uri = uri.into();
+        let parsed = Url::parse(&uri).map_err(|_| DataGovernanceError::InvalidDestination)?;
+        if !matches!(parsed.scheme.as_str(), "mqtt" | "mqtts")
+            || parsed.host.is_none()
+            || parsed.port.is_none()
+            || parsed.userinfo.is_some()
+            || parsed.query.is_some()
+            || parsed.fragment.is_some()
+            || !matches!(parsed.path.as_str(), "" | "/")
+            || has_unsafe_text(&uri)
+        {
+            return Err(DataGovernanceError::InvalidDestination);
+        }
+        Ok(Self::MqttBroker(uri.trim_end_matches('/').to_string()))
+    }
+
     pub fn kind(&self) -> DataDestinationKind {
         match self {
             Self::LocalDevice => DataDestinationKind::LocalDevice,
             Self::HttpsOrigin(_) => DataDestinationKind::HttpsOrigin,
+            Self::MqttBroker(_) => DataDestinationKind::MqttBroker,
         }
     }
 }
@@ -68,6 +88,7 @@ impl DataDestination {
 pub enum DataDestinationKind {
     LocalDevice,
     HttpsOrigin,
+    MqttBroker,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -328,16 +349,13 @@ fn has_unsafe_text(value: &str) -> bool {
     value.chars().any(char::is_control)
 }
 
-fn operation_destination_is_valid(
-    operation: DataOperation,
-    destination: &DataDestination,
-) -> bool {
+fn operation_destination_is_valid(operation: DataOperation, destination: &DataDestination) -> bool {
     matches!(
         (operation, destination),
         (DataOperation::Configure, DataDestination::LocalDevice)
             | (
                 DataOperation::StartEgress | DataOperation::StopEgress,
-                DataDestination::HttpsOrigin(_)
+                DataDestination::HttpsOrigin(_) | DataDestination::MqttBroker(_)
             )
     )
 }
@@ -352,6 +370,10 @@ mod tests {
 
     fn cloud() -> DataDestination {
         DataDestination::https_origin("https://api.airgradient.com").unwrap()
+    }
+
+    fn mqtt() -> DataDestination {
+        DataDestination::mqtt_broker("mqtts://broker.example.test:8883").unwrap()
     }
 
     fn grant() -> DataUseGrant {
@@ -487,6 +509,61 @@ mod tests {
         assert_eq!(
             DataPurpose::new("line\tbreak"),
             Err(DataGovernanceError::InvalidPurpose)
+        );
+        for destination in [
+            "mqtts://broker.example.test",
+            "mqtts://user:secret@broker.example.test:8883",
+            "mqtts://broker.example.test:8883/topic",
+            "http://broker.example.test:8883",
+        ] {
+            assert_eq!(
+                DataDestination::mqtt_broker(destination),
+                Err(DataGovernanceError::InvalidDestination)
+            );
+        }
+        assert!(!format!("{:?}", mqtt()).contains("broker.example.test"));
+    }
+
+    #[test]
+    fn mqtt_grants_are_exact_and_stop_is_privacy_protective() {
+        let principal = principal();
+        let mut policy = DataGovernancePolicy::default();
+        policy
+            .add_grant(
+                DataUseGrant::new(
+                    principal.clone(),
+                    "airgradient:monitor:configuration",
+                    DataCategory::EnvironmentalTelemetry,
+                    DataOperation::StartEgress,
+                    mqtt(),
+                    DataPurpose::new("operator-selected MQTT telemetry route").unwrap(),
+                    ConsentReceiptRef::new("consent://smart-home/mqtt-1").unwrap(),
+                    100,
+                    200,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        assert!(policy
+            .decide(&DataUseRequest {
+                principal_id: &principal,
+                resource_id: "airgradient:monitor:configuration",
+                category: DataCategory::EnvironmentalTelemetry,
+                operation: DataOperation::StartEgress,
+                destination: mqtt(),
+                now_ms: 150,
+            })
+            .is_allowed());
+        assert_eq!(
+            policy.decide(&DataUseRequest {
+                principal_id: &principal,
+                resource_id: "airgradient:monitor:configuration",
+                category: DataCategory::EnvironmentalTelemetry,
+                operation: DataOperation::StopEgress,
+                destination: mqtt(),
+                now_ms: 250,
+            }),
+            DataGovernanceDecision::Allow(DataGovernanceAllowance::PrivacyProtective)
         );
     }
 }

--- a/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
+++ b/code/packages/rust/smart-home-integration-catalog/CHANGELOG.md
@@ -35,6 +35,8 @@
 
 ## Unreleased
 
+- Record AirGradient's exact-consent, readback-verified credential-free MQTT
+  broker and coupled custom HTTPS-domain controls.
 - Add the reusable data-governance primitive family and require it for
   AirGradient country and vendor-cloud upload controls.
 - Upgraded HEOS runtime coverage with D23-authorized local playback, volume,

--- a/code/packages/rust/smart-home-integration-catalog/src/lib.rs
+++ b/code/packages/rust/smart-home-integration-catalog/src/lib.rs
@@ -45564,7 +45564,7 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
         base_entry(
             "airgradient",
             "AirGradient",
-            "Local AirGradient telemetry, indicator/display control, calibration, and typed non-credential configuration.",
+            "Local AirGradient telemetry, indicator/display control, calibration, typed configuration, and consent-bound custom egress.",
             IntegrationCategory::EnergyClimate,
             ConnectivityClass::LocalPolling,
             ImplementationStatus::FirstPartyRuntime,
@@ -45594,7 +45594,8 @@ pub fn first_party_catalog() -> Vec<IntegrationCatalogEntry> {
             "Cloud-only configuration is rejected locally; dual local/cloud control returns an explicit overwrite warning.",
             "Country and vendor-cloud upload controls require human approval; country and upload enablement also require an exact host-owned consent grant before transport I/O.",
             "Typed local settings validate documented ranges and sensor-specific correction algorithms before transport I/O.",
-            "Credential-bearing MQTT and custom HTTP destinations remain blocked on Vault leasing and destination policy.",
+            "Credential-free MQTT and coupled custom HTTPS destinations require exact consent before transport and native readback after mutation; shutdown remains privacy-protective.",
+            "Credential-bearing MQTT remains blocked because current upstream firmware logs parsed credentials; command input rejects userinfo.",
         ]),
         energy_entry(
             "tesla_powerwall",

--- a/code/packages/rust/smart-home-platform-http/CHANGELOG.md
+++ b/code/packages/rust/smart-home-platform-http/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Add stable local API labels for MQTT-broker and custom-HTTP-domain commands.
 - Add stable local API labels for country and cloud-upload configuration.
 - Add the stable `camera_set_recording` local API command label.
 - Add stable local API labels for typed device-configuration commands.

--- a/code/packages/rust/smart-home-platform-http/src/lib.rs
+++ b/code/packages/rust/smart-home-platform-http/src/lib.rs
@@ -10306,6 +10306,12 @@ fn command_type_label(command_type: CommandType) -> &'static str {
         CommandType::DeviceControl(DeviceControlCommandType::SetCloudUpload) => {
             "device_set_cloud_upload"
         }
+        CommandType::DeviceControl(DeviceControlCommandType::SetMqttBroker) => {
+            "device_set_mqtt_broker"
+        }
+        CommandType::DeviceControl(DeviceControlCommandType::SetHttpDomain) => {
+            "device_set_http_domain"
+        }
         CommandType::DeviceControl(DeviceControlCommandType::SetCameraRecording) => {
             "camera_set_recording"
         }
@@ -10374,6 +10380,12 @@ fn command_type_from_label(command_type: &str) -> Result<CommandType, ApiError> 
         )),
         "device_set_cloud_upload" => Ok(CommandType::DeviceControl(
             DeviceControlCommandType::SetCloudUpload,
+        )),
+        "device_set_mqtt_broker" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetMqttBroker,
+        )),
+        "device_set_http_domain" => Ok(CommandType::DeviceControl(
+            DeviceControlCommandType::SetHttpDomain,
         )),
         "camera_set_recording" => Ok(CommandType::DeviceControl(
             DeviceControlCommandType::SetCameraRecording,
@@ -13913,6 +13925,14 @@ mod tests {
             (
                 "device_set_cloud_upload",
                 DeviceControlCommandType::SetCloudUpload,
+            ),
+            (
+                "device_set_mqtt_broker",
+                DeviceControlCommandType::SetMqttBroker,
+            ),
+            (
+                "device_set_http_domain",
+                DeviceControlCommandType::SetHttpDomain,
             ),
             (
                 "camera_set_recording",

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Keep MQTT-broker and custom-HTTP-domain configuration commands non-optimistic
+  until a native integration confirms exact device readback.
 - Keep country and cloud-upload configuration commands non-optimistic until a
   native integration confirms device readback.
 - Keep camera recording changes non-optimistic until a native integration

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -6480,6 +6480,8 @@ fn optimistic_snapshot_for_command(command: &DeviceCommand, now_ms: u64) -> Opti
             | DeviceControlCommandType::SetCorrectionProfile
             | DeviceControlCommandType::SetCountry
             | DeviceControlCommandType::SetCloudUpload
+            | DeviceControlCommandType::SetMqttBroker
+            | DeviceControlCommandType::SetHttpDomain
             | DeviceControlCommandType::SetCameraRecording
             | DeviceControlCommandType::RecallCameraPtzPreset
             | DeviceControlCommandType::MoveCameraPtz,

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1131,111 +1131,143 @@ prerequisite for AirGradient's documented country and vendor-cloud controls:
 - Local HTTP request-plan debug output now reports only body length, preventing
   country or future configuration bodies from leaking through derived debug.
 
+## Current AirGradient Custom Egress Slice
+
+This slice closes the safely executable part of AirGradient's documented MQTT
+broker and custom HTTP routing surface:
+
+- D23 adds human-approved `device_set_mqtt_broker` and
+  `device_set_http_domain` contracts. The runtime keeps both non-optimistic
+  until exact native readback.
+- MQTT command values accept only credential-free `mqtt://` or `mqtts://`
+  broker URIs with an explicit port. Custom HTTP routing accepts only a fully
+  qualified DNS name and is governed as its exact HTTPS origin.
+- Enabling either route requires an active environmental-telemetry grant bound
+  to the exact principal, configuration entity, operation, and destination
+  before any device I/O. Disabling an existing route remains
+  privacy-protective without a consent grant.
+- The production local HTTP transport performs the documented `PUT /config`
+  mutation and exact `GET /config` readback. Tests prove consent denial before
+  transport, while real loopback tests prove wire shapes and verified
+  enable/disable flows.
+- Normalized state exposes only whether MQTT and custom HTTP routing are
+  configured. Destination identities and pre-existing MQTT userinfo are
+  redacted from debug and never enter normalized state.
+- AirGradient's `httpDomain` applies to telemetry, remote configuration, and OTA
+  together; this slice treats the coupled HTTPS origin as one governed route.
+- Credential-bearing MQTT remains blocked: current upstream firmware logs the
+  parsed username and password, so host-side Vault leasing cannot prevent the
+  device-side disclosure. Command input rejects MQTT userinfo.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
-1. Add AirGradient MQTT broker and custom HTTP routing settings only after
-   credential-bearing values use Vault leasing and destination validation.
-2. Add authenticated HEOS source browsing and queue insertion only after the
+1. Add authenticated AirGradient MQTT only after official firmware removes
+   plaintext credential logging and one-shot Vault-leased credential injection
+   can be proven without request-plan or normalized-state exposure.
+2. Add independent AirGradient telemetry, remote-configuration, and OTA
+   destinations only if firmware exposes separate settings; the current
+   `httpDomain` contract intentionally governs all three as one HTTPS origin.
+3. Add authenticated HEOS source browsing and queue insertion only after the
    account/session and Vault-leasing prerequisites are concrete.
-3. Automate Enphase access-token acquisition or renewal only after Enphase
+4. Automate Enphase access-token acquisition or renewal only after Enphase
    account authentication, cloud-session handling, operator consent, and
    Vault-leased credential policy are concrete; the current host accepts a
    pre-generated token.
-4. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
+5. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
    stable LAN advertisement; the current production path uses explicit local
    HTTPS endpoint and gateway-serial configuration.
-5. Add Enphase per-inverter production inspection only after device-identifier
+6. Add Enphase per-inverter production inspection only after device-identifier
    privacy, purpose, and retention policy are concrete because the native
    response exposes every microinverter serial number.
-6. Add Enphase live battery, relay, generator, grid, and system-topology state
+7. Add Enphase live battery, relay, generator, grid, and system-topology state
    only after the normalized energy topology and retention semantics are
    concrete.
-7. Add Enphase relay, grid-services, or configuration controls only with
+8. Add Enphase relay, grid-services, or configuration controls only with
    operation-specific D23 contracts, explicit safety approval, bounded native
    semantics, and readable postcondition verification.
-8. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
+9. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
    supervised session lifecycle and Vault policy for refresh-token residency are
    concrete; the current isolated inspection drops both tokens after each read.
-9. Add ZoneMinder event push only after a concrete authenticated event host and
+10. Add ZoneMinder event push only after a concrete authenticated event host and
     supervised subscription lifecycle exist.
-10. Add ZoneMinder snapshots, streams, recordings, export, and playback only
+11. Add ZoneMinder snapshots, streams, recordings, export, and playback only
     through the camera-media lease and a concrete media executor.
-11. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
+12. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
     mutations only with operation-specific D23 contracts, least-privilege user
     checks, bounded semantics, and readable postcondition verification.
-12. Add UniFi Network connected-client inspection only after privacy, presence,
+13. Add UniFi Network connected-client inspection only after privacy, presence,
    identifier-retention, and operator-purpose policy are concrete.
-13. Add UniFi Network latest device statistics only after metrics schema,
+14. Add UniFi Network latest device statistics only after metrics schema,
    retention, and bounded polling-load policy are concrete.
-14. Add remote UniFi Site Manager inspection only after telemetry-egress,
+15. Add remote UniFi Site Manager inspection only after telemetry-egress,
    destination, and operator-consent policy are concrete; keep the current host
    local-only.
-15. Add UniFi Network push or change events only after a concrete authenticated
+16. Add UniFi Network push or change events only after a concrete authenticated
    event host and supervised subscription lifecycle exist.
-16. Add UniFi adoption, guest authorization, port actions, or configuration
+17. Add UniFi adoption, guest authorization, port actions, or configuration
    mutations only with operation-specific D23 contracts, least-privilege API
    keys, bounded semantics, and readable postcondition verification.
-17. Add Synology Surveillance Station OTP and remembered-device authentication
+18. Add Synology Surveillance Station OTP and remembered-device authentication
    only after an interactive challenge lifecycle and Vault-leased device-token
    policy are concrete.
-18. Add Synology Surveillance Station events only after a concrete authenticated
+19. Add Synology Surveillance Station events only after a concrete authenticated
    event host and supervised subscription lifecycle exist.
-19. Add Synology Surveillance Station snapshots, recordings, export, and
+20. Add Synology Surveillance Station snapshots, recordings, export, and
    playback only through the camera-media lease and a concrete executor.
-20. Add Synology Surveillance Station PTZ, external recording, or configuration
+21. Add Synology Surveillance Station PTZ, external recording, or configuration
    mutations only with operation-specific D23 contracts, least-privilege API
    checks, bounded semantics, and readable postcondition verification.
-21. Add Frigate event and review push only after a concrete authenticated event
+22. Add Frigate event and review push only after a concrete authenticated event
    or WebSocket host and supervised subscription lifecycle exist.
-22. Add Frigate snapshots, recordings, export, and playback only through the
+23. Add Frigate snapshots, recordings, export, and playback only through the
    camera-media lease and a concrete executor.
-23. Add Frigate commands or configuration mutations only with operation-specific
+24. Add Frigate commands or configuration mutations only with operation-specific
    D23 contracts, least-privilege role checks, and readable postcondition
    verification.
-24. Add Blue Iris snapshots, alert/clip search, export, and playback only through
+25. Add Blue Iris snapshots, alert/clip search, export, and playback only through
    the camera-media lease and a concrete media executor.
-25. Add broader Blue Iris `camconfig` or administrative mutations only with
+26. Add broader Blue Iris `camconfig` or administrative mutations only with
    operation-specific D23 contracts, least-privilege permissions, and readable
    postcondition verification; do not persist the license value returned at
    login.
-26. Add automatic Blue Iris discovery only if the server exposes a documented,
+27. Add automatic Blue Iris discovery only if the server exposes a documented,
    stable LAN advertisement; the current production path is explicit local
    HTTPS endpoint configuration.
-27. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
+28. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
    controls only when each operation has a specific native capability probe,
    bounded semantics, and readable verification where the device exposes it.
-28. Add Axis event streaming only after the existing WebSocket protocol core has
+29. Add Axis event streaming only after the existing WebSocket protocol core has
    a concrete authenticated host using the completed Digest primitive or a
    short-lived session token, plus subscription supervision.
-29. Add Axis snapshots and media transfer only through the camera-media lease and
+30. Add Axis snapshots and media transfer only through the camera-media lease and
    a concrete media executor.
-30. Enumerate Axis video sources/channels before extending PTZ beyond the current
+31. Enumerate Axis video sources/channels before extending PTZ beyond the current
    capability-probed VAPIX camera 1 boundary.
-31. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
+32. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
    only when each operation has a specific capability probe and readable state.
-32. Add Reolink snapshot, recording search/download, and playback operations only
+33. Add Reolink snapshot, recording search/download, and playback operations only
    through the existing camera-media lease and a concrete media executor.
-33. Add Reolink current-position, zoom, guard-point, or patrol controls only when
+34. Add Reolink current-position, zoom, guard-point, or patrol controls only when
    each operation has a capability-specific probe and the firmware exposes the
    native state needed to avoid invented orientation claims.
-34. Add Reolink push events only after a concrete webhook or event-stream host
+35. Add Reolink push events only after a concrete webhook or event-stream host
    and subscription lifecycle exist.
-35. Add authenticated KLAP/Tapo devices and other broader-device families only
+36. Add authenticated KLAP/Tapo devices and other broader-device families only
    after their authentication and session prerequisites are concrete.
-36. Add ONVIF PullPoint events once a concrete event host and subscription
+37. Add ONVIF PullPoint events once a concrete event host and subscription
    lifecycle exist.
-37. Add RTSP media transfer and recording once concrete media transfer and
+38. Add RTSP media transfer and recording once concrete media transfer and
    recorder host primitives exist.
-38. Add a production Matter commissioning, secure-session, and network host only
+39. Add a production Matter commissioning, secure-session, and network host only
    after certificate, fabric, Interaction Model encoding, subscription, and
    transport prerequisites exist.
-39. Add a Thread border-router host only after an actual host transport exists.
-40. Add a production Zigbee coordinator, join, and security host only after
+40. Add a Thread border-router host only after an actual host transport exists.
+41. Add a production Zigbee coordinator, join, and security host only after
    concrete coordinator transport and security primitives exist.
-41. Add production Z-Wave inclusion and S2 only after concrete host transport
+42. Add production Z-Wave inclusion and S2 only after concrete host transport
    and security primitives exist.
 
 ## End-To-End Definition


### PR DESCRIPTION
## Summary

- add D23 human-approved AirGradient MQTT broker and custom HTTP-domain controls with exact native readback
- extend host-owned data governance with strict credential-free MQTT destinations and exact consent-bound egress decisions
- keep destination identities and pre-existing MQTT userinfo out of normalized state and debug output, while permitting privacy-protective shutdown
- document the coupled telemetry/configuration/OTA HTTPS route and retain authenticated MQTT as a prerequisite block because current upstream firmware logs parsed credentials
- reprioritize the Smart Home remaining-work inventory with the concrete follow-ups discovered in this slice

## Validation

- `cargo test -p smart-home-airgradient-local-integration -p smart-home-data-governance -p smart-home-core -p smart-home-runtime -p chief-of-staff-smart-home-tools -p smart-home-platform-http -p smart-home-integration-catalog --no-fail-fast`
- `cargo clippy -p smart-home-airgradient-local-integration -p smart-home-data-governance -p smart-home-core -p smart-home-runtime -p chief-of-staff-smart-home-tools -p smart-home-platform-http -p smart-home-integration-catalog --all-targets -- -D warnings`
- every impacted package `BUILD` script under `code/packages/rust`
- post-rebase: focused AirGradient/data-governance tests and strict Clippy
- `git diff --check`