### PR TITLE
Give MOS T_NOM canonical precedence

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give canonical MOS Level-1 `T_NOM` precedence over the `TNOM` alias.
 - Give canonical BJT and JFET `TNOM` precedence over the `T_NOM` alias.
 - Validate finite JFET `LAMBDA` and `LAM` model-card values.
 - Validate finite JFET `VTO`, `VT0`, and `VTH` model-card values.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -2660,7 +2660,10 @@ _LEVEL1_PARAM_ALIASES = {
 
 
 def _build_mosfet_model(model: ModelCard, instance_params: dict[str, float]) -> MOSFET:
-    params = {**model.params, **instance_params}
+    model_params = dict(model.params)
+    if "T_NOM" in model_params:
+        model_params.pop("TNOM", None)
+    params = {**model_params, **instance_params}
     defaults = Level1Params()
     values = {
         field.name: getattr(defaults, field.name)
@@ -2672,8 +2675,8 @@ def _build_mosfet_model(model: ModelCard, instance_params: dict[str, float]) -> 
         if param_name in values and not isinstance(values[param_name], bool):
             values[param_name] = value
     canonical_params = {_LEVEL1_PARAM_ALIASES.get(name, name) for name in params}
-    if "TOX" in model.params:
-        derivation_params = dict(model.params)
+    if "TOX" in model_params:
+        derivation_params = dict(model_params)
         derivation_params["U0"] = values["U0"]
         normalized = normalize_model_card(model.name, model.kind, derivation_params)
         derived = mosfet_from_model_card("M", "d", "g", "s", "b", normalized)

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -3554,6 +3554,15 @@ def test_lowers_positive_mosfet_model_nominal_temperature(alias: str) -> None:
     assert mosfet.model.model.params.T_NOM == 325.0
 
 
+def test_gives_mosfet_t_nom_precedence_over_tnom() -> None:
+    parsed = parse_netlist(
+        ".model nfast NMOS(T_NOM=325 TNOM=350)\nM1 d g s b nfast\n"
+    )
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.model.model.params.T_NOM == 325.0
+
+
 @pytest.mark.parametrize("drain_resistance", ["-1", "1e999"])
 def test_rejects_invalid_mosfet_model_drain_resistance(
     drain_resistance: str,

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give canonical MOS Level-1 `T_NOM` precedence over the `TNOM` alias.
 - Give canonical BJT and JFET `TNOM` precedence over the `T_NOM` alias.
 - Validate finite JFET `LAMBDA` and `LAM` model-card values.
 - Validate finite JFET `VTO`, `VT0`, and `VTH` model-card values.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -2138,7 +2138,8 @@ function mosfetParams(
   model: ModelCard,
   instanceParams: ReadonlyMap<string, number>,
 ): Partial<MosfetLevel1Params> {
-  const modelParams = model.params;
+  const modelParams = new Map(model.params);
+  if (modelParams.has("T_NOM")) modelParams.delete("TNOM");
   const params: Record<string, number> = {};
   for (const [name, value] of [...modelParams, ...instanceParams]) {
     const key = MOSFET_PARAM_ALIASES.get(name) ?? (name as keyof MosfetLevel1Params);

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -3613,6 +3613,14 @@ Xright c d load
     expect(element.params.T_NOM).toBe(325);
   });
 
+  it("gives MOSFET T_NOM precedence over TNOM", () => {
+    const parsed = parseNetlist(".model nfast NMOS(T_NOM=325 TNOM=350)\nM1 d g s b nfast\n");
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.T_NOM).toBe(325);
+  });
+
   it.each(["-1", "1e999"])("rejects invalid MOSFET model RD=%s", (drainResistance) => {
     expect(() =>
       parseNetlist(`.model nfast NMOS(RD=${drainResistance})\nM1 d g s b nfast\n`),

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4817,10 +4817,16 @@ the Rust, Python, and TypeScript surfaces together.
      parameter policy.
 
 491. Python and TypeScript Berkeley SPICE BJT/JFET nominal-temperature alias precedence.
-   - Status: implemented in this nominal-temperature precedence slice.
+   - Status: completed in PR 10187.
    - Both parser facades give engine-canonical `TNOM` precedence over the
      `T_NOM` alias for BJT and JFET validation and lowering, without changing
      the unresolved JFET `B` parameter policy.
+
+492. Python and TypeScript Berkeley SPICE MOS nominal-temperature alias precedence.
+   - Status: implemented in this MOS nominal-temperature precedence slice.
+   - Both parser facades give engine-canonical Level-1 `T_NOM` precedence over
+     the `TNOM` alias during lowering, matching validation while preserving
+     instance parameter overrides.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- give canonical MOS Level-1 `T_NOM` precedence over the `TNOM` alias in both parser lowering facades
- preserve instance parameter overrides and use the same normalized model map for TOX-derived defaults
- add Python and TypeScript mixed-alias regression coverage and record plan item 492

## Verification

- Python parser `bash BUILD` (658 passed, 90.68% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (643 passed)
- TypeScript parser `npx vitest run --coverage` (643 passed, 88.48% line coverage)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
- confirmed no BUILD or dependency metadata changes
