### PR TITLE
Give canonical model parameters precedence

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Give explicitly supplied canonical model-card parameter names precedence over
+  aliases regardless of source order.
+
 - Reject negative and non-finite Level-1 MOS model-card `AF` values before
   flicker-noise calculations.
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -552,14 +552,18 @@ def normalize_model_card(
 
     kind = normalize_model_card_type(model_type)
     aliases = _parameter_aliases(kind)
+    raw_parameters = parameters or {}
+    parameter_keys = {_parameter_key(raw_name) for raw_name in raw_parameters}
     normalized: dict[str, float] = {}
     unsupported: list[str] = []
-    for raw_name, raw_value in (parameters or {}).items():
+    for raw_name, raw_value in raw_parameters.items():
         key = _parameter_key(raw_name)
         canonical = aliases.get(key)
         if canonical is None:
             if key not in unsupported:
                 unsupported.append(key)
+            continue
+        if key != canonical and canonical in parameter_keys:
             continue
         value = float(raw_value)
         if canonical == "LEVEL":

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -815,6 +815,14 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.4) == mos_model.model.model.params.AF
 
 
+def test_model_card_normalization_gives_canonical_parameters_precedence() -> None:
+    diode_card = normalize_model_card(
+        "Dfast", "diode", {"IS": 2.0e-14, "JS": 4.0e-14}
+    )
+
+    assert diode_card.parameters["IS"] == pytest.approx(2.0e-14)
+
+
 def test_mos_model_card_surface_mobility_derives_kp_with_explicit_precedence() -> None:
     default_mobility = mosfet_from_model_card(
         "M1",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Give explicitly supplied canonical model-card parameter names precedence over
+  aliases regardless of source order.
+
 - Reject negative and non-finite Level-1 MOS model-card `AF` values before
   flicker-noise calculations.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8411,6 +8411,7 @@ export function normalizeModelCard(
 ): NormalizedModelCard {
   const kind = normalizeModelCardType(modelType);
   const aliases = parameterAliases(kind);
+  const parameterKeys = new Set(Object.keys(parameters).map(parameterKey));
   const normalized: Record<string, number> = {};
   const unsupported: string[] = [];
   for (const [rawName, rawValue] of Object.entries(parameters)) {
@@ -8422,6 +8423,7 @@ export function normalizeModelCard(
       }
       continue;
     }
+    if (key !== canonical && parameterKeys.has(canonical)) continue;
     const value = Number(rawValue);
     if (canonical === "LEVEL") {
       if (!Number.isFinite(value) || Math.abs(value - 1.0) > 1.0e-12) {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -480,6 +480,15 @@ describe("dcOp", () => {
     expectClose(mosModel.params.AF, 1.4);
   });
 
+  it("gives canonical model-card parameters precedence during normalization", () => {
+    const diodeCard = normalizeModelCard("Dfast", "diode", {
+      IS: 2.0e-14,
+      JS: 4.0e-14,
+    });
+
+    expectClose(diodeCard.parameters.IS, 2.0e-14);
+  });
+
   it("derives MOS KP from surface mobility with explicit-KP precedence", () => {
     const defaultMobility = mosfetFromModelCard(
       "M1",

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -4859,10 +4859,16 @@ the Rust, Python, and TypeScript surfaces together.
      instance parameter overrides.
 
 498. Python and TypeScript Berkeley SPICE MOS drain-junction capacitance alias precedence.
-   - Status: implemented in this MOS drain-junction capacitance precedence slice.
+   - Status: completed in PR 10206.
    - Both parser facades give engine-canonical Level-1 `CBD` precedence over
      the `CJD` alias during lowering, matching validation while preserving
      instance parameter overrides.
+
+499. Python and TypeScript model-card engine canonical alias precedence.
+   - Status: implemented in this engine normalization precedence slice.
+   - Both engine normalizers give explicitly supplied canonical parameter names
+     precedence over aliases regardless of source order, matching parser-facade
+     validation and lowering while leaving the unresolved JFET `B` policy unchanged.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- give explicitly supplied canonical model-card parameter names precedence over aliases regardless of source order
- mirror the rule in Python and TypeScript engine normalizers
- add cross-language diode `IS`/`JS` regression coverage and reconcile SPICE plan tracking

## Verification

- Python spice-engine: `bash BUILD` (706 passed, 88.91% coverage)
- Python spice-engine: `.venv/bin/ruff check .`
- TypeScript spice-engine: `bash BUILD` (449 passed)
- `git diff --check`

## Audit notes

- Existing BUILD dependencies cover all touched engine packages; no BUILD metadata change is required.
- Alias-only model cards retain their existing behavior.
- The documented JFET `B` beta-alias versus Parker-Skellern doping-tail policy collision remains unresolved and untouched.
