### PR TITLE
Canonicalize the Chief vault lease tool

### DIFF
--- a/code/packages/rust/chief-of-staff-host-runtime/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-host-runtime/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Accept canonical colon-delimited D18D capability scopes in reviewed host
+  profiles so built-in service policy can be registered without aliases.
 - Support a distinct signed, code-free `SKILL.md` package layout alongside the
   canonical deny-all Deno layout.
 - Add no-overwrite package signing and retain authenticated Level 1 source bytes

--- a/code/packages/rust/chief-of-staff-host-runtime/README.md
+++ b/code/packages/rust/chief-of-staff-host-runtime/README.md
@@ -5,6 +5,8 @@ active D18D tool runtimes. Each host names its privilege ceiling, capability
 surface, and exact tool ids. The orchestrator profile requires one owner per
 tool and routes calls only to that host. Activation fails unless every
 allowlisted tool has been registered and every definition fits those bounds.
+Capability entries accept D18D colon-delimited service scopes such as
+`vault:lease` while retaining existing single-segment labels.
 
 This is the first production-shaped replacement for wiring an unrestricted
 `InMemoryToolRuntime` directly inside each Chief job. Profiles can now activate

--- a/code/packages/rust/chief-of-staff-host-runtime/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-host-runtime/src/lib.rs
@@ -75,7 +75,7 @@ impl HostProfile {
 
         let mut capabilities = BTreeSet::new();
         for capability in &self.capabilities {
-            validate_label("capability", capability)?;
+            validate_capability(capability)?;
             if !capabilities.insert(capability.clone()) {
                 return Err(HostRuntimeError::DuplicateCapability(capability.clone()));
             }
@@ -1164,6 +1164,23 @@ fn validate_label(field: &str, value: &str) -> Result<(), HostRuntimeError> {
     Ok(())
 }
 
+fn validate_capability(value: &str) -> Result<(), HostRuntimeError> {
+    let valid = !value.is_empty()
+        && value.split(':').all(|segment| {
+            !segment.is_empty()
+                && segment.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || character == '_' || character == '-'
+                })
+        });
+    if !valid {
+        return Err(HostRuntimeError::InvalidField {
+            field: "capability".to_string(),
+            message: "expected a colon-delimited non-empty ASCII capability scope".to_string(),
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1563,6 +1580,31 @@ while (true) {
             ),
             Err(HostRuntimeError::MissingCapability { .. })
         ));
+    }
+
+    #[test]
+    fn profile_accepts_scoped_capabilities_and_rejects_empty_segments() {
+        let scoped = PROFILE.replace("demo_read", "demo:read:account-one");
+        let mut runtime = HostProfileRuntime::from_json(&scoped).unwrap();
+        runtime
+            .register_handler(
+                definition(
+                    "demo.read",
+                    PrivilegeTier::Tier1,
+                    &["demo:read:account-one"],
+                ),
+                |_arguments, _context| Ok(ToolHandlerOutput::new(JsonValue::Null)),
+            )
+            .unwrap();
+        assert!(runtime.activate().is_ok());
+
+        for invalid in ["demo::read", ":demo", "demo:", "demo/read"] {
+            let profile = PROFILE.replace("demo_read", invalid);
+            assert!(matches!(
+                HostProfile::from_json(&profile),
+                Err(HostRuntimeError::InvalidField { field, .. }) if field == "capability"
+            ));
+        }
     }
 
     #[test]

--- a/code/packages/rust/chief-of-staff-tool-api/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-tool-api/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- Added the canonical Tier-2 `vault.request_lease` built-in with strict opaque
+  receipt schemas and the D18D `vault:lease` policy capability.
 - Added canonical approval challenges and explicit-consent, biometric, and
   hardware-key assurance levels. Tier-aware policy can now require approval at
   a privilege threshold, and Tier 2+ grants must match the active challenge

--- a/code/packages/rust/chief-of-staff-tool-api/README.md
+++ b/code/packages/rust/chief-of-staff-tool-api/README.md
@@ -20,8 +20,8 @@ The crate intentionally stops at the contract layer:
 - structured tool events and final results
 - JSON-schema-like argument validation
 - first-phase built-in store/job tool definitions from the D18D catalog,
-  including ContextStore, ArtifactStore, SkillStore, MemoryStore, and Job
-  runtime parity definitions
+  including ContextStore, ArtifactStore, SkillStore, MemoryStore, Job runtime,
+  and the Tier-2 opaque Vault lease contract
 - a deterministic in-memory registry for runtimes and tests
 - explicit policy decisions for permission, tier, and approval gates
 - user-visible approval challenges plus assurance-bearing, challenge-bound

--- a/code/packages/rust/chief-of-staff-tool-api/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-tool-api/src/lib.rs
@@ -567,6 +567,7 @@ pub enum BuiltinToolFamily {
     Skill,
     Memory,
     Job,
+    Vault,
 }
 
 impl BuiltinToolFamily {
@@ -577,6 +578,7 @@ impl BuiltinToolFamily {
             Self::Skill => "skill",
             Self::Memory => "memory",
             Self::Job => "job",
+            Self::Vault => "vault",
         }
     }
 }
@@ -852,6 +854,7 @@ pub fn builtin_tool_catalog() -> Vec<ToolDefinition> {
         job_run_now_definition(),
         job_list_definition(),
         job_status_definition(),
+        vault_request_lease_definition(),
     ]
     .into()
 }
@@ -2057,6 +2060,38 @@ fn job_status_definition() -> ToolDefinition {
         vec!["jobs:read"],
         None,
         vec!["job", "scheduler"],
+    )
+}
+
+fn vault_request_lease_definition() -> ToolDefinition {
+    builtin_definition(
+        "vault.request_lease",
+        "Request vault lease",
+        "Issue a short-lived opaque VaultRef for use by a trusted host tool.",
+        object_schema(
+            vec![
+                SchemaProperty::new("secret_name", JsonSchema::String),
+                SchemaProperty::new("ttl_ms", JsonSchema::Integer),
+            ],
+            vec!["secret_name", "ttl_ms"],
+            false,
+        ),
+        Some(object_schema(
+            vec![
+                SchemaProperty::new("vault_ref", JsonSchema::String),
+                SchemaProperty::new("expires_at_ms", JsonSchema::Integer),
+            ],
+            vec!["vault_ref", "expires_at_ms"],
+            false,
+        )),
+        ToolSideEffects::External,
+        ToolIdempotency::Never,
+        ToolConcurrency::Serialized,
+        ToolStreaming::Events,
+        PrivilegeTier::Tier2,
+        vec!["vault:lease"],
+        Some("vault"),
+        vec!["vault", "lease", "secret"],
     )
 }
 
@@ -5465,7 +5500,7 @@ mod tests {
         let catalog = builtin_tool_catalog();
         let mut registry = InMemoryToolRegistry::new();
 
-        assert_eq!(catalog.len(), 33);
+        assert_eq!(catalog.len(), 34);
         for definition in catalog {
             assert!(
                 definition.validate().ok,
@@ -5516,6 +5551,7 @@ mod tests {
                 "skill.read_asset",
                 "skill.read_manifest",
                 "skill.uninstall",
+                "vault.request_lease",
             ]
         );
     }
@@ -5529,6 +5565,11 @@ mod tests {
             .collect();
         let skill_tools = builtin_tools_for_family(BuiltinToolFamily::Skill);
         let skill_ids: Vec<_> = skill_tools
+            .iter()
+            .map(|definition| definition.tool_id.as_str())
+            .collect();
+        let vault_tools = builtin_tools_for_family(BuiltinToolFamily::Vault);
+        let vault_ids: Vec<_> = vault_tools
             .iter()
             .map(|definition| definition.tool_id.as_str())
             .collect();
@@ -5557,6 +5598,7 @@ mod tests {
                 "skill.uninstall",
             ]
         );
+        assert_eq!(vault_ids, vec!["vault.request_lease"]);
         assert_eq!(
             builtin_tool_definition("job.install")
                 .unwrap()
@@ -5575,7 +5617,66 @@ mod tests {
                 .required_capabilities,
             vec!["skills:install"]
         );
-        assert!(builtin_tool_definition("vault.request_lease").is_none());
+        assert_eq!(
+            builtin_tool_definition("vault.request_lease")
+                .unwrap()
+                .required_capabilities,
+            vec!["vault:lease"]
+        );
+    }
+
+    #[test]
+    fn vault_lease_builtin_has_opaque_tier2_contract() {
+        let definition =
+            builtin_tool_definition("vault.request_lease").expect("vault built-in should exist");
+
+        assert_eq!(definition.side_effects, ToolSideEffects::External);
+        assert_eq!(definition.idempotency, ToolIdempotency::Never);
+        assert_eq!(definition.concurrency, ToolConcurrency::Serialized);
+        assert_eq!(definition.streaming, ToolStreaming::Events);
+        assert_eq!(definition.required_tier, PrivilegeTier::Tier2);
+        assert_eq!(definition.preferred_lock_scope.as_deref(), Some("vault"));
+
+        let arguments = JsonValue::Object(vec![
+            (
+                "secret_name".to_string(),
+                JsonValue::String("weather-api-key".to_string()),
+            ),
+            (
+                "ttl_ms".to_string(),
+                JsonValue::Number(JsonNumber::Integer(30_000)),
+            ),
+        ]);
+        assert!(definition.input_schema.validate_value(&arguments).ok);
+
+        let receipt = JsonValue::Object(vec![
+            (
+                "vault_ref".to_string(),
+                JsonValue::String("vault-lease:opaque".to_string()),
+            ),
+            (
+                "expires_at_ms".to_string(),
+                JsonValue::Number(JsonNumber::Integer(1_800_000_000_000)),
+            ),
+        ]);
+        let output = definition.output_schema.as_ref().unwrap();
+        assert!(output.validate_value(&receipt).ok);
+
+        let exposed_secret = JsonValue::Object(vec![
+            (
+                "vault_ref".to_string(),
+                JsonValue::String("vault-lease:opaque".to_string()),
+            ),
+            (
+                "expires_at_ms".to_string(),
+                JsonValue::Number(JsonNumber::Integer(1_800_000_000_000)),
+            ),
+            (
+                "secret_b64".to_string(),
+                JsonValue::String("must-not-cross-boundary".to_string()),
+            ),
+        ]);
+        assert!(!output.validate_value(&exposed_secret).ok);
     }
 
     #[test]
@@ -5611,20 +5712,22 @@ mod tests {
         let export = builtin_tool_catalog_export(ToolCatalogQuery::new());
 
         assert!(export.ok());
-        assert_eq!(export.summary.total_tools, 33);
-        assert_eq!(export.schema_documents.len(), 33);
+        assert_eq!(export.summary.total_tools, 34);
+        assert_eq!(export.schema_documents.len(), 34);
         assert_eq!(export.summary.by_family.get("context"), Some(&6));
         assert_eq!(export.summary.by_family.get("artifact"), Some(&7));
         assert_eq!(export.summary.by_family.get("skill"), Some(&7));
         assert_eq!(export.summary.by_family.get("memory"), Some(&7));
         assert_eq!(export.summary.by_family.get("job"), Some(&6));
+        assert_eq!(export.summary.by_family.get("vault"), Some(&1));
         assert_eq!(export.summary.tag_count("store"), 27);
         assert_eq!(export.summary.tag_count("scheduler"), 6);
         assert_eq!(export.summary.required_capability_count("memory:read"), 3);
         assert_eq!(export.summary.required_capability_count("skills:read"), 3);
         assert!(export.summary.has_tag("store"));
         assert!(export.summary.has_required_capability("jobs:run"));
-        assert_eq!(export.summary.streaming_tools, 17);
+        assert!(export.summary.has_required_capability("vault:lease"));
+        assert_eq!(export.summary.streaming_tools, 18);
         assert!(export.summary.has_write_or_external_tools());
         assert!(export.summary.has_serialized_tools());
         assert!(export.summary.has_capability_gates());

--- a/code/packages/rust/skill-store/CHANGELOG.md
+++ b/code/packages/rust/skill-store/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- Accept canonical colon-delimited capability scopes in stored skill manifests
+  and requirement filters.
 - `SkillCatalogSummary` plus `SkillStore::catalog_summary()` for compact
   installed-version, active-state, and asset-material rollups.
 - `SkillRequirementSummary` plus `SkillStore::requirement_summary()` for

--- a/code/packages/rust/skill-store/README.md
+++ b/code/packages/rust/skill-store/README.md
@@ -79,6 +79,8 @@ asset material without returning raw manifests or asset bodies.
 compact rollup across filtered skill versions, entrypoints, required tools,
 required capabilities, and requirement gaps without returning raw manifests or
 asset bodies.
+Required capability entries accept canonical colon-delimited D18D/D21 scopes,
+including target-qualified values such as `vault:lease:bank-creds`.
 
 `SkillAssetInventorySummary` gives catalog and preload planners a compact
 rollup over one skill version's asset metadata, including content-type classes,

--- a/code/packages/rust/skill-store/src/lib.rs
+++ b/code/packages/rust/skill-store/src/lib.rs
@@ -334,8 +334,7 @@ impl SkillSourceSummary {
         }
 
         summary.unique_source_kinds = source_kinds.len();
-        summary.source_kinds = source_kinds.into_values()
-            .collect();
+        summary.source_kinds = source_kinds.into_values().collect();
         summary
     }
 
@@ -871,7 +870,7 @@ fn validate_skill_list_options(options: &SkillListOptions) -> Result<(), Storage
     }
     validate_id_list("entrypoints", &options.entrypoints)?;
     validate_id_list("required_tools", &options.required_tools)?;
-    validate_id_list("required_capabilities", &options.required_capabilities)
+    validate_capability_list(&options.required_capabilities)
 }
 
 fn validate_skill_asset_list_options(options: &SkillAssetListOptions) -> Result<(), StorageError> {
@@ -1161,7 +1160,7 @@ fn validate_manifest(manifest: &SkillManifest) -> Result<(), StorageError> {
     validate_name("description", &manifest.description)?;
     validate_id_list("entrypoints", &manifest.entrypoints)?;
     validate_id_list("required_tools", &manifest.required_tools)?;
-    validate_id_list("required_capabilities", &manifest.required_capabilities)?;
+    validate_capability_list(&manifest.required_capabilities)?;
     for asset in &manifest.assets {
         validate_asset_path(asset)?;
     }
@@ -1187,6 +1186,25 @@ fn validate_id(field: &str, value: &str) -> Result<(), StorageError> {
 fn validate_id_list(field: &str, values: &[String]) -> Result<(), StorageError> {
     for value in values {
         validate_id(field, value)?;
+    }
+    Ok(())
+}
+
+fn validate_capability_list(values: &[String]) -> Result<(), StorageError> {
+    for value in values {
+        if value.is_empty()
+            || !value.split(':').all(|segment| {
+                !segment.is_empty()
+                    && segment.chars().all(|character| {
+                        character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+                    })
+            })
+        {
+            return Err(validation(
+                "required_capabilities",
+                "must be a colon-delimited ASCII capability scope",
+            ));
+        }
     }
     Ok(())
 }
@@ -1297,6 +1315,32 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(asset.body, b"# hi".to_vec());
+    }
+
+    #[test]
+    fn manifests_accept_scoped_capabilities_and_reject_empty_segments() {
+        let store = SkillStore::new(InMemoryStorageBackend::new());
+        let mut scoped = manifest(true);
+        scoped.required_capabilities = vec!["vault:lease:bank-creds".to_string()];
+        store.install_skill(scoped, Vec::new()).unwrap();
+        assert_eq!(
+            store
+                .load_manifest("planner", "v1")
+                .unwrap()
+                .unwrap()
+                .required_capabilities,
+            vec!["vault:lease:bank-creds"]
+        );
+
+        for invalid in ["vault::lease", ":vault", "vault:", "vault/lease"] {
+            let mut rejected = manifest(false);
+            rejected.required_capabilities = vec![invalid.to_string()];
+            assert!(matches!(
+                store.install_skill(rejected, Vec::new()),
+                Err(StorageError::Validation { field, .. })
+                    if field == "required_capabilities"
+            ));
+        }
     }
 
     #[test]

--- a/code/packages/rust/weather-agent-e2e/CHANGELOG.md
+++ b/code/packages/rust/weather-agent-e2e/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- Reuse the canonical Tier-2 `vault.request_lease` catalog definition for the
+  real opaque-lease handler instead of maintaining a private duplicate schema,
+  and align its policy profile to the D18D `vault:lease` capability.
 - Loaded the Weather Agent D18D catalog from a reviewed orchestrator profile
   with isolated fetcher, classifier, and writer hosts through
   `chief-of-staff-host-runtime`.

--- a/code/packages/rust/weather-agent-e2e/orchestrator_profile.json
+++ b/code/packages/rust/weather-agent-e2e/orchestrator_profile.json
@@ -5,7 +5,7 @@
       "host_id": "vault",
       "max_tier": "tier2",
       "allowed_tools": ["vault.request_lease"],
-      "capabilities": ["vault_lease"]
+      "capabilities": ["vault:lease"]
     },
     {
       "host_id": "weather_fetcher",

--- a/code/packages/rust/weather-agent-e2e/src/lib.rs
+++ b/code/packages/rust/weather-agent-e2e/src/lib.rs
@@ -27,11 +27,12 @@ use chief_of_staff_host_runtime::{
     OrchestratorProfileSummary,
 };
 use chief_of_staff_tool_api::{
-    ApprovalAssurance, ApprovalState, JsonSchema, PrivilegeTier, RequestedBy, SchemaProperty,
-    ToolApiError, ToolApprovalChallenge, ToolApprovalGrant, ToolAuditRecordQuery, ToolCallError,
-    ToolConcurrency, ToolDefinition, ToolErrorKind, ToolEventKind, ToolExecutionJournal,
-    ToolExecutionJournalHealthSummary, ToolHandlerOutput, ToolIdempotency, ToolInvocationRequest,
-    ToolPolicyProfile, ToolSideEffects, ToolStability, ToolStreaming,
+    builtin_tool_definition, ApprovalAssurance, ApprovalState, JsonSchema, PrivilegeTier,
+    RequestedBy, SchemaProperty, ToolApiError, ToolApprovalChallenge, ToolApprovalGrant,
+    ToolAuditRecordQuery, ToolCallError, ToolConcurrency, ToolDefinition, ToolErrorKind,
+    ToolEventKind, ToolExecutionJournal, ToolExecutionJournalHealthSummary, ToolHandlerOutput,
+    ToolIdempotency, ToolInvocationRequest, ToolPolicyProfile, ToolSideEffects, ToolStability,
+    ToolStreaming,
 };
 use chief_of_staff_tool_audit_store::{ToolAuditStore, ToolAuditStoreInventorySummary};
 use chief_of_staff_vault_runtime::ChiefVaultRuntime;
@@ -1055,7 +1056,7 @@ impl UmbrellaPipeline {
                     WRITE_TOOL_ID.to_string(),
                 ],
                 required_capabilities: vec![
-                    "vault_lease".to_string(),
+                    "vault:lease".to_string(),
                     "weather_api_read".to_string(),
                     "filesystem_write".to_string(),
                 ],
@@ -1611,34 +1612,8 @@ fn register_vault_lease_tool(
     runtime: &mut OrchestratorProfileRuntime,
     vault: Arc<ChiefVaultRuntime>,
 ) -> Result<(), HostRuntimeError> {
-    let mut definition = tool_definition(
-        VAULT_TOOL_ID,
-        "Request vault lease",
-        "Issue a short-lived opaque VaultRef for use by a trusted host tool.",
-        JsonSchema::Object {
-            properties: vec![
-                SchemaProperty::new("secret_name", JsonSchema::String),
-                SchemaProperty::new("ttl_ms", JsonSchema::Integer),
-            ],
-            required: vec!["secret_name".to_string(), "ttl_ms".to_string()],
-            allow_unknown_fields: false,
-        },
-        Some(JsonSchema::Object {
-            properties: vec![
-                SchemaProperty::new("vault_ref", JsonSchema::String),
-                SchemaProperty::new("expires_at_ms", JsonSchema::Integer),
-            ],
-            required: vec!["vault_ref".to_string(), "expires_at_ms".to_string()],
-            allow_unknown_fields: false,
-        }),
-        ToolSideEffects::External,
-        ToolIdempotency::Never,
-        ToolConcurrency::Serialized,
-        ToolStreaming::Events,
-        vec!["vault_lease"],
-        vec!["vault", "lease", "secret"],
-    );
-    definition.required_tier = PrivilegeTier::Tier2;
+    let definition = builtin_tool_definition(VAULT_TOOL_ID)
+        .expect("the canonical vault lease built-in must be present");
     runtime.register_handler(definition, move |arguments, _context| {
         let secret_name = field_string(&arguments, "secret_name")?;
         let ttl_ms = field_i64(&arguments, "ttl_ms")?;


### PR DESCRIPTION
## Summary

- promote the existing Tier 2 opaque Vault lease contract into the canonical Chief built-in tool catalog
- align host profiles and skill manifests with strict colon-delimited D18D capability scopes
- migrate the Weather Agent lease handler and profile from its private definition to the shared catalog contract

## Validation

- cargo test -p chief-of-staff-tool-api -p chief-of-staff-host-runtime -p skill-store -p weather-agent-e2e -- --nocapture (85 passed, 1 intentional live HTTPS test ignored)
- cargo clippy --all-targets --all-features -- -D warnings for all four changed packages
- RUSTDOCFLAGS=-D warnings cargo doc --no-deps for all four changed packages
- repository affected-package build gate: 84 built, 871 skipped
- git diff --check

Progresses #128
Progresses #134
Progresses #139