### PR TITLE
Give TNOM canonical model precedence

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give canonical BJT and JFET `TNOM` precedence over the `T_NOM` alias.
 - Validate finite JFET `LAMBDA` and `LAM` model-card values.
 - Validate finite JFET `VTO`, `VT0`, and `VTH` model-card values.
 - Validate positive, finite JFET `BETA` and `BET` model-card values.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -1299,7 +1299,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
         base_collector_leakage_current = model.params.get(
             "ISC", model.params.get("C4", 0.0) * saturation_current
         )
-        nominal_temperature = model.params.get("T_NOM", model.params.get("TNOM"))
+        nominal_temperature = model.params.get("TNOM", model.params.get("T_NOM"))
         return BJT(
             name,
             fields[1],
@@ -1366,7 +1366,7 @@ def _parse_element(fields: list[str], models: dict[str, ModelCard]) -> object:
             raise NetlistParseError(
                 f"model {model.name!r} has kind {model.kind!r}, expected 'NJF' or 'PJF'"
             )
-        nominal_temperature = model.params.get("T_NOM", model.params.get("TNOM"))
+        nominal_temperature = model.params.get("TNOM", model.params.get("T_NOM"))
         return JFET(
             name,
             fields[1],
@@ -2275,7 +2275,7 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             or reverse_beta_rolloff_current < 0.0
         ):
             raise NetlistParseError("BJT IKR must be finite and non-negative")
-        nominal_temperature = params.get("T_NOM", params.get("TNOM"))
+        nominal_temperature = params.get("TNOM", params.get("T_NOM"))
         if nominal_temperature is not None and (
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0
         ):
@@ -2453,7 +2453,7 @@ def _parse_model_card(fields: list[str]) -> ModelCard:
             )
         ):
             raise NetlistParseError("JFET VTOTC must be finite")
-        nominal_temperature = params.get("T_NOM", params.get("TNOM"))
+        nominal_temperature = params.get("TNOM", params.get("T_NOM"))
         if nominal_temperature is not None and (
             not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0
         ):

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -1820,14 +1820,14 @@ def test_parse_bjt_nominal_temperature(alias: str, value: str) -> None:
     assert transistor.Tnom == pytest.approx(float(value) + 273.15)
 
 
-def test_bjt_t_nom_takes_precedence_over_tnom() -> None:
+def test_bjt_tnom_takes_precedence_over_t_nom() -> None:
     parsed = parse_netlist(
-        ".model fast NPN(TNOM=-1 T_NOM=50)\nQ1 col base emit fast"
+        ".model fast NPN(TNOM=25 T_NOM=50)\nQ1 col base emit fast"
     )
 
     transistor = parsed.circuit.elements[0]
     assert isinstance(transistor, BJT)
-    assert transistor.Tnom == pytest.approx(323.15)
+    assert transistor.Tnom == pytest.approx(298.15)
 
 
 @pytest.mark.parametrize("alias", ["TNOM", "T_NOM"])
@@ -2561,7 +2561,7 @@ J1 drain gate source fast
     assert jfet.Tnom == pytest.approx(float(value) + 273.15)
 
 
-def test_jfet_t_nom_takes_precedence_over_tnom() -> None:
+def test_jfet_tnom_takes_precedence_over_t_nom() -> None:
     parsed = parse_netlist(
         """
 .model fast NJF(TNOM=25 T_NOM=50)
@@ -2571,7 +2571,7 @@ J1 drain gate source fast
 
     jfet = parsed.circuit.elements[0]
     assert isinstance(jfet, JFET)
-    assert jfet.Tnom == pytest.approx(323.15)
+    assert jfet.Tnom == pytest.approx(298.15)
 
 
 @pytest.mark.parametrize("alias", ["TNOM", "T_NOM"])

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give canonical BJT and JFET `TNOM` precedence over the `T_NOM` alias.
 - Validate finite JFET `LAMBDA` and `LAM` model-card values.
 - Validate finite JFET `VTO`, `VT0`, and `VTH` model-card values.
 - Validate positive, finite JFET `BETA` and `BET` model-card values.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -1528,7 +1528,7 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("BJT IKR must be finite and non-negative");
   }
-  const bjtNominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
+  const bjtNominalTemperature = params.get("TNOM") ?? params.get("T_NOM");
   if (
     (kind === "NPN" || kind === "PNP") &&
     bjtNominalTemperature !== undefined &&
@@ -1787,7 +1787,7 @@ function parseModelCard(fields: readonly string[]): ModelCard {
   ) {
     throw new NetlistParseError("JFET VTOTC must be finite");
   }
-  const jfetNominalTemperature = params.get("T_NOM") ?? params.get("TNOM");
+  const jfetNominalTemperature = params.get("TNOM") ?? params.get("T_NOM");
   if (
     (kind === "NJF" || kind === "PJF") &&
     jfetNominalTemperature !== undefined &&
@@ -2377,7 +2377,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       (model.params.get("C2") ?? 0.0) * saturationCurrent;
     const baseCollectorLeakageCurrent = model.params.get("ISC") ??
       (model.params.get("C4") ?? 0.0) * saturationCurrent;
-    const nominalTemperature = model.params.get("T_NOM") ?? model.params.get("TNOM");
+    const nominalTemperature = model.params.get("TNOM") ?? model.params.get("T_NOM");
     return bjt(
       name,
       fields[1],
@@ -2449,7 +2449,7 @@ function parseElement(fields: readonly string[], models: ReadonlyMap<string, Mod
       );
     }
     const polarity = model.kind as JfetPolarity;
-    const nominalTemperature = model.params.get("T_NOM") ?? model.params.get("TNOM");
+    const nominalTemperature = model.params.get("TNOM") ?? model.params.get("T_NOM");
     return jfet(
       name,
       fields[1],

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -1891,12 +1891,12 @@ Q1 col base emit fast
     });
   });
 
-  it("gives BJT T_NOM precedence over TNOM", () => {
-    const parsed = parseNetlist(`.model fast NPN(TNOM=-1 T_NOM=50)\nQ1 col base emit fast`);
+  it("gives BJT TNOM precedence over T_NOM", () => {
+    const parsed = parseNetlist(`.model fast NPN(TNOM=25 T_NOM=50)\nQ1 col base emit fast`);
 
     expect(parsed.circuit.elements()[0]).toMatchObject({
       kind: "bjt",
-      nominalTemperatureKelvin: 323.15,
+      nominalTemperatureKelvin: 298.15,
     });
   });
 
@@ -2671,7 +2671,7 @@ J1 drain gate source fast
     });
   });
 
-  it("gives JFET T_NOM precedence over TNOM", () => {
+  it("gives JFET TNOM precedence over T_NOM", () => {
     const parsed = parseNetlist(`
 .model fast NJF(TNOM=25 T_NOM=50)
 J1 drain gate source fast
@@ -2679,7 +2679,7 @@ J1 drain gate source fast
 
     expect(parsed.circuit.elements()[0]).toMatchObject({
       kind: "jfet",
-      nominalTemperatureKelvin: 323.15,
+      nominalTemperatureKelvin: 298.15,
     });
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4811,10 +4811,16 @@ the Rust, Python, and TypeScript surfaces together.
      parameter policy.
 
 490. Python and TypeScript Berkeley SPICE JFET channel-length-modulation validation parity.
-   - Status: implemented in this JFET channel-length-modulation validation slice.
+   - Status: completed in PR 10185.
    - Both parser facades reject non-finite `LAMBDA` and `LAM` values with
      canonical `LAMBDA` precedence, without changing the unresolved `B`
      parameter policy.
+
+491. Python and TypeScript Berkeley SPICE BJT/JFET nominal-temperature alias precedence.
+   - Status: implemented in this nominal-temperature precedence slice.
+   - Both parser facades give engine-canonical `TNOM` precedence over the
+     `T_NOM` alias for BJT and JFET validation and lowering, without changing
+     the unresolved JFET `B` parameter policy.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- give engine-canonical `TNOM` precedence over `T_NOM` for BJT and JFET cards
- align validation and device lowering in both parser facades
- preserve the unresolved JFET `B` parameter policy and reconcile the SPICE plan

## Verification

- Python parser `bash BUILD` (657 passed, 90.66% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (642 passed)
- TypeScript parser `npx vitest run --coverage` (88.47% line coverage)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
- BUILD/dependency metadata audit: no changes required
