### PR TITLE
Authorize and dispatch authenticated host data-plane requests

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -765,6 +765,7 @@ members = [
     "chief-of-staff-channel-endpoints",
     "chief-of-staff-secure-host-channel",
     "chief-of-staff-host-control-protocol",
+    "chief-of-staff-host-data-plane",
     "chief-of-staff-service-registry",
     "chief-of-staff-pipeline-bindings",
     "chief-of-staff-service-reconciler",

--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Compose durable per-request host data-plane authorization with a fail-closed
+  unavailable service until channel-key custody and model providers are injected.
 - Compose the storage-backed durable pipeline launch-binding provider. Host
   starts now require an exact registered package plus current immutable channel
   claims, active membership, and bounded persisted model settings.

--- a/code/packages/rust/chief-of-staff-daemon/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon/Cargo.toml
@@ -20,6 +20,7 @@ chief-of-staff-daemon-credential = { path = "../chief-of-staff-daemon-credential
 chief-of-staff-daemon-keyring = { path = "../chief-of-staff-daemon-keyring" }
 chief-of-staff-daemon-policy = { path = "../chief-of-staff-daemon-policy" }
 chief-of-staff-daemon-runtime = { path = "../chief-of-staff-daemon-runtime" }
+chief-of-staff-host-data-plane = { path = "../chief-of-staff-host-data-plane" }
 chief-of-staff-orchestrator-core = { path = "../chief-of-staff-orchestrator-core" }
 chief-of-staff-process-supervisor = { path = "../chief-of-staff-process-supervisor" }
 chief-of-staff-service-reconciler = { path = "../chief-of-staff-service-reconciler" }

--- a/code/packages/rust/chief-of-staff-daemon/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon/src/lib.rs
@@ -9,6 +9,9 @@ use chief_of_staff_daemon_credential::{load_or_create_credential, CredentialFile
 use chief_of_staff_daemon_keyring::{load_package_keyring, KeyringLoadError};
 use chief_of_staff_daemon_policy::{DenyChannelWiring, LocalAuthError, LocalBearerAuthorizer};
 use chief_of_staff_daemon_runtime::{ChiefDaemonRuntime, DaemonRuntimeError, ReconcileSchedule};
+use chief_of_staff_host_data_plane::{
+    DurableHostDataPlaneDispatcher, UnavailableHostDataPlaneService,
+};
 use chief_of_staff_orchestrator_core::OrchestratorCore;
 use chief_of_staff_process_supervisor::{
     DurableHostLaunchBindings, HostProgram, ProcessSupervisorConfig, ProcessSupervisorError,
@@ -253,11 +256,16 @@ pub fn run(config: ChiefConfig, home: &Path) -> Result<(), ChiefDaemonError> {
     let schedule = ReconcileSchedule::new(interval).map_err(ChiefDaemonError::Runtime)?;
     let clock = Arc::new(SystemMonotonicClock::new());
     let launch_bindings = Arc::new(DurableHostLaunchBindings::new(Arc::clone(&backend)));
+    let data_plane = Arc::new(DurableHostDataPlaneDispatcher::new(
+        Arc::clone(&backend),
+        Arc::new(UnavailableHostDataPlaneService),
+    ));
     let core = OrchestratorCore::with_process_supervisor(
         backend,
         process_config,
         keyring,
         launch_bindings,
+        data_plane,
         Arc::new(generate_identity_keypair()),
         clock,
         Box::new(UuidV7SessionIdSource),

--- a/code/packages/rust/chief-of-staff-host-data-plane/BUILD
+++ b/code/packages/rust/chief-of-staff-host-data-plane/BUILD
@@ -1,0 +1,1 @@
+cargo test -p chief-of-staff-host-data-plane -- --nocapture

--- a/code/packages/rust/chief-of-staff-host-data-plane/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-data-plane/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+
+- Add durable per-request pipeline authorization, injected service dispatch,
+  response-shape validation, and a fail-closed unavailable production service.

--- a/code/packages/rust/chief-of-staff-host-data-plane/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-host-data-plane/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "chief-of-staff-host-data-plane"
+version = "0.1.0"
+edition = "2021"
+description = "Durably authorized host data-plane dispatch for D18 Chief"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-host-control-protocol = { path = "../chief-of-staff-host-control-protocol" }
+chief-of-staff-pipeline-bindings = { path = "../chief-of-staff-pipeline-bindings" }
+chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }
+storage-core = { path = "../storage-core" }
+
+[dev-dependencies]
+chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
+chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }

--- a/code/packages/rust/chief-of-staff-host-data-plane/README.md
+++ b/code/packages/rust/chief-of-staff-host-data-plane/README.md
@@ -1,0 +1,22 @@
+# chief-of-staff-host-data-plane
+
+`chief-of-staff-host-data-plane` is the manifest-blind authorization boundary
+between an authenticated child request and injected channel/model services.
+Every request reloads the exact durable pipeline binding, registration, immutable
+channel claims, active topology, and directional membership. Receive and
+acknowledge require a read binding, publish requires a write binding, and model
+calls must exactly match the launch-time selector, temperature, and token cap.
+
+The dispatcher redacts all failures into the stable host-control taxonomy and
+validates service responses before they re-enter the authenticated session. The
+production daemon currently injects an unavailable service after authorization;
+concrete channel-key custody and model-provider composition can replace that
+service without weakening this boundary or changing process supervision.
+
+## Validation
+
+```sh
+cargo test -p chief-of-staff-host-data-plane -- --nocapture
+cargo clippy -p chief-of-staff-host-data-plane --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-host-data-plane --no-deps
+```

--- a/code/packages/rust/chief-of-staff-host-data-plane/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-data-plane/src/lib.rs
@@ -1,0 +1,474 @@
+//! Durable authorization and injected execution for the D18 host data plane.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_host_control_protocol::{
+    ChannelBindingAccess, DataPlaneFailure, DataPlaneRequest, DataPlaneResponse,
+};
+use chief_of_staff_pipeline_bindings::{
+    HostPipelineBinding, PipelineBindingError, PipelineBindingStore,
+};
+use chief_of_staff_service_registry::HostRegistration;
+use std::sync::Arc;
+use storage_core::StorageBackend;
+
+/// Injected execution authority reached only after durable request authorization.
+pub trait HostDataPlaneService: Send + Sync {
+    /// Execute one already-authorized request for the exact current pipeline binding.
+    fn execute(
+        &self,
+        binding: &HostPipelineBinding,
+        request: &DataPlaneRequest,
+    ) -> Result<DataPlaneResponse, DataPlaneFailure>;
+}
+
+/// Manifest-blind boundary used by process supervision to answer one child request.
+pub trait HostDataPlaneDispatcher: Send + Sync {
+    /// Reauthorize, execute, and return one exactly correlated response.
+    fn dispatch(
+        &self,
+        registration: &HostRegistration,
+        request: &DataPlaneRequest,
+    ) -> DataPlaneResponse;
+}
+
+/// Dispatcher for compositions that intentionally expose no data-plane service.
+#[derive(Default)]
+pub struct UnavailableHostDataPlaneDispatcher;
+
+impl HostDataPlaneDispatcher for UnavailableHostDataPlaneDispatcher {
+    fn dispatch(
+        &self,
+        _registration: &HostRegistration,
+        request: &DataPlaneRequest,
+    ) -> DataPlaneResponse {
+        failed(request, DataPlaneFailure::Unavailable)
+    }
+}
+
+/// Fail-closed service used until channel-key and model-provider authorities are composed.
+#[derive(Default)]
+pub struct UnavailableHostDataPlaneService;
+
+impl HostDataPlaneService for UnavailableHostDataPlaneService {
+    fn execute(
+        &self,
+        _binding: &HostPipelineBinding,
+        _request: &DataPlaneRequest,
+    ) -> Result<DataPlaneResponse, DataPlaneFailure> {
+        Err(DataPlaneFailure::Unavailable)
+    }
+}
+
+/// Storage-backed dispatcher that revalidates pipeline authority for every request.
+pub struct DurableHostDataPlaneDispatcher {
+    backend: Arc<dyn StorageBackend>,
+    service: Arc<dyn HostDataPlaneService>,
+}
+
+impl DurableHostDataPlaneDispatcher {
+    /// Bind durable authorization to one backend and separately injected service.
+    pub fn new(backend: Arc<dyn StorageBackend>, service: Arc<dyn HostDataPlaneService>) -> Self {
+        Self { backend, service }
+    }
+}
+
+impl HostDataPlaneDispatcher for DurableHostDataPlaneDispatcher {
+    fn dispatch(
+        &self,
+        registration: &HostRegistration,
+        request: &DataPlaneRequest,
+    ) -> DataPlaneResponse {
+        let binding = match PipelineBindingStore::new(self.backend.as_ref())
+            .resolve_launch_binding(registration)
+        {
+            Ok(binding) => binding,
+            Err(error) => return failed(request, binding_failure(&error)),
+        };
+        if !request_is_authorized(&binding, request) {
+            return failed(request, DataPlaneFailure::Unauthorized);
+        }
+        match self.service.execute(&binding, request) {
+            Ok(response) if response_matches(request, &response) => response,
+            Ok(_) => failed(request, DataPlaneFailure::Internal),
+            Err(failure) => failed(request, failure),
+        }
+    }
+}
+
+fn request_is_authorized(binding: &HostPipelineBinding, request: &DataPlaneRequest) -> bool {
+    match request {
+        DataPlaneRequest::Receive { channel_id, .. }
+        | DataPlaneRequest::Acknowledge { channel_id, .. } => {
+            binding.launch_bindings().channels().iter().any(|binding| {
+                binding.channel_id() == *channel_id
+                    && binding.access() == ChannelBindingAccess::Read
+            })
+        }
+        DataPlaneRequest::Publish { channel_id, .. } => {
+            binding.launch_bindings().channels().iter().any(|binding| {
+                binding.channel_id() == *channel_id
+                    && binding.access() == ChannelBindingAccess::Write
+            })
+        }
+        DataPlaneRequest::Complete { call, .. } => binding
+            .launch_bindings()
+            .level_one_model()
+            .is_some_and(|model| {
+                model.model() == call.model
+                    && model.temperature().to_bits() == call.temperature.to_bits()
+                    && Some(model.max_tokens()) == call.max_tokens
+            }),
+    }
+}
+
+fn response_matches(request: &DataPlaneRequest, response: &DataPlaneResponse) -> bool {
+    response.id() == request.id()
+        && response
+            .operation()
+            .is_none_or(|operation| operation == request.operation())
+}
+
+fn failed(request: &DataPlaneRequest, failure: DataPlaneFailure) -> DataPlaneResponse {
+    DataPlaneResponse::Failed {
+        id: request.id(),
+        failure,
+    }
+}
+
+fn binding_failure(error: &PipelineBindingError) -> DataPlaneFailure {
+    match error {
+        PipelineBindingError::Storage(_)
+        | PipelineBindingError::Registry(_)
+        | PipelineBindingError::Channel(_)
+        | PipelineBindingError::ConcurrentUpdate => DataPlaneFailure::Unavailable,
+        PipelineBindingError::CorruptRecord => DataPlaneFailure::Internal,
+        PipelineBindingError::InvalidPipelineId
+        | PipelineBindingError::HostNotRegistered
+        | PipelineBindingError::RegistrationMismatch
+        | PipelineBindingError::ChannelUnavailable
+        | PipelineBindingError::ChannelUnauthorized
+        | PipelineBindingError::CrossPipelineChannel
+        | PipelineBindingError::ConflictingHostBinding => DataPlaneFailure::Unauthorized,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chief_of_staff_channel_crypto::{ChannelId, KeyEpoch};
+    use chief_of_staff_channel_endpoints::{
+        AgentId, ChannelDefinition, ChannelDefinitionStore, OriginatorIdentity, ReceiverIdentity,
+    };
+    use chief_of_staff_host_control_protocol::{
+        ChannelBinding, CompletionCall, DataPlaneMessage, LevelOneModelBinding, PromptMessage,
+        PromptRole, RequestId,
+    };
+    use chief_of_staff_pipeline_bindings::PipelineId;
+    use chief_of_staff_service_registry::{
+        DesiredState, HostEntry, HostName, PackagePath, RestartPolicy, ServiceRegistry,
+    };
+    use std::collections::BTreeMap;
+    use storage_core::InMemoryStorageBackend;
+
+    fn uuid_v7(last: u8) -> [u8; 16] {
+        let mut bytes = [0; 16];
+        bytes[6] = 0x70;
+        bytes[8] = 0x80;
+        bytes[15] = last;
+        bytes
+    }
+
+    fn agent(name: &str) -> AgentId {
+        AgentId::new(name.as_bytes().to_vec()).unwrap()
+    }
+
+    fn registration() -> HostRegistration {
+        HostRegistration::new(
+            HostName::new("weather-host").unwrap(),
+            PackagePath::new("/srv/weather.agent").unwrap(),
+            [7; 32],
+            RestartPolicy::Always,
+        )
+    }
+
+    fn install_binding(backend: &dyn StorageBackend) -> HostPipelineBinding {
+        let registration = registration();
+        ServiceRegistry::new(backend)
+            .register(&HostEntry::registered(
+                registration.clone(),
+                DesiredState::Running,
+            ))
+            .unwrap();
+        let worker = agent("weather-agent");
+        let read_id = uuid_v7(1);
+        let write_id = uuid_v7(2);
+        let definitions = ChannelDefinitionStore::new(backend);
+        definitions
+            .create(
+                &ChannelDefinition::new(
+                    ChannelId(read_id),
+                    OriginatorIdentity {
+                        agent_id: agent("request-source"),
+                        public_key: [1; 32],
+                    },
+                    vec![ReceiverIdentity {
+                        agent_id: worker.clone(),
+                        public_key: [2; 32],
+                    }],
+                    1,
+                    KeyEpoch(0),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        definitions
+            .create(
+                &ChannelDefinition::new(
+                    ChannelId(write_id),
+                    OriginatorIdentity {
+                        agent_id: worker.clone(),
+                        public_key: [3; 32],
+                    },
+                    vec![ReceiverIdentity {
+                        agent_id: agent("report-sink"),
+                        public_key: [4; 32],
+                    }],
+                    2,
+                    KeyEpoch(0),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        let binding = HostPipelineBinding::new(
+            PipelineId::new(uuid_v7(9)).unwrap(),
+            registration,
+            worker,
+            chief_of_staff_host_control_protocol::LaunchBindings::new(
+                vec![
+                    ChannelBinding::new("weather-requests", ChannelBindingAccess::Read, read_id)
+                        .unwrap(),
+                    ChannelBinding::new("weather-reports", ChannelBindingAccess::Write, write_id)
+                        .unwrap(),
+                ],
+                Some(LevelOneModelBinding::new("test-model", 0.25, 256).unwrap()),
+            )
+            .unwrap(),
+        );
+        PipelineBindingStore::new(backend).wire(&binding).unwrap();
+        binding
+    }
+
+    fn request_id(value: u64) -> RequestId {
+        RequestId::new(value).unwrap()
+    }
+
+    fn completion(id: u64, model: &str, temperature: f32, max_tokens: u32) -> DataPlaneRequest {
+        DataPlaneRequest::Complete {
+            id: request_id(id),
+            call: CompletionCall {
+                model: model.to_string(),
+                system: None,
+                messages: vec![PromptMessage {
+                    role: PromptRole::User,
+                    text: "Seattle".to_string(),
+                }],
+                temperature,
+                max_tokens: Some(max_tokens),
+                stop_sequences: Vec::new(),
+                seed: None,
+                metadata: BTreeMap::new(),
+            },
+        }
+    }
+
+    struct EchoService;
+
+    impl HostDataPlaneService for EchoService {
+        fn execute(
+            &self,
+            binding: &HostPipelineBinding,
+            request: &DataPlaneRequest,
+        ) -> Result<DataPlaneResponse, DataPlaneFailure> {
+            assert_eq!(binding.agent_id().as_bytes(), b"weather-agent");
+            Ok(match request {
+                DataPlaneRequest::Receive { id, .. } => DataPlaneResponse::Received {
+                    id: *id,
+                    messages: vec![DataPlaneMessage {
+                        message_id: uuid_v7(4),
+                        sequence: 1,
+                        timestamp_ns: 10,
+                        content_type: "text/plain".to_string(),
+                        payload: b"Seattle".to_vec(),
+                    }],
+                },
+                DataPlaneRequest::Publish { id, .. } => DataPlaneResponse::Published {
+                    id: *id,
+                    message_id: uuid_v7(5),
+                    sequence: 2,
+                    timestamp_ns: 11,
+                },
+                DataPlaneRequest::Acknowledge { id, .. } => DataPlaneResponse::Acknowledged {
+                    id: *id,
+                    sequence: 1,
+                },
+                DataPlaneRequest::Complete { id, .. } => DataPlaneResponse::Failed {
+                    id: *id,
+                    failure: DataPlaneFailure::Completion,
+                },
+            })
+        }
+    }
+
+    fn dispatcher(
+        backend: Arc<dyn StorageBackend>,
+        service: Arc<dyn HostDataPlaneService>,
+    ) -> DurableHostDataPlaneDispatcher {
+        DurableHostDataPlaneDispatcher::new(backend, service)
+    }
+
+    #[test]
+    fn authorized_channel_operations_reach_the_service() {
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryStorageBackend::new());
+        install_binding(backend.as_ref());
+        let dispatcher = dispatcher(Arc::clone(&backend), Arc::new(EchoService));
+        let requests = [
+            DataPlaneRequest::Receive {
+                id: request_id(1),
+                channel_id: uuid_v7(1),
+                limit: 1,
+            },
+            DataPlaneRequest::Publish {
+                id: request_id(2),
+                channel_id: uuid_v7(2),
+                content_type: "text/plain".to_string(),
+                payload: b"forecast".to_vec(),
+            },
+            DataPlaneRequest::Acknowledge {
+                id: request_id(3),
+                channel_id: uuid_v7(1),
+                message_id: uuid_v7(4),
+            },
+        ];
+        for request in requests {
+            let response = dispatcher.dispatch(&registration(), &request);
+            assert_eq!(response.id(), request.id());
+            assert_eq!(response.operation(), Some(request.operation()));
+        }
+        assert!(matches!(
+            dispatcher.dispatch(&registration(), &completion(4, "test-model", 0.25, 256)),
+            DataPlaneResponse::Failed {
+                failure: DataPlaneFailure::Completion,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn directions_unknown_channels_and_model_drift_are_denied() {
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryStorageBackend::new());
+        install_binding(backend.as_ref());
+        let dispatcher = dispatcher(Arc::clone(&backend), Arc::new(EchoService));
+        let requests = [
+            DataPlaneRequest::Receive {
+                id: request_id(1),
+                channel_id: uuid_v7(2),
+                limit: 1,
+            },
+            DataPlaneRequest::Publish {
+                id: request_id(2),
+                channel_id: uuid_v7(1),
+                content_type: "text/plain".to_string(),
+                payload: Vec::new(),
+            },
+            DataPlaneRequest::Receive {
+                id: request_id(3),
+                channel_id: uuid_v7(8),
+                limit: 1,
+            },
+            completion(4, "wrong-model", 0.25, 256),
+            completion(5, "test-model", 0.5, 256),
+            completion(6, "test-model", 0.25, 128),
+        ];
+        for request in requests {
+            assert!(matches!(
+                dispatcher.dispatch(&registration(), &request),
+                DataPlaneResponse::Failed {
+                    failure: DataPlaneFailure::Unauthorized,
+                    ..
+                }
+            ));
+        }
+    }
+
+    #[test]
+    fn every_request_revalidates_current_durable_authority() {
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryStorageBackend::new());
+        install_binding(backend.as_ref());
+        let dispatcher = dispatcher(Arc::clone(&backend), Arc::new(EchoService));
+        let request = DataPlaneRequest::Receive {
+            id: request_id(1),
+            channel_id: uuid_v7(1),
+            limit: 1,
+        };
+        assert!(matches!(
+            dispatcher.dispatch(&registration(), &request),
+            DataPlaneResponse::Received { .. }
+        ));
+        ChannelDefinitionStore::new(backend.as_ref())
+            .destroy(ChannelId(uuid_v7(1)))
+            .unwrap();
+        assert!(matches!(
+            dispatcher.dispatch(&registration(), &request),
+            DataPlaneResponse::Failed {
+                failure: DataPlaneFailure::Unauthorized,
+                ..
+            }
+        ));
+    }
+
+    struct WrongResponseService;
+
+    impl HostDataPlaneService for WrongResponseService {
+        fn execute(
+            &self,
+            _binding: &HostPipelineBinding,
+            request: &DataPlaneRequest,
+        ) -> Result<DataPlaneResponse, DataPlaneFailure> {
+            Ok(DataPlaneResponse::Acknowledged {
+                id: request.id(),
+                sequence: 1,
+            })
+        }
+    }
+
+    #[test]
+    fn unavailable_and_malformed_services_are_redacted() {
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryStorageBackend::new());
+        install_binding(backend.as_ref());
+        let request = DataPlaneRequest::Receive {
+            id: request_id(1),
+            channel_id: uuid_v7(1),
+            limit: 1,
+        };
+        assert!(matches!(
+            dispatcher(
+                Arc::clone(&backend),
+                Arc::new(UnavailableHostDataPlaneService)
+            )
+            .dispatch(&registration(), &request),
+            DataPlaneResponse::Failed {
+                failure: DataPlaneFailure::Unavailable,
+                ..
+            }
+        ));
+        assert!(matches!(
+            dispatcher(backend, Arc::new(WrongResponseService)).dispatch(&registration(), &request),
+            DataPlaneResponse::Failed {
+                failure: DataPlaneFailure::Internal,
+                ..
+            }
+        ));
+    }
+}

--- a/code/packages/rust/chief-of-staff-orchestrator-core/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Require the production process composition to inject a host data-plane
+  dispatcher while keeping the generic orchestration core payload-blind.
 - Require the production process composition to inject a manifest-blind host
   launch-binding authority alongside package trust and process identity.
 - Add safe package reload for stopped hosts with absent or exited supervisor authority.

--- a/code/packages/rust/chief-of-staff-orchestrator-core/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
 chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }
 chief-of-staff-host-runtime = { path = "../chief-of-staff-host-runtime" }
+chief-of-staff-host-data-plane = { path = "../chief-of-staff-host-data-plane" }
 chief-of-staff-process-supervisor = { path = "../chief-of-staff-process-supervisor" }
 chief-of-staff-service-reconciler = { path = "../chief-of-staff-service-reconciler" }
 chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }

--- a/code/packages/rust/chief-of-staff-orchestrator-core/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-orchestrator-core/src/lib.rs
@@ -10,6 +10,7 @@ use chief_of_staff_channel_crypto::ChannelId;
 use chief_of_staff_channel_endpoints::{
     ChannelDefinition, ChannelDefinitionStore, ChannelEndpointError,
 };
+use chief_of_staff_host_data_plane::HostDataPlaneDispatcher;
 use chief_of_staff_host_runtime::PackageKeyring;
 use chief_of_staff_process_supervisor::{
     HostLaunchBindingProvider, MonotonicClock, ProcessHostSupervisor, ProcessSupervisorConfig,
@@ -420,6 +421,7 @@ impl<A> OrchestratorCore<ProcessHostSupervisor, A> {
         process_config: ProcessSupervisorConfig,
         keyring: Arc<PackageKeyring>,
         launch_bindings: Arc<dyn HostLaunchBindingProvider>,
+        data_plane_dispatcher: Arc<dyn HostDataPlaneDispatcher>,
         identity: Arc<IdentityKeyPair>,
         clock: Arc<dyn MonotonicClock>,
         sessions: Box<dyn SessionIdSource>,
@@ -433,7 +435,8 @@ impl<A> OrchestratorCore<ProcessHostSupervisor, A> {
             identity,
             Arc::clone(&clock),
             sessions,
-        );
+        )
+        .with_data_plane_dispatcher(data_plane_dispatcher);
         Self::new(backend, supervisor, authorizer, clock, reconcile_config)
     }
 }
@@ -445,6 +448,7 @@ mod tests {
     use chief_of_staff_channel_endpoints::{
         AgentId, ChannelLifecycle, OriginatorIdentity, ReceiverIdentity,
     };
+    use chief_of_staff_host_data_plane::UnavailableHostDataPlaneDispatcher;
     use chief_of_staff_process_supervisor::{
         DenyHostLaunchBindings, HostProgram, UuidV7SessionIdSource,
     };
@@ -1205,6 +1209,7 @@ mod tests {
             config,
             keyring,
             Arc::new(DenyHostLaunchBindings),
+            Arc::new(UnavailableHostDataPlaneDispatcher),
             identity,
             clock,
             Box::<UuidV7SessionIdSource>::default(),

--- a/code/packages/rust/chief-of-staff-pipeline-bindings/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-pipeline-bindings/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Expose complete revalidated launch authority, including the pipeline's agent
+  identity, for per-request host data-plane authorization and service dispatch.
+
 ## 0.1.0
 
 - Add bounded versioned host-binding and immutable channel-claim records.

--- a/code/packages/rust/chief-of-staff-pipeline-bindings/README.md
+++ b/code/packages/rust/chief-of-staff-pipeline-bindings/README.md
@@ -15,6 +15,9 @@ irreversibly destroyed and UUIDs must never be recycled.
 Launch resolution repeats the registration, claim, lifecycle, and membership
 checks. A stale record therefore cannot authorize a replaced package, destroyed
 channel, changed topology, or cross-pipeline channel.
+Callers that service the host data plane resolve the complete current binding,
+including the pipeline's authorized agent identity; child launch delivery keeps
+using the narrower channel/model-only view.
 Unwiring is revision-CAS guarded while the host record exists and idempotent
 after it is absent; immutable channel claims remain as non-authorizing audit state.
 

--- a/code/packages/rust/chief-of-staff-pipeline-bindings/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-pipeline-bindings/src/lib.rs
@@ -282,11 +282,11 @@ impl<'a> PipelineBindingStore<'a> {
         }
     }
 
-    /// Revalidate and return exact launch authority for one durable registration.
-    pub fn resolve_launch(
+    /// Revalidate and return the complete launch authority for one durable registration.
+    pub fn resolve_launch_binding(
         &self,
         registration: &HostRegistration,
-    ) -> Result<LaunchBindings, PipelineBindingError> {
+    ) -> Result<HostPipelineBinding, PipelineBindingError> {
         let loaded = self
             .load(registration.host_name())?
             .ok_or(PipelineBindingError::HostNotRegistered)?;
@@ -296,7 +296,16 @@ impl<'a> PipelineBindingStore<'a> {
         self.require_registration(&loaded.binding)?;
         self.require_claims(&loaded.binding)?;
         self.require_authorized_channels(&loaded.binding)?;
-        Ok(loaded.binding.launch_bindings.clone())
+        Ok(loaded.binding)
+    }
+
+    /// Revalidate and return the child-visible launch bindings for one registration.
+    pub fn resolve_launch(
+        &self,
+        registration: &HostRegistration,
+    ) -> Result<LaunchBindings, PipelineBindingError> {
+        self.resolve_launch_binding(registration)
+            .map(|binding| binding.launch_bindings)
     }
 
     fn require_registration(
@@ -814,6 +823,10 @@ mod tests {
         assert_eq!(
             store.resolve_launch(&registration).unwrap(),
             expected.launch_bindings
+        );
+        assert_eq!(
+            store.resolve_launch_binding(&registration).unwrap(),
+            expected
         );
         assert!(!first.revision().as_str().is_empty());
     }

--- a/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Accept an optional authenticated data-plane dispatcher, retain the exact host
+  registration for each owned child, and automatically send validated responses
+  without exposing request payloads to the orchestration core.
+- Exercise automatic receive, publish, acknowledge, and completion dispatch
+  through a real signed-package child process and encrypted cross-platform pipes.
 - Add a production durable launch-binding provider backed by the pipeline
   binding store; every launch revalidates registration, channel claims,
   lifecycle, and directional membership before process creation.

--- a/code/packages/rust/chief-of-staff-process-supervisor/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-process-supervisor/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 [dependencies]
 chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
 chief-of-staff-host-control-protocol = { path = "../chief-of-staff-host-control-protocol" }
+chief-of-staff-host-data-plane = { path = "../chief-of-staff-host-data-plane" }
 chief-of-staff-host-runtime = { path = "../chief-of-staff-host-runtime" }
 chief-of-staff-pipeline-bindings = { path = "../chief-of-staff-pipeline-bindings" }
 chief-of-staff-secure-host-channel = { path = "../chief-of-staff-secure-host-channel" }

--- a/code/packages/rust/chief-of-staff-process-supervisor/README.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/README.md
@@ -14,10 +14,12 @@ environment or registry input.
 
 The same authenticated session now carries the host data plane. Child-side
 helpers serialize bounded channel receive/publish/acknowledge and provider-neutral
-completion exchanges. The supervisor retains one authenticated request per host
-until an injected service adapter answers through `respond_data_plane`, preserving
-exact correlation across real cross-platform process pipes without adding an
-unauthenticated side channel.
+completion exchanges. When a dispatcher is injected, the supervisor automatically
+reauthorizes and answers each request before processing the next record. A manual
+composition may instead retain one authenticated request per host until its
+service adapter answers through `respond_data_plane`. Both paths preserve exact
+correlation across real cross-platform process pipes without adding an
+unauthenticated side channel or exposing payloads to the orchestration core.
 
 Its keyring and X3DH identity are shared through owned `Arc` handles, and its
 session source is `Send`, so the complete supervisor can move with the daemon's
@@ -30,9 +32,8 @@ orchestrator. The production storage-backed provider revalidates exact host
 registration, immutable pipeline channel claims, active topology, and directional
 membership before every spawn. A fail-closed provider remains available to
 compositions that intentionally have no durable pipeline wiring.
-Channel endpoint and LLM service implementations remain injected by
-the concrete host/daemon composition rather than entering this process-authority
-crate.
+Channel endpoint and LLM service implementations remain injected behind
+`chief-of-staff-host-data-plane` rather than entering this process-authority crate.
 
 ## Validation
 

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
@@ -12,6 +12,7 @@ use chief_of_staff_host_control_protocol::{
     ChildControl, ChildEvent, CompletionCall, DataPlaneRequest, DataPlaneResponse, LaunchBindings,
     OrchestratorControl, OrchestratorEvent, PackageTrust, PackageTrustType,
 };
+use chief_of_staff_host_data_plane::HostDataPlaneDispatcher;
 use chief_of_staff_host_runtime::{
     verify_agent_package, AgentPackageRuntime, PackageKeyType, PackageKeyring, TrustedPackageKey,
 };
@@ -302,6 +303,7 @@ enum InstancePhase {
 }
 
 struct OwnedInstance {
+    registration: HostRegistration,
     package_hash: [u8; 32],
     child: Option<Child>,
     stdin: Option<BufWriter<ChildStdin>>,
@@ -358,7 +360,10 @@ impl OwnedInstance {
         Ok(())
     }
 
-    fn refresh(&mut self) -> Result<(), ProcessSupervisorError> {
+    fn refresh(
+        &mut self,
+        dispatcher: Option<&dyn HostDataPlaneDispatcher>,
+    ) -> Result<(), ProcessSupervisorError> {
         if matches!(self.phase, InstancePhase::Exited { .. }) {
             return Ok(());
         }
@@ -381,7 +386,14 @@ impl OwnedInstance {
                             self.last_heartbeat_ns = Some(received_at_ns);
                         }
                         Ok(ChildEvent::Request(request)) => {
-                            self.pending_data_plane_request = Some(request);
+                            self.pending_data_plane_request = Some(request.clone());
+                            if let Some(dispatcher) = dispatcher {
+                                let response = dispatcher.dispatch(&self.registration, &request);
+                                if let Err(error) = self.send_data_plane_response(response) {
+                                    let _ = self.hard_kill_and_reap();
+                                    return Err(error);
+                                }
+                            }
                         }
                         Err(error) => {
                             let _ = self.hard_kill_and_reap();
@@ -405,6 +417,25 @@ impl OwnedInstance {
                 self.finish_exit(status);
             }
         }
+        Ok(())
+    }
+
+    fn send_data_plane_response(
+        &mut self,
+        response: DataPlaneResponse,
+    ) -> Result<(), ProcessSupervisorError> {
+        let frame = self
+            .control
+            .as_mut()
+            .ok_or(ProcessSupervisorError::Control)?
+            .respond(response)
+            .map_err(|_| ProcessSupervisorError::Control)?;
+        let stdin = self
+            .stdin
+            .as_mut()
+            .ok_or(ProcessSupervisorError::ProcessIo)?;
+        write_record(stdin, &frame)?;
+        self.pending_data_plane_request = None;
         Ok(())
     }
 
@@ -451,6 +482,7 @@ pub struct ProcessHostSupervisor {
     identity: Arc<IdentityKeyPair>,
     clock: Arc<dyn MonotonicClock>,
     sessions: Box<dyn SessionIdSource>,
+    data_plane_dispatcher: Option<Arc<dyn HostDataPlaneDispatcher>>,
     instances: BTreeMap<String, OwnedInstance>,
 }
 
@@ -471,8 +503,18 @@ impl ProcessHostSupervisor {
             identity,
             clock,
             sessions,
+            data_plane_dispatcher: None,
             instances: BTreeMap::new(),
         }
+    }
+
+    /// Automatically answer authenticated child requests through one injected dispatcher.
+    pub fn with_data_plane_dispatcher(
+        mut self,
+        dispatcher: Arc<dyn HostDataPlaneDispatcher>,
+    ) -> Self {
+        self.data_plane_dispatcher = Some(dispatcher);
+        self
     }
 
     fn spawn_verified(
@@ -593,6 +635,7 @@ impl ProcessHostSupervisor {
 
         match startup {
             Ok(control) => Ok(OwnedInstance {
+                registration: registration.clone(),
                 package_hash: *registration.package_hash(),
                 child: Some(child),
                 stdin: Some(stdin),
@@ -633,11 +676,12 @@ impl ProcessHostSupervisor {
         &mut self,
         host_name: &HostName,
     ) -> Result<Option<DataPlaneRequest>, ProcessSupervisorError> {
+        let dispatcher = self.data_plane_dispatcher.as_deref();
         let instance = self
             .instances
             .get_mut(host_name.as_str())
             .ok_or(ProcessSupervisorError::HostNotFound)?;
-        instance.refresh()?;
+        instance.refresh(dispatcher)?;
         Ok(instance.pending_data_plane_request.clone())
     }
 
@@ -647,27 +691,16 @@ impl ProcessHostSupervisor {
         host_name: &HostName,
         response: DataPlaneResponse,
     ) -> Result<(), ProcessSupervisorError> {
+        let dispatcher = self.data_plane_dispatcher.as_deref();
         let instance = self
             .instances
             .get_mut(host_name.as_str())
             .ok_or(ProcessSupervisorError::HostNotFound)?;
-        instance.refresh()?;
-        let frame = instance
-            .control
-            .as_mut()
-            .ok_or(ProcessSupervisorError::Control)?
-            .respond(response)
-            .map_err(|_| ProcessSupervisorError::Control)?;
-        let result = instance
-            .stdin
-            .as_mut()
-            .ok_or(ProcessSupervisorError::ProcessIo)
-            .and_then(|stdin| write_record(stdin, &frame));
-        if let Err(error) = result {
+        instance.refresh(dispatcher)?;
+        if let Err(error) = instance.send_data_plane_response(response) {
             let _ = instance.hard_kill_and_reap();
             return Err(error);
         }
-        instance.pending_data_plane_request = None;
         Ok(())
     }
 }
@@ -679,16 +712,18 @@ impl HostSupervisor for ProcessHostSupervisor {
         &mut self,
         registration: &HostRegistration,
     ) -> Result<SupervisorObservation, Self::Error> {
+        let dispatcher = self.data_plane_dispatcher.as_deref();
         let Some(instance) = self.instances.get_mut(registration.host_name().as_str()) else {
             return Ok(SupervisorObservation::absent());
         };
-        instance.refresh()?;
+        instance.refresh(dispatcher)?;
         instance.observation()
     }
 
     fn start(&mut self, registration: &HostRegistration) -> Result<(), Self::Error> {
+        let dispatcher = self.data_plane_dispatcher.as_deref();
         if let Some(instance) = self.instances.get_mut(registration.host_name().as_str()) {
-            instance.refresh()?;
+            instance.refresh(dispatcher)?;
             if instance.is_active() {
                 return if instance.package_hash == *registration.package_hash() {
                     Ok(())
@@ -704,10 +739,11 @@ impl HostSupervisor for ProcessHostSupervisor {
     }
 
     fn stop(&mut self, host_name: &HostName) -> Result<(), Self::Error> {
+        let dispatcher = self.data_plane_dispatcher.as_deref();
         let Some(instance) = self.instances.get_mut(host_name.as_str()) else {
             return Ok(());
         };
-        instance.refresh()?;
+        instance.refresh(dispatcher)?;
         if matches!(
             instance.phase,
             InstancePhase::Stopping | InstancePhase::Exited { .. }

--- a/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/tests/process_supervisor.rs
@@ -2,6 +2,7 @@ use chief_of_staff_host_control_protocol::{
     ChannelBinding, ChannelBindingAccess, DataPlaneFailure, DataPlaneRequest, DataPlaneResponse,
     LaunchBindings, LevelOneModelBinding, RequestId,
 };
+use chief_of_staff_host_data_plane::HostDataPlaneDispatcher;
 use chief_of_staff_host_runtime::{
     AgentPackageRuntime, DenoLaunchPlan, PackageKeyType, PackageKeyring, TrustedPackageKey,
 };
@@ -20,7 +21,7 @@ use coding_adventures_x3dh::generate_identity_keypair;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -394,6 +395,94 @@ fn real_child_exchanges_all_authenticated_data_plane_operations() {
     );
     supervisor.stop(&host_name).unwrap();
     assert_eq!(supervisor.pending_data_plane_request(&host_name), Ok(None));
+}
+
+#[derive(Default)]
+struct TestDataPlaneDispatcher {
+    operations: Mutex<Vec<&'static str>>,
+}
+
+impl HostDataPlaneDispatcher for TestDataPlaneDispatcher {
+    fn dispatch(
+        &self,
+        _registration: &HostRegistration,
+        request: &DataPlaneRequest,
+    ) -> DataPlaneResponse {
+        match request {
+            DataPlaneRequest::Receive { id, .. } => {
+                self.operations.lock().unwrap().push("receive");
+                DataPlaneResponse::Received {
+                    id: *id,
+                    messages: Vec::new(),
+                }
+            }
+            DataPlaneRequest::Publish { id, .. } => {
+                self.operations.lock().unwrap().push("publish");
+                DataPlaneResponse::Published {
+                    id: *id,
+                    message_id: uuid_v7(4),
+                    sequence: 1,
+                    timestamp_ns: 10,
+                }
+            }
+            DataPlaneRequest::Acknowledge { id, .. } => {
+                self.operations.lock().unwrap().push("acknowledge");
+                DataPlaneResponse::Acknowledged {
+                    id: *id,
+                    sequence: 2,
+                }
+            }
+            DataPlaneRequest::Complete { id, .. } => {
+                self.operations.lock().unwrap().push("complete");
+                DataPlaneResponse::Failed {
+                    id: *id,
+                    failure: DataPlaneFailure::Unavailable,
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn injected_dispatcher_answers_authenticated_requests_automatically() {
+    let package = TestPackage::new("automatic-data-plane", Some("DATA_PLANE"));
+    let registration = package.registration("automatic-data-plane-host");
+    let dispatcher = Arc::new(TestDataPlaneDispatcher::default());
+    let mut supervisor = new_supervisor(
+        Arc::new(keyring()),
+        Arc::new(generate_identity_keypair()),
+        Duration::from_secs(2),
+        Duration::from_secs(2),
+    )
+    .with_data_plane_dispatcher(dispatcher.clone());
+    supervisor.start(&registration).unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        supervisor.inspect(&registration).unwrap();
+        if dispatcher.operations.lock().unwrap().len() == 4 {
+            break;
+        }
+        assert!(Instant::now() < deadline, "timed out waiting for dispatch");
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert_eq!(
+        *dispatcher.operations.lock().unwrap(),
+        ["receive", "publish", "acknowledge", "complete"]
+    );
+    assert_eq!(
+        supervisor
+            .pending_data_plane_request(registration.host_name())
+            .unwrap(),
+        None
+    );
+    supervisor.stop(registration.host_name()).unwrap();
+    let exited = await_phase(
+        &mut supervisor,
+        &registration,
+        SupervisorPhase::Exited { exit_code: Some(0) },
+    );
+    assert_eq!(exited.process_id(), None);
 }
 
 #[test]

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -522,9 +522,15 @@ The strict readiness, heartbeat, and termination state machine is specified in
 That same authenticated session carries a serialized, bounded channel and
 provider-neutral completion data plane after readiness. The protocol permits one
 request in flight with exact monotonic correlation; the orchestrator-side adapter
-authorizes and executes the operation without creating a second child pipe. The
-payload-blind orchestration core receives no request body; the process adapter
-hands it only to the separately injected channel/LLM authority.
+authorizes and executes the operation without creating a second child pipe. For
+every request, the dedicated data-plane dispatcher reloads the exact pipeline
+binding, immutable claims, active channel topology, directional membership, and
+model settings. It rejects unknown or wrong-direction channel UUIDs and any model
+setting drift before invoking the separately injected channel/LLM service, then
+validates response identity and operation shape before returning it. The
+payload-blind orchestration core receives no request body. Until concrete channel
+key custody and model providers are composed, the production daemon uses the same
+authorization boundary with a redacted unavailable service.
 
 ```
 ┌────────────────────────────────────────────────────────────────┐

--- a/code/specs/host-control-protocol.md
+++ b/code/specs/host-control-protocol.md
@@ -69,6 +69,12 @@ successful response kind must match the pending operation; a redacted `Failed`
 response may complete any operation. Duplicate, skipped, unsolicited, or
 cross-operation responses close the peer endpoint. This deliberately serial
 contract matches the Level 1 runtime and avoids an unbounded correlation table.
+Correlation is not authorization. Before service execution, the parent-side
+dispatcher reloads the complete current durable pipeline binding. Receive and
+acknowledge require the requested UUID to have read access, publish requires write
+access, and completion requires the exact authorized model selector, temperature,
+and token cap. A service response must preserve the request ID and successful
+operation kind; drift is returned only as a redacted stable failure.
 
 ## Lifecycle
 

--- a/code/specs/process-host-supervisor.md
+++ b/code/specs/process-host-supervisor.md
@@ -58,6 +58,10 @@ UUID and optional Level 1 model bindings. A provider failure or runtime/model
 mismatch fails before process creation. The child-side helper performs the inverse
 bootstrap over any `Read` and `Write`, receives both authenticated inputs, then
 exposes readiness, heartbeat, termination, and data-plane operations.
+An optional injected `HostDataPlaneDispatcher` automatically answers each
+authenticated request before the next record is processed. The dispatcher owns
+durable per-request authorization and the separately injected service boundary;
+the supervisor retains correlation and encrypted pipe ownership.
 
 ## Package and Identity Safety
 
@@ -141,8 +145,9 @@ The package exposes:
   `HostSupervisor` trait;
 - `ChildProcessControl<R, W>` for lifecycle plus serialized authenticated
   receive/publish/acknowledge/completion exchanges;
-- `pending_data_plane_request` and `respond_data_plane` hooks that retain one
-  correlated request until an injected service adapter answers; and
+- automatic request dispatch when a `HostDataPlaneDispatcher` is injected;
+- `pending_data_plane_request` and `respond_data_plane` hooks for manual
+  compositions, retaining one correlated request until an adapter answers; and
 - bounded, input-independent `ProcessSupervisorError` diagnostics.
 
 ## Capabilities
@@ -166,6 +171,8 @@ The package must cover:
   graceful termination;
 - real cross-platform child exchanges for every data-plane operation over the
   established secure process pipes;
+- automatic injected dispatch for every data-plane operation without a pending
+  request leak;
 - pending-request retention and exact response correlation;
 - idempotent same-hash start and refusal of an active different-hash launch;
 - compile-time `Send + 'static` production composition with shared trust and

--- a/code/specs/runnable-orchestrator-core.md
+++ b/code/specs/runnable-orchestrator-core.md
@@ -35,7 +35,9 @@ The generic core receives:
 A production constructor composes the core with `ProcessHostSupervisor`, owned
 shared handles to its trusted package keyring and long-lived X3DH identity, a
 fixed absolute child program, fresh UUID-v7 session source, and the same
-monotonic clock used for authenticated receipt evidence.
+monotonic clock used for authenticated receipt evidence. It also requires a
+`HostDataPlaneDispatcher`; the supervisor hands authenticated requests directly
+to that injected boundary, so the generic core remains payload-blind.
 
 The core owns an `Arc<dyn StorageBackend>` and the process supervisor owns
 `Arc` handles to its cryptographic trust objects. The complete control plane is


### PR DESCRIPTION
## Summary
- add a durable per-request host data-plane authorization and dispatch boundary
- require exact read/write channel UUID directions and exact Level 1 model settings, revalidating registration, claims, lifecycle, membership, and AgentId on every request
- automatically answer authenticated child requests in process supervision while keeping the orchestration core payload-blind
- wire the daemon to a redacted unavailable service until concrete channel-key custody and model-provider authority land

## Validation
- 44 focused tests across host data plane, pipeline bindings, process supervisor, orchestrator core, and daemon
- strict Clippy and rustdoc for all changed packages
- repository planner: 5 changed packages and 71 affected/prerequisite/dependent packages, all green
- real encrypted signed-package child dispatches receive, publish, acknowledge, and completion automatically
- daemon smoke test

## Follow-up
- compose the concrete Level 1 host and its model/channel authority
- define safe multi-read/multi-write Level 1 routing semantics

Progresses #128
Progresses #138