### PR TITLE
Validate JFET threshold model values

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate finite JFET `VTO`, `VT0`, and `VTH` model-card values.
 - Validate positive, finite JFET `BETA` and `BET` model-card values.
 - Lower the JFET `LAM` alias with canonical `LAMBDA` precedence.
 - Lower the JFET `VT0` and `VTH` threshold aliases with canonical `VTO` precedence.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -2354,6 +2354,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             not math.isfinite(transconductance) or transconductance <= 0.0
         ):
             raise NetlistParseError("JFET BETA must be finite and positive")
+        threshold_voltage = params.get(
+            "VTO", params.get("VT0", params.get("VTH"))
+        )
+        if threshold_voltage is not None and not math.isfinite(threshold_voltage):
+            raise NetlistParseError("JFET VTO must be finite")
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (
             not math.isfinite(gate_source_capacitance)

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2162,6 +2162,12 @@ def test_parse_jfet_threshold_aliases_with_canonical_precedence() -> None:
     assert threshold.vto == -1.0
 
 
+@pytest.mark.parametrize("parameter", ["VTO", "VT0", "VTH"])
+def test_rejects_non_finite_jfet_threshold_voltage(parameter: str) -> None:
+    with pytest.raises(NetlistParseError, match="JFET VTO must be finite"):
+        parse_netlist(f".model fast NJF({parameter}=1e999)")
+
+
 def test_parse_jfet_lam_alias_with_canonical_precedence() -> None:
     parsed = parse_netlist(
         ".model canonical NJF(LAMBDA=0.02 LAM=0.03)\n"

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate finite JFET `VTO`, `VT0`, and `VTH` model-card values.
 - Validate positive, finite JFET `BETA` and `BET` model-card values.
 - Lower the JFET `LAM` alias with canonical `LAMBDA` precedence.
 - Lower the JFET `VT0` and `VTH` threshold aliases with canonical `VTO` precedence.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1643,6 +1643,15 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET BETA must be finite and positive");
   }
+  const jfetThresholdVoltage =
+    params.get("VTO") ?? params.get("VT0") ?? params.get("VTH");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetThresholdVoltage !== undefined &&
+    !Number.isFinite(jfetThresholdVoltage)
+  ) {
+    throw new NetlistParseError("JFET VTO must be finite");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2252,6 +2252,15 @@ J1 drain gate source fast
     });
   });
 
+  it.each(["VTO", "VT0", "VTH"])(
+    "rejects non-finite JFET threshold voltage %s",
+    (parameter) => {
+      expect(() => parseNetlist(`.model fast NJF(${parameter}=1e999)`)).toThrow(
+        "JFET VTO must be finite",
+      );
+    },
+  );
+
   it("parses the JFET LAM alias with canonical precedence", () => {
     const parsed = parseNetlist(
       ".model canonical NJF(LAMBDA=0.02 LAM=0.03)\n" +

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4799,10 +4799,16 @@ the Rust, Python, and TypeScript surfaces together.
      without changing the unresolved `B` parameter policy.
 
 488. Python and TypeScript Berkeley SPICE JFET transconductance validation parity.
-   - Status: implemented in this JFET transconductance-validation slice.
+   - Status: completed in PR 10181.
    - Both parser facades reject non-finite or non-positive `BETA` and `BET`
      values with canonical `BETA` precedence, without changing the unresolved
      `B` parameter policy.
+
+489. Python and TypeScript Berkeley SPICE JFET threshold-voltage validation parity.
+   - Status: implemented in this JFET threshold-validation slice.
+   - Both parser facades reject non-finite `VTO`, `VT0`, and `VTH` values
+     with canonical `VTO` precedence, without changing the unresolved `B`
+     parameter policy.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- validate finite JFET `VTO`, `VT0`, and `VTH` values in both parser facades
- preserve canonical `VTO` precedence and the unresolved `B` parameter policy
- add cross-language regression coverage and reconcile the SPICE plan

## Verification

- Python parser `bash BUILD` (655 passed, 90.64% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (640 passed)
- TypeScript parser `npx vitest run --coverage` (88.44% line coverage)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
- BUILD/dependency metadata audit: no changes required
