### PR TITLE
Verify Tamil ல handwriting ductus

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -69,9 +69,10 @@ from the same canonical lesson ASTs used by Language Ladder, narration, objectiv
 activities, and back matter. The twelve former handwritten entries are protected
 generated targets with checked hashes, titles, labels, order, and output. HL-C19
 is already complete; HL-C09A verified Tamil அ in #10222, HL-C09B verified
-Tamil ஆ in #10223, HL-C09C verified Tamil இ in #10226, and HL-C09D verified
-Tamil க in #10228. HL-C09E is the next bounded stroke-order tranche: verify
-Tamil வ from Frame 9 of the cited primer before widening DUCTUS across scripts.
+Tamil ஆ in #10223, HL-C09C verified Tamil இ in #10226, HL-C09D verified
+Tamil க in #10228, and HL-C09E verified Tamil வ in #10230. HL-C09F is the next
+bounded stroke-order tranche: verify Tamil ல from Frame 9 of the cited primer
+before widening DUCTUS across scripts.
 The index audit found **2,075** canonical candidates across the corpus: **1,426**
 word and phrase lessons for English-first lookup, **136** dedicated grammar,
 writing, etymology, culture, and pronunciation lessons, **427** chapter
@@ -231,12 +232,13 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C06 | Complete (#10219) | Add the figure pipeline: SVG generation, `graphicx`, SVG→PDF in CI, and a `--check` hash gate. | A generated figure round-trips from canonical data into a compiled PDF and fails CI on drift, reusing `paint-vm-svg`'s `renderToSvgString`. |
 | HL-C07 | Complete (#9963) | Add the log-scanning warning gate with recorded per-track baselines. | Overfull/underfull boxes, missing glyphs, hyperref warnings, duplicate destinations, and font substitutions are machine-checked by `scan_latex_log_warnings.py` after the `latexmk` loop, against `core/latex-warning-baseline.json`. Baselines ship unseeded — `null` means unmeasured, never zero — so the gate reports today and fails the moment a seeded track regresses. The first CI run on main emits the real counts into the job summary for a human to paste back. |
 | HL-C08 | Complete (#9974) | Render the ductus in Language Ladder. | `penPathD`/`penTip` drive the tested SVG stroke build-up in the app; the currently authored ductus is shared with validation and script practice. |
-| HL-C09 | Queued — 6 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 222 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
+| HL-C09 | Queued — 7 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 221 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
 | HL-C09A | Complete (#10222) | Verify Tamil அ as the first post-HL-C19 expansion tranche, using the primer already cited for Tamil handwriting. | அ carries a source-aligned two-stroke path with exactly one lift; its five movements, learner prose, source metadata, font-outline geometry, and rendered filmstrip agree. |
 | HL-C09B | Complete (#10223) | Verify Tamil ஆ as the next source-backed expansion tranche from Frame 4 of the same primer. | ஆ carries a font-checked path for the அ body plus its long-vowel right-hand loop; its learner prose states every verified lift, and source, geometry, and filmstrip tests agree. |
 | HL-C09C | Complete (#10226) | Verify Tamil இ as Frame 4's third source-backed vowel tranche. | இ carries a seven-movement, font-checked path whose learner prose states each evidenced lift; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C09D | Complete (#10228) | Verify Tamil க from Frame 3's final source-backed consonant row. | க carries a six-movement, font-checked three-stroke path whose learner prose states its two evidenced lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C09E | Complete (#10230) | Verify Tamil வ from Frame 9's first source-backed consonant row. | வ carries a five-movement, font-checked unbroken path whose learner prose states the evidenced zero lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
+| HL-C09F | Complete (#10234) | Verify Tamil ல from Frame 9's second source-backed consonant row. | ல carries a four-movement, font-checked unbroken path whose learner prose states the evidenced zero lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C10 | Complete (#10010, #10013, #10067) | Complete A1 and add the A2-through-C2 spine tranches with all registered realization ledgers. | All seven declared stages carry nodes; every one of the 22 registered tracks has a non-drifting ledger entry for every node. |
 | HL-C11 | Queued — capability and closure coverage complete | Finish representative chapter payoffs across all 22 tracks. | #10128 brought all 513 chapters to an authored `canDo`, spine mapping, known payoff lesson, and closed assessment. Remediate the remaining 27 payoffs below the 0.5 representativeness floor across ten tracks, then enforce the clean tracks instead of leaving their gates report-only. |
 | HL-C12 | Queued — licensing decided, pipeline outstanding | Add the Class C illustration pipeline with provenance sidecars and a size budget. Licensing is settled and recorded in [`_assets/LICENSE.md`](./_assets/LICENSE.md); the remaining work is the pipeline itself. | Every asset carries `license`, `rightsAsserted`, `generator`, `model`, `prompt`, `date`, and `sha256`; CI fails any asset without a provenance sidecar or a recorded licence, and enforces the per-track size budget. |
@@ -2639,7 +2641,7 @@ problem.
   **61 glyph violations plus five multi-system Japanese openings**. The current
   corpus is 91% core-drivable, not the historical 84% recorded before later work.
 - HL-C19 supersedes HL-C09's old estimate. There are **228** prose stroke-order
-  entries across ten scripts: six verified ductus paths and 222 entries still needing cited,
+  entries across ten scripts: seven verified ductus paths and 221 entries still needing cited,
   font-checked pen-lift evidence.
 
 ## Findings from HL-C05

--- a/code/learning/human-languages/data/scripts/README.md
+++ b/code/learning/human-languages/data/scripts/README.md
@@ -130,7 +130,7 @@ and given the same citation.
 4. Where no ductus exists, do not invent lifts — keep the steps as part order and
    leave `penLifts` out.
 
-Tamil **அ**, **ஆ**, **இ**, **க**, and **வ** now join **ம** with authored ductus paths. The primer's
+Tamil **அ**, **ஆ**, **இ**, **க**, **வ**, and **ல** now join **ம** with authored ductus paths. The primer's
 Frame 4 shows four connected movements for their shared curl-and-loop body,
 followed by one lift and the separate right upright; ஆ then continues without
 another lift into its long-vowel loop. Frame 4's next row gives இ five joined
@@ -138,11 +138,12 @@ inner-and-lower movements, one lift, then a joined outer-left climb and final
 arch. The font-backed paths and learner prose preserve those orders exactly. The
 Frame 3 row for க separates its upper frame and two lower bowls into three
 pen-down runs with two verified lifts. Frame 9 joins வ's spiral body, bottom
-bar, and right upright as five movements in one unbroken run. The remaining
-**222** prose part
+bar, and right upright as five movements in one unbroken run; its next row
+traces ல's outward spiral, middle descent, deep right-hand turn, and open tip
+as four movements without lifting. The remaining **221** prose part
 orders across ten scripts (`arabic` 21, `chinese` 24, `cyrillic` 33,
 `devanagari` 28, `gujarati` 33, `hebrew` 22, `japanese` 34,
-`perso-arabic` 9, `tamil` 5, `urdu-nastaliq` 13) are explicitly **unverified for
+`perso-arabic` 9, `tamil` 4, `urdu-nastaliq` 13) are explicitly **unverified for
 pen lifts**. The data validator rejects a lift count without a citation (or a
 citation without a count), and Language Ladder's ductus test proves every verified
 claim has the same cited, font-checked path. That closes `HL-C19`; future entries

--- a/code/learning/human-languages/data/scripts/tamil.json
+++ b/code/learning/human-languages/data/scripts/tamil.json
@@ -7,7 +7,7 @@
   "signature": "Curvy and loopy with flat top-bars on many letters, repeated arches, and no continuous head-line.",
   "complete": false,
   "combination": "A consonant carries an inherent 'a' (க = ka). A vowel sign replaces that vowel (க + ா → கா = kā). The puḷḷi ் — a DOT above the letter — removes the vowel entirely (க் = k). Unlike Devanagari, Tamil does NOT fuse the bare consonant into a conjunct: the dot stays visible and both letters keep their full shape. (A handful of Sanskrit-borrowed ligatures are the exception — க்ஷ kṣa and ஸ்ரீ śrī.)",
-  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, இ, க, ம, and வ have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ and ஆ each have two pen-down runs with one lift before the separate right upright; ஆ then continues into its long-vowel loop without another lift. இ keeps its first five movements joined, lifts once before the outer-left climb, and joins that climb to the final arch. க uses three pen-down runs: its upper frame, lower-left bowl, and lower-right bowl. ம and வ are each a single unbroken stroke even though their parts have separate names. The other five letters here have no verified pen path, so read their steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
+  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, இ, க, ம, வ, and ல have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ and ஆ each have two pen-down runs with one lift before the separate right upright; ஆ then continues into its long-vowel loop without another lift. இ keeps its first five movements joined, lifts once before the outer-left climb, and joins that climb to the final arch. க uses three pen-down runs: its upper frame, lower-left bowl, and lower-right bowl. ம, வ, and ல are each a single unbroken stroke even though their parts have separate names. The other four letters here have no verified pen path, so read their steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
   "letters": [
     {
       "glyph": "அ",
@@ -177,9 +177,21 @@
       "sound": "la",
       "role": "consonant",
       "inherentVowel": "a",
-      "components": ["a curl that turns back on itself", "a stroke rising to the right"],
-      "strokeOrder": ["curl", "rising stroke"],
-      "strokeOrderNote": "conventional"
+      "components": ["a spiral loop on the left", "a deep U-shaped turn", "an open rising tip on the right"],
+      "strokeOrder": [
+        "start at the inner curl and spiral outward, climbing the left side",
+        "without lifting, arch over the top and descend through the middle",
+        "without lifting, turn around the deep right-hand curve",
+        "without lifting, rise to the open right tip — and only now lift"
+      ],
+      "strokeOrderNote": "one unbroken stroke — four joined movements, no pen lift; cited to Radhakrishnan, Tamil Script Learners Manual, Frame 9, ல",
+      "penLifts": 0,
+      "strokeOrderSource": {
+        "citation": "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 9, ல (Univ. of Texas at Austin), p. 194",
+        "url": "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+        "variation": "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order."
+      },
+      "notes": "Frame 9's four numbered movements form one continuous spiral-to-rising-tip motion, not four strokes: the pen stays down through the deep right-hand turn and leaves the page only after the open tip."
     },
     {
       "glyph": "ற",

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -34,6 +34,13 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
   and right upright form one unbroken pen-down run with zero lifts, matching the
   Frame 9 source and Language Ladder's font-checked path.
 
+### Added - verified Tamil ல handwriting
+
+- Record the cited four-movement order for Tamil ல: its outward spiral, middle
+  descent, deep right-hand turn, and open tip form one unbroken pen-down run
+  with zero lifts, matching the next row of Frame 9 and Language Ladder's
+  font-checked path.
+
 ### Added - generated lesson figures
 
 - Generate deterministic etymology-route SVGs from the canonical lesson `roots`

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -43,6 +43,14 @@
 - Check the complete path against the Noto Sans Tamil outline and pin its zero
   lifts in the real five-frame filmstrip and learner prose.
 
+### Added — cited unbroken ductus for Tamil ல (HL-C09F)
+
+- Add Frame 9's second row, Tamil ல: four joined movements carry its outward
+  spiral through the middle descent and deep right-hand turn to the open tip
+  without a pen lift.
+- Check the complete path against the Noto Sans Tamil outline and pin its zero
+  lifts in the real four-frame filmstrip and learner prose.
+
 ### Added — canonical lesson figures
 
 - Preserve standalone Markdown images as typed lesson blocks instead of flattening

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -165,7 +165,7 @@ in font units, and `ductusview.ts` flips them together with exactly **one**
 `scale(1,-1)` group — so a mistake cannot leave a plausible-looking stroke
 sitting upside down on a correct letter.
 
-**Tamil அ, ஆ, இ, க, ம, and வ have authored pen paths today.** `DUCTUS` admits no letter
+**Tamil அ, ஆ, இ, க, ம, வ, and ல have authored pen paths today.** `DUCTUS` admits no letter
 without a citation for its stroke order, and hand-drawing a letter is forbidden
 outright (a subtly wrong Tamil ண looks perfect to exactly the audience that
 cannot yet read Tamil, so the error would ship *as the lesson*). அ and ஆ exercise
@@ -174,7 +174,9 @@ the same pen-down run. இ keeps five inner-and-lower movements together, lifts
 once, then joins its outer-left climb to the final arch; ம remains one unbroken
 stroke. க exercises a real three-stroke path: its upper frame and two lower bowls
 are separated by two verified lifts. வ joins its spiral body, bottom bar, and
-right upright in one five-movement run with no lift. Every other
+right upright in one five-movement run with no lift. ல carries its outward
+spiral through a middle descent and deep right-hand turn to the open tip in one
+four-movement run with no lift. Every other
 letter falls back to the numbered prose list, unchanged. Extending the coverage
 is HL-C09, and it needs a cited source per letter.
 

--- a/code/programs/typescript/language-ladder/src/strokes.ts
+++ b/code/programs/typescript/language-ladder/src/strokes.ts
@@ -202,6 +202,8 @@ const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n);
 // 4-5 make the lower-left bowl, and movement 6 makes the lower-right bowl.
 // வ is Frame 9's first row: all five movements join the spiral body to its
 // bottom bar and right upright without a pen lift.
+// ல is Frame 9's second row: all four movements join its spiral body to the
+// deep right-hand turn and rising finish without a pen lift.
 // ம is Frame 1's third row: all five movements join into one unbroken stroke.
 // ---------------------------------------------------------------------------
 
@@ -705,6 +707,85 @@ export const DUCTUS: Record<string, LetterDuctus> = {
     source: {
       citation:
         "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 9, வ (Univ. of Texas at Austin), p. 194",
+      url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+      variation:
+        "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",
+    },
+  },
+  ல: {
+    glyph: "ல",
+    strokes: [
+      {
+        segments: [
+          {
+            label: "curl outward and climb the left",
+            path: [
+              { x: 300, y: 35 },
+              { x: 310, y: 55 },
+              { x: 350, y: 90 },
+              { x: 380, y: 145 },
+              { x: 380, y: 205 },
+              { x: 340, y: 260 },
+              { x: 285, y: 292 },
+              { x: 225, y: 290 },
+              { x: 170, y: 275 },
+              { x: 120, y: 275 },
+              { x: 95, y: 270 },
+              { x: 95, y: 180 },
+              { x: 115, y: 105 },
+              { x: 175, y: 45 },
+              { x: 250, y: 25 },
+              { x: 175, y: 45 },
+              { x: 115, y: 105 },
+              { x: 95, y: 180 },
+              { x: 95, y: 270 },
+              { x: 120, y: 360 },
+              { x: 180, y: 450 },
+            ],
+          },
+          {
+            label: "arch over and descend through the middle",
+            path: [
+              { x: 180, y: 450 },
+              { x: 260, y: 520 },
+              { x: 370, y: 560 },
+              { x: 470, y: 530 },
+              { x: 530, y: 480 },
+              { x: 560, y: 430 },
+              { x: 570, y: 350 },
+              { x: 570, y: 250 },
+              { x: 580, y: 160 },
+              { x: 590, y: 100 },
+            ],
+          },
+          {
+            label: "turn around the deep right-hand curve",
+            path: [
+              { x: 590, y: 100 },
+              { x: 620, y: 60 },
+              { x: 690, y: 30 },
+              { x: 770, y: 25 },
+              { x: 840, y: 60 },
+              { x: 875, y: 110 },
+            ],
+          },
+          {
+            label: "rise to the open right tip",
+            path: [
+              { x: 875, y: 110 },
+              { x: 900, y: 200 },
+              { x: 900, y: 350 },
+              { x: 875, y: 450 },
+              { x: 825, y: 540 },
+              { x: 790, y: 580 },
+            ],
+          },
+        ],
+      },
+    ],
+    source: {
+      citation:
+        "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 9, ல (Univ. of Texas at Austin), p. 194",
       url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
       variation:
         "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",

--- a/code/programs/typescript/language-ladder/tests/ductusview.test.ts
+++ b/code/programs/typescript/language-ladder/tests/ductusview.test.ts
@@ -59,6 +59,8 @@ const KA = DUCTUS["க"];
 const kaOutline = tamilOutline("க");
 const VA = DUCTUS["வ"];
 const vaOutline = tamilOutline("வ");
+const LA = DUCTUS["ல"];
+const laOutline = tamilOutline("ல");
 
 /** Walk a node tree, collecting every node the predicate accepts. */
 function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = []): SvgNode[] {
@@ -70,13 +72,14 @@ function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = 
 const byTag = (node: SvgNode, tag: string) => collect(node, (n) => n.tag === tag);
 
 describe("ductusFor — only cited letters have a ductus", () => {
-  it("finds all six authored Tamil letters", () => {
+  it("finds all seven authored Tamil letters", () => {
     expect(ductusFor("ம")?.glyph).toBe("ம");
     expect(ductusFor("அ")?.glyph).toBe("அ");
     expect(ductusFor("ஆ")?.glyph).toBe("ஆ");
     expect(ductusFor("இ")?.glyph).toBe("இ");
     expect(ductusFor("க")?.glyph).toBe("க");
     expect(ductusFor("வ")?.glyph).toBe("வ");
+    expect(ductusFor("ல")?.glyph).toBe("ல");
   });
 
   it("returns undefined for a letter nobody has authored a stroke order for", () => {
@@ -404,6 +407,30 @@ describe("வ — a real cited unbroken five-movement filmstrip", () => {
     const pen = byTag(last, "path").find((path) => path.attrs.class === "ductus__pen")!;
     expect(done).toHaveLength(0);
     expect(pen.attrs.d).toBe(penPathD(VA.strokes[0], 1));
+  });
+});
+
+describe("ல — a real cited unbroken four-movement filmstrip", () => {
+  const steps = ductusSteps(LA);
+  const strip = ductusFilmstrip(LA, laOutline);
+
+  it("keeps every movement in the same pen-down run", () => {
+    expect(steps.map((step) => step.startsAfterLift)).toEqual([false, false, false, false]);
+    expect(steps.map((step) => step.strokeIndex)).toEqual([0, 0, 0, 0]);
+  });
+
+  it("reports four movements in one unbroken stroke", () => {
+    expect(strip.frames).toHaveLength(4);
+    expect(strip.penLifts).toBe(0);
+    expect(strip.summary).toBe("one unbroken stroke · 4 movements");
+  });
+
+  it("finishes the sole stroke without any completed-stroke overlay", () => {
+    const last = strip.frames[3];
+    const done = byTag(last, "path").filter((path) => path.attrs.class === "ductus__done");
+    const pen = byTag(last, "path").find((path) => path.attrs.class === "ductus__pen")!;
+    expect(done).toHaveLength(0);
+    expect(pen.attrs.d).toBe(penPathD(LA.strokes[0], 1));
   });
 });
 

--- a/code/programs/typescript/language-ladder/tests/strokes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/strokes.test.ts
@@ -204,6 +204,12 @@ describe("handwriting ductus", () => {
     expect(DUCTUS["வ"].strokes[0].segments).toHaveLength(5);
   });
 
+  it("ல joins all four movements without lifting the pen", () => {
+    expect(penLifts(DUCTUS["ல"])).toBe(0);
+    expect(DUCTUS["ல"].strokes).toHaveLength(1);
+    expect(DUCTUS["ல"].strokes[0].segments).toHaveLength(4);
+  });
+
   // The PROVENANCE GATE. A stroke's SHAPE is checked against the font above;
   // its ORDER cannot be — so it must trace to a cited source, or it does not
   // ship. This is the counterpart, for hand-authored order, of "facts enter
@@ -277,6 +283,13 @@ describe("handwriting ductus", () => {
     const src = DUCTUS["வ"].source;
     expect(src.url).toContain("tamilscript");
     expect(src.citation).toMatch(/Appendix I.*Frame 9.*வ/);
+    expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
+  });
+
+  it("ல's stroke order traces to Frame 9's second row", () => {
+    const src = DUCTUS["ல"].source;
+    expect(src.url).toContain("tamilscript");
+    expect(src.citation).toMatch(/Appendix I.*Frame 9.*ல/);
     expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
   });
 });


### PR DESCRIPTION
## What changed

- replace Tamil ல's prose-only placeholder with a cited, four-movement handwriting order from Frame 9 of the UT Austin primer
- add a font-checked, single-stroke `DUCTUS` path and real four-frame Language Ladder filmstrip coverage
- update the HL-C09 inventory to 7 of 228 verified entries, with 221 remaining

## Why

Frame 9 shows ல as one continuous path, but the curriculum previously had no verified pen-lift claim or renderable ductus. This tranche preserves the source's outward spiral, middle descent, deep right-hand turn, and open tip without inventing a lift between numbered movements.

## Learner impact

Language Ladder can now animate ல with the same cited path that backs its learner prose, while validators keep the source, lift count, font geometry, and filmstrip in agreement.

## Validation

- `npx vitest run tests/strokes.test.ts tests/ductusview.test.ts` (104 tests)
- `bash BUILD` in `code/packages/typescript/human-language-data` (460 tests)
- `bash BUILD` in `code/programs/typescript/language-ladder` (typecheck, production build, bundle check, 583 tests)
- `bash code/scripts/verify-human-languages.sh --fast`
- `git diff --check`