### PR TITLE
Lower JFET LAM model alias

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lower the JFET `LAM` alias with canonical `LAMBDA` precedence.
 - Lower the JFET `VT0` and `VTH` threshold aliases with canonical `VTO` precedence.
 - Lower the JFET `BET` transconductance alias with canonical `BETA` precedence.
 - Normalize hyphens in supported model-card parameter aliases.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1382,7 +1382,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
                     "VT0", model.params.get("VTH", -2.0 if model.kind == "NJF" else 2.0)
                 ),
             ),
-            lambda_=model.params.get("LAMBDA", 0.0),
+            lambda_=model.params.get("LAMBDA", model.params.get("LAM", 0.0)),
             Cgs=model.params.get("CGS", model.params.get("CGS0", 0.0)),
             Cgd=model.params.get("CGD", model.params.get("CGD0", 0.0)),
             Kf=model.params.get("KF", 0.0),

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2153,6 +2153,21 @@ def test_parse_jfet_threshold_aliases_with_canonical_precedence() -> None:
     assert threshold.vto == -1.0
 
 
+def test_parse_jfet_lam_alias_with_canonical_precedence() -> None:
+    parsed = parse_netlist(
+        ".model canonical NJF(LAMBDA=0.02 LAM=0.03)\n"
+        ".model aliased NJF(LAM=0.04)\n"
+        "J1 drain gate source canonical\n"
+        "J2 drain gate source aliased"
+    )
+
+    canonical, aliased = parsed.circuit.elements
+    assert isinstance(canonical, JFET)
+    assert canonical.lambda_ == 0.02
+    assert isinstance(aliased, JFET)
+    assert aliased.lambda_ == 0.04
+
+
 def test_parse_pjfet_model_type_alias() -> None:
     parsed = parse_netlist(
         ".model fast PJFET(BETA=2m)\nJ1 drain gate source fast"

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lower the JFET `LAM` alias with canonical `LAMBDA` precedence.
 - Lower the JFET `VT0` and `VTH` threshold aliases with canonical `VTO` precedence.
 - Lower the JFET `BET` transconductance alias with canonical `BETA` precedence.
 - Normalize hyphens in supported model-card parameter aliases.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -2439,7 +2439,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
         model.params.get("VT0") ??
         model.params.get("VTH") ??
         (polarity === "NJF" ? -2.0 : 2.0),
-      model.params.get("LAMBDA") ?? 0.0,
+      model.params.get("LAMBDA") ?? model.params.get("LAM") ?? 0.0,
       model.params.get("CGS") ?? model.params.get("CGS0") ?? 0.0,
       model.params.get("CGD") ?? model.params.get("CGD0") ?? 0.0,
       model.params.get("KF") ?? 0.0,

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2239,6 +2239,24 @@ J1 drain gate source fast
     });
   });
 
+  it("parses the JFET LAM alias with canonical precedence", () => {
+    const parsed = parseNetlist(
+      ".model canonical NJF(LAMBDA=0.02 LAM=0.03)\n" +
+        ".model aliased NJF(LAM=0.04)\n" +
+        "J1 drain gate source canonical\n" +
+        "J2 drain gate source aliased",
+    );
+
+    expect(parsed.circuit.elements()[0]).toMatchObject({
+      kind: "jfet",
+      channelLengthModulation: 0.02,
+    });
+    expect(parsed.circuit.elements()[1]).toMatchObject({
+      kind: "jfet",
+      channelLengthModulation: 0.04,
+    });
+  });
+
   it("parses the PJFET model type alias", () => {
     const parsed = parseNetlist(".model fast PJFET(BETA=2m)\nJ1 drain gate source fast");
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4787,9 +4787,15 @@ the Rust, Python, and TypeScript surfaces together.
      the unresolved legacy `B` beta-alias versus doping-tail policy collision.
 
 486. Python and TypeScript Berkeley SPICE JFET threshold-alias parity.
-   - Status: implemented in this JFET threshold-alias slice.
+   - Status: completed in PR 10176.
    - Both parser facades lower the engine-advertised `VT0` and `VTH` aliases
      into the JFET threshold-voltage field with canonical `VTO` precedence,
+     without changing the unresolved `B` parameter policy.
+
+487. Python and TypeScript Berkeley SPICE JFET `LAM` alias parity.
+   - Status: implemented in this JFET `LAM` alias slice.
+   - Both parser facades lower the engine-advertised `LAM` alias into the JFET
+     channel-length-modulation field with canonical `LAMBDA` precedence,
      without changing the unresolved `B` parameter policy.
 
 ## Backlog


### PR DESCRIPTION
## Summary

- lower the engine-advertised JFET `LAM` alias in both parser facades
- preserve canonical `LAMBDA` precedence and the unresolved `B` parameter policy
- add cross-language regression coverage and reconcile the SPICE plan

## Verification

- Python parser `bash BUILD` (646 passed, 90.60% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (631 passed)
- TypeScript parser `npx vitest run --coverage` (88.38% line coverage)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
- BUILD/dependency metadata audit: no changes required
