### PR TITLE
Add owner-only secret file reader

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1027,6 +1027,7 @@ members = [
   "task-core",
   "task-wasm",
   "chief-of-staff-daemon-credential",
+  "chief-of-staff-daemon-secret-file",
   "chief-of-staff-daemon",
   "chief-of-staff-daemon-service-files",
   "chief-of-staff-daemon-installer",

--- a/code/packages/rust/chief-of-staff-daemon-secret-file/BUILD
+++ b/code/packages/rust/chief-of-staff-daemon-secret-file/BUILD
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+cargo test -p chief-of-staff-daemon-secret-file -- --nocapture
+cargo clippy -p chief-of-staff-daemon-secret-file --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-daemon-secret-file --no-deps

--- a/code/packages/rust/chief-of-staff-daemon-secret-file/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-secret-file/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-08-09
+
+### Added
+
+- Add exact-length reads into zeroizing storage.
+- Add descriptor-relative Unix no-follow traversal plus effective-owner and
+  owner-only mode checks.
+- Add Windows ancestor locking, reparse-point rejection, and protected
+  current-user-only DACL validation.
+- Add stable payload-blind failures and cross-platform regression coverage.

--- a/code/packages/rust/chief-of-staff-daemon-secret-file/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon-secret-file/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "chief-of-staff-daemon-secret-file"
+version = "0.1.0"
+edition = "2021"
+description = "Race-resistant owner-only secret-file loading for the D18 Chief daemon"
+license = "MIT"
+
+[dependencies]
+coding_adventures_zeroize = { path = "../zeroize" }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+] }

--- a/code/packages/rust/chief-of-staff-daemon-secret-file/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-secret-file/README.md
@@ -1,0 +1,23 @@
+# chief-of-staff-daemon-secret-file
+
+Race-resistant owner-only secret-file loading for D18 production adapters.
+
+`read_owner_only_secret` accepts one bounded absolute path and an exact non-zero
+byte length. It rejects linked or non-regular objects, foreign ownership, broad
+access controls, missing or overlong content, and parent-directory link traversal.
+The bounded result is always returned in a zeroizing allocation.
+
+Unix walks from `/` through directory file descriptors, opens every component with
+`O_NOFOLLOW`, and requires the final file to belong to the effective user with no
+group or world access. Windows holds every ancestor without delete sharing, rejects
+reparse points, and requires a protected DACL containing exactly one allow ACE for
+the current token user.
+
+The package only reads existing operator-owned files. It never creates, repairs,
+rewrites, logs, or exposes secret content through its errors.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/chief-of-staff-daemon-secret-file/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-daemon-secret-file/required_capabilities.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/chief-of-staff-daemon-secret-file",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "configured operator-owned secret paths",
+      "justification": "Loads bounded private material only after rejecting linked objects, foreign ownership, and broad access controls."
+    },
+    {
+      "category": "ffi",
+      "action": "call",
+      "target": "libc openat/fstat and Windows file/token/security APIs",
+      "justification": "Uses handle-relative no-follow file operations and native ownership/access-control inspection unavailable through portable Rust filesystem APIs."
+    }
+  ],
+  "justification": "Reusable OS trust-boundary adapter for exact-length owner-only secret reads into zeroizing storage."
+}

--- a/code/packages/rust/chief-of-staff-daemon-secret-file/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-secret-file/src/lib.rs
@@ -1,0 +1,251 @@
+//! Race-resistant owner-only secret-file loading for D18 production adapters.
+
+#![deny(missing_docs)]
+
+use coding_adventures_zeroize::Zeroizing;
+use core::fmt::{self, Display, Formatter};
+use std::path::Path;
+
+#[cfg(unix)]
+mod unix;
+#[cfg(windows)]
+mod windows;
+
+const MAX_PATH_BYTES: usize = 4096;
+const MAX_SECRET_BYTES: usize = 64 * 1024;
+
+/// Stable payload-blind failure while loading one operator-owned secret file.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SecretFileError {
+    /// The supplied path was not a bounded absolute path with a regular final name.
+    InvalidPath,
+    /// The parent directory chain could not be opened without following links.
+    ParentUnavailable,
+    /// The secret file could not be opened, inspected, or read.
+    AccessFailed,
+    /// The path resolved to a link, reparse point, directory, or other non-regular object.
+    UnsafeFileType,
+    /// The file is not owned by the current effective user.
+    InsecureOwner,
+    /// The file grants access beyond its owner.
+    InsecurePermissions,
+    /// The requested or stored secret length violated the exact bounded contract.
+    InvalidLength,
+}
+
+impl Display for SecretFileError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidPath => "chief secret file: invalid path",
+            Self::ParentUnavailable => "chief secret file: parent unavailable",
+            Self::AccessFailed => "chief secret file: access failed",
+            Self::UnsafeFileType => "chief secret file: unsafe file type",
+            Self::InsecureOwner => "chief secret file: insecure owner",
+            Self::InsecurePermissions => "chief secret file: insecure permissions",
+            Self::InvalidLength => "chief secret file: invalid length",
+        })
+    }
+}
+
+impl std::error::Error for SecretFileError {}
+
+/// Read one existing exact-length secret after enforcing platform owner-only policy.
+///
+/// The path must be absolute and the expected length must be between 1 byte and
+/// 64 KiB. Parent traversal and the final open never follow links. Returned bytes
+/// are wiped on drop; errors never include paths or file content.
+pub fn read_owner_only_secret(
+    path: &Path,
+    expected_length: usize,
+) -> Result<Zeroizing<Vec<u8>>, SecretFileError> {
+    if expected_length == 0 || expected_length > MAX_SECRET_BYTES {
+        return Err(SecretFileError::InvalidLength);
+    }
+    #[cfg(unix)]
+    {
+        unix::read(path, expected_length)
+    }
+    #[cfg(windows)]
+    {
+        windows::read(path, expected_length)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = path;
+        Err(SecretFileError::AccessFailed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(label: &str) -> Self {
+            let sequence = NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "chief-secret-file-{label}-{}-{sequence}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(fs::canonicalize(path).unwrap())
+        }
+
+        fn secret(&self) -> PathBuf {
+            self.0.join("secret.bin")
+        }
+
+        fn write_secret(&self, bytes: &[u8]) {
+            #[cfg(unix)]
+            unix::write_test_secret(&self.secret(), bytes);
+            #[cfg(windows)]
+            windows::write_test_secret(&self.secret(), bytes);
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn error(result: Result<Zeroizing<Vec<u8>>, SecretFileError>) -> SecretFileError {
+        match result {
+            Err(error) => error,
+            Ok(_) => panic!("secret read unexpectedly succeeded"),
+        }
+    }
+
+    #[test]
+    fn reads_only_the_exact_secret_into_zeroizing_storage() {
+        let directory = TestDirectory::new("exact");
+        directory.write_secret(&[0x42; 32]);
+        let secret = read_owner_only_secret(&directory.secret(), 32).unwrap();
+        assert_eq!(secret.as_slice(), &[0x42; 32]);
+        assert_eq!(
+            error(read_owner_only_secret(&directory.secret(), 31)),
+            SecretFileError::InvalidLength
+        );
+        assert_eq!(
+            error(read_owner_only_secret(&directory.secret(), 33)),
+            SecretFileError::InvalidLength
+        );
+    }
+
+    #[test]
+    fn invalid_lengths_paths_and_objects_fail_closed() {
+        let directory = TestDirectory::new("invalid");
+        assert_eq!(
+            error(read_owner_only_secret(&directory.secret(), 0)),
+            SecretFileError::InvalidLength
+        );
+        assert_eq!(
+            error(read_owner_only_secret(
+                &directory.secret(),
+                MAX_SECRET_BYTES + 1,
+            )),
+            SecretFileError::InvalidLength
+        );
+        assert_eq!(
+            error(read_owner_only_secret(Path::new("relative.bin"), 32)),
+            SecretFileError::InvalidPath
+        );
+        assert_eq!(
+            error(read_owner_only_secret(&directory.secret(), 32)),
+            SecretFileError::AccessFailed
+        );
+        fs::create_dir(directory.secret()).unwrap();
+        assert_eq!(
+            error(read_owner_only_secret(&directory.secret(), 32)),
+            SecretFileError::UnsafeFileType
+        );
+    }
+
+    #[test]
+    fn errors_are_stable_and_payload_blind() {
+        let messages = [
+            (
+                SecretFileError::InvalidPath,
+                "chief secret file: invalid path",
+            ),
+            (
+                SecretFileError::ParentUnavailable,
+                "chief secret file: parent unavailable",
+            ),
+            (
+                SecretFileError::AccessFailed,
+                "chief secret file: access failed",
+            ),
+            (
+                SecretFileError::UnsafeFileType,
+                "chief secret file: unsafe file type",
+            ),
+            (
+                SecretFileError::InsecureOwner,
+                "chief secret file: insecure owner",
+            ),
+            (
+                SecretFileError::InsecurePermissions,
+                "chief secret file: insecure permissions",
+            ),
+            (
+                SecretFileError::InvalidLength,
+                "chief secret file: invalid length",
+            ),
+        ];
+        for (error, message) in messages {
+            assert_eq!(error.to_string(), message);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_link_traversal_and_broad_permissions() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let directory = TestDirectory::new("unix-policy");
+        directory.write_secret(&[0x55; 32]);
+        fs::set_permissions(directory.secret(), fs::Permissions::from_mode(0o640)).unwrap();
+        assert_eq!(
+            error(read_owner_only_secret(&directory.secret(), 32)),
+            SecretFileError::InsecurePermissions
+        );
+
+        let target = directory.0.join("target.bin");
+        fs::rename(directory.secret(), &target).unwrap();
+        symlink(&target, directory.secret()).unwrap();
+        assert_eq!(
+            error(read_owner_only_secret(&directory.secret(), 32)),
+            SecretFileError::UnsafeFileType
+        );
+
+        let real_parent = directory.0.join("real-parent");
+        let linked_parent = directory.0.join("linked-parent");
+        fs::create_dir(&real_parent).unwrap();
+        symlink(&real_parent, &linked_parent).unwrap();
+        assert_eq!(
+            error(read_owner_only_secret(
+                &linked_parent.join("secret.bin"),
+                32,
+            )),
+            SecretFileError::ParentUnavailable
+        );
+
+        let fifo = directory.0.join("secret.fifo");
+        let fifo_path = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) }, 0);
+        assert_eq!(
+            error(read_owner_only_secret(&fifo, 32)),
+            SecretFileError::UnsafeFileType
+        );
+    }
+}

--- a/code/packages/rust/chief-of-staff-daemon-secret-file/src/unix.rs
+++ b/code/packages/rust/chief-of-staff-daemon-secret-file/src/unix.rs
@@ -1,0 +1,121 @@
+use super::{SecretFileError, MAX_PATH_BYTES};
+use coding_adventures_zeroize::Zeroizing;
+use std::ffi::{CString, OsStr};
+use std::fs::File;
+use std::io::Read;
+use std::mem::MaybeUninit;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Component, Path};
+
+pub(super) fn read(
+    path: &Path,
+    expected_length: usize,
+) -> Result<Zeroizing<Vec<u8>>, SecretFileError> {
+    let (parent, name) = open_parent(path)?;
+    let raw = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_NONBLOCK | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if raw < 0 {
+        return match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ELOOP) => Err(SecretFileError::UnsafeFileType),
+            _ => Err(SecretFileError::AccessFailed),
+        };
+    }
+    let file = File::from(unsafe { OwnedFd::from_raw_fd(raw) });
+    verify_file(&file)?;
+    read_exact_bounded(file, expected_length)
+}
+
+fn open_parent(path: &Path) -> Result<(OwnedFd, CString), SecretFileError> {
+    if !path.is_absolute() || path.as_os_str().as_bytes().len() > MAX_PATH_BYTES {
+        return Err(SecretFileError::InvalidPath);
+    }
+    let components: Vec<_> = path.components().collect();
+    if components.len() < 2 || components[0] != Component::RootDir {
+        return Err(SecretFileError::InvalidPath);
+    }
+    let name = match components.last() {
+        Some(Component::Normal(name)) => c_string(name)?,
+        _ => return Err(SecretFileError::InvalidPath),
+    };
+    let root = unsafe {
+        libc::open(
+            c"/".as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    let mut directory = owned_fd(root).map_err(|_| SecretFileError::ParentUnavailable)?;
+    for component in &components[1..components.len() - 1] {
+        let Component::Normal(part) = component else {
+            return Err(SecretFileError::InvalidPath);
+        };
+        let part = c_string(part)?;
+        let next = unsafe {
+            libc::openat(
+                directory.as_raw_fd(),
+                part.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        directory = owned_fd(next).map_err(|_| SecretFileError::ParentUnavailable)?;
+    }
+    Ok((directory, name))
+}
+
+fn c_string(value: &OsStr) -> Result<CString, SecretFileError> {
+    CString::new(value.as_bytes()).map_err(|_| SecretFileError::InvalidPath)
+}
+
+fn owned_fd(raw: libc::c_int) -> Result<OwnedFd, ()> {
+    if raw < 0 {
+        Err(())
+    } else {
+        Ok(unsafe { OwnedFd::from_raw_fd(raw) })
+    }
+}
+
+fn verify_file(file: &File) -> Result<(), SecretFileError> {
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) } != 0 {
+        return Err(SecretFileError::AccessFailed);
+    }
+    let stat = unsafe { stat.assume_init() };
+    if stat.st_mode & libc::S_IFMT != libc::S_IFREG {
+        return Err(SecretFileError::UnsafeFileType);
+    }
+    if stat.st_uid != unsafe { libc::geteuid() } {
+        return Err(SecretFileError::InsecureOwner);
+    }
+    if stat.st_mode & 0o077 != 0 || stat.st_mode & 0o400 == 0 {
+        return Err(SecretFileError::InsecurePermissions);
+    }
+    Ok(())
+}
+
+fn read_exact_bounded(
+    file: File,
+    expected_length: usize,
+) -> Result<Zeroizing<Vec<u8>>, SecretFileError> {
+    let mut bytes = Zeroizing::new(Vec::with_capacity(expected_length + 1));
+    file.take((expected_length + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|_| SecretFileError::AccessFailed)?;
+    if bytes.len() != expected_length {
+        return Err(SecretFileError::InvalidLength);
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+pub(super) fn write_test_secret(path: &Path, bytes: &[u8]) {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::write(path, bytes).unwrap();
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600)).unwrap();
+}

--- a/code/packages/rust/chief-of-staff-daemon-secret-file/src/windows.rs
+++ b/code/packages/rust/chief-of-staff-daemon-secret-file/src/windows.rs
@@ -1,0 +1,366 @@
+use super::{SecretFileError, MAX_PATH_BYTES};
+use coding_adventures_zeroize::Zeroizing;
+use std::ffi::c_void;
+use std::fs::File;
+use std::io::Read;
+#[cfg(test)]
+use std::io::Write;
+use std::mem::{size_of, MaybeUninit};
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+use std::path::{Component, Path};
+use std::ptr::{addr_of, null, null_mut};
+use windows_sys::Win32::Foundation::{BOOL, HANDLE, INVALID_HANDLE_VALUE, PSID};
+use windows_sys::Win32::Security::{
+    AclSizeInformation, EqualSid, GetAce, GetAclInformation, GetKernelObjectSecurity, GetLengthSid,
+    GetSecurityDescriptorControl, GetSecurityDescriptorDacl, GetSecurityDescriptorOwner,
+    GetTokenInformation, TokenUser, ACCESS_ALLOWED_ACE, ACL, ACL_SIZE_INFORMATION,
+    DACL_SECURITY_INFORMATION, OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, SE_DACL_PROTECTED,
+    TOKEN_QUERY, TOKEN_USER,
+};
+#[cfg(test)]
+use windows_sys::Win32::Security::{
+    AddAccessAllowedAce, InitializeAcl, InitializeSecurityDescriptor, SetSecurityDescriptorControl,
+    SetSecurityDescriptorDacl, SetSecurityDescriptorOwner, ACL_REVISION, SECURITY_ATTRIBUTES,
+    SECURITY_DESCRIPTOR,
+};
+#[cfg(test)]
+use windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_WRITE;
+use windows_sys::Win32::Storage::FileSystem::{
+    CreateFileW, FileAttributeTagInfo, GetFileInformationByHandleEx, FILE_ATTRIBUTE_DIRECTORY,
+    FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO, FILE_FLAG_BACKUP_SEMANTICS,
+    FILE_FLAG_OPEN_REPARSE_POINT, FILE_GENERIC_READ, FILE_READ_ATTRIBUTES, FILE_SHARE_READ,
+    FILE_SHARE_WRITE, OPEN_EXISTING,
+};
+use windows_sys::Win32::System::SystemServices::ACCESS_ALLOWED_ACE_TYPE;
+#[cfg(test)]
+use windows_sys::Win32::System::SystemServices::SECURITY_DESCRIPTOR_REVISION;
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+#[cfg(test)]
+const OWNER_ACCESS: u32 = FILE_GENERIC_READ | FILE_GENERIC_WRITE;
+const MAX_SECURITY_DESCRIPTOR_BYTES: u32 = 64 * 1024;
+const MINIMUM_SID_BYTES: usize = 8;
+
+pub(super) fn read(
+    path: &Path,
+    expected_length: usize,
+) -> Result<Zeroizing<Vec<u8>>, SecretFileError> {
+    validate_path(path)?;
+    let _parent_locks = lock_parents(path)?;
+    let wide = wide_path(path)?;
+    let raw = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            FILE_GENERIC_READ,
+            0,
+            null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            0,
+        )
+    };
+    let file = File::from(owned_handle(raw).map_err(|_| SecretFileError::AccessFailed)?);
+    verify_file(&file)?;
+    let mut bytes = Zeroizing::new(Vec::with_capacity(expected_length + 1));
+    file.take((expected_length + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|_| SecretFileError::AccessFailed)?;
+    if bytes.len() != expected_length {
+        return Err(SecretFileError::InvalidLength);
+    }
+    Ok(bytes)
+}
+
+fn validate_path(path: &Path) -> Result<(), SecretFileError> {
+    let encoded_units = path.as_os_str().encode_wide().count();
+    if !path.is_absolute()
+        || encoded_units == 0
+        || encoded_units > MAX_PATH_BYTES
+        || path
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+        || !matches!(path.components().next_back(), Some(Component::Normal(_)))
+        || path.as_os_str().encode_wide().any(|unit| unit == 0)
+    {
+        return Err(SecretFileError::InvalidPath);
+    }
+    Ok(())
+}
+
+fn lock_parents(path: &Path) -> Result<Vec<OwnedHandle>, SecretFileError> {
+    let parent = path.parent().ok_or(SecretFileError::InvalidPath)?;
+    let mut ancestors: Vec<_> = parent
+        .ancestors()
+        .filter(|ancestor| !ancestor.as_os_str().is_empty())
+        .collect();
+    ancestors.reverse();
+    ancestors
+        .into_iter()
+        .map(open_directory)
+        .collect::<Result<Vec<_>, _>>()
+}
+
+fn open_directory(path: &Path) -> Result<OwnedHandle, SecretFileError> {
+    let wide = wide_path(path)?;
+    let raw = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            0,
+        )
+    };
+    let handle = owned_handle(raw).map_err(|_| SecretFileError::ParentUnavailable)?;
+    let attributes = file_attributes(raw).map_err(|_| SecretFileError::ParentUnavailable)?;
+    if attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY == 0
+        || attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    {
+        return Err(SecretFileError::ParentUnavailable);
+    }
+    Ok(handle)
+}
+
+fn wide_path(path: &Path) -> Result<Vec<u16>, SecretFileError> {
+    let mut wide: Vec<_> = path.as_os_str().encode_wide().collect();
+    if wide.is_empty() || wide.len() > MAX_PATH_BYTES || wide.contains(&0) {
+        return Err(SecretFileError::InvalidPath);
+    }
+    wide.push(0);
+    Ok(wide)
+}
+
+fn owned_handle(raw: HANDLE) -> Result<OwnedHandle, ()> {
+    if raw == INVALID_HANDLE_VALUE {
+        Err(())
+    } else {
+        Ok(unsafe { OwnedHandle::from_raw_handle(raw as *mut c_void) })
+    }
+}
+
+fn verify_file(file: &File) -> Result<(), SecretFileError> {
+    let raw = file.as_raw_handle() as HANDLE;
+    let attributes = file_attributes(raw)?;
+    if attributes.FileAttributes & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+        return Err(SecretFileError::UnsafeFileType);
+    }
+    verify_owner_acl(raw)
+}
+
+fn file_attributes(raw: HANDLE) -> Result<FILE_ATTRIBUTE_TAG_INFO, SecretFileError> {
+    let mut information = MaybeUninit::<FILE_ATTRIBUTE_TAG_INFO>::zeroed();
+    if unsafe {
+        GetFileInformationByHandleEx(
+            raw,
+            FileAttributeTagInfo,
+            information.as_mut_ptr().cast(),
+            size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
+        )
+    } == 0
+    {
+        return Err(SecretFileError::AccessFailed);
+    }
+    Ok(unsafe { information.assume_init() })
+}
+
+struct CurrentUserSid {
+    _storage: Vec<usize>,
+    sid: PSID,
+}
+
+impl CurrentUserSid {
+    fn query() -> Result<Self, SecretFileError> {
+        let mut raw_token = 0;
+        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut raw_token) } == 0 {
+            return Err(SecretFileError::AccessFailed);
+        }
+        let _token = owned_handle(raw_token).map_err(|_| SecretFileError::AccessFailed)?;
+        let mut needed = 0;
+        unsafe {
+            GetTokenInformation(raw_token, TokenUser, null_mut(), 0, &mut needed);
+        }
+        if needed == 0 || needed > MAX_SECURITY_DESCRIPTOR_BYTES {
+            return Err(SecretFileError::AccessFailed);
+        }
+        let mut storage = vec![0usize; bytes_to_words(needed)];
+        if unsafe {
+            GetTokenInformation(
+                raw_token,
+                TokenUser,
+                storage.as_mut_ptr().cast(),
+                needed,
+                &mut needed,
+            )
+        } == 0
+        {
+            return Err(SecretFileError::AccessFailed);
+        }
+        let token_user = storage.as_ptr().cast::<TOKEN_USER>();
+        let sid = unsafe { (*token_user).User.Sid };
+        if sid.is_null() || unsafe { GetLengthSid(sid) } == 0 {
+            return Err(SecretFileError::AccessFailed);
+        }
+        Ok(Self {
+            _storage: storage,
+            sid,
+        })
+    }
+}
+
+fn verify_owner_acl(raw: HANDLE) -> Result<(), SecretFileError> {
+    let current = CurrentUserSid::query()?;
+    let information = OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION;
+    let mut needed = 0;
+    unsafe {
+        GetKernelObjectSecurity(raw, information, null_mut(), 0, &mut needed);
+    }
+    if needed == 0 || needed > MAX_SECURITY_DESCRIPTOR_BYTES {
+        return Err(SecretFileError::AccessFailed);
+    }
+    let mut storage = vec![0usize; bytes_to_words(needed)];
+    let descriptor: PSECURITY_DESCRIPTOR = storage.as_mut_ptr().cast();
+    if unsafe { GetKernelObjectSecurity(raw, information, descriptor, needed, &mut needed) } == 0 {
+        return Err(SecretFileError::AccessFailed);
+    }
+    let mut owner = null_mut();
+    let mut owner_defaulted: BOOL = 0;
+    if unsafe { GetSecurityDescriptorOwner(descriptor, &mut owner, &mut owner_defaulted) } == 0 {
+        return Err(SecretFileError::AccessFailed);
+    }
+    if owner.is_null() || unsafe { EqualSid(owner, current.sid) } == 0 {
+        return Err(SecretFileError::InsecureOwner);
+    }
+    let mut control = 0;
+    let mut revision = 0;
+    if unsafe { GetSecurityDescriptorControl(descriptor, &mut control, &mut revision) } == 0 {
+        return Err(SecretFileError::AccessFailed);
+    }
+    if control & SE_DACL_PROTECTED == 0 {
+        return Err(SecretFileError::InsecurePermissions);
+    }
+    let mut present: BOOL = 0;
+    let mut dacl: *mut ACL = null_mut();
+    let mut defaulted: BOOL = 0;
+    if unsafe { GetSecurityDescriptorDacl(descriptor, &mut present, &mut dacl, &mut defaulted) }
+        == 0
+        || present == 0
+        || dacl.is_null()
+    {
+        return Err(SecretFileError::InsecurePermissions);
+    }
+    let mut acl_information = MaybeUninit::<ACL_SIZE_INFORMATION>::zeroed();
+    if unsafe {
+        GetAclInformation(
+            dacl,
+            acl_information.as_mut_ptr().cast(),
+            size_of::<ACL_SIZE_INFORMATION>() as u32,
+            AclSizeInformation,
+        )
+    } == 0
+        || unsafe { acl_information.assume_init() }.AceCount != 1
+    {
+        return Err(SecretFileError::InsecurePermissions);
+    }
+    let mut ace_pointer: *mut c_void = null_mut();
+    if unsafe { GetAce(dacl, 0, &mut ace_pointer) } == 0 || ace_pointer.is_null() {
+        return Err(SecretFileError::AccessFailed);
+    }
+    let ace = unsafe { &*ace_pointer.cast::<ACCESS_ALLOWED_ACE>() };
+    let sid_offset = size_of::<ACCESS_ALLOWED_ACE>() - size_of::<u32>();
+    if usize::from(ace.Header.AceSize) < sid_offset + MINIMUM_SID_BYTES {
+        return Err(SecretFileError::InsecurePermissions);
+    }
+    let sid = addr_of!(ace.SidStart).cast_mut().cast();
+    let sid_bytes = unsafe { GetLengthSid(sid) } as usize;
+    if u32::from(ace.Header.AceType) != ACCESS_ALLOWED_ACE_TYPE
+        || ace.Header.AceFlags != 0
+        || sid_bytes < MINIMUM_SID_BYTES
+        || usize::from(ace.Header.AceSize) < sid_offset + sid_bytes
+        || unsafe { EqualSid(sid, current.sid) } == 0
+    {
+        return Err(SecretFileError::InsecurePermissions);
+    }
+    Ok(())
+}
+
+fn bytes_to_words(bytes: u32) -> usize {
+    (bytes as usize).div_ceil(size_of::<usize>())
+}
+
+#[cfg(test)]
+struct OwnerSecurity {
+    _owner: CurrentUserSid,
+    _acl_storage: Vec<u32>,
+    descriptor: SECURITY_DESCRIPTOR,
+}
+
+#[cfg(test)]
+impl OwnerSecurity {
+    fn new() -> Result<Self, SecretFileError> {
+        let owner = CurrentUserSid::query()?;
+        let sid_bytes = unsafe { GetLengthSid(owner.sid) } as usize;
+        let acl_bytes =
+            size_of::<ACL>() + size_of::<ACCESS_ALLOWED_ACE>() - size_of::<u32>() + sid_bytes;
+        let mut acl_storage = vec![0u32; acl_bytes.div_ceil(size_of::<u32>())];
+        let acl = acl_storage.as_mut_ptr().cast::<ACL>();
+        if unsafe { InitializeAcl(acl, acl_bytes as u32, ACL_REVISION) } == 0
+            || unsafe { AddAccessAllowedAce(acl, ACL_REVISION, OWNER_ACCESS, owner.sid) } == 0
+        {
+            return Err(SecretFileError::AccessFailed);
+        }
+        let mut descriptor = unsafe { MaybeUninit::<SECURITY_DESCRIPTOR>::zeroed().assume_init() };
+        let descriptor_ptr: PSECURITY_DESCRIPTOR =
+            (&mut descriptor as *mut SECURITY_DESCRIPTOR).cast();
+        if unsafe { InitializeSecurityDescriptor(descriptor_ptr, SECURITY_DESCRIPTOR_REVISION) }
+            == 0
+            || unsafe { SetSecurityDescriptorOwner(descriptor_ptr, owner.sid, 0) } == 0
+            || unsafe { SetSecurityDescriptorDacl(descriptor_ptr, 1, acl, 0) } == 0
+            || unsafe {
+                SetSecurityDescriptorControl(descriptor_ptr, SE_DACL_PROTECTED, SE_DACL_PROTECTED)
+            } == 0
+        {
+            return Err(SecretFileError::AccessFailed);
+        }
+        Ok(Self {
+            _owner: owner,
+            _acl_storage: acl_storage,
+            descriptor,
+        })
+    }
+
+    fn attributes(&mut self) -> SECURITY_ATTRIBUTES {
+        SECURITY_ATTRIBUTES {
+            nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: (&mut self.descriptor as *mut SECURITY_DESCRIPTOR).cast(),
+            bInheritHandle: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+pub(super) fn write_test_secret(path: &Path, bytes: &[u8]) {
+    use windows_sys::Win32::Storage::FileSystem::CREATE_NEW;
+
+    validate_path(path).unwrap();
+    let _parent_locks = lock_parents(path).unwrap();
+    let wide = wide_path(path).unwrap();
+    let mut security = OwnerSecurity::new().unwrap();
+    let attributes = security.attributes();
+    let raw = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            OWNER_ACCESS,
+            0,
+            &attributes,
+            CREATE_NEW,
+            FILE_FLAG_OPEN_REPARSE_POINT,
+            0,
+        )
+    };
+    let mut file = File::from(owned_handle(raw).unwrap());
+    file.write_all(bytes).unwrap();
+    file.sync_all().unwrap();
+}

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -2184,6 +2184,14 @@ creation supplies a protected DACL with exactly one allow ACE for the current to
 user. Existing Windows credentials must retain that owner and protected one-ACE DACL;
 inherited directory permissions are not sufficient.
 
+Production adapters that load private key material from operator-owned files MUST
+use the same no-link path traversal and current-user-only access policy. Those
+reads are existing-file-only, exact-length, bounded, and returned in zeroizing
+storage; the adapter never creates, repairs, rewrites, or logs secret content.
+Unix non-regular opens MUST be non-blocking so a FIFO or device cannot stall daemon
+startup. Windows reads retain ancestor handles and reject reparse points before
+requiring a protected current-user-only DACL.
+
 The concrete `chief-of-staff-daemon` executable is the composition root for these
 contracts. With no arguments it resolves `~/.chief-of-staff/config.toml` from the
 platform user-home environment; one explicit absolute config path is also accepted.


### PR DESCRIPTION
## Summary

- add a reusable exact-length secret-file reader that returns only zeroizing storage
- reject symlink/reparse traversal, non-regular files, foreign ownership, and broad access controls on Unix and Windows
- make Unix non-regular opens non-blocking so FIFOs and devices cannot stall startup
- document the trust-boundary requirement for production private-key adapters

## Validation

- 4 focused tests
- strict Clippy and rustdoc
- repository dependency-closed gate: 2 built, 1,237 skipped

## Follow-up

- build typed channel-key and exact Ollama provisioning on this reader
- inject the provisioned authorities into the production daemon

Progresses #128
Progresses #138