### PR TITLE
Add nested structural groups for C4 boundaries

### DIFF
--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.2.0 — DG00/DG04 semantic IR
+//! diagram-ir v0.3.0 — DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.2.0";
+pub const VERSION: &str = "0.3.0";
 
 #[derive(Clone, Debug, PartialEq)]
 #[derive(Default)]
@@ -155,7 +155,10 @@ pub enum CompartmentKind { Header, Fields, Methods, Values }
 pub struct Compartment { pub kind: CompartmentKind, pub entries: Vec<String> }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct StructuralNode { pub id: String, pub label: String, pub stereotype: Option<String>, pub node_kind: StructuralNodeKind, pub compartments: Vec<Compartment> }
+pub struct StructuralNode { pub id: String, pub label: String, pub stereotype: Option<String>, pub node_kind: StructuralNodeKind, pub compartments: Vec<Compartment>, pub parent_group: Option<String> }
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct StructuralGroup { pub id: String, pub label: String, pub stereotype: Option<String>, pub parent_group: Option<String> }
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum RelKind { Inheritance, Realization, Composition, Aggregation, Association, Dependency, Link }
@@ -164,7 +167,7 @@ pub enum RelKind { Inheritance, Realization, Composition, Aggregation, Associati
 pub struct StructuralRelationship { pub from: String, pub to: String, pub kind: RelKind, pub from_mult: Option<String>, pub to_mult: Option<String>, pub label: Option<String> }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct StructuralDiagram { pub kind: StructuralKind, pub title: Option<String>, pub nodes: Vec<StructuralNode>, pub relationships: Vec<StructuralRelationship> }
+pub struct StructuralDiagram { pub kind: StructuralKind, pub title: Option<String>, pub nodes: Vec<StructuralNode>, pub groups: Vec<StructuralGroup>, pub relationships: Vec<StructuralRelationship> }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct LayoutedCompartment { pub y_offset: f64, pub height: f64, pub rows: Vec<String> }
@@ -173,10 +176,13 @@ pub struct LayoutedCompartment { pub y_offset: f64, pub height: f64, pub rows: V
 pub struct LayoutedStructuralNode { pub id: String, pub x: f64, pub y: f64, pub width: f64, pub height: f64, pub header: String, pub stereotype: Option<String>, pub compartments: Vec<LayoutedCompartment> }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct LayoutedStructuralGroup { pub id: String, pub x: f64, pub y: f64, pub width: f64, pub height: f64, pub label: String, pub stereotype: Option<String>, pub parent_group: Option<String> }
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct LayoutedStructuralRelationship { pub from_id: String, pub to_id: String, pub kind: RelKind, pub points: Vec<Point>, pub from_mult: Option<String>, pub to_mult: Option<String>, pub label: Option<(Point, String)> }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct LayoutedStructuralDiagram { pub width: f64, pub height: f64, pub nodes: Vec<LayoutedStructuralNode>, pub relationships: Vec<LayoutedStructuralRelationship> }
+pub struct LayoutedStructuralDiagram { pub width: f64, pub height: f64, pub groups: Vec<LayoutedStructuralGroup>, pub nodes: Vec<LayoutedStructuralNode>, pub relationships: Vec<LayoutedStructuralRelationship> }
 
 // TEMPORAL FAMILY
 #[derive(Clone, Debug, PartialEq)]
@@ -264,7 +270,7 @@ pub struct LayoutedGeometricDiagram { pub width: f64, pub height: f64, pub eleme
 mod tests {
     use super::*;
 
-    #[test] fn version_is_0_2_0() { assert_eq!(VERSION, "0.2.0"); }
+    #[test] fn version_is_0_3_0() { assert_eq!(VERSION, "0.3.0"); }
     #[test] fn default_direction_is_tb() { assert_eq!(DiagramDirection::default(), DiagramDirection::Tb); }
     #[test] fn default_shape_is_rounded_rect() { assert_eq!(DiagramShape::default(), DiagramShape::RoundedRect); }
     #[test] fn resolve_style_none_gives_defaults() {
@@ -294,8 +300,8 @@ mod tests {
         assert_eq!(d.series[0].data.len(), 2);
     }
     #[test] fn structural_diagram_builds() {
-        let node = StructuralNode { id:"A".into(), label:"A".into(), stereotype:None, node_kind:StructuralNodeKind::Class, compartments:vec![] };
-        let d = StructuralDiagram { kind:StructuralKind::Class, title:None, nodes:vec![node], relationships:vec![] };
+        let node = StructuralNode { id:"A".into(), label:"A".into(), stereotype:None, node_kind:StructuralNodeKind::Class, compartments:vec![], parent_group:None };
+        let d = StructuralDiagram { kind:StructuralKind::Class, title:None, nodes:vec![node], groups:vec![], relationships:vec![] };
         assert_eq!(d.nodes[0].id, "A");
     }
     #[test] fn gantt_diagram_builds() {

--- a/code/packages/rust/diagram-layout-structural/Cargo.toml
+++ b/code/packages/rust/diagram-layout-structural/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-structural"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Class, ER, and C4 diagram layout engine (DG04)"
 

--- a/code/packages/rust/diagram-layout-structural/src/lib.rs
+++ b/code/packages/rust/diagram-layout-structural/src/lib.rs
@@ -7,11 +7,12 @@
 //! polyline paths for all relationships.
 
 use diagram_ir::{
-    LayoutedCompartment, LayoutedStructuralDiagram,
+    LayoutedCompartment, LayoutedStructuralDiagram, LayoutedStructuralGroup,
     LayoutedStructuralNode, LayoutedStructuralRelationship, Point, StructuralDiagram, StructuralNode,
 };
+use std::collections::{HashMap, HashSet};
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 
 const MIN_NODE_W: f64 = 160.0;
 const HEADER_H:   f64 = 40.0;
@@ -20,15 +21,18 @@ const COMP_PAD:   f64 = 8.0;
 const COL_GAP:    f64 = 80.0;
 const ROW_GAP:    f64 = 60.0;
 const COLS:       usize = 3;
+const GROUP_PAD:  f64 = 24.0;
+const GROUP_HEADER_H: f64 = 32.0;
 
 /// Lay out a `StructuralDiagram` using a simple grid arrangement.
 pub fn layout_structural_diagram(diagram: &StructuralDiagram) -> LayoutedStructuralDiagram {
-    let nodes = layout_nodes(&diagram.nodes);
-    let canvas_w = canvas_width(&nodes);
-    let canvas_h = canvas_height(&nodes);
+    let nodes = layout_nodes(&diagram.nodes, &diagram.groups);
+    let groups = layout_groups(diagram, &nodes);
+    let canvas_w = canvas_width(&nodes, &groups);
+    let canvas_h = canvas_height(&nodes, &groups);
     let rels = layout_relationships(diagram, &nodes);
     LayoutedStructuralDiagram {
-        width: canvas_w, height: canvas_h, nodes, relationships: rels,
+        width: canvas_w, height: canvas_h, groups, nodes, relationships: rels,
     }
 }
 
@@ -51,7 +55,10 @@ fn node_height(node: &StructuralNode) -> f64 {
     h
 }
 
-fn layout_nodes(nodes: &[StructuralNode]) -> Vec<LayoutedStructuralNode> {
+fn layout_nodes(
+    nodes: &[StructuralNode],
+    groups: &[diagram_ir::StructuralGroup],
+) -> Vec<LayoutedStructuralNode> {
     let mut out: Vec<LayoutedStructuralNode> = Vec::with_capacity(nodes.len());
     // Track max height per row so rows don't overlap.
     let mut row_y: Vec<f64> = vec![COMP_PAD];
@@ -66,7 +73,8 @@ fn layout_nodes(nodes: &[StructuralNode]) -> Vec<LayoutedStructuralNode> {
         while row_y.len() <= row { row_y.push(*row_y.last().unwrap_or(&COMP_PAD)); }
 
         let x = COMP_PAD + col as f64 * (MIN_NODE_W + COL_GAP);
-        let y = row_y[row];
+        let y = row_y[row]
+            + group_depth(node.parent_group.as_deref(), groups) as f64 * GROUP_HEADER_H;
 
         // Update the starting y for the next row.
         let next_row_y = y + nh + ROW_GAP;
@@ -99,16 +107,135 @@ fn layout_nodes(nodes: &[StructuralNode]) -> Vec<LayoutedStructuralNode> {
     out
 }
 
-fn canvas_width(nodes: &[LayoutedStructuralNode]) -> f64 {
+fn group_depth(
+    parent_group: Option<&str>,
+    groups: &[diagram_ir::StructuralGroup],
+) -> usize {
+    let mut depth = 0;
+    let mut current = parent_group;
+    let mut visited = HashSet::new();
+    while let Some(group_id) = current {
+        if !visited.insert(group_id) {
+            break;
+        }
+        depth += 1;
+        current = groups
+            .iter()
+            .find(|group| group.id == group_id)
+            .and_then(|group| group.parent_group.as_deref());
+    }
+    depth
+}
+
+fn canvas_width(nodes: &[LayoutedStructuralNode], groups: &[LayoutedStructuralGroup]) -> f64 {
     nodes.iter()
         .map(|n| n.x + n.width + COMP_PAD)
+        .chain(groups.iter().map(|g| g.x + g.width + COMP_PAD))
         .fold(200.0_f64, f64::max)
 }
 
-fn canvas_height(nodes: &[LayoutedStructuralNode]) -> f64 {
+fn canvas_height(nodes: &[LayoutedStructuralNode], groups: &[LayoutedStructuralGroup]) -> f64 {
     nodes.iter()
         .map(|n| n.y + n.height + COMP_PAD)
+        .chain(groups.iter().map(|g| g.y + g.height + COMP_PAD))
         .fold(100.0_f64, f64::max)
+}
+
+fn layout_groups(
+    diagram: &StructuralDiagram,
+    nodes: &[LayoutedStructuralNode],
+) -> Vec<LayoutedStructuralGroup> {
+    let mut cache: HashMap<String, (f64, f64, f64, f64)> = HashMap::new();
+    let mut visiting = HashSet::new();
+
+    for group in &diagram.groups {
+        group_bounds(&group.id, diagram, nodes, &mut cache, &mut visiting);
+    }
+
+    let mut groups: Vec<LayoutedStructuralGroup> = diagram
+        .groups
+        .iter()
+        .filter_map(|group| {
+            let (x, y, max_x, max_y) = cache.get(&group.id).copied()?;
+            Some(LayoutedStructuralGroup {
+                id: group.id.clone(),
+                x,
+                y,
+                width: max_x - x,
+                height: max_y - y,
+                label: group.label.clone(),
+                stereotype: group.stereotype.clone(),
+                parent_group: group.parent_group.clone(),
+            })
+        })
+        .collect();
+    groups.sort_by(|a, b| {
+        (b.width * b.height)
+            .partial_cmp(&(a.width * a.height))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    groups
+}
+
+fn group_bounds(
+    group_id: &str,
+    diagram: &StructuralDiagram,
+    nodes: &[LayoutedStructuralNode],
+    cache: &mut HashMap<String, (f64, f64, f64, f64)>,
+    visiting: &mut HashSet<String>,
+) -> Option<(f64, f64, f64, f64)> {
+    if let Some(bounds) = cache.get(group_id).copied() {
+        return Some(bounds);
+    }
+    if !visiting.insert(group_id.to_string()) {
+        return None;
+    }
+
+    let mut children: Vec<(f64, f64, f64, f64)> = diagram
+        .nodes
+        .iter()
+        .filter(|node| node.parent_group.as_deref() == Some(group_id))
+        .filter_map(|node| {
+            nodes
+                .iter()
+                .find(|layouted| layouted.id == node.id)
+                .map(|layouted| {
+                    (
+                        layouted.x,
+                        layouted.y,
+                        layouted.x + layouted.width,
+                        layouted.y + layouted.height,
+                    )
+                })
+        })
+        .collect();
+
+    for child in diagram
+        .groups
+        .iter()
+        .filter(|group| group.parent_group.as_deref() == Some(group_id))
+    {
+        if let Some(bounds) = group_bounds(&child.id, diagram, nodes, cache, visiting) {
+            children.push(bounds);
+        }
+    }
+    visiting.remove(group_id);
+    if children.is_empty() {
+        return None;
+    }
+
+    let min_x = children.iter().map(|bounds| bounds.0).fold(f64::INFINITY, f64::min);
+    let min_y = children.iter().map(|bounds| bounds.1).fold(f64::INFINITY, f64::min);
+    let max_x = children.iter().map(|bounds| bounds.2).fold(f64::NEG_INFINITY, f64::max);
+    let max_y = children.iter().map(|bounds| bounds.3).fold(f64::NEG_INFINITY, f64::max);
+    let bounds = (
+        (min_x - GROUP_PAD).max(0.0),
+        (min_y - GROUP_HEADER_H).max(0.0),
+        max_x + GROUP_PAD,
+        max_y + GROUP_PAD,
+    );
+    cache.insert(group_id.to_string(), bounds);
+    Some(bounds)
 }
 
 fn find_node<'a>(nodes: &'a [LayoutedStructuralNode], id: &str) -> Option<&'a LayoutedStructuralNode> {
@@ -186,6 +313,7 @@ mod tests {
                         kind: CompartmentKind::Methods,
                         entries: vec!["speak() void".into()],
                     }],
+                    parent_group: None,
                 },
                 StructuralNode {
                     id: "Dog".into(), label: "Dog".into(),
@@ -195,8 +323,10 @@ mod tests {
                         kind: CompartmentKind::Fields,
                         entries: vec!["name: String".into()],
                     }],
+                    parent_group: None,
                 },
             ],
+            groups: vec![],
             relationships: vec![StructuralRelationship {
                 from: "Dog".into(), to: "Animal".into(),
                 kind: RelKind::Inheritance,
@@ -205,7 +335,7 @@ mod tests {
         }
     }
 
-    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.1.0"); }
+    #[test] fn version_exists() { assert_eq!(crate::VERSION, "0.2.0"); }
 
     #[test]
     fn two_nodes_laid_out() {
@@ -241,5 +371,25 @@ mod tests {
         let r = layout_structural_diagram(&two_class_diagram());
         let animal = r.nodes.iter().find(|n| n.id == "Animal").unwrap();
         assert_eq!(animal.compartments[0].rows, vec!["speak() void"]);
+    }
+
+    #[test]
+    fn structural_group_bounds_contain_member_nodes() {
+        let mut diagram = two_class_diagram();
+        diagram.nodes[0].parent_group = Some("domain".into());
+        diagram.groups.push(StructuralGroup {
+            id: "domain".into(),
+            label: "Domain".into(),
+            stereotype: Some("System_Boundary".into()),
+            parent_group: None,
+        });
+
+        let layout = layout_structural_diagram(&diagram);
+        let group = layout.groups.iter().find(|group| group.id == "domain").unwrap();
+        let animal = layout.nodes.iter().find(|node| node.id == "Animal").unwrap();
+        assert!(group.x <= animal.x);
+        assert!(group.y <= animal.y);
+        assert!(group.x + group.width >= animal.x + animal.width);
+        assert!(group.y + group.height >= animal.y + animal.height);
     }
 }

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.2.0";
+pub const VERSION: &str = "0.3.0";
 
 use std::collections::HashMap;
 
@@ -611,6 +611,26 @@ where
     let lf = options.label_font.clone();
     let ls = lf.size;
     const HEADER_H: f64 = 40.0;
+
+    // Groups are backend-neutral containers. Draw outer groups first so nested
+    // groups, relationships, and nodes naturally layer above them.
+    for group in &diagram.groups {
+        instructions.push(PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: group.x, y: group.y, width: group.width, height: group.height,
+            fill: Some("#f8fafc".into()), stroke: Some("#94a3b8".into()),
+            stroke_width: Some(1.5), corner_radius: Some(8.0),
+            stroke_dash: Some(vec![6.0, 4.0]), stroke_dash_offset: None,
+        }));
+        let label = match &group.stereotype {
+            Some(stereotype) => format!("«{stereotype}» {}", group.label),
+            None => group.label.clone(),
+        };
+        text_children.push(text_node(
+            &label, group.x + 10.0, group.y + 6.0, group.width - 20.0, ls * 1.3,
+            lf.clone(), Color { r: 71, g: 85, b: 105, a: 255 },
+        ));
+    }
 
     // ── Relationships (drawn behind nodes) ───────────────────────────────────
     for rel in &diagram.relationships {
@@ -1284,7 +1304,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.2.0");
+        assert_eq!(crate::VERSION, "0.3.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -310,6 +310,7 @@ mod apple {
         )
         .expect("Mermaid C4 parse failed");
         let layout = layout_structural_diagram(&diagram);
+        assert_eq!(layout.groups.len(), 1);
 
         let shaper = CoreTextShaper;
         let metrics = CoreTextMetrics;
@@ -337,5 +338,9 @@ mod apple {
         assert!(pixels.width > 0);
         assert!(pixels.height > 0);
         assert!(!scene.instructions.is_empty());
+        assert!(scene.instructions.iter().any(|instruction| matches!(
+            instruction,
+            paint_instructions::PaintInstruction::Rect(rect) if rect.stroke_dash.is_some()
+        )));
     }
 }

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -432,8 +432,8 @@ use diagram_ir::{
     Axis, AxisKind, ChartDiagram, ChartKind, ChartOrientation, ChartSeries, Compartment,
     CompartmentKind, GanttDiagram, GanttSection, GanttTask, GitBranch, GitCommitType, GitDiagram,
     GitEvent, PieSlice, RelKind, SankeyFlow, SankeyNode, SeriesKind, StructuralDiagram,
-    StructuralKind, StructuralNode, StructuralNodeKind, StructuralRelationship, TaskStart,
-    TaskStatus, TemporalBody, TemporalDiagram, TemporalKind,
+    StructuralGroup, StructuralKind, StructuralNode, StructuralNodeKind, StructuralRelationship,
+    TaskStart, TaskStatus, TemporalBody, TemporalDiagram, TemporalKind,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -771,6 +771,7 @@ pub fn parse_class_diagram(source: &str) -> Result<StructuralDiagram, ParseError
                     stereotype: None,
                     node_kind: StructuralNodeKind::Class,
                     compartments,
+                    parent_group: None,
                 });
             }
         } else if let Some(rel) = parse_class_relationship(t) {
@@ -783,6 +784,7 @@ pub fn parse_class_diagram(source: &str) -> Result<StructuralDiagram, ParseError
                         stereotype: None,
                         node_kind: StructuralNodeKind::Class,
                         compartments: vec![],
+                        parent_group: None,
                     });
                 }
             }
@@ -794,6 +796,7 @@ pub fn parse_class_diagram(source: &str) -> Result<StructuralDiagram, ParseError
         kind: StructuralKind::Class,
         title,
         nodes,
+        groups: vec![],
         relationships,
     })
 }
@@ -1523,6 +1526,7 @@ pub fn parse_er_diagram(source: &str) -> Result<StructuralDiagram, ParseError> {
         kind: StructuralKind::Er,
         title,
         nodes,
+        groups: vec![],
         relationships,
     })
 }
@@ -1598,6 +1602,7 @@ fn upsert_er_node(
         stereotype: Some("entity".to_string()),
         node_kind: StructuralNodeKind::Entity,
         compartments: Vec::new(),
+        parent_group: None,
     });
     index
 }
@@ -1618,6 +1623,8 @@ pub fn parse_c4_diagram(source: &str) -> Result<StructuralDiagram, ParseError> {
     let mut title = None;
     let mut nodes = Vec::new();
     let mut node_indices = HashMap::new();
+    let mut groups = Vec::new();
+    let mut group_stack: Vec<String> = Vec::new();
     let mut relationships = Vec::new();
 
     while !cursor.at_eof() {
@@ -1634,8 +1641,33 @@ pub fn parse_c4_diagram(source: &str) -> Result<StructuralDiagram, ParseError> {
             }
             "RBRACE" => {
                 cursor.advance();
+                group_stack.pop();
             }
-            "BOUNDARY_MACRO" | "ELEMENT_MACRO" => {
+            "BOUNDARY_MACRO" => {
+                let macro_token = cursor.advance().clone();
+                let args = parse_c4_arguments(&mut cursor)?;
+                let id = args.first().cloned().unwrap_or_default();
+                if id.is_empty() {
+                    return Err(token_error(&macro_token, "C4 boundary requires an alias"));
+                }
+                let label = args
+                    .get(1)
+                    .filter(|value| !value.is_empty())
+                    .cloned()
+                    .unwrap_or_else(|| id.clone());
+                groups.push(StructuralGroup {
+                    id: id.clone(),
+                    label,
+                    stereotype: Some(macro_token.value),
+                    parent_group: group_stack.last().cloned(),
+                });
+                cursor.skip_terminators();
+                cursor.consume_if("LBRACE").ok_or_else(|| {
+                    token_error(cursor.current(), "expected '{' after C4 boundary")
+                })?;
+                group_stack.push(id);
+            }
+            "ELEMENT_MACRO" => {
                 let macro_token = cursor.advance().clone();
                 let args = parse_c4_arguments(&mut cursor)?;
                 let id = args.first().cloned().unwrap_or_default();
@@ -1652,7 +1684,8 @@ pub fn parse_c4_diagram(source: &str) -> Result<StructuralDiagram, ParseError> {
                     &mut node_indices,
                     id,
                     label,
-                    macro_token.value.clone(),
+                    macro_token.value,
+                    group_stack.last().cloned(),
                 );
                 let details: Vec<String> = args
                     .iter()
@@ -1665,9 +1698,6 @@ pub fn parse_c4_diagram(source: &str) -> Result<StructuralDiagram, ParseError> {
                         kind: CompartmentKind::Fields,
                         entries: details,
                     });
-                }
-                if token_name(cursor.current()) == "LBRACE" {
-                    cursor.advance();
                 }
             }
             "RELATION_MACRO" => {
@@ -1697,6 +1727,7 @@ pub fn parse_c4_diagram(source: &str) -> Result<StructuralDiagram, ParseError> {
         kind: StructuralKind::C4,
         title,
         nodes,
+        groups,
         relationships,
     })
 }
@@ -1754,6 +1785,7 @@ fn upsert_c4_node(
     id: String,
     label: String,
     stereotype: String,
+    parent_group: Option<String>,
 ) -> usize {
     if let Some(index) = indices.get(&id).copied() {
         return index;
@@ -1766,6 +1798,7 @@ fn upsert_c4_node(
         stereotype: Some(stereotype),
         node_kind: StructuralNodeKind::Class,
         compartments: Vec::new(),
+        parent_group,
     });
     index
 }
@@ -2114,10 +2147,30 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
         let d = parse_c4_diagram(C4_SRC).unwrap();
         assert_eq!(d.kind, StructuralKind::C4);
         assert_eq!(d.title.as_deref(), Some("Banking System"));
-        assert_eq!(d.nodes.len(), 3);
+        assert_eq!(d.nodes.len(), 2);
+        assert_eq!(d.groups.len(), 1);
+        assert_eq!(d.groups[0].id, "bank");
+        assert_eq!(
+            d.nodes
+                .iter()
+                .find(|node| node.id == "web")
+                .and_then(|node| node.parent_group.as_deref()),
+            Some("bank")
+        );
         assert_eq!(d.relationships.len(), 1);
         assert_eq!(d.relationships[0].from, "customer");
         assert_eq!(d.relationships[0].to, "web");
+    }
+
+    #[test]
+    fn c4_preserves_nested_boundary_membership() {
+        let d = parse_c4_diagram(
+            "C4Deployment\nDeployment_Node(cloud, \"Cloud\") {\nContainer_Boundary(apps, \"Apps\") {\nContainer(api, \"API\", \"Rust\")\n}\n}",
+        )
+        .unwrap();
+        assert_eq!(d.groups.len(), 2);
+        assert_eq!(d.groups[1].parent_group.as_deref(), Some("cloud"));
+        assert_eq!(d.nodes[0].parent_group.as_deref(), Some("apps"));
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -103,6 +103,16 @@ Sharing a domain IR does not require sharing a source AST. For example,
 Sequence Diagram and ZenUML should have different parsers but may lower into
 the same participant/message/lifeline IR.
 
+### Structural Groups
+
+Nested containers such as C4 boundaries are semantic structural groups, not
+ordinary nodes and not backend-specific paint primitives. A structural group
+records its parent group, while member nodes record their immediate group.
+Layout computes nested group bounds from child nodes and groups, then lowers
+the result through existing rectangle, stroke, and glyph PaintInstructions.
+This model is reusable for package boundaries, deployment nodes, clusters, and
+future diagram families with nested visual containment.
+
 ## Grammar Source Of Truth
 
 Shared grammar files live under:


### PR DESCRIPTION
## Summary

- add backend-neutral nested structural groups and node membership to diagram IR
- compute recursive group bounds in structural layout, including nested boundary depth
- paint group containers with existing rectangle, dashed-stroke, and glyph instructions
- lower C4 boundary/deployment macros into groups instead of misleading ordinary nodes
- preserve parent membership for nested C4 boundaries and contained elements
- bump the affected pre-1.0 IR/layout/paint package versions

## Result

C4 boundaries now render as dashed containers behind their child systems while relationships continue to target the actual contained elements. No new PaintInstruction or backend-specific implementation is required.

## Validation

- `cargo test -p diagram-ir -p diagram-layout-structural -p mermaid-parser -p diagram-to-paint -- --nocapture`
- `cargo clippy -p diagram-ir -p diagram-layout-structural -p mermaid-parser --all-targets -- -D warnings`
- all 7 Apple Metal-to-PNG end-to-end tests
- visual inspection of the corrected C4 boundary render
