### PR TITLE
Verify Tamil இ handwriting ductus

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -68,9 +68,9 @@ HL-C77 closes that migration boundary: all 41 Spanish book chapters now generate
 from the same canonical lesson ASTs used by Language Ladder, narration, objective
 activities, and back matter. The twelve former handwritten entries are protected
 generated targets with checked hashes, titles, labels, order, and output. HL-C19
-is already complete and HL-C09A verified Tamil அ in #10222. HL-C09B is the next
-bounded stroke-order tranche: verify Tamil ஆ from the cited primer before
-widening DUCTUS across scripts.
+is already complete; HL-C09A verified Tamil அ in #10222 and HL-C09B verified
+Tamil ஆ in #10223. HL-C09C is the next bounded stroke-order tranche: verify
+Tamil இ from the cited primer before widening DUCTUS across scripts.
 The index audit found **2,075** canonical candidates across the corpus: **1,426**
 word and phrase lessons for English-first lookup, **136** dedicated grammar,
 writing, etymology, culture, and pronunciation lessons, **427** chapter
@@ -230,9 +230,10 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C06 | Complete (#10219) | Add the figure pipeline: SVG generation, `graphicx`, SVG→PDF in CI, and a `--check` hash gate. | A generated figure round-trips from canonical data into a compiled PDF and fails CI on drift, reusing `paint-vm-svg`'s `renderToSvgString`. |
 | HL-C07 | Complete (#9963) | Add the log-scanning warning gate with recorded per-track baselines. | Overfull/underfull boxes, missing glyphs, hyperref warnings, duplicate destinations, and font substitutions are machine-checked by `scan_latex_log_warnings.py` after the `latexmk` loop, against `core/latex-warning-baseline.json`. Baselines ship unseeded — `null` means unmeasured, never zero — so the gate reports today and fails the moment a seeded track regresses. The first CI run on main emits the real counts into the job summary for a human to paste back. |
 | HL-C08 | Complete (#9974) | Render the ductus in Language Ladder. | `penPathD`/`penTip` drive the tested SVG stroke build-up in the app; the currently authored ductus is shared with validation and script practice. |
-| HL-C09 | Queued — 3 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 225 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
+| HL-C09 | Queued — 4 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 224 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
 | HL-C09A | Complete (#10222) | Verify Tamil அ as the first post-HL-C19 expansion tranche, using the primer already cited for Tamil handwriting. | அ carries a source-aligned two-stroke path with exactly one lift; its five movements, learner prose, source metadata, font-outline geometry, and rendered filmstrip agree. |
 | HL-C09B | Complete (#10223) | Verify Tamil ஆ as the next source-backed expansion tranche from Frame 4 of the same primer. | ஆ carries a font-checked path for the அ body plus its long-vowel right-hand loop; its learner prose states every verified lift, and source, geometry, and filmstrip tests agree. |
+| HL-C09C | Complete (#10226) | Verify Tamil இ as Frame 4's third source-backed vowel tranche. | இ carries a seven-movement, font-checked path whose learner prose states each evidenced lift; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C10 | Complete (#10010, #10013, #10067) | Complete A1 and add the A2-through-C2 spine tranches with all registered realization ledgers. | All seven declared stages carry nodes; every one of the 22 registered tracks has a non-drifting ledger entry for every node. |
 | HL-C11 | Queued — capability and closure coverage complete | Finish representative chapter payoffs across all 22 tracks. | #10128 brought all 513 chapters to an authored `canDo`, spine mapping, known payoff lesson, and closed assessment. Remediate the remaining 27 payoffs below the 0.5 representativeness floor across ten tracks, then enforce the clean tracks instead of leaving their gates report-only. |
 | HL-C12 | Queued — licensing decided, pipeline outstanding | Add the Class C illustration pipeline with provenance sidecars and a size budget. Licensing is settled and recorded in [`_assets/LICENSE.md`](./_assets/LICENSE.md); the remaining work is the pipeline itself. | Every asset carries `license`, `rightsAsserted`, `generator`, `model`, `prompt`, `date`, and `sha256`; CI fails any asset without a provenance sidecar or a recorded licence, and enforces the per-track size budget. |
@@ -2635,7 +2636,7 @@ problem.
   **61 glyph violations plus five multi-system Japanese openings**. The current
   corpus is 91% core-drivable, not the historical 84% recorded before later work.
 - HL-C19 supersedes HL-C09's old estimate. There are **228** prose stroke-order
-  entries across ten scripts: three verified ductus paths and 225 entries still needing cited,
+  entries across ten scripts: four verified ductus paths and 224 entries still needing cited,
   font-checked pen-lift evidence.
 
 ## Findings from HL-C05

--- a/code/learning/human-languages/data/scripts/README.md
+++ b/code/learning/human-languages/data/scripts/README.md
@@ -130,14 +130,16 @@ and given the same citation.
 4. Where no ductus exists, do not invent lifts — keep the steps as part order and
    leave `penLifts` out.
 
-Tamil **அ** and **ஆ** now join **ம** with authored ductus paths. The primer's
+Tamil **அ**, **ஆ**, and **இ** now join **ம** with authored ductus paths. The primer's
 Frame 4 shows four connected movements for their shared curl-and-loop body,
 followed by one lift and the separate right upright; ஆ then continues without
-another lift into its long-vowel loop. The font-backed paths and learner prose
-preserve those orders exactly. The remaining **225** prose part
+another lift into its long-vowel loop. Frame 4's next row gives இ five joined
+inner-and-lower movements, one lift, then a joined outer-left climb and final
+arch. The font-backed paths and learner prose preserve those orders exactly. The
+remaining **224** prose part
 orders across ten scripts (`arabic` 21, `chinese` 24, `cyrillic` 33,
 `devanagari` 28, `gujarati` 33, `hebrew` 22, `japanese` 34,
-`perso-arabic` 9, `tamil` 8, `urdu-nastaliq` 13) are explicitly **unverified for
+`perso-arabic` 9, `tamil` 7, `urdu-nastaliq` 13) are explicitly **unverified for
 pen lifts**. The data validator rejects a lift count without a citation (or a
 citation without a count), and Language Ladder's ductus test proves every verified
 claim has the same cited, font-checked path. That closes `HL-C19`; future entries

--- a/code/learning/human-languages/data/scripts/tamil.json
+++ b/code/learning/human-languages/data/scripts/tamil.json
@@ -7,7 +7,7 @@
   "signature": "Curvy and loopy with flat top-bars on many letters, repeated arches, and no continuous head-line.",
   "complete": false,
   "combination": "A consonant carries an inherent 'a' (க = ka). A vowel sign replaces that vowel (க + ா → கா = kā). The puḷḷi ் — a DOT above the letter — removes the vowel entirely (க் = k). Unlike Devanagari, Tamil does NOT fuse the bare consonant into a conjunct: the dot stays visible and both letters keep their full shape. (A handful of Sanskrit-borrowed ligatures are the exception — க்ஷ kṣa and ஸ்ரீ śrī.)",
-  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, and ம have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ and ஆ each have two pen-down runs with one lift before the separate right upright; ஆ then continues into its long-vowel loop without another lift. ம is a single unbroken stroke even though its parts have separate names. The other eight letters here have no verified pen path, so read their steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
+  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, இ, and ம have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ and ஆ each have two pen-down runs with one lift before the separate right upright; ஆ then continues into its long-vowel loop without another lift. இ keeps its first five movements joined, lifts once before the outer-left climb, and joins that climb to the final arch. ம is a single unbroken stroke even though its parts have separate names. The other seven letters here have no verified pen path, so read their steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
   "letters": [
     {
       "glyph": "அ",
@@ -56,9 +56,24 @@
       "glyph": "இ",
       "sound": "i",
       "role": "independent-vowel",
-      "components": ["a crossing spiral on the left", "a tall straight vertical on the right"],
-      "strokeOrder": ["spiral", "right vertical"],
-      "strokeOrderNote": "conventional"
+      "components": ["an inner curl", "two crossing lower loops", "a large outer arch ending in a right descender"],
+      "strokeOrder": [
+        "start inside the upper curl and sweep around it",
+        "without lifting, sweep down the inner right curve",
+        "without lifting, carry left across the middle and turn around the lower-left loop",
+        "without lifting, climb the lower diagonal back to the left crossing",
+        "without lifting, carry right across the middle and turn around the lower-right loop — then lift once",
+        "set the pen at the lower outer-left side and climb it",
+        "without lifting again, arch over the top and down the far right — and only now lift"
+      ],
+      "strokeOrderNote": "two strokes — five joined inner-and-lower movements, one pen lift, then the joined outer-left climb and arch; cited to Radhakrishnan, Tamil Script Learners Manual, Frame 4, இ",
+      "penLifts": 1,
+      "strokeOrderSource": {
+        "citation": "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 4, இ (Univ. of Texas at Austin), p. 192",
+        "url": "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+        "variation": "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order."
+      },
+      "notes": "The compact curl, crossing lower loops, and large outside arch are seven named movements, not seven separate strokes. The first five stay connected; after one lift, the outside climb flows straight into the final arch as the second pen-down run."
     },
     {
       "glyph": "க",

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
   shared அ-shaped body from a second run whose upright flows into the long-vowel
   loop without another lift.
 
+### Added - verified Tamil இ handwriting
+
+- Record the cited seven-movement order for Tamil இ: five joined movements form
+  its inner curl and lower loops, then one lift precedes a second run joining the
+  outer-left climb to the final arch.
+
 ### Added - generated lesson figures
 
 - Generate deterministic etymology-route SVGs from the canonical lesson `roots`

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -19,6 +19,15 @@
 - Check all six movements against the full Noto Sans Tamil outline and pin the
   real filmstrip's one-lift transition so list numbering cannot invent a second.
 
+### Added — cited two-stroke ductus for Tamil இ (HL-C09C)
+
+- Add Frame 4's third row, Tamil இ: five joined movements build its inner curl
+  and crossing lower loops, then one verified lift precedes the outer-left climb
+  and final arch.
+- Check all seven movements against the full Noto Sans Tamil outline and pin the
+  real filmstrip's sole lift so its numbered parts cannot be mistaken for seven
+  separate strokes.
+
 ### Added — canonical lesson figures
 
 - Preserve standalone Markdown images as typed lesson blocks instead of flattening

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -165,12 +165,14 @@ in font units, and `ductusview.ts` flips them together with exactly **one**
 `scale(1,-1)` group — so a mistake cannot leave a plausible-looking stroke
 sitting upside down on a correct letter.
 
-**Tamil அ, ஆ, and ம have authored pen paths today.** `DUCTUS` admits no letter
+**Tamil அ, ஆ, இ, and ம have authored pen paths today.** `DUCTUS` admits no letter
 without a citation for its stroke order, and hand-drawing a letter is forbidden
 outright (a subtly wrong Tamil ண looks perfect to exactly the audience that
 cannot yet read Tamil, so the error would ship *as the lesson*). அ and ஆ exercise
 real two-stroke paths with one lift; ஆ keeps its upright and long-vowel loop in
-the same pen-down run, while ம remains one unbroken stroke. Every other
+the same pen-down run. இ keeps five inner-and-lower movements together, lifts
+once, then joins its outer-left climb to the final arch; ம remains one unbroken
+stroke. Every other
 letter falls back to the numbered prose list, unchanged. Extending the coverage
 is HL-C09, and it needs a cited source per letter.
 

--- a/code/programs/typescript/language-ladder/src/strokes.ts
+++ b/code/programs/typescript/language-ladder/src/strokes.ts
@@ -195,7 +195,9 @@ const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n);
 // அ is Frame 4's first row: movements 1-4 remain on the connected body, then
 // the hand lifts once before movement 5 draws the separate right upright. ஆ is
 // the next row: it repeats movements 1-5, then continues from that upright into
-// movement 6's long-vowel loop without another lift.
+// movement 6's long-vowel loop without another lift. இ is Frame 4's third row:
+// movements 1-5 form the inner and lower body, then the hand lifts once before
+// movements 6-7 climb the separate outer-left start and complete its arch.
 // ம is Frame 1's third row: all five movements join into one unbroken stroke.
 // ---------------------------------------------------------------------------
 
@@ -392,6 +394,136 @@ export const DUCTUS: Record<string, LetterDuctus> = {
     source: {
       citation:
         "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 4, ஆ (Univ. of Texas at Austin), p. 192",
+      url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+      variation:
+        "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",
+    },
+  },
+  இ: {
+    glyph: "இ",
+    strokes: [
+      {
+        segments: [
+          {
+            label: "curl around the inner loop",
+            path: [
+              { x: 500, y: 510 },
+              { x: 440, y: 535 },
+              { x: 370, y: 510 },
+              { x: 330, y: 460 },
+              { x: 325, y: 400 },
+              { x: 345, y: 340 },
+              { x: 400, y: 290 },
+              { x: 460, y: 280 },
+              { x: 520, y: 300 },
+              { x: 570, y: 340 },
+              { x: 590, y: 390 },
+            ],
+          },
+          {
+            label: "sweep down the inner right curve",
+            path: [
+              { x: 590, y: 390 },
+              { x: 590, y: 470 },
+              { x: 630, y: 480 },
+              { x: 650, y: 450 },
+              { x: 720, y: 430 },
+              { x: 760, y: 350 },
+              { x: 760, y: 250 },
+              { x: 750, y: 150 },
+              { x: 720, y: 70 },
+              { x: 690, y: 0 },
+            ],
+          },
+          {
+            label: "carry left and turn through the lower loop",
+            path: [
+              { x: 690, y: 0 },
+              { x: 700, y: 90 },
+              { x: 600, y: 105 },
+              { x: 470, y: 110 },
+              { x: 320, y: 100 },
+              { x: 240, y: 80 },
+              { x: 190, y: 110 },
+              { x: 170, y: 80 },
+              { x: 130, y: 10 },
+              { x: 95, y: -60 },
+              { x: 80, y: -140 },
+              { x: 100, y: -210 },
+              { x: 180, y: -260 },
+              { x: 300, y: -285 },
+              { x: 450, y: -270 },
+              { x: 540, y: -200 },
+            ],
+          },
+          {
+            label: "climb the lower diagonal",
+            path: [
+              { x: 540, y: -200 },
+              { x: 470, y: -185 },
+              { x: 400, y: -150 },
+              { x: 330, y: -110 },
+              { x: 270, y: -60 },
+              { x: 220, y: 0 },
+              { x: 190, y: 80 },
+              { x: 190, y: 110 },
+            ],
+          },
+          {
+            label: "carry right and turn around the lower loop",
+            path: [
+              { x: 190, y: 110 },
+              { x: 240, y: 80 },
+              { x: 320, y: 100 },
+              { x: 470, y: 110 },
+              { x: 600, y: 105 },
+              { x: 700, y: 90 },
+              { x: 780, y: 50 },
+              { x: 835, y: -10 },
+              { x: 850, y: -90 },
+              { x: 830, y: -170 },
+              { x: 790, y: -225 },
+              { x: 740, y: -270 },
+              { x: 670, y: -280 },
+              { x: 610, y: -250 },
+            ],
+          },
+        ],
+      },
+      {
+        segments: [
+          {
+            label: "climb the outer left side",
+            path: [
+              { x: 170, y: 80 },
+              { x: 170, y: 180 },
+              { x: 120, y: 280 },
+              { x: 120, y: 380 },
+            ],
+          },
+          {
+            label: "arch over the top and down the right",
+            path: [
+              { x: 120, y: 380 },
+              { x: 130, y: 500 },
+              { x: 200, y: 650 },
+              { x: 330, y: 760 },
+              { x: 500, y: 800 },
+              { x: 650, y: 800 },
+              { x: 800, y: 740 },
+              { x: 900, y: 650 },
+              { x: 970, y: 520 },
+              { x: 990, y: 350 },
+              { x: 990, y: 150 },
+              { x: 990, y: 40 },
+            ],
+          },
+        ],
+      },
+    ],
+    source: {
+      citation:
+        "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 4, இ (Univ. of Texas at Austin), p. 192",
       url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
       variation:
         "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",

--- a/code/programs/typescript/language-ladder/tests/ductusview.test.ts
+++ b/code/programs/typescript/language-ladder/tests/ductusview.test.ts
@@ -53,6 +53,8 @@ const A = DUCTUS["அ"];
 const aOutline = tamilOutline("அ");
 const AA = DUCTUS["ஆ"];
 const aaOutline = tamilOutline("ஆ");
+const I = DUCTUS["இ"];
+const iOutline = tamilOutline("இ");
 
 /** Walk a node tree, collecting every node the predicate accepts. */
 function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = []): SvgNode[] {
@@ -64,10 +66,11 @@ function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = 
 const byTag = (node: SvgNode, tag: string) => collect(node, (n) => n.tag === tag);
 
 describe("ductusFor — only cited letters have a ductus", () => {
-  it("finds all three authored Tamil letters", () => {
+  it("finds all four authored Tamil letters", () => {
     expect(ductusFor("ம")?.glyph).toBe("ம");
     expect(ductusFor("அ")?.glyph).toBe("அ");
     expect(ductusFor("ஆ")?.glyph).toBe("ஆ");
+    expect(ductusFor("இ")?.glyph).toBe("இ");
   });
 
   it("returns undefined for a letter nobody has authored a stroke order for", () => {
@@ -321,6 +324,31 @@ describe("ஆ — the upright and long-vowel loop stay connected", () => {
     expect(done).toHaveLength(1);
     expect(done[0].attrs.d).toBe(penPathD(AA.strokes[0], 1));
     expect(pen.attrs.d).toBe(penPathD(AA.strokes[1], 1));
+  });
+});
+
+describe("இ — a real cited seven-movement filmstrip", () => {
+  const steps = ductusSteps(I);
+  const strip = ductusFilmstrip(I, iOutline);
+
+  it("places one lift before the outer climb and joins that climb to the arch", () => {
+    expect(steps.map((step) => step.startsAfterLift)).toEqual([false, false, false, false, false, true, false]);
+    expect(steps.map((step) => step.strokeIndex)).toEqual([0, 0, 0, 0, 0, 1, 1]);
+  });
+
+  it("reports seven movements in two strokes with one lift", () => {
+    expect(strip.frames).toHaveLength(7);
+    expect(strip.penLifts).toBe(1);
+    expect(strip.summary).toBe("2 strokes · 1 pen lift · 7 movements");
+  });
+
+  it("finishes the joined outer climb-and-arch stroke in the last frame", () => {
+    const last = strip.frames[6];
+    const done = byTag(last, "path").filter((path) => path.attrs.class === "ductus__done");
+    const pen = byTag(last, "path").find((path) => path.attrs.class === "ductus__pen")!;
+    expect(done).toHaveLength(1);
+    expect(done[0].attrs.d).toBe(penPathD(I.strokes[0], 1));
+    expect(pen.attrs.d).toBe(penPathD(I.strokes[1], 1));
   });
 });
 

--- a/code/programs/typescript/language-ladder/tests/strokes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/strokes.test.ts
@@ -185,6 +185,13 @@ describe("handwriting ductus", () => {
     expect(DUCTUS["ஆ"].strokes[1].segments).toHaveLength(2);
   });
 
+  it("இ lifts once before its joined outer climb and arch", () => {
+    expect(penLifts(DUCTUS["இ"])).toBe(1);
+    expect(DUCTUS["இ"].strokes).toHaveLength(2);
+    expect(DUCTUS["இ"].strokes[0].segments).toHaveLength(5);
+    expect(DUCTUS["இ"].strokes[1].segments).toHaveLength(2);
+  });
+
   // The PROVENANCE GATE. A stroke's SHAPE is checked against the font above;
   // its ORDER cannot be — so it must trace to a cited source, or it does not
   // ship. This is the counterpart, for hand-authored order, of "facts enter
@@ -237,6 +244,13 @@ describe("handwriting ductus", () => {
     const src = DUCTUS["ஆ"].source;
     expect(src.url).toContain("tamilscript");
     expect(src.citation).toMatch(/Appendix I.*Frame 4.*ஆ/);
+    expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
+  });
+
+  it("இ's stroke order traces to Frame 4's third row", () => {
+    const src = DUCTUS["இ"].source;
+    expect(src.url).toContain("tamilscript");
+    expect(src.citation).toMatch(/Appendix I.*Frame 4.*இ/);
     expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
   });
 });


### PR DESCRIPTION
## Summary

- add the cited seven-movement Tamil இ ductus from Frame 4 of the UT Austin primer
- preserve the source-backed single lift before the joined outer climb and arch
- align learner prose, lift metadata, documentation, backlog counts, and the real filmstrip tests

## Why

HL-C09 expands verified handwriting coverage one bounded glyph at a time. Tamil இ was the next Frame 4 vowel after அ and ஆ; its numbered movements needed explicit, font-checked pen-lift evidence so learners do not read seven list items as seven separate strokes.

## Validation

- `bash BUILD` in `code/packages/typescript/human-language-data` — 460 tests passed
- `bash BUILD` in `code/programs/typescript/language-ladder` — typecheck, production build, bundle check, 559 tests passed
- `bash code/scripts/verify-human-languages.sh --fast` — all local checks passed
- `git diff --check`
- visual review of all seven generated filmstrip frames