### PR TITLE
Validate JFET channel modulation values

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate finite JFET `LAMBDA` and `LAM` model-card values.
 - Validate finite JFET `VTO`, `VT0`, and `VTH` model-card values.
 - Validate positive, finite JFET `BETA` and `BET` model-card values.
 - Lower the JFET `LAM` alias with canonical `LAMBDA` precedence.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -2359,6 +2359,11 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
         )
         if threshold_voltage is not None and not math.isfinite(threshold_voltage):
             raise NetlistParseError("JFET VTO must be finite")
+        channel_length_modulation = params.get("LAMBDA", params.get("LAM"))
+        if channel_length_modulation is not None and not math.isfinite(
+            channel_length_modulation
+        ):
+            raise NetlistParseError("JFET LAMBDA must be finite")
         gate_source_capacitance = params.get("CGS", params.get("CGS0"))
         if gate_source_capacitance is not None and (
             not math.isfinite(gate_source_capacitance)

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -2183,6 +2183,12 @@ def test_parse_jfet_lam_alias_with_canonical_precedence() -> None:
     assert aliased.lambda_ == 0.04
 
 
+@pytest.mark.parametrize("parameter", ["LAMBDA", "LAM"])
+def test_rejects_non_finite_jfet_channel_length_modulation(parameter: str) -> None:
+    with pytest.raises(NetlistParseError, match="JFET LAMBDA must be finite"):
+        parse_netlist(f".model fast NJF({parameter}=1e999)")
+
+
 def test_parse_pjfet_model_type_alias() -> None:
     parsed = parse_netlist(
         ".model fast PJFET(BETA=2m)\nJ1 drain gate source fast"

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate finite JFET `LAMBDA` and `LAM` model-card values.
 - Validate finite JFET `VTO`, `VT0`, and `VTH` model-card values.
 - Validate positive, finite JFET `BETA` and `BET` model-card values.
 - Lower the JFET `LAM` alias with canonical `LAMBDA` precedence.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1652,6 +1652,14 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET VTO must be finite");
   }
+  const jfetChannelLengthModulation = params.get("LAMBDA") ?? params.get("LAM");
+  if (
+    (kind === "NJF" || kind === "PJF") &&
+    jfetChannelLengthModulation !== undefined &&
+    !Number.isFinite(jfetChannelLengthModulation)
+  ) {
+    throw new NetlistParseError("JFET LAMBDA must be finite");
+  }
   const gateSourceCapacitance = params.get("CGS") ?? params.get("CGS0");
   if (
     (kind === "NJF" || kind === "PJF") &&

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -2279,6 +2279,15 @@ J1 drain gate source fast
     });
   });
 
+  it.each(["LAMBDA", "LAM"])(
+    "rejects non-finite JFET channel-length modulation %s",
+    (parameter) => {
+      expect(() => parseNetlist(`.model fast NJF(${parameter}=1e999)`)).toThrow(
+        "JFET LAMBDA must be finite",
+      );
+    },
+  );
+
   it("parses the PJFET model type alias", () => {
     const parsed = parseNetlist(".model fast PJFET(BETA=2m)\nJ1 drain gate source fast");
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4805,9 +4805,15 @@ the Rust, Python, and TypeScript surfaces together.
      `B` parameter policy.
 
 489. Python and TypeScript Berkeley SPICE JFET threshold-voltage validation parity.
-   - Status: implemented in this JFET threshold-validation slice.
+   - Status: completed in PR 10182.
    - Both parser facades reject non-finite `VTO`, `VT0`, and `VTH` values
      with canonical `VTO` precedence, without changing the unresolved `B`
+     parameter policy.
+
+490. Python and TypeScript Berkeley SPICE JFET channel-length-modulation validation parity.
+   - Status: implemented in this JFET channel-length-modulation validation slice.
+   - Both parser facades reject non-finite `LAMBDA` and `LAM` values with
+     canonical `LAMBDA` precedence, without changing the unresolved `B`
      parameter policy.
 
 ## Backlog


### PR DESCRIPTION
## Summary

- validate finite JFET `LAMBDA` and `LAM` values in both parser facades
- preserve canonical `LAMBDA` precedence and the unresolved `B` parameter policy
- add cross-language regression coverage and reconcile the SPICE plan

## Verification

- Python parser `bash BUILD` (657 passed, 90.66% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (642 passed)
- TypeScript parser `npx vitest run --coverage` (88.47% line coverage)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
- BUILD/dependency metadata audit: no changes required
