### PR TITLE
Add opaque Vault bindings to Chief SDK

### DIFF
--- a/code/packages/typescript/chief-of-staff-sdk/CHANGELOG.md
+++ b/code/packages/typescript/chief-of-staff-sdk/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.3.0] - 2026-08-08
+
+### Added
+
+- Typed Level 3 Vault lease, direct-delivery, and release APIs.
+- Strict Vault parameter/result validation and redaction-safe opaque lease
+  receipts.
+
 ## [0.2.0] - 2026-08-03
 
 ### Added

--- a/code/packages/typescript/chief-of-staff-sdk/README.md
+++ b/code/packages/typescript/chief-of-staff-sdk/README.md
@@ -6,7 +6,7 @@ clock, or random-number permissions. It sends typed requests to a host over an
 injected transport, and the host enforces the sealed manifest.
 
 The SDK supports Level 2 one-file handlers and Level 3 direct encrypted-channel
-access. A Level 2 agent contains only its handler:
+and Vault access. A Level 2 agent contains only its handler:
 
 ```typescript
 import { defineAgent } from "@coding-adventures/chief-of-staff-sdk";
@@ -55,6 +55,29 @@ Channel payloads use canonical base64 on the wire and `Uint8Array` in agent
 code. Sequence numbers and nanosecond timestamps use decimal strings on the
 wire and `bigint` in agent code, avoiding JavaScript's 53-bit integer limit.
 
+Level 3 agents can request host-mediated Vault operations without receiving
+secret bytes or cryptographic keys:
+
+```typescript
+import {
+  vault_release_lease,
+  vault_request_direct,
+  vault_request_lease,
+} from "@coding-adventures/chief-of-staff-sdk";
+
+const lease = await vault_request_lease("bank-creds", 10_000);
+await approvedHostOperation({ vault_ref: lease.vault_ref });
+await vault_release_lease(lease.vault_ref);
+
+await vault_request_direct("browser-session", "browser-agent");
+```
+
+The returned `vault_ref` is an opaque bearer capability. It remains directly
+accessible for approved host calls but is non-enumerable, immutable, and
+replaced with `<redacted>` by JSON serialization. Agent code must not log,
+persist, derive meaning from, or send the reference outside approved host
+operations.
+
 ## Security properties
 
 - JSON-RPC version, response ID, result/error exclusivity, and result shapes
@@ -63,5 +86,7 @@ wire and `bigint` in agent code, avoiding JavaScript's 53-bit integer limit.
   content types, payloads, and protocol lines are rejected.
 - Host errors retain their numeric code and structured data without exposing
   unchecked response objects as SDK values.
+- Vault TTLs, receipts, and null acknowledgements are validated before use;
+  opaque lease references are redacted from enumerable and JSON diagnostics.
 - Level 2 input must be strict UTF-8, handler output must be non-empty text,
   and publication must succeed before acknowledgement.

--- a/code/packages/typescript/chief-of-staff-sdk/package-lock.json
+++ b/code/packages/typescript/chief-of-staff-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coding-adventures/chief-of-staff-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coding-adventures/chief-of-staff-sdk",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.0",

--- a/code/packages/typescript/chief-of-staff-sdk/package.json
+++ b/code/packages/typescript/chief-of-staff-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/chief-of-staff-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Capability-safe TypeScript SDK for Chief of Staff agents",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/chief-of-staff-sdk/src/index.ts
+++ b/code/packages/typescript/chief-of-staff-sdk/src/index.ts
@@ -4,6 +4,7 @@ const MAX_IDENTIFIER_BYTES = 4 * 1024;
 const MAX_CONTENT_TYPE_BYTES = 1024;
 const MAX_PAYLOAD_BYTES = 64 * 1024 * 1024;
 const MAX_PROTOCOL_LINE_BYTES = 90 * 1024 * 1024;
+const MAX_VAULT_LEASE_TTL_MS = 7_776_000_000;
 const BASE64_ALPHABET =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
@@ -152,6 +153,20 @@ export interface Message {
   readonly contentType: string;
   /** Verified plaintext payload. */
   readonly payload: Uint8Array;
+}
+
+/**
+ * Opaque, agent-facing Vault lease receipt.
+ *
+ * `vault_ref` is a bearer capability, not a secret or a secret identifier.
+ * It is deliberately non-enumerable on receipts returned by this SDK, and
+ * JSON diagnostics replace it with `<redacted>`.
+ */
+export interface VaultLeaseReceipt {
+  /** Opaque reference accepted only by approved host-mediated operations. */
+  readonly vault_ref: string;
+  /** Unix expiry time in milliseconds. */
+  readonly expires_at_ms: number;
 }
 
 /** UTF-8 message presented to a one-file Level 2 agent handler. */
@@ -337,7 +352,50 @@ export class ChannelClient {
   }
 }
 
+/** Typed Level 3 Vault client over one host transport. */
+export class VaultClient {
+  constructor(private readonly transport: HostTransport) {}
+
+  /** Request a time-limited opaque reference without exposing secret bytes. */
+  async requestLease(
+    secretName: string,
+    ttlMs: number,
+  ): Promise<VaultLeaseReceipt> {
+    validateIdentifier(secretName, "secretName");
+    validateVaultLeaseTtl(ttlMs);
+    const result = await this.transport.request("vault.requestLease", {
+      name: secretName,
+      ttl_ms: ttlMs,
+    });
+    return decodeVaultLeaseReceipt(result);
+  }
+
+  /** Ask the host to deliver a secret directly to another trusted consumer. */
+  async requestDirect(
+    secretName: string,
+    consumerAgentId: string,
+  ): Promise<void> {
+    validateIdentifier(secretName, "secretName");
+    validateIdentifier(consumerAgentId, "consumerAgentId");
+    const result = await this.transport.request("vault.requestDirect", {
+      name: secretName,
+      consumer_agent_id: consumerAgentId,
+    });
+    validateNullResult(result, "vault.requestDirect");
+  }
+
+  /** Surrender an unused bearer reference before its normal expiry. */
+  async releaseLease(vaultRef: string): Promise<void> {
+    validateIdentifier(vaultRef, "vaultRef");
+    const result = await this.transport.request("vault.releaseLease", {
+      vault_ref: vaultRef,
+    });
+    validateNullResult(result, "vault.releaseLease");
+  }
+}
+
 let defaultChannelClient: ChannelClient | undefined;
+let defaultVaultClient: VaultClient | undefined;
 
 /** Configure the host transport used by the module-level SDK functions. */
 export function configureHostTransport(transport: HostTransport): void {
@@ -349,11 +407,13 @@ export function configureHostTransport(transport: HostTransport): void {
     throw new ChiefSdkError("transport must implement request(method, params)");
   }
   defaultChannelClient = new ChannelClient(transport);
+  defaultVaultClient = new VaultClient(transport);
 }
 
 /** Remove the configured transport, primarily for wrapper shutdown and tests. */
 export function clearHostTransport(): void {
   defaultChannelClient = undefined;
+  defaultVaultClient = undefined;
 }
 
 /** Read through the configured Level 3 channel client. */
@@ -378,11 +438,95 @@ export function channel_ack(
   return configuredClient().ack(channelId, messageId);
 }
 
+/** Request an opaque lease through the configured Level 3 Vault client. */
+export function vault_request_lease(
+  secretName: string,
+  ttlMs: number,
+): Promise<VaultLeaseReceipt> {
+  return configuredVaultClient().requestLease(secretName, ttlMs);
+}
+
+/** Request host-to-consumer secret delivery without receiving secret bytes. */
+export function vault_request_direct(
+  secretName: string,
+  consumerAgentId: string,
+): Promise<void> {
+  return configuredVaultClient().requestDirect(secretName, consumerAgentId);
+}
+
+/** Release an opaque Vault lease through the configured host transport. */
+export function vault_release_lease(vaultRef: string): Promise<void> {
+  return configuredVaultClient().releaseLease(vaultRef);
+}
+
 function configuredClient(): ChannelClient {
   if (defaultChannelClient === undefined) {
     throw new ChiefSdkError("host transport is not configured");
   }
   return defaultChannelClient;
+}
+
+function configuredVaultClient(): VaultClient {
+  if (defaultVaultClient === undefined) {
+    throw new ChiefSdkError("host transport is not configured");
+  }
+  return defaultVaultClient;
+}
+
+function decodeVaultLeaseReceipt(value: unknown): VaultLeaseReceipt {
+  if (!isRecord(value)) {
+    throw new ChiefSdkError("vault.requestLease result must be an object");
+  }
+  const vaultRef = value["vault_ref"];
+  const expiresAtMs = value["expires_at_ms"];
+  validateIdentifier(vaultRef, "vault.requestLease vault_ref");
+  if (
+    typeof expiresAtMs !== "number" ||
+    !Number.isSafeInteger(expiresAtMs) ||
+    expiresAtMs < 0
+  ) {
+    throw new ChiefSdkError(
+      "vault.requestLease expires_at_ms must be a non-negative safe integer",
+    );
+  }
+
+  const receipt = { expires_at_ms: expiresAtMs } as VaultLeaseReceipt;
+  Object.defineProperties(receipt, {
+    vault_ref: {
+      value: vaultRef,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    },
+    toJSON: {
+      value: () => ({
+        vault_ref: "<redacted>",
+        expires_at_ms: expiresAtMs,
+      }),
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    },
+  });
+  return Object.freeze(receipt);
+}
+
+function validateVaultLeaseTtl(value: number): void {
+  if (
+    !Number.isSafeInteger(value) ||
+    value < 1 ||
+    value > MAX_VAULT_LEASE_TTL_MS
+  ) {
+    throw new ChiefSdkError(
+      "ttlMs must be an integer from 1 through 7776000000 milliseconds",
+    );
+  }
+}
+
+function validateNullResult(value: unknown, method: string): void {
+  if (value !== null) {
+    throw new ChiefSdkError(`${method} result must be null`);
+  }
 }
 
 function decodeMessage(value: unknown): Message {

--- a/code/packages/typescript/chief-of-staff-sdk/tests/sdk.test.ts
+++ b/code/packages/typescript/chief-of-staff-sdk/tests/sdk.test.ts
@@ -6,6 +6,7 @@ import {
   HostRpcError,
   JsonRpcLineTransport,
   SimpleAgentRuntime,
+  VaultClient,
   channel_ack,
   channel_read,
   channel_write,
@@ -14,6 +15,9 @@ import {
   configureHostTransport,
   createDefinedAgentRuntime,
   defineAgent,
+  vault_release_lease,
+  vault_request_direct,
+  vault_request_lease,
   type HostTransport,
   type JsonLineDuplex,
 } from "../src/index.js";
@@ -295,6 +299,146 @@ describe("module-level channel API", () => {
       "channel.read",
       "channel.write",
       "channel.ack",
+    ]);
+  });
+});
+
+describe("VaultClient", () => {
+  it("requests an opaque lease and redacts its bearer reference from diagnostics", async () => {
+    const transport = new ScriptedTransport({
+      vault_ref: "vault-ref-secret-bearer",
+      expires_at_ms: 1_800_000_000_000,
+    });
+
+    const receipt = await new VaultClient(transport).requestLease(
+      "bank-creds",
+      10_000,
+    );
+
+    expect(transport.calls).toEqual([
+      {
+        method: "vault.requestLease",
+        params: { name: "bank-creds", ttl_ms: 10_000 },
+      },
+    ]);
+    expect(receipt.vault_ref).toBe("vault-ref-secret-bearer");
+    expect(receipt.expires_at_ms).toBe(1_800_000_000_000);
+    expect(Object.keys(receipt)).toEqual(["expires_at_ms"]);
+    expect({ ...receipt }).toEqual({ expires_at_ms: 1_800_000_000_000 });
+    expect(JSON.stringify(receipt)).toBe(
+      '{"vault_ref":"<redacted>","expires_at_ms":1800000000000}',
+    );
+    expect(JSON.stringify(receipt)).not.toContain("secret-bearer");
+    expect(Object.isFrozen(receipt)).toBe(true);
+  });
+
+  it("requests direct delivery and releases only through the host", async () => {
+    const transport = new ScriptedTransport(null, null);
+    const client = new VaultClient(transport);
+
+    await expect(
+      client.requestDirect("bank-creds", "browser-agent"),
+    ).resolves.toBeUndefined();
+    await expect(
+      client.releaseLease("vault-ref-secret-bearer"),
+    ).resolves.toBeUndefined();
+    expect(transport.calls).toEqual([
+      {
+        method: "vault.requestDirect",
+        params: {
+          name: "bank-creds",
+          consumer_agent_id: "browser-agent",
+        },
+      },
+      {
+        method: "vault.releaseLease",
+        params: { vault_ref: "vault-ref-secret-bearer" },
+      },
+    ]);
+  });
+
+  it.each([
+    [null, "object"],
+    [{}, "vault_ref"],
+    [{ vault_ref: "", expires_at_ms: 1 }, "vault_ref"],
+    [{ vault_ref: 7, expires_at_ms: 1 }, "vault_ref"],
+    [{ vault_ref: "ref", expires_at_ms: -1 }, "expires_at_ms"],
+    [{ vault_ref: "ref", expires_at_ms: 1.5 }, "expires_at_ms"],
+    [
+      { vault_ref: "ref", expires_at_ms: Number.MAX_SAFE_INTEGER + 1 },
+      "expires_at_ms",
+    ],
+    [{ vault_ref: "ref", expires_at_ms: "1" }, "expires_at_ms"],
+  ])("rejects malformed vault.requestLease result %j", async (result, message) => {
+    await expect(
+      new VaultClient(new ScriptedTransport(result)).requestLease("secret", 1),
+    ).rejects.toThrow(message);
+  });
+
+  it.each([0, 7_776_000_001, 1.5, Number.NaN])(
+    "rejects invalid lease TTL %j before calling the host",
+    async (ttlMs) => {
+      const transport = new ScriptedTransport();
+      await expect(
+        new VaultClient(transport).requestLease("secret", ttlMs),
+      ).rejects.toThrow("ttlMs");
+      expect(transport.calls).toEqual([]);
+    },
+  );
+
+  it("rejects invalid arguments and malformed null acknowledgements", async () => {
+    const invalid = new ScriptedTransport();
+    const invalidClient = new VaultClient(invalid);
+    await expect(invalidClient.requestLease("", 1)).rejects.toThrow(
+      "secretName",
+    );
+    await expect(invalidClient.requestDirect("secret", "")).rejects.toThrow(
+      "consumerAgentId",
+    );
+    await expect(invalidClient.releaseLease("")).rejects.toThrow("vaultRef");
+    expect(invalid.calls).toEqual([]);
+
+    await expect(
+      new VaultClient(new ScriptedTransport({})).requestDirect(
+        "secret",
+        "consumer",
+      ),
+    ).rejects.toThrow("must be null");
+    await expect(
+      new VaultClient(new ScriptedTransport("ok")).releaseLease("ref"),
+    ).rejects.toThrow("must be null");
+  });
+});
+
+describe("module-level Vault API", () => {
+  it("fails closed until configured", () => {
+    expect(() => vault_request_lease("secret", 1)).toThrow("not configured");
+    expect(() => vault_request_direct("secret", "consumer")).toThrow(
+      "not configured",
+    );
+    expect(() => vault_release_lease("ref")).toThrow("not configured");
+  });
+
+  it("delegates lease, direct delivery, and release to the configured transport", async () => {
+    const transport = new ScriptedTransport(
+      { vault_ref: "opaque-ref", expires_at_ms: 2_000 },
+      null,
+      null,
+    );
+    configureHostTransport(transport);
+
+    await expect(vault_request_lease("secret", 1_000)).resolves.toMatchObject({
+      vault_ref: "opaque-ref",
+      expires_at_ms: 2_000,
+    });
+    await expect(
+      vault_request_direct("secret", "consumer"),
+    ).resolves.toBeUndefined();
+    await expect(vault_release_lease("opaque-ref")).resolves.toBeUndefined();
+    expect(transport.calls.map((call) => call.method)).toEqual([
+      "vault.requestLease",
+      "vault.requestDirect",
+      "vault.releaseLease",
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- add typed Vault lease, direct-delivery, and release clients plus module-level APIs
- preserve the canonical opaque receipt while preventing bearer references from appearing in enumerable or JSON diagnostics
- fail closed on invalid TTLs, malformed receipts, bad acknowledgements, and unconfigured transports

## Validation

- `npm test` (48 tests)
- `npm run build`
- `npm run test:coverage` (96.63% statements, 92.3% branches)
- `code/programs/go/build-tool/build-tool -language typescript`
- `git diff --check`

Progresses #128
Progresses #134
Progresses #139