### PR TITLE
Inject data-plane authorities into Chief daemon

### DIFF
--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
-- Compose durable per-request host data-plane authorization with a fail-closed
-  unavailable service until channel-key custody and model providers are injected.
+- Provision non-empty typed data-plane declarations into the production daemon's
+  exact channel-key and Ollama authorities, with UUID-v7/process-monotonic publish
+  metadata and no startup network probe. Empty declarations remain unavailable.
+- Compose durable per-request host data-plane authorization.
 - Compose the storage-backed durable pipeline launch-binding provider. Host
   starts now require an exact registered package plus current immutable channel
   claims, active membership, and bounded persisted model settings.

--- a/code/packages/rust/chief-of-staff-daemon/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-daemon/Cargo.toml
@@ -14,7 +14,9 @@ name = "chief-of-staff-daemon"
 path = "src/main.rs"
 
 [dependencies]
+chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }
 chief-of-staff-daemon-api = { path = "../chief-of-staff-daemon-api" }
+chief-of-staff-daemon-authority-provisioning = { path = "../chief-of-staff-daemon-authority-provisioning" }
 chief-of-staff-daemon-config = { path = "../chief-of-staff-daemon-config" }
 chief-of-staff-daemon-credential = { path = "../chief-of-staff-daemon-credential" }
 chief-of-staff-daemon-keyring = { path = "../chief-of-staff-daemon-keyring" }
@@ -25,6 +27,7 @@ chief-of-staff-orchestrator-core = { path = "../chief-of-staff-orchestrator-core
 chief-of-staff-process-supervisor = { path = "../chief-of-staff-process-supervisor" }
 chief-of-staff-service-reconciler = { path = "../chief-of-staff-service-reconciler" }
 coding_adventures_x3dh = { path = "../x3dh" }
+coding_adventures_uuid = { path = "../uuid" }
 process-shutdown = { path = "../process-shutdown" }
 storage-core = { path = "../storage-core" }
 coding_adventures_storage_fs = { path = "../storage-fs" }

--- a/code/packages/rust/chief-of-staff-daemon/README.md
+++ b/code/packages/rust/chief-of-staff-daemon/README.md
@@ -2,8 +2,9 @@
 
 Concrete, dependency-free-at-runtime executable for the D18 Chief of Staff
 orchestrator. It composes the repository-owned configuration, credential,
-package trust, storage, process supervision, control API, WebSocket runtime,
-reconciliation, and shutdown packages without adding new policy.
+package trust, storage, process supervision, exact data-plane authorities,
+control API, WebSocket runtime, reconciliation, and shutdown packages without
+adding new policy.
 
 Run with the spec-default config path:
 
@@ -26,6 +27,13 @@ interval. Channel topology mutation remains denied until the Trust Checker is
 implemented. Host launch bindings come only from the shared durable pipeline
 binding store; absent, stale, destroyed, directionally unauthorized, or
 cross-pipeline records fail before process creation.
+
+A non-empty optional `[data_plane]` table is provisioned before serving. Raw
+32-byte channel secrets are loaded through the owner-only no-link reader, model
+tags resolve only to their explicitly configured Ollama clients, and publishes
+receive fresh UUID-v7 identities plus process-monotonic timestamps. Startup does
+not probe model endpoints. An absent or empty table preserves the fail-closed
+unavailable service for existing control-plane-only deployments.
 
 SIGINT, SIGTERM, Ctrl+C, Ctrl+Break, console close, logoff, and system shutdown
 request a cooperative listener stop. Dropping the composed process supervisor

--- a/code/packages/rust/chief-of-staff-daemon/required_capabilities.json
+++ b/code/packages/rust/chief-of-staff-daemon/required_capabilities.json
@@ -12,8 +12,8 @@
     {
       "category": "fs",
       "action": "read",
-      "target": "configured config, public keys, packages, credential, and state paths",
-      "justification": "Loads bounded configuration and composes the existing keyring, package verification, credential, and durable registry adapters."
+      "target": "configured config, public keys, private channel keys, packages, credential, and state paths",
+      "justification": "Loads bounded configuration and composes the keyring, owner-only channel-key provisioning, package verification, credential, and durable registry adapters."
     },
     {
       "category": "fs",
@@ -32,6 +32,12 @@
       "action": "listen",
       "target": "configured loopback address",
       "justification": "Serves the authenticated local WebSocket control API."
+    },
+    {
+      "category": "net",
+      "action": "connect",
+      "target": "explicitly configured Ollama endpoints",
+      "justification": "Executes exact authorized Level 1 completion requests without probing endpoints during startup."
     },
     {
       "category": "proc",

--- a/code/packages/rust/chief-of-staff-daemon/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon/src/lib.rs
@@ -3,19 +3,26 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
+use chief_of_staff_channel_endpoints::{
+    MessageId, MessageMetadata, MessageMetadataError, MessageMetadataSource,
+};
 use chief_of_staff_daemon_api::{BindAddress, DaemonApi, DaemonApiError};
+use chief_of_staff_daemon_authority_provisioning::{
+    provision_authorities, AuthorityProvisioningError,
+};
 use chief_of_staff_daemon_config::{parse_config, ChiefConfig, ConfigError};
 use chief_of_staff_daemon_credential::{load_or_create_credential, CredentialFileError};
 use chief_of_staff_daemon_keyring::{load_package_keyring, KeyringLoadError};
 use chief_of_staff_daemon_policy::{DenyChannelWiring, LocalAuthError, LocalBearerAuthorizer};
 use chief_of_staff_daemon_runtime::{ChiefDaemonRuntime, DaemonRuntimeError, ReconcileSchedule};
 use chief_of_staff_host_data_plane::{
-    DurableHostDataPlaneDispatcher, UnavailableHostDataPlaneService,
+    AuthorityBackedHostDataPlaneService, DurableHostDataPlaneDispatcher, HostDataPlaneService,
+    UnavailableHostDataPlaneService,
 };
 use chief_of_staff_orchestrator_core::OrchestratorCore;
 use chief_of_staff_process_supervisor::{
-    DurableHostLaunchBindings, HostProgram, ProcessSupervisorConfig, ProcessSupervisorError,
-    SystemMonotonicClock, UuidV7SessionIdSource,
+    DurableHostLaunchBindings, HostProgram, MonotonicClock, ProcessSupervisorConfig,
+    ProcessSupervisorError, SystemMonotonicClock, UuidV7SessionIdSource,
 };
 use chief_of_staff_service_reconciler::{ConfigError as ReconcileConfigError, ReconcileConfig};
 use coding_adventures_storage_fs::FsStorageBackend;
@@ -58,6 +65,8 @@ pub enum ChiefDaemonError {
     Config(ConfigError),
     /// A configured trusted package key could not be loaded.
     Keyring(KeyringLoadError),
+    /// Explicit channel-key or model-provider authority provisioning failed.
+    Authority(AuthorityProvisioningError),
     /// The local operator credential could not be loaded or created safely.
     Credential(CredentialFileError),
     /// Local bearer policy construction failed.
@@ -94,6 +103,7 @@ impl Display for ChiefDaemonError {
             Self::ConfigFileEncoding => "chief daemon: config file is not UTF-8",
             Self::Config(_) => "chief daemon: config validation failed",
             Self::Keyring(_) => "chief daemon: package keyring failed",
+            Self::Authority(_) => "chief daemon: data-plane authority provisioning failed",
             Self::Credential(_) => "chief daemon: operator credential failed",
             Self::Authentication(_) => "chief daemon: local authentication policy failed",
             Self::Storage(_) => "chief daemon: durable storage failed",
@@ -254,11 +264,14 @@ pub fn run(config: ChiefConfig, home: &Path) -> Result<(), ChiefDaemonError> {
         ReconcileConfig::new(interval_ns.saturating_mul(HEARTBEAT_GRACE_INTERVALS))
             .map_err(ChiefDaemonError::Reconciliation)?;
     let schedule = ReconcileSchedule::new(interval).map_err(ChiefDaemonError::Runtime)?;
-    let clock = Arc::new(SystemMonotonicClock::new());
+    let clock: Arc<dyn MonotonicClock> = Arc::new(SystemMonotonicClock::new());
     let launch_bindings = Arc::new(DurableHostLaunchBindings::new(Arc::clone(&backend)));
+    let metadata_source: Arc<dyn MessageMetadataSource> =
+        Arc::new(SystemMessageMetadataSource::new(Arc::clone(&clock)));
+    let service = compose_data_plane_service(&config, home, Arc::clone(&backend), metadata_source)?;
     let data_plane = Arc::new(DurableHostDataPlaneDispatcher::new(
         Arc::clone(&backend),
-        Arc::new(UnavailableHostDataPlaneService),
+        service,
     ));
     let core = OrchestratorCore::with_process_supervisor(
         backend,
@@ -278,6 +291,51 @@ pub fn run(config: ChiefConfig, home: &Path) -> Result<(), ChiefDaemonError> {
         config.orchestrator().port(),
     ));
     run_platform(address, api, schedule)
+}
+
+fn compose_data_plane_service(
+    config: &ChiefConfig,
+    home: &Path,
+    backend: Arc<dyn StorageBackend>,
+    metadata_source: Arc<dyn MessageMetadataSource>,
+) -> Result<Arc<dyn HostDataPlaneService>, ChiefDaemonError> {
+    if config.data_plane().channel_keys().is_empty()
+        && config.data_plane().ollama_models().is_empty()
+    {
+        return Ok(Arc::new(UnavailableHostDataPlaneService));
+    }
+    let authorities =
+        provision_authorities(config.data_plane(), home).map_err(ChiefDaemonError::Authority)?;
+    let (channel_keys, models) = authorities.into_parts();
+    Ok(Arc::new(AuthorityBackedHostDataPlaneService::new(
+        backend,
+        Arc::new(channel_keys),
+        Arc::new(models),
+        metadata_source,
+    )))
+}
+
+struct SystemMessageMetadataSource {
+    clock: Arc<dyn MonotonicClock>,
+}
+
+impl SystemMessageMetadataSource {
+    fn new(clock: Arc<dyn MonotonicClock>) -> Self {
+        Self { clock }
+    }
+}
+
+impl MessageMetadataSource for SystemMessageMetadataSource {
+    fn next_metadata(&self) -> Result<MessageMetadata, MessageMetadataError> {
+        let uuid = coding_adventures_uuid::v7()
+            .map_err(|_| MessageMetadataError::new("message identity unavailable"))?;
+        let message_id = MessageId::from_uuid_v7(uuid.bytes())
+            .map_err(|_| MessageMetadataError::new("message identity invalid"))?;
+        Ok(MessageMetadata {
+            message_id,
+            timestamp_ns: self.clock.now_ns(),
+        })
+    }
 }
 
 fn serve<P, C, A>(
@@ -438,6 +496,7 @@ fn same_file(left: &Metadata, right: &Metadata) -> bool {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU64, Ordering};
+    use storage_core::InMemoryStorageBackend;
 
     static NEXT_DIR: AtomicU64 = AtomicU64::new(0);
 
@@ -547,6 +606,40 @@ hardware_key_timeout = 60
         fs::write(&path, VALID_CONFIG).unwrap();
         let config = load_config_file(&path).unwrap();
         assert_eq!(config.orchestrator().port(), 7463);
+    }
+
+    #[test]
+    fn configured_authorities_fail_startup_without_disclosing_secret_paths() {
+        let directory = TestDir::new();
+        let config = parse_config(&format!(
+            "{VALID_CONFIG}\n[data_plane]\nchannel_keys = [\n  {{ pipeline_id = \"018f0c10-7b4a-7cc0-8000-000000000001\", agent_id = \"weather\", channel_id = \"018f0c10-7b4a-7cc0-8000-000000000002\", access = \"read\", private_key_path = \"~/missing-private-key.bin\" }},\n]\nollama_models = []\n"
+        ))
+        .unwrap();
+        let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryStorageBackend::new());
+        let clock: Arc<dyn MonotonicClock> = Arc::new(SystemMonotonicClock::new());
+        let metadata: Arc<dyn MessageMetadataSource> =
+            Arc::new(SystemMessageMetadataSource::new(clock));
+        let Err(error) = compose_data_plane_service(&config, &directory.0, backend, metadata)
+        else {
+            panic!("missing private authority unexpectedly composed");
+        };
+        assert!(matches!(error, ChiefDaemonError::Authority(_)));
+        assert_eq!(
+            error.to_string(),
+            "chief daemon: data-plane authority provisioning failed"
+        );
+        assert!(!error.to_string().contains("missing-private-key.bin"));
+    }
+
+    #[test]
+    fn production_publish_metadata_is_uuid_v7_and_monotonic() {
+        let clock: Arc<dyn MonotonicClock> = Arc::new(SystemMonotonicClock::new());
+        let source = SystemMessageMetadataSource::new(clock);
+        let first = source.next_metadata().unwrap();
+        let second = source.next_metadata().unwrap();
+        assert_eq!(first.message_id.as_bytes()[6] >> 4, 7);
+        assert_eq!(first.message_id.as_bytes()[8] & 0xc0, 0x80);
+        assert!(second.timestamp_ns >= first.timestamp_ns);
     }
 
     #[test]

--- a/code/packages/rust/chief-of-staff-daemon/tests/daemon_smoke.rs
+++ b/code/packages/rust/chief-of-staff-daemon/tests/daemon_smoke.rs
@@ -98,6 +98,12 @@ container = true
 tier_1_auto_approve_timeout = 5
 biometric_timeout = 30
 hardware_key_timeout = 60
+
+[data_plane]
+channel_keys = []
+ollama_models = [
+  {{ model = "qwen2.5:0.5b", endpoint = "http://127.0.0.1:9", timeout = 1000 }},
+]
 "#
     );
     let path = home.join("config.toml");
@@ -106,7 +112,7 @@ hardware_key_timeout = 60
 }
 
 #[test]
-fn daemon_binds_reconciles_and_stops_on_sigterm() {
+fn daemon_provisions_without_network_probe_binds_and_stops_on_sigterm() {
     let directory = TestDir::new();
     let port = TcpListener::bind(("127.0.0.1", 0))
         .unwrap()

--- a/code/packages/rust/chief-of-staff-host-data-plane/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-data-plane/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-- Expose exact model-registry cardinality without exposing provider clients.
-
 ## Unreleased
 
+- Expose exact model-registry cardinality without exposing provider clients.
+- Document production daemon injection for non-empty typed authority declarations.
 - Add an exact zeroizing pipeline/agent/channel key registry for safe production
   provisioning adapters, with fail-closed duplicate, direction, and identity scope.
 

--- a/code/packages/rust/chief-of-staff-host-data-plane/README.md
+++ b/code/packages/rust/chief-of-staff-host-data-plane/README.md
@@ -30,10 +30,10 @@ and releases fresh short-lived crypto owners only when the current durable bindi
 matches all three identities. It deliberately does not read files or define a
 vault format; those are replaceable provisioning adapters.
 
-The production daemon still injects the unavailable service because its closed
-configuration and pipeline-wiring APIs do not yet provision channel custody or
-model providers. A later composition PR must add those explicit operator-owned
-inputs rather than inventing secret storage or a default network endpoint here.
+The production daemon injects this service only for a non-empty typed data-plane
+configuration. It provisions explicit operator-owned channel-key files and exact
+Ollama clients; absent or empty declarations retain the unavailable service. No
+secret format or default network endpoint is invented here.
 
 ## Validation
 

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -540,10 +540,11 @@ binding, immutable claims, active channel topology, directional membership, and
 model settings. It rejects unknown or wrong-direction channel UUIDs and any model
 setting drift before invoking the separately injected channel/LLM service, then
 validates response identity and operation shape before returning it. The
-payload-blind orchestration core receives no request body. Until the provisioned
-authorities are injected into composition, the production daemon uses the same
-authorization boundary with a redacted unavailable service. The reusable
-authority-backed service now executes against the real encrypted durable channel
+payload-blind orchestration core receives no request body. When the optional
+data-plane table is absent or empty, the production daemon uses the same
+authorization boundary with a redacted unavailable service. A non-empty table is
+provisioned at daemon startup and injects the authority-backed service, which
+executes against the real encrypted durable channel
 endpoints, retains a bounded delivery-to-acknowledgement ledger, provisions sealed
 receiver grants before publication, and resolves only exact model selectors. Key
 release and provider construction remain separately injected authorities so the
@@ -553,7 +554,8 @@ The concrete pre-composition key registry owns only zeroizing secret buffers, bi
 each directional key to an exact pipeline, agent, and channel, and releases a new
 short-lived crypto owner only after all three identities match the reloaded durable
 binding. Filesystem and Vault formats remain separate provisioning adapters.
-The file-backed production adapter consumes only the typed declarations above,
+The file-backed production adapter in the concrete daemon consumes only the typed
+declarations above,
 loads raw private material through owner-only no-link exact-length reads, and
 constructs exact Ollama clients without probing the network. A future Vault
 adapter may populate the same registries without changing execution semantics.
@@ -2220,9 +2222,10 @@ contracts. With no arguments it resolves `~/.chief-of-staff/config.toml` from th
 platform user-home environment; one explicit absolute config path is also accepted.
 The config file is bounded to 256 KiB, must remain a regular non-link file throughout
 loading, and is parsed by the closed schema above. Startup then loads the package
-keyring and local credential, initializes the filesystem service registry, constructs
-the verified shell-free host supervisor, binds the authenticated WebSocket API to the
-validated loopback address, reconciles once, and schedules further reconciliation at
+keyring and local credential, initializes the filesystem service registry, provisions
+any non-empty typed data-plane declarations, constructs the verified shell-free host
+supervisor, binds the authenticated WebSocket API to the validated loopback address,
+reconciles once, and schedules further reconciliation at
 `health_check_interval`. Three missed intervals are tolerated before a heartbeat is
 stale. Channel topology mutation remains fail-closed until the Trust Checker exists.
 Unix `SIGINT`/`SIGTERM` and Windows console termination events cooperatively stop the


### PR DESCRIPTION
## Summary

- provision non-empty typed data-plane declarations into the production daemon’s exact channel-key and Ollama authorities
- preserve the fail-closed unavailable service for absent or empty declarations
- mint channel publication metadata with fresh UUID-v7 identities and the daemon’s process-monotonic clock
- prove configured Ollama construction makes no startup network probe with the real daemon subprocess smoke test

## Validation

- 19 focused tests across daemon, provisioning, and the real encrypted data plane
- strict Clippy and rustdoc
- capability taxonomy conformance
- repository dependency-closed gate: 82 built, 1,158 skipped

## Follow-up

- exercise the real Level 1 weather flow through production composition

Progresses #128
Progresses #138