### PR TITLE
Add UniFi connected-client key rotation

### DIFF
--- a/code/packages/rust/smart-home-unifi-network-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-unifi-network-integration/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.4.0
+
+- Add host-owned connected-client pseudonym-key rotation for an explicit UniFi
+  site using one bounded authenticated client response and two atomically
+  consumed one-shot 32-byte key leases.
+- Require exact correspondence with the installed pseudonymous client set,
+  preserve each client's existing five-minute presence expiry, and dispose
+  native identifiers and both keys before runtime migration.
+- Persist all client device/entity replacements through expected-revision
+  runtime-store CAS and reject stale automation identity references before live
+  state changes.
+
 ## 0.3.0
 
 - Add official per-device latest-statistics inspection for explicitly selected,

--- a/code/packages/rust/smart-home-unifi-network-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-unifi-network-integration/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "smart-home-unifi-network-integration"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Authenticated local UniFi Network health, bounded live statistics, and pseudonymous client inspection"
 license = "MIT"
 
 [dependencies]
 coding_adventures_sha256 = { path = "../sha256" }
+coding_adventures_vault_leases = { path = "../vault-leases" }
 coding_adventures_zeroize = { path = "../zeroize" }
 http-core = { path = "../http-core" }
 http1 = { path = "../http1" }
@@ -16,5 +17,10 @@ smart-home-data-governance = { path = "../smart-home-data-governance" }
 smart-home-discovery = { path = "../smart-home-discovery" }
 smart-home-local-http = { path = "../smart-home-local-http" }
 smart-home-runtime = { path = "../smart-home-runtime" }
+smart-home-runtime-store = { path = "../smart-home-runtime-store" }
+storage-core = { path = "../storage-core" }
 tls-platform = { path = "../tls-platform" }
 url-parser = { path = "../url-parser" }
+
+[dev-dependencies]
+storage-local-folder = { path = "../storage-local-folder" }

--- a/code/packages/rust/smart-home-unifi-network-integration/README.md
+++ b/code/packages/rust/smart-home-unifi-network-integration/README.md
@@ -25,6 +25,16 @@ runtime identity, state, metadata, errors, or debug output. Pseudonymous client
 state exposes only current presence, connection type, and optional access shape,
 and expires after five minutes.
 
+Host-owned presence-key rotation accepts one explicit safe site ID and two
+distinct one-shot Vault leases containing 32-byte keys. After the same D23 read,
+device-identifier, and five-minute presence grants succeed, the integration
+atomically consumes both leases and makes exactly one bounded request for the
+site's first client page. The page must be complete, non-empty, and contain at
+most 100 clients. It derives exact old/new pseudonym correspondence while the
+native response remains zeroizing, drops both keys before migration, preserves
+the existing five-minute state expiry, rejects stale automation references, and
+persists every client device/entity replacement through expected-revision CAS.
+
 Live adopted-device statistics use the official
 `/v1/sites/{siteId}/devices/{deviceId}/statistics/latest` endpoint only for an
 explicit set of already-installed devices. D23 read authorization and an exact
@@ -36,11 +46,12 @@ readings are validated before installation and expire after two minutes. Native
 heartbeat timestamps are intentionally discarded.
 
 This slice intentionally excludes remote Site Manager access, connected-client
-native details and retained identity migration, historical statistics,
-unbounded fleet polling, event streaming, adoption, guest authorization, port
-actions, and configuration mutations. Those require privacy and
-telemetry-egress policy, supervised event hosts, or operation-specific D23
-contracts and readable verification.
+native details, multi-site or paginated client-key rotation, historical
+statistics, unbounded fleet polling, event streaming, adoption, guest
+authorization, port actions, and configuration mutations. Those require
+privacy and telemetry-egress policy, a resumable atomic rotation protocol,
+supervised event hosts, or operation-specific D23 contracts and readable
+verification.
 
 Protocol references:
 

--- a/code/packages/rust/smart-home-unifi-network-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-unifi-network-integration/src/lib.rs
@@ -3,6 +3,7 @@
 #![forbid(unsafe_code)]
 
 use coding_adventures_sha256::sha256;
+use coding_adventures_vault_leases::{LeaseError, LeaseId, LeaseManager};
 use coding_adventures_zeroize::{Zeroize, Zeroizing};
 use http1::{parse_response_head, Http1ParseError};
 use http_core::{BodyKind, Header};
@@ -24,16 +25,23 @@ use smart_home_local_http::{
     LocalHttpAuth, LocalHttpEndpoint, LocalHttpError, LocalHttpMethod, LocalHttpRequestPlan,
     LocalHttpRequestTemplate, LocalHttpScheme,
 };
-use smart_home_runtime::{RuntimeError, SmartHomeRuntime};
-use std::collections::BTreeSet;
+use smart_home_runtime::{
+    RetainedDeviceIdentityReplacement, RetainedEntityIdentityReplacement, RuntimeError,
+    RuntimeRetainedIdentityMigration, RuntimeRetainedIdentityMigrationReport, SmartHomeRuntime,
+};
+use smart_home_runtime_store::{
+    DurableAutomationDefinition, RuntimeStoreError, SmartHomeRuntimeStore,
+};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::time::Duration;
+use storage_core::{Revision, StorageBackend};
 use tls_platform::{default_connector, TlsConfig, TlsConnector};
 use url_parser::{Url, UrlError};
 
-pub const VERSION: &str = "0.3.0";
+pub const VERSION: &str = "0.4.0";
 pub const INTEGRATION_ID: &str = "unifi";
 pub const PROTOCOL_ID: &str = "unifi_network_integration_api";
 pub const API_BASE_PATH: &str = "/proxy/network/integration";
@@ -78,6 +86,8 @@ pub enum UniFiError {
     },
     DataGovernanceDenied(DataGovernanceDenial),
     Runtime(RuntimeError),
+    RuntimeStore(RuntimeStoreError),
+    Lease(LeaseError),
 }
 
 impl fmt::Display for UniFiError {
@@ -112,6 +122,8 @@ impl fmt::Display for UniFiError {
                 )
             }
             Self::Runtime(error) => error.fmt(formatter),
+            Self::RuntimeStore(error) => error.fmt(formatter),
+            Self::Lease(error) => write!(formatter, "UniFi presence-key lease failed: {error}"),
         }
     }
 }
@@ -139,6 +151,18 @@ impl From<serde_json::Error> for UniFiError {
 impl From<RuntimeError> for UniFiError {
     fn from(error: RuntimeError) -> Self {
         Self::Runtime(error)
+    }
+}
+
+impl From<RuntimeStoreError> for UniFiError {
+    fn from(error: RuntimeStoreError) -> Self {
+        Self::RuntimeStore(error)
+    }
+}
+
+impl From<LeaseError> for UniFiError {
+    fn from(error: LeaseError) -> Self {
+        Self::Lease(error)
     }
 }
 
@@ -305,6 +329,62 @@ pub struct UniFiConnectedClient {
     pub access_authorized: Option<bool>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UniFiClientIdentityRotation {
+    pub source_pseudonym: String,
+    pub destination_pseudonym: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UniFiPresenceKeyRotationReport {
+    pub rotated_clients: usize,
+    pub migration: RuntimeRetainedIdentityMigrationReport,
+    pub revision: Revision,
+}
+
+pub struct UniFiPresenceKeyRotationRequest<'a> {
+    pub principal_id: AgentId,
+    pub site_id: String,
+    pub source_key_lease_id: &'a LeaseId,
+    pub destination_key_lease_id: &'a LeaseId,
+    pub automation_definitions: &'a [DurableAutomationDefinition],
+    pub automation_state: Option<JsonValue>,
+    pub observed_at_ms: u64,
+    pub expected_revision: Revision,
+}
+
+impl<'a> UniFiPresenceKeyRotationRequest<'a> {
+    pub fn new(
+        principal_id: AgentId,
+        site_id: impl Into<String>,
+        source_key_lease_id: &'a LeaseId,
+        destination_key_lease_id: &'a LeaseId,
+        observed_at_ms: u64,
+        expected_revision: Revision,
+    ) -> Self {
+        Self {
+            principal_id,
+            site_id: site_id.into(),
+            source_key_lease_id,
+            destination_key_lease_id,
+            automation_definitions: &[],
+            automation_state: None,
+            observed_at_ms,
+            expected_revision,
+        }
+    }
+
+    pub fn with_automation_context(
+        mut self,
+        automation_definitions: &'a [DurableAutomationDefinition],
+        automation_state: Option<JsonValue>,
+    ) -> Self {
+        self.automation_definitions = automation_definitions;
+        self.automation_state = automation_state;
+        self
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UniFiStatisticsTarget {
     pub site_id: String,
@@ -369,6 +449,19 @@ pub trait UniFiTransport {
     ) -> Result<Vec<UniFiConnectedClient>, UniFiError> {
         Err(UniFiError::Validation(
             "transport does not implement connected-client inspection".to_string(),
+        ))
+    }
+
+    fn inspect_client_identity_rotation(
+        &mut self,
+        _plans: &UniFiRequestPlans,
+        _api_key: &UniFiApiKey,
+        _site_id: &str,
+        _source_key: &UniFiPresenceKey,
+        _destination_key: &UniFiPresenceKey,
+    ) -> Result<Vec<UniFiClientIdentityRotation>, UniFiError> {
+        Err(UniFiError::Validation(
+            "transport does not implement connected-client identity rotation".to_string(),
         ))
     }
 
@@ -591,6 +684,26 @@ impl UniFiTransport for UniFiLanTransport {
         Ok(clients)
     }
 
+    fn inspect_client_identity_rotation(
+        &mut self,
+        plans: &UniFiRequestPlans,
+        api_key: &UniFiApiKey,
+        site_id: &str,
+        source_key: &UniFiPresenceKey,
+        destination_key: &UniFiPresenceKey,
+    ) -> Result<Vec<UniFiClientIdentityRotation>, UniFiError> {
+        let path = format!("/v1/sites/{}/clients", safe_path_id(site_id)?);
+        let plan = paginated_plan(
+            &plans.endpoint,
+            &plans.api_key_ref,
+            &path,
+            0,
+            plans.timeout_ms,
+        )?;
+        let response = self.get_sensitive_json(&plan, api_key, "connected client list")?;
+        parse_client_identity_rotation(&response.0, site_id, source_key, destination_key)
+    }
+
     fn inspect_device_statistics(
         &mut self,
         plans: &UniFiRequestPlans,
@@ -670,6 +783,21 @@ impl<T: UniFiTransport> UniFiClient<T> {
             &snapshot.sites,
         )?;
         Ok(snapshot)
+    }
+
+    fn inspect_client_identity_rotation(
+        &mut self,
+        site_id: &str,
+        source_key: &UniFiPresenceKey,
+        destination_key: &UniFiPresenceKey,
+    ) -> Result<Vec<UniFiClientIdentityRotation>, UniFiError> {
+        self.transport.inspect_client_identity_rotation(
+            &self.plans,
+            &self.api_key,
+            site_id,
+            source_key,
+            destination_key,
+        )
     }
 
     pub fn inspect_device_statistics(
@@ -756,6 +884,85 @@ impl<T: UniFiTransport> UniFiRuntimeIntegration<T> {
         )?;
         let snapshot = self.client.inspect_with_connected_clients()?;
         install_snapshot(runtime, &self.client.config, &snapshot, observed_at_ms)
+    }
+
+    pub fn rotate_client_presence_key_authorized<B, L>(
+        &mut self,
+        runtime: &mut SmartHomeRuntime,
+        store: &SmartHomeRuntimeStore<B>,
+        leases: &L,
+        request: UniFiPresenceKeyRotationRequest<'_>,
+    ) -> Result<UniFiPresenceKeyRotationReport, UniFiError>
+    where
+        B: StorageBackend,
+        L: LeaseManager + ?Sized,
+    {
+        safe_path_id(&request.site_id)?;
+        if request.source_key_lease_id == request.destination_key_lease_id {
+            return Err(UniFiError::Validation(
+                "source and destination presence-key leases must be distinct".to_string(),
+            ));
+        }
+        authorize_read(
+            runtime,
+            request.principal_id.clone(),
+            request.observed_at_ms,
+        )?;
+        authorize_client_inspection(
+            &self.data_governance,
+            &request.principal_id,
+            &self.client.config,
+            request.observed_at_ms,
+        )?;
+
+        let mut payloads = leases.consume_many(&[
+            request.source_key_lease_id.clone(),
+            request.destination_key_lease_id.clone(),
+        ])?;
+        let destination_payload = payloads
+            .pop()
+            .expect("two requested leases return two ordered payloads");
+        let source_payload = payloads
+            .pop()
+            .expect("two requested leases return two ordered payloads");
+        let source_key = UniFiPresenceKey::new(source_payload.as_bytes().to_vec())?;
+        let destination_key = UniFiPresenceKey::new(destination_payload.as_bytes().to_vec())?;
+        drop(source_payload);
+        drop(destination_payload);
+        if source_key.bytes.as_slice() == destination_key.bytes.as_slice() {
+            return Err(UniFiError::Validation(
+                "destination presence key must differ from the source key".to_string(),
+            ));
+        }
+
+        let rotations = self.client.inspect_client_identity_rotation(
+            &request.site_id,
+            &source_key,
+            &destination_key,
+        )?;
+        drop(source_key);
+        drop(destination_key);
+
+        let rotated_clients = rotations.len();
+        let migration = build_client_identity_migration(
+            runtime,
+            &self.client.config,
+            &rotations,
+            request.observed_at_ms,
+        )?;
+        let (migration, revision) = store.migrate_retained_identities(
+            runtime,
+            &migration,
+            request.automation_definitions,
+            request.automation_state,
+            request.observed_at_ms,
+            request.expected_revision,
+        )?;
+        Ok(UniFiPresenceKeyRotationReport {
+            rotated_clients,
+            migration,
+            revision,
+        })
     }
 
     pub fn inspect_statistics_and_install_authorized(
@@ -1281,6 +1488,59 @@ fn parse_client_page(
     })
 }
 
+fn parse_client_identity_rotation(
+    value: &JsonValue,
+    site_id: &str,
+    source_key: &UniFiPresenceKey,
+    destination_key: &UniFiPresenceKey,
+) -> Result<Vec<UniFiClientIdentityRotation>, UniFiError> {
+    safe_path_id(site_id)?;
+    let object = value
+        .as_object()
+        .ok_or(UniFiError::MissingField("client page object"))?;
+    let (offset, count, total_count, data) = page_fields(object, 0)?;
+    if offset != 0 || count == 0 || count != total_count || total_count > PAGE_LIMIT {
+        return Err(UniFiError::Validation(format!(
+            "client rotation requires one complete page containing 1-{PAGE_LIMIT} clients"
+        )));
+    }
+
+    let mut source_pseudonyms = BTreeSet::new();
+    let mut destination_pseudonyms = BTreeSet::new();
+    let mut rotations = Vec::with_capacity(data.len());
+    for item in data {
+        let object = item
+            .as_object()
+            .ok_or(UniFiError::MissingField("client data item"))?;
+        let native_id = Zeroizing::new(required_text(object, "id")?);
+        safe_path_id(native_id.as_str())?;
+        let source_pseudonym = connected_client_pseudonym(source_key, site_id, native_id.as_str());
+        let destination_pseudonym =
+            connected_client_pseudonym(destination_key, site_id, native_id.as_str());
+        if source_pseudonym == destination_pseudonym {
+            return Err(UniFiError::Validation(
+                "presence-key rotation produced an unchanged pseudonym".to_string(),
+            ));
+        }
+        if !source_pseudonyms.insert(source_pseudonym.clone()) {
+            return Err(UniFiError::Validation(
+                "duplicate source connected-client identifier".to_string(),
+            ));
+        }
+        if !destination_pseudonyms.insert(destination_pseudonym.clone()) {
+            return Err(UniFiError::Validation(
+                "duplicate destination connected-client identifier".to_string(),
+            ));
+        }
+        rotations.push(UniFiClientIdentityRotation {
+            source_pseudonym,
+            destination_pseudonym,
+        });
+    }
+    rotations.sort_by(|left, right| left.source_pseudonym.cmp(&right.source_pseudonym));
+    Ok(rotations)
+}
+
 fn parse_client_access(
     value: Option<&JsonValue>,
 ) -> Result<(Option<String>, Option<bool>), UniFiError> {
@@ -1460,6 +1720,165 @@ fn connected_client_pseudonym(
     input.extend_from_slice(native_id.as_bytes());
     let digest = Zeroizing::new(sha256(input.as_slice()));
     lowercase_hex(&digest[..16])
+}
+
+fn build_client_identity_migration(
+    runtime: &SmartHomeRuntime,
+    config: &UniFiConfig,
+    rotations: &[UniFiClientIdentityRotation],
+    observed_at_ms: u64,
+) -> Result<RuntimeRetainedIdentityMigration, UniFiError> {
+    if rotations.is_empty() {
+        return Err(UniFiError::Validation(
+            "presence-key rotation requires at least one connected client".to_string(),
+        ));
+    }
+
+    let mut source_devices = BTreeMap::new();
+    for device in runtime.registry().devices().filter(|device| {
+        device.bridge_id == config.bridge_id
+            && metadata_value(&device.metadata, "unifi.identifier_form") == Some("keyed_pseudonym")
+    }) {
+        let identifiers = device
+            .identifiers
+            .iter()
+            .filter(|identifier| {
+                identifier.family == ProtocolFamily::Vendor(PROTOCOL_ID.to_string())
+                    && identifier.kind == "client_pseudonym"
+            })
+            .collect::<Vec<_>>();
+        let [identifier] = identifiers.as_slice() else {
+            return Err(UniFiError::Validation(format!(
+                "installed client {} must have exactly one governed pseudonym",
+                device.device_id
+            )));
+        };
+        validate_pseudonym(&identifier.value)?;
+        if source_devices
+            .insert(identifier.value.clone(), device)
+            .is_some()
+        {
+            return Err(UniFiError::Validation(
+                "installed connected-client pseudonyms must be unique".to_string(),
+            ));
+        }
+    }
+    if source_devices.len() != rotations.len() {
+        return Err(UniFiError::Validation(
+            "client response does not exactly match the installed pseudonymous client set"
+                .to_string(),
+        ));
+    }
+
+    let mut replacements = Vec::with_capacity(rotations.len());
+    for rotation in rotations {
+        let source_device = source_devices
+            .remove(&rotation.source_pseudonym)
+            .ok_or_else(|| {
+                UniFiError::Validation(
+                    "client response does not correspond to an installed pseudonym".to_string(),
+                )
+            })?;
+        validate_pseudonym(&rotation.destination_pseudonym)?;
+        let [source_entity_id] = source_device.entity_ids.as_slice() else {
+            return Err(UniFiError::Validation(format!(
+                "installed client {} must have exactly one presence entity",
+                source_device.device_id
+            )));
+        };
+        let source_entity = runtime.registry().entity(source_entity_id).ok_or_else(|| {
+            UniFiError::Validation(format!(
+                "installed client references missing entity {source_entity_id}"
+            ))
+        })?;
+        let state = source_entity.state.as_ref().ok_or_else(|| {
+            UniFiError::Validation(format!(
+                "installed client entity {source_entity_id} has no presence state"
+            ))
+        })?;
+        let maximum_expiry = state
+            .observed_at_ms
+            .checked_add(CLIENT_PRESENCE_RETENTION_MS)
+            .ok_or_else(|| {
+                UniFiError::Validation("client presence expiry overflows time".to_string())
+            })?;
+        if state
+            .expires_at_ms
+            .is_none_or(|expiry| expiry <= observed_at_ms || expiry > maximum_expiry)
+        {
+            return Err(UniFiError::Validation(format!(
+                "installed client entity {source_entity_id} is outside the five-minute presence boundary"
+            )));
+        }
+
+        let destination_device_id =
+            DeviceId::trusted(format!("unifi:client:{}", rotation.destination_pseudonym));
+        let destination_entity_id = EntityId::trusted(format!(
+            "unifi:client:{}:presence",
+            rotation.destination_pseudonym
+        ));
+        let mut replacement_entity = source_entity.clone();
+        replacement_entity.entity_id = destination_entity_id.clone();
+        replacement_entity.device_id = destination_device_id.clone();
+        replacement_entity.name = format!(
+            "UniFi client {} presence",
+            &rotation.destination_pseudonym[..8]
+        );
+        replacement_entity.state = None;
+
+        let mut replacement_device = source_device.clone();
+        replacement_device.device_id = destination_device_id;
+        replacement_device.name = format!(
+            "UniFi connected client {}",
+            &rotation.destination_pseudonym[..8]
+        );
+        replacement_device.entity_ids = vec![destination_entity_id];
+        let identifier = replacement_device
+            .identifiers
+            .iter_mut()
+            .find(|identifier| {
+                identifier.family == ProtocolFamily::Vendor(PROTOCOL_ID.to_string())
+                    && identifier.kind == "client_pseudonym"
+            })
+            .expect("validated client pseudonym identifier remains present");
+        identifier.value = rotation.destination_pseudonym.clone();
+        replacements.push(RetainedDeviceIdentityReplacement::new(
+            source_device.device_id.clone(),
+            replacement_device,
+            vec![RetainedEntityIdentityReplacement::new(
+                source_entity_id.clone(),
+                replacement_entity,
+            )],
+        ));
+    }
+    if !source_devices.is_empty() {
+        return Err(UniFiError::Validation(
+            "client response does not exactly match the installed pseudonymous client set"
+                .to_string(),
+        ));
+    }
+    Ok(RuntimeRetainedIdentityMigration::new(replacements))
+}
+
+fn validate_pseudonym(value: &str) -> Result<(), UniFiError> {
+    if value.len() == 32
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        Ok(())
+    } else {
+        Err(UniFiError::Validation(
+            "connected-client pseudonym must be 128-bit lowercase hexadecimal text".to_string(),
+        ))
+    }
+}
+
+fn metadata_value<'a>(metadata: &'a [Metadata], key: &str) -> Option<&'a str> {
+    metadata
+        .iter()
+        .find(|entry| entry.key == key)
+        .map(|entry| entry.value.as_str())
 }
 
 fn lowercase_hex(bytes: &[u8]) -> String {
@@ -2185,15 +2604,20 @@ fn decode_chunked(input: &[u8], maximum: usize) -> Result<Vec<u8>, UniFiError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use coding_adventures_vault_leases::{InMemoryLeaseManager, LeasePayload, LeaseStatus};
     use smart_home_core::{CapabilityGrant, CapabilityGrantId, PrivilegeTier};
     use smart_home_data_governance::{ConsentReceiptRef, DataPurpose, DataUseGrant};
     use std::io::{BufRead, BufReader};
     use std::net::TcpListener;
+    use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{mpsc, Arc, Mutex};
     use std::thread;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use storage_local_folder::LocalFolderStorageBackend;
 
     const PRESENCE_KEY: [u8; 32] = [0x6c; 32];
+    const ROTATED_PRESENCE_KEY: [u8; 32] = [0x7d; 32];
     const CLIENT_ID: &str = "f27a1d16-6f5d-4bd8-a12c-c9ed87f17c14";
     const CLIENT_NAME: &str = "Private Phone";
     const CLIENT_MAC: &str = "aa:bb:cc:dd:ee:ff";
@@ -2204,9 +2628,13 @@ mod tests {
     }
 
     fn config(port: u16) -> UniFiConfig {
+        config_for(&format!("http://127.0.0.1:{port}"))
+    }
+
+    fn config_for(base_url: &str) -> UniFiConfig {
         UniFiConfig::new(
             BridgeId::trusted("unifi.test"),
-            format!("http://127.0.0.1:{port}"),
+            base_url,
             VaultRef::trusted("vault://unifi/test"),
         )
         .unwrap()
@@ -2400,6 +2828,40 @@ mod tests {
         policy
     }
 
+    fn temp_root(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "smart-home-unifi-{name}-{}-{unique}",
+            std::process::id()
+        ))
+    }
+
+    fn installed_client_runtime(
+        base_url: &str,
+    ) -> (SmartHomeRuntime, AgentId, InstalledUniFiNetwork) {
+        let mut runtime = SmartHomeRuntime::new();
+        let principal = AgentId::trusted("agent:presence-rotation");
+        authorize(&mut runtime, principal.clone());
+        let site = snapshot().sites[0].clone();
+        let key = UniFiPresenceKey::new(PRESENCE_KEY.to_vec()).unwrap();
+        let sensitive = SensitiveJson(connected_client_page());
+        let mut installed_snapshot = snapshot();
+        installed_snapshot.connected_clients = parse_client_page(&sensitive.0, 0, &site, &key)
+            .unwrap()
+            .data;
+        let installed = install_snapshot(
+            &mut runtime,
+            &config_for(base_url),
+            &installed_snapshot,
+            4_000,
+        )
+        .unwrap();
+        (runtime, principal, installed)
+    }
+
     fn statistics_policy(principal: &AgentId) -> DataGovernancePolicy {
         let mut policy = DataGovernancePolicy::default();
         policy
@@ -2523,6 +2985,180 @@ mod tests {
             ))
         ));
         assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    struct RotationCountingTransport {
+        calls: usize,
+    }
+
+    impl UniFiTransport for RotationCountingTransport {
+        fn inspect(
+            &mut self,
+            _plans: &UniFiRequestPlans,
+            _api_key: &UniFiApiKey,
+        ) -> Result<UniFiSnapshot, UniFiError> {
+            panic!("rotation tests must not run aggregate inspection")
+        }
+
+        fn inspect_client_identity_rotation(
+            &mut self,
+            _plans: &UniFiRequestPlans,
+            _api_key: &UniFiApiKey,
+            site_id: &str,
+            source_key: &UniFiPresenceKey,
+            destination_key: &UniFiPresenceKey,
+        ) -> Result<Vec<UniFiClientIdentityRotation>, UniFiError> {
+            self.calls = self.calls.saturating_add(1);
+            parse_client_identity_rotation(
+                &connected_client_page(),
+                site_id,
+                source_key,
+                destination_key,
+            )
+        }
+    }
+
+    #[test]
+    fn rotation_without_presence_consent_consumes_no_key_and_reaches_no_transport() {
+        let (mut runtime, principal, _) = installed_client_runtime("http://127.0.0.1:1");
+        let root = temp_root("rotation-consent-denial");
+        let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+        let revision = store.save(&runtime, &[], 4_000).unwrap();
+        let leases = InMemoryLeaseManager::new();
+        let source_lease = leases
+            .issue(LeasePayload::new(PRESENCE_KEY.to_vec()), 60_000)
+            .unwrap();
+        let destination_lease = leases
+            .issue(LeasePayload::new(ROTATED_PRESENCE_KEY.to_vec()), 60_000)
+            .unwrap();
+        let client =
+            UniFiClient::new(config(1), api_key(), RotationCountingTransport { calls: 0 }).unwrap();
+        let mut integration = UniFiRuntimeIntegration::new(client);
+
+        assert!(matches!(
+            integration.rotate_client_presence_key_authorized(
+                &mut runtime,
+                &store,
+                &leases,
+                UniFiPresenceKeyRotationRequest::new(
+                    principal,
+                    "site-1",
+                    &source_lease,
+                    &destination_lease,
+                    5_000,
+                    revision,
+                ),
+            ),
+            Err(UniFiError::DataGovernanceDenied(
+                DataGovernanceDenial::NoMatchingConsent
+            ))
+        ));
+        assert_eq!(integration.client.transport.calls, 0);
+        assert_eq!(
+            leases.consume(&source_lease).unwrap().as_bytes(),
+            PRESENCE_KEY
+        );
+        assert_eq!(
+            leases.consume(&destination_lease).unwrap().as_bytes(),
+            ROTATED_PRESENCE_KEY
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rotation_parser_derives_exact_pseudonyms_and_requires_one_complete_page() {
+        let source_key = UniFiPresenceKey::new(PRESENCE_KEY.to_vec()).unwrap();
+        let destination_key = UniFiPresenceKey::new(ROTATED_PRESENCE_KEY.to_vec()).unwrap();
+        let sensitive = SensitiveJson(connected_client_page());
+        let rotations =
+            parse_client_identity_rotation(&sensitive.0, "site-1", &source_key, &destination_key)
+                .unwrap();
+        assert_eq!(rotations.len(), 1);
+        assert_eq!(rotations[0].source_pseudonym.len(), 32);
+        assert_eq!(rotations[0].destination_pseudonym.len(), 32);
+        assert_ne!(
+            rotations[0].source_pseudonym,
+            rotations[0].destination_pseudonym
+        );
+        for raw in [CLIENT_ID, CLIENT_NAME, CLIENT_MAC, CLIENT_IP] {
+            assert!(!format!("{rotations:?}").contains(raw));
+        }
+
+        let mut partial = connected_client_page();
+        partial["totalCount"] = serde_json::json!(2);
+        assert!(
+            parse_client_identity_rotation(&partial, "site-1", &source_key, &destination_key,)
+                .unwrap_err()
+                .to_string()
+                .contains("one complete page")
+        );
+    }
+
+    #[test]
+    fn rotation_rejects_stale_automation_identity_without_swapping_live_state() {
+        let (mut runtime, principal, installed) = installed_client_runtime("http://127.0.0.1:1");
+        let source_entity_id = installed.connected_client_entity_ids[0].clone();
+        let source_device_id = runtime
+            .registry()
+            .entity(&source_entity_id)
+            .unwrap()
+            .device_id
+            .clone();
+        let root = temp_root("rotation-stale-automation");
+        let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+        let revision = store.save(&runtime, &[], 4_000).unwrap();
+        let leases = InMemoryLeaseManager::new();
+        let source_lease = leases
+            .issue(LeasePayload::new(PRESENCE_KEY.to_vec()), 60_000)
+            .unwrap();
+        let destination_lease = leases
+            .issue(LeasePayload::new(ROTATED_PRESENCE_KEY.to_vec()), 60_000)
+            .unwrap();
+        let definitions = vec![DurableAutomationDefinition::new(
+            "automation:stale-unifi-client",
+            true,
+            serde_json::json!({"entity_id": source_entity_id.to_string()}),
+        )
+        .unwrap()];
+        let client =
+            UniFiClient::new(config(1), api_key(), RotationCountingTransport { calls: 0 }).unwrap();
+        let mut integration =
+            UniFiRuntimeIntegration::new(client).with_data_governance(client_policy(&principal));
+
+        let error = integration
+            .rotate_client_presence_key_authorized(
+                &mut runtime,
+                &store,
+                &leases,
+                UniFiPresenceKeyRotationRequest::new(
+                    principal,
+                    "site-1",
+                    &source_lease,
+                    &destination_lease,
+                    5_000,
+                    revision,
+                )
+                .with_automation_context(&definitions, None),
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            UniFiError::RuntimeStore(RuntimeStoreError::Validation {
+                field: "automation_definitions",
+                ..
+            })
+        ));
+        assert_eq!(integration.client.transport.calls, 1);
+        assert!(runtime.registry().device(&source_device_id).is_some());
+        assert!(runtime.registry().entity(&source_entity_id).is_some());
+        let restored = store.load().unwrap().unwrap();
+        assert!(restored
+            .runtime
+            .registry()
+            .device(&source_device_id)
+            .is_some());
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]
@@ -2991,6 +3627,135 @@ mod tests {
         for raw in [CLIENT_ID, CLIENT_NAME, CLIENT_MAC, CLIENT_IP] {
             assert!(!debug.contains(raw));
         }
+    }
+
+    #[test]
+    fn governed_rotation_consumes_two_keys_reads_once_and_persists_atomically() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let base_url = format!("http://{address}");
+        let (sender, receiver) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream);
+            let mut head = String::new();
+            loop {
+                let mut line = String::new();
+                reader.read_line(&mut line).unwrap();
+                if line == "\r\n" {
+                    break;
+                }
+                head.push_str(&line);
+            }
+            sender.send(head).unwrap();
+            let body = serde_json::to_vec(&connected_client_page()).unwrap();
+            let response_head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            reader
+                .get_mut()
+                .write_all(response_head.as_bytes())
+                .unwrap();
+            reader.get_mut().write_all(&body).unwrap();
+        });
+
+        let (mut runtime, principal, installed) = installed_client_runtime(&base_url);
+        let source_entity_id = installed.connected_client_entity_ids[0].clone();
+        let source_device_id = runtime
+            .registry()
+            .entity(&source_entity_id)
+            .unwrap()
+            .device_id
+            .clone();
+        let root = temp_root("presence-key-rotation");
+        let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+        let initial_revision = store.save(&runtime, &[], 4_000).unwrap();
+        let leases = InMemoryLeaseManager::new();
+        let source_lease = leases
+            .issue(LeasePayload::new(PRESENCE_KEY.to_vec()), 60_000)
+            .unwrap();
+        let destination_lease = leases
+            .issue(LeasePayload::new(ROTATED_PRESENCE_KEY.to_vec()), 60_000)
+            .unwrap();
+        let expected_pseudonym = connected_client_pseudonym(
+            &UniFiPresenceKey::new(ROTATED_PRESENCE_KEY.to_vec()).unwrap(),
+            "site-1",
+            CLIENT_ID,
+        );
+        let expected_device_id = DeviceId::trusted(format!("unifi:client:{expected_pseudonym}"));
+        let expected_entity_id =
+            EntityId::trusted(format!("unifi:client:{expected_pseudonym}:presence"));
+        let client = UniFiClient::new(
+            config_for(&base_url),
+            api_key(),
+            UniFiLanTransport::default(),
+        )
+        .unwrap();
+        let mut integration =
+            UniFiRuntimeIntegration::new(client).with_data_governance(client_policy(&principal));
+
+        let report = integration
+            .rotate_client_presence_key_authorized(
+                &mut runtime,
+                &store,
+                &leases,
+                UniFiPresenceKeyRotationRequest::new(
+                    principal,
+                    "site-1",
+                    &source_lease,
+                    &destination_lease,
+                    5_000,
+                    initial_revision,
+                ),
+            )
+            .unwrap();
+        server.join().unwrap();
+
+        assert_eq!(report.rotated_clients, 1);
+        assert_eq!(report.migration.migrated_devices, 1);
+        assert_eq!(report.migration.migrated_entities, 1);
+        let requests = receiver.try_iter().collect::<Vec<_>>();
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].starts_with(
+            "GET /proxy/network/integration/v1/sites/site-1/clients?offset=0&limit=100 HTTP/1.1"
+        ));
+        assert!(requests[0].contains("X-API-Key: secret-api-key\r\n"));
+        assert_eq!(
+            leases.lookup(&source_lease).unwrap().status_at(0),
+            LeaseStatus::Revoked
+        );
+        assert_eq!(
+            leases.lookup(&destination_lease).unwrap().status_at(0),
+            LeaseStatus::Revoked
+        );
+        assert!(runtime.registry().device(&source_device_id).is_none());
+        assert!(runtime.registry().entity(&source_entity_id).is_none());
+        let replacement = runtime.registry().device(&expected_device_id).unwrap();
+        assert_eq!(replacement.entity_ids, vec![expected_entity_id.clone()]);
+        let presence = runtime.registry().entity(&expected_entity_id).unwrap();
+        assert_eq!(
+            presence.state.as_ref().unwrap().expires_at_ms,
+            Some(4_000 + CLIENT_PRESENCE_RETENTION_MS)
+        );
+        let debug = format!("{:?}", runtime.registry());
+        for raw in [CLIENT_ID, CLIENT_NAME, CLIENT_MAC, CLIENT_IP] {
+            assert!(!debug.contains(raw));
+        }
+
+        let restored = store.load().unwrap().unwrap();
+        assert_eq!(restored.revision, report.revision);
+        assert!(restored
+            .runtime
+            .registry()
+            .device(&expected_device_id)
+            .is_some());
+        assert!(restored
+            .runtime
+            .registry()
+            .entity(&expected_entity_id)
+            .is_some());
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1256,11 +1256,10 @@ rotation without starting either vendor-specific rotation workflow:
   succeeds. A stale revision leaves both live and durable state unchanged.
   Supplied automation definitions and execution state must already use the
   destination identities; exact source-ID references fail before mutation.
-- Enphase key rotation now uses this path in the completed slice below. UniFi
-  key rotation remains a separate production-integration slice and must derive
-  old and new pseudonyms from one bounded sensitive response while two one-shot
-  keys are leased, dispose native identifiers before returning, and submit the
-  complete migration through this revision-guarded path.
+- Enphase and bounded UniFi connected-client key rotation now use this path in
+  the completed slices below. Multi-site or paginated UniFi rotation remains
+  prerequisite-gated because one-shot keys cannot safely span a partially
+  persisted multi-response operation.
 
 ## Current Enphase Identifier-Key Rotation Slice
 
@@ -1291,49 +1290,72 @@ identity migration path:
   exclusion of native inverter serials from runtime debug state. Consent denial
   occurs before either lease or transport is touched.
 
+## Current UniFi Connected-Client Identifier-Key Rotation Slice
+
+This slice closes bounded UniFi connected-client pseudonym-key rotation over
+the shared retained-identity migration path:
+
+- The host supplies one explicit safe site ID and two distinct one-shot
+  32-byte key leases. D23 read authorization and the exact ephemeral
+  device-identifier plus five-minute presence grants succeed before either
+  lease is consumed or transport is reached.
+- Both leases are consumed atomically. Exactly one authenticated first-page
+  client response must be non-empty, complete, and contain no more than 100
+  clients; hidden pagination fails closed.
+- The zeroizing native response derives exact source/destination pseudonym
+  correspondence under both keys. Raw client IDs and both key objects are
+  disposed before retained-identity migration begins.
+- The response must correspond exactly to the installed pseudonymous client
+  set. Every replacement preserves its existing bounded presence state and
+  expiry while changing the complete client device/entity identity pair.
+- `smart-home-runtime-store` persists the replacements with the caller's
+  expected revision and swaps live state only after durable success. Opaque
+  automation definitions and state must already use destination identities or
+  prove absence of source references.
+- Real loopback coverage proves one API-key-authenticated client request,
+  atomic two-key consumption, live and restart identity replacement, and raw
+  identifier exclusion. Consent denial occurs before leases or transport.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
-1. Add UniFi connected-client pseudonym-key rotation over the same completed
-   migration path. One bounded authenticated client response must derive exact
-   old/new correspondence under two one-shot Vault-leased keys, preserve the
-   five-minute presence boundary, dispose of native identifiers and keys, and
-   migrate or prove absence of automation references before revision-guarded
-   persistence.
-
-2. Add authenticated AirGradient MQTT only after official firmware removes
+1. Add authenticated AirGradient MQTT only after official firmware removes
    plaintext credential logging and one-shot Vault-leased credential injection
    can be proven without request-plan or normalized-state exposure.
-3. Add independent AirGradient telemetry, remote-configuration, and OTA
+2. Add independent AirGradient telemetry, remote-configuration, and OTA
    destinations only if firmware exposes separate settings; the current
    `httpDomain` contract intentionally governs all three as one HTTPS origin.
-4. Add authenticated HEOS source browsing and queue insertion only after the
+3. Add authenticated HEOS source browsing and queue insertion only after the
    account/session and Vault-leasing prerequisites are concrete.
-5. Automate Enphase access-token acquisition or renewal only after Enphase
+4. Automate Enphase access-token acquisition or renewal only after Enphase
    account authentication, cloud-session handling, operator consent, and
    Vault-leased credential policy are concrete; the current host accepts a
    pre-generated token.
-6. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
+5. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
    stable LAN advertisement; the current production path uses explicit local
    HTTPS endpoint and gateway-serial configuration.
-7. Add Enphase live battery, relay, generator, grid, and system-topology state
+6. Add Enphase live battery, relay, generator, grid, and system-topology state
    only after the normalized energy topology and retention semantics are
    concrete.
-8. Add Enphase relay, grid-services, or configuration controls only with
+7. Add Enphase relay, grid-services, or configuration controls only with
    operation-specific D23 contracts, explicit safety approval, bounded native
    semantics, and readable postcondition verification.
-9. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
+8. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
    supervised session lifecycle and Vault policy for refresh-token residency are
    concrete; the current isolated inspection drops both tokens after each read.
-10. Add ZoneMinder event push only after a concrete authenticated event host and
+9. Add ZoneMinder event push only after a concrete authenticated event host and
     supervised subscription lifecycle exist.
-11. Add ZoneMinder snapshots, streams, recordings, export, and playback only
+10. Add ZoneMinder snapshots, streams, recordings, export, and playback only
     through the camera-media lease and a concrete media executor.
-12. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
+11. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
     mutations only with operation-specific D23 contracts, least-privilege user
     checks, bounded semantics, and readable postcondition verification.
+12. Add UniFi connected-client key rotation across multiple sites or more than
+    one 100-client page only after a resumable protocol can prove exact global
+    correspondence and all-or-none persistence without extending native-ID or
+    one-shot key residency across partial responses.
 13. Add UniFi connected-client native details only after field-specific
    minimization and retention are approved; current presence intentionally
    excludes names, native IDs, MACs, IPs, and connection timestamps.


### PR DESCRIPTION
## Summary
- add D23-authorized UniFi connected-client pseudonym-key rotation using two atomically consumed one-shot 32-byte Vault leases
- derive exact old/new correspondence from one bounded authenticated site response, preserve five-minute presence expiry, and dispose native identifiers and keys before migration
- persist complete client device/entity replacements through expected-revision runtime-store CAS with stale automation-reference rejection
- record multi-site and paginated rotation as a separate prerequisite-gated follow-up

## Validation
- cargo test --manifest-path code/packages/rust/smart-home-unifi-network-integration/Cargo.toml
- cargo clippy --manifest-path code/packages/rust/smart-home-unifi-network-integration/Cargo.toml --all-targets --all-features -- -D warnings
- smart-home-unifi-network-integration/BUILD
- cargo fmt --manifest-path code/packages/rust/smart-home-unifi-network-integration/Cargo.toml -- --check
- git diff --check