### PR TITLE
Persist authorized Chief pipeline launch bindings

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -766,6 +766,7 @@ members = [
     "chief-of-staff-secure-host-channel",
     "chief-of-staff-host-control-protocol",
     "chief-of-staff-service-registry",
+    "chief-of-staff-pipeline-bindings",
     "chief-of-staff-service-reconciler",
     "chief-of-staff-process-supervisor",
     "chief-of-staff-orchestrator-core",

--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-- Compose a fail-closed host launch-binding provider until durable pipeline
-  wiring is connected; hosts cannot start with ambient or invented bindings.
+- Compose the storage-backed durable pipeline launch-binding provider. Host
+  starts now require an exact registered package plus current immutable channel
+  claims, active membership, and bounded persisted model settings.
 
 ## 0.1.0 - 2026-08-03
 

--- a/code/packages/rust/chief-of-staff-daemon/README.md
+++ b/code/packages/rust/chief-of-staff-daemon/README.md
@@ -23,7 +23,9 @@ exist. The daemon creates or initializes the configured state directory, binds
 only the loopback address accepted by `chief-of-staff-daemon-config`, performs
 one reconciliation before serving, and then reconciles at the configured health
 interval. Channel topology mutation remains denied until the Trust Checker is
-implemented.
+implemented. Host launch bindings come only from the shared durable pipeline
+binding store; absent, stale, destroyed, directionally unauthorized, or
+cross-pipeline records fail before process creation.
 
 SIGINT, SIGTERM, Ctrl+C, Ctrl+Break, console close, logoff, and system shutdown
 request a cooperative listener stop. Dropping the composed process supervisor

--- a/code/packages/rust/chief-of-staff-daemon/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon/src/lib.rs
@@ -11,7 +11,7 @@ use chief_of_staff_daemon_policy::{DenyChannelWiring, LocalAuthError, LocalBeare
 use chief_of_staff_daemon_runtime::{ChiefDaemonRuntime, DaemonRuntimeError, ReconcileSchedule};
 use chief_of_staff_orchestrator_core::OrchestratorCore;
 use chief_of_staff_process_supervisor::{
-    DenyHostLaunchBindings, HostProgram, ProcessSupervisorConfig, ProcessSupervisorError,
+    DurableHostLaunchBindings, HostProgram, ProcessSupervisorConfig, ProcessSupervisorError,
     SystemMonotonicClock, UuidV7SessionIdSource,
 };
 use chief_of_staff_service_reconciler::{ConfigError as ReconcileConfigError, ReconcileConfig};
@@ -252,11 +252,12 @@ pub fn run(config: ChiefConfig, home: &Path) -> Result<(), ChiefDaemonError> {
             .map_err(ChiefDaemonError::Reconciliation)?;
     let schedule = ReconcileSchedule::new(interval).map_err(ChiefDaemonError::Runtime)?;
     let clock = Arc::new(SystemMonotonicClock::new());
+    let launch_bindings = Arc::new(DurableHostLaunchBindings::new(Arc::clone(&backend)));
     let core = OrchestratorCore::with_process_supervisor(
         backend,
         process_config,
         keyring,
-        Arc::new(DenyHostLaunchBindings),
+        launch_bindings,
         Arc::new(generate_identity_keypair()),
         clock,
         Box::new(UuidV7SessionIdSource),

--- a/code/packages/rust/chief-of-staff-pipeline-bindings/BUILD
+++ b/code/packages/rust/chief-of-staff-pipeline-bindings/BUILD
@@ -1,0 +1,1 @@
+cargo test -p chief-of-staff-pipeline-bindings -- --nocapture

--- a/code/packages/rust/chief-of-staff-pipeline-bindings/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-pipeline-bindings/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Add bounded versioned host-binding and immutable channel-claim records.
+- Require exact durable registration and current one-way channel membership
+  before wiring and again before every launch resolution.
+- Add create-if-absent wiring, revision-CAS replacement and unwiring, strict
+  corruption rejection, cross-pipeline isolation, and restart coverage.

--- a/code/packages/rust/chief-of-staff-pipeline-bindings/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-pipeline-bindings/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "chief-of-staff-pipeline-bindings"
+version = "0.1.0"
+edition = "2021"
+description = "Durable authorized pipeline launch bindings for D18 Chief hosts"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
+chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }
+chief-of-staff-host-control-protocol = { path = "../chief-of-staff-host-control-protocol" }
+chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }
+coding-adventures-json-value = { path = "../json-value" }
+storage-core = { path = "../storage-core" }
+
+[dev-dependencies]
+storage-local-folder = { path = "../storage-local-folder" }

--- a/code/packages/rust/chief-of-staff-pipeline-bindings/README.md
+++ b/code/packages/rust/chief-of-staff-pipeline-bindings/README.md
@@ -1,0 +1,27 @@
+# chief-of-staff-pipeline-bindings
+
+`chief-of-staff-pipeline-bindings` persists the manifest-blind launch authority
+needed by D18 Chief hosts. One record binds an exact durable host registration
+and package hash to a pipeline UUID, the pipeline's agent identity, canonical
+named channel UUIDs, and optional Level 1 model settings.
+
+Wiring fails closed unless the host is currently registered and every channel
+definition is active and authorizes that agent in the requested direction.
+Each channel UUID also receives an immutable create-if-absent pipeline claim, so
+the same durable channel can never be reused across isolated pipelines. Claims
+are intentionally retained after unwiring because channel definitions are
+irreversibly destroyed and UUIDs must never be recycled.
+
+Launch resolution repeats the registration, claim, lifecycle, and membership
+checks. A stale record therefore cannot authorize a replaced package, destroyed
+channel, changed topology, or cross-pipeline channel.
+Unwiring is revision-CAS guarded while the host record exists and idempotent
+after it is absent; immutable channel claims remain as non-authorizing audit state.
+
+## Validation
+
+```sh
+cargo test -p chief-of-staff-pipeline-bindings -- --nocapture
+cargo clippy -p chief-of-staff-pipeline-bindings --all-targets -- -D warnings
+cargo doc -p chief-of-staff-pipeline-bindings --no-deps
+```

--- a/code/packages/rust/chief-of-staff-pipeline-bindings/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-pipeline-bindings/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/chief-of-staff-pipeline-bindings",
+  "capabilities": [],
+  "justification": "Pure durable pipeline-binding and channel-authorization logic over an injected repository-owned StorageBackend. The package directly performs no filesystem, process, network, environment, clock, or random access."
+}

--- a/code/packages/rust/chief-of-staff-pipeline-bindings/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-pipeline-bindings/src/lib.rs
@@ -1,0 +1,957 @@
+//! Durable, manifest-blind launch authority for D18 Chief pipelines.
+//!
+//! Host records are revision-CAS protected and exact-package bound. Immutable
+//! channel claims prevent a UUID from crossing pipeline boundaries. Both wiring
+//! and launch resolution reload authoritative channel membership and fail closed.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_channel_crypto::wire::MAX_IDENTITY_BYTES;
+use chief_of_staff_channel_crypto::ChannelId;
+use chief_of_staff_channel_endpoints::{
+    AgentId, ChannelDefinition, ChannelDefinitionStore, ChannelEndpointError, ChannelLifecycle,
+};
+use chief_of_staff_host_control_protocol::{
+    ChannelBinding, ChannelBindingAccess, LaunchBindings, LevelOneModelBinding,
+    MAX_LAUNCH_CHANNEL_BINDINGS, MAX_LAUNCH_CHANNEL_NAME_BYTES, MAX_LAUNCH_MODEL_BYTES,
+};
+use chief_of_staff_service_registry::{
+    HostName, HostRegistration, PackagePath, RegistryError, RestartPolicy, ServiceRegistry,
+};
+use coding_adventures_json_value::JsonValue;
+use core::fmt::{self, Display, Formatter};
+use storage_core::{Revision, StorageBackend, StorageError, StoragePutInput, StorageRecord};
+
+const NAMESPACE: &str = "chief-pipeline-bindings";
+const HOST_PREFIX: &str = "hosts/";
+const CHANNEL_PREFIX: &str = "channels/";
+const HOST_CONTENT_TYPE: &str = "application/vnd.coding-adventures.chief-host-bindings-v1";
+const CLAIM_CONTENT_TYPE: &str = "application/vnd.coding-adventures.chief-channel-claim-v1";
+const HOST_MAGIC: &[u8; 4] = b"D18B";
+const CLAIM_MAGIC: &[u8; 4] = b"D18P";
+const VERSION: u8 = 1;
+const MAX_HOST_NAME_BYTES: usize = 64;
+const MAX_PACKAGE_PATH_BYTES: usize = 4096;
+const MAX_HOST_RECORD_BYTES: usize = 32 * 1024;
+const CLAIM_RECORD_BYTES: usize = 37;
+
+/// Canonical UUID-v7 identity for one isolated pipeline.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PipelineId([u8; 16]);
+
+impl PipelineId {
+    /// Validate and own one canonical UUID-v7 pipeline identity.
+    pub fn new(bytes: [u8; 16]) -> Result<Self, PipelineBindingError> {
+        if !is_uuid_v7(&bytes) {
+            return Err(PipelineBindingError::InvalidPipelineId);
+        }
+        Ok(Self(bytes))
+    }
+
+    /// Return the canonical 16-byte identity.
+    pub fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+}
+
+/// One exact host package's durable pipeline launch authority.
+#[derive(Clone, Debug, PartialEq)]
+pub struct HostPipelineBinding {
+    pipeline_id: PipelineId,
+    registration: HostRegistration,
+    agent_id: AgentId,
+    launch_bindings: LaunchBindings,
+}
+
+impl HostPipelineBinding {
+    /// Construct one already bounded binding record.
+    pub fn new(
+        pipeline_id: PipelineId,
+        registration: HostRegistration,
+        agent_id: AgentId,
+        launch_bindings: LaunchBindings,
+    ) -> Self {
+        Self {
+            pipeline_id,
+            registration,
+            agent_id,
+            launch_bindings,
+        }
+    }
+
+    /// Return the isolated pipeline identity.
+    pub fn pipeline_id(&self) -> PipelineId {
+        self.pipeline_id
+    }
+
+    /// Return the exact durable host registration.
+    pub fn registration(&self) -> &HostRegistration {
+        &self.registration
+    }
+
+    /// Return the channel-membership identity authorized by pipeline wiring.
+    pub fn agent_id(&self) -> &AgentId {
+        &self.agent_id
+    }
+
+    /// Return the canonical named channels and optional model settings.
+    pub fn launch_bindings(&self) -> &LaunchBindings {
+        &self.launch_bindings
+    }
+}
+
+/// One loaded host binding plus its storage revision.
+#[derive(Clone, Debug, PartialEq)]
+pub struct LoadedHostPipelineBinding {
+    binding: HostPipelineBinding,
+    revision: Revision,
+}
+
+impl LoadedHostPipelineBinding {
+    /// Borrow the decoded durable binding.
+    pub fn binding(&self) -> &HostPipelineBinding {
+        &self.binding
+    }
+
+    /// Borrow the revision required for replacement or unwiring.
+    pub fn revision(&self) -> &Revision {
+        &self.revision
+    }
+}
+
+/// Stable failure from durable pipeline binding storage or authorization.
+#[derive(Debug)]
+pub enum PipelineBindingError {
+    /// The injected storage backend failed.
+    Storage(StorageError),
+    /// The durable service registry failed validation or storage.
+    Registry(RegistryError),
+    /// Authoritative channel definition storage failed.
+    Channel(ChannelEndpointError),
+    /// A pipeline identity was not a canonical UUID v7.
+    InvalidPipelineId,
+    /// The host does not have a durable service registration.
+    HostNotRegistered,
+    /// The requested or loaded binding disagrees with durable registration.
+    RegistrationMismatch,
+    /// A referenced channel definition or immutable claim is absent.
+    ChannelUnavailable,
+    /// A channel is destroyed or does not authorize this agent and direction.
+    ChannelUnauthorized,
+    /// The channel UUID was already claimed by a different pipeline.
+    CrossPipelineChannel,
+    /// A different binding already exists for the same host name.
+    ConflictingHostBinding,
+    /// A revision-CAS replacement or unwiring lost a race.
+    ConcurrentUpdate,
+    /// A persisted record was malformed or inconsistent with its storage key.
+    CorruptRecord,
+}
+
+impl Display for PipelineBindingError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Storage(_) => "pipeline bindings: storage failure",
+            Self::Registry(_) => "pipeline bindings: registry failure",
+            Self::Channel(_) => "pipeline bindings: channel lookup failure",
+            Self::InvalidPipelineId => "pipeline bindings: invalid pipeline identity",
+            Self::HostNotRegistered => "pipeline bindings: host is not registered",
+            Self::RegistrationMismatch => "pipeline bindings: host registration mismatch",
+            Self::ChannelUnavailable => "pipeline bindings: channel unavailable",
+            Self::ChannelUnauthorized => "pipeline bindings: channel direction unauthorized",
+            Self::CrossPipelineChannel => "pipeline bindings: channel belongs to another pipeline",
+            Self::ConflictingHostBinding => "pipeline bindings: different host binding exists",
+            Self::ConcurrentUpdate => "pipeline bindings: concurrent update",
+            Self::CorruptRecord => "pipeline bindings: corrupt durable record",
+        })
+    }
+}
+
+impl std::error::Error for PipelineBindingError {}
+
+impl From<StorageError> for PipelineBindingError {
+    fn from(error: StorageError) -> Self {
+        Self::Storage(error)
+    }
+}
+
+impl From<RegistryError> for PipelineBindingError {
+    fn from(error: RegistryError) -> Self {
+        Self::Registry(error)
+    }
+}
+
+impl From<ChannelEndpointError> for PipelineBindingError {
+    fn from(error: ChannelEndpointError) -> Self {
+        Self::Channel(error)
+    }
+}
+
+/// CAS-backed host bindings and immutable cross-pipeline channel claims.
+pub struct PipelineBindingStore<'a> {
+    backend: &'a dyn StorageBackend,
+}
+
+impl<'a> PipelineBindingStore<'a> {
+    /// Bind the store to one initialized or uninitialized repository backend.
+    pub fn new(backend: &'a dyn StorageBackend) -> Self {
+        Self { backend }
+    }
+
+    /// Authorize and atomically create one host binding.
+    ///
+    /// Channel claims are created first and intentionally survive a later host
+    /// conflict. That failure mode can deny reuse but cannot grant authority.
+    pub fn wire(
+        &self,
+        binding: &HostPipelineBinding,
+    ) -> Result<LoadedHostPipelineBinding, PipelineBindingError> {
+        self.backend.initialize()?;
+        self.require_registration(binding)?;
+        self.require_authorized_channels(binding)?;
+        self.claim_channels(binding)?;
+        let key = host_key(binding.registration.host_name());
+        let body = encode_host_binding(binding);
+        let input = put(&key, HOST_CONTENT_TYPE, body.clone())?.with_if_absent();
+        match self.backend.put(input) {
+            Ok(record) => decode_host_record(record, binding.registration.host_name()),
+            Err(StorageError::Conflict { .. }) => {
+                let existing = self
+                    .load(binding.registration.host_name())?
+                    .ok_or(PipelineBindingError::ConflictingHostBinding)?;
+                if existing.binding == *binding {
+                    Ok(existing)
+                } else {
+                    Err(PipelineBindingError::ConflictingHostBinding)
+                }
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    /// Load one host binding without treating it as current launch authority.
+    pub fn load(
+        &self,
+        host_name: &HostName,
+    ) -> Result<Option<LoadedHostPipelineBinding>, PipelineBindingError> {
+        self.backend.initialize()?;
+        self.backend
+            .get(NAMESPACE, &host_key(host_name))?
+            .map(|record| decode_host_record(record, host_name))
+            .transpose()
+    }
+
+    /// Claim any new channels, then revision-CAS replace one host binding.
+    pub fn replace(
+        &self,
+        loaded: &LoadedHostPipelineBinding,
+        replacement: &HostPipelineBinding,
+    ) -> Result<LoadedHostPipelineBinding, PipelineBindingError> {
+        if loaded.binding.registration.host_name() != replacement.registration.host_name() {
+            return Err(PipelineBindingError::RegistrationMismatch);
+        }
+        self.require_registration(replacement)?;
+        self.require_authorized_channels(replacement)?;
+        self.claim_channels(replacement)?;
+        let name = replacement.registration.host_name();
+        let input = put(
+            &host_key(name),
+            HOST_CONTENT_TYPE,
+            encode_host_binding(replacement),
+        )?
+        .with_if_revision(Some(loaded.revision.clone()));
+        match self.backend.put(input) {
+            Ok(record) => decode_host_record(record, name),
+            Err(StorageError::Conflict { .. }) => Err(PipelineBindingError::ConcurrentUpdate),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    /// Revision-CAS remove one host binding while retaining immutable claims.
+    /// Repeating the removal after absence is idempotent.
+    pub fn unwire(&self, loaded: &LoadedHostPipelineBinding) -> Result<(), PipelineBindingError> {
+        match self.backend.delete(
+            NAMESPACE,
+            &host_key(loaded.binding.registration.host_name()),
+            Some(&loaded.revision),
+        ) {
+            Ok(()) => Ok(()),
+            Err(StorageError::Conflict { .. }) => Err(PipelineBindingError::ConcurrentUpdate),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    /// Revalidate and return exact launch authority for one durable registration.
+    pub fn resolve_launch(
+        &self,
+        registration: &HostRegistration,
+    ) -> Result<LaunchBindings, PipelineBindingError> {
+        let loaded = self
+            .load(registration.host_name())?
+            .ok_or(PipelineBindingError::HostNotRegistered)?;
+        if loaded.binding.registration != *registration {
+            return Err(PipelineBindingError::RegistrationMismatch);
+        }
+        self.require_registration(&loaded.binding)?;
+        self.require_claims(&loaded.binding)?;
+        self.require_authorized_channels(&loaded.binding)?;
+        Ok(loaded.binding.launch_bindings.clone())
+    }
+
+    fn require_registration(
+        &self,
+        binding: &HostPipelineBinding,
+    ) -> Result<(), PipelineBindingError> {
+        let loaded = ServiceRegistry::new(self.backend)
+            .load(binding.registration.host_name())?
+            .ok_or(PipelineBindingError::HostNotRegistered)?;
+        if loaded.entry().registration() != &binding.registration {
+            return Err(PipelineBindingError::RegistrationMismatch);
+        }
+        Ok(())
+    }
+
+    fn require_authorized_channels(
+        &self,
+        binding: &HostPipelineBinding,
+    ) -> Result<(), PipelineBindingError> {
+        let definitions = ChannelDefinitionStore::new(self.backend);
+        for channel in binding.launch_bindings.channels() {
+            let definition = definitions
+                .load(ChannelId(channel.channel_id()))?
+                .ok_or(PipelineBindingError::ChannelUnavailable)?;
+            authorize_channel(&definition, binding.agent_id(), channel.access())?;
+        }
+        Ok(())
+    }
+
+    fn claim_channels(&self, binding: &HostPipelineBinding) -> Result<(), PipelineBindingError> {
+        for channel in binding.launch_bindings.channels() {
+            let channel_id = ChannelId(channel.channel_id());
+            let key = channel_key(channel_id);
+            let body = encode_claim(binding.pipeline_id, channel_id);
+            let input = put(&key, CLAIM_CONTENT_TYPE, body.clone())?.with_if_absent();
+            match self.backend.put(input) {
+                Ok(record) => require_claim_record(&record, binding.pipeline_id, channel_id)?,
+                Err(StorageError::Conflict { .. }) => {
+                    let record = self
+                        .backend
+                        .get(NAMESPACE, &key)?
+                        .ok_or(PipelineBindingError::ChannelUnavailable)?;
+                    require_claim_record(&record, binding.pipeline_id, channel_id)?;
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Ok(())
+    }
+
+    fn require_claims(&self, binding: &HostPipelineBinding) -> Result<(), PipelineBindingError> {
+        for channel in binding.launch_bindings.channels() {
+            let channel_id = ChannelId(channel.channel_id());
+            let record = self
+                .backend
+                .get(NAMESPACE, &channel_key(channel_id))?
+                .ok_or(PipelineBindingError::ChannelUnavailable)?;
+            require_claim_record(&record, binding.pipeline_id, channel_id)?;
+        }
+        Ok(())
+    }
+}
+
+fn authorize_channel(
+    definition: &ChannelDefinition,
+    agent_id: &AgentId,
+    access: ChannelBindingAccess,
+) -> Result<(), PipelineBindingError> {
+    if definition.lifecycle() != ChannelLifecycle::Active {
+        return Err(PipelineBindingError::ChannelUnauthorized);
+    }
+    let authorized = match access {
+        ChannelBindingAccess::Read => definition.receiver(agent_id).is_some(),
+        ChannelBindingAccess::Write => definition.originator().agent_id == *agent_id,
+    };
+    if !authorized {
+        return Err(PipelineBindingError::ChannelUnauthorized);
+    }
+    Ok(())
+}
+
+fn host_key(host_name: &HostName) -> String {
+    format!("{HOST_PREFIX}{}", host_name.as_str())
+}
+
+fn channel_key(channel_id: ChannelId) -> String {
+    let mut encoded = String::with_capacity(32);
+    for byte in channel_id.0 {
+        use core::fmt::Write;
+        write!(&mut encoded, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    format!("{CHANNEL_PREFIX}{encoded}")
+}
+
+fn put(key: &str, content_type: &str, body: Vec<u8>) -> Result<StoragePutInput, StorageError> {
+    StoragePutInput::new(
+        NAMESPACE,
+        key,
+        content_type,
+        JsonValue::Object(Vec::new()),
+        body,
+    )
+}
+
+/// Encode one strict bounded version-1 host binding.
+pub fn encode_host_binding(binding: &HostPipelineBinding) -> Vec<u8> {
+    let mut output = Vec::with_capacity(512);
+    output.extend_from_slice(HOST_MAGIC);
+    output.push(VERSION);
+    output.extend_from_slice(binding.pipeline_id.as_bytes());
+    push_u16_bytes(
+        &mut output,
+        binding.registration.host_name().as_str().as_bytes(),
+    );
+    push_u16_bytes(
+        &mut output,
+        binding.registration.package_path().as_str().as_bytes(),
+    );
+    output.extend_from_slice(binding.registration.package_hash());
+    output.push(restart_policy_tag(binding.registration.restart_policy()));
+    push_u16_bytes(&mut output, binding.agent_id.as_bytes());
+    output.extend_from_slice(&(binding.launch_bindings.channels().len() as u16).to_be_bytes());
+    for channel in binding.launch_bindings.channels() {
+        output.push(match channel.access() {
+            ChannelBindingAccess::Read => 1,
+            ChannelBindingAccess::Write => 2,
+        });
+        output.push(channel.name().len() as u8);
+        output.extend_from_slice(channel.name().as_bytes());
+        output.extend_from_slice(&channel.channel_id());
+    }
+    match binding.launch_bindings.level_one_model() {
+        None => output.push(0),
+        Some(model) => {
+            output.push(1);
+            push_u16_bytes(&mut output, model.model().as_bytes());
+            output.extend_from_slice(&model.temperature().to_bits().to_be_bytes());
+            output.extend_from_slice(&model.max_tokens().to_be_bytes());
+        }
+    }
+    output
+}
+
+/// Decode one strict bounded version-1 host binding.
+pub fn decode_host_binding(bytes: &[u8]) -> Result<HostPipelineBinding, PipelineBindingError> {
+    if bytes.len() > MAX_HOST_RECORD_BYTES {
+        return Err(PipelineBindingError::CorruptRecord);
+    }
+    let mut reader = Reader::new(bytes);
+    if reader.take(4)? != HOST_MAGIC || reader.u8()? != VERSION {
+        return Err(PipelineBindingError::CorruptRecord);
+    }
+    let mut pipeline_bytes = [0u8; 16];
+    pipeline_bytes.copy_from_slice(reader.take(16)?);
+    let pipeline_id =
+        PipelineId::new(pipeline_bytes).map_err(|_| PipelineBindingError::CorruptRecord)?;
+    let host_name = HostName::new(reader.string_u16(MAX_HOST_NAME_BYTES)?)
+        .map_err(|_| PipelineBindingError::CorruptRecord)?;
+    let package_path = PackagePath::new(reader.string_u16(MAX_PACKAGE_PATH_BYTES)?)
+        .map_err(|_| PipelineBindingError::CorruptRecord)?;
+    let mut package_hash = [0u8; 32];
+    package_hash.copy_from_slice(reader.take(32)?);
+    let restart_policy = match reader.u8()? {
+        1 => RestartPolicy::Always,
+        2 => RestartPolicy::OnFailure,
+        3 => RestartPolicy::Never,
+        _ => return Err(PipelineBindingError::CorruptRecord),
+    };
+    let agent_id = AgentId::new(reader.vec_u16(MAX_IDENTITY_BYTES)?)
+        .map_err(|_| PipelineBindingError::CorruptRecord)?;
+    let channel_count = usize::from(reader.u16()?);
+    if channel_count > MAX_LAUNCH_CHANNEL_BINDINGS {
+        return Err(PipelineBindingError::CorruptRecord);
+    }
+    let mut channels = Vec::with_capacity(channel_count);
+    for _ in 0..channel_count {
+        let access = match reader.u8()? {
+            1 => ChannelBindingAccess::Read,
+            2 => ChannelBindingAccess::Write,
+            _ => return Err(PipelineBindingError::CorruptRecord),
+        };
+        let name_length = usize::from(reader.u8()?);
+        if name_length == 0 || name_length > MAX_LAUNCH_CHANNEL_NAME_BYTES {
+            return Err(PipelineBindingError::CorruptRecord);
+        }
+        let name = std::str::from_utf8(reader.take(name_length)?)
+            .map_err(|_| PipelineBindingError::CorruptRecord)?;
+        let mut channel_id = [0u8; 16];
+        channel_id.copy_from_slice(reader.take(16)?);
+        channels.push(
+            ChannelBinding::new(name, access, channel_id)
+                .map_err(|_| PipelineBindingError::CorruptRecord)?,
+        );
+    }
+    let model = match reader.u8()? {
+        0 => None,
+        1 => {
+            let selector = reader.string_u16(MAX_LAUNCH_MODEL_BYTES)?;
+            let temperature = f32::from_bits(reader.u32()?);
+            let max_tokens = reader.u32()?;
+            Some(
+                LevelOneModelBinding::new(selector, temperature, max_tokens)
+                    .map_err(|_| PipelineBindingError::CorruptRecord)?,
+            )
+        }
+        _ => return Err(PipelineBindingError::CorruptRecord),
+    };
+    reader.finish()?;
+    let launch_bindings =
+        LaunchBindings::new(channels, model).map_err(|_| PipelineBindingError::CorruptRecord)?;
+    Ok(HostPipelineBinding::new(
+        pipeline_id,
+        HostRegistration::new(host_name, package_path, package_hash, restart_policy),
+        agent_id,
+        launch_bindings,
+    ))
+}
+
+fn decode_host_record(
+    record: StorageRecord,
+    expected_name: &HostName,
+) -> Result<LoadedHostPipelineBinding, PipelineBindingError> {
+    if record.namespace != NAMESPACE
+        || record.key != host_key(expected_name)
+        || record.content_type != HOST_CONTENT_TYPE
+    {
+        return Err(PipelineBindingError::CorruptRecord);
+    }
+    let binding = decode_host_binding(&record.body)?;
+    if binding.registration.host_name() != expected_name {
+        return Err(PipelineBindingError::CorruptRecord);
+    }
+    Ok(LoadedHostPipelineBinding {
+        binding,
+        revision: record.revision,
+    })
+}
+
+fn encode_claim(pipeline_id: PipelineId, channel_id: ChannelId) -> Vec<u8> {
+    let mut output = Vec::with_capacity(CLAIM_RECORD_BYTES);
+    output.extend_from_slice(CLAIM_MAGIC);
+    output.push(VERSION);
+    output.extend_from_slice(pipeline_id.as_bytes());
+    output.extend_from_slice(&channel_id.0);
+    output
+}
+
+fn require_claim_record(
+    record: &StorageRecord,
+    expected_pipeline: PipelineId,
+    expected_channel: ChannelId,
+) -> Result<(), PipelineBindingError> {
+    if record.namespace != NAMESPACE
+        || record.key != channel_key(expected_channel)
+        || record.content_type != CLAIM_CONTENT_TYPE
+        || record.body.len() != CLAIM_RECORD_BYTES
+        || &record.body[..4] != CLAIM_MAGIC
+        || record.body[4] != VERSION
+        || &record.body[21..] != expected_channel.0.as_slice()
+    {
+        return Err(PipelineBindingError::CorruptRecord);
+    }
+    if &record.body[5..21] != expected_pipeline.as_bytes() {
+        return Err(PipelineBindingError::CrossPipelineChannel);
+    }
+    Ok(())
+}
+
+fn push_u16_bytes(output: &mut Vec<u8>, bytes: &[u8]) {
+    output.extend_from_slice(&(bytes.len() as u16).to_be_bytes());
+    output.extend_from_slice(bytes);
+}
+
+fn restart_policy_tag(policy: RestartPolicy) -> u8 {
+    match policy {
+        RestartPolicy::Always => 1,
+        RestartPolicy::OnFailure => 2,
+        RestartPolicy::Never => 3,
+    }
+}
+
+fn is_uuid_v7(bytes: &[u8; 16]) -> bool {
+    bytes[6] >> 4 == 7 && bytes[8] & 0xc0 == 0x80
+}
+
+struct Reader<'a> {
+    remaining: &'a [u8],
+}
+
+impl<'a> Reader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { remaining: bytes }
+    }
+
+    fn take(&mut self, length: usize) -> Result<&'a [u8], PipelineBindingError> {
+        if self.remaining.len() < length {
+            return Err(PipelineBindingError::CorruptRecord);
+        }
+        let (value, rest) = self.remaining.split_at(length);
+        self.remaining = rest;
+        Ok(value)
+    }
+
+    fn u8(&mut self) -> Result<u8, PipelineBindingError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, PipelineBindingError> {
+        let bytes = self
+            .take(2)?
+            .try_into()
+            .map_err(|_| PipelineBindingError::CorruptRecord)?;
+        Ok(u16::from_be_bytes(bytes))
+    }
+
+    fn u32(&mut self) -> Result<u32, PipelineBindingError> {
+        let bytes = self
+            .take(4)?
+            .try_into()
+            .map_err(|_| PipelineBindingError::CorruptRecord)?;
+        Ok(u32::from_be_bytes(bytes))
+    }
+
+    fn vec_u16(&mut self, maximum: usize) -> Result<Vec<u8>, PipelineBindingError> {
+        let length = usize::from(self.u16()?);
+        if length == 0 || length > maximum {
+            return Err(PipelineBindingError::CorruptRecord);
+        }
+        Ok(self.take(length)?.to_vec())
+    }
+
+    fn string_u16(&mut self, maximum: usize) -> Result<String, PipelineBindingError> {
+        let bytes = self.vec_u16(maximum)?;
+        String::from_utf8(bytes).map_err(|_| PipelineBindingError::CorruptRecord)
+    }
+
+    fn finish(self) -> Result<(), PipelineBindingError> {
+        if self.remaining.is_empty() {
+            Ok(())
+        } else {
+            Err(PipelineBindingError::CorruptRecord)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chief_of_staff_channel_crypto::KeyEpoch;
+    use chief_of_staff_channel_endpoints::{OriginatorIdentity, ReceiverIdentity};
+    use chief_of_staff_service_registry::{DesiredState, HostEntry};
+    use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use storage_core::InMemoryStorageBackend;
+    use storage_local_folder::LocalFolderStorageBackend;
+
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn uuid_v7(tag: u8) -> [u8; 16] {
+        let mut bytes = [0u8; 16];
+        bytes[0] = tag;
+        bytes[6] = 0x70;
+        bytes[8] = 0x80;
+        bytes
+    }
+
+    fn pipeline(tag: u8) -> PipelineId {
+        PipelineId::new(uuid_v7(tag)).unwrap()
+    }
+
+    fn agent(value: &str) -> AgentId {
+        AgentId::new(value.as_bytes().to_vec()).unwrap()
+    }
+
+    fn registration(host: &str, hash: u8) -> HostRegistration {
+        HostRegistration::new(
+            HostName::new(host).unwrap(),
+            PackagePath::new(format!("agents/{host}.agent")).unwrap(),
+            [hash; 32],
+            RestartPolicy::OnFailure,
+        )
+    }
+
+    fn register(backend: &dyn StorageBackend, registration: HostRegistration) {
+        ServiceRegistry::new(backend)
+            .register(&HostEntry::registered(registration, DesiredState::Stopped))
+            .unwrap();
+    }
+
+    fn create_channels(backend: &dyn StorageBackend, agent_id: &AgentId) -> ([u8; 16], [u8; 16]) {
+        let read_id = uuid_v7(11);
+        let write_id = uuid_v7(12);
+        let definitions = ChannelDefinitionStore::new(backend);
+        definitions
+            .create(
+                &ChannelDefinition::new(
+                    ChannelId(read_id),
+                    OriginatorIdentity {
+                        agent_id: agent("request-source"),
+                        public_key: [1; 32],
+                    },
+                    vec![ReceiverIdentity {
+                        agent_id: agent_id.clone(),
+                        public_key: [2; 32],
+                    }],
+                    1,
+                    KeyEpoch(0),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        definitions
+            .create(
+                &ChannelDefinition::new(
+                    ChannelId(write_id),
+                    OriginatorIdentity {
+                        agent_id: agent_id.clone(),
+                        public_key: [3; 32],
+                    },
+                    vec![ReceiverIdentity {
+                        agent_id: agent("report-sink"),
+                        public_key: [4; 32],
+                    }],
+                    2,
+                    KeyEpoch(0),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        (read_id, write_id)
+    }
+
+    fn launch(read_id: [u8; 16], write_id: [u8; 16], model: &str) -> LaunchBindings {
+        LaunchBindings::new(
+            vec![
+                ChannelBinding::new("weather-requests", ChannelBindingAccess::Read, read_id)
+                    .unwrap(),
+                ChannelBinding::new("weather-reports", ChannelBindingAccess::Write, write_id)
+                    .unwrap(),
+            ],
+            Some(LevelOneModelBinding::new(model, 0.25, 256).unwrap()),
+        )
+        .unwrap()
+    }
+
+    fn binding(
+        pipeline_id: PipelineId,
+        registration: HostRegistration,
+        agent_id: AgentId,
+        channels: ([u8; 16], [u8; 16]),
+        model: &str,
+    ) -> HostPipelineBinding {
+        HostPipelineBinding::new(
+            pipeline_id,
+            registration,
+            agent_id,
+            launch(channels.0, channels.1, model),
+        )
+    }
+
+    fn temporary_directory(label: &str) -> std::path::PathBuf {
+        let nonce = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "chief-pipeline-bindings-{label}-{}-{now}-{nonce}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn codec_round_trips_and_rejects_every_truncation_and_trailing_byte() {
+        let expected = binding(
+            pipeline(1),
+            registration("weather-host", 7),
+            agent("weather-agent"),
+            (uuid_v7(11), uuid_v7(12)),
+            "test-model",
+        );
+        let encoded = encode_host_binding(&expected);
+        assert_eq!(decode_host_binding(&encoded).unwrap(), expected);
+        for length in 0..encoded.len() {
+            assert!(
+                decode_host_binding(&encoded[..length]).is_err(),
+                "accepted {length}"
+            );
+        }
+        let mut trailing = encoded;
+        trailing.push(0);
+        assert!(decode_host_binding(&trailing).is_err());
+        assert!(PipelineId::new([0; 16]).is_err());
+    }
+
+    #[test]
+    fn wire_is_idempotent_and_launch_revalidates_exact_authority() {
+        let backend = InMemoryStorageBackend::new();
+        let registration = registration("weather-host", 7);
+        let agent_id = agent("weather-agent");
+        register(&backend, registration.clone());
+        let channels = create_channels(&backend, &agent_id);
+        let expected = binding(
+            pipeline(1),
+            registration.clone(),
+            agent_id,
+            channels,
+            "test-model",
+        );
+        let store = PipelineBindingStore::new(&backend);
+        let first = store.wire(&expected).unwrap();
+        let second = store.wire(&expected).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(
+            store.resolve_launch(&registration).unwrap(),
+            expected.launch_bindings
+        );
+        assert!(!first.revision().as_str().is_empty());
+    }
+
+    #[test]
+    fn registration_direction_lifecycle_and_pipeline_isolation_fail_closed() {
+        let backend = InMemoryStorageBackend::new();
+        let first_registration = registration("weather-host", 7);
+        let second_registration = registration("second-host", 8);
+        let agent_id = agent("weather-agent");
+        let channels = create_channels(&backend, &agent_id);
+        let first = binding(
+            pipeline(1),
+            first_registration.clone(),
+            agent_id.clone(),
+            channels,
+            "test-model",
+        );
+        let store = PipelineBindingStore::new(&backend);
+        assert!(matches!(
+            store.wire(&first),
+            Err(PipelineBindingError::HostNotRegistered)
+        ));
+        register(&backend, first_registration.clone());
+        register(&backend, second_registration.clone());
+
+        let wrong_direction = HostPipelineBinding::new(
+            pipeline(1),
+            second_registration.clone(),
+            agent_id.clone(),
+            LaunchBindings::new(
+                vec![ChannelBinding::new(
+                    "weather-requests",
+                    ChannelBindingAccess::Write,
+                    channels.0,
+                )
+                .unwrap()],
+                None,
+            )
+            .unwrap(),
+        );
+        assert!(matches!(
+            store.wire(&wrong_direction),
+            Err(PipelineBindingError::ChannelUnauthorized)
+        ));
+
+        store.wire(&first).unwrap();
+        let cross_pipeline = binding(
+            pipeline(2),
+            second_registration,
+            agent_id,
+            channels,
+            "other-model",
+        );
+        assert!(matches!(
+            store.wire(&cross_pipeline),
+            Err(PipelineBindingError::CrossPipelineChannel)
+        ));
+
+        ChannelDefinitionStore::new(&backend)
+            .destroy(ChannelId(channels.0))
+            .unwrap();
+        assert!(matches!(
+            store.resolve_launch(&first_registration),
+            Err(PipelineBindingError::ChannelUnauthorized)
+        ));
+        assert!(matches!(
+            store.resolve_launch(&registration("weather-host", 99)),
+            Err(PipelineBindingError::RegistrationMismatch)
+        ));
+    }
+
+    #[test]
+    fn replacement_and_unwiring_are_revision_cas_guarded() {
+        let backend = InMemoryStorageBackend::new();
+        let registration = registration("weather-host", 7);
+        let agent_id = agent("weather-agent");
+        register(&backend, registration.clone());
+        let channels = create_channels(&backend, &agent_id);
+        let store = PipelineBindingStore::new(&backend);
+        let first = store
+            .wire(&binding(
+                pipeline(1),
+                registration.clone(),
+                agent_id.clone(),
+                channels,
+                "first-model",
+            ))
+            .unwrap();
+        let replacement = binding(
+            pipeline(1),
+            registration.clone(),
+            agent_id,
+            channels,
+            "second-model",
+        );
+        let replaced = store.replace(&first, &replacement).unwrap();
+        assert!(matches!(
+            store.replace(&first, &replacement),
+            Err(PipelineBindingError::ConcurrentUpdate)
+        ));
+        assert_eq!(
+            store.resolve_launch(&registration).unwrap(),
+            replacement.launch_bindings
+        );
+        store.unwire(&replaced).unwrap();
+        store.unwire(&replaced).unwrap();
+        assert!(store.load(registration.host_name()).unwrap().is_none());
+    }
+
+    #[test]
+    fn local_folder_restart_recovers_and_revalidates_launch_authority() {
+        let root = temporary_directory("restart");
+        let registration = registration("weather-host", 7);
+        let expected;
+        {
+            let backend = LocalFolderStorageBackend::new(&root);
+            let agent_id = agent("weather-agent");
+            register(&backend, registration.clone());
+            let channels = create_channels(&backend, &agent_id);
+            expected = binding(
+                pipeline(1),
+                registration.clone(),
+                agent_id,
+                channels,
+                "test-model",
+            );
+            PipelineBindingStore::new(&backend).wire(&expected).unwrap();
+        }
+        {
+            let backend = LocalFolderStorageBackend::new(&root);
+            assert_eq!(
+                PipelineBindingStore::new(&backend)
+                    .resolve_launch(&registration)
+                    .unwrap(),
+                expected.launch_bindings
+            );
+        }
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add a production durable launch-binding provider backed by the pipeline
+  binding store; every launch revalidates registration, channel claims,
+  lifecycle, and directional membership before process creation.
 - Require an injected manifest-blind launch-binding provider, authenticate its
   channel UUID and Level 1 model bindings before readiness, and fail closed when
   bindings are unavailable or incompatible with the verified package runtime.

--- a/code/packages/rust/chief-of-staff-process-supervisor/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-process-supervisor/Cargo.toml
@@ -9,12 +9,14 @@ license = "MIT"
 chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
 chief-of-staff-host-control-protocol = { path = "../chief-of-staff-host-control-protocol" }
 chief-of-staff-host-runtime = { path = "../chief-of-staff-host-runtime" }
+chief-of-staff-pipeline-bindings = { path = "../chief-of-staff-pipeline-bindings" }
 chief-of-staff-secure-host-channel = { path = "../chief-of-staff-secure-host-channel" }
 chief-of-staff-service-reconciler = { path = "../chief-of-staff-service-reconciler" }
 chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }
 chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
 coding_adventures_uuid = { path = "../uuid" }
 coding_adventures_x3dh = { path = "../x3dh" }
+storage-core = { path = "../storage-core" }
 
 [dev-dependencies]
 coding_adventures_ed25519 = { path = "../ed25519" }

--- a/code/packages/rust/chief-of-staff-process-supervisor/README.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/README.md
@@ -26,8 +26,10 @@ threaded control plane without copying secret key material.
 The crate implements the dependency-light service reconciler's
 `HostSupervisor` interface. It deliberately leaves durable restart policy,
 scheduling, backoff, and registry updates to the reconciler and runnable
-orchestrator. A fail-closed binding provider is available to compositions that do
-not yet have durable pipeline wiring; such a composition cannot launch a host.
+orchestrator. The production storage-backed provider revalidates exact host
+registration, immutable pipeline channel claims, active topology, and directional
+membership before every spawn. A fail-closed provider remains available to
+compositions that intentionally have no durable pipeline wiring.
 Channel endpoint and LLM service implementations remain injected by
 the concrete host/daemon composition rather than entering this process-authority
 crate.

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
@@ -15,6 +15,7 @@ use chief_of_staff_host_control_protocol::{
 use chief_of_staff_host_runtime::{
     verify_agent_package, AgentPackageRuntime, PackageKeyType, PackageKeyring, TrustedPackageKey,
 };
+use chief_of_staff_pipeline_bindings::PipelineBindingStore;
 use chief_of_staff_secure_host_channel::{
     BootstrapOffer, ChildBootstrap, ClientHello, HostId, OrchestratorBootstrap, SessionId,
 };
@@ -32,6 +33,7 @@ use std::sync::mpsc::{self, Receiver, RecvTimeoutError, TryRecvError};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
+use storage_core::StorageBackend;
 
 const MAX_RECORD_BYTES: usize = 1024 * 1024;
 const MAX_FIXED_ARGUMENTS: usize = 128;
@@ -129,6 +131,30 @@ impl HostLaunchBindingProvider for DenyHostLaunchBindings {
         _runtime: AgentPackageRuntime,
     ) -> Result<LaunchBindings, LaunchBindingProviderError> {
         Err(LaunchBindingProviderError)
+    }
+}
+
+/// Storage-backed manifest-blind launch authority for production composition.
+pub struct DurableHostLaunchBindings {
+    backend: Arc<dyn StorageBackend>,
+}
+
+impl DurableHostLaunchBindings {
+    /// Bind launch resolution to the daemon's durable storage backend.
+    pub fn new(backend: Arc<dyn StorageBackend>) -> Self {
+        Self { backend }
+    }
+}
+
+impl HostLaunchBindingProvider for DurableHostLaunchBindings {
+    fn launch_bindings(
+        &self,
+        registration: &HostRegistration,
+        _runtime: AgentPackageRuntime,
+    ) -> Result<LaunchBindings, LaunchBindingProviderError> {
+        PipelineBindingStore::new(self.backend.as_ref())
+            .resolve_launch(registration)
+            .map_err(|_| LaunchBindingProviderError)
     }
 }
 

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -201,6 +201,13 @@ record from manifest-blind pipeline wiring. It requires the exact signed channel
 name and read/write sets, resolves them to canonical UUID-v7 endpoints, and binds
 the supplied model selector, temperature, and token cap. Missing, extra,
 wrong-direction, or runtime-incompatible bindings fail closed.
+Pipeline wiring persists this authority as a bounded versioned record tied to
+the exact durable host registration and package hash. Every channel UUID receives
+an immutable create-if-absent pipeline claim. Wiring and each later launch both
+reload the authoritative active channel definition and require the pipeline's
+agent identity to be the originator for writes or a receiver for reads. Claims
+survive unwiring and destroyed channel UUIDs are never recycled, preventing
+partial failures or stale records from creating a cross-pipeline path.
 
 ### Level 4 any-language stdio contract
 

--- a/code/specs/host-control-protocol.md
+++ b/code/specs/host-control-protocol.md
@@ -49,6 +49,13 @@ verified child must require the exact signed name and direction sets and must
 reject missing, extra, or wrong-direction bindings before readiness. The parent
 never learns the signed manifest from this comparison.
 
+The production provider reads a bounded versioned host-binding record tied to
+the exact durable registration. Wiring creates immutable channel-to-pipeline
+claims and verifies current one-way membership before storing the record.
+Launch resolution repeats registration, claim, active-lifecycle, and directional
+membership checks, so package replacement, channel destruction, topology drift,
+or cross-pipeline reuse fails before process creation.
+
 The timestamp attached to a received child event is not sent by the child. It is a
 caller-supplied monotonic receipt time sampled by the supervising process after the
 encrypted frame is received. This prevents a compromised child from forging a

--- a/code/specs/process-host-supervisor.md
+++ b/code/specs/process-host-supervisor.md
@@ -134,8 +134,9 @@ The package exposes:
 
 - validated `ProcessSupervisorConfig` and `HostProgram` values;
 - `MonotonicClock` and `SessionIdSource` interfaces plus production adapters;
-- `HostLaunchBindingProvider` plus a fail-closed provider for compositions that
-  have not connected durable pipeline wiring;
+- `HostLaunchBindingProvider`, a production storage-backed provider that
+  revalidates durable pipeline authority before every launch, and a fail-closed
+  provider for compositions without pipeline wiring;
 - owned, movable `ProcessHostSupervisor`, implementing the reconciler
   `HostSupervisor` trait;
 - `ChildProcessControl<R, W>` for lifecycle plus serialized authenticated
@@ -149,7 +150,9 @@ The package exposes:
 The concrete adapter requires direct filesystem/package-read, process
 spawn/kill/reap, pipe I/O, clock, randomness, and thread capabilities. It opens
 no network sockets, reads no ambient environment variables, invokes no shell,
-and persists no state.
+and persists no state itself. The production launch-binding adapter reads the
+repository `StorageBackend`; the dedicated pipeline-binding package owns that
+bounded persistence contract.
 
 ## Required Tests
 


### PR DESCRIPTION
## Summary
- persist exact host/package, pipeline UUID, agent identity, named channel UUID, and optional Level 1 model bindings in a strict bounded versioned store
- authorize wiring and every later launch against durable host registration plus current active originator/receiver membership
- create immutable channel-to-pipeline claims so a durable channel UUID cannot cross isolated pipelines
- replace the daemon deny-only provider with the storage-backed fail-closed resolver

## Validation
- 52 focused store, supervisor, orchestrator, API, daemon, and real filesystem restart tests
- strict Clippy, rustdoc, targeted rustfmt, and diff checks
- dependency-closed planner: all 70 affected, prerequisite, and dependent packages

## Follow-up
The durable authority is now available to pipeline wiring and production launch. The next P0 is the concrete `chief-of-staff-host` process composition that consumes authenticated trust, bindings, lifecycle, channel, and completion records.

Progresses #128
Progresses #138