### PR TITLE
Give MOS VT0 canonical precedence

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give canonical MOS Level-1 `VT0` precedence over the `VTO` and `VTH` aliases.
 - Give canonical MOS Level-1 `U0` precedence over the `UO` alias.
 - Give canonical MOS Level-1 `LAMBDA` precedence over the `LAM` alias.
 - Give canonical MOS Level-1 `T_NOM` precedence over the `TNOM` alias.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -2667,6 +2667,9 @@ def _build_mosfet_model(model: ModelCard, instance_params: dict[str, float]) -> 
         model_params.pop("LAM", None)
     if "U0" in model_params:
         model_params.pop("UO", None)
+    if "VT0" in model_params:
+        model_params.pop("VTO", None)
+        model_params.pop("VTH", None)
     params = {**model_params, **instance_params}
     defaults = Level1Params()
     values = {

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -3426,6 +3426,16 @@ def test_lowers_finite_mosfet_model_threshold_voltage_aliases(alias: str) -> Non
     assert mosfet.model.model.params.VT0 == -0.38
 
 
+def test_gives_mosfet_vt0_precedence_over_threshold_aliases() -> None:
+    parsed = parse_netlist(
+        ".model nfast NMOS(VT0=-0.38 VTO=-0.42 VTH=-0.46)\nM1 d g s b nfast\n"
+    )
+
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.model.model.params.VT0 == -0.38
+
+
 @pytest.mark.parametrize("alias", ["LAMBDA", "LAM"])
 def test_rejects_non_finite_mosfet_model_channel_modulation(alias: str) -> None:
     with pytest.raises(NetlistParseError, match="MOSFET LAMBDA must be finite"):

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give canonical MOS Level-1 `VT0` precedence over the `VTO` and `VTH` aliases.
 - Give canonical MOS Level-1 `U0` precedence over the `UO` alias.
 - Give canonical MOS Level-1 `LAMBDA` precedence over the `LAM` alias.
 - Give canonical MOS Level-1 `T_NOM` precedence over the `TNOM` alias.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -2142,6 +2142,10 @@ function mosfetParams(
   if (modelParams.has("T_NOM")) modelParams.delete("TNOM");
   if (modelParams.has("LAMBDA")) modelParams.delete("LAM");
   if (modelParams.has("U0")) modelParams.delete("UO");
+  if (modelParams.has("VT0")) {
+    modelParams.delete("VTO");
+    modelParams.delete("VTH");
+  }
   const params: Record<string, number> = {};
   for (const [name, value] of [...modelParams, ...instanceParams]) {
     const key = MOSFET_PARAM_ALIASES.get(name) ?? (name as keyof MosfetLevel1Params);

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -3483,6 +3483,16 @@ Xright c d load
     },
   );
 
+  it("gives MOSFET VT0 precedence over threshold aliases", () => {
+    const parsed = parseNetlist(
+      ".model nfast NMOS(VT0=-0.38 VTO=-0.42 VTH=-0.46)\nM1 d g s b nfast\n",
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.VT0).toBe(-0.38);
+  });
+
   it.each(["LAMBDA", "LAM"])(
     "rejects non-finite MOSFET model channel-modulation alias %s",
     (alias) => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4835,9 +4835,15 @@ the Rust, Python, and TypeScript surfaces together.
      instance parameter overrides.
 
 494. Python and TypeScript Berkeley SPICE MOS surface-mobility alias precedence.
-   - Status: implemented in this MOS surface-mobility precedence slice.
+   - Status: completed in PR 10196.
    - Both parser facades give engine-canonical Level-1 `U0` precedence over the
      `UO` alias during lowering and `TOX`-based `KP` derivation, while
+     preserving instance parameter overrides.
+
+495. Python and TypeScript Berkeley SPICE MOS threshold-voltage alias precedence.
+   - Status: implemented in this MOS threshold-voltage precedence slice.
+   - Both parser facades give engine-canonical Level-1 `VT0` precedence over
+     the `VTO` and `VTH` aliases during lowering, matching validation while
      preserving instance parameter overrides.
 
 ## Backlog


### PR DESCRIPTION
## Summary

- give canonical MOS Level-1 `VT0` precedence over `VTO` and `VTH` during Python and TypeScript lowering
- preserve instance-parameter overrides
- add cross-language regression coverage, changelog entries, and SPICE plan tracking

## Verification

- Python spice-netlist-parser: `bash BUILD` (661 passed, 90.72% coverage)
- Python spice-netlist-parser: `.venv/bin/ruff check .`
- TypeScript spice-netlist-parser: `bash BUILD`
- TypeScript spice-netlist-parser: `npx vitest run --coverage` (646 passed, 88.52% line coverage)
- TypeScript spice-engine: `bash BUILD` (448 passed)
- `git diff --check`

## Audit notes

- Existing BUILD dependencies already cover the touched parser and downstream engine packages; no BUILD metadata change is required.
- The documented JFET `B` beta-alias versus Parker-Skellern doping-tail policy collision remains unresolved and untouched.
