### PR TITLE
Verify Tamil வ handwriting ductus

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -69,9 +69,9 @@ from the same canonical lesson ASTs used by Language Ladder, narration, objectiv
 activities, and back matter. The twelve former handwritten entries are protected
 generated targets with checked hashes, titles, labels, order, and output. HL-C19
 is already complete; HL-C09A verified Tamil அ in #10222, HL-C09B verified
-Tamil ஆ in #10223, and HL-C09C verified Tamil இ in #10226. HL-C09D is the
-next bounded stroke-order tranche: verify Tamil க from Frame 3 of the cited
-primer before widening DUCTUS across scripts.
+Tamil ஆ in #10223, HL-C09C verified Tamil இ in #10226, and HL-C09D verified
+Tamil க in #10228. HL-C09E is the next bounded stroke-order tranche: verify
+Tamil வ from Frame 9 of the cited primer before widening DUCTUS across scripts.
 The index audit found **2,075** canonical candidates across the corpus: **1,426**
 word and phrase lessons for English-first lookup, **136** dedicated grammar,
 writing, etymology, culture, and pronunciation lessons, **427** chapter
@@ -231,11 +231,12 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C06 | Complete (#10219) | Add the figure pipeline: SVG generation, `graphicx`, SVG→PDF in CI, and a `--check` hash gate. | A generated figure round-trips from canonical data into a compiled PDF and fails CI on drift, reusing `paint-vm-svg`'s `renderToSvgString`. |
 | HL-C07 | Complete (#9963) | Add the log-scanning warning gate with recorded per-track baselines. | Overfull/underfull boxes, missing glyphs, hyperref warnings, duplicate destinations, and font substitutions are machine-checked by `scan_latex_log_warnings.py` after the `latexmk` loop, against `core/latex-warning-baseline.json`. Baselines ship unseeded — `null` means unmeasured, never zero — so the gate reports today and fails the moment a seeded track regresses. The first CI run on main emits the real counts into the job summary for a human to paste back. |
 | HL-C08 | Complete (#9974) | Render the ductus in Language Ladder. | `penPathD`/`penTip` drive the tested SVG stroke build-up in the app; the currently authored ductus is shared with validation and script practice. |
-| HL-C09 | Queued — 5 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 223 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
+| HL-C09 | Queued — 6 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 222 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
 | HL-C09A | Complete (#10222) | Verify Tamil அ as the first post-HL-C19 expansion tranche, using the primer already cited for Tamil handwriting. | அ carries a source-aligned two-stroke path with exactly one lift; its five movements, learner prose, source metadata, font-outline geometry, and rendered filmstrip agree. |
 | HL-C09B | Complete (#10223) | Verify Tamil ஆ as the next source-backed expansion tranche from Frame 4 of the same primer. | ஆ carries a font-checked path for the அ body plus its long-vowel right-hand loop; its learner prose states every verified lift, and source, geometry, and filmstrip tests agree. |
 | HL-C09C | Complete (#10226) | Verify Tamil இ as Frame 4's third source-backed vowel tranche. | இ carries a seven-movement, font-checked path whose learner prose states each evidenced lift; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C09D | Complete (#10228) | Verify Tamil க from Frame 3's final source-backed consonant row. | க carries a six-movement, font-checked three-stroke path whose learner prose states its two evidenced lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
+| HL-C09E | Complete (#10230) | Verify Tamil வ from Frame 9's first source-backed consonant row. | வ carries a five-movement, font-checked unbroken path whose learner prose states the evidenced zero lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C10 | Complete (#10010, #10013, #10067) | Complete A1 and add the A2-through-C2 spine tranches with all registered realization ledgers. | All seven declared stages carry nodes; every one of the 22 registered tracks has a non-drifting ledger entry for every node. |
 | HL-C11 | Queued — capability and closure coverage complete | Finish representative chapter payoffs across all 22 tracks. | #10128 brought all 513 chapters to an authored `canDo`, spine mapping, known payoff lesson, and closed assessment. Remediate the remaining 27 payoffs below the 0.5 representativeness floor across ten tracks, then enforce the clean tracks instead of leaving their gates report-only. |
 | HL-C12 | Queued — licensing decided, pipeline outstanding | Add the Class C illustration pipeline with provenance sidecars and a size budget. Licensing is settled and recorded in [`_assets/LICENSE.md`](./_assets/LICENSE.md); the remaining work is the pipeline itself. | Every asset carries `license`, `rightsAsserted`, `generator`, `model`, `prompt`, `date`, and `sha256`; CI fails any asset without a provenance sidecar or a recorded licence, and enforces the per-track size budget. |
@@ -2638,7 +2639,7 @@ problem.
   **61 glyph violations plus five multi-system Japanese openings**. The current
   corpus is 91% core-drivable, not the historical 84% recorded before later work.
 - HL-C19 supersedes HL-C09's old estimate. There are **228** prose stroke-order
-  entries across ten scripts: five verified ductus paths and 223 entries still needing cited,
+  entries across ten scripts: six verified ductus paths and 222 entries still needing cited,
   font-checked pen-lift evidence.
 
 ## Findings from HL-C05

--- a/code/learning/human-languages/data/scripts/README.md
+++ b/code/learning/human-languages/data/scripts/README.md
@@ -130,17 +130,19 @@ and given the same citation.
 4. Where no ductus exists, do not invent lifts — keep the steps as part order and
    leave `penLifts` out.
 
-Tamil **அ**, **ஆ**, **இ**, and **க** now join **ம** with authored ductus paths. The primer's
+Tamil **அ**, **ஆ**, **இ**, **க**, and **வ** now join **ம** with authored ductus paths. The primer's
 Frame 4 shows four connected movements for their shared curl-and-loop body,
 followed by one lift and the separate right upright; ஆ then continues without
 another lift into its long-vowel loop. Frame 4's next row gives இ five joined
 inner-and-lower movements, one lift, then a joined outer-left climb and final
 arch. The font-backed paths and learner prose preserve those orders exactly. The
 Frame 3 row for க separates its upper frame and two lower bowls into three
-pen-down runs with two verified lifts. The remaining **223** prose part
+pen-down runs with two verified lifts. Frame 9 joins வ's spiral body, bottom
+bar, and right upright as five movements in one unbroken run. The remaining
+**222** prose part
 orders across ten scripts (`arabic` 21, `chinese` 24, `cyrillic` 33,
 `devanagari` 28, `gujarati` 33, `hebrew` 22, `japanese` 34,
-`perso-arabic` 9, `tamil` 6, `urdu-nastaliq` 13) are explicitly **unverified for
+`perso-arabic` 9, `tamil` 5, `urdu-nastaliq` 13) are explicitly **unverified for
 pen lifts**. The data validator rejects a lift count without a citation (or a
 citation without a count), and Language Ladder's ductus test proves every verified
 claim has the same cited, font-checked path. That closes `HL-C19`; future entries

--- a/code/learning/human-languages/data/scripts/tamil.json
+++ b/code/learning/human-languages/data/scripts/tamil.json
@@ -7,7 +7,7 @@
   "signature": "Curvy and loopy with flat top-bars on many letters, repeated arches, and no continuous head-line.",
   "complete": false,
   "combination": "A consonant carries an inherent 'a' (க = ka). A vowel sign replaces that vowel (க + ா → கா = kā). The puḷḷi ் — a DOT above the letter — removes the vowel entirely (க் = k). Unlike Devanagari, Tamil does NOT fuse the bare consonant into a conjunct: the dot stays visible and both letters keep their full shape. (A handful of Sanskrit-borrowed ligatures are the exception — க்ஷ kṣa and ஸ்ரீ śrī.)",
-  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, இ, க, and ம have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ and ஆ each have two pen-down runs with one lift before the separate right upright; ஆ then continues into its long-vowel loop without another lift. இ keeps its first five movements joined, lifts once before the outer-left climb, and joins that climb to the final arch. க uses three pen-down runs: its upper frame, lower-left bowl, and lower-right bowl. ம is a single unbroken stroke even though its parts have separate names. The other six letters here have no verified pen path, so read their steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
+  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, இ, க, ம, and வ have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ and ஆ each have two pen-down runs with one lift before the separate right upright; ஆ then continues into its long-vowel loop without another lift. இ keeps its first five movements joined, lifts once before the outer-left climb, and joins that climb to the final arch. க uses three pen-down runs: its upper frame, lower-left bowl, and lower-right bowl. ம and வ are each a single unbroken stroke even though their parts have separate names. The other five letters here have no verified pen path, so read their steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
   "letters": [
     {
       "glyph": "அ",
@@ -125,10 +125,22 @@
       "sound": "va",
       "role": "consonant",
       "inherentVowel": "a",
-      "components": ["a near-closed loop on the left", "a full-height arm across the top ending in a descender on the right"],
-      "strokeOrder": ["left loop", "top arm and descender"],
-      "strokeOrderNote": "conventional",
-      "notes": "One of the plainer shapes, and a reasonable first letter to draw."
+      "components": ["a spiral loop on the left", "a bottom bar", "a tall right upright"],
+      "strokeOrder": [
+        "start at the inner curl and spiral outward, climbing the left side",
+        "without lifting, arch over the top and descend on the right",
+        "without lifting, turn down to the baseline",
+        "without lifting, carry the bottom bar to the right",
+        "without lifting, rise up the right upright — and only now lift"
+      ],
+      "strokeOrderNote": "one unbroken stroke — five joined movements, no pen lift; cited to Radhakrishnan, Tamil Script Learners Manual, Frame 9, வ",
+      "penLifts": 0,
+      "strokeOrderSource": {
+        "citation": "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 9, வ (Univ. of Texas at Austin), p. 194",
+        "url": "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+        "variation": "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order."
+      },
+      "notes": "One of the plainer shapes, and a reasonable first letter to draw. Frame 9's five numbered movements are parts of one continuous spiral-to-upright motion, not five strokes: the pen stays down until the right upright ends."
     },
     {
       "glyph": "ண",

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -28,6 +28,12 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
   bowls form three pen-down runs with exactly two lifts, matching the Frame 3
   source and Language Ladder's font-checked path.
 
+### Added - verified Tamil வ handwriting
+
+- Record the cited five-movement order for Tamil வ: its spiral body, bottom bar,
+  and right upright form one unbroken pen-down run with zero lifts, matching the
+  Frame 9 source and Language Ladder's font-checked path.
+
 ### Added - generated lesson figures
 
 - Generate deterministic etymology-route SVGs from the canonical lesson `roots`

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -36,6 +36,13 @@
 - Check all six movements against the full Noto Sans Tamil outline and pin both
   lift transitions in the real filmstrip and learner prose.
 
+### Added — cited unbroken ductus for Tamil வ (HL-C09E)
+
+- Add Frame 9's first row, Tamil வ: five joined movements carry its spiral body
+  into the bottom bar and right upright without a pen lift.
+- Check the complete path against the Noto Sans Tamil outline and pin its zero
+  lifts in the real five-frame filmstrip and learner prose.
+
 ### Added — canonical lesson figures
 
 - Preserve standalone Markdown images as typed lesson blocks instead of flattening

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -165,7 +165,7 @@ in font units, and `ductusview.ts` flips them together with exactly **one**
 `scale(1,-1)` group — so a mistake cannot leave a plausible-looking stroke
 sitting upside down on a correct letter.
 
-**Tamil அ, ஆ, இ, க, and ம have authored pen paths today.** `DUCTUS` admits no letter
+**Tamil அ, ஆ, இ, க, ம, and வ have authored pen paths today.** `DUCTUS` admits no letter
 without a citation for its stroke order, and hand-drawing a letter is forbidden
 outright (a subtly wrong Tamil ண looks perfect to exactly the audience that
 cannot yet read Tamil, so the error would ship *as the lesson*). அ and ஆ exercise
@@ -173,7 +173,8 @@ real two-stroke paths with one lift; ஆ keeps its upright and long-vowel loop i
 the same pen-down run. இ keeps five inner-and-lower movements together, lifts
 once, then joins its outer-left climb to the final arch; ம remains one unbroken
 stroke. க exercises a real three-stroke path: its upper frame and two lower bowls
-are separated by two verified lifts. Every other
+are separated by two verified lifts. வ joins its spiral body, bottom bar, and
+right upright in one five-movement run with no lift. Every other
 letter falls back to the numbered prose list, unchanged. Extending the coverage
 is HL-C09, and it needs a cited source per letter.
 

--- a/code/programs/typescript/language-ladder/src/strokes.ts
+++ b/code/programs/typescript/language-ladder/src/strokes.ts
@@ -200,6 +200,8 @@ const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n);
 // movements 6-7 climb the separate outer-left start and complete its arch.
 // க is Frame 3's final row: movements 1-3 make the upper frame, movements
 // 4-5 make the lower-left bowl, and movement 6 makes the lower-right bowl.
+// வ is Frame 9's first row: all five movements join the spiral body to its
+// bottom bar and right upright without a pen lift.
 // ம is Frame 1's third row: all five movements join into one unbroken stroke.
 // ---------------------------------------------------------------------------
 
@@ -619,6 +621,90 @@ export const DUCTUS: Record<string, LetterDuctus> = {
     source: {
       citation:
         "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 3, க (Univ. of Texas at Austin), p. 191",
+      url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+      variation:
+        "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",
+    },
+  },
+  வ: {
+    glyph: "வ",
+    strokes: [
+      {
+        segments: [
+          {
+            label: "curl outward and climb the left",
+            path: [
+              { x: 300, y: 35 },
+              { x: 310, y: 55 },
+              { x: 350, y: 90 },
+              { x: 380, y: 145 },
+              { x: 380, y: 205 },
+              { x: 340, y: 260 },
+              { x: 285, y: 292 },
+              { x: 225, y: 290 },
+              { x: 170, y: 275 },
+              { x: 120, y: 275 },
+              { x: 95, y: 270 },
+              { x: 95, y: 180 },
+              { x: 115, y: 105 },
+              { x: 175, y: 45 },
+              { x: 250, y: 25 },
+              { x: 175, y: 45 },
+              { x: 115, y: 105 },
+              { x: 95, y: 180 },
+              { x: 95, y: 270 },
+              { x: 120, y: 360 },
+              { x: 180, y: 450 },
+            ],
+          },
+          {
+            label: "arch over the top and down the right",
+            path: [
+              { x: 180, y: 450 },
+              { x: 270, y: 525 },
+              { x: 370, y: 530 },
+              { x: 470, y: 500 },
+              { x: 545, y: 430 },
+              { x: 600, y: 340 },
+              { x: 605, y: 255 },
+              { x: 585, y: 175 },
+              { x: 545, y: 105 },
+            ],
+          },
+          {
+            label: "turn down to the baseline",
+            path: [
+              { x: 545, y: 105 },
+              { x: 550, y: 80 },
+              { x: 555, y: 55 },
+              { x: 555, y: 35 },
+              { x: 515, y: 35 },
+            ],
+          },
+          {
+            label: "carry the bottom bar right",
+            path: [
+              { x: 515, y: 35 },
+              { x: 650, y: 35 },
+              { x: 780, y: 35 },
+              { x: 913, y: 35 },
+            ],
+          },
+          {
+            label: "rise up the right upright",
+            path: [
+              { x: 913, y: 35 },
+              { x: 913, y: 180 },
+              { x: 913, y: 350 },
+              { x: 913, y: 515 },
+            ],
+          },
+        ],
+      },
+    ],
+    source: {
+      citation:
+        "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 9, வ (Univ. of Texas at Austin), p. 194",
       url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
       variation:
         "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",

--- a/code/programs/typescript/language-ladder/tests/ductusview.test.ts
+++ b/code/programs/typescript/language-ladder/tests/ductusview.test.ts
@@ -57,6 +57,8 @@ const I = DUCTUS["இ"];
 const iOutline = tamilOutline("இ");
 const KA = DUCTUS["க"];
 const kaOutline = tamilOutline("க");
+const VA = DUCTUS["வ"];
+const vaOutline = tamilOutline("வ");
 
 /** Walk a node tree, collecting every node the predicate accepts. */
 function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = []): SvgNode[] {
@@ -68,12 +70,13 @@ function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = 
 const byTag = (node: SvgNode, tag: string) => collect(node, (n) => n.tag === tag);
 
 describe("ductusFor — only cited letters have a ductus", () => {
-  it("finds all five authored Tamil letters", () => {
+  it("finds all six authored Tamil letters", () => {
     expect(ductusFor("ம")?.glyph).toBe("ம");
     expect(ductusFor("அ")?.glyph).toBe("அ");
     expect(ductusFor("ஆ")?.glyph).toBe("ஆ");
     expect(ductusFor("இ")?.glyph).toBe("இ");
     expect(ductusFor("க")?.glyph).toBe("க");
+    expect(ductusFor("வ")?.glyph).toBe("வ");
   });
 
   it("returns undefined for a letter nobody has authored a stroke order for", () => {
@@ -377,6 +380,30 @@ describe("க — a real cited three-stroke filmstrip", () => {
     expect(done).toHaveLength(2);
     expect(done.map((path) => path.attrs.d)).toEqual([penPathD(KA.strokes[0], 1), penPathD(KA.strokes[1], 1)]);
     expect(pen.attrs.d).toBe(penPathD(KA.strokes[2], 1));
+  });
+});
+
+describe("வ — a real cited unbroken five-movement filmstrip", () => {
+  const steps = ductusSteps(VA);
+  const strip = ductusFilmstrip(VA, vaOutline);
+
+  it("keeps every movement in the same pen-down run", () => {
+    expect(steps.map((step) => step.startsAfterLift)).toEqual([false, false, false, false, false]);
+    expect(steps.map((step) => step.strokeIndex)).toEqual([0, 0, 0, 0, 0]);
+  });
+
+  it("reports five movements in one unbroken stroke", () => {
+    expect(strip.frames).toHaveLength(5);
+    expect(strip.penLifts).toBe(0);
+    expect(strip.summary).toBe("one unbroken stroke · 5 movements");
+  });
+
+  it("finishes the sole stroke without any completed-stroke overlay", () => {
+    const last = strip.frames[4];
+    const done = byTag(last, "path").filter((path) => path.attrs.class === "ductus__done");
+    const pen = byTag(last, "path").find((path) => path.attrs.class === "ductus__pen")!;
+    expect(done).toHaveLength(0);
+    expect(pen.attrs.d).toBe(penPathD(VA.strokes[0], 1));
   });
 });
 

--- a/code/programs/typescript/language-ladder/tests/strokes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/strokes.test.ts
@@ -198,6 +198,12 @@ describe("handwriting ductus", () => {
     expect(DUCTUS["க"].strokes.map((stroke) => stroke.segments.length)).toEqual([3, 2, 1]);
   });
 
+  it("வ joins all five movements without lifting the pen", () => {
+    expect(penLifts(DUCTUS["வ"])).toBe(0);
+    expect(DUCTUS["வ"].strokes).toHaveLength(1);
+    expect(DUCTUS["வ"].strokes[0].segments).toHaveLength(5);
+  });
+
   // The PROVENANCE GATE. A stroke's SHAPE is checked against the font above;
   // its ORDER cannot be — so it must trace to a cited source, or it does not
   // ship. This is the counterpart, for hand-authored order, of "facts enter
@@ -264,6 +270,13 @@ describe("handwriting ductus", () => {
     const src = DUCTUS["க"].source;
     expect(src.url).toContain("tamilscript");
     expect(src.citation).toMatch(/Appendix I.*Frame 3.*க/);
+    expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
+  });
+
+  it("வ's stroke order traces to Frame 9's first row", () => {
+    const src = DUCTUS["வ"].source;
+    expect(src.url).toContain("tamilscript");
+    expect(src.citation).toMatch(/Appendix I.*Frame 9.*வ/);
     expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
   });
 });


### PR DESCRIPTION
## What changed

- add a cited, font-checked five-movement ductus for Tamil வ from Frame 9 of the UT Austin primer
- record that all five movements form one unbroken pen-down run with zero lifts
- align learner data, Language Ladder filmstrip behavior, source metadata, coverage counts, changelogs, and HL-C09E backlog tracking

## Why

HL-C09 requires every prose stroke-order claim to have a cited ductus and verified pen-lift metadata. வ is the next bounded Tamil row with an official source and reduces the remaining unverified inventory from 223 to 222.

## Validation

- `bash BUILD` in `code/packages/typescript/human-language-data` (460 tests)
- `bash BUILD` in `code/programs/typescript/language-ladder` (575 tests plus typecheck and production bundle)
- `bash code/scripts/verify-human-languages.sh --fast`
- focused `strokes.test.ts` and `ductusview.test.ts` after rebasing onto latest `origin/main`
- `git diff --check`