### PR TITLE
Lower JFET threshold aliases

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lower the JFET `VT0` and `VTH` threshold aliases with canonical `VTO` precedence.
 - Lower the JFET `BET` transconductance alias with canonical `BETA` precedence.
 - Normalize hyphens in supported model-card parameter aliases.
 - Normalize hyphen and underscore separators in supported model type aliases.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1376,7 +1376,12 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             beta=model.params.get(
                 "BETA", model.params.get("BET", model.params.get("B", 1.0e-4))
             ),
-            vto=model.params.get("VTO", -2.0 if model.kind == "NJF" else 2.0),
+            vto=model.params.get(
+                "VTO",
+                model.params.get(
+                    "VT0", model.params.get("VTH", -2.0 if model.kind == "NJF" else 2.0)
+                ),
+            ),
             lambda_=model.params.get("LAMBDA", 0.0),
             Cgs=model.params.get("CGS", model.params.get("CGS0", 0.0)),
             Cgd=model.params.get("CGD", model.params.get("CGD0", 0.0)),

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2134,6 +2134,25 @@ def test_parse_jfet_bet_alias_with_canonical_precedence() -> None:
     assert aliased.beta == 900.0e-6
 
 
+def test_parse_jfet_threshold_aliases_with_canonical_precedence() -> None:
+    parsed = parse_netlist(
+        ".model canonical NJF(VTO=-3 VT0=-2 VTH=-1)\n"
+        ".model vtzero NJF(VT0=-2)\n"
+        ".model threshold NJF(VTH=-1)\n"
+        "J1 drain gate source canonical\n"
+        "J2 drain gate source vtzero\n"
+        "J3 drain gate source threshold"
+    )
+
+    canonical, vtzero, threshold = parsed.circuit.elements
+    assert isinstance(canonical, JFET)
+    assert canonical.vto == -3.0
+    assert isinstance(vtzero, JFET)
+    assert vtzero.vto == -2.0
+    assert isinstance(threshold, JFET)
+    assert threshold.vto == -1.0
+
+
 def test_parse_pjfet_model_type_alias() -> None:
     parsed = parse_netlist(
         ".model fast PJFET(BETA=2m)\nJ1 drain gate source fast"

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lower the JFET `VT0` and `VTH` threshold aliases with canonical `VTO` precedence.
 - Lower the JFET `BET` transconductance alias with canonical `BETA` precedence.
 - Normalize hyphens in supported model-card parameter aliases.
 - Normalize hyphen and underscore separators in supported model type aliases.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -2435,7 +2435,10 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
         model.params.get("BET") ??
         model.params.get("B") ??
         1.0e-4,
-      model.params.get("VTO") ?? (polarity === "NJF" ? -2.0 : 2.0),
+      model.params.get("VTO") ??
+        model.params.get("VT0") ??
+        model.params.get("VTH") ??
+        (polarity === "NJF" ? -2.0 : 2.0),
       model.params.get("LAMBDA") ?? 0.0,
       model.params.get("CGS") ?? model.params.get("CGS0") ?? 0.0,
       model.params.get("CGD") ?? model.params.get("CGD0") ?? 0.0,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2215,6 +2215,30 @@ J1 drain gate source fast
     });
   });
 
+  it("parses JFET threshold aliases with canonical precedence", () => {
+    const parsed = parseNetlist(
+      ".model canonical NJF(VTO=-3 VT0=-2 VTH=-1)\n" +
+        ".model vtzero NJF(VT0=-2)\n" +
+        ".model threshold NJF(VTH=-1)\n" +
+        "J1 drain gate source canonical\n" +
+        "J2 drain gate source vtzero\n" +
+        "J3 drain gate source threshold",
+    );
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      thresholdVoltage: -3.0,
+    });
+    expect(parsed.circuit.elements()[1]).toMatchObject({
+      kind: "jfet",
+      thresholdVoltage: -2.0,
+    });
+    expect(parsed.circuit.elements()[2]).toMatchObject({
+      kind: "jfet",
+      thresholdVoltage: -1.0,
+    });
+  });
+
   it("parses the PJFET model type alias", () => {
     const parsed = parseNetlist(".model fast PJFET(BETA=2m)\nJ1 drain gate source fast");
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4781,10 +4781,16 @@ the Rust, Python, and TypeScript surfaces together.
      `BETA-F` and `T-NOM`.
 
 485. Python and TypeScript Berkeley SPICE JFET `BET` beta-alias parity.
-   - Status: implemented in this JFET `BET` alias slice.
+   - Status: completed in PR 10174.
    - Both parser facades lower the engine-advertised `BET` alias into the JFET
      transconductance field with canonical `BETA` precedence, while preserving
      the unresolved legacy `B` beta-alias versus doping-tail policy collision.
+
+486. Python and TypeScript Berkeley SPICE JFET threshold-alias parity.
+   - Status: implemented in this JFET threshold-alias slice.
+   - Both parser facades lower the engine-advertised `VT0` and `VTH` aliases
+     into the JFET threshold-voltage field with canonical `VTO` precedence,
+     without changing the unresolved `B` parameter policy.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- lower the engine-advertised JFET `VT0` and `VTH` aliases into the threshold-voltage field in both parser facades
- preserve canonical `VTO` precedence and leave the unresolved JFET `B` policy unchanged
- reconcile the completed `BET` alias slice in the SPICE plan

## Verification

- Python parser `bash BUILD` (`645 passed`, 90.60% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (`630 passed`)
- TypeScript parser `npx vitest run --coverage` (88.38% line coverage)
- TypeScript engine `bash BUILD` (`448 passed`)
- `git diff --check`
- BUILD and dependency manifest audit (no changes required)
