### PR TITLE
Add the concrete Level 1 Chief host

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1036,6 +1036,7 @@ members = [
   "chief-of-staff-skill-parser",
   "chief-of-staff-skill-package",
   "chief-of-staff-skill-runtime",
+  "chief-of-staff-host",
   "chief-of-staff-agent-stdio-protocol",
   "chief-of-staff-agent-stdio-host",
 ]

--- a/code/packages/rust/chief-of-staff-host/BUILD
+++ b/code/packages/rust/chief-of-staff-host/BUILD
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+cargo test -p chief-of-staff-host -- --nocapture
+cargo clippy -p chief-of-staff-host --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-host --no-deps

--- a/code/packages/rust/chief-of-staff-host/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+- Add the concrete Level 1 host executable with independent package verification,
+  exact authenticated launch-policy matching, serialized channel/model requests,
+  bounded idle polling, heartbeats, and graceful authenticated termination.
+- Back off and retry only read-only receive unavailability; keep failures after
+  input delivery terminal to avoid unsafe completion or publication retries.
+- Fail closed unless the first Level 1 production topology has exactly one read
+  channel and one write channel.

--- a/code/packages/rust/chief-of-staff-host/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-host/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "chief-of-staff-host"
+version = "0.1.0"
+edition = "2021"
+description = "Concrete authenticated host executable for Chief agent packages"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-host-control-protocol = { path = "../chief-of-staff-host-control-protocol" }
+chief-of-staff-host-runtime = { path = "../chief-of-staff-host-runtime" }
+chief-of-staff-process-supervisor = { path = "../chief-of-staff-process-supervisor" }
+chief-of-staff-skill-runtime = { path = "../chief-of-staff-skill-runtime" }
+llm-gateway = { path = "../llm-gateway" }
+
+[dev-dependencies]
+chief-of-staff-host-data-plane = { path = "../chief-of-staff-host-data-plane" }
+chief-of-staff-secure-host-channel = { path = "../chief-of-staff-secure-host-channel" }
+chief-of-staff-service-reconciler = { path = "../chief-of-staff-service-reconciler" }
+chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }
+chief-of-staff-skill-package = { path = "../chief-of-staff-skill-package" }
+chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
+coding_adventures_ed25519 = { path = "../ed25519" }
+coding_adventures_x3dh = { path = "../x3dh" }
+
+[[bin]]
+name = "chief-of-staff-host"
+path = "src/main.rs"
+test = false

--- a/code/packages/rust/chief-of-staff-host/README.md
+++ b/code/packages/rust/chief-of-staff-host/README.md
@@ -1,0 +1,30 @@
+# chief-of-staff-host
+
+Concrete child executable for supervised D18 Chief agent packages. The process
+bootstraps the encrypted control session over standard input/output, accepts only
+the authenticated public package trust and launch bindings, independently verifies
+the sealed package in its working directory, and sends readiness only after the
+signed Level 1 policy matches those bindings exactly.
+
+The first production Level 1 loop deliberately requires exactly one read channel
+and one write channel. It requests one verified message, executes the existing
+provider-neutral `SKILL.md` runtime through the authenticated completion data plane,
+publishes the response, and acknowledges only after publication. Idle reads sleep
+before retrying, and the host emits authenticated heartbeats without busy-spinning.
+A redacted unavailable response to the read-only receive operation follows the same
+bounded backoff path, allowing the daemon's fail-closed placeholder service to stay
+healthy until concrete authority is composed. Failures after an input remain terminal
+so the child never guesses whether a completion or publication can be retried safely.
+An authenticated `Terminate` received while waiting for any operation is a clean
+exit. Data-plane failures are redacted and terminal for this child, leaving durable
+input acknowledgement unchanged when processing did not finish.
+
+The executable rejects `--package-runtime deno` until a separately reviewed Deno
+adapter is composed. It uses no ambient environment configuration and inherits the
+supervisor-selected package directory as its only package location.
+
+## Validation
+
+```sh
+sh chief-of-staff-host/BUILD
+```

--- a/code/packages/rust/chief-of-staff-host/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host/src/lib.rs
@@ -1,0 +1,506 @@
+//! Concrete authenticated child host for D18 Chief agent packages.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_host_control_protocol::{
+    ChannelBindingAccess, CompletionCall, CompletionFinishReason, CompletionProvider,
+    CompletionResult, DataPlaneFailure, DataPlaneResponse, LaunchBindings, PromptMessage,
+    PromptRole,
+};
+use chief_of_staff_host_runtime::{
+    verify_agent_package, AgentPackageRuntime, PackageKeyring, PackageVerificationError,
+};
+use chief_of_staff_process_supervisor::{ChildProcessControl, ProcessSupervisorError};
+use chief_of_staff_skill_runtime::{
+    LevelOneLaunchPlan, LevelOneRuntimeError, LevelOneSkillRuntime, LEVEL_ONE_RESPONSE_CONTENT_TYPE,
+};
+use llm_gateway::{
+    Capabilities, CompletionJsonResponse, CompletionRequest, CompletionResponse, FinishReason,
+    JsonSchema, LlmClient, LlmError, MessageContent, ProviderIdentity, Role, TokenUsage,
+};
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::fmt::{self, Display, Formatter};
+use std::io::{self, BufReader, BufWriter, Read, Write};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, MutexGuard};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const PACKAGE_RUNTIME_ARGUMENT: &str = "--package-runtime";
+const SKILL_RUNTIME_LABEL: &str = "skill";
+const IDLE_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Normal terminal condition for one concrete host process.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HostExit {
+    /// The orchestrator sent an authenticated graceful termination record.
+    Terminated,
+}
+
+/// Stable failure from host arguments, verification, policy, control, or execution.
+#[derive(Debug)]
+pub enum HostError {
+    /// Reserved process arguments were absent, duplicated, or malformed.
+    InvalidArguments,
+    /// The configured package runtime has no concrete adapter in this executable.
+    UnsupportedRuntime,
+    /// The first Level 1 host requires exactly one read and one write channel.
+    UnsupportedTopology,
+    /// Package verification failed against authenticated public trust.
+    Package(Box<PackageVerificationError>),
+    /// Signed Level 1 policy or execution failed.
+    Runtime(Box<LevelOneRuntimeError>),
+    /// Secure bootstrap, framing, or authenticated control failed.
+    Control(ProcessSupervisorError),
+    /// An authenticated data-plane operation returned a redacted failure.
+    DataPlane(DataPlaneFailure),
+    /// A successful response did not have the exact locally required shape.
+    ResponseShape,
+    /// An internal control lock was poisoned by an earlier failure.
+    ControlPoisoned,
+}
+
+impl Display for HostError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidArguments => "chief-host: invalid process arguments",
+            Self::UnsupportedRuntime => "chief-host: package runtime is not supported",
+            Self::UnsupportedTopology => "chief-host: Level 1 topology is not supported",
+            Self::Package(_) => "chief-host: package verification failed",
+            Self::Runtime(_) => "chief-host: Level 1 execution failed",
+            Self::Control(_) => "chief-host: authenticated control failed",
+            Self::DataPlane(_) => "chief-host: data-plane operation failed",
+            Self::ResponseShape => "chief-host: invalid data-plane response",
+            Self::ControlPoisoned => "chief-host: control state is unavailable",
+        })
+    }
+}
+
+impl std::error::Error for HostError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Package(error) => Some(error),
+            Self::Runtime(error) => Some(error),
+            Self::Control(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<PackageVerificationError> for HostError {
+    fn from(error: PackageVerificationError) -> Self {
+        Self::Package(Box::new(error))
+    }
+}
+
+impl From<LevelOneRuntimeError> for HostError {
+    fn from(error: LevelOneRuntimeError) -> Self {
+        Self::Runtime(Box::new(error))
+    }
+}
+
+impl From<ProcessSupervisorError> for HostError {
+    fn from(error: ProcessSupervisorError) -> Self {
+        Self::Control(error)
+    }
+}
+
+/// Parse the reserved runtime argument and run the concrete host over stdio.
+pub fn run_from_env() -> Result<HostExit, HostError> {
+    let arguments = std::env::args_os().skip(1).collect::<Vec<_>>();
+    require_skill_runtime_argument(&arguments)?;
+    let reader = BufReader::new(io::stdin());
+    let writer = BufWriter::new(io::stdout());
+    run_level_one_host(reader, writer, Path::new("."))
+}
+
+/// Run one independently verifying Level 1 host over caller-owned streams.
+pub fn run_level_one_host<R, W>(
+    reader: R,
+    writer: W,
+    package_path: &Path,
+) -> Result<HostExit, HostError>
+where
+    R: Read + Send,
+    W: Write + Send,
+{
+    let mut control = ChildProcessControl::bootstrap(reader, writer)?;
+    let mut keyring = PackageKeyring::new();
+    keyring.trust(control.receive_package_trust()?)?;
+    let package = verify_agent_package(package_path, &keyring)?;
+    if package.runtime() != AgentPackageRuntime::Skill {
+        return Err(HostError::UnsupportedRuntime);
+    }
+    let bindings = control.receive_launch_bindings()?;
+    let plan = LevelOneLaunchPlan::from_verified_package(&package, &bindings)?;
+    let (read_channel, write_channel) = sole_level_one_channels(&bindings)?;
+    control.ready(package.digest())?;
+
+    let terminated = AtomicBool::new(false);
+    let control = Mutex::new(control);
+    let client = ControlLlmClient::new(&control, &terminated, plan.config().model());
+    let runtime = plan.runtime(&client)?;
+    let mut last_heartbeat = Instant::now();
+
+    loop {
+        match run_level_one_once(&control, &terminated, &runtime, read_channel, write_channel) {
+            Ok(HostStep::Idle | HostStep::Unavailable) => thread::sleep(IDLE_POLL_INTERVAL),
+            Ok(HostStep::Processed) => {}
+            Err(HostError::Control(ProcessSupervisorError::Terminated)) => {
+                return Ok(HostExit::Terminated)
+            }
+            Err(HostError::Runtime(_)) if terminated.load(Ordering::SeqCst) => {
+                return Ok(HostExit::Terminated)
+            }
+            Err(error) => return Err(error),
+        }
+        if last_heartbeat.elapsed() >= HEARTBEAT_INTERVAL {
+            lock_control(&control)?.heartbeat()?;
+            last_heartbeat = Instant::now();
+        }
+    }
+}
+
+fn require_skill_runtime_argument(arguments: &[OsString]) -> Result<(), HostError> {
+    if arguments.len() != 2 || arguments[0] != PACKAGE_RUNTIME_ARGUMENT {
+        return Err(HostError::InvalidArguments);
+    }
+    match arguments[1].to_str() {
+        Some(SKILL_RUNTIME_LABEL) => Ok(()),
+        Some(_) => Err(HostError::UnsupportedRuntime),
+        None => Err(HostError::InvalidArguments),
+    }
+}
+
+fn sole_level_one_channels(bindings: &LaunchBindings) -> Result<([u8; 16], [u8; 16]), HostError> {
+    let reads = bindings
+        .channels()
+        .iter()
+        .filter(|binding| binding.access() == ChannelBindingAccess::Read)
+        .collect::<Vec<_>>();
+    let writes = bindings
+        .channels()
+        .iter()
+        .filter(|binding| binding.access() == ChannelBindingAccess::Write)
+        .collect::<Vec<_>>();
+    match (reads.as_slice(), writes.as_slice()) {
+        ([read], [write]) => Ok((read.channel_id(), write.channel_id())),
+        _ => Err(HostError::UnsupportedTopology),
+    }
+}
+
+enum HostStep {
+    Idle,
+    Unavailable,
+    Processed,
+}
+
+fn run_level_one_once<R, W>(
+    control: &Mutex<ChildProcessControl<R, W>>,
+    terminated: &AtomicBool,
+    runtime: &LevelOneSkillRuntime<'_>,
+    read_channel: [u8; 16],
+    write_channel: [u8; 16],
+) -> Result<HostStep, HostError>
+where
+    R: Read + Send,
+    W: Write + Send,
+{
+    let received = lock_control(control)?.request_receive(read_channel, 1)?;
+    let message = match received {
+        DataPlaneResponse::Received { messages, .. } => match messages.as_slice() {
+            [] => return Ok(HostStep::Idle),
+            [message] => message.clone(),
+            _ => return Err(HostError::ResponseShape),
+        },
+        DataPlaneResponse::Failed {
+            failure: DataPlaneFailure::Unavailable,
+            ..
+        } => return Ok(HostStep::Unavailable),
+        DataPlaneResponse::Failed { failure, .. } => return Err(HostError::DataPlane(failure)),
+        _ => return Err(HostError::ResponseShape),
+    };
+    let input =
+        std::str::from_utf8(&message.payload).map_err(|_| LevelOneRuntimeError::NonUtf8Input)?;
+    let response = match runtime.respond(input, &message.content_type) {
+        Ok(response) => response,
+        Err(_error) if terminated.load(Ordering::SeqCst) => {
+            return Err(HostError::Control(ProcessSupervisorError::Terminated))
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let published = lock_control(control)?.request_publish(
+        write_channel,
+        LEVEL_ONE_RESPONSE_CONTENT_TYPE.to_string(),
+        response.text.into_bytes(),
+    )?;
+    match published {
+        DataPlaneResponse::Published { .. } => {}
+        DataPlaneResponse::Failed { failure, .. } => return Err(HostError::DataPlane(failure)),
+        _ => return Err(HostError::ResponseShape),
+    }
+    let acknowledged =
+        lock_control(control)?.request_acknowledge(read_channel, message.message_id)?;
+    match acknowledged {
+        DataPlaneResponse::Acknowledged { .. } => Ok(HostStep::Processed),
+        DataPlaneResponse::Failed { failure, .. } => Err(HostError::DataPlane(failure)),
+        _ => Err(HostError::ResponseShape),
+    }
+}
+
+fn lock_control<R, W>(
+    control: &Mutex<ChildProcessControl<R, W>>,
+) -> Result<MutexGuard<'_, ChildProcessControl<R, W>>, HostError>
+where
+    R: Read + Send,
+    W: Write + Send,
+{
+    control.lock().map_err(|_| HostError::ControlPoisoned)
+}
+
+struct ControlLlmClient<'a, R: Read + Send, W: Write + Send> {
+    control: &'a Mutex<ChildProcessControl<R, W>>,
+    terminated: &'a AtomicBool,
+    identity: ProviderIdentity,
+}
+
+#[derive(Clone, Copy)]
+enum CompletionAdapterError {
+    Multimodal,
+    TokenCap,
+    Usage,
+}
+
+impl CompletionAdapterError {
+    fn message(self) -> &'static str {
+        match self {
+            Self::Multimodal => "multimodal completion is unavailable",
+            Self::TokenCap => "completion token cap is out of range",
+            Self::Usage => "completion usage is out of range",
+        }
+    }
+}
+
+impl<'a, R: Read + Send, W: Write + Send> ControlLlmClient<'a, R, W> {
+    fn new(
+        control: &'a Mutex<ChildProcessControl<R, W>>,
+        terminated: &'a AtomicBool,
+        model: &str,
+    ) -> Self {
+        Self {
+            control,
+            terminated,
+            identity: ProviderIdentity {
+                vendor: "chief-host-data-plane".to_string(),
+                model_family: model.to_string(),
+                model_version: "authenticated".to_string(),
+                endpoint: None,
+            },
+        }
+    }
+
+    fn error(&self, message: &str) -> LlmError {
+        LlmError::Other {
+            provider: self.identity.clone(),
+            message: message.to_string(),
+        }
+    }
+
+    fn completion_call(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<CompletionCall, CompletionAdapterError> {
+        let messages = request
+            .messages
+            .into_iter()
+            .map(|message| {
+                let role = match message.role {
+                    Role::System => PromptRole::System,
+                    Role::User => PromptRole::User,
+                    Role::Assistant => PromptRole::Assistant,
+                };
+                let MessageContent::Text(text) = message.content else {
+                    return Err(CompletionAdapterError::Multimodal);
+                };
+                Ok(PromptMessage { role, text })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let max_tokens = request
+            .max_tokens
+            .map(u32::try_from)
+            .transpose()
+            .map_err(|_| CompletionAdapterError::TokenCap)?;
+        Ok(CompletionCall {
+            model: request.model,
+            system: request.system,
+            messages,
+            temperature: request.temperature,
+            max_tokens,
+            stop_sequences: request.stop_sequences,
+            seed: request.seed,
+            metadata: request.metadata.into_iter().collect::<BTreeMap<_, _>>(),
+        })
+    }
+
+    fn completion_response(
+        &self,
+        result: CompletionResult,
+    ) -> Result<CompletionResponse, CompletionAdapterError> {
+        let input_tokens = usize::try_from(result.usage.input_tokens)
+            .map_err(|_| CompletionAdapterError::Usage)?;
+        let output_tokens = usize::try_from(result.usage.output_tokens)
+            .map_err(|_| CompletionAdapterError::Usage)?;
+        let cached_tokens = usize::try_from(result.usage.cached_tokens)
+            .map_err(|_| CompletionAdapterError::Usage)?;
+        Ok(CompletionResponse {
+            text: result.text,
+            model: result.model,
+            usage: TokenUsage {
+                input_tokens,
+                output_tokens,
+                cached_tokens,
+            },
+            finish_reason: match result.finish_reason {
+                CompletionFinishReason::Stop => FinishReason::Stop,
+                CompletionFinishReason::MaxTokens => FinishReason::MaxTokens,
+                CompletionFinishReason::Refusal => FinishReason::Refusal,
+                CompletionFinishReason::Other => FinishReason::Other,
+            },
+            provider_id: provider_identity(result.provider),
+            latency_ms: result.latency_ms,
+        })
+    }
+}
+
+impl<R: Read + Send, W: Write + Send> LlmClient for ControlLlmClient<'_, R, W> {
+    fn identity(&self) -> ProviderIdentity {
+        self.identity.clone()
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            json_mode_native: false,
+            tool_use_native: false,
+            streaming_native: false,
+            prompt_caching_native: false,
+            multimodal_image_input: false,
+            max_context_window: 0,
+        }
+    }
+
+    fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+        let call = self
+            .completion_call(request)
+            .map_err(|error| self.error(error.message()))?;
+        let response = self
+            .control
+            .lock()
+            .map_err(|_| self.error("host control is unavailable"))?
+            .request_completion(call);
+        let response = match response {
+            Ok(response) => response,
+            Err(ProcessSupervisorError::Terminated) => {
+                self.terminated.store(true, Ordering::SeqCst);
+                return Err(self.error("host termination requested"));
+            }
+            Err(_) => return Err(self.error("host control is unavailable")),
+        };
+        match response {
+            DataPlaneResponse::Completed { result, .. } => self
+                .completion_response(*result)
+                .map_err(|error| self.error(error.message())),
+            DataPlaneResponse::Failed { .. } => Err(self.error("completion failed")),
+            _ => Err(self.error("invalid completion response")),
+        }
+    }
+
+    fn complete_json(
+        &self,
+        _request: CompletionRequest,
+        _schema: &JsonSchema,
+    ) -> Result<CompletionJsonResponse, LlmError> {
+        Err(self.error("structured completion is unavailable"))
+    }
+}
+
+fn provider_identity(provider: CompletionProvider) -> ProviderIdentity {
+    ProviderIdentity {
+        vendor: provider.vendor,
+        model_family: provider.model_family,
+        model_version: provider.model_version,
+        endpoint: provider.endpoint,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chief_of_staff_host_control_protocol::{ChannelBinding, LevelOneModelBinding};
+
+    fn uuid_v7(last: u8) -> [u8; 16] {
+        let mut bytes = [0; 16];
+        bytes[6] = 0x70;
+        bytes[8] = 0x80;
+        bytes[15] = last;
+        bytes
+    }
+
+    fn binding(name: &str, access: ChannelBindingAccess, id: u8) -> ChannelBinding {
+        ChannelBinding::new(name, access, uuid_v7(id)).unwrap()
+    }
+
+    #[test]
+    fn process_arguments_select_only_the_skill_runtime() {
+        assert!(require_skill_runtime_argument(&[
+            OsString::from("--package-runtime"),
+            OsString::from("skill")
+        ])
+        .is_ok());
+        assert!(matches!(
+            require_skill_runtime_argument(&[
+                OsString::from("--package-runtime"),
+                OsString::from("deno")
+            ]),
+            Err(HostError::UnsupportedRuntime)
+        ));
+        assert!(matches!(
+            require_skill_runtime_argument(&[]),
+            Err(HostError::InvalidArguments)
+        ));
+    }
+
+    #[test]
+    fn first_level_one_host_requires_one_read_and_one_write() {
+        let model = Some(LevelOneModelBinding::new("test-model", 0.0, 128).unwrap());
+        let supported = LaunchBindings::new(
+            vec![
+                binding("requests", ChannelBindingAccess::Read, 1),
+                binding("reports", ChannelBindingAccess::Write, 2),
+            ],
+            model.clone(),
+        )
+        .unwrap();
+        assert_eq!(
+            sole_level_one_channels(&supported).unwrap(),
+            (uuid_v7(1), uuid_v7(2))
+        );
+
+        let multiple_reads = LaunchBindings::new(
+            vec![
+                binding("alerts", ChannelBindingAccess::Read, 3),
+                binding("requests", ChannelBindingAccess::Read, 1),
+                binding("reports", ChannelBindingAccess::Write, 2),
+            ],
+            model,
+        )
+        .unwrap();
+        assert!(matches!(
+            sole_level_one_channels(&multiple_reads),
+            Err(HostError::UnsupportedTopology)
+        ));
+    }
+}

--- a/code/packages/rust/chief-of-staff-host/src/main.rs
+++ b/code/packages/rust/chief-of-staff-host/src/main.rs
@@ -1,0 +1,8 @@
+//! Process entry point for the concrete D18 Chief host.
+
+fn main() {
+    if let Err(error) = chief_of_staff_host::run_from_env() {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}

--- a/code/packages/rust/chief-of-staff-host/tests/level_one_host.rs
+++ b/code/packages/rust/chief-of-staff-host/tests/level_one_host.rs
@@ -1,0 +1,326 @@
+use chief_of_staff_host_control_protocol::{
+    ChannelBinding, ChannelBindingAccess, CompletionFinishReason, CompletionProvider,
+    CompletionResult, CompletionUsage, DataPlaneFailure, DataPlaneMessage, DataPlaneOperation,
+    DataPlaneRequest, DataPlaneResponse, LaunchBindings, LevelOneModelBinding, PromptRole,
+};
+use chief_of_staff_host_data_plane::HostDataPlaneDispatcher;
+use chief_of_staff_host_runtime::{
+    verify_agent_package, AgentPackageRuntime, PackageKeyType, PackageKeyring, TrustedPackageKey,
+};
+use chief_of_staff_process_supervisor::{
+    HostLaunchBindingProvider, HostProgram, LaunchBindingProviderError, MonotonicClock,
+    ProcessHostSupervisor, ProcessSupervisorConfig, ProcessSupervisorError, SessionIdSource,
+};
+use chief_of_staff_secure_host_channel::SessionId;
+use chief_of_staff_service_reconciler::{HostSupervisor, SupervisorObservation, SupervisorPhase};
+use chief_of_staff_service_registry::{HostName, HostRegistration, PackagePath, RestartPolicy};
+use chief_of_staff_skill_package::build_signed_skill_package;
+use chief_of_staff_skill_runtime::LEVEL_ONE_RESPONSE_CONTENT_TYPE;
+use chief_of_staff_tool_api::PrivilegeTier;
+use coding_adventures_ed25519::generate_keypair;
+use coding_adventures_x3dh::generate_identity_keypair;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const TEST_KEY_ID: &str = "level-one-host-test";
+const TEST_SEED: [u8; 32] = [73; 32];
+const SKILL: &str = "---\nagent: weather-reporter\ndescription: Reports a forecast for a requested city.\nprivilege_tier: 0\nreads: [weather-requests]\nwrites: [weather-reports]\nmessage_schema_versions: [weather-requests=1, weather-reports=1]\n---\n# Weather Reporter\n\nReport a brief forecast for the requested city.\n\n## Capabilities needed\n- none\n";
+
+fn uuid_v7(last: u8) -> [u8; 16] {
+    let mut bytes = [0; 16];
+    bytes[6] = 0x70;
+    bytes[8] = 0x80;
+    bytes[15] = last;
+    bytes
+}
+
+struct TestPackage {
+    path: PathBuf,
+    digest: [u8; 32],
+}
+
+impl TestPackage {
+    fn new() -> (Self, PackageKeyring) {
+        let path = std::env::temp_dir().join(format!(
+            "chief-level-one-host-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let (public_key, secret_key) = generate_keypair(&TEST_SEED);
+        build_signed_skill_package(&path, SKILL, TEST_KEY_ID, &secret_key).unwrap();
+        let mut keyring = PackageKeyring::new();
+        keyring
+            .trust(
+                TrustedPackageKey::new(
+                    TEST_KEY_ID,
+                    PackageKeyType::Developer,
+                    public_key,
+                    PrivilegeTier::Tier1,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        let digest = verify_agent_package(&path, &keyring).unwrap().digest();
+        (Self { path, digest }, keyring)
+    }
+
+    fn registration(&self) -> HostRegistration {
+        HostRegistration::new(
+            HostName::new("weather-level-one").unwrap(),
+            PackagePath::new(self.path.to_str().unwrap()).unwrap(),
+            self.digest,
+            RestartPolicy::Always,
+        )
+    }
+}
+
+impl Drop for TestPackage {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+struct TestLaunchBindings;
+
+impl HostLaunchBindingProvider for TestLaunchBindings {
+    fn launch_bindings(
+        &self,
+        _registration: &HostRegistration,
+        runtime: AgentPackageRuntime,
+    ) -> Result<LaunchBindings, LaunchBindingProviderError> {
+        if runtime != AgentPackageRuntime::Skill {
+            return Err(LaunchBindingProviderError);
+        }
+        LaunchBindings::new(
+            vec![
+                ChannelBinding::new("weather-requests", ChannelBindingAccess::Read, uuid_v7(1))
+                    .unwrap(),
+                ChannelBinding::new("weather-reports", ChannelBindingAccess::Write, uuid_v7(2))
+                    .unwrap(),
+            ],
+            Some(LevelOneModelBinding::new("test-model", 0.0, 128).unwrap()),
+        )
+        .map_err(|_| LaunchBindingProviderError)
+    }
+}
+
+#[derive(Default)]
+struct TestClock(AtomicU64);
+
+impl MonotonicClock for TestClock {
+    fn now_ns(&self) -> u64 {
+        self.0.fetch_add(1, Ordering::SeqCst) + 1
+    }
+}
+
+struct TestSessions(u8);
+
+impl SessionIdSource for TestSessions {
+    fn next_session(&mut self) -> Result<SessionId, ProcessSupervisorError> {
+        self.0 = self.0.wrapping_add(1);
+        SessionId::new(uuid_v7(self.0)).map_err(|_| ProcessSupervisorError::SessionGeneration)
+    }
+}
+
+#[derive(Default)]
+struct ScriptedDataPlane {
+    operations: Mutex<Vec<DataPlaneOperation>>,
+}
+
+impl ScriptedDataPlane {
+    fn operations(&self) -> Vec<DataPlaneOperation> {
+        self.operations.lock().unwrap().clone()
+    }
+}
+
+impl HostDataPlaneDispatcher for ScriptedDataPlane {
+    fn dispatch(
+        &self,
+        _registration: &HostRegistration,
+        request: &DataPlaneRequest,
+    ) -> DataPlaneResponse {
+        let mut operations = self.operations.lock().unwrap();
+        match request {
+            DataPlaneRequest::Receive {
+                id,
+                channel_id,
+                limit,
+            } => {
+                assert_eq!(*channel_id, uuid_v7(1));
+                assert_eq!(*limit, 1);
+                operations.push(DataPlaneOperation::Receive);
+                let receive_count = operations
+                    .iter()
+                    .filter(|operation| **operation == DataPlaneOperation::Receive)
+                    .count();
+                match receive_count {
+                    1 => DataPlaneResponse::Received {
+                        id: *id,
+                        messages: vec![DataPlaneMessage {
+                            message_id: uuid_v7(3),
+                            sequence: 7,
+                            timestamp_ns: 99,
+                            content_type: "text/plain".to_string(),
+                            payload: b"Paris".to_vec(),
+                        }],
+                    },
+                    2 => DataPlaneResponse::Failed {
+                        id: *id,
+                        failure: DataPlaneFailure::Unavailable,
+                    },
+                    _ => DataPlaneResponse::Received {
+                        id: *id,
+                        messages: Vec::new(),
+                    },
+                }
+            }
+            DataPlaneRequest::Complete { id, call } => {
+                assert_eq!(call.model, "test-model");
+                assert_eq!(call.temperature, 0.0);
+                assert_eq!(call.max_tokens, Some(128));
+                assert!(call
+                    .system
+                    .as_deref()
+                    .is_some_and(|system| system.contains("brief forecast")));
+                assert_eq!(call.messages.len(), 1);
+                assert_eq!(call.messages[0].role, PromptRole::User);
+                assert_eq!(call.messages[0].text, "Paris");
+                assert_eq!(
+                    call.metadata.get("agent").map(String::as_str),
+                    Some("weather-reporter")
+                );
+                operations.push(DataPlaneOperation::Complete);
+                DataPlaneResponse::Completed {
+                    id: *id,
+                    result: Box::new(CompletionResult {
+                        text: "Sunny and mild.".to_string(),
+                        model: "test-model".to_string(),
+                        provider: CompletionProvider {
+                            vendor: "fixture".to_string(),
+                            model_family: "weather".to_string(),
+                            model_version: "1".to_string(),
+                            endpoint: None,
+                        },
+                        usage: CompletionUsage {
+                            input_tokens: 8,
+                            output_tokens: 4,
+                            cached_tokens: 0,
+                        },
+                        finish_reason: CompletionFinishReason::Stop,
+                        latency_ms: 1,
+                    }),
+                }
+            }
+            DataPlaneRequest::Publish {
+                id,
+                channel_id,
+                content_type,
+                payload,
+            } => {
+                assert_eq!(*channel_id, uuid_v7(2));
+                assert_eq!(content_type, LEVEL_ONE_RESPONSE_CONTENT_TYPE);
+                assert_eq!(payload, b"Sunny and mild.");
+                operations.push(DataPlaneOperation::Publish);
+                DataPlaneResponse::Published {
+                    id: *id,
+                    message_id: uuid_v7(4),
+                    sequence: 8,
+                    timestamp_ns: 100,
+                }
+            }
+            DataPlaneRequest::Acknowledge {
+                id,
+                channel_id,
+                message_id,
+            } => {
+                assert_eq!(*channel_id, uuid_v7(1));
+                assert_eq!(*message_id, uuid_v7(3));
+                operations.push(DataPlaneOperation::Acknowledge);
+                DataPlaneResponse::Acknowledged {
+                    id: *id,
+                    sequence: 7,
+                }
+            }
+        }
+    }
+}
+
+fn await_phase(
+    supervisor: &mut ProcessHostSupervisor,
+    registration: &HostRegistration,
+    expected: SupervisorPhase,
+) {
+    let deadline = Instant::now() + Duration::from_secs(8);
+    loop {
+        match supervisor.inspect(registration) {
+            Ok(SupervisorObservation::Instance(instance)) if instance.phase() == expected => return,
+            Ok(_) => {}
+            Err(error) => panic!("unexpected supervisor error: {error}"),
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {expected:?}"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn real_level_one_host_runs_one_authenticated_turn_and_terminates_cleanly() {
+    let (package, keyring) = TestPackage::new();
+    let registration = package.registration();
+    let dispatcher = Arc::new(ScriptedDataPlane::default());
+    let program = HostProgram::new(
+        env!("CARGO_BIN_EXE_chief-of-staff-host"),
+        std::iter::empty::<&str>(),
+    )
+    .unwrap();
+    let config =
+        ProcessSupervisorConfig::new(program, Duration::from_secs(3), Duration::from_secs(3))
+            .unwrap();
+    let mut supervisor = ProcessHostSupervisor::new(
+        config,
+        Arc::new(keyring),
+        Arc::new(TestLaunchBindings),
+        Arc::new(generate_identity_keypair()),
+        Arc::new(TestClock::default()),
+        Box::new(TestSessions(0)),
+    )
+    .with_data_plane_dispatcher(dispatcher.clone());
+
+    supervisor.start(&registration).unwrap();
+    let expected = [
+        DataPlaneOperation::Receive,
+        DataPlaneOperation::Complete,
+        DataPlaneOperation::Publish,
+        DataPlaneOperation::Acknowledge,
+        DataPlaneOperation::Receive,
+        DataPlaneOperation::Receive,
+    ];
+    let deadline = Instant::now() + Duration::from_secs(8);
+    loop {
+        supervisor.inspect(&registration).unwrap();
+        if dispatcher.operations() == expected {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for Level 1 turn"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    supervisor.stop(registration.host_name()).unwrap();
+    await_phase(
+        &mut supervisor,
+        &registration,
+        SupervisorPhase::Exited { exit_code: Some(0) },
+    );
+    assert_eq!(dispatcher.operations(), expected);
+}

--- a/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Surface an authenticated `Terminate` received during a child data-plane
+  exchange as a distinct graceful-termination condition.
 - Accept an optional authenticated data-plane dispatcher, retain the exact host
   registration for each owned child, and automatically send validated responses
   without exposing request payloads to the orchestration core.

--- a/code/packages/rust/chief-of-staff-process-supervisor/README.md
+++ b/code/packages/rust/chief-of-staff-process-supervisor/README.md
@@ -20,6 +20,9 @@ composition may instead retain one authenticated request per host until its
 service adapter answers through `respond_data_plane`. Both paths preserve exact
 correlation across real cross-platform process pipes without adding an
 unauthenticated side channel or exposing payloads to the orchestration core.
+If graceful termination arrives while the child is blocked on an exchange, the
+child helper returns a distinct termination condition so a concrete host can exit
+successfully instead of misclassifying shutdown as a protocol failure.
 
 Its keyring and X3DH identity are shared through owned `Arc` handles, and its
 session source is `Send`, so the complete supervisor can move with the daemon's

--- a/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-process-supervisor/src/lib.rs
@@ -65,6 +65,8 @@ pub enum ProcessSupervisorError {
     Framing,
     /// Authenticated host-control processing failed closed.
     Control,
+    /// The orchestrator requested graceful termination during a data-plane exchange.
+    Terminated,
     /// Pipeline launch bindings were absent, invalid, or incompatible with the package runtime.
     LaunchBindings,
     /// A different package is already active under this host name.
@@ -86,6 +88,7 @@ impl Display for ProcessSupervisorError {
             Self::BootstrapTimeout => "process-supervisor: bootstrap timed out",
             Self::Framing => "process-supervisor: invalid framed record",
             Self::Control => "process-supervisor: host-control failure",
+            Self::Terminated => "process-supervisor: graceful termination requested",
             Self::LaunchBindings => "process-supervisor: launch bindings unavailable",
             Self::ActivePackageMismatch => "process-supervisor: active package identity mismatch",
             Self::HostNotFound => "process-supervisor: host not found",
@@ -957,9 +960,10 @@ impl<R: Read, W: Write> ChildProcessControl<R, W> {
             .map_err(|_| ProcessSupervisorError::Control)?
         {
             OrchestratorEvent::Response(response) => Ok(response),
-            OrchestratorEvent::PackageTrust(_)
-            | OrchestratorEvent::LaunchBindings(_)
-            | OrchestratorEvent::Terminate => Err(ProcessSupervisorError::Control),
+            OrchestratorEvent::Terminate => Err(ProcessSupervisorError::Terminated),
+            OrchestratorEvent::PackageTrust(_) | OrchestratorEvent::LaunchBindings(_) => {
+                Err(ProcessSupervisorError::Control)
+            }
         }
     }
 }
@@ -1233,6 +1237,10 @@ mod tests {
             ),
             (ProcessSupervisorError::Framing, "invalid framed record"),
             (ProcessSupervisorError::Control, "host-control failure"),
+            (
+                ProcessSupervisorError::Terminated,
+                "graceful termination requested",
+            ),
             (
                 ProcessSupervisorError::ActivePackageMismatch,
                 "active package identity mismatch",

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -201,6 +201,16 @@ record from manifest-blind pipeline wiring. It requires the exact signed channel
 name and read/write sets, resolves them to canonical UUID-v7 endpoints, and binds
 the supplied model selector, temperature, and token cap. Missing, extra,
 wrong-direction, or runtime-incompatible bindings fail closed.
+The concrete `chief-of-staff-host` independently performs that verification and
+executes the first production Level 1 loop over the authenticated host data plane.
+V1 intentionally requires exactly one signed read channel and one signed write
+channel; packages declaring broader topology remain valid and discoverable but
+cannot reach readiness in this host until deterministic multi-channel routing is
+specified. The host performs receive, completion, publish, then acknowledge,
+sleeps between empty or read-service-unavailable polls, emits authenticated
+heartbeats, and treats an authenticated termination received during any exchange
+as a successful shutdown. Failures after input delivery remain terminal rather
+than risking duplicate model or publication effects.
 Pipeline wiring persists this authority as a bounded versioned record tied to
 the exact durable host registration and package hash. Every channel UUID receives
 an immutable create-if-absent pipeline claim. Wiring and each later launch both
@@ -519,6 +529,8 @@ by the security escort (host process), not the Chief of Staff.
 
 The strict readiness, heartbeat, and termination state machine is specified in
 [`host-control-protocol.md`](host-control-protocol.md).
+The concrete Level 1 child composition is specified in
+[`level-one-host.md`](level-one-host.md).
 That same authenticated session carries a serialized, bounded channel and
 provider-neutral completion data plane after readiness. The protocol permits one
 request in flight with exact monotonic correlation; the orchestrator-side adapter

--- a/code/specs/host-control-protocol.md
+++ b/code/specs/host-control-protocol.md
@@ -106,6 +106,10 @@ The child endpoint begins in `AwaitingReady`:
 6. It accepts only correlated responses or `Terminate` from the orchestrator and
    enters `Terminating` on the latter.
 
+A stream-owning child adapter must preserve that distinction while blocked on an
+exchange: `Terminate` is a normal shutdown outcome, whereas an unexpected trust or
+launch record, malformed frame, or wrong response shape remains terminal failure.
+
 Duplicate readiness, heartbeat-before-ready, child-sent terminate,
 orchestrator-sent ready/heartbeat/request, child-sent response/terminate, invalid
 correlation, and messages after termination are protocol violations.
@@ -232,6 +236,8 @@ and authenticates requests but does not authorize or execute them. Length-prefix
 framing, pipe ownership, process launch/reap, heartbeat scheduling, time sampling,
 service dispatch, and hard-kill fallback belong to adapters specified in
 [`process-host-supervisor.md`](process-host-supervisor.md).
+The production Level 1 consumer is specified in
+[`level-one-host.md`](level-one-host.md).
 
 ## Required Tests
 

--- a/code/specs/level-one-host.md
+++ b/code/specs/level-one-host.md
@@ -1,0 +1,105 @@
+# D18 Level 1 Host
+
+## Status
+
+This document specifies the first concrete child executable for D18 Level 1
+`SKILL.md` packages. The implementation package and binary are both named
+`chief-of-staff-host`.
+
+## Purpose
+
+The process supervisor owns package registration, process authority, and the
+orchestrator half of the encrypted control channel. The skill runtime owns prompt
+construction and turn ordering but has no process or transport capability. The
+Level 1 host composes those existing boundaries into the executable selected by
+the daemon's explicit host path.
+
+The host is not a second orchestrator. It receives only one launch's authenticated
+public package trust and pipeline bindings, independently verifies the sealed
+package in its working directory, interprets the signed skill, and sends data-plane
+requests over the existing authenticated session.
+
+## Launch and Verification
+
+The executable accepts exactly `--package-runtime skill`. Missing, extra, non-UTF-8,
+or different runtime arguments fail before bootstrap. Deno packages are rejected
+until a separately reviewed adapter is composed. No environment variable selects
+the package, runtime, channels, model, or trust.
+
+After secure bootstrap, the host:
+
+1. receives the exact authenticated public package trust;
+2. constructs a one-key `PackageKeyring`;
+3. independently verifies the sealed package rooted at its current directory;
+4. requires the verified runtime to be `Skill`;
+5. receives authenticated launch bindings;
+6. derives `LevelOneLaunchPlan` and requires exact signed names and directions;
+7. requires exactly one read binding and one write binding; and
+8. sends `Ready` with the independently verified package digest.
+
+No data-plane request or readiness record is emitted before all checks pass.
+
+## V1 Topology
+
+The signed package and launch protocol permit multiple read and write bindings,
+but the current Level 1 turn has one input and one output. Choosing the first name,
+merging channels, or broadcasting responses would silently invent routing policy.
+V1 therefore fails closed unless there is exactly one read channel and one write
+channel. Multi-channel packages remain valid inputs to discovery and wiring; a
+future host revision must define deterministic routing before executing them.
+
+## Turn and Recovery Ordering
+
+Each iteration requests at most one verified message. An empty page sleeps for a
+bounded interval before the next poll. A non-empty page executes these operations
+in order:
+
+1. require UTF-8 input;
+2. construct the provider-neutral completion from authenticated skill instructions
+   and model settings;
+3. request completion through the parent-side authorized service;
+4. publish the non-empty text result to the sole write channel; and
+5. acknowledge the input on the sole read channel.
+
+A redacted `Unavailable` response to the read-only receive operation follows the
+same bounded delay as an empty page. This lets the daemon's fail-closed placeholder
+service remain supervised without a restart loop. Other receive failures and every
+completion, publication, acknowledgement, response-shape, or control failure are
+terminal for that child. Because acknowledgement is last, failures before it leave
+the durable receiver cursor unchanged for supervised restart and replay. The host
+never retries a possibly completed provider or publication operation inside the
+same process without a durable idempotency contract.
+
+## Health and Shutdown
+
+The host emits authenticated heartbeats after readiness at a bounded interval. It
+does not busy-spin while its input channel is empty. The serialized protocol still
+permits only one request in flight.
+
+The orchestrator may send authenticated `Terminate` instead of a data-plane
+response. The child helper surfaces this as a distinct graceful condition, and the
+host exits successfully whether termination arrives during receive, completion,
+publish, or acknowledgement. Authentication, framing, correlation, and unexpected
+message-kind failures remain unsuccessful exits.
+
+## Boundaries
+
+The host directly uses only its standard streams, process arguments, current
+package directory, monotonic process-local time, and bounded sleep. It opens no
+network socket, reads no model credential, holds no channel key, and accesses no
+durable channel store. Channel cryptography, key custody, authorization, and model
+execution remain behind the parent-side `HostDataPlaneService`.
+
+## Required Tests
+
+The package must cover:
+
+- exact process argument selection and unsupported runtime rejection;
+- one-read/one-write topology acceptance and multi-channel rejection;
+- real cross-platform process bootstrap with a signed Level 1 package;
+- independent child verification and exact launch-plan matching before readiness;
+- receive, completion, publish, acknowledge, then idle receive over the encrypted
+  process pipes;
+- exact channel UUID, model, prompt, payload, and acknowledgement mapping;
+- authenticated termination during an exchange producing exit code zero; and
+- strict Clippy and rustdoc gates with unsafe code forbidden.

--- a/code/specs/process-host-supervisor.md
+++ b/code/specs/process-host-supervisor.md
@@ -58,6 +58,9 @@ UUID and optional Level 1 model bindings. A provider failure or runtime/model
 mismatch fails before process creation. The child-side helper performs the inverse
 bootstrap over any `Read` and `Write`, receives both authenticated inputs, then
 exposes readiness, heartbeat, termination, and data-plane operations.
+An authenticated `Terminate` received while a child helper waits for a data-plane
+response is surfaced as a distinct graceful-termination condition. This lets a
+real host exit cleanly even when the parent begins shutdown between idle polls.
 An optional injected `HostDataPlaneDispatcher` automatically answers each
 authenticated request before the next record is processed. The dispatcher owns
 durable per-request authorization and the separately injected service boundary;
@@ -144,7 +147,8 @@ The package exposes:
 - owned, movable `ProcessHostSupervisor`, implementing the reconciler
   `HostSupervisor` trait;
 - `ChildProcessControl<R, W>` for lifecycle plus serialized authenticated
-  receive/publish/acknowledge/completion exchanges;
+  receive/publish/acknowledge/completion exchanges and distinct graceful
+  termination during an exchange;
 - automatic request dispatch when a `HostDataPlaneDispatcher` is injected;
 - `pending_data_plane_request` and `respond_data_plane` hooks for manual
   compositions, retaining one correlated request until an adapter answers; and


### PR DESCRIPTION
## Summary
- add the concrete `chief-of-staff-host` executable for signed Level 1 `SKILL.md` packages
- independently verify authenticated package trust and exact launch bindings before readiness, failing closed unless V1 has one read and one write channel
- execute receive, completion, publish, acknowledge over the encrypted host data plane with bounded idle/unavailable backoff, heartbeats, and clean authenticated termination
- preserve replay safety by keeping all failures after input delivery terminal

## Validation
- 19 focused host/supervisor unit and integration tests
- real signed-package subprocess over encrypted pipes, including unavailable receive recovery and exit-code-zero termination
- strict Clippy and rustdoc for both changed packages
- repository planner: 2 changed packages and 79 affected/prerequisite/dependent packages, all green

## Follow-up
- compose real channel-key custody and model-provider authority for the host data-plane service
- run the weather Level 1 flow end to end
- define deterministic multi-read/multi-write routing before enabling broader topology

Progresses #128
Progresses #138
Progresses #139