### PR TITLE
Give MOS CBD canonical precedence

### DIFF
--- a/code/packages/python/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/python/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give canonical MOS Level-1 `CBD` precedence over the `CJD` alias.
 - Give canonical MOS Level-1 `CBS` precedence over the `CJS` alias.
 - Give canonical MOS Level-1 `N_SUB` precedence over the `NSUB` and `N` aliases.
 - Give canonical MOS Level-1 `VT0` precedence over the `VTO` and `VTH` aliases.

--- a/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
+++ b/code/packages/python/spice-netlist-parser/src/spice_netlist_parser/parser.py
@@ -2675,6 +2675,8 @@ def _build_mosfet_model(model: ModelCard, instance_params: dict[str, float]) -> 
         model_params.pop("N", None)
     if "CBS" in model_params:
         model_params.pop("CJS", None)
+    if "CBD" in model_params:
+        model_params.pop("CJD", None)
     params = {**model_params, **instance_params}
     defaults = Level1Params()
     values = {

--- a/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
+++ b/code/packages/python/spice-netlist-parser/tests/test_spice_netlist_parser.py
@@ -3456,6 +3456,16 @@ def test_gives_mosfet_cbs_precedence_over_source_junction_capacitance_alias() ->
     assert isclose(mosfet.model.model.params.CBS, 6.0e-12)
 
 
+def test_gives_mosfet_cbd_precedence_over_drain_junction_capacitance_alias() -> None:
+    parsed = parse_netlist(
+        ".model nfast NMOS(CBD=7p CJD=9p)\nM1 d g s b nfast\n"
+    )
+
+    mosfet = parsed.circuit.elements[0]
+    assert isinstance(mosfet, Mosfet)
+    assert isclose(mosfet.model.model.params.CBD, 7.0e-12)
+
+
 @pytest.mark.parametrize("alias", ["LAMBDA", "LAM"])
 def test_rejects_non_finite_mosfet_model_channel_modulation(alias: str) -> None:
     with pytest.raises(NetlistParseError, match="MOSFET LAMBDA must be finite"):

--- a/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/typescript/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give canonical MOS Level-1 `CBD` precedence over the `CJD` alias.
 - Give canonical MOS Level-1 `CBS` precedence over the `CJS` alias.
 - Give canonical MOS Level-1 `N_SUB` precedence over the `NSUB` and `N` aliases.
 - Give canonical MOS Level-1 `VT0` precedence over the `VTO` and `VTH` aliases.

--- a/code/packages/typescript/spice-netlist-parser/src/index.ts
+++ b/code/packages/typescript/spice-netlist-parser/src/index.ts
@@ -2151,6 +2151,7 @@ function mosfetParams(
     modelParams.delete("N");
   }
   if (modelParams.has("CBS")) modelParams.delete("CJS");
+  if (modelParams.has("CBD")) modelParams.delete("CJD");
   const params: Record<string, number> = {};
   for (const [name, value] of [...modelParams, ...instanceParams]) {
     const key = MOSFET_PARAM_ALIASES.get(name) ?? (name as keyof MosfetLevel1Params);

--- a/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
+++ b/code/packages/typescript/spice-netlist-parser/tests/spice-netlist-parser.test.ts
@@ -3513,6 +3513,16 @@ Xright c d load
     expect(element.params.CBS).toBeCloseTo(6.0e-12, 18);
   });
 
+  it("gives MOSFET CBD precedence over the drain-junction capacitance alias", () => {
+    const parsed = parseNetlist(
+      ".model nfast NMOS(CBD=7p CJD=9p)\nM1 d g s b nfast\n",
+    );
+    const element = parsed.circuit.elements()[0];
+    expect(element.kind).toBe("mosfet");
+    if (element.kind !== "mosfet") throw new Error("unexpected element kind");
+    expect(element.params.CBD).toBeCloseTo(7.0e-12, 18);
+  });
+
   it.each(["LAMBDA", "LAM"])(
     "rejects non-finite MOSFET model channel-modulation alias %s",
     (alias) => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4853,9 +4853,15 @@ the Rust, Python, and TypeScript surfaces together.
      preserving instance parameter overrides.
 
 497. Python and TypeScript Berkeley SPICE MOS source-junction capacitance alias precedence.
-   - Status: implemented in this MOS source-junction capacitance precedence slice.
+   - Status: completed in PR 10204.
    - Both parser facades give engine-canonical Level-1 `CBS` precedence over
      the `CJS` alias during lowering, matching validation while preserving
+     instance parameter overrides.
+
+498. Python and TypeScript Berkeley SPICE MOS drain-junction capacitance alias precedence.
+   - Status: implemented in this MOS drain-junction capacitance precedence slice.
+   - Both parser facades give engine-canonical Level-1 `CBD` precedence over
+     the `CJD` alias during lowering, matching validation while preserving
      instance parameter overrides.
 
 ## Backlog


### PR DESCRIPTION
## Summary

- give canonical MOS Level-1 `CBD` precedence over `CJD` during Python and TypeScript lowering
- preserve instance-parameter overrides
- add cross-language regression coverage, changelog entries, and SPICE plan tracking

## Verification

- Python spice-netlist-parser: `bash BUILD` (664 passed, 90.77% coverage)
- Python spice-netlist-parser: `.venv/bin/ruff check .`
- TypeScript spice-netlist-parser: `bash BUILD`
- TypeScript spice-netlist-parser: `npx vitest run --coverage` (649 passed, 88.57% line coverage)
- TypeScript spice-engine: `bash BUILD` (448 passed)
- `git diff --check`

## Audit notes

- Existing BUILD dependencies already cover the touched parser and downstream engine packages; no BUILD metadata change is required.
- The documented JFET `B` beta-alias versus Parker-Skellern doping-tail policy collision remains unresolved and untouched.
