### PR TITLE
Validate JFET beta model values

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate positive, finite JFET `BETA` and `BET` model-card values.
 - Lower the JFET `LAM` alias with canonical `LAMBDA` precedence.
 - Lower the JFET `VT0` and `VTH` threshold aliases with canonical `VTO` precedence.
 - Lower the JFET `BET` transconductance alias with canonical `BETA` precedence.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -2349,6 +2349,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         ):
             raise NetlistParseError("BJT XCJC must be finite and between zero and one")
     if kind in {"NJF", "PJF"}:
+        transconductance = params.get("BETA", params.get("BET"))
+        if transconductance is not None and (
+            not math.isfinite(transconductance) or transconductance <= 0.0
+        ):
+            raise NetlistParseError("JFET BETA must be finite and positive")
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (
             not math.isfinite(gate_source_capacitance)

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2134,6 +2134,15 @@ def test_parse_jfet_bet_alias_with_canonical_precedence() -> None:
     assert aliased.beta == 900.0e-6
 
 
+@pytest.mark.parametrize("parameter", ["BETA", "BET"])
+@pytest.mark.parametrize("value", ["0", "-1m", "1e999"])
+def test_rejects_invalid_jfet_transconductance(parameter: str, value: str) -> None:
+    with pytest.raises(
+        NetlistParseError, match="JFET BETA must be finite and positive"
+    ):
+        parse_netlist(f".model fast NJF({parameter}={value})")
+
+
 def test_parse_jfet_threshold_aliases_with_canonical_precedence() -> None:
     parsed = parse_netlist(
         ".model canonical NJF(VTO=-3 VT0=-2 VTH=-1)\n"

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate positive, finite JFET `BETA` and `BET` model-card values.
 - Lower the JFET `LAM` alias with canonical `LAMBDA` precedence.
 - Lower the JFET `VT0` and `VTH` threshold aliases with canonical `VTO` precedence.
 - Lower the JFET `BET` transconductance alias with canonical `BETA` precedence.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1635,6 +1635,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT XCJC must be finite and between zero and one");
   }
+  const jfetTransconductance = params.get("BETA") ?? params.get("BET");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetTransconductance !== undefined &&
+    (!Number.isFinite(jfetTransconductance) || jfetTransconductance <= 0.0)
+  ) {
+    throw new NetlistParseError("JFET BETA must be finite and positive");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2215,6 +2215,19 @@ J1 drain gate source fast
     });
   });
 
+  it.each([
+    ["BETA", "0"],
+    ["BETA", "-1m"],
+    ["BETA", "1e999"],
+    ["BET", "0"],
+    ["BET", "-1m"],
+    ["BET", "1e999"],
+  ])("rejects invalid JFET transconductance %s=%s", (parameter, value) => {
+    expect(() => parseNetlist(`.model fast NJF(${parameter}=${value})`)).toThrow(
+      "JFET BETA must be finite and positive",
+    );
+  });
+
   it("parses JFET threshold aliases with canonical precedence", () => {
     const parsed = parseNetlist(
       ".model canonical NJF(VTO=-3 VT0=-2 VTH=-1)\n" +

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4793,10 +4793,16 @@ the Rust, Python, and TypeScript surfaces together.
      without changing the unresolved `B` parameter policy.
 
 487. Python and TypeScript Berkeley SPICE JFET `LAM` alias parity.
-   - Status: implemented in this JFET `LAM` alias slice.
+   - Status: completed in PR 10178.
    - Both parser facades lower the engine-advertised `LAM` alias into the JFET
      channel-length-modulation field with canonical `LAMBDA` precedence,
      without changing the unresolved `B` parameter policy.
+
+488. Python and TypeScript Berkeley SPICE JFET transconductance validation parity.
+   - Status: implemented in this JFET transconductance-validation slice.
+   - Both parser facades reject non-finite or non-positive `BETA` and `BET`
+     values with canonical `BETA` precedence, without changing the unresolved
+     `B` parameter policy.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- validate positive, finite JFET `BETA` and `BET` values in both parser facades
- preserve canonical `BETA` precedence and the unresolved `B` parameter policy
- add cross-language regression coverage and reconcile the SPICE plan

## Verification

- Python parser `bash BUILD` (652 passed, 90.62% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (637 passed)
- TypeScript parser `npx vitest run --coverage` (88.41% line coverage)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
- BUILD/dependency metadata audit: no changes required
