### PR TITLE
Execute authorized host data-plane operations

### DIFF
--- a/code/packages/rust/chief-of-staff-host-control-protocol/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Expose response validation so injected data-plane services can reject malformed
+  or oversized provider/channel output before authenticated framing.
 - Add an exactly-once pre-ready `LaunchBindings` record with canonical bounded
   channel name-to-UUID mappings and optional bounded Level 1 model settings.
 - Add a bounded authenticated `PackageTrust` record that must be delivered

--- a/code/packages/rust/chief-of-staff-host-control-protocol/src/data_plane.rs
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/src/data_plane.rs
@@ -300,6 +300,15 @@ pub enum DataPlaneResponse {
     },
 }
 
+/// Validate that a response can be encoded within every public data-plane bound.
+///
+/// Services can call this before returning provider- or channel-supplied fields so
+/// an oversized or malformed result becomes a stable adapter failure instead of a
+/// later authenticated-session framing failure.
+pub fn validate_data_plane_response(response: &DataPlaneResponse) -> Result<(), ControlError> {
+    encode(&DataRecord::Response(response.clone())).map(|_| ())
+}
+
 impl DataPlaneResponse {
     /// Return the correlation identity.
     pub fn id(&self) -> RequestId {
@@ -1120,6 +1129,10 @@ mod tests {
                 .collect(),
         };
         assert_eq!(
+            validate_data_plane_response(&too_many_messages),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
+        assert_eq!(
             encode(&DataRecord::Response(too_many_messages)),
             Err(ControlError::InvalidDataPlaneRecord)
         );
@@ -1146,6 +1159,10 @@ mod tests {
             sequence: 0,
             timestamp_ns: 0,
         };
+        assert_eq!(
+            validate_data_plane_response(&invalid_published),
+            Err(ControlError::InvalidDataPlaneRecord)
+        );
         assert_eq!(
             encode(&DataRecord::Response(invalid_published)),
             Err(ControlError::InvalidDataPlaneRecord)

--- a/code/packages/rust/chief-of-staff-host-control-protocol/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-control-protocol/src/lib.rs
@@ -14,10 +14,10 @@ mod data_plane;
 mod launch;
 
 pub use data_plane::{
-    CompletionCall, CompletionFinishReason, CompletionProvider, CompletionResult, CompletionUsage,
-    DataPlaneFailure, DataPlaneMessage, DataPlaneOperation, DataPlaneRequest, DataPlaneResponse,
-    PromptMessage, PromptRole, RequestId, MAX_DATA_PLANE_MESSAGES, MAX_DATA_PLANE_PAYLOAD_BYTES,
-    MAX_DATA_PLANE_RECORD_BYTES,
+    validate_data_plane_response, CompletionCall, CompletionFinishReason, CompletionProvider,
+    CompletionResult, CompletionUsage, DataPlaneFailure, DataPlaneMessage, DataPlaneOperation,
+    DataPlaneRequest, DataPlaneResponse, PromptMessage, PromptRole, RequestId,
+    MAX_DATA_PLANE_MESSAGES, MAX_DATA_PLANE_PAYLOAD_BYTES, MAX_DATA_PLANE_RECORD_BYTES,
 };
 use data_plane::{DataRecord, ACKNOWLEDGED_RESPONSE_TAG, ACKNOWLEDGE_REQUEST_TAG};
 use data_plane::{

--- a/code/packages/rust/chief-of-staff-host-data-plane/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-data-plane/CHANGELOG.md
@@ -2,5 +2,11 @@
 
 ## Unreleased
 
+- Add the authority-backed concrete service over real encrypted durable channel
+  endpoints and exact provider-neutral LLM clients.
+- Retain a bounded receive-to-ack delivery ledger, provision sealed receiver
+  grants before publication, and fail closed on unknown keys or model selectors.
+- Validate all channel/provider response fields against the authenticated wire
+  bounds before returning them to process supervision.
 - Add durable per-request pipeline authorization, injected service dispatch,
   response-shape validation, and a fail-closed unavailable production service.

--- a/code/packages/rust/chief-of-staff-host-data-plane/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-host-data-plane/Cargo.toml
@@ -6,11 +6,13 @@ description = "Durably authorized host data-plane dispatch for D18 Chief"
 license = "MIT"
 
 [dependencies]
+chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
+chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }
+chief-of-staff-channel-store = { path = "../chief-of-staff-channel-store" }
 chief-of-staff-host-control-protocol = { path = "../chief-of-staff-host-control-protocol" }
 chief-of-staff-pipeline-bindings = { path = "../chief-of-staff-pipeline-bindings" }
 chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }
+llm-gateway = { path = "../llm-gateway" }
 storage-core = { path = "../storage-core" }
 
 [dev-dependencies]
-chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
-chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }

--- a/code/packages/rust/chief-of-staff-host-data-plane/README.md
+++ b/code/packages/rust/chief-of-staff-host-data-plane/README.md
@@ -8,15 +8,31 @@ acknowledge require a read binding, publish requires a write binding, and model
 calls must exactly match the launch-time selector, temperature, and token cap.
 
 The dispatcher redacts all failures into the stable host-control taxonomy and
-validates service responses before they re-enter the authenticated session. The
-production daemon currently injects an unavailable service after authorization;
-concrete channel-key custody and model-provider composition can replace that
-service without weakening this boundary or changing process supervision.
+validates service responses before they re-enter the authenticated session.
+
+`AuthorityBackedHostDataPlaneService` is the concrete execution layer. It opens
+the real durable encrypted receiver/originator endpoints, retains a bounded
+receive-to-ack delivery ledger, provisions sealed receiver grants before a
+publication, and maps provider-neutral completion calls to an exact model client.
+Keys are released one operation at a time by `ChannelKeyAuthority`; provider
+credentials and selection remain behind `ModelProviderAuthority`. Neither secret
+boundary is visible to the payload-blind dispatcher or orchestration core.
+
+`ExactModelProviderRegistry` supplies an immutable exact-selector implementation
+for already-constructed clients. Provider and channel output is validated against
+the public wire bounds before it can turn into an authenticated-session framing
+failure.
+
+The production daemon still injects the unavailable service because its closed
+configuration and pipeline-wiring APIs do not yet provision channel custody or
+model providers. A later composition PR must add those explicit operator-owned
+inputs rather than inventing secret storage or a default network endpoint here.
 
 ## Validation
 
 ```sh
 cargo test -p chief-of-staff-host-data-plane -- --nocapture
+cargo test -p chief-of-staff-host-control-protocol -- --nocapture
 cargo clippy -p chief-of-staff-host-data-plane --all-targets -- -D warnings
 RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-host-data-plane --no-deps
 ```

--- a/code/packages/rust/chief-of-staff-host-data-plane/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-data-plane/src/lib.rs
@@ -3,15 +3,29 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
+use chief_of_staff_channel_crypto::{
+    ChannelId, ChannelMasterKey, OriginatorSigningKey, ReceiverKeyPair, Sequence,
+};
+use chief_of_staff_channel_endpoints::{
+    ChannelDefinitionStore, ChannelEndpointError, DurableOriginator, DurableReceiver, MessageId,
+    MessageMetadataSource, Originator, Receiver,
+};
+use chief_of_staff_channel_store::ChannelStore;
 use chief_of_staff_host_control_protocol::{
-    ChannelBindingAccess, DataPlaneFailure, DataPlaneRequest, DataPlaneResponse,
+    validate_data_plane_response, ChannelBindingAccess, CompletionFinishReason, CompletionProvider,
+    CompletionResult, CompletionUsage, DataPlaneFailure, DataPlaneMessage, DataPlaneRequest,
+    DataPlaneResponse, PromptRole, MAX_DATA_PLANE_MESSAGES, MAX_DATA_PLANE_PAYLOAD_BYTES,
 };
 use chief_of_staff_pipeline_bindings::{
     HostPipelineBinding, PipelineBindingError, PipelineBindingStore,
 };
 use chief_of_staff_service_registry::HostRegistration;
-use std::sync::Arc;
+use llm_gateway::{CompletionRequest, FinishReason, LlmClient, Message, MessageContent, Role};
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex};
 use storage_core::StorageBackend;
+
+const MAX_PENDING_DELIVERIES: usize = MAX_DATA_PLANE_MESSAGES * 64;
 
 /// Injected execution authority reached only after durable request authorization.
 pub trait HostDataPlaneService: Send + Sync {
@@ -58,6 +72,465 @@ impl HostDataPlaneService for UnavailableHostDataPlaneService {
         _request: &DataPlaneRequest,
     ) -> Result<DataPlaneResponse, DataPlaneFailure> {
         Err(DataPlaneFailure::Unavailable)
+    }
+}
+
+/// Stable channel-key lookup failure supplied by an isolated custody adapter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChannelKeyAuthorityError {
+    /// Key custody is temporarily sealed or otherwise unavailable.
+    Unavailable,
+    /// The exact pipeline, agent, channel, or direction has no matching key authority.
+    Unauthorized,
+}
+
+impl core::fmt::Display for ChannelKeyAuthorityError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(match self {
+            Self::Unavailable => "channel key authority unavailable",
+            Self::Unauthorized => "channel key authority denied the request",
+        })
+    }
+}
+
+impl std::error::Error for ChannelKeyAuthorityError {}
+
+/// Owned originator secrets released for one exact authorized channel operation.
+pub struct OriginatorChannelKeys {
+    signing_key: OriginatorSigningKey,
+    channel_key: ChannelMasterKey,
+}
+
+impl OriginatorChannelKeys {
+    /// Bind one signing key and channel master key for a single service operation.
+    pub fn new(signing_key: OriginatorSigningKey, channel_key: ChannelMasterKey) -> Self {
+        Self {
+            signing_key,
+            channel_key,
+        }
+    }
+}
+
+/// Isolated authority that releases only keys for an exact durable pipeline binding.
+///
+/// Production implementations may be backed by a vault actor, hardware custodian,
+/// or another process boundary. The dispatcher and orchestration core never receive
+/// these values.
+pub trait ChannelKeyAuthority: Send + Sync {
+    /// Release the receiver private key for one exact read channel.
+    fn receiver_key(
+        &self,
+        binding: &HostPipelineBinding,
+        channel_id: ChannelId,
+    ) -> Result<ReceiverKeyPair, ChannelKeyAuthorityError>;
+
+    /// Release the signing and current-epoch channel keys for one exact write channel.
+    fn originator_keys(
+        &self,
+        binding: &HostPipelineBinding,
+        channel_id: ChannelId,
+    ) -> Result<OriginatorChannelKeys, ChannelKeyAuthorityError>;
+}
+
+/// Stable exact-model provider lookup failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ModelProviderError;
+
+impl core::fmt::Display for ModelProviderError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str("exact model provider unavailable")
+    }
+}
+
+impl std::error::Error for ModelProviderError {}
+
+/// Authority that resolves one exact authorized model selector to an LLM client.
+pub trait ModelProviderAuthority: Send + Sync {
+    /// Resolve a client for the exact durable pipeline and model selector.
+    fn resolve(
+        &self,
+        binding: &HostPipelineBinding,
+        model: &str,
+    ) -> Result<Arc<dyn LlmClient>, ModelProviderError>;
+}
+
+/// Immutable exact-selector registry for already-constructed provider clients.
+#[derive(Default)]
+pub struct ExactModelProviderRegistry {
+    providers: BTreeMap<String, Arc<dyn LlmClient>>,
+}
+
+impl ExactModelProviderRegistry {
+    /// Create an empty registry that fails closed for every selector.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register one non-empty selector exactly once before sharing the registry.
+    pub fn register(
+        &mut self,
+        model: impl Into<String>,
+        provider: Arc<dyn LlmClient>,
+    ) -> Result<(), ModelProviderError> {
+        let model = model.into();
+        if model.is_empty() || self.providers.contains_key(&model) {
+            return Err(ModelProviderError);
+        }
+        self.providers.insert(model, provider);
+        Ok(())
+    }
+}
+
+impl ModelProviderAuthority for ExactModelProviderRegistry {
+    fn resolve(
+        &self,
+        _binding: &HostPipelineBinding,
+        model: &str,
+    ) -> Result<Arc<dyn LlmClient>, ModelProviderError> {
+        self.providers.get(model).cloned().ok_or(ModelProviderError)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct DeliveryKey {
+    pipeline_id: [u8; 16],
+    agent_id: Vec<u8>,
+    channel_id: [u8; 16],
+    message_id: [u8; 16],
+}
+
+/// Concrete service that executes authorized operations against encrypted durable
+/// channel endpoints and exact provider-neutral LLM clients.
+///
+/// Receiver delivery receipts are retained until acknowledgement so a child may
+/// acknowledge only a message returned by this service instance. Channel keys and
+/// provider credentials stay behind separately injected authorities.
+pub struct AuthorityBackedHostDataPlaneService {
+    backend: Arc<dyn StorageBackend>,
+    key_authority: Arc<dyn ChannelKeyAuthority>,
+    model_authority: Arc<dyn ModelProviderAuthority>,
+    metadata_source: Arc<dyn MessageMetadataSource>,
+    deliveries: Mutex<BTreeMap<DeliveryKey, Sequence>>,
+}
+
+impl AuthorityBackedHostDataPlaneService {
+    /// Compose storage, isolated key custody, exact model authority, and metadata.
+    pub fn new(
+        backend: Arc<dyn StorageBackend>,
+        key_authority: Arc<dyn ChannelKeyAuthority>,
+        model_authority: Arc<dyn ModelProviderAuthority>,
+        metadata_source: Arc<dyn MessageMetadataSource>,
+    ) -> Self {
+        Self {
+            backend,
+            key_authority,
+            model_authority,
+            metadata_source,
+            deliveries: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    fn receive(
+        &self,
+        binding: &HostPipelineBinding,
+        id: chief_of_staff_host_control_protocol::RequestId,
+        channel_id: [u8; 16],
+        limit: u16,
+    ) -> Result<DataPlaneResponse, DataPlaneFailure> {
+        let channel_id = ChannelId(channel_id);
+        let receiver_key = self
+            .key_authority
+            .receiver_key(binding, channel_id)
+            .map_err(key_failure)?;
+        let mut receiver = DurableReceiver::open(
+            self.backend.as_ref(),
+            channel_id,
+            binding.agent_id().clone(),
+            receiver_key,
+        )
+        .map_err(endpoint_failure)?;
+        let received = receiver
+            .receive(usize::from(limit))
+            .map_err(endpoint_failure)?;
+        let mut prepared = Vec::with_capacity(received.len());
+        for message in received {
+            let message_id = *message.message_id.as_bytes();
+            let key = delivery_key(binding, channel_id, message_id);
+            prepared.push((
+                key,
+                message.sequence,
+                DataPlaneMessage {
+                    message_id,
+                    sequence: message.sequence.0,
+                    timestamp_ns: message.timestamp_ns,
+                    content_type: message.content_type,
+                    payload: message.payload,
+                },
+            ));
+        }
+        let mut deliveries = self
+            .deliveries
+            .lock()
+            .map_err(|_| DataPlaneFailure::Internal)?;
+        let new_deliveries = prepared
+            .iter()
+            .filter(|(key, _, _)| !deliveries.contains_key(key))
+            .count();
+        if deliveries
+            .len()
+            .checked_add(new_deliveries)
+            .is_none_or(|total| total > MAX_PENDING_DELIVERIES)
+        {
+            return Err(DataPlaneFailure::Unavailable);
+        }
+        let mut messages = Vec::with_capacity(prepared.len());
+        for (key, sequence, message) in prepared {
+            if deliveries
+                .insert(key, sequence)
+                .is_some_and(|previous| previous != sequence)
+            {
+                return Err(DataPlaneFailure::Internal);
+            }
+            messages.push(message);
+        }
+        Ok(DataPlaneResponse::Received { id, messages })
+    }
+
+    fn publish(
+        &self,
+        binding: &HostPipelineBinding,
+        id: chief_of_staff_host_control_protocol::RequestId,
+        channel_id: [u8; 16],
+        content_type: &str,
+        payload: &[u8],
+    ) -> Result<DataPlaneResponse, DataPlaneFailure> {
+        let channel_id = ChannelId(channel_id);
+        let keys = self
+            .key_authority
+            .originator_keys(binding, channel_id)
+            .map_err(key_failure)?;
+        let originator = DurableOriginator::open(
+            self.backend.as_ref(),
+            channel_id,
+            binding.agent_id(),
+            &keys.signing_key,
+            &keys.channel_key,
+            self.metadata_source.as_ref(),
+        )
+        .map_err(endpoint_failure)?;
+        let definition = ChannelDefinitionStore::new(self.backend.as_ref())
+            .load(channel_id)
+            .map_err(endpoint_failure)?
+            .ok_or(DataPlaneFailure::Unauthorized)?;
+        for receiver in definition.receivers() {
+            originator
+                .grant_receiver(&receiver.agent_id)
+                .map_err(endpoint_failure)?;
+        }
+        let published = originator
+            .publish(payload, content_type)
+            .map_err(endpoint_failure)?;
+        Ok(DataPlaneResponse::Published {
+            id,
+            message_id: *published.message_id.as_bytes(),
+            sequence: published.sequence.0,
+            timestamp_ns: published.timestamp_ns,
+        })
+    }
+
+    fn acknowledge(
+        &self,
+        binding: &HostPipelineBinding,
+        id: chief_of_staff_host_control_protocol::RequestId,
+        channel_id: [u8; 16],
+        message_id: [u8; 16],
+    ) -> Result<DataPlaneResponse, DataPlaneFailure> {
+        let channel_id = ChannelId(channel_id);
+        let receiver_key = self
+            .key_authority
+            .receiver_key(binding, channel_id)
+            .map_err(key_failure)?;
+        DurableReceiver::open(
+            self.backend.as_ref(),
+            channel_id,
+            binding.agent_id().clone(),
+            receiver_key,
+        )
+        .map_err(endpoint_failure)?;
+        MessageId::from_uuid_v7(message_id).map_err(endpoint_failure)?;
+        let key = delivery_key(binding, channel_id, message_id);
+        let mut deliveries = self
+            .deliveries
+            .lock()
+            .map_err(|_| DataPlaneFailure::Internal)?;
+        let sequence = deliveries
+            .get(&key)
+            .copied()
+            .ok_or(DataPlaneFailure::Unauthorized)?;
+        let acknowledged = ChannelStore::new(self.backend.as_ref(), channel_id)
+            .acknowledge(binding.agent_id().as_bytes(), sequence)
+            .map_err(|_| DataPlaneFailure::Channel)?;
+        deliveries.retain(|candidate, delivered_sequence| {
+            candidate.pipeline_id != *binding.pipeline_id().as_bytes()
+                || candidate.agent_id != binding.agent_id().as_bytes()
+                || candidate.channel_id != channel_id.0
+                || *delivered_sequence >= acknowledged
+        });
+        Ok(DataPlaneResponse::Acknowledged {
+            id,
+            sequence: acknowledged.0,
+        })
+    }
+
+    fn complete(
+        &self,
+        binding: &HostPipelineBinding,
+        id: chief_of_staff_host_control_protocol::RequestId,
+        call: &chief_of_staff_host_control_protocol::CompletionCall,
+    ) -> Result<DataPlaneResponse, DataPlaneFailure> {
+        let provider = self
+            .model_authority
+            .resolve(binding, &call.model)
+            .map_err(|_| DataPlaneFailure::Unavailable)?;
+        let request = CompletionRequest {
+            model: call.model.clone(),
+            system: call.system.clone(),
+            messages: call
+                .messages
+                .iter()
+                .map(|message| Message {
+                    role: match message.role {
+                        PromptRole::System => Role::System,
+                        PromptRole::User => Role::User,
+                        PromptRole::Assistant => Role::Assistant,
+                    },
+                    content: MessageContent::Text(message.text.clone()),
+                })
+                .collect(),
+            temperature: call.temperature,
+            max_tokens: call.max_tokens.map(|value| value as usize),
+            stop_sequences: call.stop_sequences.clone(),
+            seed: call.seed,
+            metadata: call
+                .metadata
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect::<HashMap<_, _>>(),
+        };
+        let response = provider
+            .complete(request)
+            .map_err(|_| DataPlaneFailure::Completion)?;
+        if response.text.len() > MAX_DATA_PLANE_PAYLOAD_BYTES {
+            return Err(DataPlaneFailure::Completion);
+        }
+        let input_tokens =
+            u64::try_from(response.usage.input_tokens).map_err(|_| DataPlaneFailure::Internal)?;
+        let output_tokens =
+            u64::try_from(response.usage.output_tokens).map_err(|_| DataPlaneFailure::Internal)?;
+        let cached_tokens =
+            u64::try_from(response.usage.cached_tokens).map_err(|_| DataPlaneFailure::Internal)?;
+        Ok(DataPlaneResponse::Completed {
+            id,
+            result: Box::new(CompletionResult {
+                text: response.text,
+                model: response.model,
+                provider: CompletionProvider {
+                    vendor: response.provider_id.vendor,
+                    model_family: response.provider_id.model_family,
+                    model_version: response.provider_id.model_version,
+                    endpoint: response.provider_id.endpoint,
+                },
+                usage: CompletionUsage {
+                    input_tokens,
+                    output_tokens,
+                    cached_tokens,
+                },
+                finish_reason: match response.finish_reason {
+                    FinishReason::Stop => CompletionFinishReason::Stop,
+                    FinishReason::MaxTokens => CompletionFinishReason::MaxTokens,
+                    FinishReason::Refusal => CompletionFinishReason::Refusal,
+                    FinishReason::Other => CompletionFinishReason::Other,
+                },
+                latency_ms: response.latency_ms,
+            }),
+        })
+    }
+}
+
+impl HostDataPlaneService for AuthorityBackedHostDataPlaneService {
+    fn execute(
+        &self,
+        binding: &HostPipelineBinding,
+        request: &DataPlaneRequest,
+    ) -> Result<DataPlaneResponse, DataPlaneFailure> {
+        let response = match request {
+            DataPlaneRequest::Receive {
+                id,
+                channel_id,
+                limit,
+            } => self.receive(binding, *id, *channel_id, *limit),
+            DataPlaneRequest::Publish {
+                id,
+                channel_id,
+                content_type,
+                payload,
+            } => self.publish(binding, *id, *channel_id, content_type, payload),
+            DataPlaneRequest::Acknowledge {
+                id,
+                channel_id,
+                message_id,
+            } => self.acknowledge(binding, *id, *channel_id, *message_id),
+            DataPlaneRequest::Complete { id, call } => self.complete(binding, *id, call),
+        }?;
+        validate_data_plane_response(&response).map_err(|_| match request {
+            DataPlaneRequest::Complete { .. } => DataPlaneFailure::Completion,
+            _ => DataPlaneFailure::Channel,
+        })?;
+        Ok(response)
+    }
+}
+
+fn delivery_key(
+    binding: &HostPipelineBinding,
+    channel_id: ChannelId,
+    message_id: [u8; 16],
+) -> DeliveryKey {
+    DeliveryKey {
+        pipeline_id: *binding.pipeline_id().as_bytes(),
+        agent_id: binding.agent_id().as_bytes().to_vec(),
+        channel_id: channel_id.0,
+        message_id,
+    }
+}
+
+fn key_failure(error: ChannelKeyAuthorityError) -> DataPlaneFailure {
+    match error {
+        ChannelKeyAuthorityError::Unavailable => DataPlaneFailure::Unavailable,
+        ChannelKeyAuthorityError::Unauthorized => DataPlaneFailure::Unauthorized,
+    }
+}
+
+fn endpoint_failure(error: ChannelEndpointError) -> DataPlaneFailure {
+    match error {
+        ChannelEndpointError::DefinitionNotFound
+        | ChannelEndpointError::DefinitionChanged
+        | ChannelEndpointError::ChannelDestroyed
+        | ChannelEndpointError::UnauthorizedOriginator
+        | ChannelEndpointError::UnauthorizedReceiver
+        | ChannelEndpointError::PublicKeyMismatch
+        | ChannelEndpointError::UnauthorizedMessage => DataPlaneFailure::Unauthorized,
+        ChannelEndpointError::Storage(_) | ChannelEndpointError::ConcurrentUpdate => {
+            DataPlaneFailure::Unavailable
+        }
+        ChannelEndpointError::InvalidDefinition(_)
+        | ChannelEndpointError::InvalidMessageId
+        | ChannelEndpointError::ConflictingDefinition
+        | ChannelEndpointError::CorruptDefinition(_)
+        | ChannelEndpointError::MissingKeyGrant(_)
+        | ChannelEndpointError::UnknownMessageId(_)
+        | ChannelEndpointError::Store(_)
+        | ChannelEndpointError::Crypto(_)
+        | ChannelEndpointError::Metadata(_) => DataPlaneFailure::Channel,
     }
 }
 
@@ -157,9 +630,12 @@ fn binding_failure(error: &PipelineBindingError) -> DataPlaneFailure {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chief_of_staff_channel_crypto::{ChannelId, KeyEpoch};
+    use chief_of_staff_channel_crypto::{
+        ChannelId, ChannelMasterKey, KeyEpoch, OriginatorSigningKey, ReceiverKeyPair,
+    };
     use chief_of_staff_channel_endpoints::{
-        AgentId, ChannelDefinition, ChannelDefinitionStore, OriginatorIdentity, ReceiverIdentity,
+        AgentId, ChannelDefinition, ChannelDefinitionStore, DurableOriginator, DurableReceiver,
+        MessageMetadata, MessageMetadataError, OriginatorIdentity, ReceiverIdentity,
     };
     use chief_of_staff_host_control_protocol::{
         ChannelBinding, CompletionCall, DataPlaneMessage, LevelOneModelBinding, PromptMessage,
@@ -169,6 +645,7 @@ mod tests {
     use chief_of_staff_service_registry::{
         DesiredState, HostEntry, HostName, PackagePath, RestartPolicy, ServiceRegistry,
     };
+    use llm_gateway::{MockLlmClient, MockResponse, ProviderIdentity};
     use std::collections::BTreeMap;
     use storage_core::InMemoryStorageBackend;
 
@@ -257,6 +734,137 @@ mod tests {
             .unwrap(),
         );
         PipelineBindingStore::new(backend).wire(&binding).unwrap();
+        binding
+    }
+
+    struct FixedMetadata {
+        message_id: [u8; 16],
+        timestamp_ns: u64,
+    }
+
+    impl MessageMetadataSource for FixedMetadata {
+        fn next_metadata(&self) -> Result<MessageMetadata, MessageMetadataError> {
+            Ok(MessageMetadata {
+                message_id: MessageId::from_uuid_v7(self.message_id)
+                    .map_err(|_| MessageMetadataError::new("invalid fixed message ID"))?,
+                timestamp_ns: self.timestamp_ns,
+            })
+        }
+    }
+
+    struct FixedKeyAuthority;
+
+    impl ChannelKeyAuthority for FixedKeyAuthority {
+        fn receiver_key(
+            &self,
+            binding: &HostPipelineBinding,
+            channel_id: ChannelId,
+        ) -> Result<ReceiverKeyPair, ChannelKeyAuthorityError> {
+            if binding.agent_id().as_bytes() != b"weather-agent" || channel_id.0 != uuid_v7(1) {
+                return Err(ChannelKeyAuthorityError::Unauthorized);
+            }
+            ReceiverKeyPair::from_private_key([0x13; 32])
+                .map_err(|_| ChannelKeyAuthorityError::Unavailable)
+        }
+
+        fn originator_keys(
+            &self,
+            binding: &HostPipelineBinding,
+            channel_id: ChannelId,
+        ) -> Result<OriginatorChannelKeys, ChannelKeyAuthorityError> {
+            if binding.agent_id().as_bytes() != b"weather-agent" || channel_id.0 != uuid_v7(2) {
+                return Err(ChannelKeyAuthorityError::Unauthorized);
+            }
+            Ok(OriginatorChannelKeys::new(
+                OriginatorSigningKey::from_seed([0x21; 32]),
+                ChannelMasterKey::from_bytes([0x22; 32]),
+            ))
+        }
+    }
+
+    fn install_real_binding(backend: &dyn StorageBackend) -> HostPipelineBinding {
+        let registration = registration();
+        ServiceRegistry::new(backend)
+            .register(&HostEntry::registered(
+                registration.clone(),
+                DesiredState::Running,
+            ))
+            .unwrap();
+        let worker = agent("weather-agent");
+        let input_originator = OriginatorSigningKey::from_seed([0x11; 32]);
+        let worker_receiver = ReceiverKeyPair::from_private_key([0x13; 32]).unwrap();
+        let worker_originator = OriginatorSigningKey::from_seed([0x21; 32]);
+        let sink_receiver = ReceiverKeyPair::from_private_key([0x23; 32]).unwrap();
+        let definitions = ChannelDefinitionStore::new(backend);
+        definitions
+            .create(
+                &ChannelDefinition::new(
+                    ChannelId(uuid_v7(1)),
+                    OriginatorIdentity {
+                        agent_id: agent("request-source"),
+                        public_key: input_originator.public_key(),
+                    },
+                    vec![ReceiverIdentity {
+                        agent_id: worker.clone(),
+                        public_key: worker_receiver.public_key(),
+                    }],
+                    1,
+                    KeyEpoch(0),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        definitions
+            .create(
+                &ChannelDefinition::new(
+                    ChannelId(uuid_v7(2)),
+                    OriginatorIdentity {
+                        agent_id: worker.clone(),
+                        public_key: worker_originator.public_key(),
+                    },
+                    vec![ReceiverIdentity {
+                        agent_id: agent("report-sink"),
+                        public_key: sink_receiver.public_key(),
+                    }],
+                    2,
+                    KeyEpoch(0),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        let binding = HostPipelineBinding::new(
+            PipelineId::new(uuid_v7(9)).unwrap(),
+            registration,
+            worker,
+            chief_of_staff_host_control_protocol::LaunchBindings::new(
+                vec![
+                    ChannelBinding::new("weather-requests", ChannelBindingAccess::Read, uuid_v7(1))
+                        .unwrap(),
+                    ChannelBinding::new("weather-reports", ChannelBindingAccess::Write, uuid_v7(2))
+                        .unwrap(),
+                ],
+                Some(LevelOneModelBinding::new("test-model", 0.25, 256).unwrap()),
+            )
+            .unwrap(),
+        );
+        PipelineBindingStore::new(backend).wire(&binding).unwrap();
+
+        let input_metadata = FixedMetadata {
+            message_id: uuid_v7(4),
+            timestamp_ns: 10,
+        };
+        let input_key = ChannelMasterKey::from_bytes([0x12; 32]);
+        let input = DurableOriginator::open(
+            backend,
+            ChannelId(uuid_v7(1)),
+            &agent("request-source"),
+            &input_originator,
+            &input_key,
+            &input_metadata,
+        )
+        .unwrap();
+        input.grant_receiver(&agent("weather-agent")).unwrap();
+        input.publish(b"Seattle", "text/plain").unwrap();
         binding
     }
 
@@ -470,5 +1078,161 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn authority_backed_service_executes_real_encrypted_turn() {
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryStorageBackend::new());
+        let binding = install_real_binding(backend.as_ref());
+        let mut models = ExactModelProviderRegistry::new();
+        models
+            .register(
+                "test-model",
+                Arc::new(
+                    MockLlmClient::new()
+                        .with_default(MockResponse::Text("Bring an umbrella".to_string()))
+                        .with_identity(ProviderIdentity {
+                            vendor: "fixture".to_string(),
+                            model_family: "weather".to_string(),
+                            model_version: "v1".to_string(),
+                            endpoint: Some("in-process".to_string()),
+                        }),
+                ),
+            )
+            .unwrap();
+        let service = AuthorityBackedHostDataPlaneService::new(
+            Arc::clone(&backend),
+            Arc::new(FixedKeyAuthority),
+            Arc::new(models),
+            Arc::new(FixedMetadata {
+                message_id: uuid_v7(5),
+                timestamp_ns: 11,
+            }),
+        );
+
+        let received = service
+            .execute(
+                &binding,
+                &DataPlaneRequest::Receive {
+                    id: request_id(1),
+                    channel_id: uuid_v7(1),
+                    limit: 1,
+                },
+            )
+            .unwrap();
+        let DataPlaneResponse::Received { messages, .. } = received else {
+            panic!("expected received response");
+        };
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].payload, b"Seattle");
+
+        let completed = service
+            .execute(&binding, &completion(2, "test-model", 0.25, 256))
+            .unwrap();
+        let DataPlaneResponse::Completed { result, .. } = completed else {
+            panic!("expected completed response");
+        };
+        assert_eq!(result.text, "Bring an umbrella");
+        assert_eq!(result.provider.vendor, "fixture");
+
+        let published = service
+            .execute(
+                &binding,
+                &DataPlaneRequest::Publish {
+                    id: request_id(3),
+                    channel_id: uuid_v7(2),
+                    content_type: "text/plain".to_string(),
+                    payload: result.text.into_bytes(),
+                },
+            )
+            .unwrap();
+        assert!(matches!(
+            published,
+            DataPlaneResponse::Published {
+                message_id,
+                sequence: 0,
+                timestamp_ns: 11,
+                ..
+            } if message_id == uuid_v7(5)
+        ));
+
+        let acknowledged = service
+            .execute(
+                &binding,
+                &DataPlaneRequest::Acknowledge {
+                    id: request_id(4),
+                    channel_id: uuid_v7(1),
+                    message_id: messages[0].message_id,
+                },
+            )
+            .unwrap();
+        assert!(matches!(
+            acknowledged,
+            DataPlaneResponse::Acknowledged { sequence: 1, .. }
+        ));
+        assert_eq!(
+            ChannelStore::new(backend.as_ref(), ChannelId(uuid_v7(1)))
+                .receiver_cursor(b"weather-agent")
+                .unwrap(),
+            Sequence(1)
+        );
+
+        let mut sink = DurableReceiver::open(
+            backend.as_ref(),
+            ChannelId(uuid_v7(2)),
+            agent("report-sink"),
+            ReceiverKeyPair::from_private_key([0x23; 32]).unwrap(),
+        )
+        .unwrap();
+        let reports = sink.receive(1).unwrap();
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].payload, b"Bring an umbrella");
+    }
+
+    #[test]
+    fn exact_model_registry_and_delivery_ledger_fail_closed() {
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryStorageBackend::new());
+        let binding = install_real_binding(backend.as_ref());
+        let mut models = ExactModelProviderRegistry::new();
+        let provider: Arc<dyn LlmClient> = Arc::new(
+            MockLlmClient::new()
+                .with_default(MockResponse::Text("forecast".to_string()))
+                .with_identity(ProviderIdentity {
+                    vendor: "x".repeat(513),
+                    model_family: "weather".to_string(),
+                    model_version: "v1".to_string(),
+                    endpoint: None,
+                }),
+        );
+        assert!(models.register("", Arc::clone(&provider)).is_err());
+        models
+            .register("test-model", Arc::clone(&provider))
+            .unwrap();
+        assert!(models.register("test-model", provider).is_err());
+        assert!(models.resolve(&binding, "other-model").is_err());
+        let service = AuthorityBackedHostDataPlaneService::new(
+            backend,
+            Arc::new(FixedKeyAuthority),
+            Arc::new(models),
+            Arc::new(FixedMetadata {
+                message_id: uuid_v7(5),
+                timestamp_ns: 11,
+            }),
+        );
+        assert_eq!(
+            service.execute(
+                &binding,
+                &DataPlaneRequest::Acknowledge {
+                    id: request_id(1),
+                    channel_id: uuid_v7(1),
+                    message_id: uuid_v7(4),
+                },
+            ),
+            Err(DataPlaneFailure::Unauthorized)
+        );
+        assert_eq!(
+            service.execute(&binding, &completion(2, "test-model", 0.25, 256)),
+            Err(DataPlaneFailure::Completion)
+        );
     }
 }

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -541,8 +541,14 @@ model settings. It rejects unknown or wrong-direction channel UUIDs and any mode
 setting drift before invoking the separately injected channel/LLM service, then
 validates response identity and operation shape before returning it. The
 payload-blind orchestration core receives no request body. Until concrete channel
-key custody and model providers are composed, the production daemon uses the same
-authorization boundary with a redacted unavailable service.
+key custody and model providers are provisioned, the production daemon uses the
+same authorization boundary with a redacted unavailable service. The reusable
+authority-backed service now executes against the real encrypted durable channel
+endpoints, retains a bounded delivery-to-acknowledgement ledger, provisions sealed
+receiver grants before publication, and resolves only exact model selectors. Key
+release and provider construction remain separately injected authorities so the
+orchestration core stays payload- and secret-blind; production configuration must
+make those authorities explicit before replacing the unavailable adapter.
 
 ```
 ┌────────────────────────────────────────────────────────────────┐

--- a/code/specs/host-control-protocol.md
+++ b/code/specs/host-control-protocol.md
@@ -75,6 +75,9 @@ acknowledge require the requested UUID to have read access, publish requires wri
 access, and completion requires the exact authorized model selector, temperature,
 and token cap. A service response must preserve the request ID and successful
 operation kind; drift is returned only as a redacted stable failure.
+Injected services validate complete responses against the same public codec bounds
+before returning channel- or provider-supplied fields, so malformed output cannot
+defer failure into authenticated framing.
 
 ## Lifecycle
 


### PR DESCRIPTION
## Summary
- add an authority-backed host data-plane service over the real durable encrypted channel endpoints
- keep channel keys and model providers behind exact injected authorities while the payload-blind dispatcher reauthorizes every request
- retain a bounded receive-to-ack delivery ledger, provision sealed receiver grants before publication, and fail closed on unknown key/model authority
- validate channel/provider output against the public authenticated wire bounds before framing

## Validation
- 30 focused protocol/data-plane tests
- real encrypted durable receive -> completion -> publish -> acknowledge turn, including sink decryption and cursor verification
- strict Clippy and rustdoc for both changed packages
- repository planner: 2 changed packages and 79 affected/prerequisite/dependent packages, all green

## Follow-up
- add explicit production channel-key/model-provider provisioning to the closed daemon configuration and pipeline APIs
- inject this service in the daemon composition root
- run the Level 1 weather process flow end to end

Progresses #128
Progresses #138