### PR TITLE
Verify Tamil ஆ handwriting ductus

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -68,8 +68,9 @@ HL-C77 closes that migration boundary: all 41 Spanish book chapters now generate
 from the same canonical lesson ASTs used by Language Ladder, narration, objective
 activities, and back matter. The twelve former handwritten entries are protected
 generated targets with checked hashes, titles, labels, order, and output. HL-C19
-is already complete, so HL-C09A is the next bounded stroke-order tranche: verify
-Tamil அ from the cited primer before widening DUCTUS across scripts.
+is already complete and HL-C09A verified Tamil அ in #10222. HL-C09B is the next
+bounded stroke-order tranche: verify Tamil ஆ from the cited primer before
+widening DUCTUS across scripts.
 The index audit found **2,075** canonical candidates across the corpus: **1,426**
 word and phrase lessons for English-first lookup, **136** dedicated grammar,
 writing, etymology, culture, and pronunciation lessons, **427** chapter
@@ -229,8 +230,9 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C06 | Complete (#10219) | Add the figure pipeline: SVG generation, `graphicx`, SVG→PDF in CI, and a `--check` hash gate. | A generated figure round-trips from canonical data into a compiled PDF and fails CI on drift, reusing `paint-vm-svg`'s `renderToSvgString`. |
 | HL-C07 | Complete (#9963) | Add the log-scanning warning gate with recorded per-track baselines. | Overfull/underfull boxes, missing glyphs, hyperref warnings, duplicate destinations, and font substitutions are machine-checked by `scan_latex_log_warnings.py` after the `latexmk` loop, against `core/latex-warning-baseline.json`. Baselines ship unseeded — `null` means unmeasured, never zero — so the gate reports today and fails the moment a seeded track regresses. The first CI run on main emits the real counts into the job summary for a human to paste back. |
 | HL-C08 | Complete (#9974) | Render the ductus in Language Ladder. | `penPathD`/`penTip` drive the tested SVG stroke build-up in the app; the currently authored ductus is shared with validation and script practice. |
-| HL-C09 | Queued — 2 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 226 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
+| HL-C09 | Queued — 3 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 225 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
 | HL-C09A | Complete (#10222) | Verify Tamil அ as the first post-HL-C19 expansion tranche, using the primer already cited for Tamil handwriting. | அ carries a source-aligned two-stroke path with exactly one lift; its five movements, learner prose, source metadata, font-outline geometry, and rendered filmstrip agree. |
+| HL-C09B | Complete (#10223) | Verify Tamil ஆ as the next source-backed expansion tranche from Frame 4 of the same primer. | ஆ carries a font-checked path for the அ body plus its long-vowel right-hand loop; its learner prose states every verified lift, and source, geometry, and filmstrip tests agree. |
 | HL-C10 | Complete (#10010, #10013, #10067) | Complete A1 and add the A2-through-C2 spine tranches with all registered realization ledgers. | All seven declared stages carry nodes; every one of the 22 registered tracks has a non-drifting ledger entry for every node. |
 | HL-C11 | Queued — capability and closure coverage complete | Finish representative chapter payoffs across all 22 tracks. | #10128 brought all 513 chapters to an authored `canDo`, spine mapping, known payoff lesson, and closed assessment. Remediate the remaining 27 payoffs below the 0.5 representativeness floor across ten tracks, then enforce the clean tracks instead of leaving their gates report-only. |
 | HL-C12 | Queued — licensing decided, pipeline outstanding | Add the Class C illustration pipeline with provenance sidecars and a size budget. Licensing is settled and recorded in [`_assets/LICENSE.md`](./_assets/LICENSE.md); the remaining work is the pipeline itself. | Every asset carries `license`, `rightsAsserted`, `generator`, `model`, `prompt`, `date`, and `sha256`; CI fails any asset without a provenance sidecar or a recorded licence, and enforces the per-track size budget. |
@@ -2633,7 +2635,7 @@ problem.
   **61 glyph violations plus five multi-system Japanese openings**. The current
   corpus is 91% core-drivable, not the historical 84% recorded before later work.
 - HL-C19 supersedes HL-C09's old estimate. There are **228** prose stroke-order
-  entries across ten scripts: two verified ductus paths and 226 entries still needing cited,
+  entries across ten scripts: three verified ductus paths and 225 entries still needing cited,
   font-checked pen-lift evidence.
 
 ## Findings from HL-C05

--- a/code/learning/human-languages/data/scripts/README.md
+++ b/code/learning/human-languages/data/scripts/README.md
@@ -130,13 +130,14 @@ and given the same citation.
 4. Where no ductus exists, do not invent lifts — keep the steps as part order and
    leave `penLifts` out.
 
-Tamil **அ** now joins **ம** with an authored ductus. The primer's Frame 4 shows
-four connected movements for அ's curl-and-loop body, followed by one lift and
-the separate right upright; the font-backed path and learner prose preserve that
-five-movement, two-stroke order exactly. The remaining **226** prose part
+Tamil **அ** and **ஆ** now join **ம** with authored ductus paths. The primer's
+Frame 4 shows four connected movements for their shared curl-and-loop body,
+followed by one lift and the separate right upright; ஆ then continues without
+another lift into its long-vowel loop. The font-backed paths and learner prose
+preserve those orders exactly. The remaining **225** prose part
 orders across ten scripts (`arabic` 21, `chinese` 24, `cyrillic` 33,
 `devanagari` 28, `gujarati` 33, `hebrew` 22, `japanese` 34,
-`perso-arabic` 9, `tamil` 9, `urdu-nastaliq` 13) are explicitly **unverified for
+`perso-arabic` 9, `tamil` 8, `urdu-nastaliq` 13) are explicitly **unverified for
 pen lifts**. The data validator rejects a lift count without a citation (or a
 citation without a count), and Language Ladder's ductus test proves every verified
 claim has the same cited, font-checked path. That closes `HL-C19`; future entries

--- a/code/learning/human-languages/data/scripts/tamil.json
+++ b/code/learning/human-languages/data/scripts/tamil.json
@@ -7,7 +7,7 @@
   "signature": "Curvy and loopy with flat top-bars on many letters, repeated arches, and no continuous head-line.",
   "complete": false,
   "combination": "A consonant carries an inherent 'a' (க = ka). A vowel sign replaces that vowel (க + ா → கா = kā). The puḷḷi ் — a DOT above the letter — removes the vowel entirely (க் = k). Unlike Devanagari, Tamil does NOT fuse the bare consonant into a conjunct: the dot stays visible and both letters keep their full shape. (A handful of Sanskrit-borrowed ligatures are the exception — க்ஷ kṣa and ஸ்ரீ śrī.)",
-  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ and ம have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ has two pen-down runs with one lift before its separate right upright; ம is a single unbroken stroke even though its parts have separate names. The other nine letters here have no verified pen path, so read their steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
+  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, and ம have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ and ஆ each have two pen-down runs with one lift before the separate right upright; ஆ then continues into its long-vowel loop without another lift. ம is a single unbroken stroke even though its parts have separate names. The other eight letters here have no verified pen path, so read their steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
   "letters": [
     {
       "glyph": "அ",
@@ -35,9 +35,22 @@
       "sound": "ā",
       "role": "independent-vowel",
       "components": ["the whole of அ", "a tail added on the right"],
-      "strokeOrder": ["write அ", "add the right-hand tail"],
-      "strokeOrderNote": "conventional",
-      "notes": "Long ā is short அ plus a tail — the same lengthening idea that appears as the ா sign on consonants."
+      "strokeOrder": [
+        "start inside the upper curl and sweep around it",
+        "without lifting, continue down the outer curve",
+        "without lifting, turn around the lower loop",
+        "without lifting, carry the horizontal to the right edge — then lift once",
+        "set the pen at the top of the separate right upright and draw straight down",
+        "without lifting again, continue into the long-vowel loop, curve right and around the bottom, then finish inside — and only now lift"
+      ],
+      "strokeOrderNote": "two strokes — four joined body movements, one pen lift, then the joined upright and long-vowel loop; cited to Radhakrishnan, Tamil Script Learners Manual, Frame 4, ஆ",
+      "penLifts": 1,
+      "strokeOrderSource": {
+        "citation": "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 4, ஆ (Univ. of Texas at Austin), p. 192",
+        "url": "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+        "variation": "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order."
+      },
+      "notes": "Long ā is short அ plus a tail — the same lengthening idea that appears as the ா sign on consonants. The அ-shaped body is the first pen-down run; after the one lift, the upright and long-vowel loop stay connected as the second."
     },
     {
       "glyph": "இ",

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
   pen lift before its separate right upright, matching Language Ladder's
   font-checked ductus and the UT Austin primer's Frame 4.
 
+### Added - verified Tamil ஆ handwriting
+
+- Record the cited six-movement order for Tamil ஆ: one lift separates the
+  shared அ-shaped body from a second run whose upright flows into the long-vowel
+  loop without another lift.
+
 ### Added - generated lesson figures
 
 - Generate deterministic etymology-route SVGs from the canonical lesson `roots`

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -11,6 +11,14 @@
   learner prose and citation identical to the authored path, and exercise the
   real two-stroke filmstrip instead of relying only on a synthetic fixture.
 
+### Added — connected long-vowel loop for Tamil ஆ (HL-C09B)
+
+- Add Frame 4's next row, Tamil ஆ, reusing the source's four-movement அ body,
+  then preserving one lift before a second pen-down run that joins the right
+  upright directly to the long-vowel loop.
+- Check all six movements against the full Noto Sans Tamil outline and pin the
+  real filmstrip's one-lift transition so list numbering cannot invent a second.
+
 ### Added — canonical lesson figures
 
 - Preserve standalone Markdown images as typed lesson blocks instead of flattening

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -165,11 +165,12 @@ in font units, and `ductusview.ts` flips them together with exactly **one**
 `scale(1,-1)` group — so a mistake cannot leave a plausible-looking stroke
 sitting upside down on a correct letter.
 
-**Tamil அ and ம have authored pen paths today.** `DUCTUS` admits no letter
+**Tamil அ, ஆ, and ம have authored pen paths today.** `DUCTUS` admits no letter
 without a citation for its stroke order, and hand-drawing a letter is forbidden
 outright (a subtly wrong Tamil ண looks perfect to exactly the audience that
-cannot yet read Tamil, so the error would ship *as the lesson*). அ exercises a
-real two-stroke path with one lift; ம remains one unbroken stroke. Every other
+cannot yet read Tamil, so the error would ship *as the lesson*). அ and ஆ exercise
+real two-stroke paths with one lift; ஆ keeps its upright and long-vowel loop in
+the same pen-down run, while ம remains one unbroken stroke. Every other
 letter falls back to the numbered prose list, unchanged. Extending the coverage
 is HL-C09, and it needs a cited source per letter.
 

--- a/code/programs/typescript/language-ladder/src/strokes.ts
+++ b/code/programs/typescript/language-ladder/src/strokes.ts
@@ -193,7 +193,9 @@ const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n);
 // against `source` (order), not trusted because they look plausible here.
 //
 // அ is Frame 4's first row: movements 1-4 remain on the connected body, then
-// the hand lifts once before movement 5 draws the separate right upright.
+// the hand lifts once before movement 5 draws the separate right upright. ஆ is
+// the next row: it repeats movements 1-5, then continues from that upright into
+// movement 6's long-vowel loop without another lift.
 // ம is Frame 1's third row: all five movements join into one unbroken stroke.
 // ---------------------------------------------------------------------------
 
@@ -280,6 +282,116 @@ export const DUCTUS: Record<string, LetterDuctus> = {
     source: {
       citation:
         "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 4, அ (Univ. of Texas at Austin), p. 192",
+      url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+      variation:
+        "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",
+    },
+  },
+  ஆ: {
+    glyph: "ஆ",
+    strokes: [
+      {
+        segments: [
+          {
+            label: "curl around the upper loop",
+            path: [
+              { x: 500, y: 510 },
+              { x: 440, y: 530 },
+              { x: 380, y: 500 },
+              { x: 340, y: 445 },
+              { x: 335, y: 385 },
+              { x: 360, y: 330 },
+              { x: 420, y: 285 },
+              { x: 490, y: 280 },
+              { x: 550, y: 310 },
+              { x: 590, y: 365 },
+              { x: 595, y: 430 },
+            ],
+          },
+          {
+            label: "sweep down the outer curve",
+            path: [
+              { x: 595, y: 430 },
+              { x: 650, y: 500 },
+              { x: 710, y: 460 },
+              { x: 755, y: 390 },
+              { x: 775, y: 300 },
+              { x: 775, y: 215 },
+              { x: 755, y: 130 },
+              { x: 710, y: 55 },
+            ],
+          },
+          {
+            label: "turn around the lower loop",
+            path: [
+              { x: 710, y: 55 },
+              { x: 650, y: -5 },
+              { x: 570, y: -50 },
+              { x: 470, y: -80 },
+              { x: 350, y: -90 },
+              { x: 240, y: -80 },
+              { x: 150, y: -50 },
+              { x: 90, y: 0 },
+              { x: 70, y: 55 },
+              { x: 90, y: 105 },
+              { x: 145, y: 140 },
+              { x: 215, y: 140 },
+            ],
+          },
+          {
+            label: "carry the horizontal to the right",
+            path: [
+              { x: 215, y: 140 },
+              { x: 350, y: 140 },
+              { x: 520, y: 140 },
+              { x: 700, y: 140 },
+              { x: 850, y: 140 },
+              { x: 950, y: 140 },
+            ],
+          },
+        ],
+      },
+      {
+        segments: [
+          {
+            label: "draw the right upright down",
+            path: [
+              { x: 990, y: 530 },
+              { x: 990, y: 390 },
+              { x: 990, y: 230 },
+              { x: 990, y: 70 },
+              { x: 990, y: 50 },
+            ],
+          },
+          {
+            label: "loop the long-vowel tail to the left",
+            path: [
+              { x: 990, y: 50 },
+              { x: 1050, y: 55 },
+              { x: 1120, y: 65 },
+              { x: 1200, y: 45 },
+              { x: 1250, y: 10 },
+              { x: 1265, y: -70 },
+              { x: 1230, y: -140 },
+              { x: 1180, y: -205 },
+              { x: 1100, y: -260 },
+              { x: 960, y: -285 },
+              { x: 850, y: -280 },
+              { x: 760, y: -245 },
+              { x: 700, y: -200 },
+              { x: 685, y: -155 },
+              { x: 700, y: -105 },
+              { x: 750, y: -75 },
+              { x: 820, y: -75 },
+              { x: 880, y: -95 },
+            ],
+          },
+        ],
+      },
+    ],
+    source: {
+      citation:
+        "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 4, ஆ (Univ. of Texas at Austin), p. 192",
       url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
       variation:
         "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",

--- a/code/programs/typescript/language-ladder/tests/ductusview.test.ts
+++ b/code/programs/typescript/language-ladder/tests/ductusview.test.ts
@@ -51,6 +51,8 @@ const MA = DUCTUS["ம"];
 const outline = tamilOutline("ம");
 const A = DUCTUS["அ"];
 const aOutline = tamilOutline("அ");
+const AA = DUCTUS["ஆ"];
+const aaOutline = tamilOutline("ஆ");
 
 /** Walk a node tree, collecting every node the predicate accepts. */
 function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = []): SvgNode[] {
@@ -62,9 +64,10 @@ function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = 
 const byTag = (node: SvgNode, tag: string) => collect(node, (n) => n.tag === tag);
 
 describe("ductusFor — only cited letters have a ductus", () => {
-  it("finds both authored Tamil letters", () => {
+  it("finds all three authored Tamil letters", () => {
     expect(ductusFor("ம")?.glyph).toBe("ம");
     expect(ductusFor("அ")?.glyph).toBe("அ");
+    expect(ductusFor("ஆ")?.glyph).toBe("ஆ");
   });
 
   it("returns undefined for a letter nobody has authored a stroke order for", () => {
@@ -293,6 +296,31 @@ describe("அ — a real cited two-stroke filmstrip", () => {
     expect(done).toHaveLength(1);
     expect(done[0].attrs.d).toBe(penPathD(A.strokes[0], 1));
     expect(pen.attrs.d).toBe(penPathD(A.strokes[1], 1));
+  });
+});
+
+describe("ஆ — the upright and long-vowel loop stay connected", () => {
+  const steps = ductusSteps(AA);
+  const strip = ductusFilmstrip(AA, aaOutline);
+
+  it("places one lift before the upright and none before its loop", () => {
+    expect(steps.map((step) => step.startsAfterLift)).toEqual([false, false, false, false, true, false]);
+    expect(steps.map((step) => step.strokeIndex)).toEqual([0, 0, 0, 0, 1, 1]);
+  });
+
+  it("reports six movements in two strokes with one lift", () => {
+    expect(strip.frames).toHaveLength(6);
+    expect(strip.penLifts).toBe(1);
+    expect(strip.summary).toBe("2 strokes · 1 pen lift · 6 movements");
+  });
+
+  it("finishes the connected upright-and-loop stroke in the last frame", () => {
+    const last = strip.frames[5];
+    const done = byTag(last, "path").filter((path) => path.attrs.class === "ductus__done");
+    const pen = byTag(last, "path").find((path) => path.attrs.class === "ductus__pen")!;
+    expect(done).toHaveLength(1);
+    expect(done[0].attrs.d).toBe(penPathD(AA.strokes[0], 1));
+    expect(pen.attrs.d).toBe(penPathD(AA.strokes[1], 1));
   });
 });
 

--- a/code/programs/typescript/language-ladder/tests/strokes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/strokes.test.ts
@@ -179,6 +179,12 @@ describe("handwriting ductus", () => {
     expect(DUCTUS["அ"].strokes).toHaveLength(2);
   });
 
+  it("ஆ lifts once, then joins its upright and long-vowel loop", () => {
+    expect(penLifts(DUCTUS["ஆ"])).toBe(1);
+    expect(DUCTUS["ஆ"].strokes).toHaveLength(2);
+    expect(DUCTUS["ஆ"].strokes[1].segments).toHaveLength(2);
+  });
+
   // The PROVENANCE GATE. A stroke's SHAPE is checked against the font above;
   // its ORDER cannot be — so it must trace to a cited source, or it does not
   // ship. This is the counterpart, for hand-authored order, of "facts enter
@@ -224,6 +230,13 @@ describe("handwriting ductus", () => {
     const src = DUCTUS["அ"].source;
     expect(src.url).toContain("tamilscript");
     expect(src.citation).toMatch(/Appendix I.*Frame 4.*அ/);
+    expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
+  });
+
+  it("ஆ's stroke order traces to the next row of Frame 4", () => {
+    const src = DUCTUS["ஆ"].source;
+    expect(src.url).toContain("tamilscript");
+    expect(src.citation).toMatch(/Appendix I.*Frame 4.*ஆ/);
     expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
   });
 });


### PR DESCRIPTION
## Summary

- add the cited six-movement ductus for Tamil ஆ from Frame 4 of Radhakrishnan's *Tamil Script Learners Manual*
- preserve the single verified lift between the shared அ-shaped body and a second run whose upright flows into the long-vowel loop
- align learner prose, source metadata, documentation, filmstrip behavior, and HL-C09 counts at 3 of 228 verified entries

## Why

HL-C09A established the first source-backed Tamil vowel. The next primer row extends that shape family, but its numbered parts could be misread as extra pen lifts. This tranche records the actual two-stroke path and leaves every unsupported glyph explicitly unverified.

## Validation

- visual review of the source PDF and the rendered six-frame learner filmstrip
- `bash BUILD` in `code/programs/typescript/language-ladder` — typecheck, production build, bundle budgets, 551 tests
- `bash BUILD` in `code/packages/typescript/human-language-data` — 460 tests with coverage
- `bash code/scripts/verify-human-languages.sh --fast` — all local checks passed
- `git diff --check`