### PR TITLE
Give MOS N_SUB canonical precedence

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give canonical MOS Level-1 `N_SUB` precedence over the `NSUB` and `N` aliases.
 - Give canonical MOS Level-1 `VT0` precedence over the `VTO` and `VTH` aliases.
 - Give canonical MOS Level-1 `U0` precedence over the `UO` alias.
 - Give canonical MOS Level-1 `LAMBDA` precedence over the `LAM` alias.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -2670,6 +2670,9 @@ def _build_mosfet_model(model: ModelCard, instance_params: dict[str, float]) -> 
     if "VT0" in model_params:
         model_params.pop("VTO", None)
         model_params.pop("VTH", None)
+    if "N_SUB" in model_params:
+        model_params.pop("NSUB", None)
+        model_params.pop("N", None)
     params = {**model_params, **instance_params}
     defaults = Level1Params()
     values = {

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -3436,6 +3436,16 @@ def test_gives_mosfet_vt0_precedence_over_threshold_aliases() -> None:
     assert mosfet.model.model.params.VT0 == -0.38
 
 
+def test_gives_mosfet_n_sub_precedence_over_substrate_doping_aliases() -> None:
+    parsed = parse_netlist(
+        ".model nfast NMOS(N_SUB=1.8 NSUB=1.6 N=1.4)\nM1 d g s b nfast\n"
+    )
+
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert mosfet.model.model.params.N_SUB == 1.8
+
+
 @pytest.mark.parametrize("alias", ["LAMBDA", "LAM"])
 def test_rejects_non_finite_mosfet_model_channel_modulation(alias: str) -> None:
     with pytest.raises(NetlistParseError, match="MOSFET LAMBDA must be finite"):

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give canonical MOS Level-1 `N_SUB` precedence over the `NSUB` and `N` aliases.
 - Give canonical MOS Level-1 `VT0` precedence over the `VTO` and `VTH` aliases.
 - Give canonical MOS Level-1 `U0` precedence over the `UO` alias.
 - Give canonical MOS Level-1 `LAMBDA` precedence over the `LAM` alias.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -2146,6 +2146,10 @@ function mosfetParams(
     modelParams.delete("VTO");
     modelParams.delete("VTH");
   }
+  if (modelParams.has("N_SUB")) {
+    modelParams.delete("NSUB");
+    modelParams.delete("N");
+  }
   const params: Record<string, number> = {};
   for (const [name, value] of [...modelParams, ...instanceParams]) {
     const key = MOSFET_PARAM_ALIASES.get(name) ?? (name as keyof MosfetLevel1Params);

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -3493,6 +3493,16 @@ Xright c d load
     expect(element.params.VT0).toBe(-0.38);
   });
 
+  it("gives MOSFET N_SUB precedence over substrate-doping aliases", () => {
+    const parsed = parseNetlist(
+      ".model nfast NMOS(N_SUB=1.8 NSUB=1.6 N=1.4)\nM1 d g s b nfast\n",
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.N_SUB).toBe(1.8);
+  });
+
   it.each(["LAMBDA", "LAM"])(
     "rejects non-finite MOSFET model channel-modulation alias %s",
     (alias) => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4841,9 +4841,15 @@ the Rust, Python, and TypeScript surfaces together.
      preserving instance parameter overrides.
 
 495. Python and TypeScript Berkeley SPICE MOS threshold-voltage alias precedence.
-   - Status: implemented in this MOS threshold-voltage precedence slice.
+   - Status: completed in PR 10198.
    - Both parser facades give engine-canonical Level-1 `VT0` precedence over
      the `VTO` and `VTH` aliases during lowering, matching validation while
+     preserving instance parameter overrides.
+
+496. Python and TypeScript Berkeley SPICE MOS substrate-doping alias precedence.
+   - Status: implemented in this MOS substrate-doping precedence slice.
+   - Both parser facades give engine-canonical Level-1 `N_SUB` precedence over
+     the `NSUB` and `N` aliases during lowering, matching validation while
      preserving instance parameter overrides.
 
 ## Backlog


### PR DESCRIPTION
## Summary

- give canonical MOS Level-1 `N_SUB` precedence over `NSUB` and `N` during Python and TypeScript lowering
- preserve instance-parameter overrides
- add cross-language regression coverage, changelog entries, and SPICE plan tracking

## Verification

- Python spice-netlist-parser: `bash BUILD` (662 passed, 90.74% coverage)
- Python spice-netlist-parser: `.venv/bin/ruff check .`
- TypeScript spice-netlist-parser: `bash BUILD`
- TypeScript spice-netlist-parser: `npx vitest run --coverage` (647 passed, 88.55% line coverage)
- TypeScript spice-engine: `bash BUILD` (448 passed)
- `git diff --check`

## Audit notes

- Existing BUILD dependencies already cover the touched parser and downstream engine packages; no BUILD metadata change is required.
- The documented JFET `B` beta-alias versus Parker-Skellern doping-tail policy collision remains unresolved and untouched.
