### PR TITLE
Give MOS U0 canonical precedence

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give canonical MOS Level-1 `U0` precedence over the `UO` alias.
 - Give canonical MOS Level-1 `LAMBDA` precedence over the `LAM` alias.
 - Give canonical MOS Level-1 `T_NOM` precedence over the `TNOM` alias.
 - Give canonical BJT and JFET `TNOM` precedence over the `T_NOM` alias.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -2665,6 +2665,8 @@ def _build_mosfet_model(model: ModelCard, instance_params: dict[str, float]) -> 
         model_params.pop("TNOM", None)
     if "LAMBDA" in model_params:
         model_params.pop("LAM", None)
+    if "U0" in model_params:
+        model_params.pop("UO", None)
     params = {**model_params, **instance_params}
     defaults = Level1Params()
     values = {

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -3373,6 +3373,17 @@ def test_lowers_mosfet_model_surface_mobility_and_derives_kp(alias: str) -> None
     assert isclose(mosfet.model.model.params.KP, 1.294924875e-4)
 
 
+def test_gives_mosfet_u0_precedence_over_uo_for_kp_derivation() -> None:
+    parsed = parse_netlist(
+        ".model nfast NMOS(U0=450 UO=600 TOX=12n)\nM1 d g s b nfast\n"
+    )
+
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.model.model.params.U0 == 450.0
+    assert isclose(mosfet.model.model.params.KP, 1.294924875e-4)
+
+
 def test_explicit_mosfet_model_kp_overrides_mobility_derivation() -> None:
     parsed = parse_netlist(".model nfast NMOS(U0=450 TOX=12n KP=123u)\nM1 d g s b nfast\n")
 

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give canonical MOS Level-1 `U0` precedence over the `UO` alias.
 - Give canonical MOS Level-1 `LAMBDA` precedence over the `LAM` alias.
 - Give canonical MOS Level-1 `T_NOM` precedence over the `TNOM` alias.
 - Give canonical BJT and JFET `TNOM` precedence over the `T_NOM` alias.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -2141,6 +2141,7 @@ function mosfetParams(
   const modelParams = new Map(model.params);
   if (modelParams.has("T_NOM")) modelParams.delete("TNOM");
   if (modelParams.has("LAMBDA")) modelParams.delete("LAM");
+  if (modelParams.has("U0")) modelParams.delete("UO");
   const params: Record<string, number> = {};
   for (const [name, value] of [...modelParams, ...instanceParams]) {
     const key = MOSFET_PARAM_ALIASES.get(name) ?? (name as keyof MosfetLevel1Params);

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -3421,6 +3421,17 @@ Xright c d load
     },
   );
 
+  it("gives MOSFET U0 precedence over UO for KP derivation", () => {
+    const parsed = parseNetlist(
+      ".model nfast NMOS(U0=450 UO=600 TOX=12n)\nM1 d g s b nfast\n",
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.U0).toBe(450.0);
+    expect(element.params.KP).toBeCloseTo(1.294924875e-4, 15);
+  });
+
   it("preserves explicit MOSFET model KP over mobility derivation", () => {
     const parsed = parseNetlist(".model nfast NMOS(U0=450 TOX=12n KP=123u)\nM1 d g s b nfast\n");
     const element = parsed.circuit.elements()[0];

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4829,10 +4829,16 @@ the Rust, Python, and TypeScript surfaces together.
      instance parameter overrides.
 
 493. Python and TypeScript Berkeley SPICE MOS channel-modulation alias precedence.
-   - Status: implemented in this MOS channel-modulation precedence slice.
+   - Status: completed in PR 10191.
    - Both parser facades give engine-canonical Level-1 `LAMBDA` precedence over
      the `LAM` alias during lowering, matching validation while preserving
      instance parameter overrides.
+
+494. Python and TypeScript Berkeley SPICE MOS surface-mobility alias precedence.
+   - Status: implemented in this MOS surface-mobility precedence slice.
+   - Both parser facades give engine-canonical Level-1 `U0` precedence over the
+     `UO` alias during lowering and `TOX`-based `KP` derivation, while
+     preserving instance parameter overrides.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- give canonical MOS Level-1 `U0` precedence over the `UO` alias in both parser lowering facades
- use the canonical mobility consistently for TOX-based `KP` derivation while preserving instance overrides
- add Python and TypeScript mixed-alias regression coverage and record plan item 494

## Verification

- Python parser `bash BUILD` (660 passed, 90.70% coverage)
- Python parser `.venv/bin/ruff check .`
- TypeScript parser `bash BUILD` (645 passed)
- TypeScript parser `npx vitest run --coverage` (645 passed, 88.49% line coverage)
- TypeScript engine `bash BUILD` (448 passed)
- `git diff --check`
- confirmed no BUILD or dependency metadata changes
