### PR TITLE
Lower JFET BET model alias

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lower the JFET `BET` transconductance alias with canonical `BETA` precedence.
 - Normalize hyphens in supported model-card parameter aliases.
 - Normalize hyphen and underscore separators in supported model type aliases.
 - Normalize the `PCH` model type alias to canonical `PMOS` cards.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1373,7 +1373,9 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             fields[2],
             fields[3],
             polarity=model.kind,
-            beta=model.params.get("BETA", model.params.get("B", 1.0e-4)),
+            beta=model.params.get(
+                "BETA", model.params.get("BET", model.params.get("B", 1.0e-4))
+            ),
             vto=model.params.get("VTO", -2.0 if model.kind == "NJF" else 2.0),
             lambda_=model.params.get("LAMBDA", 0.0),
             Cgs=model.params.get("CGS", model.params.get("CGS0", 0.0)),

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2119,6 +2119,21 @@ def test_parse_nj_model_type_alias() -> None:
     assert jfet.beta == 2.0e-3
 
 
+def test_parse_jfet_bet_alias_with_canonical_precedence() -> None:
+    parsed = parse_netlist(
+        ".model canonical NJF(BETA=2m BET=1m B=500u)\n"
+        ".model aliased NJF(BET=900u)\n"
+        "J1 drain gate source canonical\n"
+        "J2 drain gate source aliased"
+    )
+
+    canonical, aliased = parsed.circuit.elements
+    assert isinstance(canonical, JFET)
+    assert canonical.beta == 2.0e-3
+    assert isinstance(aliased, JFET)
+    assert aliased.beta == 900.0e-6
+
+
 def test_parse_pjfet_model_type_alias() -> None:
     parsed = parse_netlist(
         ".model fast PJFET(BETA=2m)\nJ1 drain gate source fast"

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lower the JFET `BET` transconductance alias with canonical `BETA` precedence.
 - Normalize hyphens in supported model-card parameter aliases.
 - Normalize hyphen and underscore separators in supported model type aliases.
 - Normalize the `PCH` model type alias to canonical `PMOS` cards.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -2431,7 +2431,10 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       fields[2],
       fields[3],
       polarity,
-      model.params.get("BETA") ?? model.params.get("B") ?? 1.0e-4,
+      model.params.get("BETA") ??
+        model.params.get("BET") ??
+        model.params.get("B") ??
+        1.0e-4,
       model.params.get("VTO") ?? (polarity === "NJF" ? -2.0 : 2.0),
       model.params.get("LAMBDA") ?? 0.0,
       model.params.get("CGS") ?? model.params.get("CGS0") ?? 0.0,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2197,6 +2197,24 @@ J1 drain gate source fast
     });
   });
 
+  it("parses the JFET BET alias with canonical precedence", () => {
+    const parsed = parseNetlist(
+      ".model canonical NJF(BETA=2m BET=1m B=500u)\n" +
+        ".model aliased NJF(BET=900u)\n" +
+        "J1 drain gate source canonical\n" +
+        "J2 drain gate source aliased",
+    );
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      beta: 2.0e-3,
+    });
+    expect(parsed.circuit.elements()[1]).toMatchObject({
+      kind: "jfet",
+      beta: 900.0e-6,
+    });
+  });
+
   it("parses the PJFET model type alias", () => {
     const parsed = parseNetlist(".model fast PJFET(BETA=2m)\nJ1 drain gate source fast");
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4774,11 +4774,17 @@ the Rust, Python, and TypeScript surfaces together.
      engine-tested `n-jfet` spelling, while preserving unknown model kinds.
 
 484. Python and TypeScript Berkeley SPICE model-parameter separator normalization parity.
-   - Status: implemented in this model-parameter separator normalization slice.
+   - Status: completed in PR 10172.
    - Both parser facades mirror the engine parameter-key contract by converting
      hyphens to underscores in `.model` parameter names, preserving existing
      validation, alias precedence, and lowering for spellings such as
      `BETA-F` and `T-NOM`.
+
+485. Python and TypeScript Berkeley SPICE JFET `BET` beta-alias parity.
+   - Status: implemented in this JFET `BET` alias slice.
+   - Both parser facades lower the engine-advertised `BET` alias into the JFET
+     transconductance field with canonical `BETA` precedence, while preserving
+     the unresolved legacy `B` beta-alias versus doping-tail policy collision.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- lower the engine-advertised JFET `BET` alias into the transconductance field in both parser facades
- preserve canonical `BETA` precedence and leave the unresolved legacy `B` doping-tail collision unchanged
- reconcile the completed model-parameter separator slice in the SPICE plan

## Verification

- Python parser `bash BUILD` (`644 passed`, 90.60% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (`629 passed`)
- TypeScript parser `npx vitest run --coverage` (88.38% line coverage)
- TypeScript engine `bash BUILD` (`448 passed`)
- `git diff --check`
- BUILD and dependency manifest audit (no changes required)
