### PR TITLE
Smart Home: add authorized ONVIF snapshot delivery host

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -936,6 +936,7 @@ members = [
     "smart-home-zigbee-integration",
     "smart-home-matter-integration",
     "smart-home-onvif-integration",
+    "smart-home-onvif-snapshot-host",
     "smart-home-shelly-integration",
     "smart-home-wled-integration",
     "smart-home-nanoleaf-local-integration",

--- a/code/packages/rust/smart-home-camera-media-http-executor/CHANGELOG.md
+++ b/code/packages/rust/smart-home-camera-media-http-executor/CHANGELOG.md
@@ -8,3 +8,5 @@
   content-encoding, HTTP-framing, and payload-signature rejection.
 - Added zeroizing process-local Basic and RFC 7616 Digest credentials, SHA-256
   preference, CSPRNG client nonces, and one refreshed-challenge retry.
+- Implemented the shared credential registry and reject replacement until the
+  existing entity credentials are explicitly removed.

--- a/code/packages/rust/smart-home-camera-media-http-executor/README.md
+++ b/code/packages/rust/smart-home-camera-media-http-executor/README.md
@@ -19,3 +19,7 @@ probes without credentials, prefers advertised SHA-256 Digest over MD5 and
 Basic, uses a fresh CSPRNG client nonce, and permits one refreshed Digest
 challenge retry. Endpoint URIs, credentials, authorization values, and response
 bytes are absent from errors and debug output.
+
+Credential registration fails when an entity already has credentials. Hosts
+must explicitly remove the old value before replacement, which keeps one
+delivery from silently overwriting another host-owned credential lifetime.

--- a/code/packages/rust/smart-home-camera-media-http-executor/src/lib.rs
+++ b/code/packages/rust/smart-home-camera-media-http-executor/src/lib.rs
@@ -10,8 +10,8 @@ use http1::parse_response_head;
 use http_core::{find_header, BodyKind, Header};
 use http_digest_auth::{DigestAlgorithm, DigestChallenge};
 use smart_home_camera_media::{
-    CameraMediaExecution, CameraMediaExecutionError, CameraMediaExecutionResult,
-    CameraMediaExecutor, CameraMediaKind,
+    CameraMediaCredentialRegistry, CameraMediaExecution, CameraMediaExecutionError,
+    CameraMediaExecutionResult, CameraMediaExecutor, CameraMediaKind,
 };
 use smart_home_core::EntityId;
 use std::collections::BTreeMap;
@@ -81,6 +81,7 @@ impl fmt::Debug for CameraMediaHttpCredentials {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CameraMediaHttpCredentialError {
     CredentialQuotaExceeded { maximum: usize },
+    CredentialAlreadyRegistered,
 }
 
 impl fmt::Display for CameraMediaHttpCredentialError {
@@ -91,6 +92,9 @@ impl fmt::Display for CameraMediaHttpCredentialError {
                     formatter,
                     "camera media credential quota of {maximum} is exhausted"
                 )
+            }
+            Self::CredentialAlreadyRegistered => {
+                formatter.write_str("camera media credentials are already registered")
             }
         }
     }
@@ -148,9 +152,10 @@ impl CameraMediaHttpExecutor {
         entity_id: EntityId,
         credentials: CameraMediaHttpCredentials,
     ) -> Result<(), CameraMediaHttpCredentialError> {
-        if !self.credentials.contains_key(&entity_id)
-            && self.credentials.len() >= self.policy.max_credentials
-        {
+        if self.credentials.contains_key(&entity_id) {
+            return Err(CameraMediaHttpCredentialError::CredentialAlreadyRegistered);
+        }
+        if self.credentials.len() >= self.policy.max_credentials {
             return Err(CameraMediaHttpCredentialError::CredentialQuotaExceeded {
                 maximum: self.policy.max_credentials,
             });
@@ -282,6 +287,23 @@ impl CameraMediaExecutor for CameraMediaHttpExecutor {
         _stream: &mut Self::Stream,
     ) -> Result<(), CameraMediaExecutionError> {
         Err(CameraMediaExecutionError::Rejected)
+    }
+}
+
+impl CameraMediaCredentialRegistry for CameraMediaHttpExecutor {
+    type Credentials = CameraMediaHttpCredentials;
+    type Error = CameraMediaHttpCredentialError;
+
+    fn register_credentials(
+        &mut self,
+        entity_id: EntityId,
+        credentials: Self::Credentials,
+    ) -> Result<(), Self::Error> {
+        CameraMediaHttpExecutor::register_credentials(self, entity_id, credentials)
+    }
+
+    fn unregister_credentials(&mut self, entity_id: &EntityId) -> bool {
+        CameraMediaHttpExecutor::unregister_credentials(self, entity_id)
     }
 }
 
@@ -927,6 +949,32 @@ mod tests {
         let debug = format!("{executor:?}");
         assert!(!debug.contains("operator"));
         assert!(!debug.contains("secret"));
+    }
+
+    #[test]
+    fn credential_registration_requires_explicit_removal_before_replacement() {
+        let entity_id = EntityId::trusted("camera.one");
+        let mut executor = fixture_executor();
+        executor
+            .register_credentials(
+                entity_id.clone(),
+                CameraMediaHttpCredentials::new("operator", "first-secret").unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            executor.register_credentials(
+                entity_id.clone(),
+                CameraMediaHttpCredentials::new("operator", "second-secret").unwrap(),
+            ),
+            Err(CameraMediaHttpCredentialError::CredentialAlreadyRegistered)
+        );
+        assert!(executor.unregister_credentials(&entity_id));
+        executor
+            .register_credentials(
+                entity_id,
+                CameraMediaHttpCredentials::new("operator", "second-secret").unwrap(),
+            )
+            .unwrap();
     }
 
     #[test]

--- a/code/packages/rust/smart-home-camera-media/CHANGELOG.md
+++ b/code/packages/rust/smart-home-camera-media/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Add a grant-only authorization preflight and endpoint-presence query so a
+  production host can reject work before touching credential or network
+  boundaries without exposing retained endpoint values.
+- Add a narrow executor credential-registry boundary for host-scoped credential
+  registration and removal around one authorized delivery.
+
 ## 0.3.0
 
 - Retain an optional reviewed canonical host and pinned socket with registered

--- a/code/packages/rust/smart-home-camera-media/README.md
+++ b/code/packages/rust/smart-home-camera-media/README.md
@@ -37,6 +37,11 @@ The security context is installed once in `CameraMediaService` by the native hos
 - `CameraMediaPrincipalSource` derives the authenticated `AgentId` from the
   active host/session, not the untrusted access request or each operation call.
 - `CameraMediaExecutor` owns the actual network/media operation.
+- `CameraMediaCredentialRegistry` lets a trusted host scope transport
+  credentials around delivery without exposing them through broker state.
+
+Hosts can perform the same exact grant check as lease issuance before resolving
+credentials, and can test endpoint presence without reading the secret URI.
 
 The policy core itself performs no filesystem, network, process, environment, FFI,
 clock, standard-I/O, or entropy operation. Endpoint and lease tables are bounded;

--- a/code/packages/rust/smart-home-camera-media/src/lib.rs
+++ b/code/packages/rust/smart-home-camera-media/src/lib.rs
@@ -456,6 +456,24 @@ pub trait CameraMediaExecutor {
     fn close_stream(&mut self, stream: &mut Self::Stream) -> Result<(), CameraMediaExecutionError>;
 }
 
+/// Process-local credential storage owned by a concrete media executor.
+///
+/// The service exposes this narrow contract so a trusted host can install
+/// credentials only around one authorized delivery without gaining access to
+/// endpoint URIs or the executor's other transport state.
+pub trait CameraMediaCredentialRegistry {
+    type Credentials;
+    type Error;
+
+    fn register_credentials(
+        &mut self,
+        entity_id: EntityId,
+        credentials: Self::Credentials,
+    ) -> Result<(), Self::Error>;
+
+    fn unregister_credentials(&mut self, entity_id: &EntityId) -> bool;
+}
+
 /// Authenticated identity source installed once by the native host.
 pub trait CameraMediaPrincipalSource {
     fn current_principal(&self) -> Option<AgentId>;
@@ -778,6 +796,27 @@ where
             .unregister_endpoint_at(self.clock.now_ms(), entity_id, kind)
     }
 
+    /// Validate current host identity and the exact D23 media grant without
+    /// requiring a registered endpoint or issuing a bearer lease.
+    pub fn authorize_access(
+        &self,
+        runtime: &SmartHomeRuntime,
+        entity_id: &EntityId,
+        kind: CameraMediaKind,
+    ) -> Result<(), CameraMediaError> {
+        let principal_id = self.authenticated_principal()?;
+        authorize_camera_access(runtime, &principal_id, entity_id, kind, self.clock.now_ms())
+            .map(|_| ())
+    }
+
+    /// Report whether this host currently owns an endpoint without revealing
+    /// its URI or reviewed connection target.
+    pub fn has_endpoint(&self, entity_id: &EntityId, kind: CameraMediaKind) -> bool {
+        self.broker
+            .endpoints
+            .contains_key(&(entity_id.clone(), kind))
+    }
+
     pub fn issue_lease(
         &mut self,
         runtime: &SmartHomeRuntime,
@@ -1011,6 +1050,26 @@ where
         self.principal_source
             .current_principal()
             .ok_or(CameraMediaError::Unauthenticated)
+    }
+}
+
+impl<Clock, Nonce, Principals, Executor> CameraMediaService<Clock, Nonce, Principals, Executor>
+where
+    Clock: CameraMediaClock,
+    Nonce: CameraMediaNonceSource,
+    Principals: CameraMediaPrincipalSource,
+    Executor: CameraMediaExecutor + CameraMediaCredentialRegistry,
+{
+    pub fn register_executor_credentials(
+        &mut self,
+        entity_id: EntityId,
+        credentials: Executor::Credentials,
+    ) -> Result<(), Executor::Error> {
+        self.executor.register_credentials(entity_id, credentials)
+    }
+
+    pub fn unregister_executor_credentials(&mut self, entity_id: &EntityId) -> bool {
+        self.executor.unregister_credentials(entity_id)
     }
 }
 

--- a/code/packages/rust/smart-home-onvif-snapshot-host/BUILD
+++ b/code/packages/rust/smart-home-onvif-snapshot-host/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-onvif-snapshot-host -- --nocapture

--- a/code/packages/rust/smart-home-onvif-snapshot-host/CHANGELOG.md
+++ b/code/packages/rust/smart-home-onvif-snapshot-host/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0
+
+- Add a production ONVIF snapshot host that requires exact D23 Human Approval
+  before resolving durable sealed-Vault credentials or reaching media I/O.
+- Keep HTTP credentials process-local and remove them after every delivery
+  attempt while retaining only opaque endpoint and Vault references.
+- Require a bounded versioned credential envelope so future schema changes fail
+  closed instead of being interpreted ambiguously.

--- a/code/packages/rust/smart-home-onvif-snapshot-host/Cargo.toml
+++ b/code/packages/rust/smart-home-onvif-snapshot-host/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "smart-home-onvif-snapshot-host"
+version = "0.1.0"
+edition = "2021"
+description = "Authorized ONVIF snapshot delivery host for the smart-home runtime"
+license = "MIT"
+
+[dependencies]
+coding_adventures_csprng = { path = "../csprng" }
+coding_adventures_vault_leases = { path = "../vault-leases" }
+coding_adventures_vault_sealed_store = { path = "../vault-sealed-store" }
+coding_adventures_zeroize = { path = "../zeroize" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+smart-home-camera-media = { path = "../smart-home-camera-media" }
+smart-home-camera-media-http-executor = { path = "../smart-home-camera-media-http-executor" }
+smart-home-core = { path = "../smart-home-core" }
+smart-home-onvif-integration = { path = "../smart-home-onvif-integration" }
+smart-home-runtime = { path = "../smart-home-runtime" }
+tls-platform = { path = "../tls-platform" }
+
+[dev-dependencies]
+storage-core = { path = "../storage-core" }

--- a/code/packages/rust/smart-home-onvif-snapshot-host/README.md
+++ b/code/packages/rust/smart-home-onvif-snapshot-host/README.md
@@ -1,0 +1,19 @@
+# smart-home-onvif-snapshot-host
+
+This package composes installed ONVIF camera entities with the D23 camera-media
+broker, the pinned native HTTPS snapshot executor, and the durable sealed Vault.
+The host checks the current authenticated principal's exact Human Approval grant
+before resolving the opaque credential reference or performing network I/O.
+
+Snapshot endpoints remain process-local in `CameraMediaService`. A delivery
+resolves the target camera's opaque bridge credential reference to one bounded,
+versioned, zeroizing JSON credential payload, registers credentials for that
+entity, redeems one short-lived snapshot lease, and removes the credentials on
+every return path. The stable Vault record remains available for later approved
+snapshots. Endpoint URIs, credential bytes, and media bearer IDs are absent from
+errors and debug output.
+
+The production constructor supplies system time, OS CSPRNG lease nonces, and the
+strict native HTTPS executor. The authenticated principal source and Vault
+boundary remain host inputs. RTSP streams are intentionally outside this package
+until a supervised resource owner and teardown lifecycle exist.

--- a/code/packages/rust/smart-home-onvif-snapshot-host/src/lib.rs
+++ b/code/packages/rust/smart-home-onvif-snapshot-host/src/lib.rs
@@ -1,0 +1,415 @@
+//! Authorized production host for bounded ONVIF snapshot delivery.
+
+#![forbid(unsafe_code)]
+
+use coding_adventures_csprng::random_array;
+use coding_adventures_vault_leases::LeasePayload;
+use coding_adventures_vault_sealed_store::SealedStore;
+use coding_adventures_zeroize::Zeroizing;
+use serde::{Deserialize, Deserializer, Serialize};
+use smart_home_camera_media::{
+    CameraMediaAccessRequest, CameraMediaClock, CameraMediaCredentialRegistry, CameraMediaDelivery,
+    CameraMediaEndpointRegistry, CameraMediaError, CameraMediaExecutor, CameraMediaKind,
+    CameraMediaNonceError, CameraMediaNonceSource, CameraMediaPolicy, CameraMediaPrincipalSource,
+    CameraMediaService,
+};
+use smart_home_camera_media_http_executor::{
+    CameraMediaHttpCredentialError, CameraMediaHttpCredentials, CameraMediaHttpExecutor,
+};
+use smart_home_core::{EntityId, IntegrationId, VaultRef};
+use smart_home_onvif_integration::{
+    INTEGRATION_ID, MAX_ONVIF_CREDENTIAL_BYTES, MAX_ONVIF_VALUE_BYTES,
+};
+use smart_home_runtime::SmartHomeRuntime;
+use std::fmt;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const VERSION: &str = "0.1.0";
+pub const MAX_CREDENTIAL_PAYLOAD_BYTES: usize = MAX_ONVIF_CREDENTIAL_BYTES * 2 + 256;
+pub const ONVIF_VAULT_NAMESPACE: &str = "smart_home.onvif.credentials";
+pub const ONVIF_VAULT_REF_PREFIX: &str = "vault://smart-home/onvif/";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OnvifCredentialSourceError;
+
+pub trait OnvifCredentialSource {
+    fn resolve(&self, vault_ref: &VaultRef) -> Result<LeasePayload, OnvifCredentialSourceError>;
+}
+
+pub struct OnvifSealedStoreCredentialSource {
+    vault: Arc<SealedStore>,
+}
+
+impl OnvifSealedStoreCredentialSource {
+    pub fn new(vault: Arc<SealedStore>) -> Self {
+        Self { vault }
+    }
+}
+
+impl OnvifCredentialSource for OnvifSealedStoreCredentialSource {
+    fn resolve(&self, vault_ref: &VaultRef) -> Result<LeasePayload, OnvifCredentialSourceError> {
+        let key = onvif_vault_record_key(vault_ref).ok_or(OnvifCredentialSourceError)?;
+        let record = self
+            .vault
+            .get(ONVIF_VAULT_NAMESPACE, key)
+            .map_err(|_| OnvifCredentialSourceError)?
+            .ok_or(OnvifCredentialSourceError)?;
+        Ok(LeasePayload::new(record.plaintext.into_inner()))
+    }
+}
+
+pub fn onvif_vault_record_key(vault_ref: &VaultRef) -> Option<&str> {
+    vault_ref
+        .as_str()
+        .strip_prefix(ONVIF_VAULT_REF_PREFIX)
+        .filter(|key| !key.is_empty())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OnvifSnapshotRequest {
+    pub entity_id: EntityId,
+    pub purpose: String,
+    pub ttl_ms: u64,
+}
+
+impl OnvifSnapshotRequest {
+    pub fn new(entity_id: EntityId, purpose: impl Into<String>, ttl_ms: u64) -> Self {
+        Self {
+            entity_id,
+            purpose: purpose.into(),
+            ttl_ms,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OnvifSnapshotHostError {
+    InvalidRequest,
+    MissingEndpoint,
+    InvalidTarget,
+    MissingCredentialReference,
+    CredentialResolutionRejected,
+    InvalidCredentialPayload,
+    CredentialRegistrationRejected,
+    CredentialRemovalFailed,
+    Media(CameraMediaError),
+}
+
+impl fmt::Display for OnvifSnapshotHostError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidRequest => "invalid ONVIF snapshot request",
+            Self::MissingEndpoint => "ONVIF snapshot endpoint is not registered",
+            Self::InvalidTarget => "snapshot target is not an installed ONVIF camera",
+            Self::MissingCredentialReference => "ONVIF camera has no credential reference",
+            Self::CredentialResolutionRejected => "ONVIF credential lookup was rejected",
+            Self::InvalidCredentialPayload => "ONVIF credential payload is invalid",
+            Self::CredentialRegistrationRejected => {
+                "ONVIF snapshot credentials could not be registered"
+            }
+            Self::CredentialRemovalFailed => "ONVIF snapshot credentials could not be removed",
+            Self::Media(error) => return error.fmt(formatter),
+        })
+    }
+}
+
+impl std::error::Error for OnvifSnapshotHostError {}
+
+impl From<CameraMediaError> for OnvifSnapshotHostError {
+    fn from(value: CameraMediaError) -> Self {
+        Self::Media(value)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CredentialEnvelope {
+    schema_version: u64,
+    #[serde(deserialize_with = "deserialize_secret_string")]
+    username: Zeroizing<String>,
+    #[serde(deserialize_with = "deserialize_secret_string")]
+    password: Zeroizing<String>,
+}
+
+#[derive(Serialize)]
+struct BorrowedCredentialEnvelope<'a> {
+    schema_version: u64,
+    username: &'a str,
+    password: &'a str,
+}
+
+pub fn encode_onvif_credentials(
+    username: &str,
+    password: &str,
+) -> Result<LeasePayload, OnvifSnapshotHostError> {
+    validate_credential_fields(username, password)?;
+    let bytes = Zeroizing::new(
+        serde_json::to_vec(&BorrowedCredentialEnvelope {
+            schema_version: 1,
+            username,
+            password,
+        })
+        .map_err(|_| OnvifSnapshotHostError::InvalidCredentialPayload)?,
+    );
+    if bytes.len() > MAX_CREDENTIAL_PAYLOAD_BYTES {
+        return Err(OnvifSnapshotHostError::InvalidCredentialPayload);
+    }
+    Ok(LeasePayload::new(bytes.into_inner()))
+}
+
+pub struct SystemCameraMediaClock;
+
+impl CameraMediaClock for SystemCameraMediaClock {
+    fn now_ms(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX)
+    }
+}
+
+pub struct OsCameraMediaNonceSource;
+
+impl CameraMediaNonceSource for OsCameraMediaNonceSource {
+    fn fill_nonce(&mut self, output: &mut [u8; 16]) -> Result<(), CameraMediaNonceError> {
+        *output = random_array().map_err(|_| CameraMediaNonceError)?;
+        Ok(())
+    }
+}
+
+pub struct OnvifSnapshotHost<Clock, Nonce, Principals, Executor, Credentials>
+where
+    Clock: CameraMediaClock,
+    Nonce: CameraMediaNonceSource,
+    Principals: CameraMediaPrincipalSource,
+    Executor: CameraMediaExecutor
+        + CameraMediaCredentialRegistry<
+            Credentials = CameraMediaHttpCredentials,
+            Error = CameraMediaHttpCredentialError,
+        >,
+    Credentials: OnvifCredentialSource,
+{
+    media: CameraMediaService<Clock, Nonce, Principals, Executor>,
+    credentials: Credentials,
+    max_snapshot_ttl_ms: u64,
+}
+
+impl<Clock, Nonce, Principals, Executor, Credentials>
+    OnvifSnapshotHost<Clock, Nonce, Principals, Executor, Credentials>
+where
+    Clock: CameraMediaClock,
+    Nonce: CameraMediaNonceSource,
+    Principals: CameraMediaPrincipalSource,
+    Executor: CameraMediaExecutor
+        + CameraMediaCredentialRegistry<
+            Credentials = CameraMediaHttpCredentials,
+            Error = CameraMediaHttpCredentialError,
+        >,
+    Credentials: OnvifCredentialSource,
+{
+    pub fn new(
+        policy: CameraMediaPolicy,
+        clock: Clock,
+        nonce_source: Nonce,
+        principal_source: Principals,
+        executor: Executor,
+        credentials: Credentials,
+    ) -> Self {
+        let max_snapshot_ttl_ms = policy.max_snapshot_ttl_ms;
+        Self {
+            media: CameraMediaService::new(policy, clock, nonce_source, principal_source, executor),
+            credentials,
+            max_snapshot_ttl_ms,
+        }
+    }
+
+    pub fn deliver_snapshot(
+        &mut self,
+        runtime: &SmartHomeRuntime,
+        request: OnvifSnapshotRequest,
+    ) -> Result<CameraMediaDelivery, OnvifSnapshotHostError> {
+        self.validate_request(&request)?;
+        self.media
+            .authorize_access(runtime, &request.entity_id, CameraMediaKind::Snapshot)?;
+        if !self
+            .media
+            .has_endpoint(&request.entity_id, CameraMediaKind::Snapshot)
+        {
+            return Err(OnvifSnapshotHostError::MissingEndpoint);
+        }
+        let credential_ref = installed_credential_ref(runtime, &request.entity_id)?;
+        let payload = self
+            .credentials
+            .resolve(&credential_ref)
+            .map_err(|_| OnvifSnapshotHostError::CredentialResolutionRejected)?;
+        let credentials = decode_credentials(payload.as_bytes())?;
+        drop(payload);
+
+        self.media
+            .register_executor_credentials(request.entity_id.clone(), credentials)
+            .map_err(|_| OnvifSnapshotHostError::CredentialRegistrationRejected)?;
+        let delivery = (|| {
+            let lease = self.media.issue_lease(
+                runtime,
+                CameraMediaAccessRequest::new(
+                    request.entity_id.clone(),
+                    CameraMediaKind::Snapshot,
+                    request.purpose,
+                    request.ttl_ms,
+                ),
+            )?;
+            self.media
+                .deliver_lease(runtime, &lease.lease_id)
+                .map_err(Into::into)
+        })();
+        let removed = self
+            .media
+            .unregister_executor_credentials(&request.entity_id);
+        if !removed {
+            return Err(OnvifSnapshotHostError::CredentialRemovalFailed);
+        }
+        delivery
+    }
+
+    pub fn media_snapshot(&self) -> smart_home_camera_media::CameraMediaBrokerSnapshot {
+        self.media.snapshot()
+    }
+
+    fn validate_request(
+        &self,
+        request: &OnvifSnapshotRequest,
+    ) -> Result<(), OnvifSnapshotHostError> {
+        if request.purpose.trim().is_empty()
+            || request.ttl_ms == 0
+            || request.ttl_ms > self.max_snapshot_ttl_ms
+        {
+            return Err(OnvifSnapshotHostError::InvalidRequest);
+        }
+        Ok(())
+    }
+}
+
+impl<Principals, Credentials>
+    OnvifSnapshotHost<
+        SystemCameraMediaClock,
+        OsCameraMediaNonceSource,
+        Principals,
+        CameraMediaHttpExecutor,
+        Credentials,
+    >
+where
+    Principals: CameraMediaPrincipalSource,
+    Credentials: OnvifCredentialSource,
+{
+    pub fn production(principal_source: Principals, credentials: Credentials) -> Self {
+        Self::new(
+            CameraMediaPolicy::default(),
+            SystemCameraMediaClock,
+            OsCameraMediaNonceSource,
+            principal_source,
+            CameraMediaHttpExecutor::default(),
+            credentials,
+        )
+    }
+}
+
+impl<Clock, Nonce, Principals, Executor, Credentials> CameraMediaEndpointRegistry
+    for OnvifSnapshotHost<Clock, Nonce, Principals, Executor, Credentials>
+where
+    Clock: CameraMediaClock,
+    Nonce: CameraMediaNonceSource,
+    Principals: CameraMediaPrincipalSource,
+    Executor: CameraMediaExecutor
+        + CameraMediaCredentialRegistry<
+            Credentials = CameraMediaHttpCredentials,
+            Error = CameraMediaHttpCredentialError,
+        >,
+    Credentials: OnvifCredentialSource,
+{
+    fn register_camera_endpoint(
+        &mut self,
+        entity_id: EntityId,
+        kind: CameraMediaKind,
+        uri: &str,
+    ) -> Result<(), CameraMediaError> {
+        self.media.register_endpoint(entity_id, kind, uri)
+    }
+
+    fn register_pinned_camera_endpoint(
+        &mut self,
+        entity_id: EntityId,
+        kind: CameraMediaKind,
+        uri: &str,
+        connection_target: smart_home_camera_media::CameraMediaConnectionTarget,
+    ) -> Result<(), CameraMediaError> {
+        self.media
+            .register_pinned_endpoint(entity_id, kind, uri, connection_target)
+    }
+}
+
+fn installed_credential_ref(
+    runtime: &SmartHomeRuntime,
+    entity_id: &EntityId,
+) -> Result<VaultRef, OnvifSnapshotHostError> {
+    let registry = runtime.registry();
+    let entity = registry
+        .entity(entity_id)
+        .ok_or(OnvifSnapshotHostError::InvalidTarget)?;
+    let device = registry
+        .device(&entity.device_id)
+        .ok_or(OnvifSnapshotHostError::InvalidTarget)?;
+    let bridge = registry
+        .bridge(&device.bridge_id)
+        .ok_or(OnvifSnapshotHostError::InvalidTarget)?;
+    if bridge.integration_id != IntegrationId::trusted(INTEGRATION_ID) {
+        return Err(OnvifSnapshotHostError::InvalidTarget);
+    }
+    bridge
+        .auth_ref
+        .clone()
+        .ok_or(OnvifSnapshotHostError::MissingCredentialReference)
+}
+
+fn decode_credentials(bytes: &[u8]) -> Result<CameraMediaHttpCredentials, OnvifSnapshotHostError> {
+    if bytes.len() > MAX_CREDENTIAL_PAYLOAD_BYTES {
+        return Err(OnvifSnapshotHostError::InvalidCredentialPayload);
+    }
+    let envelope: CredentialEnvelope = serde_json::from_slice(bytes)
+        .map_err(|_| OnvifSnapshotHostError::InvalidCredentialPayload)?;
+    if envelope.schema_version != 1 {
+        return Err(OnvifSnapshotHostError::InvalidCredentialPayload);
+    }
+    validate_credential_fields(&envelope.username, &envelope.password)?;
+    CameraMediaHttpCredentials::new(
+        envelope.username.into_inner(),
+        envelope.password.into_inner(),
+    )
+    .map_err(|_| OnvifSnapshotHostError::InvalidCredentialPayload)
+}
+
+fn deserialize_secret_string<'de, D>(deserializer: D) -> Result<Zeroizing<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer).map(Zeroizing::new)
+}
+
+fn validate_credential_fields(
+    username: &str,
+    password: &str,
+) -> Result<(), OnvifSnapshotHostError> {
+    if username.trim().is_empty()
+        || password.is_empty()
+        || username.len() > MAX_ONVIF_VALUE_BYTES
+        || password.len() > MAX_ONVIF_CREDENTIAL_BYTES
+        || username.contains(':')
+        || username.contains(['\r', '\n', '\0'])
+        || password.contains(['\r', '\n', '\0'])
+    {
+        return Err(OnvifSnapshotHostError::InvalidCredentialPayload);
+    }
+    Ok(())
+}

--- a/code/packages/rust/smart-home-onvif-snapshot-host/tests/host.rs
+++ b/code/packages/rust/smart-home-onvif-snapshot-host/tests/host.rs
@@ -1,0 +1,536 @@
+use coding_adventures_vault_leases::LeasePayload;
+use coding_adventures_vault_sealed_store::{InitOptions, SealedStore};
+use smart_home_camera_media::{
+    CameraMediaClock, CameraMediaConnectionTarget, CameraMediaCredentialRegistry,
+    CameraMediaEndpointRegistry, CameraMediaExecution, CameraMediaExecutionError,
+    CameraMediaExecutionResult, CameraMediaExecutor, CameraMediaKind, CameraMediaNonceError,
+    CameraMediaNonceSource, CameraMediaPolicy, CameraMediaPrincipalSource,
+};
+use smart_home_camera_media_http_executor::{
+    CameraMediaHttpCredentialError, CameraMediaHttpCredentials, CameraMediaHttpExecutor,
+    CameraMediaHttpPolicy,
+};
+use smart_home_core::{
+    AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityGrant, CapabilityGrantId,
+    CapabilityMode, Device, DeviceId, Entity, EntityId, EntityKind, Health, IntegrationId,
+    PrivilegeTier, ValueKind, VaultRef,
+};
+use smart_home_onvif_snapshot_host::{
+    encode_onvif_credentials, OnvifCredentialSource, OnvifCredentialSourceError,
+    OnvifSealedStoreCredentialSource, OnvifSnapshotHost, OnvifSnapshotHostError,
+    OnvifSnapshotRequest, ONVIF_VAULT_NAMESPACE, ONVIF_VAULT_REF_PREFIX,
+};
+use smart_home_runtime::SmartHomeRuntime;
+use std::cell::{Cell, RefCell};
+use std::collections::BTreeSet;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::thread;
+use storage_core::{InMemoryStorageBackend, StorageBackend};
+use tls_platform::{default_connector, TlsConfig};
+
+#[derive(Clone)]
+struct FixedClock(u64);
+
+impl CameraMediaClock for FixedClock {
+    fn now_ms(&self) -> u64 {
+        self.0
+    }
+}
+
+struct TestNonce(u8);
+
+impl CameraMediaNonceSource for TestNonce {
+    fn fill_nonce(&mut self, output: &mut [u8; 16]) -> Result<(), CameraMediaNonceError> {
+        output.fill(self.0);
+        self.0 = self.0.wrapping_add(1);
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct FixedPrincipal(Option<AgentId>);
+
+impl CameraMediaPrincipalSource for FixedPrincipal {
+    fn current_principal(&self) -> Option<AgentId> {
+        self.0.clone()
+    }
+}
+
+#[derive(Clone)]
+struct TestCredentials {
+    state: Rc<LeaseState>,
+}
+
+struct LeaseState {
+    resolve_count: Cell<usize>,
+    payload: LeasePayload,
+}
+
+impl TestCredentials {
+    fn new(payload: LeasePayload) -> Self {
+        Self {
+            state: Rc::new(LeaseState {
+                resolve_count: Cell::new(0),
+                payload,
+            }),
+        }
+    }
+
+    fn resolve_count(&self) -> usize {
+        self.state.resolve_count.get()
+    }
+}
+
+impl OnvifCredentialSource for TestCredentials {
+    fn resolve(&self, _vault_ref: &VaultRef) -> Result<LeasePayload, OnvifCredentialSourceError> {
+        self.state
+            .resolve_count
+            .set(self.state.resolve_count.get() + 1);
+        Ok(self.state.payload.clone())
+    }
+}
+
+#[derive(Default)]
+struct ExecutorState {
+    registered: BTreeSet<EntityId>,
+    register_count: usize,
+    unregister_count: usize,
+    delivery_count: usize,
+    fail_delivery: bool,
+}
+
+struct TestExecutor(Rc<RefCell<ExecutorState>>);
+
+type TestHost =
+    OnvifSnapshotHost<FixedClock, TestNonce, FixedPrincipal, TestExecutor, TestCredentials>;
+type TestHostFixture = (
+    SmartHomeRuntime,
+    EntityId,
+    TestCredentials,
+    Rc<RefCell<ExecutorState>>,
+    TestHost,
+);
+
+impl CameraMediaCredentialRegistry for TestExecutor {
+    type Credentials = CameraMediaHttpCredentials;
+    type Error = CameraMediaHttpCredentialError;
+
+    fn register_credentials(
+        &mut self,
+        entity_id: EntityId,
+        _credentials: Self::Credentials,
+    ) -> Result<(), Self::Error> {
+        let mut state = self.0.borrow_mut();
+        state.register_count += 1;
+        state.registered.insert(entity_id);
+        Ok(())
+    }
+
+    fn unregister_credentials(&mut self, entity_id: &EntityId) -> bool {
+        let mut state = self.0.borrow_mut();
+        state.unregister_count += 1;
+        state.registered.remove(entity_id)
+    }
+}
+
+impl CameraMediaExecutor for TestExecutor {
+    type Stream = ();
+
+    fn deliver(
+        &mut self,
+        execution: CameraMediaExecution<'_>,
+    ) -> Result<CameraMediaExecutionResult<Self::Stream>, CameraMediaExecutionError> {
+        let mut state = self.0.borrow_mut();
+        assert!(state.registered.contains(execution.entity_id()));
+        state.delivery_count += 1;
+        if state.fail_delivery {
+            return Err(CameraMediaExecutionError::Unavailable);
+        }
+        Ok(CameraMediaExecutionResult::snapshot(vec![
+            0xff, 0xd8, 0xff, 0xd9,
+        ]))
+    }
+
+    fn close_stream(
+        &mut self,
+        _stream: &mut Self::Stream,
+    ) -> Result<(), CameraMediaExecutionError> {
+        Err(CameraMediaExecutionError::Rejected)
+    }
+}
+
+fn fixture_runtime(granted: bool) -> (SmartHomeRuntime, EntityId, AgentId) {
+    let mut runtime = SmartHomeRuntime::new();
+    let bridge_id = BridgeId::trusted("bridge:onvif:test");
+    let device_id = DeviceId::trusted("onvif:test-camera");
+    let entity_id = EntityId::trusted("onvif:test-camera:main");
+    let principal_id = AgentId::trusted("operator");
+    let mut bridge = Bridge::new(
+        bridge_id.clone(),
+        IntegrationId::trusted("onvif"),
+        BridgeTransport::LanHttp,
+    );
+    bridge.auth_ref = Some(VaultRef::trusted("vault-lease:fixture"));
+    runtime.upsert_bridge(bridge).unwrap();
+    runtime
+        .upsert_device(Device {
+            device_id: device_id.clone(),
+            bridge_id,
+            manufacturer: "Fixture".to_string(),
+            model: "Camera".to_string(),
+            name: "Camera".to_string(),
+            serial: None,
+            firmware_version: None,
+            room_id: None,
+            entity_ids: vec![entity_id.clone()],
+            identifiers: Vec::new(),
+            health: Health::Online,
+            metadata: Vec::new(),
+        })
+        .unwrap();
+    runtime
+        .upsert_entity(Entity {
+            entity_id: entity_id.clone(),
+            device_id,
+            kind: EntityKind::Camera,
+            name: "Main profile".to_string(),
+            capabilities: vec![Capability::new(
+                CameraMediaKind::Snapshot.capability_id(),
+                CapabilityMode::Command,
+                ValueKind::Text,
+            )],
+            state: None,
+            metadata: Vec::new(),
+        })
+        .unwrap();
+    if granted {
+        runtime
+            .registry_mut()
+            .upsert_capability_grant(CapabilityGrant::for_entity_capability(
+                CapabilityGrantId::trusted("grant:snapshot"),
+                principal_id.clone(),
+                entity_id.clone(),
+                CameraMediaKind::Snapshot.capability_id(),
+                PrivilegeTier::HumanApproval,
+                "user",
+                1,
+            ));
+    }
+    (runtime, entity_id, principal_id)
+}
+
+fn test_host(granted: bool, fail_delivery: bool) -> TestHostFixture {
+    let (runtime, entity_id, principal_id) = fixture_runtime(granted);
+    let credentials =
+        TestCredentials::new(encode_onvif_credentials("camera-user", "camera-secret").unwrap());
+    let state = Rc::new(RefCell::new(ExecutorState {
+        fail_delivery,
+        ..ExecutorState::default()
+    }));
+    let policy = CameraMediaPolicy {
+        allow_plaintext_loopback: true,
+        ..CameraMediaPolicy::default()
+    };
+    let mut host = OnvifSnapshotHost::new(
+        policy,
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        TestExecutor(state.clone()),
+        credentials.clone(),
+    );
+    host.register_pinned_camera_endpoint(
+        entity_id.clone(),
+        CameraMediaKind::Snapshot,
+        "http://127.0.0.1:18080/snapshot",
+        CameraMediaConnectionTarget::new("127.0.0.1", "127.0.0.1:18080".parse().unwrap()),
+    )
+    .unwrap();
+    (runtime, entity_id, credentials, state, host)
+}
+
+#[test]
+fn authorized_delivery_scopes_and_removes_credentials() {
+    let (runtime, entity_id, credentials, state, mut host) = test_host(true, false);
+    let delivery = host
+        .deliver_snapshot(
+            &runtime,
+            OnvifSnapshotRequest::new(entity_id, "operator preview", 5_000),
+        )
+        .unwrap();
+
+    assert_eq!(
+        delivery.snapshot_bytes(),
+        Some(&[0xff, 0xd8, 0xff, 0xd9][..])
+    );
+    assert_eq!(credentials.resolve_count(), 1);
+    let state = state.borrow();
+    assert_eq!(state.register_count, 1);
+    assert_eq!(state.unregister_count, 1);
+    assert_eq!(state.delivery_count, 1);
+    assert!(state.registered.is_empty());
+}
+
+#[test]
+fn denial_happens_before_credential_resolution_or_delivery() {
+    let (runtime, entity_id, credentials, state, mut host) = test_host(false, false);
+    let error = host
+        .deliver_snapshot(
+            &runtime,
+            OnvifSnapshotRequest::new(entity_id, "operator preview", 5_000),
+        )
+        .unwrap_err();
+
+    assert!(matches!(error, OnvifSnapshotHostError::Media(_)));
+    assert_eq!(credentials.resolve_count(), 0);
+    let state = state.borrow();
+    assert_eq!(state.register_count, 0);
+    assert_eq!(state.delivery_count, 0);
+}
+
+#[test]
+fn failed_delivery_still_removes_credentials() {
+    let (runtime, entity_id, credentials, state, mut host) = test_host(true, true);
+    let error = host
+        .deliver_snapshot(
+            &runtime,
+            OnvifSnapshotRequest::new(entity_id, "operator preview", 5_000),
+        )
+        .unwrap_err();
+
+    assert!(matches!(error, OnvifSnapshotHostError::Media(_)));
+    assert_eq!(credentials.resolve_count(), 1);
+    let state = state.borrow();
+    assert_eq!(state.register_count, 1);
+    assert_eq!(state.unregister_count, 1);
+    assert!(state.registered.is_empty());
+}
+
+#[test]
+fn invalid_request_does_not_resolve_credentials() {
+    let (runtime, entity_id, credentials, state, mut host) = test_host(true, false);
+    let error = host
+        .deliver_snapshot(&runtime, OnvifSnapshotRequest::new(entity_id, " ", 5_000))
+        .unwrap_err();
+
+    assert_eq!(error, OnvifSnapshotHostError::InvalidRequest);
+    assert_eq!(credentials.resolve_count(), 0);
+    assert_eq!(state.borrow().register_count, 0);
+}
+
+#[test]
+fn missing_endpoint_does_not_resolve_credentials() {
+    let (runtime, entity_id, principal_id) = fixture_runtime(true);
+    let credentials =
+        TestCredentials::new(encode_onvif_credentials("camera-user", "camera-secret").unwrap());
+    let state = Rc::new(RefCell::new(ExecutorState::default()));
+    let mut host = OnvifSnapshotHost::new(
+        CameraMediaPolicy::default(),
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        TestExecutor(state.clone()),
+        credentials.clone(),
+    );
+
+    let error = host
+        .deliver_snapshot(
+            &runtime,
+            OnvifSnapshotRequest::new(entity_id, "operator preview", 5_000),
+        )
+        .unwrap_err();
+
+    assert_eq!(error, OnvifSnapshotHostError::MissingEndpoint);
+    assert_eq!(credentials.resolve_count(), 0);
+    assert_eq!(state.borrow().register_count, 0);
+}
+
+#[test]
+fn invalid_payload_is_redacted_and_never_registered() {
+    let (runtime, entity_id, principal_id) = fixture_runtime(true);
+    let secret = "raw-camera-password";
+    let credentials = TestCredentials::new(LeasePayload::new(
+        format!(r#"{{"username":"camera","password":"{secret}","extra":true}}"#).into_bytes(),
+    ));
+    let state = Rc::new(RefCell::new(ExecutorState::default()));
+    let policy = CameraMediaPolicy {
+        allow_plaintext_loopback: true,
+        ..CameraMediaPolicy::default()
+    };
+    let mut host = OnvifSnapshotHost::new(
+        policy,
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        TestExecutor(state.clone()),
+        credentials,
+    );
+    host.register_pinned_camera_endpoint(
+        entity_id.clone(),
+        CameraMediaKind::Snapshot,
+        "http://127.0.0.1:18080/snapshot",
+        CameraMediaConnectionTarget::new("127.0.0.1", "127.0.0.1:18080".parse().unwrap()),
+    )
+    .unwrap();
+
+    let error = host
+        .deliver_snapshot(
+            &runtime,
+            OnvifSnapshotRequest::new(entity_id, "operator preview", 5_000),
+        )
+        .unwrap_err();
+    let diagnostics = format!("{error:?} {error}");
+    assert!(!diagnostics.contains(secret));
+    assert_eq!(state.borrow().register_count, 0);
+}
+
+#[test]
+fn sealed_vault_reference_supports_repeated_independently_authorized_snapshots() {
+    let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryStorageBackend::default());
+    backend.initialize().unwrap();
+    let vault = Arc::new(SealedStore::new(backend));
+    vault
+        .init(
+            b"fixture-password",
+            &InitOptions {
+                argon2id_time_cost: 1,
+                argon2id_memory_kib: 32,
+                argon2id_parallelism: 1,
+                salt_override: Some(vec![7; 16]),
+            },
+        )
+        .unwrap();
+    let payload = encode_onvif_credentials("camera-user", "camera-secret").unwrap();
+    vault
+        .put(
+            ONVIF_VAULT_NAMESPACE,
+            "bridge/main",
+            payload.as_bytes(),
+            None,
+        )
+        .unwrap();
+
+    let (mut runtime, entity_id, principal_id) = fixture_runtime(true);
+    let bridge_id = BridgeId::trusted("bridge:onvif:test");
+    let mut bridge = runtime.registry().bridge(&bridge_id).unwrap().clone();
+    bridge.auth_ref = Some(VaultRef::trusted(format!(
+        "{ONVIF_VAULT_REF_PREFIX}bridge/main"
+    )));
+    runtime.upsert_bridge(bridge).unwrap();
+    let state = Rc::new(RefCell::new(ExecutorState::default()));
+    let policy = CameraMediaPolicy {
+        allow_plaintext_loopback: true,
+        ..CameraMediaPolicy::default()
+    };
+    let mut host = OnvifSnapshotHost::new(
+        policy,
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        TestExecutor(state.clone()),
+        OnvifSealedStoreCredentialSource::new(vault),
+    );
+    host.register_pinned_camera_endpoint(
+        entity_id.clone(),
+        CameraMediaKind::Snapshot,
+        "http://127.0.0.1:18080/snapshot",
+        CameraMediaConnectionTarget::new("127.0.0.1", "127.0.0.1:18080".parse().unwrap()),
+    )
+    .unwrap();
+
+    for purpose in ["first preview", "second preview"] {
+        host.deliver_snapshot(
+            &runtime,
+            OnvifSnapshotRequest::new(entity_id.clone(), purpose, 5_000),
+        )
+        .unwrap();
+    }
+    let state = state.borrow();
+    assert_eq!(state.register_count, 2);
+    assert_eq!(state.unregister_count, 2);
+    assert_eq!(state.delivery_count, 2);
+    assert!(state.registered.is_empty());
+}
+
+#[test]
+fn native_http_executor_delivers_one_basic_authenticated_loopback_snapshot() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let mut first = listener.accept().unwrap().0;
+        let first_request = read_request(&mut first);
+        assert!(!first_request.contains("Authorization:"));
+        first
+            .write_all(
+                b"HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: Basic realm=\"camera\"\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            )
+            .unwrap();
+        drop(first);
+
+        let mut second = listener.accept().unwrap().0;
+        let second_request = read_request(&mut second);
+        assert!(second_request.contains("Authorization: Basic dXNlcjpzZWNyZXQ="));
+        second
+            .write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: image/jpeg\r\nContent-Length: 4\r\nConnection: close\r\n\r\n\xff\xd8\xff\xd9",
+            )
+            .unwrap();
+    });
+
+    let (runtime, entity_id, principal_id) = fixture_runtime(true);
+    let credentials = TestCredentials::new(encode_onvif_credentials("user", "secret").unwrap());
+    let media_policy = CameraMediaPolicy {
+        allow_plaintext_loopback: true,
+        ..CameraMediaPolicy::default()
+    };
+    let executor = CameraMediaHttpExecutor::new(
+        default_connector(),
+        TlsConfig::https_default(),
+        CameraMediaHttpPolicy {
+            allow_plaintext_loopback: true,
+            ..CameraMediaHttpPolicy::default()
+        },
+    );
+    let mut host = OnvifSnapshotHost::new(
+        media_policy,
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        executor,
+        credentials,
+    );
+    let endpoint = format!("http://127.0.0.1:{}/snapshot", address.port());
+    host.register_pinned_camera_endpoint(
+        entity_id.clone(),
+        CameraMediaKind::Snapshot,
+        &endpoint,
+        CameraMediaConnectionTarget::new("127.0.0.1", address),
+    )
+    .unwrap();
+
+    let delivery = host
+        .deliver_snapshot(
+            &runtime,
+            OnvifSnapshotRequest::new(entity_id, "operator preview", 5_000),
+        )
+        .unwrap();
+    assert_eq!(
+        delivery.snapshot_bytes(),
+        Some(&[0xff, 0xd8, 0xff, 0xd9][..])
+    );
+    server.join().unwrap();
+}
+
+fn read_request(stream: &mut impl Read) -> String {
+    let mut bytes = Vec::new();
+    let mut buffer = [0u8; 512];
+    while !bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+        let read = stream.read(&mut buffer).unwrap();
+        assert!(read > 0);
+        bytes.extend_from_slice(&buffer[..read]);
+    }
+    String::from_utf8(bytes).unwrap()
+}

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1345,138 +1345,174 @@ broker:
   separate resource-lifecycle prerequisite; this executor deliberately rejects
   stream delivery rather than inventing teardown or retention semantics.
 
+## Current ONVIF HTTPS Snapshot Host Slice
+
+This slice composes the installed ONVIF camera topology with the completed
+camera-media policy and native HTTPS executor in one concrete production host:
+
+- `smart-home-onvif-snapshot-host` performs the current authenticated
+  principal's exact Human Approval check before resolving credentials or
+  reaching network I/O. Invalid requests and missing process-local snapshot
+  endpoints fail at the same pre-I/O boundary.
+- The host implements the existing camera endpoint registry, so ONVIF profile
+  installation registers its reviewed canonical snapshot URI and pinned socket
+  directly into the host without exposing either through durable runtime state.
+- An installed bridge retains only an opaque stable Vault reference. The
+  production credential source reads its bounded, versioned credential envelope
+  from the sealed store into zeroizing memory for one authorized delivery.
+- Basic or Digest credentials are registered for exactly the selected entity,
+  one short-lived camera-media lease is issued and redeemed, and credentials are
+  removed on every success or error return path. Duplicate registration fails
+  closed instead of replacing another active host-owned credential lifetime.
+- The production constructor supplies trusted system time, OS CSPRNG lease
+  nonces, and the strict pinned HTTPS executor. Tests cover denial before Vault
+  resolution, removal after failed delivery, repeated independently authorized
+  reads from one sealed record, and a real Basic-authenticated loopback JPEG.
+- Automated ONVIF credential provisioning remains a pairing responsibility; a
+  host must write the versioned envelope into the dedicated sealed-Vault
+  namespace before installing its opaque reference. RTSP and other streams
+  remain blocked on a supervised resource owner and teardown lifecycle.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
-The strongest next executable slice is to wire the already-registered ONVIF
-snapshot endpoints through the completed HTTPS executor in a concrete host,
-with exact Human Approval authorization and host-owned credential registration
-and removal around delivery. Do not extend that slice to RTSP streams until a
-supervised stream resource host and teardown lifecycle are concrete.
+The strongest next executable slice is bounded ZoneMinder snapshot delivery:
+the production integration already has an authenticated local HTTPS inspection
+transport and installed camera identities, while the completed camera-media
+executor and ONVIF host establish the exact Human Approval, endpoint, and
+credential-lifetime boundaries. The new host must acquire one bounded access
+token per approved operation, retain the token-bearing endpoint only in
+zeroizing process-local state, unregister it after delivery, and avoid extending
+the slice to streams, recordings, export, or playback.
 
-1. Add authenticated AirGradient MQTT only after official firmware removes
+1. Add bounded ZoneMinder snapshots through the completed camera-media HTTPS
+   executor with exact Human Approval preflight, per-operation access-token
+   acquisition, and process-local endpoint removal after delivery; streams,
+   recordings, export, and playback still require a concrete supervised
+   resource executor.
+2. Add automated ONVIF credential provisioning only through an explicit pairing
+   flow that writes the versioned envelope into the dedicated sealed-Vault
+   namespace and installs only its opaque reference. Snapshot delivery itself is
+   complete and must not become an implicit credential writer.
+3. Add authenticated AirGradient MQTT only after official firmware removes
    plaintext credential logging and one-shot Vault-leased credential injection
    can be proven without request-plan or normalized-state exposure.
-2. Add independent AirGradient telemetry, remote-configuration, and OTA
+4. Add independent AirGradient telemetry, remote-configuration, and OTA
    destinations only if firmware exposes separate settings; the current
    `httpDomain` contract intentionally governs all three as one HTTPS origin.
-3. Add authenticated HEOS source browsing and queue insertion only after the
+5. Add authenticated HEOS source browsing and queue insertion only after the
    account/session and Vault-leasing prerequisites are concrete.
-4. Automate Enphase access-token acquisition or renewal only after Enphase
+6. Automate Enphase access-token acquisition or renewal only after Enphase
    account authentication, cloud-session handling, operator consent, and
    Vault-leased credential policy are concrete; the current host accepts a
    pre-generated token.
-5. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
+7. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
    stable LAN advertisement; the current production path uses explicit local
    HTTPS endpoint and gateway-serial configuration.
-6. Add Enphase live battery, relay, generator, grid, and system-topology state
+8. Add Enphase live battery, relay, generator, grid, and system-topology state
    only after the normalized energy topology and retention semantics are
    concrete.
-7. Add Enphase relay, grid-services, or configuration controls only with
+9. Add Enphase relay, grid-services, or configuration controls only with
    operation-specific D23 contracts, explicit safety approval, bounded native
    semantics, and readable postcondition verification.
-8. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
+10. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
    supervised session lifecycle and Vault policy for refresh-token residency are
    concrete; the current isolated inspection drops both tokens after each read.
-9. Add ZoneMinder event push only after a concrete authenticated event host and
+11. Add ZoneMinder event push only after a concrete authenticated event host and
     supervised subscription lifecycle exist.
-10. Add bounded ZoneMinder snapshots through the completed camera-media HTTPS
-    executor after process-local endpoint registration and credential lifetime
-    are wired; streams, recordings, export, and playback still require a
-    concrete supervised resource executor.
-11. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
+12. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
     mutations only with operation-specific D23 contracts, least-privilege user
     checks, bounded semantics, and readable postcondition verification.
-12. Add UniFi connected-client key rotation across multiple sites or more than
+13. Add UniFi connected-client key rotation across multiple sites or more than
     one 100-client page only after a resumable protocol can prove exact global
     correspondence and all-or-none persistence without extending native-ID or
     one-shot key residency across partial responses.
-13. Add UniFi connected-client native details only after field-specific
+14. Add UniFi connected-client native details only after field-specific
    minimization and retention are approved; current presence intentionally
    excludes names, native IDs, MACs, IPs, and connection timestamps.
-14. Add UniFi historical device statistics, heartbeat-time correlation, or
+15. Add UniFi historical device statistics, heartbeat-time correlation, or
    broader fleet polling only after durable time-series schema, query access,
    clock semantics, and retention/deletion policy are concrete; current live
    statistics are explicit-target, 64-device bounded, one-minute rate-limited,
    and expire after two minutes.
-15. Add remote UniFi Site Manager inspection only after telemetry-egress,
+16. Add remote UniFi Site Manager inspection only after telemetry-egress,
    destination, and operator-consent policy are concrete; keep the current host
    local-only.
-16. Add UniFi Network push or change events only after a concrete authenticated
+17. Add UniFi Network push or change events only after a concrete authenticated
    event host and supervised subscription lifecycle exist.
-17. Add UniFi adoption, guest authorization, port actions, or configuration
+18. Add UniFi adoption, guest authorization, port actions, or configuration
    mutations only with operation-specific D23 contracts, least-privilege API
    keys, bounded semantics, and readable postcondition verification.
-18. Add Synology Surveillance Station OTP and remembered-device authentication
+19. Add Synology Surveillance Station OTP and remembered-device authentication
    only after an interactive challenge lifecycle and Vault-leased device-token
    policy are concrete.
-19. Add Synology Surveillance Station events only after a concrete authenticated
+20. Add Synology Surveillance Station events only after a concrete authenticated
    event host and supervised subscription lifecycle exist.
-20. Add bounded Synology Surveillance Station snapshots through the completed
+21. Add bounded Synology Surveillance Station snapshots through the completed
     camera-media HTTPS executor after process-local endpoint registration and
     credential lifetime are wired; recordings, export, and playback still
     require a concrete supervised resource executor.
-21. Add Synology Surveillance Station PTZ, external recording, or configuration
+22. Add Synology Surveillance Station PTZ, external recording, or configuration
    mutations only with operation-specific D23 contracts, least-privilege API
    checks, bounded semantics, and readable postcondition verification.
-22. Add Frigate event and review push only after a concrete authenticated event
+23. Add Frigate event and review push only after a concrete authenticated event
    or WebSocket host and supervised subscription lifecycle exist.
-23. Add bounded Frigate snapshots through the completed camera-media HTTPS
+24. Add bounded Frigate snapshots through the completed camera-media HTTPS
     executor after process-local endpoint registration and credential lifetime
     are wired; recordings, export, and playback still require a concrete
     supervised resource executor.
-24. Add Frigate commands or configuration mutations only with operation-specific
+25. Add Frigate commands or configuration mutations only with operation-specific
    D23 contracts, least-privilege role checks, and readable postcondition
    verification.
-25. Add bounded Blue Iris snapshots through the completed camera-media HTTPS
+26. Add bounded Blue Iris snapshots through the completed camera-media HTTPS
     executor after process-local endpoint registration and credential lifetime
     are wired; alert/clip search, export, and playback still require a concrete
     supervised resource executor.
-26. Add broader Blue Iris `camconfig` or administrative mutations only with
+27. Add broader Blue Iris `camconfig` or administrative mutations only with
    operation-specific D23 contracts, least-privilege permissions, and readable
    postcondition verification; do not persist the license value returned at
    login.
-27. Add automatic Blue Iris discovery only if the server exposes a documented,
+28. Add automatic Blue Iris discovery only if the server exposes a documented,
    stable LAN advertisement; the current production path is explicit local
    HTTPS endpoint configuration.
-28. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
+29. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
    controls only when each operation has a specific native capability probe,
    bounded semantics, and readable verification where the device exposes it.
-29. Add Axis event streaming only after the existing WebSocket protocol core has
+30. Add Axis event streaming only after the existing WebSocket protocol core has
    a concrete authenticated host using the completed Digest primitive or a
    short-lived session token, plus subscription supervision.
-30. Add bounded Axis snapshots through the completed camera-media HTTPS executor
+31. Add bounded Axis snapshots through the completed camera-media HTTPS executor
     after process-local endpoint registration and credential lifetime are
     wired; broader media transfer still requires a concrete supervised resource
     executor.
-31. Enumerate Axis video sources/channels before extending PTZ beyond the current
+32. Enumerate Axis video sources/channels before extending PTZ beyond the current
    capability-probed VAPIX camera 1 boundary.
-32. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
+33. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
    only when each operation has a specific capability probe and readable state.
-33. Add bounded Reolink snapshots through the completed camera-media HTTPS
+34. Add bounded Reolink snapshots through the completed camera-media HTTPS
     executor after process-local endpoint registration and credential lifetime
     are wired; recording search/download and playback still require a concrete
     supervised resource executor.
-34. Add Reolink current-position, zoom, guard-point, or patrol controls only when
+35. Add Reolink current-position, zoom, guard-point, or patrol controls only when
    each operation has a capability-specific probe and the firmware exposes the
    native state needed to avoid invented orientation claims.
-35. Add Reolink push events only after a concrete webhook or event-stream host
+36. Add Reolink push events only after a concrete webhook or event-stream host
    and subscription lifecycle exist.
-36. Add authenticated KLAP/Tapo devices and other broader-device families only
+37. Add authenticated KLAP/Tapo devices and other broader-device families only
    after their authentication and session prerequisites are concrete.
-37. Add ONVIF PullPoint events once a concrete event host and subscription
+38. Add ONVIF PullPoint events once a concrete event host and subscription
    lifecycle exist.
-38. Add RTSP media transfer and recording once concrete media transfer and
+39. Add RTSP media transfer and recording once concrete media transfer and
    recorder host primitives exist.
-39. Add a production Matter commissioning, secure-session, and network host only
+40. Add a production Matter commissioning, secure-session, and network host only
    after certificate, fabric, Interaction Model encoding, subscription, and
    transport prerequisites exist.
-40. Add a Thread border-router host only after an actual host transport exists.
-41. Add a production Zigbee coordinator, join, and security host only after
+41. Add a Thread border-router host only after an actual host transport exists.
+42. Add a production Zigbee coordinator, join, and security host only after
    concrete coordinator transport and security primitives exist.
-42. Add production Z-Wave inclusion and S2 only after concrete host transport
+43. Add production Z-Wave inclusion and S2 only after concrete host transport
    and security primitives exist.
 
 ## End-To-End Definition


### PR DESCRIPTION
## Summary
- compose installed ONVIF snapshot endpoints with exact D23 Human Approval preflight and the pinned native HTTPS executor
- resolve versioned credentials from the sealed Vault into zeroizing process-local state and remove them after every delivery outcome
- add executor credential-registry safeguards, real authenticated loopback coverage, and reprioritize the Smart Home completion inventory

## Validation
- `cargo test -p smart-home-camera-media -p smart-home-camera-media-http-executor -p smart-home-onvif-integration -p smart-home-onvif-snapshot-host`
- `cargo clippy -p smart-home-camera-media -p smart-home-camera-media-http-executor -p smart-home-onvif-integration -p smart-home-onvif-snapshot-host --all-targets -- -D warnings`
- `bash smart-home-camera-media/BUILD`
- `bash smart-home-camera-media-http-executor/BUILD`
- `bash smart-home-onvif-integration/BUILD`
- `bash smart-home-onvif-snapshot-host/BUILD`
