### PR TITLE
Add atomic smart-home retained identity migration

### DIFF
--- a/code/packages/rust/smart-home-runtime-store/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime-store/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Add revision-guarded retained identity migration that persists a complete
+  migrated candidate before swapping the caller's live runtime.
+- Reject automation definitions and execution state that still contain an
+  exact source device or entity identity.
+- Prove successful restart recovery and storage-conflict rollback with the
+  local-folder backend.
+
 ## 0.1.0
 
 - Add versioned, compare-and-swap smart-home runtime snapshots.

--- a/code/packages/rust/smart-home-runtime-store/Cargo.toml
+++ b/code/packages/rust/smart-home-runtime-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smart-home-runtime-store"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Restart-safe persistence for normalized smart-home runtime state"
 license = "MIT"

--- a/code/packages/rust/smart-home-runtime-store/README.md
+++ b/code/packages/rust/smart-home-runtime-store/README.md
@@ -8,3 +8,11 @@ after a process restart.
 
 Live discovery workers and event subscriptions are deliberately process-local
 and are rebuilt by their owners.
+
+Retained identity migration uses an expected storage revision. The store first
+builds and validates a migrated runtime candidate, persists its complete durable
+snapshot with compare-and-swap, and replaces the caller's live runtime only
+after that write succeeds. A stale revision leaves both the live runtime and
+the durable record unchanged. Supplied automation definitions and execution
+state must already use destination identities; exact source-ID references are
+rejected before either runtime or storage mutation.

--- a/code/packages/rust/smart-home-runtime-store/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime-store/src/lib.rs
@@ -3,7 +3,10 @@
 #![forbid(unsafe_code)]
 
 use serde::{Deserialize, Serialize};
-use smart_home_runtime::{RuntimeDurableSnapshot, RuntimeError, SmartHomeRuntime};
+use smart_home_runtime::{
+    RuntimeDurableSnapshot, RuntimeError, RuntimeRetainedIdentityMigration,
+    RuntimeRetainedIdentityMigrationReport, SmartHomeRuntime,
+};
 use std::fmt;
 use storage_core::{Revision, StorageBackend, StorageError, StorageMetadata, StoragePutInput};
 
@@ -188,6 +191,62 @@ impl<B: StorageBackend> SmartHomeRuntimeStore<B> {
         Ok(self.backend.put(input)?.revision)
     }
 
+    /// Migrates a live runtime and its durable snapshot as one revision-guarded
+    /// operation.
+    ///
+    /// The candidate runtime is validated and migrated first, then persisted
+    /// only if `expected_revision` still owns the stored record. The caller's
+    /// live runtime is replaced only after that durable write succeeds.
+    pub fn migrate_retained_identities(
+        &self,
+        runtime: &mut SmartHomeRuntime,
+        migration: &RuntimeRetainedIdentityMigration,
+        automation_definitions: &[DurableAutomationDefinition],
+        automation_state: Option<serde_json::Value>,
+        saved_at_ms: u64,
+        expected_revision: Revision,
+    ) -> Result<(RuntimeRetainedIdentityMigrationReport, Revision), RuntimeStoreError> {
+        validate_automation_definitions(automation_definitions)?;
+        if automation_state
+            .as_ref()
+            .is_some_and(|state| !state.is_object())
+        {
+            return Err(RuntimeStoreError::Validation {
+                field: "automation_state",
+                message: "must be a JSON object".to_string(),
+            });
+        }
+        validate_automation_identity_references(
+            migration,
+            automation_definitions,
+            automation_state.as_ref(),
+        )?;
+
+        let mut candidate = runtime.clone();
+        let report = candidate.migrate_retained_identities(migration)?;
+        let envelope = RuntimeStoreEnvelope {
+            schema_version: SCHEMA_VERSION,
+            saved_at_ms,
+            runtime: candidate.durable_snapshot(),
+            automation_definitions: automation_definitions.to_vec(),
+            automation_state,
+        };
+        let body = serde_json::to_vec(&envelope)
+            .map_err(|error| RuntimeStoreError::Encode(error.to_string()))?;
+        self.backend.initialize()?;
+        let input = StoragePutInput::new(
+            self.namespace.clone(),
+            self.key.clone(),
+            CONTENT_TYPE,
+            StorageMetadata::Object(Default::default()),
+            body,
+        )?
+        .with_if_revision(Some(expected_revision));
+        let revision = self.backend.put(input)?.revision;
+        *runtime = candidate;
+        Ok((report, revision))
+    }
+
     pub fn load(&self) -> Result<Option<RestoredSmartHomeRuntime>, RuntimeStoreError> {
         self.backend.initialize()?;
         let Some(record) = self.backend.get(&self.namespace, &self.key)? else {
@@ -235,6 +294,56 @@ fn validate_automation_definitions(
     Ok(())
 }
 
+fn validate_automation_identity_references(
+    migration: &RuntimeRetainedIdentityMigration,
+    definitions: &[DurableAutomationDefinition],
+    state: Option<&serde_json::Value>,
+) -> Result<(), RuntimeStoreError> {
+    let source_ids = migration
+        .source_device_ids()
+        .map(|device_id| device_id.as_str())
+        .chain(
+            migration
+                .source_entity_ids()
+                .map(|entity_id| entity_id.as_str()),
+        )
+        .collect::<std::collections::BTreeSet<_>>();
+    if definitions
+        .iter()
+        .any(|definition| json_references_any(&definition.definition, &source_ids))
+    {
+        return Err(RuntimeStoreError::Validation {
+            field: "automation_definitions",
+            message: "must not retain a source device or entity identity".to_string(),
+        });
+    }
+    if state.is_some_and(|state| json_references_any(state, &source_ids)) {
+        return Err(RuntimeStoreError::Validation {
+            field: "automation_state",
+            message: "must not retain a source device or entity identity".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn json_references_any(
+    value: &serde_json::Value,
+    source_ids: &std::collections::BTreeSet<&str>,
+) -> bool {
+    match value {
+        serde_json::Value::String(value) => source_ids.contains(value.as_str()),
+        serde_json::Value::Array(values) => values
+            .iter()
+            .any(|value| json_references_any(value, source_ids)),
+        serde_json::Value::Object(fields) => fields.iter().any(|(key, value)| {
+            source_ids.contains(key.as_str()) || json_references_any(value, source_ids)
+        }),
+        serde_json::Value::Null
+        | serde_json::Value::Bool(_)
+        | serde_json::Value::Number(_) => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -244,8 +353,10 @@ mod tests {
         DeviceId, Entity, EntityId, EntityKind, EventId, Health, IntegrationId, StateDelta, Value,
     };
     use smart_home_runtime::{
-        DesiredEntityState, DesiredStateQuery, RuntimeCommandResultQuery, RuntimeEvent,
+        DesiredEntityState, DesiredStateQuery, RetainedDeviceIdentityReplacement,
+        RetainedEntityIdentityReplacement, RuntimeCommandResultQuery, RuntimeEvent,
         RuntimePairingSession, RuntimePairingSessionId, RuntimePairingSessionQuery,
+        RuntimeRetainedIdentityMigration,
     };
     use std::fs;
     use std::path::PathBuf;
@@ -353,6 +464,33 @@ mod tests {
         runtime
     }
 
+    fn identity_migration(runtime: &SmartHomeRuntime) -> RuntimeRetainedIdentityMigration {
+        let mut device = runtime
+            .registry()
+            .device(&DeviceId::trusted("device-1"))
+            .unwrap()
+            .clone();
+        device.device_id = DeviceId::trusted("device-rotated");
+        device.entity_ids = vec![EntityId::trusted("entity-rotated")];
+        let mut entity = runtime
+            .registry()
+            .entity(&EntityId::trusted("entity-1"))
+            .unwrap()
+            .clone();
+        entity.entity_id = EntityId::trusted("entity-rotated");
+        entity.device_id = DeviceId::trusted("device-rotated");
+        entity.state = None;
+
+        RuntimeRetainedIdentityMigration::new(vec![RetainedDeviceIdentityReplacement::new(
+            DeviceId::trusted("device-1"),
+            device,
+            vec![RetainedEntityIdentityReplacement::new(
+                EntityId::trusted("entity-1"),
+                entity,
+            )],
+        )])
+    }
+
     #[test]
     fn local_folder_restart_restores_runtime_and_automation_definitions() {
         let root = temp_root("restart");
@@ -418,6 +556,118 @@ mod tests {
                 .len(),
             1
         );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn retained_identity_migration_persists_before_swapping_the_live_runtime() {
+        let root = temp_root("identity-migration");
+        let mut runtime = runtime_fixture();
+        let migration = identity_migration(&runtime);
+        let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+        let initial_revision = store.save(&runtime, &[], 500).unwrap();
+
+        let (report, migrated_revision) = store
+            .migrate_retained_identities(&mut runtime, &migration, &[], None, 600, initial_revision)
+            .unwrap();
+
+        assert_eq!(report.migrated_devices, 1);
+        assert_ne!(migrated_revision.as_str(), "");
+        assert!(runtime
+            .registry()
+            .device(&DeviceId::trusted("device-1"))
+            .is_none());
+        assert!(runtime
+            .registry()
+            .state(&EntityId::trusted("entity-rotated"))
+            .is_some());
+        let restored = store.load().unwrap().unwrap();
+        assert_eq!(restored.saved_at_ms, 600);
+        assert_eq!(restored.revision, migrated_revision);
+        assert!(restored
+            .runtime
+            .registry()
+            .device(&DeviceId::trusted("device-1"))
+            .is_none());
+        assert!(restored
+            .runtime
+            .registry()
+            .state(&EntityId::trusted("entity-rotated"))
+            .is_some());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn retained_identity_migration_storage_conflict_keeps_live_runtime_unchanged() {
+        let root = temp_root("identity-conflict");
+        let mut runtime = runtime_fixture();
+        let migration = identity_migration(&runtime);
+        let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+        let stale_revision = store.save(&runtime, &[], 500).unwrap();
+        let current_revision = store.save(&runtime, &[], 550).unwrap();
+        let before = runtime.durable_snapshot();
+
+        let error = store
+            .migrate_retained_identities(&mut runtime, &migration, &[], None, 600, stale_revision)
+            .unwrap_err();
+
+        assert!(matches!(error, RuntimeStoreError::Storage(_)));
+        assert_eq!(runtime.durable_snapshot(), before);
+        let restored = store.load().unwrap().unwrap();
+        assert_eq!(restored.revision, current_revision);
+        assert!(restored
+            .runtime
+            .registry()
+            .device(&DeviceId::trusted("device-1"))
+            .is_some());
+        assert!(restored
+            .runtime
+            .registry()
+            .device(&DeviceId::trusted("device-rotated"))
+            .is_none());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn retained_identity_migration_rejects_stale_automation_identity_references() {
+        let root = temp_root("identity-automation-reference");
+        let mut runtime = runtime_fixture();
+        let migration = identity_migration(&runtime);
+        let automation = DurableAutomationDefinition::new(
+            "automation-1",
+            true,
+            serde_json::json!({"action": {"entity_id": "entity-1"}}),
+        )
+        .unwrap();
+        let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+        let revision = store
+            .save(&runtime, std::slice::from_ref(&automation), 500)
+            .unwrap();
+        let before = runtime.durable_snapshot();
+
+        let error = store
+            .migrate_retained_identities(
+                &mut runtime,
+                &migration,
+                std::slice::from_ref(&automation),
+                None,
+                600,
+                revision.clone(),
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RuntimeStoreError::Validation {
+                field: "automation_definitions",
+                ..
+            }
+        ));
+        assert_eq!(runtime.durable_snapshot(), before);
+        assert_eq!(store.load().unwrap().unwrap().revision, revision);
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Add validated whole-device retained identity migration with all-child
+  coverage, destination collision checks, capability-shape preservation, and
+  atomic replacement only after every retained and live reference is rebuilt.
+- Rewrite current and optimistic state, scenes, device/runtime history,
+  entity-scoped grants, authorization decisions, desired state, subscription
+  filters, and queued deliveries during migration.
 - Keep MQTT-broker and custom-HTTP-domain configuration commands non-optimistic
   until a native integration confirms exact device readback.
 - Keep country and cloud-upload configuration commands non-optimistic until a

--- a/code/packages/rust/smart-home-runtime/Cargo.toml
+++ b/code/packages/rust/smart-home-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smart-home-runtime"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Smart-home runtime coordinator for event routing, command validation, state cache, and supervision"
 license = "MIT"

--- a/code/packages/rust/smart-home-runtime/README.md
+++ b/code/packages/rust/smart-home-runtime/README.md
@@ -122,6 +122,10 @@ Included surfaces:
 - read-only supervision observations that combine due action counts with worker
   heartbeat schedules for Chief of Staff status tools
 - replay of device events into the registry-backed state cache
+- host-only, whole-device retained identity migration that validates every
+  child replacement and atomically rewrites topology, current and optimistic
+  state, scenes, retained events, grants, authorization decisions, desired
+  state, event filters, and queued deliveries without changing capability shape
 - bridge health reports that update health without removing identities
 - supervised bridge-worker heartbeat tracking and restart signals
 - read-side worker queries by bridge, integration, status, restart count, and

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -10,14 +10,13 @@
 use serde::{Deserialize, Serialize};
 use smart_home_core::{
     tier_for_command, AgentId, AuthorizationDecision, AuthorizationDecisionLogSummary,
-    AuthorizationOutcome, Bridge, BridgeId, Capability, CapabilityGrant,
+    AuthorizationOutcome, AuthorizationSubject, Bridge, BridgeId, Capability, CapabilityGrant,
     CapabilityGrantInventorySummary, CapabilityGrantScope, CapabilityGrantStatus, CapabilityId,
     CapabilityMode, CommandId, CommandResult, CommandStatus, CommandType, CorrelationId, Device,
     DeviceCommand, DeviceControlCommandType, DeviceEvent, DeviceEventType, DeviceId, Entity,
-    EntityId, EventId, Health,
-    IntegrationId, Metadata, PrivilegeTier, Scene, SceneId, SceneScope, SmartHomeError,
-    MediaCommandType, SmartHomeTool, StateConfidence, StateDelta, StateSnapshot, StateSource, Value,
-    VaultRef,
+    EntityId, EventId, Health, IntegrationId, MediaCommandType, Metadata, PrivilegeTier, Scene,
+    SceneId, SceneScope, SmartHomeError, SmartHomeTool, StateConfidence, StateDelta, StateSnapshot,
+    StateSource, Value, VaultRef,
 };
 use smart_home_discovery::{
     run_mdns_worker_scan_plan_with_executor, DiscoveryCatalog, DiscoveryError,
@@ -93,6 +92,10 @@ pub enum RuntimeError {
         principal_id: AgentId,
         tool: SmartHomeTool,
         missing_capabilities: Vec<CapabilityId>,
+    },
+    InvalidRetainedIdentityMigration {
+        field: &'static str,
+        message: String,
     },
 }
 
@@ -178,6 +181,10 @@ impl fmt::Display for RuntimeError {
             } => write!(
                 f,
                 "agent {principal_id} is not authorized for tool {tool:?}; missing grants for {missing_capabilities:?}"
+            ),
+            Self::InvalidRetainedIdentityMigration { field, message } => write!(
+                f,
+                "invalid retained identity migration field `{field}`: {message}"
             ),
         }
     }
@@ -385,6 +392,31 @@ impl RuntimeEventBus {
             }
         }
         self.published.push(event);
+    }
+
+    fn migrate_retained_identities(
+        &mut self,
+        device_ids: &BTreeMap<DeviceId, DeviceId>,
+        entity_ids: &BTreeMap<EntityId, EntityId>,
+    ) -> (usize, usize) {
+        let mut rewritten_subscriptions = 0;
+        for filter in self.subscriptions.values_mut() {
+            if let RuntimeEventFilter::Entity(entity_id) = filter {
+                rewritten_subscriptions += replace_entity_id(entity_id, entity_ids) as usize;
+            }
+        }
+
+        let mut rewritten_runtime_records = 0;
+        for event in &mut self.published {
+            rewritten_runtime_records +=
+                migrate_runtime_event(event, device_ids, entity_ids) as usize;
+        }
+        for queue in self.deliveries.values_mut() {
+            for event in queue {
+                migrate_runtime_event(event, device_ids, entity_ids);
+            }
+        }
+        (rewritten_runtime_records, rewritten_subscriptions)
     }
 
     pub fn checkpoint(&self) -> RuntimeEventCheckpoint {
@@ -4268,6 +4300,91 @@ impl RuntimePairingCompletion {
     }
 }
 
+/// One complete replacement for a retained child entity identity.
+///
+/// The replacement carries the destination identity metadata and capability
+/// shape. Runtime-owned state and history are migrated from the source.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RetainedEntityIdentityReplacement {
+    pub source_entity_id: EntityId,
+    pub replacement: Entity,
+}
+
+impl RetainedEntityIdentityReplacement {
+    pub fn new(source_entity_id: EntityId, replacement: Entity) -> Self {
+        Self {
+            source_entity_id,
+            replacement,
+        }
+    }
+}
+
+/// One whole-device identity replacement, including every retained child.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RetainedDeviceIdentityReplacement {
+    pub source_device_id: DeviceId,
+    pub replacement: Device,
+    pub entities: Vec<RetainedEntityIdentityReplacement>,
+}
+
+impl RetainedDeviceIdentityReplacement {
+    pub fn new(
+        source_device_id: DeviceId,
+        replacement: Device,
+        entities: Vec<RetainedEntityIdentityReplacement>,
+    ) -> Self {
+        Self {
+            source_device_id,
+            replacement,
+            entities,
+        }
+    }
+}
+
+/// A validated batch of whole-device retained identity replacements.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RuntimeRetainedIdentityMigration {
+    pub devices: Vec<RetainedDeviceIdentityReplacement>,
+}
+
+impl RuntimeRetainedIdentityMigration {
+    pub fn new(devices: Vec<RetainedDeviceIdentityReplacement>) -> Self {
+        Self { devices }
+    }
+
+    pub fn source_device_ids(&self) -> impl Iterator<Item = &DeviceId> {
+        self.devices.iter().map(|device| &device.source_device_id)
+    }
+
+    pub fn source_entity_ids(&self) -> impl Iterator<Item = &EntityId> {
+        self.devices
+            .iter()
+            .flat_map(|device| device.entities.iter())
+            .map(|entity| &entity.source_entity_id)
+    }
+}
+
+/// Counts returned after one atomic retained identity migration.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RuntimeRetainedIdentityMigrationReport {
+    pub migrated_devices: usize,
+    pub migrated_entities: usize,
+    pub rewritten_states: usize,
+    pub rewritten_scene_actions: usize,
+    pub rewritten_history_records: usize,
+    pub rewritten_policy_records: usize,
+    pub rewritten_runtime_records: usize,
+    pub rewritten_subscriptions: usize,
+}
+
+#[derive(Debug)]
+struct ValidatedRetainedIdentityMigration {
+    device_ids: BTreeMap<DeviceId, DeviceId>,
+    entity_ids: BTreeMap<EntityId, EntityId>,
+    devices: BTreeMap<DeviceId, Device>,
+    entities: BTreeMap<EntityId, Entity>,
+}
+
 #[derive(Debug, Clone)]
 pub struct SmartHomeRuntime {
     registry: InMemorySmartHomeRegistry,
@@ -4339,6 +4456,252 @@ impl SmartHomeRuntime {
             optimistic_states: self.optimistic_states.values().cloned().collect(),
             desired_states: self.desired_states.values().cloned().collect(),
         }
+    }
+
+    /// Atomically replaces retained device and entity identities.
+    ///
+    /// Every child entity of a migrated device must be supplied. Validation and
+    /// reconstruction happen against a candidate runtime; `self` is replaced
+    /// only after the complete durable graph and live event subscriptions have
+    /// been rewritten successfully.
+    pub fn migrate_retained_identities(
+        &mut self,
+        migration: &RuntimeRetainedIdentityMigration,
+    ) -> Result<RuntimeRetainedIdentityMigrationReport, RuntimeError> {
+        let validated = self.validate_retained_identity_migration(migration)?;
+        let mut snapshot = self.durable_snapshot();
+        let mut report = migrate_durable_snapshot(&mut snapshot, &validated);
+        let mut replacement = Self::restore_durable_snapshot(snapshot)?;
+
+        replacement.discovery = self.discovery.clone();
+        replacement.discovery_scheduler = self.discovery_scheduler.clone();
+        replacement.supervisor = self.supervisor.clone();
+        replacement.event_bus = self.event_bus.clone();
+        let (runtime_records, subscriptions) = replacement
+            .event_bus
+            .migrate_retained_identities(&validated.device_ids, &validated.entity_ids);
+        report.rewritten_runtime_records = runtime_records;
+        report.rewritten_subscriptions = subscriptions;
+
+        *self = replacement;
+        Ok(report)
+    }
+
+    fn validate_retained_identity_migration(
+        &self,
+        migration: &RuntimeRetainedIdentityMigration,
+    ) -> Result<ValidatedRetainedIdentityMigration, RuntimeError> {
+        if migration.devices.is_empty() {
+            return Err(invalid_identity_migration(
+                "devices",
+                "must contain at least one whole-device replacement",
+            ));
+        }
+
+        let mut device_ids = BTreeMap::new();
+        let mut entity_ids = BTreeMap::new();
+        let mut devices = BTreeMap::new();
+        let mut entities = BTreeMap::new();
+        let mut destination_device_ids = BTreeSet::new();
+        let mut destination_entity_ids = BTreeSet::new();
+
+        for device_migration in &migration.devices {
+            let source = self
+                .registry
+                .device(&device_migration.source_device_id)
+                .ok_or_else(|| {
+                    invalid_identity_migration(
+                        "source_device_id",
+                        format!("unknown device {}", device_migration.source_device_id),
+                    )
+                })?;
+            let destination_id = device_migration.replacement.device_id.clone();
+            if destination_id == device_migration.source_device_id {
+                return Err(invalid_identity_migration(
+                    "replacement.device_id",
+                    format!("device {} is a no-op replacement", destination_id),
+                ));
+            }
+            if self.registry.device(&destination_id).is_some() {
+                return Err(invalid_identity_migration(
+                    "replacement.device_id",
+                    format!("destination device {destination_id} already exists"),
+                ));
+            }
+            if !destination_device_ids.insert(destination_id.clone()) {
+                return Err(invalid_identity_migration(
+                    "replacement.device_id",
+                    format!("duplicate destination device {destination_id}"),
+                ));
+            }
+            if source.bridge_id != device_migration.replacement.bridge_id {
+                return Err(invalid_identity_migration(
+                    "replacement.bridge_id",
+                    format!(
+                        "device {} must remain on bridge {}",
+                        source.device_id, source.bridge_id
+                    ),
+                ));
+            }
+
+            let source_entity_ids = self
+                .registry
+                .entities_for_device(&source.device_id)
+                .map(|entity| entity.entity_id.clone())
+                .collect::<BTreeSet<_>>();
+            let supplied_source_ids = device_migration
+                .entities
+                .iter()
+                .map(|entity| entity.source_entity_id.clone())
+                .collect::<BTreeSet<_>>();
+            if source_entity_ids != supplied_source_ids
+                || source_entity_ids.len() != device_migration.entities.len()
+            {
+                return Err(invalid_identity_migration(
+                    "entities",
+                    format!(
+                        "device {} replacement must cover each of its {} child entities exactly once",
+                        source.device_id,
+                        source_entity_ids.len()
+                    ),
+                ));
+            }
+
+            let replacement_entity_ids = device_migration
+                .replacement
+                .entity_ids
+                .iter()
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            let supplied_destination_ids = device_migration
+                .entities
+                .iter()
+                .map(|entity| entity.replacement.entity_id.clone())
+                .collect::<BTreeSet<_>>();
+            if replacement_entity_ids != supplied_destination_ids
+                || replacement_entity_ids.len() != device_migration.replacement.entity_ids.len()
+            {
+                return Err(invalid_identity_migration(
+                    "replacement.entity_ids",
+                    format!(
+                        "destination device {destination_id} must list each replacement entity exactly once"
+                    ),
+                ));
+            }
+
+            if device_ids
+                .insert(source.device_id.clone(), destination_id.clone())
+                .is_some()
+            {
+                return Err(invalid_identity_migration(
+                    "source_device_id",
+                    format!("duplicate source device {}", source.device_id),
+                ));
+            }
+            devices.insert(
+                source.device_id.clone(),
+                device_migration.replacement.clone(),
+            );
+
+            for entity_migration in &device_migration.entities {
+                let source_entity = self
+                    .registry
+                    .entity(&entity_migration.source_entity_id)
+                    .ok_or_else(|| {
+                        invalid_identity_migration(
+                            "source_entity_id",
+                            format!("unknown entity {}", entity_migration.source_entity_id),
+                        )
+                    })?;
+                let replacement_entity = &entity_migration.replacement;
+                if source_entity.device_id != source.device_id {
+                    return Err(invalid_identity_migration(
+                        "source_entity_id",
+                        format!(
+                            "entity {} is not owned by device {}",
+                            source_entity.entity_id, source.device_id
+                        ),
+                    ));
+                }
+                if replacement_entity.device_id != destination_id {
+                    return Err(invalid_identity_migration(
+                        "replacement.device_id",
+                        format!(
+                            "entity {} must belong to destination device {destination_id}",
+                            replacement_entity.entity_id
+                        ),
+                    ));
+                }
+                if replacement_entity.entity_id == source_entity.entity_id {
+                    return Err(invalid_identity_migration(
+                        "replacement.entity_id",
+                        format!("entity {} is a no-op replacement", source_entity.entity_id),
+                    ));
+                }
+                if self
+                    .registry
+                    .entity(&replacement_entity.entity_id)
+                    .is_some()
+                {
+                    return Err(invalid_identity_migration(
+                        "replacement.entity_id",
+                        format!(
+                            "destination entity {} already exists",
+                            replacement_entity.entity_id
+                        ),
+                    ));
+                }
+                if !destination_entity_ids.insert(replacement_entity.entity_id.clone()) {
+                    return Err(invalid_identity_migration(
+                        "replacement.entity_id",
+                        format!(
+                            "duplicate destination entity {}",
+                            replacement_entity.entity_id
+                        ),
+                    ));
+                }
+                if source_entity.kind != replacement_entity.kind
+                    || source_entity.capabilities != replacement_entity.capabilities
+                {
+                    return Err(invalid_identity_migration(
+                        "replacement.capabilities",
+                        format!(
+                            "entity {} must preserve its kind and capability surface",
+                            source_entity.entity_id
+                        ),
+                    ));
+                }
+                if replacement_entity.state.is_some() {
+                    return Err(invalid_identity_migration(
+                        "replacement.state",
+                        format!(
+                            "entity {} replacement state must be empty; retained state is migrated by the runtime",
+                            replacement_entity.entity_id
+                        ),
+                    ));
+                }
+                if entity_ids
+                    .insert(
+                        source_entity.entity_id.clone(),
+                        replacement_entity.entity_id.clone(),
+                    )
+                    .is_some()
+                {
+                    return Err(invalid_identity_migration(
+                        "source_entity_id",
+                        format!("duplicate source entity {}", source_entity.entity_id),
+                    ));
+                }
+                entities.insert(source_entity.entity_id.clone(), replacement_entity.clone());
+            }
+        }
+
+        Ok(ValidatedRetainedIdentityMigration {
+            device_ids,
+            entity_ids,
+            devices,
+            entities,
+        })
     }
 
     pub fn restore_durable_snapshot(
@@ -6220,6 +6583,135 @@ impl Default for SmartHomeRuntime {
     }
 }
 
+fn invalid_identity_migration(field: &'static str, message: impl Into<String>) -> RuntimeError {
+    RuntimeError::InvalidRetainedIdentityMigration {
+        field,
+        message: message.into(),
+    }
+}
+
+fn migrate_durable_snapshot(
+    snapshot: &mut RuntimeDurableSnapshot,
+    migration: &ValidatedRetainedIdentityMigration,
+) -> RuntimeRetainedIdentityMigrationReport {
+    let mut report = RuntimeRetainedIdentityMigrationReport {
+        migrated_devices: migration.devices.len(),
+        migrated_entities: migration.entities.len(),
+        ..RuntimeRetainedIdentityMigrationReport::default()
+    };
+
+    for device in &mut snapshot.devices {
+        if let Some(replacement) = migration.devices.get(&device.device_id) {
+            *device = replacement.clone();
+        }
+    }
+    for entity in &mut snapshot.entities {
+        let Some(mut replacement) = migration.entities.get(&entity.entity_id).cloned() else {
+            continue;
+        };
+        replacement.state = entity.state.clone().map(|mut state| {
+            replace_entity_id(&mut state.entity_id, &migration.entity_ids);
+            report.rewritten_states += 1;
+            state
+        });
+        *entity = replacement;
+    }
+    for state in &mut snapshot.states {
+        report.rewritten_states +=
+            replace_entity_id(&mut state.entity_id, &migration.entity_ids) as usize;
+    }
+    for scene in &mut snapshot.scenes {
+        for action in &mut scene.actions {
+            report.rewritten_scene_actions +=
+                replace_entity_id(&mut action.entity_id, &migration.entity_ids) as usize;
+        }
+    }
+    for event in &mut snapshot.registry_events {
+        report.rewritten_history_records +=
+            migrate_device_event(event, &migration.device_ids, &migration.entity_ids) as usize;
+    }
+    for grant in &mut snapshot.capability_grants {
+        if let CapabilityGrantScope::EntityCapability { entity_id, .. } = &mut grant.scope {
+            report.rewritten_policy_records +=
+                replace_entity_id(entity_id, &migration.entity_ids) as usize;
+        }
+    }
+    for decision in &mut snapshot.authorization_decisions {
+        if let AuthorizationSubject::Command { entity_id, .. } = &mut decision.subject {
+            report.rewritten_policy_records +=
+                replace_entity_id(entity_id, &migration.entity_ids) as usize;
+        }
+    }
+    for event in &mut snapshot.runtime_events {
+        report.rewritten_runtime_records +=
+            migrate_runtime_event(event, &migration.device_ids, &migration.entity_ids) as usize;
+    }
+    for state in &mut snapshot.optimistic_states {
+        report.rewritten_states +=
+            replace_entity_id(&mut state.entity_id, &migration.entity_ids) as usize;
+    }
+    for desired_state in &mut snapshot.desired_states {
+        report.rewritten_states +=
+            replace_entity_id(&mut desired_state.entity_id, &migration.entity_ids) as usize;
+    }
+
+    report
+}
+
+fn replace_device_id(
+    device_id: &mut DeviceId,
+    replacements: &BTreeMap<DeviceId, DeviceId>,
+) -> bool {
+    let Some(replacement) = replacements.get(device_id) else {
+        return false;
+    };
+    *device_id = replacement.clone();
+    true
+}
+
+fn replace_entity_id(
+    entity_id: &mut EntityId,
+    replacements: &BTreeMap<EntityId, EntityId>,
+) -> bool {
+    let Some(replacement) = replacements.get(entity_id) else {
+        return false;
+    };
+    *entity_id = replacement.clone();
+    true
+}
+
+fn migrate_device_event(
+    event: &mut DeviceEvent,
+    device_ids: &BTreeMap<DeviceId, DeviceId>,
+    entity_ids: &BTreeMap<EntityId, EntityId>,
+) -> bool {
+    let mut changed = false;
+    if let Some(device_id) = &mut event.device_id {
+        changed |= replace_device_id(device_id, device_ids);
+    }
+    if let Some(entity_id) = &mut event.entity_id {
+        changed |= replace_entity_id(entity_id, entity_ids);
+    }
+    changed
+}
+
+fn migrate_runtime_event(
+    event: &mut RuntimeEvent,
+    device_ids: &BTreeMap<DeviceId, DeviceId>,
+    entity_ids: &BTreeMap<EntityId, EntityId>,
+) -> bool {
+    match event {
+        RuntimeEvent::Device(event) => migrate_device_event(event, device_ids, entity_ids),
+        RuntimeEvent::StateExpired { entity_id, .. }
+        | RuntimeEvent::DesiredStateDrift { entity_id, .. } => {
+            replace_entity_id(entity_id, entity_ids)
+        }
+        RuntimeEvent::CommandResult(_)
+        | RuntimeEvent::BridgeHealth { .. }
+        | RuntimeEvent::WorkerNeedsRestart { .. } => false,
+    }
+}
+
 pub fn health_name(health: Health) -> &'static str {
     match health {
         Health::Unknown => "unknown",
@@ -6991,6 +7483,233 @@ mod tests {
             correlation_id: CorrelationId::trusted("corr-1"),
             message: None,
         })
+    }
+
+    fn retained_identity_migration(runtime: &SmartHomeRuntime) -> RuntimeRetainedIdentityMigration {
+        let mut replacement_device = runtime
+            .registry()
+            .device(&DeviceId::trusted("device-1"))
+            .unwrap()
+            .clone();
+        replacement_device.device_id = DeviceId::trusted("device-rotated");
+        replacement_device.name = "Kitchen rotated".to_string();
+        replacement_device.entity_ids = vec![EntityId::trusted("entity-rotated")];
+        replacement_device.identifiers =
+            vec![ProtocolIdentifier::new(ProtocolFamily::Hue, "pseudonym", "rotated").unwrap()];
+
+        let mut replacement_entity = runtime
+            .registry()
+            .entity(&EntityId::trusted("entity-1"))
+            .unwrap()
+            .clone();
+        replacement_entity.entity_id = EntityId::trusted("entity-rotated");
+        replacement_entity.device_id = DeviceId::trusted("device-rotated");
+        replacement_entity.name = "Kitchen Light rotated".to_string();
+        replacement_entity.state = None;
+        replacement_entity.metadata = vec![Metadata::new("identity.generation", "rotated")];
+
+        RuntimeRetainedIdentityMigration::new(vec![RetainedDeviceIdentityReplacement::new(
+            DeviceId::trusted("device-1"),
+            replacement_device,
+            vec![RetainedEntityIdentityReplacement::new(
+                EntityId::trusted("entity-1"),
+                replacement_entity,
+            )],
+        )])
+    }
+
+    #[test]
+    fn retained_identity_migration_rewrites_topology_state_history_policy_and_subscriptions() {
+        let mut runtime = runtime_with_entity(vec![Capability::light_on_off()]);
+        let state = StateSnapshot {
+            entity_id: EntityId::trusted("entity-1"),
+            value: Value::Bool(true),
+            source: StateSource::Poll,
+            observed_at_ms: 1_000,
+            received_at_ms: 1_001,
+            expires_at_ms: Some(2_000),
+            confidence: StateConfidence::Confirmed,
+        };
+        runtime
+            .registry_mut()
+            .apply_state_snapshot(state.clone())
+            .unwrap();
+        runtime.optimistic_states.insert(
+            EntityId::trusted("entity-1"),
+            StateSnapshot {
+                confidence: StateConfidence::Optimistic,
+                ..state.clone()
+            },
+        );
+        runtime
+            .upsert_desired_state(DesiredEntityState::new(
+                EntityId::trusted("entity-1"),
+                vec![StateDelta {
+                    capability_id: CapabilityId::trusted("light.on_off"),
+                    value: Value::Bool(true),
+                }],
+            ))
+            .unwrap();
+        runtime
+            .upsert_scene(Scene {
+                scene_id: SceneId::trusted("scene-1"),
+                scope: SceneScope::Room,
+                native_ref: None,
+                actions: vec![smart_home_core::SceneAction {
+                    entity_id: EntityId::trusted("entity-1"),
+                    desired_state: Value::Bool(true),
+                }],
+                metadata: Vec::new(),
+            })
+            .unwrap();
+        let event = match device_runtime_event("event-1", 1_100) {
+            RuntimeEvent::Device(event) => event,
+            _ => unreachable!(),
+        };
+        runtime.registry_mut().record_event(event.clone()).unwrap();
+        let principal = AgentId::trusted("agent:identity-test");
+        let grant = CapabilityGrant::for_entity_capability(
+            CapabilityGrantId::trusted("grant-identity"),
+            principal.clone(),
+            EntityId::trusted("entity-1"),
+            CapabilityId::trusted("light.on_off"),
+            PrivilegeTier::LowRisk,
+            "test",
+            900,
+        );
+        runtime
+            .registry_mut()
+            .upsert_capability_grant(grant.clone());
+        runtime
+            .registry_mut()
+            .record_authorization_decision(AuthorizationDecision::for_command(
+                principal,
+                &command(CommandType::TurnOn, Value::Null),
+                [&grant],
+                1_050,
+            ));
+        let subscription_id = RuntimeSubscriptionId::trusted("entity-stream");
+        runtime
+            .event_bus_mut()
+            .subscribe(
+                subscription_id.clone(),
+                RuntimeEventFilter::Entity(EntityId::trusted("entity-1")),
+            )
+            .unwrap();
+        runtime.event_bus_mut().publish(RuntimeEvent::Device(event));
+        let retained_value = runtime
+            .registry()
+            .state(&EntityId::trusted("entity-1"))
+            .unwrap()
+            .value
+            .clone();
+
+        let report = runtime
+            .migrate_retained_identities(&retained_identity_migration(&runtime))
+            .unwrap();
+
+        assert_eq!(report.migrated_devices, 1);
+        assert_eq!(report.migrated_entities, 1);
+        assert_eq!(report.rewritten_scene_actions, 1);
+        assert_eq!(report.rewritten_history_records, 1);
+        assert_eq!(report.rewritten_policy_records, 2);
+        assert_eq!(report.rewritten_runtime_records, 1);
+        assert_eq!(report.rewritten_subscriptions, 1);
+        assert!(runtime
+            .registry()
+            .device(&DeviceId::trusted("device-1"))
+            .is_none());
+        assert!(runtime
+            .registry()
+            .entity(&EntityId::trusted("entity-1"))
+            .is_none());
+        assert_eq!(
+            runtime
+                .registry()
+                .state(&EntityId::trusted("entity-rotated"))
+                .unwrap()
+                .value,
+            retained_value
+        );
+        assert_eq!(
+            runtime
+                .registry()
+                .scene(&SceneId::trusted("scene-1"))
+                .unwrap()
+                .actions[0]
+                .entity_id,
+            EntityId::trusted("entity-rotated")
+        );
+        let migrated_event = runtime.registry().events().next().unwrap();
+        assert_eq!(
+            migrated_event.device_id,
+            Some(DeviceId::trusted("device-rotated"))
+        );
+        assert_eq!(
+            migrated_event.entity_id,
+            Some(EntityId::trusted("entity-rotated"))
+        );
+        assert!(matches!(
+            &runtime.registry().capability_grants().next().unwrap().scope,
+            CapabilityGrantScope::EntityCapability { entity_id, .. }
+                if entity_id == &EntityId::trusted("entity-rotated")
+        ));
+        assert!(matches!(
+            &runtime.registry().authorization_decisions().next().unwrap().subject,
+            AuthorizationSubject::Command { entity_id, .. }
+                if entity_id == &EntityId::trusted("entity-rotated")
+        ));
+        assert!(runtime
+            .desired_state(&EntityId::trusted("entity-rotated"))
+            .is_some());
+        assert!(runtime
+            .optimistic_states
+            .contains_key(&EntityId::trusted("entity-rotated")));
+        let subscription = runtime
+            .event_bus()
+            .query_subscriptions(&RuntimeSubscriptionQuery::new())
+            .into_iter()
+            .next()
+            .unwrap();
+        assert_eq!(
+            subscription.filter,
+            RuntimeEventFilter::Entity(EntityId::trusted("entity-rotated"))
+        );
+        assert!(matches!(
+            &runtime
+                .event_bus()
+                .peek_deliveries(&subscription_id, RuntimeEventDeliveryOptions::new())
+                .unwrap()
+                .events[0],
+            RuntimeEvent::Device(event)
+                if event.entity_id == Some(EntityId::trusted("entity-rotated"))
+                    && event.device_id == Some(DeviceId::trusted("device-rotated"))
+        ));
+    }
+
+    #[test]
+    fn retained_identity_migration_rejects_collisions_without_mutation() {
+        let mut runtime = runtime_with_entity(vec![Capability::light_on_off()]);
+        runtime
+            .upsert_device(device("device-existing", "bridge-1"))
+            .unwrap();
+        let before = runtime.durable_snapshot();
+        let mut migration = retained_identity_migration(&runtime);
+        migration.devices[0].replacement.device_id = DeviceId::trusted("device-existing");
+        migration.devices[0].replacement.entity_ids = vec![EntityId::trusted("entity-rotated")];
+        migration.devices[0].entities[0].replacement.device_id =
+            DeviceId::trusted("device-existing");
+
+        let error = runtime.migrate_retained_identities(&migration).unwrap_err();
+
+        assert!(matches!(
+            error,
+            RuntimeError::InvalidRetainedIdentityMigration {
+                field: "replacement.device_id",
+                ..
+            }
+        ));
+        assert_eq!(runtime.durable_snapshot(), before);
     }
 
     #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1234,121 +1234,157 @@ broker and custom HTTP routing surface:
   parsed username and password, so host-side Vault leasing cannot prevent the
   device-side disclosure. Command input rejects MQTT userinfo.
 
+## Current Retained Identity Migration Slice
+
+This slice closes the shared runtime prerequisite for safe pseudonym-key
+rotation without starting either vendor-specific rotation workflow:
+
+- `smart-home-runtime` accepts host-only whole-device identity replacements
+  that cover every retained child entity exactly once. It rejects missing
+  children, destination collisions, no-op identities, bridge changes, and
+  capability-shape drift before mutating runtime state.
+- A successful migration atomically rewrites device/entity topology, embedded
+  and current state, scenes, registry and runtime event history,
+  entity-scoped grants, command authorization decisions, optimistic and
+  desired state, live entity subscription filters, and queued deliveries.
+- Replacement devices and entities carry the destination pseudonym metadata;
+  opaque metadata is never heuristically edited. The runtime preserves the
+  source state and history under the supplied destination identities.
+- `smart-home-runtime-store` builds the migrated runtime as a candidate,
+  persists its complete durable snapshot with an expected-revision
+  compare-and-swap, and replaces the caller's live runtime only after storage
+  succeeds. A stale revision leaves both live and durable state unchanged.
+  Supplied automation definitions and execution state must already use the
+  destination identities; exact source-ID references fail before mutation.
+- Enphase and UniFi key rotation remain separate production-integration
+  slices. Each must derive old and new pseudonyms from one bounded sensitive
+  response while two one-shot keys are leased, dispose of native identifiers
+  before returning, and submit the resulting complete migration through this
+  revision-guarded path.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
-1. Add authenticated AirGradient MQTT only after official firmware removes
+1. Add Enphase pseudonym-key rotation over the completed atomic retained
+   identity migration. One bounded authenticated inverter response must derive
+   old and new identities under two one-shot Vault-leased keys, prove exact
+   source correspondence, dispose of raw serials and both keys before return,
+   migrate or prove absence of automation references, and persist the complete
+   migration with an expected runtime-store revision.
+2. Add UniFi connected-client pseudonym-key rotation over the same completed
+   migration path. One bounded authenticated client response must derive exact
+   old/new correspondence under two one-shot Vault-leased keys, preserve the
+   five-minute presence boundary, dispose of native identifiers and keys, and
+   migrate or prove absence of automation references before revision-guarded
+   persistence.
+
+3. Add authenticated AirGradient MQTT only after official firmware removes
    plaintext credential logging and one-shot Vault-leased credential injection
    can be proven without request-plan or normalized-state exposure.
-2. Add independent AirGradient telemetry, remote-configuration, and OTA
+4. Add independent AirGradient telemetry, remote-configuration, and OTA
    destinations only if firmware exposes separate settings; the current
    `httpDomain` contract intentionally governs all three as one HTTPS origin.
-3. Add authenticated HEOS source browsing and queue insertion only after the
+5. Add authenticated HEOS source browsing and queue insertion only after the
    account/session and Vault-leasing prerequisites are concrete.
-4. Automate Enphase access-token acquisition or renewal only after Enphase
+6. Automate Enphase access-token acquisition or renewal only after Enphase
    account authentication, cloud-session handling, operator consent, and
    Vault-leased credential policy are concrete; the current host accepts a
    pre-generated token.
-5. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
+7. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
    stable LAN advertisement; the current production path uses explicit local
    HTTPS endpoint and gateway-serial configuration.
-6. Add Enphase pseudonym-key rotation and retained-identity migration only after
-   the runtime can atomically replace entity identifiers without duplicating or
-   orphaning historical inverter state.
-7. Add Enphase live battery, relay, generator, grid, and system-topology state
+8. Add Enphase live battery, relay, generator, grid, and system-topology state
    only after the normalized energy topology and retention semantics are
    concrete.
-8. Add Enphase relay, grid-services, or configuration controls only with
+9. Add Enphase relay, grid-services, or configuration controls only with
    operation-specific D23 contracts, explicit safety approval, bounded native
    semantics, and readable postcondition verification.
-9. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
+10. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
    supervised session lifecycle and Vault policy for refresh-token residency are
    concrete; the current isolated inspection drops both tokens after each read.
-10. Add ZoneMinder event push only after a concrete authenticated event host and
+11. Add ZoneMinder event push only after a concrete authenticated event host and
     supervised subscription lifecycle exist.
-11. Add ZoneMinder snapshots, streams, recordings, export, and playback only
+12. Add ZoneMinder snapshots, streams, recordings, export, and playback only
     through the camera-media lease and a concrete media executor.
-12. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
+13. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
     mutations only with operation-specific D23 contracts, least-privilege user
     checks, bounded semantics, and readable postcondition verification.
-13. Add UniFi connected-client native details or pseudonym-key rotation only
-   after field-specific minimization and retention are approved and the runtime
-   can atomically migrate retained entity identifiers without duplicates or
-   orphaned history; current presence intentionally excludes names, native IDs,
-   MACs, IPs, and connection timestamps.
-14. Add UniFi historical device statistics, heartbeat-time correlation, or
+14. Add UniFi connected-client native details only after field-specific
+   minimization and retention are approved; current presence intentionally
+   excludes names, native IDs, MACs, IPs, and connection timestamps.
+15. Add UniFi historical device statistics, heartbeat-time correlation, or
    broader fleet polling only after durable time-series schema, query access,
    clock semantics, and retention/deletion policy are concrete; current live
    statistics are explicit-target, 64-device bounded, one-minute rate-limited,
    and expire after two minutes.
-15. Add remote UniFi Site Manager inspection only after telemetry-egress,
+16. Add remote UniFi Site Manager inspection only after telemetry-egress,
    destination, and operator-consent policy are concrete; keep the current host
    local-only.
-16. Add UniFi Network push or change events only after a concrete authenticated
+17. Add UniFi Network push or change events only after a concrete authenticated
    event host and supervised subscription lifecycle exist.
-17. Add UniFi adoption, guest authorization, port actions, or configuration
+18. Add UniFi adoption, guest authorization, port actions, or configuration
    mutations only with operation-specific D23 contracts, least-privilege API
    keys, bounded semantics, and readable postcondition verification.
-18. Add Synology Surveillance Station OTP and remembered-device authentication
+19. Add Synology Surveillance Station OTP and remembered-device authentication
    only after an interactive challenge lifecycle and Vault-leased device-token
    policy are concrete.
-19. Add Synology Surveillance Station events only after a concrete authenticated
+20. Add Synology Surveillance Station events only after a concrete authenticated
    event host and supervised subscription lifecycle exist.
-20. Add Synology Surveillance Station snapshots, recordings, export, and
+21. Add Synology Surveillance Station snapshots, recordings, export, and
    playback only through the camera-media lease and a concrete executor.
-21. Add Synology Surveillance Station PTZ, external recording, or configuration
+22. Add Synology Surveillance Station PTZ, external recording, or configuration
    mutations only with operation-specific D23 contracts, least-privilege API
    checks, bounded semantics, and readable postcondition verification.
-22. Add Frigate event and review push only after a concrete authenticated event
+23. Add Frigate event and review push only after a concrete authenticated event
    or WebSocket host and supervised subscription lifecycle exist.
-23. Add Frigate snapshots, recordings, export, and playback only through the
+24. Add Frigate snapshots, recordings, export, and playback only through the
    camera-media lease and a concrete executor.
-24. Add Frigate commands or configuration mutations only with operation-specific
+25. Add Frigate commands or configuration mutations only with operation-specific
    D23 contracts, least-privilege role checks, and readable postcondition
    verification.
-25. Add Blue Iris snapshots, alert/clip search, export, and playback only through
+26. Add Blue Iris snapshots, alert/clip search, export, and playback only through
    the camera-media lease and a concrete media executor.
-26. Add broader Blue Iris `camconfig` or administrative mutations only with
+27. Add broader Blue Iris `camconfig` or administrative mutations only with
    operation-specific D23 contracts, least-privilege permissions, and readable
    postcondition verification; do not persist the license value returned at
    login.
-27. Add automatic Blue Iris discovery only if the server exposes a documented,
+28. Add automatic Blue Iris discovery only if the server exposes a documented,
    stable LAN advertisement; the current production path is explicit local
    HTTPS endpoint configuration.
-28. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
+29. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
    controls only when each operation has a specific native capability probe,
    bounded semantics, and readable verification where the device exposes it.
-29. Add Axis event streaming only after the existing WebSocket protocol core has
+30. Add Axis event streaming only after the existing WebSocket protocol core has
    a concrete authenticated host using the completed Digest primitive or a
    short-lived session token, plus subscription supervision.
-30. Add Axis snapshots and media transfer only through the camera-media lease and
+31. Add Axis snapshots and media transfer only through the camera-media lease and
    a concrete media executor.
-31. Enumerate Axis video sources/channels before extending PTZ beyond the current
+32. Enumerate Axis video sources/channels before extending PTZ beyond the current
    capability-probed VAPIX camera 1 boundary.
-32. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
+33. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
    only when each operation has a specific capability probe and readable state.
-33. Add Reolink snapshot, recording search/download, and playback operations only
+34. Add Reolink snapshot, recording search/download, and playback operations only
    through the existing camera-media lease and a concrete media executor.
-34. Add Reolink current-position, zoom, guard-point, or patrol controls only when
+35. Add Reolink current-position, zoom, guard-point, or patrol controls only when
    each operation has a capability-specific probe and the firmware exposes the
    native state needed to avoid invented orientation claims.
-35. Add Reolink push events only after a concrete webhook or event-stream host
+36. Add Reolink push events only after a concrete webhook or event-stream host
    and subscription lifecycle exist.
-36. Add authenticated KLAP/Tapo devices and other broader-device families only
+37. Add authenticated KLAP/Tapo devices and other broader-device families only
    after their authentication and session prerequisites are concrete.
-37. Add ONVIF PullPoint events once a concrete event host and subscription
+38. Add ONVIF PullPoint events once a concrete event host and subscription
    lifecycle exist.
-38. Add RTSP media transfer and recording once concrete media transfer and
+39. Add RTSP media transfer and recording once concrete media transfer and
    recorder host primitives exist.
-39. Add a production Matter commissioning, secure-session, and network host only
+40. Add a production Matter commissioning, secure-session, and network host only
    after certificate, fabric, Interaction Model encoding, subscription, and
    transport prerequisites exist.
-40. Add a Thread border-router host only after an actual host transport exists.
-41. Add a production Zigbee coordinator, join, and security host only after
+41. Add a Thread border-router host only after an actual host transport exists.
+42. Add a production Zigbee coordinator, join, and security host only after
    concrete coordinator transport and security primitives exist.
-42. Add production Z-Wave inclusion and S2 only after concrete host transport
+43. Add production Z-Wave inclusion and S2 only after concrete host transport
    and security primitives exist.
 
 ## End-To-End Definition


### PR DESCRIPTION
## Summary
- add host-only whole-device retained identity migration with complete child coverage, collision checks, and capability-shape preservation
- atomically rewrite topology, state, scenes, retained history, policy records, desired/optimistic state, and live event subscriptions
- add revision-guarded runtime-store persistence that swaps the live runtime only after durable CAS succeeds and rejects stale automation identity references
- record the completed prerequisite and reprioritize Enphase then UniFi pseudonym-key rotation in the D18-D23 inventory

## Validation
- `cargo test` across runtime, runtime-store, Enphase, UniFi, automation runtime, platform HTTP, and Chief smart-home tools (225 tests plus doc tests)
- strict `cargo clippy --all-targets --all-features -- -D warnings` across the same seven packages
- all seven impacted package `BUILD` scripts
- post-rebase runtime/runtime-store tests, strict Clippy, and both modified package `BUILD` scripts
- generated `code/packages/rust/Cargo.lock` removed and disposable Cargo artifacts cleaned