### PR TITLE
Give MOS LAMBDA canonical precedence

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give canonical MOS Level-1 `LAMBDA` precedence over the `LAM` alias.
 - Give canonical MOS Level-1 `T_NOM` precedence over the `TNOM` alias.
 - Give canonical BJT and JFET `TNOM` precedence over the `T_NOM` alias.
 - Validate finite JFET `LAMBDA` and `LAM` model-card values.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -2663,6 +2663,8 @@ def _build_mosfet_model(model: ModelCard, instance_params: dict[str, float]) -> 
     model_params = dict(model.params)
     if "T_NOM" in model_params:
         model_params.pop("TNOM", None)
+    if "LAMBDA" in model_params:
+        model_params.pop("LAM", None)
     params = {**model_params, **instance_params}
     defaults = Level1Params()
     values = {

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -3430,6 +3430,16 @@ def test_lowers_finite_mosfet_model_channel_modulation_aliases(alias: str) -> No
     assert mosfet.model.model.params.LAMBDA == -0.02
 
 
+def test_gives_mosfet_lambda_precedence_over_lam() -> None:
+    parsed = parse_netlist(
+        ".model nfast NMOS(LAMBDA=0.02 LAM=0.03)\nM1 d g s b nfast\n"
+    )
+
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.model.model.params.LAMBDA == 0.02
+
+
 @pytest.mark.parametrize("body_effect", ["-0.01", "1e999"])
 def test_rejects_invalid_mosfet_model_body_effect(body_effect: str) -> None:
     with pytest.raises(

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give canonical MOS Level-1 `LAMBDA` precedence over the `LAM` alias.
 - Give canonical MOS Level-1 `T_NOM` precedence over the `TNOM` alias.
 - Give canonical BJT and JFET `TNOM` precedence over the `T_NOM` alias.
 - Validate finite JFET `LAMBDA` and `LAM` model-card values.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -2140,6 +2140,7 @@ function mosfetParams(
 ): Partial<MosfetLevel1Params> {
   const modelParams = new Map(model.params);
   if (modelParams.has("T_NOM")) modelParams.delete("TNOM");
+  if (modelParams.has("LAMBDA")) modelParams.delete("LAM");
   const params: Record<string, number> = {};
   for (const [name, value] of [...modelParams, ...instanceParams]) {
     const key = MOSFET_PARAM_ALIASES.get(name) ?? (name as keyof MosfetLevel1Params);

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -3494,6 +3494,14 @@ Xright c d load
     },
   );
 
+  it("gives MOSFET LAMBDA precedence over LAM", () => {
+    const parsed = parseNetlist(".model nfast NMOS(LAMBDA=0.02 LAM=0.03)\nM1 d g s b nfast\n");
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.LAMBDA).toBe(0.02);
+  });
+
   it.each(["-0.01", "1e999"])("rejects invalid MOSFET model GAMMA=%s", (bodyEffect) => {
     expect(() =>
       parseNetlist(`.model nfast NMOS(GAMMA=${bodyEffect})\nM1 d g s b nfast\n`),

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4823,9 +4823,15 @@ the Rust, Python, and TypeScript surfaces together.
      the unresolved JFET `B` parameter policy.
 
 492. Python and TypeScript Berkeley SPICE MOS nominal-temperature alias precedence.
-   - Status: implemented in this MOS nominal-temperature precedence slice.
+   - Status: completed in PR 10189.
    - Both parser facades give engine-canonical Level-1 `T_NOM` precedence over
      the `TNOM` alias during lowering, matching validation while preserving
+     instance parameter overrides.
+
+493. Python and TypeScript Berkeley SPICE MOS channel-modulation alias precedence.
+   - Status: implemented in this MOS channel-modulation precedence slice.
+   - Both parser facades give engine-canonical Level-1 `LAMBDA` precedence over
+     the `LAM` alias during lowering, matching validation while preserving
      instance parameter overrides.
 
 ## Backlog


### PR DESCRIPTION
## Summary

- give canonical MOS Level-1 `LAMBDA` precedence over the `LAM` alias in both parser lowering facades
- preserve instance parameter overrides and normalized TOX-derived defaults
- add Python and TypeScript mixed-alias regression coverage and record plan item 493

## Verification

- Python parser `bash BUILD` (659 passed, 90.69% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (644 passed)
- TypeScript parser `npx vitest run --coverage` (644 passed, 88.48% line coverage)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
- confirmed no BUILD or dependency metadata changes
