### PR TITLE
Add typed data-plane authority provisioning

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1028,6 +1028,7 @@ members = [
   "task-wasm",
   "chief-of-staff-daemon-credential",
   "chief-of-staff-daemon-secret-file",
+  "chief-of-staff-daemon-authority-provisioning",
   "chief-of-staff-daemon",
   "chief-of-staff-daemon-service-files",
   "chief-of-staff-daemon-installer",

--- a/code/packages/rust/chief-of-staff-daemon-authority-provisioning/BUILD
+++ b/code/packages/rust/chief-of-staff-daemon-authority-provisioning/BUILD
@@ -1,0 +1,2 @@
+cargo test -p chief-of-staff-daemon-authority-provisioning -- --nocapture
+if [ "$(uname)" = "Linux" ]; then cargo tarpaulin -p chief-of-staff-daemon-authority-provisioning --out Stdout --skip-clean; fi

--- a/code/packages/rust/chief-of-staff-daemon-authority-provisioning/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-authority-provisioning/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Add exact typed channel-key provisioning through owner-only, no-link,
+  exact-length, zeroizing file reads.
+- Add exact model-to-Ollama client provisioning with bounded startup validation
+  and no implicit endpoint or network probe.

--- a/code/packages/rust/chief-of-staff-daemon-authority-provisioning/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon-authority-provisioning/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "chief-of-staff-daemon-authority-provisioning"
+version = "0.1.0"
+edition = "2021"
+description = "Explicit file-backed channel-key and Ollama authority provisioning for D18"
+license = "MIT"
+
+[dependencies]
+chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
+chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }
+chief-of-staff-daemon-config = { path = "../chief-of-staff-daemon-config" }
+chief-of-staff-daemon-secret-file = { path = "../chief-of-staff-daemon-secret-file" }
+chief-of-staff-host-data-plane = { path = "../chief-of-staff-host-data-plane" }
+chief-of-staff-pipeline-bindings = { path = "../chief-of-staff-pipeline-bindings" }
+coding_adventures_zeroize = { path = "../zeroize" }
+llm-provider-ollama = { path = "../llm-provider-ollama" }

--- a/code/packages/rust/chief-of-staff-daemon-authority-provisioning/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-authority-provisioning/README.md
@@ -1,0 +1,30 @@
+# chief-of-staff-daemon-authority-provisioning
+
+This package turns the daemon's optional, strictly typed `[data_plane]`
+configuration into the two immutable authorities consumed by
+`chief-of-staff-host-data-plane`.
+
+Each channel-key declaration is scoped to one canonical UUID-v7 pipeline, one
+exact agent identity, one canonical UUID-v7 channel, and one direction. Raw
+32-byte files are resolved only against the explicit home directory and read
+through `chief-of-staff-daemon-secret-file`, so links, non-regular objects,
+foreign ownership, broad permissions, short reads, and long reads all fail
+closed. Temporary and retained secret buffers are zeroizing.
+
+Each Ollama declaration registers its model tag as the exact launch selector.
+Endpoints must be explicit `http://host:port` authorities and timeouts are
+non-zero and capped at five minutes. Provisioning performs no reachability
+probe, so daemon startup never turns a temporarily stopped model server into a
+configuration mutation or a secret-bearing error.
+
+The package deliberately does not inject the resulting authorities into the
+daemon composition root. That remains a small follow-up once this loading
+boundary is independently reviewed and merged.
+
+## Validation
+
+```sh
+cargo test -p chief-of-staff-daemon-authority-provisioning -- --nocapture
+cargo clippy -p chief-of-staff-daemon-authority-provisioning --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-daemon-authority-provisioning --no-deps
+```

--- a/code/packages/rust/chief-of-staff-daemon-authority-provisioning/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-daemon-authority-provisioning/required_capabilities.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/chief-of-staff-daemon-authority-provisioning",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "*",
+      "justification": "Reads only explicitly configured raw channel-key files through the owner-only no-link secret-file boundary."
+    }
+  ],
+  "justification": "Constructs immutable exact channel-key and Ollama authorities from validated operator configuration without logging secret values or performing network access."
+}

--- a/code/packages/rust/chief-of-staff-daemon-authority-provisioning/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-authority-provisioning/src/lib.rs
@@ -1,0 +1,373 @@
+//! Explicit production authority provisioning for the D18 Chief daemon.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use chief_of_staff_channel_crypto::ChannelId;
+use chief_of_staff_channel_endpoints::AgentId;
+use chief_of_staff_daemon_config::{ChannelKeyAccess, ConfigPath, DataPlaneConfig};
+use chief_of_staff_daemon_secret_file::{read_owner_only_secret, SecretFileError};
+use chief_of_staff_host_data_plane::{
+    ChannelKeyRegistrationError, ExactChannelKeyAuthority, ExactModelProviderRegistry,
+    ModelProviderError,
+};
+use chief_of_staff_pipeline_bindings::{PipelineBindingError, PipelineId};
+use coding_adventures_zeroize::Zeroizing;
+use core::fmt::{self, Display, Formatter};
+use llm_provider_ollama::{OllamaClient, OllamaConfigurationError};
+use std::path::{Component, Path};
+use std::sync::Arc;
+
+const KEY_BYTES: usize = 32;
+
+/// Stable payload-blind failure while provisioning production data-plane authorities.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuthorityProvisioningError {
+    /// The explicit home directory was not a safe absolute path.
+    InvalidHome,
+    /// A validated configuration identity could not enter its domain type.
+    InvalidIdentity,
+    /// One configured private-key file failed the owner-only read policy.
+    SecretFile(SecretFileError),
+    /// One exact channel-key registration conflicted or contained a placeholder.
+    ChannelKey(ChannelKeyRegistrationError),
+    /// One explicit Ollama client declaration was invalid.
+    Ollama(OllamaConfigurationError),
+    /// One exact model selector was empty or registered more than once.
+    Model(ModelProviderError),
+}
+
+impl Display for AuthorityProvisioningError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidHome => "chief authority provisioning: invalid home directory",
+            Self::InvalidIdentity => "chief authority provisioning: invalid identity",
+            Self::SecretFile(_) => "chief authority provisioning: secret file failed",
+            Self::ChannelKey(_) => "chief authority provisioning: channel key failed",
+            Self::Ollama(_) => "chief authority provisioning: Ollama configuration failed",
+            Self::Model(_) => "chief authority provisioning: model registration failed",
+        })
+    }
+}
+
+impl std::error::Error for AuthorityProvisioningError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::SecretFile(error) => Some(error),
+            Self::ChannelKey(error) => Some(error),
+            Self::Ollama(error) => Some(error),
+            Self::Model(error) => Some(error),
+            Self::InvalidHome | Self::InvalidIdentity => None,
+        }
+    }
+}
+
+/// Immutable channel-key and exact-model authorities ready for daemon composition.
+pub struct ProvisionedAuthorities {
+    channel_keys: ExactChannelKeyAuthority,
+    models: ExactModelProviderRegistry,
+}
+
+impl ProvisionedAuthorities {
+    /// Borrow the exact zeroizing channel-key authority.
+    pub fn channel_keys(&self) -> &ExactChannelKeyAuthority {
+        &self.channel_keys
+    }
+
+    /// Borrow the exact model-provider authority.
+    pub fn models(&self) -> &ExactModelProviderRegistry {
+        &self.models
+    }
+
+    /// Transfer both immutable authorities to a production composition root.
+    pub fn into_parts(self) -> (ExactChannelKeyAuthority, ExactModelProviderRegistry) {
+        (self.channel_keys, self.models)
+    }
+}
+
+/// Load every explicitly configured authority without environment or network access.
+pub fn provision_authorities(
+    config: &DataPlaneConfig,
+    home: &Path,
+) -> Result<ProvisionedAuthorities, AuthorityProvisioningError> {
+    if !safe_absolute(home) {
+        return Err(AuthorityProvisioningError::InvalidHome);
+    }
+
+    let mut channel_keys = ExactChannelKeyAuthority::new();
+    for declaration in config.channel_keys() {
+        let pipeline_id = PipelineId::new(declaration.pipeline_id()).map_err(identity_error)?;
+        let agent_id = AgentId::new(declaration.agent_id().as_bytes().to_vec())
+            .map_err(|_| AuthorityProvisioningError::InvalidIdentity)?;
+        let channel_id = ChannelId(declaration.channel_id());
+        match declaration.access() {
+            ChannelKeyAccess::Read => {
+                let path = declaration
+                    .receiver_private_key_path()
+                    .ok_or(AuthorityProvisioningError::InvalidIdentity)?;
+                let private_key = load_key(path, home)?;
+                channel_keys
+                    .register_receiver(pipeline_id, &agent_id, channel_id, private_key)
+                    .map_err(AuthorityProvisioningError::ChannelKey)?;
+            }
+            ChannelKeyAccess::Write => {
+                let signing_path = declaration
+                    .originator_signing_seed_path()
+                    .ok_or(AuthorityProvisioningError::InvalidIdentity)?;
+                let channel_path = declaration
+                    .channel_master_key_path()
+                    .ok_or(AuthorityProvisioningError::InvalidIdentity)?;
+                let signing_seed = load_key(signing_path, home)?;
+                let channel_key = load_key(channel_path, home)?;
+                channel_keys
+                    .register_originator(
+                        pipeline_id,
+                        &agent_id,
+                        channel_id,
+                        signing_seed,
+                        channel_key,
+                    )
+                    .map_err(AuthorityProvisioningError::ChannelKey)?;
+            }
+        }
+    }
+
+    let mut models = ExactModelProviderRegistry::new();
+    for declaration in config.ollama_models() {
+        let client = OllamaClient::try_new(
+            declaration.model(),
+            declaration.endpoint(),
+            declaration.timeout(),
+        )
+        .map_err(AuthorityProvisioningError::Ollama)?;
+        models
+            .register(declaration.model(), Arc::new(client))
+            .map_err(AuthorityProvisioningError::Model)?;
+    }
+
+    Ok(ProvisionedAuthorities {
+        channel_keys,
+        models,
+    })
+}
+
+fn identity_error(_error: PipelineBindingError) -> AuthorityProvisioningError {
+    AuthorityProvisioningError::InvalidIdentity
+}
+
+fn load_key(
+    path: &ConfigPath,
+    home: &Path,
+) -> Result<Zeroizing<[u8; KEY_BYTES]>, AuthorityProvisioningError> {
+    let path = path
+        .resolve(home)
+        .map_err(|_| AuthorityProvisioningError::InvalidHome)?;
+    let bytes =
+        read_owner_only_secret(&path, KEY_BYTES).map_err(AuthorityProvisioningError::SecretFile)?;
+    let mut key = Zeroizing::new([0; KEY_BYTES]);
+    key.copy_from_slice(bytes.as_slice());
+    Ok(key)
+}
+
+fn safe_absolute(path: &Path) -> bool {
+    path.is_absolute()
+        && !path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir | Component::CurDir))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chief_of_staff_daemon_config::{parse_config, ChiefConfig};
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(label: &str) -> Self {
+            let sequence = NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "chief-authority-provisioning-{label}-{}-{sequence}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).unwrap();
+            Self(fs::canonicalize(path).unwrap())
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+
+        #[cfg(unix)]
+        fn write_secret(&self, name: &str, bytes: &[u8]) {
+            use std::os::unix::fs::PermissionsExt;
+            let path = self.0.join(name);
+            fs::write(&path, bytes).unwrap();
+            fs::set_permissions(path, fs::Permissions::from_mode(0o600)).unwrap();
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn config(data_plane: &str) -> ChiefConfig {
+        parse_config(&format!(
+            r#"
+[orchestrator]
+bind = "127.0.0.1"
+port = 7463
+packages_dir = "~/agents"
+state_dir = "~/state"
+credential_path = "~/operator.credential"
+
+[keyring]
+trusted_keys = [{{ id = "dev", path = "~/dev.pub", type = "developer" }}]
+
+[hosts.defaults]
+restart_policy = "on-failure"
+health_check_interval = 5000
+executable = "~/chief-of-staff-host"
+bootstrap_timeout = 10000
+graceful_stop_timeout = 5000
+
+[vault]
+storage_path = "~/vault"
+default_lease_ttl = 30
+container = true
+
+[privilege]
+tier_1_auto_approve_timeout = 5
+biometric_timeout = 30
+hardware_key_timeout = 60
+
+[data_plane]
+{data_plane}
+"#
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn provisions_exact_ollama_models_without_network_access() {
+        let home = TestDirectory::new("models");
+        let valid = config(
+            r#"
+channel_keys = []
+ollama_models = [
+  { model = "qwen2.5:0.5b", endpoint = "http://127.0.0.1:11434", timeout = 120000 },
+]
+"#,
+        );
+        let authorities = provision_authorities(valid.data_plane(), home.path()).unwrap();
+        assert!(authorities.channel_keys().is_empty());
+        assert_eq!(authorities.models().len(), 1);
+
+        let invalid = config(
+            r#"
+channel_keys = []
+ollama_models = [
+  { model = "qwen2.5:0.5b", endpoint = "http://127.0.0.1:11434/path", timeout = 120000 },
+]
+"#,
+        );
+        assert_eq!(
+            provision_authorities(invalid.data_plane(), home.path())
+                .err()
+                .unwrap(),
+            AuthorityProvisioningError::Ollama(OllamaConfigurationError::InvalidEndpoint)
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_home_and_missing_secret_without_disclosing_paths() {
+        let home = TestDirectory::new("missing");
+        let config = config(
+            r#"
+channel_keys = [
+  { pipeline_id = "018f0c10-7b4a-7cc0-8000-000000000001", agent_id = "weather", channel_id = "018f0c10-7b4a-7cc0-8000-000000000002", access = "read", private_key_path = "~/missing.bin" },
+]
+ollama_models = []
+"#,
+        );
+        assert_eq!(
+            provision_authorities(config.data_plane(), Path::new("relative"))
+                .err()
+                .unwrap(),
+            AuthorityProvisioningError::InvalidHome
+        );
+        let error = provision_authorities(config.data_plane(), home.path())
+            .err()
+            .unwrap();
+        assert!(matches!(error, AuthorityProvisioningError::SecretFile(_)));
+        assert_eq!(
+            error.to_string(),
+            "chief authority provisioning: secret file failed"
+        );
+        assert!(!error.to_string().contains("missing.bin"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provisions_exact_read_and_write_keys_from_private_raw_files() {
+        let home = TestDirectory::new("keys");
+        home.write_secret("receiver.bin", &[0x11; KEY_BYTES]);
+        home.write_secret("signing.bin", &[0x22; KEY_BYTES]);
+        home.write_secret("channel.bin", &[0x33; KEY_BYTES]);
+        let config = config(
+            r#"
+channel_keys = [
+  { pipeline_id = "018f0c10-7b4a-7cc0-8000-000000000001", agent_id = "weather", channel_id = "018f0c10-7b4a-7cc0-8000-000000000002", access = "read", private_key_path = "~/receiver.bin" },
+  { pipeline_id = "018f0c10-7b4a-7cc0-8000-000000000001", agent_id = "weather", channel_id = "018f0c10-7b4a-7cc0-8000-000000000003", access = "write", signing_seed_path = "~/signing.bin", channel_key_path = "~/channel.bin" },
+]
+ollama_models = []
+"#,
+        );
+        let authorities = provision_authorities(config.data_plane(), home.path()).unwrap();
+        assert_eq!(authorities.channel_keys().len(), 2);
+        assert!(authorities.models().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_placeholder_and_broadly_readable_key_files() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let home = TestDirectory::new("invalid-keys");
+        home.write_secret("key.bin", &[0; KEY_BYTES]);
+        let config = config(
+            r#"
+channel_keys = [
+  { pipeline_id = "018f0c10-7b4a-7cc0-8000-000000000001", agent_id = "weather", channel_id = "018f0c10-7b4a-7cc0-8000-000000000002", access = "read", private_key_path = "~/key.bin" },
+]
+ollama_models = []
+"#,
+        );
+        assert!(matches!(
+            provision_authorities(config.data_plane(), home.path()),
+            Err(AuthorityProvisioningError::ChannelKey(
+                ChannelKeyRegistrationError::InvalidSecret
+            ))
+        ));
+
+        fs::write(home.path().join("key.bin"), [0x44; KEY_BYTES]).unwrap();
+        fs::set_permissions(
+            home.path().join("key.bin"),
+            fs::Permissions::from_mode(0o640),
+        )
+        .unwrap();
+        assert_eq!(
+            provision_authorities(config.data_plane(), home.path())
+                .err()
+                .unwrap(),
+            AuthorityProvisioningError::SecretFile(SecretFileError::InsecurePermissions)
+        );
+    }
+}

--- a/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/CHANGELOG.md
@@ -9,3 +9,5 @@
 - Require explicit daemon port, state root, credential path, and host executable
   composition settings.
 - Bound secure-bootstrap and graceful-stop deadlines to five minutes.
+- Add optional, closed, typed data-plane declarations for exact directional
+  channel-key files and exact Ollama model endpoints.

--- a/code/packages/rust/chief-of-staff-daemon-config/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon-config/Cargo.toml
@@ -6,5 +6,6 @@ description = "Strict typed TOML configuration for the D18 Chief daemon"
 license = "MIT"
 
 [dependencies]
+coding_adventures_uuid = { path = "../uuid" }
 coding-adventures-toml-parser = { path = "../toml-parser" }
 parser = { path = "../parser" }

--- a/code/packages/rust/chief-of-staff-daemon-config/README.md
+++ b/code/packages/rust/chief-of-staff-daemon-config/README.md
@@ -15,6 +15,14 @@ The package performs no filesystem or environment access. `~` paths are resolved
 only when the caller supplies an explicit absolute home directory, keeping daemon
 composition deterministic and testable.
 
+An optional `[data_plane]` table declares exact production authorities without
+putting secret bytes in TOML. Directional channel-key entries bind canonical
+UUID-v7 pipeline and channel identities plus an exact agent identity to raw
+32-byte owner-only files. Ollama entries bind one unique launch model selector to
+one explicit endpoint and a non-zero timeout capped at five minutes. The parser
+validates and retains only typed declarations; a separate provisioning adapter
+performs all file and provider construction.
+
 ## Validation
 
 ```sh

--- a/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon-config/src/lib.rs
@@ -16,9 +16,15 @@ const KEYRING: &[&str] = &["keyring"];
 const HOST_DEFAULTS: &[&str] = &["hosts", "defaults"];
 const VAULT: &[&str] = &["vault"];
 const PRIVILEGE: &[&str] = &["privilege"];
+const DATA_PLANE: &[&str] = &["data_plane"];
 const MAX_CONFIG_BYTES: usize = 256 * 1024;
 const MAX_PATH_BYTES: usize = 4096;
 const MAX_TRUSTED_KEYS: usize = 256;
+const MAX_CHANNEL_KEYS: usize = 1024;
+const MAX_OLLAMA_MODELS: usize = 256;
+const MAX_AGENT_ID_BYTES: usize = 4 * 1024;
+const MAX_MODEL_BYTES: usize = 200;
+const MAX_ENDPOINT_BYTES: usize = 512;
 const MAX_PROCESS_TIMEOUT_MILLIS: u64 = 5 * 60 * 1000;
 
 /// Stable payload-blind configuration failure.
@@ -284,6 +290,108 @@ pub struct PrivilegeConfig {
     hardware_key_timeout: Duration,
 }
 
+/// Direction of one exact channel-key file declaration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChannelKeyAccess {
+    /// The agent receives from the channel using an X25519 private key.
+    Read,
+    /// The agent publishes to the channel using an Ed25519 seed and channel master key.
+    Write,
+}
+
+/// Validated file-backed key material for one exact pipeline, agent, and channel.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChannelKeyConfig {
+    pipeline_id: [u8; 16],
+    agent_id: String,
+    channel_id: [u8; 16],
+    access: ChannelKeyAccess,
+    receiver_private_key_path: Option<ConfigPath>,
+    originator_signing_seed_path: Option<ConfigPath>,
+    channel_master_key_path: Option<ConfigPath>,
+}
+
+impl ChannelKeyConfig {
+    /// Return the canonical UUID-v7 pipeline identity.
+    pub fn pipeline_id(&self) -> [u8; 16] {
+        self.pipeline_id
+    }
+
+    /// Return the exact UTF-8 channel-membership agent identity.
+    pub fn agent_id(&self) -> &str {
+        &self.agent_id
+    }
+
+    /// Return the canonical UUID-v7 channel identity.
+    pub fn channel_id(&self) -> [u8; 16] {
+        self.channel_id
+    }
+
+    /// Return whether this declaration provisions a read or write authority.
+    pub fn access(&self) -> ChannelKeyAccess {
+        self.access
+    }
+
+    /// Return the receiver private-key path for a read declaration.
+    pub fn receiver_private_key_path(&self) -> Option<&ConfigPath> {
+        self.receiver_private_key_path.as_ref()
+    }
+
+    /// Return the originator signing-seed path for a write declaration.
+    pub fn originator_signing_seed_path(&self) -> Option<&ConfigPath> {
+        self.originator_signing_seed_path.as_ref()
+    }
+
+    /// Return the channel-master-key path for a write declaration.
+    pub fn channel_master_key_path(&self) -> Option<&ConfigPath> {
+        self.channel_master_key_path.as_ref()
+    }
+}
+
+/// Validated exact Ollama model registration.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OllamaModelConfig {
+    model: String,
+    endpoint: String,
+    timeout: Duration,
+}
+
+impl OllamaModelConfig {
+    /// Return the exact launch selector and Ollama model tag.
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    /// Return the explicit plain-HTTP Ollama endpoint.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Return the bounded per-request timeout.
+    pub fn timeout(&self) -> Duration {
+        self.timeout
+    }
+}
+
+/// Optional explicit production authorities for the authenticated host data plane.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DataPlaneConfig {
+    channel_keys: Vec<ChannelKeyConfig>,
+    ollama_models: Vec<OllamaModelConfig>,
+}
+
+impl DataPlaneConfig {
+    /// Return exact file-backed directional channel-key declarations.
+    pub fn channel_keys(&self) -> &[ChannelKeyConfig] {
+        &self.channel_keys
+    }
+
+    /// Return exact Ollama model registrations.
+    pub fn ollama_models(&self) -> &[OllamaModelConfig] {
+        &self.ollama_models
+    }
+}
+
 impl PrivilegeConfig {
     /// Return the non-zero Tier 1 auto-approval timeout.
     pub fn tier_1_auto_approve_timeout(self) -> Duration {
@@ -309,6 +417,7 @@ pub struct ChiefConfig {
     host_defaults: HostDefaultsConfig,
     vault: VaultConfig,
     privilege: PrivilegeConfig,
+    data_plane: DataPlaneConfig,
 }
 
 impl ChiefConfig {
@@ -335,6 +444,11 @@ impl ChiefConfig {
     /// Return privilege-interaction deadlines.
     pub fn privilege(&self) -> PrivilegeConfig {
         self.privilege
+    }
+
+    /// Return explicit host data-plane authority declarations.
+    pub fn data_plane(&self) -> &DataPlaneConfig {
+        &self.data_plane
     }
 }
 
@@ -377,6 +491,14 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
         positive_secs(document.take(PRIVILEGE, "tier_1_auto_approve_timeout")?)?;
     let biometric_timeout = positive_secs(document.take(PRIVILEGE, "biometric_timeout")?)?;
     let hardware_key_timeout = positive_secs(document.take(PRIVILEGE, "hardware_key_timeout")?)?;
+    let data_plane = if document.has_table(DATA_PLANE) {
+        DataPlaneConfig {
+            channel_keys: parse_channel_keys(document.take(DATA_PLANE, "channel_keys")?)?,
+            ollama_models: parse_ollama_models(document.take(DATA_PLANE, "ollama_models")?)?,
+        }
+    } else {
+        DataPlaneConfig::default()
+    };
     if !document.fields.is_empty() {
         return Err(ConfigError::Unknown);
     }
@@ -407,7 +529,126 @@ pub fn parse_config(source: &str) -> Result<ChiefConfig, ConfigError> {
             biometric_timeout,
             hardware_key_timeout,
         },
+        data_plane,
     })
+}
+
+fn parse_channel_keys(value: RawValue) -> Result<Vec<ChannelKeyConfig>, ConfigError> {
+    let RawValue::Array(values) = value else {
+        return Err(ConfigError::InvalidType);
+    };
+    if values.len() > MAX_CHANNEL_KEYS {
+        return Err(ConfigError::InvalidValue);
+    }
+    let mut identities = BTreeSet::new();
+    let mut declarations = Vec::with_capacity(values.len());
+    for value in values {
+        let RawValue::InlineTable(mut fields) = value else {
+            return Err(ConfigError::InvalidType);
+        };
+        let pipeline_id = parse_uuid_v7(expect_string(take_inline(&mut fields, "pipeline_id")?)?)?;
+        let agent_id = expect_string(take_inline(&mut fields, "agent_id")?)?;
+        if agent_id.is_empty()
+            || agent_id.len() > MAX_AGENT_ID_BYTES
+            || agent_id.trim() != agent_id
+            || agent_id.chars().any(char::is_control)
+        {
+            return Err(ConfigError::InvalidValue);
+        }
+        let channel_id = parse_uuid_v7(expect_string(take_inline(&mut fields, "channel_id")?)?)?;
+        let access = match expect_string(take_inline(&mut fields, "access")?)?.as_str() {
+            "read" => ChannelKeyAccess::Read,
+            "write" => ChannelKeyAccess::Write,
+            _ => return Err(ConfigError::InvalidValue),
+        };
+        let (receiver_private_key_path, originator_signing_seed_path, channel_master_key_path) =
+            match access {
+                ChannelKeyAccess::Read => (
+                    Some(ConfigPath::parse(expect_string(take_inline(
+                        &mut fields,
+                        "private_key_path",
+                    )?)?)?),
+                    None,
+                    None,
+                ),
+                ChannelKeyAccess::Write => (
+                    None,
+                    Some(ConfigPath::parse(expect_string(take_inline(
+                        &mut fields,
+                        "signing_seed_path",
+                    )?)?)?),
+                    Some(ConfigPath::parse(expect_string(take_inline(
+                        &mut fields,
+                        "channel_key_path",
+                    )?)?)?),
+                ),
+            };
+        if !fields.is_empty() {
+            return Err(ConfigError::Unknown);
+        }
+        if !identities.insert((pipeline_id, agent_id.clone(), channel_id)) {
+            return Err(ConfigError::Duplicate);
+        }
+        declarations.push(ChannelKeyConfig {
+            pipeline_id,
+            agent_id,
+            channel_id,
+            access,
+            receiver_private_key_path,
+            originator_signing_seed_path,
+            channel_master_key_path,
+        });
+    }
+    Ok(declarations)
+}
+
+fn parse_ollama_models(value: RawValue) -> Result<Vec<OllamaModelConfig>, ConfigError> {
+    let RawValue::Array(values) = value else {
+        return Err(ConfigError::InvalidType);
+    };
+    if values.len() > MAX_OLLAMA_MODELS {
+        return Err(ConfigError::InvalidValue);
+    }
+    let mut models = BTreeSet::new();
+    let mut declarations = Vec::with_capacity(values.len());
+    for value in values {
+        let RawValue::InlineTable(mut fields) = value else {
+            return Err(ConfigError::InvalidType);
+        };
+        let model = expect_string(take_inline(&mut fields, "model")?)?;
+        let endpoint = expect_string(take_inline(&mut fields, "endpoint")?)?;
+        let timeout = bounded_process_millis(take_inline(&mut fields, "timeout")?)?;
+        if model.trim().is_empty()
+            || model.trim() != model
+            || model.len() > MAX_MODEL_BYTES
+            || model.chars().any(char::is_control)
+            || endpoint.is_empty()
+            || endpoint.len() > MAX_ENDPOINT_BYTES
+            || endpoint.chars().any(char::is_control)
+        {
+            return Err(ConfigError::InvalidValue);
+        }
+        if !fields.is_empty() {
+            return Err(ConfigError::Unknown);
+        }
+        if !models.insert(model.clone()) {
+            return Err(ConfigError::Duplicate);
+        }
+        declarations.push(OllamaModelConfig {
+            model,
+            endpoint,
+            timeout,
+        });
+    }
+    Ok(declarations)
+}
+
+fn parse_uuid_v7(value: String) -> Result<[u8; 16], ConfigError> {
+    let parsed = coding_adventures_uuid::parse(&value).map_err(|_| ConfigError::InvalidValue)?;
+    if parsed.version() != 7 || parsed.variant() != "rfc4122" || parsed.to_string() != value {
+        return Err(ConfigError::InvalidValue);
+    }
+    Ok(parsed.bytes())
 }
 
 fn parse_port(value: RawValue) -> Result<u16, ConfigError> {
@@ -570,17 +811,23 @@ impl RawDocument {
     }
 
     fn validate_tables(&self) -> Result<(), ConfigError> {
-        let allowed = [ORCHESTRATOR, KEYRING, HOST_DEFAULTS, VAULT, PRIVILEGE]
+        let required = [ORCHESTRATOR, KEYRING, HOST_DEFAULTS, VAULT, PRIVILEGE]
             .into_iter()
             .map(strings_to_vec)
             .collect::<BTreeSet<_>>();
-        if self.tables == allowed {
-            Ok(())
-        } else if self.tables.iter().any(|table| !allowed.contains(table)) {
+        let mut allowed = required.clone();
+        allowed.insert(strings_to_vec(DATA_PLANE));
+        if self.tables.iter().any(|table| !allowed.contains(table)) {
             Err(ConfigError::Unknown)
-        } else {
+        } else if required.iter().any(|table| !self.tables.contains(table)) {
             Err(ConfigError::Missing)
+        } else {
+            Ok(())
         }
+    }
+
+    fn has_table(&self, table: &[&str]) -> bool {
+        self.tables.contains(&strings_to_vec(table))
     }
 
     fn take(&mut self, table: &[&str], field: &str) -> Result<RawValue, ConfigError> {
@@ -814,6 +1061,78 @@ hardware_key_timeout = 60
         assert_eq!(
             config.privilege().hardware_key_timeout(),
             Duration::from_secs(60)
+        );
+        assert!(config.data_plane().channel_keys().is_empty());
+        assert!(config.data_plane().ollama_models().is_empty());
+    }
+
+    #[test]
+    fn parses_exact_directional_keys_and_ollama_models() {
+        let source = format!(
+            r#"{VALID}
+
+[data_plane]
+channel_keys = [
+  {{ pipeline_id = "018f0c10-7b4a-7cc0-8000-000000000001", agent_id = "weather", channel_id = "018f0c10-7b4a-7cc0-8000-000000000002", access = "read", private_key_path = "~/.chief-of-staff/keys/weather-receiver.bin" }},
+  {{ pipeline_id = "018f0c10-7b4a-7cc0-8000-000000000001", agent_id = "weather", channel_id = "018f0c10-7b4a-7cc0-8000-000000000003", access = "write", signing_seed_path = "~/.chief-of-staff/keys/weather-signing.bin", channel_key_path = "~/.chief-of-staff/keys/weather-channel.bin" }},
+]
+ollama_models = [
+  {{ model = "qwen2.5:0.5b", endpoint = "http://127.0.0.1:11434", timeout = 120000 }},
+]
+"#
+        );
+        let config = parse_config(&source).unwrap();
+        let keys = config.data_plane().channel_keys();
+        assert_eq!(keys.len(), 2);
+        assert_eq!(keys[0].access(), ChannelKeyAccess::Read);
+        assert!(keys[0].receiver_private_key_path().is_some());
+        assert!(keys[0].originator_signing_seed_path().is_none());
+        assert_eq!(keys[1].access(), ChannelKeyAccess::Write);
+        assert!(keys[1].receiver_private_key_path().is_none());
+        assert!(keys[1].originator_signing_seed_path().is_some());
+        assert!(keys[1].channel_master_key_path().is_some());
+        let models = config.data_plane().ollama_models();
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].model(), "qwen2.5:0.5b");
+        assert_eq!(models[0].endpoint(), "http://127.0.0.1:11434");
+        assert_eq!(models[0].timeout(), Duration::from_secs(120));
+    }
+
+    #[test]
+    fn data_plane_declarations_are_canonical_unique_and_closed() {
+        let section = r#"
+
+[data_plane]
+channel_keys = [
+  { pipeline_id = "018f0c10-7b4a-7cc0-8000-000000000001", agent_id = "weather", channel_id = "018f0c10-7b4a-7cc0-8000-000000000002", access = "read", private_key_path = "~/receiver.bin" },
+]
+ollama_models = [
+  { model = "qwen2.5:0.5b", endpoint = "http://127.0.0.1:11434", timeout = 120000 },
+]
+"#;
+        let valid = format!("{VALID}{section}");
+        assert!(parse_config(&valid).is_ok());
+        assert_eq!(
+            parse_config(&valid.replace("018f0c10", "018F0C10")),
+            Err(ConfigError::InvalidValue)
+        );
+        assert_eq!(
+            parse_config(&valid.replace("access = \"read\"", "access = \"both\"")),
+            Err(ConfigError::InvalidValue)
+        );
+        assert_eq!(
+            parse_config(&valid.replace(
+                "private_key_path = \"~/receiver.bin\"",
+                "private_key_path = \"~/receiver.bin\", extra = true"
+            )),
+            Err(ConfigError::Unknown)
+        );
+        assert_eq!(
+            parse_config(&valid.replace(
+                "  { model = \"qwen2.5:0.5b\", endpoint = \"http://127.0.0.1:11434\", timeout = 120000 },",
+                "  { model = \"qwen2.5:0.5b\", endpoint = \"http://127.0.0.1:11434\", timeout = 120000 },\n  { model = \"qwen2.5:0.5b\", endpoint = \"http://localhost:11434\", timeout = 120000 },"
+            )),
+            Err(ConfigError::Duplicate)
         );
     }
 

--- a/code/packages/rust/chief-of-staff-host-data-plane/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-data-plane/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Expose exact model-registry cardinality without exposing provider clients.
+
 ## Unreleased
 
 - Add an exact zeroizing pipeline/agent/channel key registry for safe production

--- a/code/packages/rust/chief-of-staff-host-data-plane/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-data-plane/src/lib.rs
@@ -358,6 +358,16 @@ impl ExactModelProviderRegistry {
         self.providers.insert(model, provider);
         Ok(())
     }
+
+    /// Return the number of exact model selectors retained by this registry.
+    pub fn len(&self) -> usize {
+        self.providers.len()
+    }
+
+    /// Return whether this registry denies every model lookup.
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
+    }
 }
 
 impl ModelProviderAuthority for ExactModelProviderRegistry {

--- a/code/packages/rust/llm-provider-ollama/CHANGELOG.md
+++ b/code/packages/rust/llm-provider-ollama/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- Add a fallible production constructor that validates a bounded model, one
+  exact `http://host:port` endpoint, and a non-zero timeout capped at five
+  minutes without performing network access.
+- Reject endpoint paths, queries, fragments, user information, extra authority
+  separators, and port zero before constructing a configured client.
+
 ## [0.3.0] - 2026-05-13 — mid-string truncation surfaces as OutputTruncated
 
 ### Fixed

--- a/code/packages/rust/llm-provider-ollama/README.md
+++ b/code/packages/rust/llm-provider-ollama/README.md
@@ -65,6 +65,25 @@ let client = OllamaClient::new("mistral:7b")
     .with_endpoint("http://my-ollama-host:11434");
 ```
 
+Production composition can validate the complete client configuration before
+serving any request, without probing the network:
+
+```rust
+use llm_provider_ollama::OllamaClient;
+use std::time::Duration;
+
+let client = OllamaClient::try_new(
+    "mistral:7b",
+    "http://127.0.0.1:11434",
+    Duration::from_secs(120),
+)?;
+# Ok::<(), llm_provider_ollama::OllamaConfigurationError>(())
+```
+
+The fallible constructor requires one exact `http://host:port` authority and
+rejects implicit ports, paths, queries, fragments, user information, port zero,
+and timeouts above five minutes.
+
 ## Capability Profile
 
 | Capability | Native | Notes |

--- a/code/packages/rust/llm-provider-ollama/src/lib.rs
+++ b/code/packages/rust/llm-provider-ollama/src/lib.rs
@@ -56,6 +56,9 @@ use llm_gateway::{
 
 const DEFAULT_ENDPOINT: &str = "http://localhost:11434";
 const CHAT_PATH: &str = "/api/chat";
+const MAX_CONFIGURED_MODEL_BYTES: usize = 200;
+const MAX_CONFIGURED_ENDPOINT_BYTES: usize = 512;
+const MAX_CONFIGURED_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
 // Cap on response body size. A misconfigured or malicious endpoint
 // could otherwise stream gigabytes before the timeout elapsed and
@@ -74,6 +77,29 @@ pub struct OllamaClient {
     timeout: Duration,
 }
 
+/// Stable payload-blind failure while constructing an explicit Ollama client.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OllamaConfigurationError {
+    /// The model selector was empty, unbounded, padded, or contained control characters.
+    InvalidModel,
+    /// The endpoint was not one exact bounded `http://host:port` authority.
+    InvalidEndpoint,
+    /// The request timeout was zero or exceeded five minutes.
+    InvalidTimeout,
+}
+
+impl core::fmt::Display for OllamaConfigurationError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidModel => "ollama client: invalid model",
+            Self::InvalidEndpoint => "ollama client: invalid endpoint",
+            Self::InvalidTimeout => "ollama client: invalid timeout",
+        })
+    }
+}
+
+impl std::error::Error for OllamaConfigurationError {}
+
 impl OllamaClient {
     /// Construct against the default `http://localhost:11434`.
     /// `model_name` should be the local model tag (e.g.,
@@ -84,6 +110,38 @@ impl OllamaClient {
             model_name: model_name.into(),
             timeout: Duration::from_secs(120),
         }
+    }
+
+    /// Construct one fully validated explicit client for production provisioning.
+    ///
+    /// The endpoint must be exactly `http://host:port` with no path, query,
+    /// fragment, user information, or implicit port. This constructor performs no
+    /// network access; reachability remains an explicit operator pre-flight.
+    pub fn try_new(
+        model_name: impl Into<String>,
+        endpoint: impl Into<String>,
+        timeout: Duration,
+    ) -> Result<Self, OllamaConfigurationError> {
+        let model_name = model_name.into();
+        let endpoint = endpoint.into();
+        if model_name.trim().is_empty()
+            || model_name.trim() != model_name
+            || model_name.len() > MAX_CONFIGURED_MODEL_BYTES
+            || model_name.chars().any(char::is_control)
+        {
+            return Err(OllamaConfigurationError::InvalidModel);
+        }
+        if endpoint.len() > MAX_CONFIGURED_ENDPOINT_BYTES || parse_endpoint(&endpoint).is_none() {
+            return Err(OllamaConfigurationError::InvalidEndpoint);
+        }
+        if timeout.is_zero() || timeout > MAX_CONFIGURED_TIMEOUT {
+            return Err(OllamaConfigurationError::InvalidTimeout);
+        }
+        Ok(Self {
+            endpoint,
+            model_name,
+            timeout,
+        })
     }
 
     /// Override the endpoint URL. Accepts forms like
@@ -192,10 +250,7 @@ impl OllamaClient {
                 serde_json::Value::String("json".to_string()),
             );
         }
-        body.insert(
-            "options".to_string(),
-            serde_json::Value::Object(options),
-        );
+        body.insert("options".to_string(), serde_json::Value::Object(options));
 
         serde_json::Value::Object(body)
     }
@@ -204,8 +259,9 @@ impl OllamaClient {
     /// response body. The function is shared between `complete` and
     /// `complete_json` so the wire-protocol logic lives in one place.
     fn post(&self, path: &str, body: &serde_json::Value, model: &str) -> Result<String, LlmError> {
-        let (host, port) = parse_endpoint(&self.endpoint)
-            .ok_or_else(|| self.transport_err(model, format!("invalid endpoint: {}", self.endpoint)))?;
+        let (host, port) = parse_endpoint(&self.endpoint).ok_or_else(|| {
+            self.transport_err(model, format!("invalid endpoint: {}", self.endpoint))
+        })?;
 
         let addr = (host.as_str(), port)
             .to_socket_addrs()
@@ -257,8 +313,7 @@ impl OllamaClient {
             ));
         }
 
-        parse_http_response(&raw)
-            .map_err(|detail| self.transport_err(model, detail))
+        parse_http_response(&raw).map_err(|detail| self.transport_err(model, detail))
     }
 }
 
@@ -290,11 +345,16 @@ fn flatten_content(c: &MessageContent) -> String {
 /// header line. Allowed: ASCII alphanumerics, `.`, `-`, `_`.
 fn parse_endpoint(endpoint: &str) -> Option<(String, u16)> {
     let rest = endpoint.strip_prefix("http://")?;
-    let rest = rest.split('/').next()?;
+    if rest
+        .bytes()
+        .any(|byte| matches!(byte, b'/' | b'?' | b'#' | b'@'))
+    {
+        return None;
+    }
     let mut parts = rest.split(':');
     let host = parts.next()?.to_string();
     let port: u16 = parts.next()?.parse().ok()?;
-    if host.is_empty() {
+    if host.is_empty() || port == 0 || parts.next().is_some() {
         return None;
     }
     if !host
@@ -322,8 +382,8 @@ fn parse_http_response(raw: &[u8]) -> Result<String, String> {
         .windows(sep.len())
         .position(|w| w == sep)
         .ok_or_else(|| "no header/body separator in response".to_string())?;
-    let header_block = std::str::from_utf8(&raw[..split])
-        .map_err(|e| format!("non-UTF-8 header: {e}"))?;
+    let header_block =
+        std::str::from_utf8(&raw[..split]).map_err(|e| format!("non-UTF-8 header: {e}"))?;
     let body_bytes = &raw[split + sep.len()..];
 
     // Status line: "HTTP/1.1 200 OK"
@@ -458,9 +518,7 @@ fn dechunk(mut buf: &[u8]) -> Result<String, String> {
 
 /// Parse Ollama's chat response. We need: assistant text,
 /// prompt_eval_count, eval_count, done_reason.
-fn parse_ollama_response(
-    body: &str,
-) -> Result<(String, TokenUsage, FinishReason), String> {
+fn parse_ollama_response(body: &str) -> Result<(String, TokenUsage, FinishReason), String> {
     let v: serde_json::Value =
         serde_json::from_str(body).map_err(|e| format!("response is not JSON: {e}"))?;
 
@@ -475,10 +533,7 @@ fn parse_ollama_response(
         .get("prompt_eval_count")
         .and_then(|n| n.as_u64())
         .unwrap_or(0) as usize;
-    let output_tokens = v
-        .get("eval_count")
-        .and_then(|n| n.as_u64())
-        .unwrap_or(0) as usize;
+    let output_tokens = v.get("eval_count").and_then(|n| n.as_u64()).unwrap_or(0) as usize;
 
     let finish_reason = match v.get("done_reason").and_then(|s| s.as_str()) {
         Some("stop") => FinishReason::Stop,
@@ -506,12 +561,12 @@ impl LlmClient for OllamaClient {
 
     fn capabilities(&self) -> Capabilities {
         Capabilities {
-            json_mode_native: true,         // via format=json
-            tool_use_native: false,          // polyfilled
-            streaming_native: true,          // we just don't expose it yet
-            prompt_caching_native: false,    // no cross-request cache
-            multimodal_image_input: false,   // model-dependent; conservative default
-            max_context_window: 8_192,       // model-dependent; conservative default
+            json_mode_native: true,        // via format=json
+            tool_use_native: false,        // polyfilled
+            streaming_native: true,        // we just don't expose it yet
+            prompt_caching_native: false,  // no cross-request cache
+            multimodal_image_input: false, // model-dependent; conservative default
+            max_context_window: 8_192,     // model-dependent; conservative default
         }
     }
 
@@ -657,8 +712,8 @@ impl LlmClient for OllamaClient {
 /// Not called automatically; exposed for callers that want a fast
 /// pre-flight before issuing real completions.
 pub fn ping(endpoint: &str, timeout: Duration) -> Result<(), String> {
-    let (host, port) = parse_endpoint(endpoint)
-        .ok_or_else(|| format!("invalid endpoint: {endpoint}"))?;
+    let (host, port) =
+        parse_endpoint(endpoint).ok_or_else(|| format!("invalid endpoint: {endpoint}"))?;
     let addr = (host.as_str(), port)
         .to_socket_addrs()
         .map_err(|e| format!("resolve: {e}"))?
@@ -669,9 +724,7 @@ pub fn ping(endpoint: &str, timeout: Duration) -> Result<(), String> {
     stream
         .set_read_timeout(Some(timeout))
         .map_err(|e| format!("set_read_timeout: {e}"))?;
-    let req = format!(
-        "GET /api/tags HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n"
-    );
+    let req = format!("GET /api/tags HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n");
     stream
         .write_all(req.as_bytes())
         .map_err(|e| format!("write: {e}"))?;
@@ -733,13 +786,9 @@ mod tests {
                     }
                     read_so_far.extend_from_slice(&buf[..n]);
                     if !headers_done {
-                        if let Some(idx) = read_so_far
-                            .windows(4)
-                            .position(|w| w == b"\r\n\r\n")
-                        {
+                        if let Some(idx) = read_so_far.windows(4).position(|w| w == b"\r\n\r\n") {
                             headers_done = true;
-                            let header_str =
-                                std::str::from_utf8(&read_so_far[..idx]).unwrap();
+                            let header_str = std::str::from_utf8(&read_so_far[..idx]).unwrap();
                             // Capture path from request line
                             if let Some(line) = header_str.lines().next() {
                                 let mut parts = line.split_whitespace();
@@ -749,9 +798,7 @@ mod tests {
                                 }
                             }
                             for line in header_str.lines() {
-                                if let Some(v) =
-                                    line.strip_prefix("Content-Length:")
-                                {
+                                if let Some(v) = line.strip_prefix("Content-Length:") {
                                     content_length = v.trim().parse().unwrap_or(0);
                                 }
                             }
@@ -766,10 +813,7 @@ mod tests {
                     } else {
                         // Header read; check whether body is complete.
                         // Find the body-start offset:
-                        if let Some(idx) = read_so_far
-                            .windows(4)
-                            .position(|w| w == b"\r\n\r\n")
-                        {
+                        if let Some(idx) = read_so_far.windows(4).position(|w| w == b"\r\n\r\n") {
                             let body_so_far = read_so_far.len() - (idx + 4);
                             if body_so_far >= content_length {
                                 let body = &read_so_far[idx + 4..idx + 4 + content_length];
@@ -781,7 +825,11 @@ mod tests {
                     }
                 }
 
-                let reason = if (200..300).contains(&response_status) { "OK" } else { "ERR" };
+                let reason = if (200..300).contains(&response_status) {
+                    "OK"
+                } else {
+                    "ERR"
+                };
                 let resp = format!(
                     "HTTP/1.1 {status} {reason}\r\n\
                      Content-Type: application/json\r\n\
@@ -806,8 +854,18 @@ mod tests {
 
         fn finish(mut self) -> (String, String) {
             self.join.take().unwrap().join().unwrap();
-            let body = self.captured_body.lock().unwrap().clone().unwrap_or_default();
-            let path = self.captured_path.lock().unwrap().clone().unwrap_or_default();
+            let body = self
+                .captured_body
+                .lock()
+                .unwrap()
+                .clone()
+                .unwrap_or_default();
+            let path = self
+                .captured_path
+                .lock()
+                .unwrap()
+                .clone()
+                .unwrap_or_default();
             (path, body)
         }
     }
@@ -873,6 +931,47 @@ mod tests {
         assert!(parse_endpoint("http://evil.example.com\r\nX-Injected:11434").is_none());
         assert!(parse_endpoint("http://has space:11434").is_none());
         assert!(parse_endpoint("http://has\ttab:11434").is_none());
+    }
+
+    #[test]
+    fn explicit_constructor_validates_the_complete_configuration() {
+        let client = OllamaClient::try_new(
+            "llama3.1:8b",
+            "http://127.0.0.1:11434",
+            Duration::from_secs(120),
+        )
+        .unwrap();
+        let identity = client.identity();
+        assert_eq!(identity.model_family, "llama3.1:8b");
+        assert_eq!(identity.endpoint.as_deref(), Some("http://127.0.0.1:11434"));
+
+        assert_eq!(
+            OllamaClient::try_new(" model", "http://127.0.0.1:11434", Duration::from_secs(1))
+                .unwrap_err(),
+            OllamaConfigurationError::InvalidModel
+        );
+        for endpoint in [
+            "https://127.0.0.1:11434",
+            "http://127.0.0.1",
+            "http://127.0.0.1:0",
+            "http://127.0.0.1:11434/",
+            "http://user@127.0.0.1:11434",
+            "http://127.0.0.1:11434:80",
+        ] {
+            assert_eq!(
+                OllamaClient::try_new("model", endpoint, Duration::from_secs(1)).unwrap_err(),
+                OllamaConfigurationError::InvalidEndpoint
+            );
+        }
+        assert_eq!(
+            OllamaClient::try_new("model", "http://127.0.0.1:11434", Duration::ZERO).unwrap_err(),
+            OllamaConfigurationError::InvalidTimeout
+        );
+        assert_eq!(
+            OllamaClient::try_new("model", "http://127.0.0.1:11434", Duration::from_secs(301))
+                .unwrap_err(),
+            OllamaConfigurationError::InvalidTimeout
+        );
     }
 
     #[test]
@@ -1045,7 +1144,9 @@ mod tests {
         let err = client.complete(req).unwrap_err();
         match err {
             LlmError::OutputTruncated {
-                output_tokens, max_tokens, ..
+                output_tokens,
+                max_tokens,
+                ..
             } => {
                 assert_eq!(output_tokens, 256);
                 assert_eq!(max_tokens, Some(256));
@@ -1093,8 +1194,7 @@ mod tests {
         // never doubled the cap. The fix in this PR routes
         // MaxTokens+parse-fail to `OutputTruncated` so the
         // retry helper can cap-double up to MAX_TOKENS_CEILING.
-        let truncated_json =
-            r#"{"document_id":"x","nodes":[{"id":"N1","term":{"functor":"foo","args":["unterminated stri"#;
+        let truncated_json = r#"{"document_id":"x","nodes":[{"id":"N1","term":{"functor":"foo","args":["unterminated stri"#;
         let server = ScriptedServer::spawn(
             200,
             &serde_json::json!({
@@ -1250,10 +1350,7 @@ mod tests {
 
     #[test]
     fn complete_json_sets_format_and_appends_schema_hint() {
-        let server = ScriptedServer::spawn(
-            200,
-            &ollama_chat_response("{\"answer\":42}", 5, 3),
-        );
+        let server = ScriptedServer::spawn(200, &ollama_chat_response("{\"answer\":42}", 5, 3));
         let client = OllamaClient::new("m").with_endpoint(server.endpoint.clone());
         let schema = JsonSchema {
             name: "AnswerObj".into(),
@@ -1274,10 +1371,7 @@ mod tests {
 
     #[test]
     fn complete_json_returns_schema_invalid_when_response_is_not_json() {
-        let server = ScriptedServer::spawn(
-            200,
-            &ollama_chat_response("not a json document", 2, 2),
-        );
+        let server = ScriptedServer::spawn(200, &ollama_chat_response("not a json document", 2, 2));
         let client = OllamaClient::new("m").with_endpoint(server.endpoint.clone());
         let schema = JsonSchema {
             name: "X".into(),

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -540,9 +540,9 @@ binding, immutable claims, active channel topology, directional membership, and
 model settings. It rejects unknown or wrong-direction channel UUIDs and any model
 setting drift before invoking the separately injected channel/LLM service, then
 validates response identity and operation shape before returning it. The
-payload-blind orchestration core receives no request body. Until concrete channel
-key custody and model providers are provisioned, the production daemon uses the
-same authorization boundary with a redacted unavailable service. The reusable
+payload-blind orchestration core receives no request body. Until the provisioned
+authorities are injected into composition, the production daemon uses the same
+authorization boundary with a redacted unavailable service. The reusable
 authority-backed service now executes against the real encrypted durable channel
 endpoints, retains a bounded delivery-to-acknowledgement ledger, provisions sealed
 receiver grants before publication, and resolves only exact model selectors. Key
@@ -553,6 +553,10 @@ The concrete pre-composition key registry owns only zeroizing secret buffers, bi
 each directional key to an exact pipeline, agent, and channel, and releases a new
 short-lived crypto owner only after all three identities match the reloaded durable
 binding. Filesystem and Vault formats remain separate provisioning adapters.
+The file-backed production adapter consumes only the typed declarations above,
+loads raw private material through owner-only no-link exact-length reads, and
+constructs exact Ollama clients without probing the network. A future Vault
+adapter may populate the same registries without changing execution semantics.
 
 ```
 ┌────────────────────────────────────────────────────────────────┐
@@ -2169,7 +2173,26 @@ container = true               # run vault in OS container
 tier_1_auto_approve_timeout = 5  # seconds
 biometric_timeout = 30           # seconds
 hardware_key_timeout = 60        # seconds
+
+[data_plane]
+channel_keys = [
+  { pipeline_id = "018f0c10-7b4a-7cc0-8000-000000000001", agent_id = "weather", channel_id = "018f0c10-7b4a-7cc0-8000-000000000002", access = "read", private_key_path = "~/.chief-of-staff/keys/weather-receiver.bin" },
+  { pipeline_id = "018f0c10-7b4a-7cc0-8000-000000000001", agent_id = "weather", channel_id = "018f0c10-7b4a-7cc0-8000-000000000003", access = "write", signing_seed_path = "~/.chief-of-staff/keys/weather-signing.bin", channel_key_path = "~/.chief-of-staff/keys/weather-channel.bin" },
+]
+ollama_models = [
+  { model = "qwen2.5:0.5b", endpoint = "http://127.0.0.1:11434", timeout = 120000 },
+]
 ```
+
+The optional data-plane table is closed and explicit. Each channel-key entry
+names one canonical UUID-v7 pipeline, exact agent identity, canonical UUID-v7
+channel, and direction. Read entries name one raw 32-byte X25519 private-key
+file; write entries name one raw 32-byte Ed25519 signing seed and one raw
+32-byte current-epoch channel master key. Secret bytes never appear in TOML.
+Each Ollama entry registers its unique model tag as the exact launch selector,
+requires one `http://host:port` authority with no implicit path or port, and
+bounds the request timeout to five minutes. Provisioning validates and
+constructs these immutable authorities without a network reachability probe.
 
 The operator credential path is a fail-closed local trust boundary. Composition
 MUST load an existing canonical 64-byte lowercase-hex credential or claim an absent


### PR DESCRIPTION
## Summary

- add an optional closed `[data_plane]` schema for exact directional channel-key files and exact Ollama models
- load raw 32-byte private material through the owner-only, no-link, exact-length, zeroizing reader
- construct immutable exact key/model authorities with stable payload-blind startup errors
- add a fallible Ollama constructor that validates one pathless `http://host:port` authority and bounded timeout without probing the network

## Validation

- 51 focused tests
- strict Clippy and rustdoc
- repository dependency-closed gate: 99 built, 1,141 skipped

## Follow-up

- inject the provisioned authorities into the production daemon
- exercise the real Level 1 weather flow through that composition

Progresses #128
Progresses #138