### PR TITLE
Exercise production Level 1 weather flow

### DIFF
--- a/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-daemon/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Expose the exact production host data-plane composition boundary so the real
+  Level 1 child can be exercised against file-provisioned keys, durable encrypted
+  channels, and the configured Ollama adapter in one end-to-end test.
 - Provision non-empty typed data-plane declarations into the production daemon's
   exact channel-key and Ollama authorities, with UUID-v7/process-monotonic publish
   metadata and no startup network probe. Empty declarations remain unavailable.

--- a/code/packages/rust/chief-of-staff-daemon/README.md
+++ b/code/packages/rust/chief-of-staff-daemon/README.md
@@ -35,6 +35,11 @@ receive fresh UUID-v7 identities plus process-monotonic timestamps. Startup does
 not probe model endpoints. An absent or empty table preserves the fail-closed
 unavailable service for existing control-plane-only deployments.
 
+The exported production data-plane composition boundary is also used by the real
+Level 1 host integration test. That test supplies owner-only key files and a
+loopback Ollama fixture, then proves encrypted receive, completion, encrypted
+publish, and input acknowledgement through the same dispatcher used by `run`.
+
 SIGINT, SIGTERM, Ctrl+C, Ctrl+Break, console close, logoff, and system shutdown
 request a cooperative listener stop. Dropping the composed process supervisor
 reaps every child still owned by this daemon instance.

--- a/code/packages/rust/chief-of-staff-daemon/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-daemon/src/lib.rs
@@ -16,8 +16,8 @@ use chief_of_staff_daemon_keyring::{load_package_keyring, KeyringLoadError};
 use chief_of_staff_daemon_policy::{DenyChannelWiring, LocalAuthError, LocalBearerAuthorizer};
 use chief_of_staff_daemon_runtime::{ChiefDaemonRuntime, DaemonRuntimeError, ReconcileSchedule};
 use chief_of_staff_host_data_plane::{
-    AuthorityBackedHostDataPlaneService, DurableHostDataPlaneDispatcher, HostDataPlaneService,
-    UnavailableHostDataPlaneService,
+    AuthorityBackedHostDataPlaneService, DurableHostDataPlaneDispatcher, HostDataPlaneDispatcher,
+    HostDataPlaneService, UnavailableHostDataPlaneService,
 };
 use chief_of_staff_orchestrator_core::OrchestratorCore;
 use chief_of_staff_process_supervisor::{
@@ -266,13 +266,8 @@ pub fn run(config: ChiefConfig, home: &Path) -> Result<(), ChiefDaemonError> {
     let schedule = ReconcileSchedule::new(interval).map_err(ChiefDaemonError::Runtime)?;
     let clock: Arc<dyn MonotonicClock> = Arc::new(SystemMonotonicClock::new());
     let launch_bindings = Arc::new(DurableHostLaunchBindings::new(Arc::clone(&backend)));
-    let metadata_source: Arc<dyn MessageMetadataSource> =
-        Arc::new(SystemMessageMetadataSource::new(Arc::clone(&clock)));
-    let service = compose_data_plane_service(&config, home, Arc::clone(&backend), metadata_source)?;
-    let data_plane = Arc::new(DurableHostDataPlaneDispatcher::new(
-        Arc::clone(&backend),
-        service,
-    ));
+    let data_plane =
+        compose_host_data_plane(&config, home, Arc::clone(&backend), Arc::clone(&clock))?;
     let core = OrchestratorCore::with_process_supervisor(
         backend,
         process_config,
@@ -291,6 +286,26 @@ pub fn run(config: ChiefConfig, home: &Path) -> Result<(), ChiefDaemonError> {
         config.orchestrator().port(),
     ));
     run_platform(address, api, schedule)
+}
+
+/// Compose the exact production host data plane from validated daemon authority.
+///
+/// The returned dispatcher reloads durable pipeline authorization for every
+/// request. Non-empty data-plane declarations provision the file-backed channel
+/// keys and explicit Ollama providers used by [`run`]; absent or empty
+/// declarations retain the redacted unavailable service.
+pub fn compose_host_data_plane(
+    config: &ChiefConfig,
+    home: &Path,
+    backend: Arc<dyn StorageBackend>,
+    clock: Arc<dyn MonotonicClock>,
+) -> Result<Arc<dyn HostDataPlaneDispatcher>, ChiefDaemonError> {
+    let metadata_source: Arc<dyn MessageMetadataSource> =
+        Arc::new(SystemMessageMetadataSource::new(clock));
+    let service = compose_data_plane_service(config, home, Arc::clone(&backend), metadata_source)?;
+    Ok(Arc::new(DurableHostDataPlaneDispatcher::new(
+        backend, service,
+    )))
 }
 
 fn compose_data_plane_service(

--- a/code/packages/rust/chief-of-staff-host/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exercise the real child with durable launch bindings and the daemon's production
+  data-plane composition: owner-only channel keys, encrypted input/output stores,
+  an explicit Ollama provider, publication, and acknowledgement all run together.
 - Add the concrete Level 1 host executable with independent package verification,
   exact authenticated launch-policy matching, serialized channel/model requests,
   bounded idle polling, heartbeats, and graceful authenticated termination.

--- a/code/packages/rust/chief-of-staff-host/Cargo.toml
+++ b/code/packages/rust/chief-of-staff-host/Cargo.toml
@@ -13,14 +13,22 @@ chief-of-staff-skill-runtime = { path = "../chief-of-staff-skill-runtime" }
 llm-gateway = { path = "../llm-gateway" }
 
 [dev-dependencies]
+chief-of-staff-channel-crypto = { path = "../chief-of-staff-channel-crypto" }
+chief-of-staff-channel-endpoints = { path = "../chief-of-staff-channel-endpoints" }
+chief-of-staff-channel-store = { path = "../chief-of-staff-channel-store" }
+chief-of-staff-daemon = { path = "../chief-of-staff-daemon" }
+chief-of-staff-daemon-config = { path = "../chief-of-staff-daemon-config" }
 chief-of-staff-host-data-plane = { path = "../chief-of-staff-host-data-plane" }
+chief-of-staff-pipeline-bindings = { path = "../chief-of-staff-pipeline-bindings" }
 chief-of-staff-secure-host-channel = { path = "../chief-of-staff-secure-host-channel" }
 chief-of-staff-service-reconciler = { path = "../chief-of-staff-service-reconciler" }
 chief-of-staff-service-registry = { path = "../chief-of-staff-service-registry" }
 chief-of-staff-skill-package = { path = "../chief-of-staff-skill-package" }
 chief-of-staff-tool-api = { path = "../chief-of-staff-tool-api" }
 coding_adventures_ed25519 = { path = "../ed25519" }
+coding_adventures_storage_fs = { path = "../storage-fs" }
 coding_adventures_x3dh = { path = "../x3dh" }
+storage-core = { path = "../storage-core" }
 
 [[bin]]
 name = "chief-of-staff-host"

--- a/code/packages/rust/chief-of-staff-host/README.md
+++ b/code/packages/rust/chief-of-staff-host/README.md
@@ -19,6 +19,12 @@ An authenticated `Terminate` received while waiting for any operation is a clean
 exit. Data-plane failures are redacted and terminal for this child, leaving durable
 input acknowledgement unchanged when processing did not finish.
 
+The production integration gate launches this executable with durable pipeline
+bindings, provisions its exact channel keys from owner-only files, sends its model
+request through the daemon's configured Ollama adapter, decrypts the published
+weather report as the authorized sink, and verifies that input acknowledgement is
+persisted only after publication.
+
 The executable rejects `--package-runtime deno` until a separately reviewed Deno
 adapter is composed. It uses no ambient environment configuration and inherits the
 supervisor-selected package directory as its only package location.

--- a/code/packages/rust/chief-of-staff-host/tests/level_one_host.rs
+++ b/code/packages/rust/chief-of-staff-host/tests/level_one_host.rs
@@ -1,3 +1,19 @@
+#[cfg(unix)]
+use chief_of_staff_channel_crypto::{
+    ChannelId, ChannelMasterKey, KeyEpoch, OriginatorSigningKey, ReceiverKeyPair, Sequence,
+};
+#[cfg(unix)]
+use chief_of_staff_channel_endpoints::{
+    AgentId, ChannelDefinition, ChannelDefinitionStore, DurableOriginator, DurableReceiver,
+    MessageId, MessageMetadata, MessageMetadataError, MessageMetadataSource, Originator,
+    OriginatorIdentity, Receiver, ReceiverIdentity,
+};
+#[cfg(unix)]
+use chief_of_staff_channel_store::ChannelStore;
+#[cfg(unix)]
+use chief_of_staff_daemon::compose_host_data_plane;
+#[cfg(unix)]
+use chief_of_staff_daemon_config::parse_config;
 use chief_of_staff_host_control_protocol::{
     ChannelBinding, ChannelBindingAccess, CompletionFinishReason, CompletionProvider,
     CompletionResult, CompletionUsage, DataPlaneFailure, DataPlaneMessage, DataPlaneOperation,
@@ -7,23 +23,39 @@ use chief_of_staff_host_data_plane::HostDataPlaneDispatcher;
 use chief_of_staff_host_runtime::{
     verify_agent_package, AgentPackageRuntime, PackageKeyType, PackageKeyring, TrustedPackageKey,
 };
+#[cfg(unix)]
+use chief_of_staff_pipeline_bindings::{HostPipelineBinding, PipelineBindingStore, PipelineId};
+#[cfg(unix)]
+use chief_of_staff_process_supervisor::DurableHostLaunchBindings;
 use chief_of_staff_process_supervisor::{
     HostLaunchBindingProvider, HostProgram, LaunchBindingProviderError, MonotonicClock,
     ProcessHostSupervisor, ProcessSupervisorConfig, ProcessSupervisorError, SessionIdSource,
 };
 use chief_of_staff_secure_host_channel::SessionId;
 use chief_of_staff_service_reconciler::{HostSupervisor, SupervisorObservation, SupervisorPhase};
+#[cfg(unix)]
+use chief_of_staff_service_registry::{DesiredState, HostEntry, ServiceRegistry};
 use chief_of_staff_service_registry::{HostName, HostRegistration, PackagePath, RestartPolicy};
 use chief_of_staff_skill_package::build_signed_skill_package;
 use chief_of_staff_skill_runtime::LEVEL_ONE_RESPONSE_CONTENT_TYPE;
 use chief_of_staff_tool_api::PrivilegeTier;
 use coding_adventures_ed25519::generate_keypair;
+#[cfg(unix)]
+use coding_adventures_storage_fs::FsStorageBackend;
 use coding_adventures_x3dh::generate_identity_keypair;
+#[cfg(unix)]
+use std::fs;
+#[cfg(unix)]
+use std::io::{Read, Write};
+#[cfg(unix)]
+use std::net::TcpListener;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+#[cfg(unix)]
+use storage_core::StorageBackend;
 
 const TEST_KEY_ID: &str = "level-one-host-test";
 const TEST_SEED: [u8; 32] = [73; 32];
@@ -83,6 +115,132 @@ impl TestPackage {
 impl Drop for TestPackage {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+#[cfg(unix)]
+struct TestHome(PathBuf);
+
+#[cfg(unix)]
+impl TestHome {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "chief-level-one-production-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir(&path).unwrap();
+        Self(path.canonicalize().unwrap())
+    }
+
+    fn write_secret(&self, name: &str, bytes: &[u8]) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let keys = self.0.join("keys");
+        fs::create_dir_all(&keys).unwrap();
+        let path = keys.join(name);
+        fs::write(&path, bytes).unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+}
+
+#[cfg(unix)]
+impl Drop for TestHome {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[cfg(unix)]
+struct FixedMetadata {
+    message_id: [u8; 16],
+    timestamp_ns: u64,
+}
+
+#[cfg(unix)]
+impl MessageMetadataSource for FixedMetadata {
+    fn next_metadata(&self) -> Result<MessageMetadata, MessageMetadataError> {
+        Ok(MessageMetadata {
+            message_id: MessageId::from_uuid_v7(self.message_id)
+                .map_err(|_| MessageMetadataError::new("invalid fixture message ID"))?,
+            timestamp_ns: self.timestamp_ns,
+        })
+    }
+}
+
+#[cfg(unix)]
+struct ScriptedOllama {
+    endpoint: String,
+    request_body: Arc<Mutex<Option<String>>>,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+#[cfg(unix)]
+impl ScriptedOllama {
+    fn spawn() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let request_body = Arc::new(Mutex::new(None));
+        let captured = Arc::clone(&request_body);
+        let join = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0; 4096];
+            let (body_start, content_length) = loop {
+                let count = stream.read(&mut buffer).unwrap();
+                assert!(count > 0, "Ollama fixture request ended before headers");
+                request.extend_from_slice(&buffer[..count]);
+                let Some(header_end) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n")
+                else {
+                    continue;
+                };
+                let headers = std::str::from_utf8(&request[..header_end]).unwrap();
+                assert!(headers.starts_with("POST /api/chat HTTP/1.1\r\n"));
+                let length = headers
+                    .lines()
+                    .find_map(|line| line.strip_prefix("Content-Length:"))
+                    .map(str::trim)
+                    .unwrap()
+                    .parse::<usize>()
+                    .unwrap();
+                break (header_end + 4, length);
+            };
+            while request.len() - body_start < content_length {
+                let count = stream.read(&mut buffer).unwrap();
+                assert!(count > 0, "Ollama fixture request ended before its body");
+                request.extend_from_slice(&buffer[..count]);
+            }
+            *captured.lock().unwrap() = Some(
+                String::from_utf8(request[body_start..body_start + content_length].to_vec())
+                    .unwrap(),
+            );
+
+            let body = r#"{"model":"weather-fixture","message":{"role":"assistant","content":"Bring an umbrella."},"done":true,"done_reason":"stop","prompt_eval_count":12,"eval_count":4}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        Self {
+            endpoint,
+            request_body,
+            join: Some(join),
+        }
+    }
+
+    fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    fn finish(mut self) -> String {
+        self.join.take().unwrap().join().unwrap();
+        let body = self.request_body.lock().unwrap().take().unwrap();
+        body
     }
 }
 
@@ -323,4 +481,232 @@ fn real_level_one_host_runs_one_authenticated_turn_and_terminates_cleanly() {
         SupervisorPhase::Exited { exit_code: Some(0) },
     );
     assert_eq!(dispatcher.operations(), expected);
+}
+
+#[cfg(unix)]
+#[test]
+fn production_composition_runs_encrypted_weather_turn_through_ollama() {
+    let home = TestHome::new();
+    let ollama = ScriptedOllama::spawn();
+    let (package, keyring) = TestPackage::new();
+    let registration = package.registration();
+    let worker = AgentId::new(b"weather-reporter".to_vec()).unwrap();
+    let request_source = AgentId::new(b"weather-request-source".to_vec()).unwrap();
+    let report_sink = AgentId::new(b"weather-report-sink".to_vec()).unwrap();
+    let pipeline_id = PipelineId::new(uuid_v7(9)).unwrap();
+    let input_channel = ChannelId(uuid_v7(1));
+    let output_channel = ChannelId(uuid_v7(2));
+
+    let input_signing = OriginatorSigningKey::from_seed([0x11; 32]);
+    let input_key = ChannelMasterKey::from_bytes([0x12; 32]);
+    let worker_receiver = ReceiverKeyPair::from_private_key([0x13; 32]).unwrap();
+    let worker_signing = OriginatorSigningKey::from_seed([0x21; 32]);
+    let sink_receiver = ReceiverKeyPair::from_private_key([0x23; 32]).unwrap();
+    home.write_secret("weather-receiver.bin", &[0x13; 32]);
+    home.write_secret("weather-signing.bin", &[0x21; 32]);
+    home.write_secret("weather-channel.bin", &[0x22; 32]);
+
+    let backend: Arc<dyn StorageBackend> = Arc::new(FsStorageBackend::new(home.0.join("state")));
+    backend.initialize().unwrap();
+    ServiceRegistry::new(backend.as_ref())
+        .register(&HostEntry::registered(
+            registration.clone(),
+            DesiredState::Running,
+        ))
+        .unwrap();
+    let definitions = ChannelDefinitionStore::new(backend.as_ref());
+    definitions
+        .create(
+            &ChannelDefinition::new(
+                input_channel,
+                OriginatorIdentity {
+                    agent_id: request_source.clone(),
+                    public_key: input_signing.public_key(),
+                },
+                vec![ReceiverIdentity {
+                    agent_id: worker.clone(),
+                    public_key: worker_receiver.public_key(),
+                }],
+                1,
+                KeyEpoch(0),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    definitions
+        .create(
+            &ChannelDefinition::new(
+                output_channel,
+                OriginatorIdentity {
+                    agent_id: worker.clone(),
+                    public_key: worker_signing.public_key(),
+                },
+                vec![ReceiverIdentity {
+                    agent_id: report_sink.clone(),
+                    public_key: sink_receiver.public_key(),
+                }],
+                2,
+                KeyEpoch(0),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    let binding = HostPipelineBinding::new(
+        pipeline_id,
+        registration.clone(),
+        worker.clone(),
+        LaunchBindings::new(
+            vec![
+                ChannelBinding::new(
+                    "weather-requests",
+                    ChannelBindingAccess::Read,
+                    input_channel.0,
+                )
+                .unwrap(),
+                ChannelBinding::new(
+                    "weather-reports",
+                    ChannelBindingAccess::Write,
+                    output_channel.0,
+                )
+                .unwrap(),
+            ],
+            Some(LevelOneModelBinding::new("weather-fixture", 0.0, 128).unwrap()),
+        )
+        .unwrap(),
+    );
+    PipelineBindingStore::new(backend.as_ref())
+        .wire(&binding)
+        .unwrap();
+
+    let input_metadata = FixedMetadata {
+        message_id: uuid_v7(4),
+        timestamp_ns: 10,
+    };
+    let input = DurableOriginator::open(
+        backend.as_ref(),
+        input_channel,
+        &request_source,
+        &input_signing,
+        &input_key,
+        &input_metadata,
+    )
+    .unwrap();
+    input.grant_receiver(&worker).unwrap();
+    input.publish(b"Seattle", "text/plain").unwrap();
+
+    let config = parse_config(&format!(
+        r#"
+[orchestrator]
+bind = "127.0.0.1"
+port = 7463
+packages_dir = "~/agents"
+state_dir = "~/state"
+credential_path = "~/run/operator.credential"
+
+[keyring]
+trusted_keys = [{{ id = "dev", path = "~/keys/dev.pub", type = "developer" }}]
+
+[hosts.defaults]
+restart_policy = "on-failure"
+health_check_interval = 20
+executable = "~/bin/chief-of-staff-host"
+bootstrap_timeout = 3000
+graceful_stop_timeout = 3000
+
+[vault]
+storage_path = "~/vault"
+default_lease_ttl = 30
+container = true
+
+[privilege]
+tier_1_auto_approve_timeout = 5
+biometric_timeout = 30
+hardware_key_timeout = 60
+
+[data_plane]
+channel_keys = [
+  {{ pipeline_id = "00000000-0000-7000-8000-000000000009", agent_id = "weather-reporter", channel_id = "00000000-0000-7000-8000-000000000001", access = "read", private_key_path = "~/keys/weather-receiver.bin" }},
+  {{ pipeline_id = "00000000-0000-7000-8000-000000000009", agent_id = "weather-reporter", channel_id = "00000000-0000-7000-8000-000000000002", access = "write", signing_seed_path = "~/keys/weather-signing.bin", channel_key_path = "~/keys/weather-channel.bin" }},
+]
+ollama_models = [
+  {{ model = "weather-fixture", endpoint = "{}", timeout = 3000 }},
+]
+"#,
+        ollama.endpoint()
+    ))
+    .unwrap();
+    let clock: Arc<dyn MonotonicClock> = Arc::new(TestClock::default());
+    let dispatcher =
+        compose_host_data_plane(&config, &home.0, Arc::clone(&backend), Arc::clone(&clock))
+            .unwrap();
+    let launch_bindings = Arc::new(DurableHostLaunchBindings::new(Arc::clone(&backend)));
+    let program = HostProgram::new(
+        env!("CARGO_BIN_EXE_chief-of-staff-host"),
+        std::iter::empty::<&str>(),
+    )
+    .unwrap();
+    let process_config =
+        ProcessSupervisorConfig::new(program, Duration::from_secs(3), Duration::from_secs(3))
+            .unwrap();
+    let mut supervisor = ProcessHostSupervisor::new(
+        process_config,
+        Arc::new(keyring),
+        launch_bindings,
+        Arc::new(generate_identity_keypair()),
+        clock,
+        Box::new(TestSessions(0)),
+    )
+    .with_data_plane_dispatcher(dispatcher);
+    let mut sink =
+        DurableReceiver::open(backend.as_ref(), output_channel, report_sink, sink_receiver)
+            .unwrap();
+
+    supervisor.start(&registration).unwrap();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let report = loop {
+        let observation = supervisor.inspect(&registration).unwrap();
+        let mut reports = sink.receive(1).unwrap();
+        if let Some(report) = reports.pop() {
+            break report;
+        }
+        assert!(
+            !matches!(
+                observation,
+                SupervisorObservation::Instance(ref instance)
+                    if matches!(instance.phase(), SupervisorPhase::Exited { .. })
+            ),
+            "production Level 1 host exited before publishing"
+        );
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for production Level 1 weather report"
+        );
+        thread::sleep(Duration::from_millis(10));
+    };
+    assert_eq!(report.payload, b"Bring an umbrella.");
+    assert_eq!(report.content_type, LEVEL_ONE_RESPONSE_CONTENT_TYPE);
+
+    while ChannelStore::new(backend.as_ref(), input_channel)
+        .receiver_cursor(worker.as_bytes())
+        .unwrap()
+        != Sequence(1)
+    {
+        supervisor.inspect(&registration).unwrap();
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for production input acknowledgement"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    supervisor.stop(registration.host_name()).unwrap();
+    await_phase(
+        &mut supervisor,
+        &registration,
+        SupervisorPhase::Exited { exit_code: Some(0) },
+    );
+    let request = ollama.finish();
+    assert!(request.contains("\"model\":\"weather-fixture\""));
+    assert!(request.contains("Weather Reporter"));
+    assert!(request.contains("\"content\":\"Seattle\""));
 }

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -559,6 +559,12 @@ declarations above,
 loads raw private material through owner-only no-link exact-length reads, and
 constructs exact Ollama clients without probing the network. A future Vault
 adapter may populate the same registries without changing execution semantics.
+The production Level 1 integration gate joins these boundaries with the real host
+process, durable launch binding, encrypted request and report channels, a loopback
+Ollama wire fixture, and the publish-before-acknowledge invariant. The fixture
+substitutes only the model server's response; package verification, process
+control, authorization, key provisioning, channel crypto, and persistence remain
+the production implementations.
 
 ```
 ┌────────────────────────────────────────────────────────────────┐


### PR DESCRIPTION
## Summary

- expose and reuse the daemon’s exact production host data-plane composition boundary
- join the real Level 1 child, durable launch bindings, owner-only channel-key provisioning, encrypted channels, and configured Ollama adapter
- prove encrypted receive -> completion -> encrypted publish -> acknowledgement with only the loopback model-server response stubbed

## Validation

- `cargo fmt -p chief-of-staff-daemon -p chief-of-staff-host -- --check`
- `cargo test -p chief-of-staff-daemon -p chief-of-staff-host`
- `cargo clippy -p chief-of-staff-daemon -p chief-of-staff-host --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p chief-of-staff-daemon -p chief-of-staff-host --no-deps`
- capability taxonomy unit suite (7 tests)
- dependency-closed build plan (82 affected Rust packages)
- `git diff --check`

Progresses #128
Progresses #138