### PR TITLE
Add Enphase pseudonym-key rotation

### DIFF
--- a/code/packages/rust/smart-home-enphase-envoy-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-enphase-envoy-integration/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.0
+
+- Add host-owned Enphase inverter pseudonym-key rotation over one bounded
+  authenticated production response and two atomically consumed one-shot key
+  leases.
+- Derive exact old/new inverter correspondence while raw serials remain in the
+  zeroizing response tree, then dispose both keys before runtime migration.
+- Persist complete gateway, meter, and inverter identity replacement through
+  the runtime store's expected-revision CAS path, rejecting stale automation
+  references before live state changes.
+
 ## 0.2.0
 
 - Add authenticated per-microinverter production inspection over Enphase's

--- a/code/packages/rust/smart-home-enphase-envoy-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-enphase-envoy-integration/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "smart-home-enphase-envoy-integration"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Authenticated local Enphase IQ Gateway aggregate and pseudonymous per-inverter telemetry inspection"
 license = "MIT"
 
 [dependencies]
+coding_adventures_vault_leases = { path = "../vault-leases" }
 coding_adventures_zeroize = { path = "../zeroize" }
 coding_adventures_sha256 = { path = "../sha256" }
 http-core = { path = "../http-core" }
@@ -16,5 +17,10 @@ smart-home-data-governance = { path = "../smart-home-data-governance" }
 smart-home-discovery = { path = "../smart-home-discovery" }
 smart-home-local-http = { path = "../smart-home-local-http" }
 smart-home-runtime = { path = "../smart-home-runtime" }
+smart-home-runtime-store = { path = "../smart-home-runtime-store" }
+storage-core = { path = "../storage-core" }
 tls-platform = { path = "../tls-platform" }
 url-parser = { path = "../url-parser" }
+
+[dev-dependencies]
+storage-local-folder = { path = "../storage-local-folder" }

--- a/code/packages/rust/smart-home-enphase-envoy-integration/README.md
+++ b/code/packages/rust/smart-home-enphase-envoy-integration/README.md
@@ -24,6 +24,15 @@ zeroizing response tree and never enter entity IDs, metadata, state, logs, or
 debug output. Confirmed inverter entities expose only last/max reported active
 power, device type, and last-report time under the pseudonym.
 
+Identifier-key rotation consumes the source and destination 32-byte leases as
+one atomic batch, reads the inverter endpoint exactly once, and derives only
+old/new pseudonym pairs from the zeroizing response. The host requires exact
+correspondence with every installed inverter before building a whole-device
+replacement, including deterministic replacement identities for the gateway's
+meter entities. Both keys and all native serial values are disposed before the
+revision-guarded runtime-store migration begins. Opaque automation definitions
+or state that still reference a source identity cause the durable write and
+live runtime swap to fail closed.
+
 Cloud login, token generation or renewal, legacy gateway authentication,
-pseudonym-key rotation or identity migration, live battery or relay topology,
-and control APIs remain outside this package.
+live battery or relay topology, and control APIs remain outside this package.

--- a/code/packages/rust/smart-home-enphase-envoy-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-enphase-envoy-integration/src/lib.rs
@@ -3,6 +3,7 @@
 #![forbid(unsafe_code)]
 
 use coding_adventures_sha256::sha256;
+use coding_adventures_vault_leases::{LeaseError, LeaseId, LeaseManager};
 use coding_adventures_zeroize::{Zeroize, Zeroizing};
 use http1::{parse_response_head, Http1ParseError};
 use http_core::{BodyKind, Header};
@@ -24,12 +25,19 @@ use smart_home_local_http::{
     LocalHttpAuth, LocalHttpEndpoint, LocalHttpError, LocalHttpMethod, LocalHttpRequestPlan,
     LocalHttpRequestTemplate, LocalHttpScheme,
 };
-use smart_home_runtime::{RuntimeError, SmartHomeRuntime};
+use smart_home_runtime::{
+    RetainedDeviceIdentityReplacement, RetainedEntityIdentityReplacement, RuntimeError,
+    RuntimeRetainedIdentityMigration, RuntimeRetainedIdentityMigrationReport, SmartHomeRuntime,
+};
+use smart_home_runtime_store::{
+    DurableAutomationDefinition, RuntimeStoreError, SmartHomeRuntimeStore,
+};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::time::Duration;
+use storage_core::{Revision, StorageBackend};
 use tls_platform::{default_connector, TlsConfig, TlsConnector};
 use url_parser::{Url, UrlError};
 
@@ -68,6 +76,8 @@ pub enum EnphaseError {
     MissingField(&'static str),
     DataGovernanceDenied(DataGovernanceDenial),
     Runtime(RuntimeError),
+    RuntimeStore(RuntimeStoreError),
+    Lease(LeaseError),
 }
 
 impl fmt::Display for EnphaseError {
@@ -98,6 +108,8 @@ impl fmt::Display for EnphaseError {
                 )
             }
             Self::Runtime(error) => error.fmt(formatter),
+            Self::RuntimeStore(error) => error.fmt(formatter),
+            Self::Lease(error) => write!(formatter, "Enphase identifier-key lease failed: {error}"),
         }
     }
 }
@@ -125,6 +137,18 @@ impl From<serde_json::Error> for EnphaseError {
 impl From<RuntimeError> for EnphaseError {
     fn from(error: RuntimeError) -> Self {
         Self::Runtime(error)
+    }
+}
+
+impl From<RuntimeStoreError> for EnphaseError {
+    fn from(error: RuntimeStoreError) -> Self {
+        Self::RuntimeStore(error)
+    }
+}
+
+impl From<LeaseError> for EnphaseError {
+    fn from(error: LeaseError) -> Self {
+        Self::Lease(error)
     }
 }
 
@@ -304,6 +328,59 @@ pub struct EnphaseInverter {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnphaseInverterIdentityRotation {
+    pub source_pseudonym: String,
+    pub destination_pseudonym: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnphaseIdentifierKeyRotationReport {
+    pub rotated_inverters: usize,
+    pub migration: RuntimeRetainedIdentityMigrationReport,
+    pub revision: Revision,
+}
+
+pub struct EnphaseIdentifierKeyRotationRequest<'a> {
+    pub principal_id: AgentId,
+    pub source_key_lease_id: &'a LeaseId,
+    pub destination_key_lease_id: &'a LeaseId,
+    pub automation_definitions: &'a [DurableAutomationDefinition],
+    pub automation_state: Option<JsonValue>,
+    pub observed_at_ms: u64,
+    pub expected_revision: Revision,
+}
+
+impl<'a> EnphaseIdentifierKeyRotationRequest<'a> {
+    pub fn new(
+        principal_id: AgentId,
+        source_key_lease_id: &'a LeaseId,
+        destination_key_lease_id: &'a LeaseId,
+        observed_at_ms: u64,
+        expected_revision: Revision,
+    ) -> Self {
+        Self {
+            principal_id,
+            source_key_lease_id,
+            destination_key_lease_id,
+            automation_definitions: &[],
+            automation_state: None,
+            observed_at_ms,
+            expected_revision,
+        }
+    }
+
+    pub fn with_automation_context(
+        mut self,
+        automation_definitions: &'a [DurableAutomationDefinition],
+        automation_state: Option<JsonValue>,
+    ) -> Self {
+        self.automation_definitions = automation_definitions;
+        self.automation_state = automation_state;
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnphaseRequestPlans {
     pub meters: LocalHttpRequestPlan,
     pub readings: LocalHttpRequestPlan,
@@ -326,6 +403,19 @@ pub trait EnphaseTransport {
     ) -> Result<Vec<EnphaseInverter>, EnphaseError> {
         Err(EnphaseError::Validation(
             "transport does not implement per-inverter inspection".to_string(),
+        ))
+    }
+
+    fn inspect_inverter_identity_rotation(
+        &mut self,
+        _plan: &LocalHttpRequestPlan,
+        _token: &EnphaseAccessToken,
+        _source_key: &EnphaseIdentifierKey,
+        _destination_key: &EnphaseIdentifierKey,
+        _gateway_serial: &str,
+    ) -> Result<Vec<EnphaseInverterIdentityRotation>, EnphaseError> {
+        Err(EnphaseError::Validation(
+            "transport does not implement per-inverter identity rotation".to_string(),
         ))
     }
 }
@@ -456,6 +546,18 @@ impl EnphaseTransport for EnphaseLanTransport {
         let response = self.get_sensitive_json(plan, token, "inverter production")?;
         parse_inverters(&response.0, identifier_key, gateway_serial)
     }
+
+    fn inspect_inverter_identity_rotation(
+        &mut self,
+        plan: &LocalHttpRequestPlan,
+        token: &EnphaseAccessToken,
+        source_key: &EnphaseIdentifierKey,
+        destination_key: &EnphaseIdentifierKey,
+        gateway_serial: &str,
+    ) -> Result<Vec<EnphaseInverterIdentityRotation>, EnphaseError> {
+        let response = self.get_sensitive_json(plan, token, "inverter production")?;
+        parse_inverter_identity_rotation(&response.0, source_key, destination_key, gateway_serial)
+    }
 }
 
 pub struct EnphaseClient<T> {
@@ -523,6 +625,20 @@ impl<T: EnphaseTransport> EnphaseClient<T> {
             &self.config.gateway_serial,
         )?;
         Ok(snapshot)
+    }
+
+    fn inspect_inverter_identity_rotation(
+        &mut self,
+        source_key: &EnphaseIdentifierKey,
+        destination_key: &EnphaseIdentifierKey,
+    ) -> Result<Vec<EnphaseInverterIdentityRotation>, EnphaseError> {
+        self.transport.inspect_inverter_identity_rotation(
+            &self.plans.inverters,
+            &self.token,
+            source_key,
+            destination_key,
+            &self.config.gateway_serial,
+        )
     }
 }
 
@@ -593,6 +709,84 @@ impl<T: EnphaseTransport> EnphaseRuntimeIntegration<T> {
         )?;
         let snapshot = self.client.inspect_with_inverters()?;
         install_snapshot(runtime, &self.client.config, &snapshot, observed_at_ms)
+    }
+
+    pub fn rotate_inverter_identifier_key_authorized<B, L>(
+        &mut self,
+        runtime: &mut SmartHomeRuntime,
+        store: &SmartHomeRuntimeStore<B>,
+        leases: &L,
+        request: EnphaseIdentifierKeyRotationRequest<'_>,
+    ) -> Result<EnphaseIdentifierKeyRotationReport, EnphaseError>
+    where
+        B: StorageBackend,
+        L: LeaseManager + ?Sized,
+    {
+        if request.source_key_lease_id == request.destination_key_lease_id {
+            return Err(EnphaseError::Validation(
+                "source and destination identifier-key leases must be distinct".to_string(),
+            ));
+        }
+        authorize_read(
+            runtime,
+            request.principal_id.clone(),
+            request.observed_at_ms,
+        )?;
+        authorize_identifier_inspection(
+            &self.data_governance,
+            &request.principal_id,
+            &self.client.config.gateway_serial,
+            request.observed_at_ms,
+        )?;
+
+        let mut payloads = leases.consume_many(&[
+            request.source_key_lease_id.clone(),
+            request.destination_key_lease_id.clone(),
+        ])?;
+        let destination_payload = payloads
+            .pop()
+            .expect("two requested leases return two ordered payloads");
+        let source_payload = payloads
+            .pop()
+            .expect("two requested leases return two ordered payloads");
+        let source_key = EnphaseIdentifierKey::new(source_payload.as_bytes().to_vec())?;
+        let destination_key = EnphaseIdentifierKey::new(destination_payload.as_bytes().to_vec())?;
+        drop(source_payload);
+        drop(destination_payload);
+        if source_key.bytes.as_slice() == destination_key.bytes.as_slice() {
+            return Err(EnphaseError::Validation(
+                "destination identifier key must differ from the source key".to_string(),
+            ));
+        }
+
+        let destination_namespace =
+            gateway_identity_pseudonym(&destination_key, &self.client.config.gateway_serial);
+        let rotations = self
+            .client
+            .inspect_inverter_identity_rotation(&source_key, &destination_key)?;
+        drop(source_key);
+        drop(destination_key);
+
+        let rotated_inverters = rotations.len();
+        let migration = build_inverter_identity_migration(
+            runtime,
+            &self.client.config,
+            &rotations,
+            &destination_namespace,
+        )?;
+        let (migration, revision) = store.migrate_retained_identities(
+            runtime,
+            &migration,
+            request.automation_definitions,
+            request.automation_state,
+            request.observed_at_ms,
+            request.expected_revision,
+        )?;
+        Ok(EnphaseIdentifierKeyRotationReport {
+            rotated_inverters,
+            migration,
+            revision,
+        })
     }
 }
 
@@ -962,44 +1156,98 @@ fn parse_inverters(
     let mut seen = BTreeSet::new();
     let mut inverters = Vec::with_capacity(values.len());
     for value in values {
-        let inverter = value
-            .as_object()
-            .ok_or(EnphaseError::MissingField("inverter production object"))?;
-        let serial = inverter
-            .get("serialNumber")
-            .and_then(JsonValue::as_str)
-            .ok_or(EnphaseError::MissingField("serialNumber"))?;
-        if serial.is_empty()
-            || serial.len() > 64
-            || !serial.bytes().all(|byte| byte.is_ascii_digit())
-        {
-            return Err(EnphaseError::Validation(
-                "microinverter serial must be bounded decimal text".to_string(),
-            ));
-        }
+        let (serial, last_report_date, device_type, last_report_watts, max_report_watts) =
+            parse_inverter_record(value)?;
         let pseudonym = inverter_pseudonym(identifier_key, gateway_serial, serial);
         if !seen.insert(pseudonym.clone()) {
             return Err(EnphaseError::Validation(
                 "duplicate microinverter identifier".to_string(),
             ));
         }
-        let last_report_watts = required_nonnegative_f64(inverter, "lastReportWatts")?;
-        let max_report_watts = required_nonnegative_f64(inverter, "maxReportWatts")?;
-        if last_report_watts > max_report_watts {
-            return Err(EnphaseError::Validation(
-                "microinverter last report exceeds its maximum report".to_string(),
-            ));
-        }
         inverters.push(EnphaseInverter {
             pseudonym,
-            last_report_date: required_u64(inverter, "lastReportDate")?,
-            device_type: required_u64(inverter, "devType")?,
+            last_report_date,
+            device_type,
             last_report_watts,
             max_report_watts,
         });
     }
     inverters.sort_by(|left, right| left.pseudonym.cmp(&right.pseudonym));
     Ok(inverters)
+}
+
+fn parse_inverter_identity_rotation(
+    data: &JsonValue,
+    source_key: &EnphaseIdentifierKey,
+    destination_key: &EnphaseIdentifierKey,
+    gateway_serial: &str,
+) -> Result<Vec<EnphaseInverterIdentityRotation>, EnphaseError> {
+    let values = data
+        .as_array()
+        .ok_or(EnphaseError::MissingField("inverter production array"))?;
+    if values.is_empty() || values.len() > MAX_INVERTERS {
+        return Err(EnphaseError::Validation(format!(
+            "inverter rotation response must contain 1-{MAX_INVERTERS} entries"
+        )));
+    }
+    let mut source_pseudonyms = BTreeSet::new();
+    let mut destination_pseudonyms = BTreeSet::new();
+    let mut rotations = Vec::with_capacity(values.len());
+    for value in values {
+        let (serial, _, _, _, _) = parse_inverter_record(value)?;
+        let source_pseudonym = inverter_pseudonym(source_key, gateway_serial, serial);
+        let destination_pseudonym = inverter_pseudonym(destination_key, gateway_serial, serial);
+        if source_pseudonym == destination_pseudonym {
+            return Err(EnphaseError::Validation(
+                "identifier-key rotation produced an unchanged pseudonym".to_string(),
+            ));
+        }
+        if !source_pseudonyms.insert(source_pseudonym.clone()) {
+            return Err(EnphaseError::Validation(
+                "duplicate source microinverter identifier".to_string(),
+            ));
+        }
+        if !destination_pseudonyms.insert(destination_pseudonym.clone()) {
+            return Err(EnphaseError::Validation(
+                "duplicate destination microinverter identifier".to_string(),
+            ));
+        }
+        rotations.push(EnphaseInverterIdentityRotation {
+            source_pseudonym,
+            destination_pseudonym,
+        });
+    }
+    rotations.sort_by(|left, right| left.source_pseudonym.cmp(&right.source_pseudonym));
+    Ok(rotations)
+}
+
+fn parse_inverter_record(value: &JsonValue) -> Result<(&str, u64, u64, f64, f64), EnphaseError> {
+    let inverter = value
+        .as_object()
+        .ok_or(EnphaseError::MissingField("inverter production object"))?;
+    let serial = inverter
+        .get("serialNumber")
+        .and_then(JsonValue::as_str)
+        .ok_or(EnphaseError::MissingField("serialNumber"))?;
+    if serial.is_empty() || serial.len() > 64 || !serial.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(EnphaseError::Validation(
+            "microinverter serial must be bounded decimal text".to_string(),
+        ));
+    }
+    let last_report_watts = required_nonnegative_f64(inverter, "lastReportWatts")?;
+    let max_report_watts = required_nonnegative_f64(inverter, "maxReportWatts")?;
+    if last_report_watts > max_report_watts {
+        return Err(EnphaseError::Validation(
+            "microinverter last report exceeds its maximum report".to_string(),
+        ));
+    }
+    Ok((
+        serial,
+        required_u64(inverter, "lastReportDate")?,
+        required_u64(inverter, "devType")?,
+        last_report_watts,
+        max_report_watts,
+    ))
 }
 
 fn required_nonnegative_f64(
@@ -1032,6 +1280,166 @@ fn inverter_pseudonym(
     input.extend_from_slice(inverter_serial.as_bytes());
     let digest = Zeroizing::new(sha256(input.as_slice()));
     lowercase_hex(&digest[..16])
+}
+
+fn gateway_identity_pseudonym(
+    identifier_key: &EnphaseIdentifierKey,
+    gateway_serial: &str,
+) -> String {
+    let mut input = Zeroizing::new(Vec::with_capacity(
+        identifier_key.bytes.len() + gateway_serial.len() + 32,
+    ));
+    input.extend_from_slice(identifier_key.bytes.as_slice());
+    input.extend_from_slice(b"enphase-gateway-identity-v1\0");
+    input.extend_from_slice(gateway_serial.as_bytes());
+    let digest = Zeroizing::new(sha256(input.as_slice()));
+    lowercase_hex(&digest[..16])
+}
+
+fn build_inverter_identity_migration(
+    runtime: &SmartHomeRuntime,
+    config: &EnphaseConfig,
+    rotations: &[EnphaseInverterIdentityRotation],
+    destination_namespace: &str,
+) -> Result<RuntimeRetainedIdentityMigration, EnphaseError> {
+    if rotations.is_empty() {
+        return Err(EnphaseError::Validation(
+            "identifier-key rotation requires at least one microinverter".to_string(),
+        ));
+    }
+    let source_devices = runtime
+        .registry()
+        .devices()
+        .filter(|device| {
+            device.bridge_id == config.bridge_id
+                && device.identifiers.iter().any(|identifier| {
+                    identifier.family == ProtocolFamily::Vendor(PROTOCOL_ID.to_string())
+                        && identifier.kind == "gateway_serial"
+                        && identifier.value == config.gateway_serial
+                })
+        })
+        .collect::<Vec<_>>();
+    let [source_device] = source_devices.as_slice() else {
+        return Err(EnphaseError::Validation(
+            "rotation requires exactly one installed Enphase gateway for the configured serial"
+                .to_string(),
+        ));
+    };
+
+    let destination_device_id = DeviceId::trusted(format!("enphase:{destination_namespace}"));
+    let mut destinations_by_source = rotations
+        .iter()
+        .map(|rotation| {
+            (
+                rotation.source_pseudonym.clone(),
+                rotation.destination_pseudonym.clone(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    if destinations_by_source.len() != rotations.len() {
+        return Err(EnphaseError::Validation(
+            "rotation response contains duplicate source pseudonyms".to_string(),
+        ));
+    }
+
+    let mut entity_replacements = Vec::with_capacity(source_device.entity_ids.len());
+    let mut destination_entity_ids = Vec::with_capacity(source_device.entity_ids.len());
+    let mut matched_inverters = 0usize;
+    for source_entity_id in &source_device.entity_ids {
+        let source_entity = runtime.registry().entity(source_entity_id).ok_or_else(|| {
+            EnphaseError::Validation(format!(
+                "installed gateway references missing entity {source_entity_id}"
+            ))
+        })?;
+        let mut replacement = source_entity.clone();
+        replacement.device_id = destination_device_id.clone();
+        replacement.state = None;
+
+        let destination_entity_id = if metadata_value(
+            &source_entity.metadata,
+            "enphase.identifier_form",
+        ) == Some("keyed_pseudonym")
+        {
+            let source_pseudonym =
+                metadata_value(&source_entity.metadata, "enphase.inverter_pseudonym").ok_or_else(
+                    || {
+                        EnphaseError::Validation(format!(
+                            "inverter entity {source_entity_id} is missing its source pseudonym"
+                        ))
+                    },
+                )?;
+            let destination_pseudonym =
+                destinations_by_source.remove(source_pseudonym).ok_or_else(|| {
+                    EnphaseError::Validation(format!(
+                        "inverter response does not correspond to installed entity {source_entity_id}"
+                    ))
+                })?;
+            replacement.name = format!("Enphase microinverter {}", &destination_pseudonym[..8]);
+            set_metadata(
+                &mut replacement.metadata,
+                "enphase.inverter_pseudonym",
+                &destination_pseudonym,
+            );
+            matched_inverters = matched_inverters.saturating_add(1);
+            EntityId::trusted(format!(
+                "enphase:{destination_namespace}:inverter:{destination_pseudonym}"
+            ))
+        } else if let Some(eid) = metadata_value(&source_entity.metadata, "enphase.eid") {
+            if eid.is_empty() || !eid.bytes().all(|byte| byte.is_ascii_digit()) {
+                return Err(EnphaseError::Validation(format!(
+                    "meter entity {source_entity_id} has an invalid native EID"
+                )));
+            }
+            EntityId::trusted(format!("enphase:{destination_namespace}:meter:{eid}"))
+        } else {
+            return Err(EnphaseError::Validation(format!(
+                "installed Enphase entity {source_entity_id} has no governed identity form"
+            )));
+        };
+        replacement.entity_id = destination_entity_id.clone();
+        destination_entity_ids.push(destination_entity_id);
+        entity_replacements.push(RetainedEntityIdentityReplacement::new(
+            source_entity_id.clone(),
+            replacement,
+        ));
+    }
+    if matched_inverters != rotations.len() || !destinations_by_source.is_empty() {
+        return Err(EnphaseError::Validation(
+            "inverter response does not exactly match the installed pseudonymous inverter set"
+                .to_string(),
+        ));
+    }
+
+    let mut replacement_device = (**source_device).clone();
+    replacement_device.device_id = destination_device_id;
+    replacement_device.entity_ids = destination_entity_ids;
+    set_metadata(
+        &mut replacement_device.metadata,
+        "enphase.identifier_namespace",
+        destination_namespace,
+    );
+    Ok(RuntimeRetainedIdentityMigration::new(vec![
+        RetainedDeviceIdentityReplacement::new(
+            source_device.device_id.clone(),
+            replacement_device,
+            entity_replacements,
+        ),
+    ]))
+}
+
+fn metadata_value<'a>(metadata: &'a [Metadata], key: &str) -> Option<&'a str> {
+    metadata
+        .iter()
+        .find(|entry| entry.key == key)
+        .map(|entry| entry.value.as_str())
+}
+
+fn set_metadata(metadata: &mut Vec<Metadata>, key: &str, value: &str) {
+    if let Some(entry) = metadata.iter_mut().find(|entry| entry.key == key) {
+        entry.value = value.to_string();
+    } else {
+        metadata.push(Metadata::new(key, value));
+    }
 }
 
 fn lowercase_hex(bytes: &[u8]) -> String {
@@ -1508,14 +1916,19 @@ fn find_crlf(bytes: &[u8], start: usize) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use coding_adventures_vault_leases::{InMemoryLeaseManager, LeasePayload, LeaseStatus};
     use smart_home_core::{CapabilityGrant, CapabilityGrantId, PrivilegeTier};
     use smart_home_data_governance::{ConsentReceiptRef, DataPurpose, DataUseGrant};
     use std::net::TcpListener;
+    use std::path::PathBuf;
     use std::sync::mpsc;
     use std::thread;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use storage_local_folder::LocalFolderStorageBackend;
 
     const TOKEN: &str = "eyJhbGciOiJFUzI1NiJ9.test.signature";
     const IDENTIFIER_KEY: [u8; 32] = [0x5a; 32];
+    const ROTATED_IDENTIFIER_KEY: [u8; 32] = [0x6b; 32];
     const INVERTER_SERIAL_1: &str = "121935144671";
     const INVERTER_SERIAL_2: &str = "121935144623";
 
@@ -1644,6 +2057,30 @@ mod tests {
             )
             .unwrap();
         policy
+    }
+
+    fn temp_root(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "smart-home-enphase-{name}-{}-{unique}",
+            std::process::id()
+        ))
+    }
+
+    fn installed_inverter_runtime(
+        base_url: &str,
+    ) -> (SmartHomeRuntime, AgentId, InstalledEnphaseGateway) {
+        let (mut runtime, principal) = authorized_runtime();
+        let key = EnphaseIdentifierKey::new(IDENTIFIER_KEY.to_vec()).unwrap();
+        let values = SensitiveJson(inverter_production());
+        let mut installed_snapshot = snapshot();
+        installed_snapshot.inverters = parse_inverters(&values.0, &key, "122233344455").unwrap();
+        let installed =
+            install_snapshot(&mut runtime, &config(base_url), &installed_snapshot, 4_000).unwrap();
+        (runtime, principal, installed)
     }
 
     #[test]
@@ -1860,6 +2297,285 @@ mod tests {
             ))
         ));
         assert_eq!(integration.client.transport.calls, 0);
+    }
+
+    struct RotationCountingTransport {
+        calls: usize,
+    }
+
+    impl EnphaseTransport for RotationCountingTransport {
+        fn inspect(
+            &mut self,
+            _plans: &EnphaseRequestPlans,
+            _token: &EnphaseAccessToken,
+        ) -> Result<EnphaseSnapshot, EnphaseError> {
+            Ok(snapshot())
+        }
+
+        fn inspect_inverter_identity_rotation(
+            &mut self,
+            _plan: &LocalHttpRequestPlan,
+            _token: &EnphaseAccessToken,
+            source_key: &EnphaseIdentifierKey,
+            destination_key: &EnphaseIdentifierKey,
+            gateway_serial: &str,
+        ) -> Result<Vec<EnphaseInverterIdentityRotation>, EnphaseError> {
+            self.calls = self.calls.saturating_add(1);
+            parse_inverter_identity_rotation(
+                &inverter_production(),
+                source_key,
+                destination_key,
+                gateway_serial,
+            )
+        }
+    }
+
+    #[test]
+    fn rotation_without_identifier_consent_consumes_no_key_and_reaches_no_transport() {
+        let (mut runtime, principal, _) = installed_inverter_runtime("http://127.0.0.1:1");
+        let root = temp_root("rotation-consent-denial");
+        let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+        let revision = store.save(&runtime, &[], 4_000).unwrap();
+        let leases = InMemoryLeaseManager::new();
+        let source_lease = leases
+            .issue(LeasePayload::new(IDENTIFIER_KEY.to_vec()), 60_000)
+            .unwrap();
+        let destination_lease = leases
+            .issue(LeasePayload::new(ROTATED_IDENTIFIER_KEY.to_vec()), 60_000)
+            .unwrap();
+        let client = EnphaseClient::new(
+            config("http://127.0.0.1:1"),
+            EnphaseAccessToken::new(TOKEN).unwrap(),
+            RotationCountingTransport { calls: 0 },
+        )
+        .unwrap();
+        let mut integration = EnphaseRuntimeIntegration::new(client);
+
+        assert!(matches!(
+            integration.rotate_inverter_identifier_key_authorized(
+                &mut runtime,
+                &store,
+                &leases,
+                EnphaseIdentifierKeyRotationRequest::new(
+                    principal,
+                    &source_lease,
+                    &destination_lease,
+                    5_000,
+                    revision,
+                ),
+            ),
+            Err(EnphaseError::DataGovernanceDenied(
+                DataGovernanceDenial::NoMatchingConsent
+            ))
+        ));
+        assert_eq!(integration.client.transport.calls, 0);
+        assert_eq!(
+            leases.consume(&source_lease).unwrap().as_bytes(),
+            IDENTIFIER_KEY
+        );
+        assert_eq!(
+            leases.consume(&destination_lease).unwrap().as_bytes(),
+            ROTATED_IDENTIFIER_KEY
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rotation_parser_derives_exact_old_and_new_pseudonyms_without_serials() {
+        let source_key = EnphaseIdentifierKey::new(IDENTIFIER_KEY.to_vec()).unwrap();
+        let destination_key = EnphaseIdentifierKey::new(ROTATED_IDENTIFIER_KEY.to_vec()).unwrap();
+        let values = SensitiveJson(inverter_production());
+
+        let rotations = parse_inverter_identity_rotation(
+            &values.0,
+            &source_key,
+            &destination_key,
+            "122233344455",
+        )
+        .unwrap();
+
+        assert_eq!(rotations.len(), 2);
+        assert!(rotations.iter().all(|rotation| {
+            rotation.source_pseudonym.len() == 32
+                && rotation.destination_pseudonym.len() == 32
+                && rotation.source_pseudonym != rotation.destination_pseudonym
+                && !format!("{rotation:?}").contains(INVERTER_SERIAL_1)
+                && !format!("{rotation:?}").contains(INVERTER_SERIAL_2)
+        }));
+    }
+
+    #[test]
+    fn rotation_rejects_stale_automation_identity_without_swapping_live_state() {
+        let (mut runtime, principal, installed) = installed_inverter_runtime("http://127.0.0.1:1");
+        let root = temp_root("rotation-stale-automation");
+        let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+        let revision = store.save(&runtime, &[], 4_000).unwrap();
+        let leases = InMemoryLeaseManager::new();
+        let source_lease = leases
+            .issue(LeasePayload::new(IDENTIFIER_KEY.to_vec()), 60_000)
+            .unwrap();
+        let destination_lease = leases
+            .issue(LeasePayload::new(ROTATED_IDENTIFIER_KEY.to_vec()), 60_000)
+            .unwrap();
+        let definitions = vec![DurableAutomationDefinition::new(
+            "automation:stale-inverter",
+            true,
+            serde_json::json!({
+                "entity_id": installed.inverter_entity_ids[0].to_string()
+            }),
+        )
+        .unwrap()];
+        let client = EnphaseClient::new(
+            config("http://127.0.0.1:1"),
+            EnphaseAccessToken::new(TOKEN).unwrap(),
+            RotationCountingTransport { calls: 0 },
+        )
+        .unwrap();
+        let mut integration = EnphaseRuntimeIntegration::new(client)
+            .with_data_governance(identifier_policy(&principal));
+
+        let error = integration
+            .rotate_inverter_identifier_key_authorized(
+                &mut runtime,
+                &store,
+                &leases,
+                EnphaseIdentifierKeyRotationRequest::new(
+                    principal,
+                    &source_lease,
+                    &destination_lease,
+                    5_000,
+                    revision,
+                )
+                .with_automation_context(&definitions, None),
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            EnphaseError::RuntimeStore(RuntimeStoreError::Validation {
+                field: "automation_definitions",
+                ..
+            })
+        ));
+        assert_eq!(integration.client.transport.calls, 1);
+        assert!(runtime.registry().device(&installed.device_id).is_some());
+        assert!(installed
+            .inverter_entity_ids
+            .iter()
+            .all(|entity_id| runtime.registry().entity(entity_id).is_some()));
+        let restored = store.load().unwrap().unwrap();
+        assert!(restored
+            .runtime
+            .registry()
+            .device(&installed.device_id)
+            .is_some());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn governed_rotation_consumes_two_keys_reads_once_and_persists_atomically() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let base_url = format!("http://{address}");
+        let (sender, receiver) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request = read_request(&mut stream);
+            sender.send(request).unwrap();
+            let body = serde_json::to_vec(&inverter_production()).unwrap();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .unwrap();
+            stream.write_all(&body).unwrap();
+        });
+
+        let (mut runtime, principal, installed) = installed_inverter_runtime(&base_url);
+        let root = temp_root("identifier-rotation");
+        let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+        let initial_revision = store.save(&runtime, &[], 4_000).unwrap();
+        let leases = InMemoryLeaseManager::new();
+        let source_lease = leases
+            .issue(LeasePayload::new(IDENTIFIER_KEY.to_vec()), 60_000)
+            .unwrap();
+        let destination_lease = leases
+            .issue(LeasePayload::new(ROTATED_IDENTIFIER_KEY.to_vec()), 60_000)
+            .unwrap();
+        let expected_namespace = gateway_identity_pseudonym(
+            &EnphaseIdentifierKey::new(ROTATED_IDENTIFIER_KEY.to_vec()).unwrap(),
+            "122233344455",
+        );
+        let expected_device_id = DeviceId::trusted(format!("enphase:{expected_namespace}"));
+        let client = EnphaseClient::new(
+            config(&base_url),
+            EnphaseAccessToken::new(TOKEN).unwrap(),
+            EnphaseLanTransport::default(),
+        )
+        .unwrap();
+        let mut integration = EnphaseRuntimeIntegration::new(client)
+            .with_data_governance(identifier_policy(&principal));
+
+        let report = integration
+            .rotate_inverter_identifier_key_authorized(
+                &mut runtime,
+                &store,
+                &leases,
+                EnphaseIdentifierKeyRotationRequest::new(
+                    principal,
+                    &source_lease,
+                    &destination_lease,
+                    5_000,
+                    initial_revision,
+                ),
+            )
+            .unwrap();
+        server.join().unwrap();
+
+        assert_eq!(report.rotated_inverters, 2);
+        assert_eq!(report.migration.migrated_devices, 1);
+        assert_eq!(report.migration.migrated_entities, 4);
+        let requests = receiver.try_iter().collect::<Vec<_>>();
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].starts_with("GET /api/v1/production/inverters HTTP/1.1\r\n"));
+        assert!(requests[0].contains(&format!("Authorization: Bearer {TOKEN}\r\n")));
+        assert_eq!(
+            leases.lookup(&source_lease).unwrap().status_at(0),
+            LeaseStatus::Revoked
+        );
+        assert_eq!(
+            leases.lookup(&destination_lease).unwrap().status_at(0),
+            LeaseStatus::Revoked
+        );
+        assert!(runtime.registry().device(&installed.device_id).is_none());
+        assert!(installed
+            .inverter_entity_ids
+            .iter()
+            .all(|entity_id| runtime.registry().entity(entity_id).is_none()));
+        let replacement = runtime.registry().device(&expected_device_id).unwrap();
+        assert_eq!(replacement.entity_ids.len(), 4);
+        assert_eq!(
+            metadata_value(&replacement.metadata, "enphase.identifier_namespace"),
+            Some(expected_namespace.as_str())
+        );
+        let debug = format!("{:?}", runtime.registry());
+        assert!(!debug.contains(INVERTER_SERIAL_1));
+        assert!(!debug.contains(INVERTER_SERIAL_2));
+
+        let restored = store.load().unwrap().unwrap();
+        assert_eq!(restored.revision, report.revision);
+        assert!(restored
+            .runtime
+            .registry()
+            .device(&expected_device_id)
+            .is_some());
+        assert!(restored
+            .runtime
+            .registry()
+            .device(&installed.device_id)
+            .is_none());
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/code/packages/rust/vault-leases/CHANGELOG.md
+++ b/code/packages/rust/vault-leases/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.2.0] - 2026-08-09
+
 ### Added
 
+- `LeaseManager::consume_many` and an atomic in-memory implementation that
+  validate every distinct lease before removing any payload, then return
+  ordered one-shot payloads or leave the complete batch untouched.
 - `LeaseTableSummary`, `InMemoryLeaseManager::summary_at`, and
-  `InMemoryLeaseManager::table_summary_at` for metadata-only
-  lease-table status, read coverage, consumed-row, payload-retention,
-  expiry-range, and pending-sweep checks.
+  `InMemoryLeaseManager::table_summary_at` for metadata-only lease-table
+  status, read coverage, consumed-row, payload-retention, expiry-range, and
+  pending-sweep checks.
 
 ## [0.1.0] — 2026-05-04
 

--- a/code/packages/rust/vault-leases/Cargo.toml
+++ b/code/packages/rust/vault-leases/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding_adventures_vault_leases"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "VLT07 — lease manager for the Vault stack. Issue / renew / revoke / lookup / consume short-lived capability tokens. The basis of HashiCorp Vault-style response wrapping and a prerequisite for VLT08 dynamic-secret engines."
 

--- a/code/packages/rust/vault-leases/README.md
+++ b/code/packages/rust/vault-leases/README.md
@@ -44,6 +44,7 @@ process(payload.as_bytes());
 | `lookup`      | read metadata only (no payload bytes)                    |
 | `read`        | multi-read: returns payload + bumps `read_count`         |
 | `consume`     | one-shot: returns payload **and** revokes atomically     |
+| `consume_many`| one-shot batch: all payloads or no lease mutation        |
 | `expire_due`  | sweep entries whose expiry is `<= now_ms` or are revoked |
 
 `InMemoryLeaseManager::summary_at(now_ms)` gives status loops a
@@ -84,8 +85,9 @@ without asking for secret payload bytes.
   vs "already reaped" — no oracle.
 - **Payload zeroization**: every payload is held in
   `Zeroizing<Vec<u8>>` and wiped on revoke / expire / drop.
-- **Atomic `consume`**: mutex-guarded read-and-revoke; a second
-  `consume` always sees `Revoked`.
+- **Atomic consumption**: `consume` provides mutex-guarded read-and-revoke;
+  `consume_many` validates a distinct batch under the same lock before taking
+  any payload. A failed batch leaves every lease usable.
 - **`Debug` on payload is redacted** so a stray `dbg!` cannot leak
   the bytes.
 

--- a/code/packages/rust/vault-leases/src/lib.rs
+++ b/code/packages/rust/vault-leases/src/lib.rs
@@ -518,6 +518,13 @@ pub trait LeaseManager: Send + Sync {
     /// to use the same ID fails with `Revoked`.
     fn consume(&self, id: &LeaseId) -> Result<LeasePayload, LeaseError>;
 
+    /// Atomically consume a non-empty set of distinct leases.
+    ///
+    /// Every lease is validated before any payload is removed. If one lease is
+    /// missing, expired, revoked, or duplicated, all leases remain untouched.
+    /// Successful payloads are returned in the same order as `ids`.
+    fn consume_many(&self, ids: &[LeaseId]) -> Result<Vec<LeasePayload>, LeaseError>;
+
     /// Reap entries whose `expires_at_ms <= now_ms` *or* that have
     /// been revoked. Returns the number of entries actually
     /// removed. Caller-driven so the manager doesn't depend on a
@@ -782,6 +789,48 @@ impl LeaseManager for InMemoryLeaseManager {
         Ok(payload)
     }
 
+    fn consume_many(&self, ids: &[LeaseId]) -> Result<Vec<LeasePayload>, LeaseError> {
+        if ids.is_empty() {
+            return Err(LeaseError::InvalidParameter(
+                "consume_many requires at least one lease",
+            ));
+        }
+        let mut unique = std::collections::HashSet::with_capacity(ids.len());
+        if ids.iter().any(|id| !unique.insert(id)) {
+            return Err(LeaseError::InvalidParameter(
+                "consume_many lease ids must be distinct",
+            ));
+        }
+
+        let mut g = self.inner.lock().expect("lease mutex poisoned");
+        let now = Self::now_ms();
+        for id in ids {
+            let entry = g.get(id).ok_or(LeaseError::NotFound)?;
+            if entry.revoked || entry.payload.is_none() {
+                return Err(LeaseError::Revoked);
+            }
+            if entry.expires_at_ms <= now {
+                return Err(LeaseError::Expired);
+            }
+        }
+
+        let mut payloads = Vec::with_capacity(ids.len());
+        for id in ids {
+            let entry = g
+                .get_mut(id)
+                .expect("consume_many validated every lease under the same lock");
+            payloads.push(
+                entry
+                    .payload
+                    .take()
+                    .expect("consume_many validated every payload under the same lock"),
+            );
+            entry.revoked = true;
+            entry.read_count = entry.read_count.saturating_add(1);
+        }
+        Ok(payloads)
+    }
+
     fn expire_due(&self, now_ms: u64) -> Result<usize, LeaseError> {
         let mut g = self.inner.lock().expect("lease mutex poisoned");
         // Collect IDs to drop first to avoid mutating-while-iterating.
@@ -895,6 +944,46 @@ mod tests {
         assert_eq!(info.read_count, 1);
         assert_eq!(info.status_at(info.issued_at_ms), LeaseStatus::Revoked);
         assert_eq!(info.remaining_ttl_ms_at(info.issued_at_ms), 0);
+    }
+
+    #[test]
+    fn consume_many_returns_ordered_payloads_and_revokes_every_lease() {
+        let mgr = InMemoryLeaseManager::new();
+        let first = mgr.issue(mk_payload("first"), 60_000).unwrap();
+        let second = mgr.issue(mk_payload("second"), 60_000).unwrap();
+
+        let payloads = mgr.consume_many(&[second.clone(), first.clone()]).unwrap();
+
+        assert_eq!(payloads[0].as_bytes(), b"second");
+        assert_eq!(payloads[1].as_bytes(), b"first");
+        assert!(matches!(mgr.read(&first), Err(LeaseError::Revoked)));
+        assert!(matches!(mgr.read(&second), Err(LeaseError::Revoked)));
+    }
+
+    #[test]
+    fn consume_many_failure_leaves_every_lease_usable() {
+        let mgr = InMemoryLeaseManager::new();
+        let first = mgr.issue(mk_payload("first"), 60_000).unwrap();
+        let second = mgr.issue(mk_payload("second"), 60_000).unwrap();
+        mgr.revoke(&second).unwrap();
+
+        assert!(matches!(
+            mgr.consume_many(&[first.clone(), second]),
+            Err(LeaseError::Revoked)
+        ));
+        assert_eq!(mgr.consume(&first).unwrap().as_bytes(), b"first");
+    }
+
+    #[test]
+    fn consume_many_rejects_duplicate_ids_without_consuming() {
+        let mgr = InMemoryLeaseManager::new();
+        let id = mgr.issue(mk_payload("once"), 60_000).unwrap();
+
+        assert!(matches!(
+            mgr.consume_many(&[id.clone(), id.clone()]),
+            Err(LeaseError::InvalidParameter(_))
+        ));
+        assert_eq!(mgr.consume(&id).unwrap().as_bytes(), b"once");
     }
 
     #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1256,135 +1256,158 @@ rotation without starting either vendor-specific rotation workflow:
   succeeds. A stale revision leaves both live and durable state unchanged.
   Supplied automation definitions and execution state must already use the
   destination identities; exact source-ID references fail before mutation.
-- Enphase and UniFi key rotation remain separate production-integration
-  slices. Each must derive old and new pseudonyms from one bounded sensitive
-  response while two one-shot keys are leased, dispose of native identifiers
-  before returning, and submit the resulting complete migration through this
-  revision-guarded path.
+- Enphase key rotation now uses this path in the completed slice below. UniFi
+  key rotation remains a separate production-integration slice and must derive
+  old and new pseudonyms from one bounded sensitive response while two one-shot
+  keys are leased, dispose native identifiers before returning, and submit the
+  complete migration through this revision-guarded path.
+
+## Current Enphase Identifier-Key Rotation Slice
+
+This slice closes Enphase pseudonym-key rotation over the shared retained
+identity migration path:
+
+- `vault-leases` can atomically consume a distinct batch of one-shot leases,
+  validating every lease before removing any payload so a failed batch leaves
+  the complete key set untouched.
+- The Enphase host authorizes the D23 read and exact ephemeral
+  device-identifier grant before consuming either key or reaching transport.
+  Source and destination leases must be distinct and each payload must contain
+  exactly 32 bytes.
+- One bounded authenticated `/api/v1/production/inverters` response derives
+  exact source/destination pseudonym pairs under both keys. Raw serials remain
+  in the zeroizing response tree, and both payloads and key objects are dropped
+  before runtime migration begins.
+- The response must correspond exactly to the currently installed inverter
+  pseudonyms. Rotation constructs one complete gateway replacement, including
+  deterministic destination identities for every meter and inverter child,
+  while preserving capability and retained-state shape.
+- `smart-home-runtime-store` persists the replacement with the caller's
+  expected revision and swaps live state only after durable success. Opaque
+  automation definitions and state must already use destination identities or
+  prove absence of source references through the store's fail-closed scan.
+- Real loopback coverage proves one bearer-authenticated inverter request,
+  atomic two-key consumption, full live and restart identity replacement, and
+  exclusion of native inverter serials from runtime debug state. Consent denial
+  occurs before either lease or transport is touched.
 
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
-1. Add Enphase pseudonym-key rotation over the completed atomic retained
-   identity migration. One bounded authenticated inverter response must derive
-   old and new identities under two one-shot Vault-leased keys, prove exact
-   source correspondence, dispose of raw serials and both keys before return,
-   migrate or prove absence of automation references, and persist the complete
-   migration with an expected runtime-store revision.
-2. Add UniFi connected-client pseudonym-key rotation over the same completed
+1. Add UniFi connected-client pseudonym-key rotation over the same completed
    migration path. One bounded authenticated client response must derive exact
    old/new correspondence under two one-shot Vault-leased keys, preserve the
    five-minute presence boundary, dispose of native identifiers and keys, and
    migrate or prove absence of automation references before revision-guarded
    persistence.
 
-3. Add authenticated AirGradient MQTT only after official firmware removes
+2. Add authenticated AirGradient MQTT only after official firmware removes
    plaintext credential logging and one-shot Vault-leased credential injection
    can be proven without request-plan or normalized-state exposure.
-4. Add independent AirGradient telemetry, remote-configuration, and OTA
+3. Add independent AirGradient telemetry, remote-configuration, and OTA
    destinations only if firmware exposes separate settings; the current
    `httpDomain` contract intentionally governs all three as one HTTPS origin.
-5. Add authenticated HEOS source browsing and queue insertion only after the
+4. Add authenticated HEOS source browsing and queue insertion only after the
    account/session and Vault-leasing prerequisites are concrete.
-6. Automate Enphase access-token acquisition or renewal only after Enphase
+5. Automate Enphase access-token acquisition or renewal only after Enphase
    account authentication, cloud-session handling, operator consent, and
    Vault-leased credential policy are concrete; the current host accepts a
    pre-generated token.
-7. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
+6. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
    stable LAN advertisement; the current production path uses explicit local
    HTTPS endpoint and gateway-serial configuration.
-8. Add Enphase live battery, relay, generator, grid, and system-topology state
+7. Add Enphase live battery, relay, generator, grid, and system-topology state
    only after the normalized energy topology and retention semantics are
    concrete.
-9. Add Enphase relay, grid-services, or configuration controls only with
+8. Add Enphase relay, grid-services, or configuration controls only with
    operation-specific D23 contracts, explicit safety approval, bounded native
    semantics, and readable postcondition verification.
-10. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
+9. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
    supervised session lifecycle and Vault policy for refresh-token residency are
    concrete; the current isolated inspection drops both tokens after each read.
-11. Add ZoneMinder event push only after a concrete authenticated event host and
+10. Add ZoneMinder event push only after a concrete authenticated event host and
     supervised subscription lifecycle exist.
-12. Add ZoneMinder snapshots, streams, recordings, export, and playback only
+11. Add ZoneMinder snapshots, streams, recordings, export, and playback only
     through the camera-media lease and a concrete media executor.
-13. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
+12. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
     mutations only with operation-specific D23 contracts, least-privilege user
     checks, bounded semantics, and readable postcondition verification.
-14. Add UniFi connected-client native details only after field-specific
+13. Add UniFi connected-client native details only after field-specific
    minimization and retention are approved; current presence intentionally
    excludes names, native IDs, MACs, IPs, and connection timestamps.
-15. Add UniFi historical device statistics, heartbeat-time correlation, or
+14. Add UniFi historical device statistics, heartbeat-time correlation, or
    broader fleet polling only after durable time-series schema, query access,
    clock semantics, and retention/deletion policy are concrete; current live
    statistics are explicit-target, 64-device bounded, one-minute rate-limited,
    and expire after two minutes.
-16. Add remote UniFi Site Manager inspection only after telemetry-egress,
+15. Add remote UniFi Site Manager inspection only after telemetry-egress,
    destination, and operator-consent policy are concrete; keep the current host
    local-only.
-17. Add UniFi Network push or change events only after a concrete authenticated
+16. Add UniFi Network push or change events only after a concrete authenticated
    event host and supervised subscription lifecycle exist.
-18. Add UniFi adoption, guest authorization, port actions, or configuration
+17. Add UniFi adoption, guest authorization, port actions, or configuration
    mutations only with operation-specific D23 contracts, least-privilege API
    keys, bounded semantics, and readable postcondition verification.
-19. Add Synology Surveillance Station OTP and remembered-device authentication
+18. Add Synology Surveillance Station OTP and remembered-device authentication
    only after an interactive challenge lifecycle and Vault-leased device-token
    policy are concrete.
-20. Add Synology Surveillance Station events only after a concrete authenticated
+19. Add Synology Surveillance Station events only after a concrete authenticated
    event host and supervised subscription lifecycle exist.
-21. Add Synology Surveillance Station snapshots, recordings, export, and
+20. Add Synology Surveillance Station snapshots, recordings, export, and
    playback only through the camera-media lease and a concrete executor.
-22. Add Synology Surveillance Station PTZ, external recording, or configuration
+21. Add Synology Surveillance Station PTZ, external recording, or configuration
    mutations only with operation-specific D23 contracts, least-privilege API
    checks, bounded semantics, and readable postcondition verification.
-23. Add Frigate event and review push only after a concrete authenticated event
+22. Add Frigate event and review push only after a concrete authenticated event
    or WebSocket host and supervised subscription lifecycle exist.
-24. Add Frigate snapshots, recordings, export, and playback only through the
+23. Add Frigate snapshots, recordings, export, and playback only through the
    camera-media lease and a concrete executor.
-25. Add Frigate commands or configuration mutations only with operation-specific
+24. Add Frigate commands or configuration mutations only with operation-specific
    D23 contracts, least-privilege role checks, and readable postcondition
    verification.
-26. Add Blue Iris snapshots, alert/clip search, export, and playback only through
+25. Add Blue Iris snapshots, alert/clip search, export, and playback only through
    the camera-media lease and a concrete media executor.
-27. Add broader Blue Iris `camconfig` or administrative mutations only with
+26. Add broader Blue Iris `camconfig` or administrative mutations only with
    operation-specific D23 contracts, least-privilege permissions, and readable
    postcondition verification; do not persist the license value returned at
    login.
-28. Add automatic Blue Iris discovery only if the server exposes a documented,
+27. Add automatic Blue Iris discovery only if the server exposes a documented,
    stable LAN advertisement; the current production path is explicit local
    HTTPS endpoint configuration.
-29. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
+28. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
    controls only when each operation has a specific native capability probe,
    bounded semantics, and readable verification where the device exposes it.
-30. Add Axis event streaming only after the existing WebSocket protocol core has
+29. Add Axis event streaming only after the existing WebSocket protocol core has
    a concrete authenticated host using the completed Digest primitive or a
    short-lived session token, plus subscription supervision.
-31. Add Axis snapshots and media transfer only through the camera-media lease and
+30. Add Axis snapshots and media transfer only through the camera-media lease and
    a concrete media executor.
-32. Enumerate Axis video sources/channels before extending PTZ beyond the current
+31. Enumerate Axis video sources/channels before extending PTZ beyond the current
    capability-probed VAPIX camera 1 boundary.
-33. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
+32. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
    only when each operation has a specific capability probe and readable state.
-34. Add Reolink snapshot, recording search/download, and playback operations only
+33. Add Reolink snapshot, recording search/download, and playback operations only
    through the existing camera-media lease and a concrete media executor.
-35. Add Reolink current-position, zoom, guard-point, or patrol controls only when
+34. Add Reolink current-position, zoom, guard-point, or patrol controls only when
    each operation has a capability-specific probe and the firmware exposes the
    native state needed to avoid invented orientation claims.
-36. Add Reolink push events only after a concrete webhook or event-stream host
+35. Add Reolink push events only after a concrete webhook or event-stream host
    and subscription lifecycle exist.
-37. Add authenticated KLAP/Tapo devices and other broader-device families only
+36. Add authenticated KLAP/Tapo devices and other broader-device families only
    after their authentication and session prerequisites are concrete.
-38. Add ONVIF PullPoint events once a concrete event host and subscription
+37. Add ONVIF PullPoint events once a concrete event host and subscription
    lifecycle exist.
-39. Add RTSP media transfer and recording once concrete media transfer and
+38. Add RTSP media transfer and recording once concrete media transfer and
    recorder host primitives exist.
-40. Add a production Matter commissioning, secure-session, and network host only
+39. Add a production Matter commissioning, secure-session, and network host only
    after certificate, fabric, Interaction Model encoding, subscription, and
    transport prerequisites exist.
-41. Add a Thread border-router host only after an actual host transport exists.
-42. Add a production Zigbee coordinator, join, and security host only after
+40. Add a Thread border-router host only after an actual host transport exists.
+41. Add a production Zigbee coordinator, join, and security host only after
    concrete coordinator transport and security primitives exist.
-43. Add production Z-Wave inclusion and S2 only after concrete host transport
+42. Add production Z-Wave inclusion and S2 only after concrete host transport
    and security primitives exist.
 
 ## End-To-End Definition


### PR DESCRIPTION
## Summary

- atomically consume two distinct one-shot Vault key leases for Enphase identifier rotation
- derive exact old/new inverter pseudonyms from one bounded authenticated production response, then dispose raw serials and both keys before migration
- persist a complete gateway and child-entity identity replacement through the expected-revision runtime-store CAS path, failing closed on stale automation references
- mark Enphase rotation complete and promote UniFi connected-client rotation in the Smart Home inventory

## Validation

- `cargo test --manifest-path smart-home-enphase-envoy-integration/Cargo.toml` (16 tests)
- `cargo test --manifest-path vault-leases/Cargo.toml` (26 tests)
- strict Clippy for both modified packages and every direct `vault-leases` consumer
- BUILD scripts: `smart-home-enphase-envoy-integration`, `vault-leases`, `chief-of-staff-vault-runtime`, `vault-engine-core`, `vault-engine-kv2`, `weather-agent-e2e`