### PR TITLE
Verify Tamil க handwriting ductus

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -68,9 +68,10 @@ HL-C77 closes that migration boundary: all 41 Spanish book chapters now generate
 from the same canonical lesson ASTs used by Language Ladder, narration, objective
 activities, and back matter. The twelve former handwritten entries are protected
 generated targets with checked hashes, titles, labels, order, and output. HL-C19
-is already complete; HL-C09A verified Tamil அ in #10222 and HL-C09B verified
-Tamil ஆ in #10223. HL-C09C is the next bounded stroke-order tranche: verify
-Tamil இ from the cited primer before widening DUCTUS across scripts.
+is already complete; HL-C09A verified Tamil அ in #10222, HL-C09B verified
+Tamil ஆ in #10223, and HL-C09C verified Tamil இ in #10226. HL-C09D is the
+next bounded stroke-order tranche: verify Tamil க from Frame 3 of the cited
+primer before widening DUCTUS across scripts.
 The index audit found **2,075** canonical candidates across the corpus: **1,426**
 word and phrase lessons for English-first lookup, **136** dedicated grammar,
 writing, etymology, culture, and pronunciation lessons, **427** chapter
@@ -230,10 +231,11 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C06 | Complete (#10219) | Add the figure pipeline: SVG generation, `graphicx`, SVG→PDF in CI, and a `--check` hash gate. | A generated figure round-trips from canonical data into a compiled PDF and fails CI on drift, reusing `paint-vm-svg`'s `renderToSvgString`. |
 | HL-C07 | Complete (#9963) | Add the log-scanning warning gate with recorded per-track baselines. | Overfull/underfull boxes, missing glyphs, hyperref warnings, duplicate destinations, and font substitutions are machine-checked by `scan_latex_log_warnings.py` after the `latexmk` loop, against `core/latex-warning-baseline.json`. Baselines ship unseeded — `null` means unmeasured, never zero — so the gate reports today and fails the moment a seeded track regresses. The first CI run on main emits the real counts into the job summary for a human to paste back. |
 | HL-C08 | Complete (#9974) | Render the ductus in Language Ladder. | `penPathD`/`penTip` drive the tested SVG stroke build-up in the app; the currently authored ductus is shared with validation and script practice. |
-| HL-C09 | Queued — 4 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 224 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
+| HL-C09 | Queued — 5 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 223 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
 | HL-C09A | Complete (#10222) | Verify Tamil அ as the first post-HL-C19 expansion tranche, using the primer already cited for Tamil handwriting. | அ carries a source-aligned two-stroke path with exactly one lift; its five movements, learner prose, source metadata, font-outline geometry, and rendered filmstrip agree. |
 | HL-C09B | Complete (#10223) | Verify Tamil ஆ as the next source-backed expansion tranche from Frame 4 of the same primer. | ஆ carries a font-checked path for the அ body plus its long-vowel right-hand loop; its learner prose states every verified lift, and source, geometry, and filmstrip tests agree. |
 | HL-C09C | Complete (#10226) | Verify Tamil இ as Frame 4's third source-backed vowel tranche. | இ carries a seven-movement, font-checked path whose learner prose states each evidenced lift; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
+| HL-C09D | Complete (#10228) | Verify Tamil க from Frame 3's final source-backed consonant row. | க carries a six-movement, font-checked three-stroke path whose learner prose states its two evidenced lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C10 | Complete (#10010, #10013, #10067) | Complete A1 and add the A2-through-C2 spine tranches with all registered realization ledgers. | All seven declared stages carry nodes; every one of the 22 registered tracks has a non-drifting ledger entry for every node. |
 | HL-C11 | Queued — capability and closure coverage complete | Finish representative chapter payoffs across all 22 tracks. | #10128 brought all 513 chapters to an authored `canDo`, spine mapping, known payoff lesson, and closed assessment. Remediate the remaining 27 payoffs below the 0.5 representativeness floor across ten tracks, then enforce the clean tracks instead of leaving their gates report-only. |
 | HL-C12 | Queued — licensing decided, pipeline outstanding | Add the Class C illustration pipeline with provenance sidecars and a size budget. Licensing is settled and recorded in [`_assets/LICENSE.md`](./_assets/LICENSE.md); the remaining work is the pipeline itself. | Every asset carries `license`, `rightsAsserted`, `generator`, `model`, `prompt`, `date`, and `sha256`; CI fails any asset without a provenance sidecar or a recorded licence, and enforces the per-track size budget. |
@@ -2636,7 +2638,7 @@ problem.
   **61 glyph violations plus five multi-system Japanese openings**. The current
   corpus is 91% core-drivable, not the historical 84% recorded before later work.
 - HL-C19 supersedes HL-C09's old estimate. There are **228** prose stroke-order
-  entries across ten scripts: four verified ductus paths and 224 entries still needing cited,
+  entries across ten scripts: five verified ductus paths and 223 entries still needing cited,
   font-checked pen-lift evidence.
 
 ## Findings from HL-C05

--- a/code/learning/human-languages/data/scripts/README.md
+++ b/code/learning/human-languages/data/scripts/README.md
@@ -130,16 +130,17 @@ and given the same citation.
 4. Where no ductus exists, do not invent lifts — keep the steps as part order and
    leave `penLifts` out.
 
-Tamil **அ**, **ஆ**, and **இ** now join **ம** with authored ductus paths. The primer's
+Tamil **அ**, **ஆ**, **இ**, and **க** now join **ம** with authored ductus paths. The primer's
 Frame 4 shows four connected movements for their shared curl-and-loop body,
 followed by one lift and the separate right upright; ஆ then continues without
 another lift into its long-vowel loop. Frame 4's next row gives இ five joined
 inner-and-lower movements, one lift, then a joined outer-left climb and final
 arch. The font-backed paths and learner prose preserve those orders exactly. The
-remaining **224** prose part
+Frame 3 row for க separates its upper frame and two lower bowls into three
+pen-down runs with two verified lifts. The remaining **223** prose part
 orders across ten scripts (`arabic` 21, `chinese` 24, `cyrillic` 33,
 `devanagari` 28, `gujarati` 33, `hebrew` 22, `japanese` 34,
-`perso-arabic` 9, `tamil` 7, `urdu-nastaliq` 13) are explicitly **unverified for
+`perso-arabic` 9, `tamil` 6, `urdu-nastaliq` 13) are explicitly **unverified for
 pen lifts**. The data validator rejects a lift count without a citation (or a
 citation without a count), and Language Ladder's ductus test proves every verified
 claim has the same cited, font-checked path. That closes `HL-C19`; future entries

--- a/code/learning/human-languages/data/scripts/tamil.json
+++ b/code/learning/human-languages/data/scripts/tamil.json
@@ -7,7 +7,7 @@
   "signature": "Curvy and loopy with flat top-bars on many letters, repeated arches, and no continuous head-line.",
   "complete": false,
   "combination": "A consonant carries an inherent 'a' (க = ka). A vowel sign replaces that vowel (க + ா → கா = kā). The puḷḷi ் — a DOT above the letter — removes the vowel entirely (க் = k). Unlike Devanagari, Tamil does NOT fuse the bare consonant into a conjunct: the dot stays visible and both letters keep their full shape. (A handful of Sanskrit-borrowed ligatures are the exception — க்ஷ kṣa and ஸ்ரீ śrī.)",
-  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, இ, and ம have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ and ஆ each have two pen-down runs with one lift before the separate right upright; ஆ then continues into its long-vowel loop without another lift. இ keeps its first five movements joined, lifts once before the outer-left climb, and joins that climb to the final arch. ம is a single unbroken stroke even though its parts have separate names. The other seven letters here have no verified pen path, so read their steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
+  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, இ, க, and ம have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ and ஆ each have two pen-down runs with one lift before the separate right upright; ஆ then continues into its long-vowel loop without another lift. இ keeps its first five movements joined, lifts once before the outer-left climb, and joins that climb to the final arch. க uses three pen-down runs: its upper frame, lower-left bowl, and lower-right bowl. ம is a single unbroken stroke even though its parts have separate names. The other six letters here have no verified pen path, so read their steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
   "letters": [
     {
       "glyph": "அ",
@@ -80,10 +80,23 @@
       "sound": "ka",
       "role": "consonant",
       "inherentVowel": "a",
-      "components": ["a straight horizontal top bar", "a bowl hanging from its left end", "a short right stroke that hooks left below"],
-      "strokeOrder": ["top bar", "left bowl", "right stroke and hook"],
-      "strokeOrderNote": "conventional",
-      "notes": "Tamil does not write separate letters for k / g / h — க covers them all, and position in the word decides which you say."
+      "components": ["an upper square frame", "a large lower-left bowl", "a lower-right bowl with an open foot"],
+      "strokeOrder": [
+        "start at the middle left and climb the left upright",
+        "without lifting, carry the top bar to the right and return along it to the inner corner",
+        "without lifting, drop the inner upright and carry the middle bar left — then lift once",
+        "set the pen at the inner crossing and curve down and around the lower-left bowl",
+        "without lifting again, return up its outer left side — then lift a second time",
+        "set the pen at the inner crossing and turn around the lower-right bowl — and only now lift"
+      ],
+      "strokeOrderNote": "three strokes — three joined upper-frame movements, one lift, two joined lower-left-bowl movements, a second lift, then the lower-right bowl; cited to Radhakrishnan, Tamil Script Learners Manual, Frame 3, க",
+      "penLifts": 2,
+      "strokeOrderSource": {
+        "citation": "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 3, க (Univ. of Texas at Austin), p. 191",
+        "url": "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+        "variation": "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order."
+      },
+      "notes": "Tamil does not write separate letters for k / g / h — க covers them all, and position in the word decides which you say. Its six numbered movements form three pen-down runs, not six strokes: the upper frame, the lower-left bowl, and the lower-right bowl."
     },
     {
       "glyph": "ம",

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -22,6 +22,12 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
   its inner curl and lower loops, then one lift precedes a second run joining the
   outer-left climb to the final arch.
 
+### Added - verified Tamil க handwriting
+
+- Record the cited six-movement order for Tamil க: its upper frame and two lower
+  bowls form three pen-down runs with exactly two lifts, matching the Frame 3
+  source and Language Ladder's font-checked path.
+
 ### Added - generated lesson figures
 
 - Generate deterministic etymology-route SVGs from the canonical lesson `roots`

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -28,6 +28,14 @@
   real filmstrip's sole lift so its numbered parts cannot be mistaken for seven
   separate strokes.
 
+### Added — cited three-stroke ductus for Tamil க (HL-C09D)
+
+- Add Frame 3's final row, Tamil க: three joined movements form its upper frame,
+  two joined movements form the lower-left bowl, and a final movement forms the
+  lower-right bowl, with exactly two verified lifts between those runs.
+- Check all six movements against the full Noto Sans Tamil outline and pin both
+  lift transitions in the real filmstrip and learner prose.
+
 ### Added — canonical lesson figures
 
 - Preserve standalone Markdown images as typed lesson blocks instead of flattening

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -165,14 +165,15 @@ in font units, and `ductusview.ts` flips them together with exactly **one**
 `scale(1,-1)` group — so a mistake cannot leave a plausible-looking stroke
 sitting upside down on a correct letter.
 
-**Tamil அ, ஆ, இ, and ம have authored pen paths today.** `DUCTUS` admits no letter
+**Tamil அ, ஆ, இ, க, and ம have authored pen paths today.** `DUCTUS` admits no letter
 without a citation for its stroke order, and hand-drawing a letter is forbidden
 outright (a subtly wrong Tamil ண looks perfect to exactly the audience that
 cannot yet read Tamil, so the error would ship *as the lesson*). அ and ஆ exercise
 real two-stroke paths with one lift; ஆ keeps its upright and long-vowel loop in
 the same pen-down run. இ keeps five inner-and-lower movements together, lifts
 once, then joins its outer-left climb to the final arch; ம remains one unbroken
-stroke. Every other
+stroke. க exercises a real three-stroke path: its upper frame and two lower bowls
+are separated by two verified lifts. Every other
 letter falls back to the numbered prose list, unchanged. Extending the coverage
 is HL-C09, and it needs a cited source per letter.
 

--- a/code/programs/typescript/language-ladder/src/strokes.ts
+++ b/code/programs/typescript/language-ladder/src/strokes.ts
@@ -198,6 +198,8 @@ const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n);
 // movement 6's long-vowel loop without another lift. இ is Frame 4's third row:
 // movements 1-5 form the inner and lower body, then the hand lifts once before
 // movements 6-7 climb the separate outer-left start and complete its arch.
+// க is Frame 3's final row: movements 1-3 make the upper frame, movements
+// 4-5 make the lower-left bowl, and movement 6 makes the lower-right bowl.
 // ம is Frame 1's third row: all five movements join into one unbroken stroke.
 // ---------------------------------------------------------------------------
 
@@ -524,6 +526,99 @@ export const DUCTUS: Record<string, LetterDuctus> = {
     source: {
       citation:
         "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 4, இ (Univ. of Texas at Austin), p. 192",
+      url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+      variation:
+        "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",
+    },
+  },
+  க: {
+    glyph: "க",
+    strokes: [
+      {
+        segments: [
+          {
+            label: "climb the left upright",
+            path: [
+              { x: 160, y: 300 },
+              { x: 160, y: 400 },
+              { x: 160, y: 510 },
+            ],
+          },
+          {
+            label: "carry the top bar to the right",
+            path: [
+              { x: 160, y: 510 },
+              { x: 300, y: 510 },
+              { x: 450, y: 510 },
+              { x: 580, y: 510 },
+              { x: 500, y: 510 },
+              { x: 420, y: 510 },
+            ],
+          },
+          {
+            label: "drop the inner upright and carry left",
+            path: [
+              { x: 420, y: 510 },
+              { x: 420, y: 410 },
+              { x: 420, y: 300 },
+              { x: 300, y: 300 },
+              { x: 160, y: 300 },
+            ],
+          },
+        ],
+      },
+      {
+        segments: [
+          {
+            label: "curve down and around the lower left",
+            path: [
+              { x: 420, y: 300 },
+              { x: 420, y: 220 },
+              { x: 440, y: 160 },
+              { x: 420, y: 100 },
+              { x: 380, y: 60 },
+              { x: 330, y: 40 },
+              { x: 280, y: 35 },
+              { x: 200, y: 35 },
+            ],
+          },
+          {
+            label: "return up the outer left side",
+            path: [
+              { x: 200, y: 35 },
+              { x: 125, y: 50 },
+              { x: 75, y: 100 },
+              { x: 65, y: 160 },
+              { x: 80, y: 225 },
+              { x: 115, y: 275 },
+              { x: 160, y: 300 },
+            ],
+          },
+        ],
+      },
+      {
+        segments: [
+          {
+            label: "turn around the lower right bowl",
+            path: [
+              { x: 420, y: 300 },
+              { x: 520, y: 300 },
+              { x: 620, y: 285 },
+              { x: 680, y: 245 },
+              { x: 710, y: 185 },
+              { x: 705, y: 120 },
+              { x: 675, y: 70 },
+              { x: 620, y: 35 },
+              { x: 555, y: 25 },
+              { x: 510, y: 40 },
+            ],
+          },
+        ],
+      },
+    ],
+    source: {
+      citation:
+        "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 3, க (Univ. of Texas at Austin), p. 191",
       url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
       variation:
         "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",

--- a/code/programs/typescript/language-ladder/tests/ductusview.test.ts
+++ b/code/programs/typescript/language-ladder/tests/ductusview.test.ts
@@ -55,6 +55,8 @@ const AA = DUCTUS["ஆ"];
 const aaOutline = tamilOutline("ஆ");
 const I = DUCTUS["இ"];
 const iOutline = tamilOutline("இ");
+const KA = DUCTUS["க"];
+const kaOutline = tamilOutline("க");
 
 /** Walk a node tree, collecting every node the predicate accepts. */
 function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = []): SvgNode[] {
@@ -66,11 +68,12 @@ function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = 
 const byTag = (node: SvgNode, tag: string) => collect(node, (n) => n.tag === tag);
 
 describe("ductusFor — only cited letters have a ductus", () => {
-  it("finds all four authored Tamil letters", () => {
+  it("finds all five authored Tamil letters", () => {
     expect(ductusFor("ம")?.glyph).toBe("ம");
     expect(ductusFor("அ")?.glyph).toBe("அ");
     expect(ductusFor("ஆ")?.glyph).toBe("ஆ");
     expect(ductusFor("இ")?.glyph).toBe("இ");
+    expect(ductusFor("க")?.glyph).toBe("க");
   });
 
   it("returns undefined for a letter nobody has authored a stroke order for", () => {
@@ -349,6 +352,31 @@ describe("இ — a real cited seven-movement filmstrip", () => {
     expect(done).toHaveLength(1);
     expect(done[0].attrs.d).toBe(penPathD(I.strokes[0], 1));
     expect(pen.attrs.d).toBe(penPathD(I.strokes[1], 1));
+  });
+});
+
+describe("க — a real cited three-stroke filmstrip", () => {
+  const steps = ductusSteps(KA);
+  const strip = ductusFilmstrip(KA, kaOutline);
+
+  it("places lifts before each lower bowl", () => {
+    expect(steps.map((step) => step.startsAfterLift)).toEqual([false, false, false, true, false, true]);
+    expect(steps.map((step) => step.strokeIndex)).toEqual([0, 0, 0, 1, 1, 2]);
+  });
+
+  it("reports six movements in three strokes with two lifts", () => {
+    expect(strip.frames).toHaveLength(6);
+    expect(strip.penLifts).toBe(2);
+    expect(strip.summary).toBe("3 strokes · 2 pen lifts · 6 movements");
+  });
+
+  it("keeps both completed strokes visible while drawing the right bowl", () => {
+    const last = strip.frames[5];
+    const done = byTag(last, "path").filter((path) => path.attrs.class === "ductus__done");
+    const pen = byTag(last, "path").find((path) => path.attrs.class === "ductus__pen")!;
+    expect(done).toHaveLength(2);
+    expect(done.map((path) => path.attrs.d)).toEqual([penPathD(KA.strokes[0], 1), penPathD(KA.strokes[1], 1)]);
+    expect(pen.attrs.d).toBe(penPathD(KA.strokes[2], 1));
   });
 });
 

--- a/code/programs/typescript/language-ladder/tests/strokes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/strokes.test.ts
@@ -192,6 +192,12 @@ describe("handwriting ductus", () => {
     expect(DUCTUS["இ"].strokes[1].segments).toHaveLength(2);
   });
 
+  it("க lifts between its upper frame and two lower bowls", () => {
+    expect(penLifts(DUCTUS["க"])).toBe(2);
+    expect(DUCTUS["க"].strokes).toHaveLength(3);
+    expect(DUCTUS["க"].strokes.map((stroke) => stroke.segments.length)).toEqual([3, 2, 1]);
+  });
+
   // The PROVENANCE GATE. A stroke's SHAPE is checked against the font above;
   // its ORDER cannot be — so it must trace to a cited source, or it does not
   // ship. This is the counterpart, for hand-authored order, of "facts enter
@@ -251,6 +257,13 @@ describe("handwriting ductus", () => {
     const src = DUCTUS["இ"].source;
     expect(src.url).toContain("tamilscript");
     expect(src.citation).toMatch(/Appendix I.*Frame 4.*இ/);
+    expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
+  });
+
+  it("க's stroke order traces to Frame 3's final row", () => {
+    const src = DUCTUS["க"].source;
+    expect(src.url).toContain("tamilscript");
+    expect(src.citation).toMatch(/Appendix I.*Frame 3.*க/);
     expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
   });
 });


### PR DESCRIPTION
## Summary

- add a source-backed six-movement ductus for Tamil க
- model the primer's three pen-down runs with exactly two lifts
- keep the path on the vendored Noto Sans Tamil outline and test the real six-frame filmstrip
- update Tamil script metadata, documentation, changelogs, and the HL-C09 backlog count to 5 of 228 verified

## Source rationale

The handwriting order follows Sankaran Radhakrishnan, *Tamil Script Learners Manual*, Appendix I: Hand-movements, Frame 3, க (University of Texas at Austin), p. 191:

https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf

The source's six numbered movements form three continuous pen-down runs: movements 1–3 build the upper frame, movements 4–5 form the lower-left bowl, and movement 6 draws the lower-right bowl.

## Validation

- `bash BUILD` in `code/packages/typescript/human-language-data` — 460 tests passed
- `bash BUILD` in `code/programs/typescript/language-ladder` — typecheck, production build, bundle check, and 567 tests passed
- `bash code/scripts/verify-human-languages.sh --fast` — all local checks passed
- `git diff --check`
