### PR TITLE
Canonicalize opaque Chief vault leases

### DIFF
--- a/code/packages/rust/chief-of-staff-vault-runtime/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-vault-runtime/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+
+- Define the opaque `{ vault_ref, expires_at_ms }` receipt as the canonical
+  agent-facing lease contract and redact the bearer reference from `Debug` output.

--- a/code/packages/rust/chief-of-staff-vault-runtime/README.md
+++ b/code/packages/rust/chief-of-staff-vault-runtime/README.md
@@ -1,0 +1,18 @@
+# Chief of Staff Vault Runtime
+
+This crate is the trusted host-side broker for short-lived secret leases.
+`request_lease` returns the canonical agent-facing receipt:
+
+```text
+{ vault_ref, expires_at_ms }
+```
+
+`vault_ref` is an opaque bearer capability. Agents may pass it only to an
+approved host operation that explicitly accepts a Vault reference; they cannot
+resolve it into secret bytes. The trusted host atomically consumes the reference,
+uses the zeroizing payload within that operation, and makes the reference unusable
+after consumption, release, revocation, or expiry.
+
+The receipt never contains plaintext, ciphertext, or a decryption key. Its `Debug`
+implementation also redacts the bearer reference so routine diagnostics do not
+turn logs into an alternate secret channel.

--- a/code/packages/rust/chief-of-staff-vault-runtime/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-vault-runtime/src/lib.rs
@@ -1,8 +1,10 @@
 //! Host-side broker for issuing opaque Chief of Staff secret leases.
 //!
-//! Model-facing tools receive only a [`VaultRef`]. Raw payload bytes remain in
-//! the zeroizing lease manager and can only be consumed by a trusted host
-//! handler.
+//! Model-facing tools receive only a [`VaultLeaseReceipt`] containing a
+//! bearer-capability [`VaultRef`] and its authoritative expiry. They never
+//! receive plaintext, ciphertext, or an unwrap key. Raw payload bytes remain
+//! in the zeroizing lease manager and can only be atomically consumed by a
+//! trusted host handler.
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
@@ -19,12 +21,21 @@ use smart_home_core::VaultRef;
 const VAULT_REF_PREFIX: &str = "vault-lease:";
 
 /// A newly issued lease receipt safe to return across the tool boundary.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct VaultLeaseReceipt {
     /// Opaque handle understood only by the trusted host broker.
     pub vault_ref: VaultRef,
     /// Authoritative lease expiry in milliseconds since Unix epoch.
     pub expires_at_ms: u64,
+}
+
+impl fmt::Debug for VaultLeaseReceipt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VaultLeaseReceipt")
+            .field("vault_ref", &"<redacted>")
+            .field("expires_at_ms", &self.expires_at_ms)
+            .finish()
+    }
 }
 
 /// Errors produced by the Chief vault lease boundary.
@@ -86,6 +97,10 @@ impl ChiefVaultRuntime {
     }
 
     /// Issue a short-lived opaque reference for a named secret.
+    ///
+    /// The receipt is the canonical agent-facing `{ vault_ref,
+    /// expires_at_ms }` shape. Secret bytes and decryption material never cross
+    /// this boundary.
     pub fn request_lease(
         &self,
         secret_name: &str,
@@ -107,6 +122,10 @@ impl ChiefVaultRuntime {
     }
 
     /// Atomically resolve and revoke a lease inside a trusted host handler.
+    ///
+    /// Agent and model code must not call this boundary directly. Successful
+    /// resolution returns zeroizing payload storage and makes the reference
+    /// unusable for every subsequent request.
     pub fn consume(&self, vault_ref: &VaultRef) -> Result<LeasePayload, VaultRuntimeError> {
         let lease_id = lease_id(vault_ref)?;
         self.leases.consume(&lease_id).map_err(Into::into)
@@ -149,6 +168,21 @@ mod tests {
             .expect("trusted host should consume lease");
         assert_eq!(payload.as_bytes(), SECRET);
         assert!(vault.consume(&receipt.vault_ref).is_err());
+    }
+
+    #[test]
+    fn lease_receipt_debug_redacts_bearer_capability() {
+        let vault = ChiefVaultRuntime::new();
+        vault.register_secret("weather-api-key", LeasePayload::new(SECRET.to_vec()));
+
+        let receipt = vault
+            .request_lease("weather-api-key", 30_000)
+            .expect("lease should be issued");
+        let debug = format!("{receipt:?}");
+
+        assert!(debug.contains("vault_ref: \"<redacted>\""));
+        assert!(debug.contains("expires_at_ms"));
+        assert!(!debug.contains(receipt.vault_ref.as_str()));
     }
 
     #[test]

--- a/code/specs/D18-chief-of-staff.md
+++ b/code/specs/D18-chief-of-staff.md
@@ -709,8 +709,9 @@ export const host = {
 
   // Vault — host checks manifest + trust boundary + tier
   vault: {
-    requestLease(secretName: string, ttl: number): Promise<Lease>,
+    requestLease(secretName: string, ttlMs: number): Promise<VaultLeaseReceipt>,
     requestDirect(secretName: string, consumer: AgentId): Promise<void>,
+    releaseLease(vaultRef: VaultRef): Promise<void>,
   },
 
   // Channels — host verifies agent is registered originator/receiver
@@ -784,7 +785,7 @@ simply never makes the call.
 Every host API call passes through a middleware chain before being proxied:
 
 ```
-Agent calls host.vault.requestLease("bank-creds", 10)
+Agent calls host.vault.requestLease("bank-creds", 10_000)
 │
 ▼
 ┌─────────────────────────────────────────────────┐
@@ -1467,16 +1468,21 @@ EncryptedSecret
 Lease
 ═══════════════════════════════════════════════════════════════
 ┌──────────────────┬─────────────────────────────────────────┐
-│ lease_id         │ UUID v7                                  │
+│ lease_id         │ Internal 128-bit CSPRNG identifier       │
 │ secret_name      │ Which secret this lease grants           │
 │ requester_id     │ Who requested the lease                  │
-│ lease_key        │ One-time symmetric key (256-bit)         │
+│ payload          │ Zeroizing bytes inside trusted runtime   │
 │ created_at       │ Timestamp                                │
 │ expires_at       │ created_at + ttl                         │
-│ expired          │ Boolean (set when TTL elapses)           │
-│ revoked          │ Boolean (set on manual revocation)       │
+│ read_count       │ Diagnostic count; zero before consume    │
+│ revoked          │ True after release, revoke, or consume   │
 └──────────────────┴─────────────────────────────────────────┘
 ```
+
+The internal `lease_id`, secret name, requester identity, and payload never cross
+the host boundary. The agent-facing receipt is exactly
+`{ vault_ref, expires_at_ms }`, where `vault_ref` is an opaque bearer capability
+that contains no secret material. Receipt diagnostics MUST redact `vault_ref`.
 
 **Vault unlock — platform-agnostic biometric abstraction:**
 
@@ -1527,8 +1533,9 @@ Agent: "log into bank"                Vault: decrypts password
   Agent never saw the password.
 ```
 
-**Leased mode** — the requesting agent gets temporary access to the secret via a
-one-time lease key with a TTL.
+**Leased mode** — the requesting agent gets a short-lived opaque reference. The
+agent can pass that reference only to an approved host operation that explicitly
+accepts a Vault reference. It cannot resolve the reference into secret bytes.
 
 ```
 Leased Mode: Weather API Key
@@ -1538,27 +1545,25 @@ Agent: "I need the weather API key"
        ▼ Channel A (encrypted)
   Vault receives request
   Vault checks: weather-api-key.allowed_mode = "leased"
-  Vault generates:
-    lease_key = random_bytes(32)
-    encrypted_secret = XChaCha20_Poly1305_encrypt(
-      key = lease_key,
-      plaintext = api_key
-    )
-    lease = { id, ttl: 10s, lease_key, ... }
+  Vault stores the API key in a zeroizing one-shot lease
+  Vault generates an unguessable bearer reference
        │
        ▼ Channel B (encrypted)
   Agent receives:
-    { lease_id, encrypted_secret, lease_key, expires_at }
-  Agent decrypts: api_key = decrypt(encrypted_secret, lease_key)
-  Agent makes HTTP request via host.network.fetch with api_key
+    { vault_ref, expires_at_ms }
+  Agent passes vault_ref to an approved host operation
+  Host atomically consumes the lease
+  Ephemeral proxy uses the API key, zeroizes it, and exits
+  Agent never receives plaintext or decryption material
   ...10 seconds pass...
-  Lease expires.
-  Vault re-encrypts api_key with a NEW lease key.
-  The old lease_key is dead.
-  Even if the agent stored lease_key, it is useless now.
+  Any unconsumed reference expires and can no longer resolve.
 ```
 
-**Three layers of encryption on any secret in transit:**
+TTL and revocation are enforceable only until a trusted operation consumes the
+reference. No design can revoke plaintext or an unwrap key after either has been
+delivered to an untrusted agent, which is why this contract delivers neither.
+
+**Protection layers on a leased secret:**
 
 ```
 Layer 0: Encryption at rest
@@ -1570,11 +1575,10 @@ Layer 1: Channel encryption
   Each authorized receiver obtains that CMK from an identity-bound
   sealed key grant. Without it, the entire payload is ciphertext.
 
-Layer 2: Lease encryption (leased mode only)
-  Even after decrypting the channel message, the secret itself
-  is encrypted with a one-time lease key. You need BOTH keys.
-
-  Total: THREE layers of encryption between disk and use.
+Layer 2: Host-resolved response wrapping (leased mode only)
+  The channel carries only an opaque VaultRef. The payload remains in
+  zeroizing trusted memory until an approved host operation atomically
+  consumes it. Expiry or release destroys the unused payload.
 ```
 
 ---
@@ -1846,7 +1850,13 @@ type MessageId = String;    // UUID v7
 type ChannelId = String;    // UUID v7
 type AgentId = String;      // UUID v7
 type HostId = String;       // UUID v7
-type LeaseId = String;      // UUID v7
+type LeaseId = String;      // internal 128-bit CSPRNG token
+type VaultRef = String;      // opaque bearer capability
+
+struct VaultLeaseReceipt {
+    vault_ref: VaultRef,
+    expires_at_ms: u64,
+}
 
 // === Enums ===
 enum PrivilegeTier { Tier0 = 0, Tier1 = 1, Tier2 = 2, Tier3 = 3 }
@@ -1872,6 +1882,11 @@ This is the JSON-RPC interface over stdin/stdout. The host process implements th
 server side in Rust; agents call the client side via the chief-of-staff SDK.
 
 ```typescript
+type VaultLeaseReceipt = {
+  vault_ref: string,
+  expires_at_ms: number,
+}
+
 // === Network ===
 // Host checks: manifest.capabilities contains net:connect:{url.host}:{url.port}
 // Host spawns: ephemeral NetworkProxyAgent → dies after response
@@ -1892,14 +1907,15 @@ function fs_write(path: string, data: Uint8Array): Promise<void>
 // Host spawns: ephemeral VaultClientAgent → dies after response
 function vault_request_lease(
   secret_name: string,
-  ttl_seconds: number
-): Promise<{ lease_id: string, encrypted_secret: Uint8Array,
-             lease_key: Uint8Array, expires_at: number }>
+  ttl_ms: number
+): Promise<{ vault_ref: string, expires_at_ms: number }>
 
 function vault_request_direct(
   secret_name: string,
   consumer_agent_id: string
 ): Promise<void>
+
+function vault_release_lease(vault_ref: string): Promise<void>
 
 // === Channels ===
 // Host checks: agent is registered originator/receiver for this channel
@@ -1962,12 +1978,14 @@ fn vault_request_direct(
     consumer_channel_id: ChannelId,
 ) -> Result<()>
 
-/// Leased mode: issue a time-limited lease.
+/// Leased mode: issue a time-limited opaque receipt. Payload bytes remain
+/// inside the trusted Vault/host boundary and are consumed atomically by an
+/// approved host operation.
 fn vault_request_lease(
     handle: &VaultHandle,
     secret_name: &str,
     requester_id: AgentId,
-    ttl_seconds: u32,
+    ttl_ms: u64,
 ) -> Result<Lease>
 
 /// Revoke a lease immediately.
@@ -2074,7 +2092,7 @@ fn request_hardware_key(
 6. Orchestrator verifies package signatures, spawns host actors.
    Each host reads its own manifest, launches its own Deno process.
 
-7. Finance Agent calls host.vault.requestLease("bank-creds", 10)
+7. Finance Agent calls host.vault.requestLease("bank-creds", 10_000)
    Finance Agent's host middleware:
    ├── Capability check: vault:lease:bank-creds in manifest? YES
    ├── Trust boundary: Tier 2, already approved via Face ID
@@ -2082,17 +2100,18 @@ fn request_hardware_key(
    └── Spawn ephemeral VaultClientAgent
 
 8. VaultClientAgent forwards request to Vault actor (via Unix socket).
-   Vault issues lease: { lease_key, encrypted_password, expires_in: 10s }
+   Vault issues receipt: { vault_ref, expires_at_ms }
    VaultClientAgent returns to host. VaultClientAgent dies.
 
-9. Host returns lease to Finance Agent via JSON-RPC.
+9. Host returns the opaque receipt to Finance Agent via JSON-RPC.
 
-10. Finance Agent calls host.network.fetch("https://bank.com/balance")
-    with decrypted credentials.
+10. Finance Agent calls the approved host-mediated bank operation with vault_ref.
+    The host atomically consumes the lease; the Finance Agent never receives the
+    credential.
     Host spawns ephemeral NetworkProxyAgent("bank.com", 443).
     NetworkProxyAgent fetches balance, returns, dies.
 
-11. Lease expires. Password gone. Lease key dead.
+11. The consumed reference is already unusable. Any unconsumed reference expires.
 
 12. Finance Agent formats result, writes via host.channel.write().
 
@@ -2287,10 +2306,10 @@ daemon instance.
     failure.
 15. **Vault direct mode.** Request direct delivery — verify secret appears on consumer
     channel, not on agent's channels.
-16. **Vault leased mode.** Request lease — verify lease key decrypts secret, verify
-    TTL is correct.
+16. **Vault leased mode.** Request lease — verify the receipt contains only an
+    opaque VaultRef and authoritative expiry, while the secret remains host-side.
 17. **Vault lease expiry.** Create lease with 1-second TTL, wait 2 seconds — verify
-    expired and lease key invalid.
+    the reference no longer resolves.
 18. **Vault lease revocation.** Create lease, revoke immediately — verify revoked.
 19. **Privilege tier 0.** Wire a Tier 0 pipeline — verify no approval triggered.
 20. **Privilege tier 2 without biometric.** Attempt Tier 2 pipeline — verify blocked.
@@ -2320,8 +2339,9 @@ daemon instance.
     end-to-end encryption and decryption through host.* API.
 33. **Pipeline isolation.** Create email pipeline and finance pipeline. Attempt to
     read from a finance channel using the email agent's host — verify denied.
-34. **Vault + host integration.** Agent requests leased secret via host, uses it,
-    lease expires, agent requests again — verify new lease key is different.
+34. **Vault + host integration.** Agent requests an opaque lease via host, passes the
+    VaultRef to an approved host operation, and verifies atomic one-shot consumption;
+    request again and verify the previous reference remains unusable.
 35. **Host crash recovery.** Kill host actor, orchestrator restarts host, host
     relaunches Deno — verify agent resumes from last channel ack.
 36. **Orchestrator crash recovery.** Kill orchestrator, OS restarts it — verify all

--- a/code/specs/host-protocol.md
+++ b/code/specs/host-protocol.md
@@ -294,13 +294,32 @@ which the host validates against the glob.
 
 | Method                | Manifest check                | Purpose                          |
 |-----------------------|-------------------------------|----------------------------------|
-| `vault.requestLease`  | `vault:read:secret-name`      | Get a TTL'd lease for a secret    |
+| `vault.requestLease`  | `vault:read:secret-name`      | Get a TTL'd opaque reference      |
 | `vault.requestDirect` | `vault:direct:secret-name`    | Send secret directly to a peer    |
 | `vault.releaseLease`  | (none — own lease)            | Surrender a lease early           |
 
 `vault.requestDirect` does not return the secret to the calling agent;
 the secret is delivered on a separate channel to a third party (e.g., the
-browser host). The calling agent only learns "lease created" or "denied."
+browser host). The calling agent only learns "delivery accepted" or "denied."
+
+The v1 lease parameter and result shapes are normative:
+
+```text
+vault.requestLease({ name: string, ttl_ms: number })
+  -> { vault_ref: string, expires_at_ms: number }
+
+vault.releaseLease({ vault_ref: string })
+  -> null
+```
+
+`ttl_ms` is an integer in `1..=7_776_000_000` (90 days); `expires_at_ms` is Unix
+time in milliseconds and remains within the lossless JSON integer range.
+`vault_ref` is an unguessable bearer capability, not a secret identifier. Agents
+may pass it only to approved host operations that explicitly accept a Vault
+reference. They cannot resolve it into plaintext, ciphertext, or a decryption key.
+The trusted host atomically consumes the reference, uses the zeroizing payload
+inside that operation, and rejects the reference after consumption, release,
+revocation, or expiry. Logs and protocol diagnostics MUST redact `vault_ref`.
 
 ### `channel.*` — corresponds to `channel` capability
 
@@ -593,10 +612,12 @@ forecast = call("network.fetch",
                  "headers": {"User-Agent": "weather-agent/0.1"}})
 body = json.loads(base64.b64decode(forecast["body_b64"]))
 
-# Get email password from vault
+# Request an opaque email-password lease
 lease = call("vault.requestLease",
              {"name": "gmail-app-password", "ttl_ms": 60_000})
-password = base64.b64decode(lease["secret_b64"]).decode()
+# Only an approved host operation may consume this reference. Agent code cannot
+# turn it into password bytes; release it if the operation is abandoned.
+call("vault.releaseLease", {"vault_ref": lease["vault_ref"]})
 ```
 
 ### Tier 1 native (Rust)
@@ -619,6 +640,12 @@ let forecast = host.call(&NetworkFetch {
 let lease = host.call(&VaultRequestLease {
     name:   "gmail-app-password",
     ttl_ms: 60_000,
+})?;
+
+// `lease.vault_ref` is passed only to an approved host operation. It cannot be
+// resolved by this SDK and must be released if the operation is abandoned.
+host.call(&VaultReleaseLease {
+    vault_ref: lease.vault_ref,
 })?;
 ```
 


### PR DESCRIPTION
## Summary

- make `{ vault_ref, expires_at_ms }` the single agent-facing Vault lease receipt
- keep secret payloads inside the trusted zeroizing host/Vault boundary with one-shot consume, release, revoke, and expiry semantics
- redact bearer Vault references from runtime Debug output and remove plaintext/ciphertext-plus-key contradictions from D18 and the host protocol

## Validation

- `cargo fmt -p chief-of-staff-vault-runtime -- --check`
- `cargo test -p chief-of-staff-vault-runtime` (3 tests)
- strict Clippy across all targets
- rustdoc with warnings denied
- capability taxonomy unit suite (7 tests)
- dependency-closed build plan (45 affected Rust packages)
- `git diff --check`

Progresses #128
Progresses #134
Progresses #139