### PR TITLE
Add native Mermaid sequence diagram pipeline

### DIFF
--- a/code/grammars/mermaid/compatibility.json
+++ b/code/grammars/mermaid/compatibility.json
@@ -23,7 +23,7 @@
     {
       "id": "sequence",
       "headers": ["sequenceDiagram"],
-      "status": "detected",
+      "status": "partial",
       "ir": "sequence",
       "smoke_source": "sequenceDiagram\nAlice->>Bob: Hello"
     },

--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -1,0 +1,17 @@
+# @version 1
+# Mermaid 11.16.1 sequence diagram parser grammar: initial native subset.
+
+document = { NEWLINE } HEADER { NEWLINE | statement } EOF ;
+statement = participant_stmt | message_stmt | activation_stmt | note_stmt | title_stmt | autonumber_stmt ;
+
+participant_stmt = ( "participant" | "actor" ) identifier [ "as" text ] ;
+message_stmt = identifier message_arrow [ PLUS | MINUS ] identifier COLON [ text ] ;
+activation_stmt = ( "activate" | "deactivate" ) identifier ;
+note_stmt = "note" ( ( "left" | "right" ) "of" identifier | "over" actor_pair ) COLON text ;
+title_stmt = "title" text ;
+autonumber_stmt = "autonumber" [ "off" | identifier [ identifier ] ] ;
+
+actor_pair = identifier [ COMMA identifier ] ;
+message_arrow = SOLID_OPEN_ARROW | DOTTED_OPEN_ARROW | SOLID_FILLED_ARROW | DOTTED_FILLED_ARROW | BIDIRECTIONAL_SOLID | BIDIRECTIONAL_DOTTED | SOLID_CROSS_ARROW | DOTTED_CROSS_ARROW | SOLID_POINT_ARROW | DOTTED_POINT_ARROW ;
+identifier = IDENTIFIER | WORD ;
+text = identifier { identifier } ;

--- a/code/grammars/mermaid/sequence.tokens
+++ b/code/grammars/mermaid/sequence.tokens
@@ -1,0 +1,41 @@
+# @version 1
+# Mermaid 11.16.1 sequence diagram token grammar.
+# Derived from packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison.
+
+skip:
+  WHITESPACE            = /[ \t]+/
+  COMMENT               = /%%[^\r\n]*/
+
+NEWLINE                  = /\r?\n/
+HEADER                   = "sequenceDiagram"
+BIDIRECTIONAL_SOLID      = "<<->>"
+BIDIRECTIONAL_DOTTED     = "<<-->>"
+DOTTED_FILLED_ARROW      = "-->>"
+DOTTED_OPEN_ARROW        = "-->"
+DOTTED_CROSS_ARROW       = "--x"
+DOTTED_POINT_ARROW       = "--)"
+SOLID_FILLED_ARROW       = "->>"
+SOLID_OPEN_ARROW         = "->"
+SOLID_CROSS_ARROW        = "-x"
+SOLID_POINT_ARROW        = "-)"
+COLON                    = ":"
+COMMA                    = ","
+PLUS                     = "+"
+MINUS                    = "-"
+IDENTIFIER               = /[A-Za-z0-9_.$@]+/
+WORD                     = /[^ \t\r\n:,+-]+/
+
+keywords:
+  participant
+  actor
+  as
+  activate
+  deactivate
+  note
+  left
+  right
+  of
+  over
+  title
+  autonumber
+  off

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -117,6 +117,7 @@ members = [
     "diagram-layout-structural",
     "diagram-layout-temporal",
     "diagram-layout-graph",
+    "diagram-layout-sequence",
     "diagram-to-paint",
     "directed-graph",
     "dsp-complex",

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — diagram-ir
 
+## 0.4.0
+
+- Added semantic sequence participants, messages, notes, and activation events.
+- Added layouted participant boxes, lifelines, message routes, notes, and activation bars.
+
 ## 0.1.0
 
 Initial release.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,43 +1,73 @@
-//! diagram-ir v0.3.0 — DG00/DG04 semantic IR
+//! diagram-ir v0.4.0 — DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.3.0";
+pub const VERSION: &str = "0.4.0";
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub enum DiagramDirection {
+    #[default]
+    Tb,
+    Lr,
+    Rl,
+    Bt,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub enum DiagramShape {
+    Rect,
+    #[default]
+    RoundedRect,
+    Ellipse,
+    Diamond,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-#[derive(Default)]
-pub enum DiagramDirection { #[default]
-Tb, Lr, Rl, Bt }
-
-#[derive(Clone, Debug, PartialEq)]
-#[derive(Default)]
-pub enum DiagramShape { Rect, #[default]
-RoundedRect, Ellipse, Diamond }
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct DiagramLabel { pub text: String }
-impl DiagramLabel { pub fn new(text: impl Into<String>) -> Self { DiagramLabel { text: text.into() } } }
+pub struct DiagramLabel {
+    pub text: String,
+}
+impl DiagramLabel {
+    pub fn new(text: impl Into<String>) -> Self {
+        DiagramLabel { text: text.into() }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct DiagramStyle {
-    pub fill: Option<String>, pub stroke: Option<String>,
-    pub stroke_width: Option<f64>, pub text_color: Option<String>,
-    pub font_size: Option<f64>, pub corner_radius: Option<f64>,
+    pub fill: Option<String>,
+    pub stroke: Option<String>,
+    pub stroke_width: Option<f64>,
+    pub text_color: Option<String>,
+    pub font_size: Option<f64>,
+    pub corner_radius: Option<f64>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ResolvedDiagramStyle {
-    pub fill: String, pub stroke: String, pub stroke_width: f64,
-    pub text_color: String, pub font_size: f64, pub corner_radius: f64,
+    pub fill: String,
+    pub stroke: String,
+    pub stroke_width: f64,
+    pub text_color: String,
+    pub font_size: f64,
+    pub corner_radius: f64,
 }
 impl Default for ResolvedDiagramStyle {
     fn default() -> Self {
-        ResolvedDiagramStyle { fill:"#eff6ff".into(), stroke:"#2563eb".into(),
-            stroke_width:2.0, text_color:"#1e40af".into(), font_size:14.0, corner_radius:8.0 }
+        ResolvedDiagramStyle {
+            fill: "#eff6ff".into(),
+            stroke: "#2563eb".into(),
+            stroke_width: 2.0,
+            text_color: "#1e40af".into(),
+            font_size: 14.0,
+            corner_radius: 8.0,
+        }
     }
 }
 pub fn resolve_style(style: Option<&DiagramStyle>) -> ResolvedDiagramStyle {
     resolve_style_with_base(style, ResolvedDiagramStyle::default())
 }
-pub fn resolve_style_with_base(style: Option<&DiagramStyle>, base: ResolvedDiagramStyle) -> ResolvedDiagramStyle {
+pub fn resolve_style_with_base(
+    style: Option<&DiagramStyle>,
+    base: ResolvedDiagramStyle,
+) -> ResolvedDiagramStyle {
     match style {
         None => base,
         Some(s) => ResolvedDiagramStyle {
@@ -52,266 +82,887 @@ pub fn resolve_style_with_base(style: Option<&DiagramStyle>, base: ResolvedDiagr
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum EdgeKind { Directed, Undirected }
+pub enum EdgeKind {
+    Directed,
+    Undirected,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GraphNode { pub id: String, pub label: DiagramLabel, pub shape: Option<DiagramShape>, pub style: Option<DiagramStyle> }
+pub struct GraphNode {
+    pub id: String,
+    pub label: DiagramLabel,
+    pub shape: Option<DiagramShape>,
+    pub style: Option<DiagramStyle>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GraphEdge { pub id: Option<String>, pub from: String, pub to: String, pub label: Option<DiagramLabel>, pub kind: EdgeKind, pub style: Option<DiagramStyle> }
+pub struct GraphEdge {
+    pub id: Option<String>,
+    pub from: String,
+    pub to: String,
+    pub label: Option<DiagramLabel>,
+    pub kind: EdgeKind,
+    pub style: Option<DiagramStyle>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GraphDiagram { pub direction: DiagramDirection, pub title: Option<String>, pub nodes: Vec<GraphNode>, pub edges: Vec<GraphEdge> }
+pub struct GraphDiagram {
+    pub direction: DiagramDirection,
+    pub title: Option<String>,
+    pub nodes: Vec<GraphNode>,
+    pub edges: Vec<GraphEdge>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Point { pub x: f64, pub y: f64 }
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct LayoutedGraphNode { pub id: String, pub label: DiagramLabel, pub shape: DiagramShape, pub x: f64, pub y: f64, pub width: f64, pub height: f64, pub style: ResolvedDiagramStyle }
+pub struct LayoutedGraphNode {
+    pub id: String,
+    pub label: DiagramLabel,
+    pub shape: DiagramShape,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub style: ResolvedDiagramStyle,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct LayoutedGraphEdge { pub id: Option<String>, pub from_node_id: String, pub to_node_id: String, pub kind: EdgeKind, pub points: Vec<Point>, pub label: Option<DiagramLabel>, pub label_position: Option<Point>, pub style: ResolvedDiagramStyle }
+pub struct LayoutedGraphEdge {
+    pub id: Option<String>,
+    pub from_node_id: String,
+    pub to_node_id: String,
+    pub kind: EdgeKind,
+    pub points: Vec<Point>,
+    pub label: Option<DiagramLabel>,
+    pub label_position: Option<Point>,
+    pub style: ResolvedDiagramStyle,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct LayoutedGraphDiagram { pub direction: DiagramDirection, pub title: Option<String>, pub width: f64, pub height: f64, pub nodes: Vec<LayoutedGraphNode>, pub edges: Vec<LayoutedGraphEdge> }
+pub struct LayoutedGraphDiagram {
+    pub direction: DiagramDirection,
+    pub title: Option<String>,
+    pub width: f64,
+    pub height: f64,
+    pub nodes: Vec<LayoutedGraphNode>,
+    pub edges: Vec<LayoutedGraphEdge>,
+}
+
+// SEQUENCE FAMILY
+#[derive(Clone, Debug, PartialEq)]
+pub enum SequenceParticipantKind {
+    Participant,
+    Actor,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SequenceParticipant {
+    pub id: String,
+    pub label: DiagramLabel,
+    pub kind: SequenceParticipantKind,
+    pub style: Option<DiagramStyle>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum SequenceLineStyle {
+    Solid,
+    Dotted,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum SequenceArrowhead {
+    Open,
+    Filled,
+    Cross,
+    Point,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum SequenceNotePlacement {
+    LeftOf,
+    RightOf,
+    Over,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum SequenceEvent {
+    Message {
+        from: String,
+        to: String,
+        label: String,
+        line_style: SequenceLineStyle,
+        arrowhead: SequenceArrowhead,
+        bidirectional: bool,
+        activate: bool,
+        deactivate: bool,
+    },
+    Activation {
+        participant: String,
+        active: bool,
+    },
+    Note {
+        participants: Vec<String>,
+        placement: SequenceNotePlacement,
+        text: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SequenceDiagram {
+    pub title: Option<String>,
+    pub auto_number: bool,
+    pub participants: Vec<SequenceParticipant>,
+    pub events: Vec<SequenceEvent>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum LayoutedSequenceItem {
+    ParticipantBox {
+        id: String,
+        label: String,
+        kind: SequenceParticipantKind,
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+    },
+    Lifeline {
+        participant: String,
+        x: f64,
+        y1: f64,
+        y2: f64,
+    },
+    Message {
+        from_x: f64,
+        to_x: f64,
+        y: f64,
+        label: String,
+        line_style: SequenceLineStyle,
+        arrowhead: SequenceArrowhead,
+        bidirectional: bool,
+        number: Option<usize>,
+    },
+    Activation {
+        participant: String,
+        x: f64,
+        y1: f64,
+        y2: f64,
+    },
+    Note {
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        text: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct LayoutedSequenceDiagram {
+    pub width: f64,
+    pub height: f64,
+    pub title: Option<String>,
+    pub items: Vec<LayoutedSequenceItem>,
+}
 
 // CHART FAMILY
 #[derive(Clone, Debug, PartialEq)]
-pub enum ChartKind { Xy, Pie, Sankey }
+pub enum ChartKind {
+    Xy,
+    Pie,
+    Sankey,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub enum ChartOrientation {
+    #[default]
+    Vertical,
+    Horizontal,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-#[derive(Default)]
-pub enum ChartOrientation { #[default]
-Vertical, Horizontal }
+pub enum AxisKind {
+    Categorical,
+    Numeric,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum AxisKind { Categorical, Numeric }
+pub struct Axis {
+    pub kind: AxisKind,
+    pub title: Option<String>,
+    pub categories: Vec<String>,
+    pub min: f64,
+    pub max: f64,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Axis { pub kind: AxisKind, pub title: Option<String>, pub categories: Vec<String>, pub min: f64, pub max: f64 }
+pub enum SeriesKind {
+    Bar,
+    Line,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum SeriesKind { Bar, Line }
+pub struct ChartSeries {
+    pub kind: SeriesKind,
+    pub label: Option<String>,
+    pub data: Vec<f64>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct ChartSeries { pub kind: SeriesKind, pub label: Option<String>, pub data: Vec<f64> }
+pub struct PieSlice {
+    pub label: String,
+    pub value: f64,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct PieSlice { pub label: String, pub value: f64 }
+pub struct SankeyNode {
+    pub id: String,
+    pub label: Option<String>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct SankeyNode { pub id: String, pub label: Option<String> }
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct SankeyFlow { pub source: String, pub target: String, pub weight: f64 }
+pub struct SankeyFlow {
+    pub source: String,
+    pub target: String,
+    pub weight: f64,
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ChartDiagram {
-    pub title: Option<String>, pub kind: ChartKind,
-    pub x_axis: Option<Axis>, pub y_axis: Option<Axis>,
-    pub series: Vec<ChartSeries>, pub slices: Vec<PieSlice>,
-    pub sankey_nodes: Vec<SankeyNode>, pub flows: Vec<SankeyFlow>,
+    pub title: Option<String>,
+    pub kind: ChartKind,
+    pub x_axis: Option<Axis>,
+    pub y_axis: Option<Axis>,
+    pub series: Vec<ChartSeries>,
+    pub slices: Vec<PieSlice>,
+    pub sankey_nodes: Vec<SankeyNode>,
+    pub flows: Vec<SankeyFlow>,
     pub orientation: ChartOrientation,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum Orientation { Horizontal, Vertical }
+pub enum Orientation {
+    Horizontal,
+    Vertical,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct LegendEntry { pub color: String, pub label: String }
+pub struct LegendEntry {
+    pub color: String,
+    pub label: String,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct LayoutedLabel { pub x: f64, pub y: f64, pub text: String }
+pub struct LayoutedLabel {
+    pub x: f64,
+    pub y: f64,
+    pub text: String,
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum LayoutedChartItem {
-    AxisSpine { x1: f64, y1: f64, x2: f64, y2: f64, orientation: Orientation },
-    AxisTick { x: f64, y: f64, label: String, orientation: Orientation },
-    GridLine { x1: f64, y1: f64, x2: f64, y2: f64 },
-    Bar { x: f64, y: f64, width: f64, height: f64, color: String },
-    LinePath { points: Vec<Point>, color: String },
-    PieArc { cx: f64, cy: f64, r: f64, start_angle: f64, end_angle: f64, color: String, label: String },
-    SankeyBand { from_x: f64, from_y: f64, to_x: f64, to_y: f64, width: f64, color: String },
-    DataLabel { x: f64, y: f64, text: String },
-    Legend { x: f64, y: f64, entries: Vec<LegendEntry> },
+    AxisSpine {
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+        orientation: Orientation,
+    },
+    AxisTick {
+        x: f64,
+        y: f64,
+        label: String,
+        orientation: Orientation,
+    },
+    GridLine {
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+    },
+    Bar {
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        color: String,
+    },
+    LinePath {
+        points: Vec<Point>,
+        color: String,
+    },
+    PieArc {
+        cx: f64,
+        cy: f64,
+        r: f64,
+        start_angle: f64,
+        end_angle: f64,
+        color: String,
+        label: String,
+    },
+    SankeyBand {
+        from_x: f64,
+        from_y: f64,
+        to_x: f64,
+        to_y: f64,
+        width: f64,
+        color: String,
+    },
+    DataLabel {
+        x: f64,
+        y: f64,
+        text: String,
+    },
+    Legend {
+        x: f64,
+        y: f64,
+        entries: Vec<LegendEntry>,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct LayoutedChartDiagram { pub width: f64, pub height: f64, pub title_box: Option<LayoutedLabel>, pub items: Vec<LayoutedChartItem> }
+pub struct LayoutedChartDiagram {
+    pub width: f64,
+    pub height: f64,
+    pub title_box: Option<LayoutedLabel>,
+    pub items: Vec<LayoutedChartItem>,
+}
 
 // STRUCTURAL FAMILY
 #[derive(Clone, Debug, PartialEq)]
-pub enum StructuralKind { Class, Er, C4 }
+pub enum StructuralKind {
+    Class,
+    Er,
+    C4,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub enum StructuralNodeKind {
+    #[default]
+    Class,
+    Interface,
+    Abstract,
+    Enum,
+    Entity,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-#[derive(Default)]
-pub enum StructuralNodeKind { #[default]
-Class, Interface, Abstract, Enum, Entity }
+pub enum CompartmentKind {
+    Header,
+    Fields,
+    Methods,
+    Values,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum CompartmentKind { Header, Fields, Methods, Values }
+pub struct Compartment {
+    pub kind: CompartmentKind,
+    pub entries: Vec<String>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Compartment { pub kind: CompartmentKind, pub entries: Vec<String> }
+pub struct StructuralNode {
+    pub id: String,
+    pub label: String,
+    pub stereotype: Option<String>,
+    pub node_kind: StructuralNodeKind,
+    pub compartments: Vec<Compartment>,
+    pub parent_group: Option<String>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct StructuralNode { pub id: String, pub label: String, pub stereotype: Option<String>, pub node_kind: StructuralNodeKind, pub compartments: Vec<Compartment>, pub parent_group: Option<String> }
+pub struct StructuralGroup {
+    pub id: String,
+    pub label: String,
+    pub stereotype: Option<String>,
+    pub parent_group: Option<String>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct StructuralGroup { pub id: String, pub label: String, pub stereotype: Option<String>, pub parent_group: Option<String> }
+pub enum RelKind {
+    Inheritance,
+    Realization,
+    Composition,
+    Aggregation,
+    Association,
+    Dependency,
+    Link,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum RelKind { Inheritance, Realization, Composition, Aggregation, Association, Dependency, Link }
+pub struct StructuralRelationship {
+    pub from: String,
+    pub to: String,
+    pub kind: RelKind,
+    pub from_mult: Option<String>,
+    pub to_mult: Option<String>,
+    pub label: Option<String>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct StructuralRelationship { pub from: String, pub to: String, pub kind: RelKind, pub from_mult: Option<String>, pub to_mult: Option<String>, pub label: Option<String> }
+pub struct StructuralDiagram {
+    pub kind: StructuralKind,
+    pub title: Option<String>,
+    pub nodes: Vec<StructuralNode>,
+    pub groups: Vec<StructuralGroup>,
+    pub relationships: Vec<StructuralRelationship>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct StructuralDiagram { pub kind: StructuralKind, pub title: Option<String>, pub nodes: Vec<StructuralNode>, pub groups: Vec<StructuralGroup>, pub relationships: Vec<StructuralRelationship> }
+pub struct LayoutedCompartment {
+    pub y_offset: f64,
+    pub height: f64,
+    pub rows: Vec<String>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct LayoutedCompartment { pub y_offset: f64, pub height: f64, pub rows: Vec<String> }
+pub struct LayoutedStructuralNode {
+    pub id: String,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub header: String,
+    pub stereotype: Option<String>,
+    pub compartments: Vec<LayoutedCompartment>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct LayoutedStructuralNode { pub id: String, pub x: f64, pub y: f64, pub width: f64, pub height: f64, pub header: String, pub stereotype: Option<String>, pub compartments: Vec<LayoutedCompartment> }
+pub struct LayoutedStructuralGroup {
+    pub id: String,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub label: String,
+    pub stereotype: Option<String>,
+    pub parent_group: Option<String>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct LayoutedStructuralGroup { pub id: String, pub x: f64, pub y: f64, pub width: f64, pub height: f64, pub label: String, pub stereotype: Option<String>, pub parent_group: Option<String> }
+pub struct LayoutedStructuralRelationship {
+    pub from_id: String,
+    pub to_id: String,
+    pub kind: RelKind,
+    pub points: Vec<Point>,
+    pub from_mult: Option<String>,
+    pub to_mult: Option<String>,
+    pub label: Option<(Point, String)>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct LayoutedStructuralRelationship { pub from_id: String, pub to_id: String, pub kind: RelKind, pub points: Vec<Point>, pub from_mult: Option<String>, pub to_mult: Option<String>, pub label: Option<(Point, String)> }
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct LayoutedStructuralDiagram { pub width: f64, pub height: f64, pub groups: Vec<LayoutedStructuralGroup>, pub nodes: Vec<LayoutedStructuralNode>, pub relationships: Vec<LayoutedStructuralRelationship> }
+pub struct LayoutedStructuralDiagram {
+    pub width: f64,
+    pub height: f64,
+    pub groups: Vec<LayoutedStructuralGroup>,
+    pub nodes: Vec<LayoutedStructuralNode>,
+    pub relationships: Vec<LayoutedStructuralRelationship>,
+}
 
 // TEMPORAL FAMILY
 #[derive(Clone, Debug, PartialEq)]
-pub enum TemporalKind { Gantt, Git }
+pub enum TemporalKind {
+    Gantt,
+    Git,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum TaskStart { Date(String), After(String) }
-
-#[derive(Clone, Debug, PartialEq)]
-#[derive(Default)]
-pub enum TaskStatus { #[default]
-Normal, Done, Active, Crit, Milestone }
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct GanttTask { pub id: String, pub label: String, pub start: TaskStart, pub duration_days: f64, pub status: TaskStatus, pub dependencies: Vec<String> }
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct GanttSection { pub label: Option<String>, pub tasks: Vec<GanttTask> }
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct GanttDiagram { pub date_format: String, pub sections: Vec<GanttSection> }
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct GitBranch { pub name: String, pub order: Option<i64> }
+pub enum TaskStart {
+    Date(String),
+    After(String),
+}
 
 #[derive(Clone, Debug, PartialEq, Default)]
-pub enum GitCommitType { #[default]
-Normal, Reverse, Highlight }
+pub enum TaskStatus {
+    #[default]
+    Normal,
+    Done,
+    Active,
+    Crit,
+    Milestone,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct GanttTask {
+    pub id: String,
+    pub label: String,
+    pub start: TaskStart,
+    pub duration_days: f64,
+    pub status: TaskStatus,
+    pub dependencies: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct GanttSection {
+    pub label: Option<String>,
+    pub tasks: Vec<GanttTask>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct GanttDiagram {
+    pub date_format: String,
+    pub sections: Vec<GanttSection>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct GitBranch {
+    pub name: String,
+    pub order: Option<i64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub enum GitCommitType {
+    #[default]
+    Normal,
+    Reverse,
+    Highlight,
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum GitEvent {
-    Commit { id: Option<String>, message: Option<String>, tag: Option<String>, branch: String, type_: GitCommitType },
-    Checkout { branch: String },
-    Merge { from: String, id: Option<String>, tag: Option<String>, type_: GitCommitType },
-    CherryPick { id: String, tag: Option<String>, parent: Option<String>, branch: String },
+    Commit {
+        id: Option<String>,
+        message: Option<String>,
+        tag: Option<String>,
+        branch: String,
+        type_: GitCommitType,
+    },
+    Checkout {
+        branch: String,
+    },
+    Merge {
+        from: String,
+        id: Option<String>,
+        tag: Option<String>,
+        type_: GitCommitType,
+    },
+    CherryPick {
+        id: String,
+        tag: Option<String>,
+        parent: Option<String>,
+        branch: String,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GitDiagram { pub direction: DiagramDirection, pub branches: Vec<GitBranch>, pub events: Vec<GitEvent> }
+pub struct GitDiagram {
+    pub direction: DiagramDirection,
+    pub branches: Vec<GitBranch>,
+    pub events: Vec<GitEvent>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum TemporalBody { Gantt(GanttDiagram), Git(GitDiagram) }
+pub enum TemporalBody {
+    Gantt(GanttDiagram),
+    Git(GitDiagram),
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct TemporalDiagram { pub kind: TemporalKind, pub title: Option<String>, pub body: TemporalBody }
+pub struct TemporalDiagram {
+    pub kind: TemporalKind,
+    pub title: Option<String>,
+    pub body: TemporalBody,
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum LayoutedTemporalItem {
-    TimeAxisSpine { x1: f64, y1: f64, x2: f64, y2: f64 },
-    TimeAxisTick { x: f64, y: f64, label: String },
-    SectionHeader { x: f64, y: f64, width: f64, height: f64, label: String },
-    TaskBar { x: f64, y: f64, width: f64, height: f64, status: TaskStatus, label: String },
-    MilestoneMarker { x: f64, y: f64, label: String },
-    TodayMarker { x: f64, y1: f64, y2: f64 },
-    BranchLane { y: f64, color: String, label: String },
-    CommitNode { x: f64, y: f64, id: String, message: Option<String>, tag: Option<String> },
-    MergeArc { from_x: f64, from_y: f64, to_x: f64, to_y: f64 },
+    TimeAxisSpine {
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+    },
+    TimeAxisTick {
+        x: f64,
+        y: f64,
+        label: String,
+    },
+    SectionHeader {
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        label: String,
+    },
+    TaskBar {
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+        status: TaskStatus,
+        label: String,
+    },
+    MilestoneMarker {
+        x: f64,
+        y: f64,
+        label: String,
+    },
+    TodayMarker {
+        x: f64,
+        y1: f64,
+        y2: f64,
+    },
+    BranchLane {
+        y: f64,
+        color: String,
+        label: String,
+    },
+    CommitNode {
+        x: f64,
+        y: f64,
+        id: String,
+        message: Option<String>,
+        tag: Option<String>,
+    },
+    MergeArc {
+        from_x: f64,
+        from_y: f64,
+        to_x: f64,
+        to_y: f64,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct LayoutedTemporalDiagram { pub width: f64, pub height: f64, pub items: Vec<LayoutedTemporalItem> }
+pub struct LayoutedTemporalDiagram {
+    pub width: f64,
+    pub height: f64,
+    pub items: Vec<LayoutedTemporalItem>,
+}
 
 // GEOMETRIC FAMILY
-#[derive(Clone, Debug, PartialEq)]
-#[derive(Default)]
-pub enum TextAlign { Left, #[default]
-Center, Right }
+#[derive(Clone, Debug, PartialEq, Default)]
+pub enum TextAlign {
+    Left,
+    #[default]
+    Center,
+    Right,
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum GeoElement {
-    Box { id: String, x: f64, y: f64, w: f64, h: f64, corner_radius: f64, label: Option<String>, fill: Option<String>, stroke: Option<String> },
-    Circle { id: String, cx: f64, cy: f64, r: f64, label: Option<String>, fill: Option<String>, stroke: Option<String> },
-    Line { id: String, x1: f64, y1: f64, x2: f64, y2: f64, arrow_end: bool, arrow_start: bool, stroke: Option<String> },
-    Arc { id: String, cx: f64, cy: f64, r: f64, start_deg: f64, end_deg: f64, stroke: Option<String> },
-    Text { id: String, x: f64, y: f64, text: String, align: TextAlign },
+    Box {
+        id: String,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+        corner_radius: f64,
+        label: Option<String>,
+        fill: Option<String>,
+        stroke: Option<String>,
+    },
+    Circle {
+        id: String,
+        cx: f64,
+        cy: f64,
+        r: f64,
+        label: Option<String>,
+        fill: Option<String>,
+        stroke: Option<String>,
+    },
+    Line {
+        id: String,
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+        arrow_end: bool,
+        arrow_start: bool,
+        stroke: Option<String>,
+    },
+    Arc {
+        id: String,
+        cx: f64,
+        cy: f64,
+        r: f64,
+        start_deg: f64,
+        end_deg: f64,
+        stroke: Option<String>,
+    },
+    Text {
+        id: String,
+        x: f64,
+        y: f64,
+        text: String,
+        align: TextAlign,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GeometricDiagram { pub title: Option<String>, pub width: Option<f64>, pub height: Option<f64>, pub elements: Vec<GeoElement> }
+pub struct GeometricDiagram {
+    pub title: Option<String>,
+    pub width: Option<f64>,
+    pub height: Option<f64>,
+    pub elements: Vec<GeoElement>,
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct LayoutedGeometricDiagram { pub width: f64, pub height: f64, pub elements: Vec<GeoElement> }
+pub struct LayoutedGeometricDiagram {
+    pub width: f64,
+    pub height: f64,
+    pub elements: Vec<GeoElement>,
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test] fn version_is_0_3_0() { assert_eq!(VERSION, "0.3.0"); }
-    #[test] fn default_direction_is_tb() { assert_eq!(DiagramDirection::default(), DiagramDirection::Tb); }
-    #[test] fn default_shape_is_rounded_rect() { assert_eq!(DiagramShape::default(), DiagramShape::RoundedRect); }
-    #[test] fn resolve_style_none_gives_defaults() {
+    #[test]
+    fn version_is_0_4_0() {
+        assert_eq!(VERSION, "0.4.0");
+    }
+    #[test]
+    fn default_direction_is_tb() {
+        assert_eq!(DiagramDirection::default(), DiagramDirection::Tb);
+    }
+    #[test]
+    fn default_shape_is_rounded_rect() {
+        assert_eq!(DiagramShape::default(), DiagramShape::RoundedRect);
+    }
+    #[test]
+    fn resolve_style_none_gives_defaults() {
         let s = resolve_style(None);
-        assert_eq!(s.fill, "#eff6ff"); assert_eq!(s.stroke, "#2563eb");
+        assert_eq!(s.fill, "#eff6ff");
+        assert_eq!(s.stroke, "#2563eb");
     }
-    #[test] fn resolve_style_partial_override() {
-        let style = DiagramStyle { fill: Some("#ff0000".to_string()), ..Default::default() };
+    #[test]
+    fn resolve_style_partial_override() {
+        let style = DiagramStyle {
+            fill: Some("#ff0000".to_string()),
+            ..Default::default()
+        };
         let s = resolve_style(Some(&style));
-        assert_eq!(s.fill, "#ff0000"); assert_eq!(s.stroke, "#2563eb");
+        assert_eq!(s.fill, "#ff0000");
+        assert_eq!(s.stroke, "#2563eb");
     }
-    #[test] fn resolve_style_with_base_overrides_base() {
-        let base = ResolvedDiagramStyle { fill:"none".into(), stroke:"#4b5563".into(), stroke_width:2.0, text_color:"#374151".into(), font_size:12.0, corner_radius:0.0 };
-        let s = resolve_style_with_base(None, base); assert_eq!(s.fill, "none");
+    #[test]
+    fn resolve_style_with_base_overrides_base() {
+        let base = ResolvedDiagramStyle {
+            fill: "none".into(),
+            stroke: "#4b5563".into(),
+            stroke_width: 2.0,
+            text_color: "#374151".into(),
+            font_size: 12.0,
+            corner_radius: 0.0,
+        };
+        let s = resolve_style_with_base(None, base);
+        assert_eq!(s.fill, "none");
     }
-    #[test] fn graph_diagram_builds_correctly() {
-        let node = GraphNode { id:"A".into(), label:DiagramLabel::new("Node A"), shape:None, style:None };
-        let edge = GraphEdge { id:None, from:"A".into(), to:"B".into(), label:None, kind:EdgeKind::Directed, style:None };
-        let d = GraphDiagram { direction:DiagramDirection::Lr, title:Some("G".into()), nodes:vec![node], edges:vec![edge] };
-        assert_eq!(d.nodes.len(), 1); assert_eq!(d.edges.len(), 1);
+    #[test]
+    fn graph_diagram_builds_correctly() {
+        let node = GraphNode {
+            id: "A".into(),
+            label: DiagramLabel::new("Node A"),
+            shape: None,
+            style: None,
+        };
+        let edge = GraphEdge {
+            id: None,
+            from: "A".into(),
+            to: "B".into(),
+            label: None,
+            kind: EdgeKind::Directed,
+            style: None,
+        };
+        let d = GraphDiagram {
+            direction: DiagramDirection::Lr,
+            title: Some("G".into()),
+            nodes: vec![node],
+            edges: vec![edge],
+        };
+        assert_eq!(d.nodes.len(), 1);
+        assert_eq!(d.edges.len(), 1);
     }
-    #[test] fn diagram_label_new() { assert_eq!(DiagramLabel::new("hello").text, "hello"); }
-    #[test] fn chart_diagram_xy_builds() {
-        let d = ChartDiagram { title:None, kind:ChartKind::Xy, x_axis:None, y_axis:None,
-            series:vec![ChartSeries{kind:SeriesKind::Bar,label:None,data:vec![40.0,60.0]}],
-            slices:vec![], sankey_nodes:vec![], flows:vec![], orientation:ChartOrientation::Vertical };
+    #[test]
+    fn diagram_label_new() {
+        assert_eq!(DiagramLabel::new("hello").text, "hello");
+    }
+    #[test]
+    fn chart_diagram_xy_builds() {
+        let d = ChartDiagram {
+            title: None,
+            kind: ChartKind::Xy,
+            x_axis: None,
+            y_axis: None,
+            series: vec![ChartSeries {
+                kind: SeriesKind::Bar,
+                label: None,
+                data: vec![40.0, 60.0],
+            }],
+            slices: vec![],
+            sankey_nodes: vec![],
+            flows: vec![],
+            orientation: ChartOrientation::Vertical,
+        };
         assert_eq!(d.series[0].data.len(), 2);
     }
-    #[test] fn structural_diagram_builds() {
-        let node = StructuralNode { id:"A".into(), label:"A".into(), stereotype:None, node_kind:StructuralNodeKind::Class, compartments:vec![], parent_group:None };
-        let d = StructuralDiagram { kind:StructuralKind::Class, title:None, nodes:vec![node], groups:vec![], relationships:vec![] };
+    #[test]
+    fn structural_diagram_builds() {
+        let node = StructuralNode {
+            id: "A".into(),
+            label: "A".into(),
+            stereotype: None,
+            node_kind: StructuralNodeKind::Class,
+            compartments: vec![],
+            parent_group: None,
+        };
+        let d = StructuralDiagram {
+            kind: StructuralKind::Class,
+            title: None,
+            nodes: vec![node],
+            groups: vec![],
+            relationships: vec![],
+        };
         assert_eq!(d.nodes[0].id, "A");
     }
-    #[test] fn gantt_diagram_builds() {
-        let task = GanttTask { id:"t1".into(), label:"D".into(), start:TaskStart::Date("2026-01-01".into()), duration_days:5.0, status:TaskStatus::Done, dependencies:vec![] };
-        let d = TemporalDiagram { kind:TemporalKind::Gantt, title:None, body:TemporalBody::Gantt(GanttDiagram { date_format:"YYYY-MM-DD".into(), sections:vec![GanttSection{label:None,tasks:vec![task]}] }) };
-        if let TemporalBody::Gantt(ref g) = d.body { assert_eq!(g.sections[0].tasks[0].id, "t1"); }
+    #[test]
+    fn gantt_diagram_builds() {
+        let task = GanttTask {
+            id: "t1".into(),
+            label: "D".into(),
+            start: TaskStart::Date("2026-01-01".into()),
+            duration_days: 5.0,
+            status: TaskStatus::Done,
+            dependencies: vec![],
+        };
+        let d = TemporalDiagram {
+            kind: TemporalKind::Gantt,
+            title: None,
+            body: TemporalBody::Gantt(GanttDiagram {
+                date_format: "YYYY-MM-DD".into(),
+                sections: vec![GanttSection {
+                    label: None,
+                    tasks: vec![task],
+                }],
+            }),
+        };
+        if let TemporalBody::Gantt(ref g) = d.body {
+            assert_eq!(g.sections[0].tasks[0].id, "t1");
+        }
     }
-    #[test] fn geometric_diagram_builds() {
-        let d = GeometricDiagram { title:None, width:Some(400.0), height:Some(200.0),
-            elements:vec![GeoElement::Box{id:"a".into(),x:10.0,y:10.0,w:100.0,h:50.0,corner_radius:0.0,label:None,fill:None,stroke:None}] };
+    #[test]
+    fn geometric_diagram_builds() {
+        let d = GeometricDiagram {
+            title: None,
+            width: Some(400.0),
+            height: Some(200.0),
+            elements: vec![GeoElement::Box {
+                id: "a".into(),
+                x: 10.0,
+                y: 10.0,
+                w: 100.0,
+                h: 50.0,
+                corner_radius: 0.0,
+                label: None,
+                fill: None,
+                stroke: None,
+            }],
+        };
         assert_eq!(d.width, Some(400.0));
     }
 }

--- a/code/packages/rust/diagram-layout-sequence/BUILD
+++ b/code/packages/rust/diagram-layout-sequence/BUILD
@@ -1,0 +1,1 @@
+cargo test -p diagram-layout-sequence -- --nocapture

--- a/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0 - 2026-08-09
+
+- Add the initial sequence layout pipeline for participants, messages, notes,
+  activation spans, and automatic message numbering.

--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "diagram-layout-sequence"
+version = "0.1.0"
+edition = "2021"
+description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
+
+[dependencies]
+diagram-ir = { path = "../diagram-ir" }

--- a/code/packages/rust/diagram-layout-sequence/README.md
+++ b/code/packages/rust/diagram-layout-sequence/README.md
@@ -1,0 +1,5 @@
+# diagram-layout-sequence
+
+Backend-neutral layout for sequence diagrams. It converts participants and
+ordered events into participant boxes, lifelines, message routes, notes, and
+activation bars for `diagram-to-paint`.

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -1,0 +1,286 @@
+//! Backend-neutral sequence diagram layout.
+
+use std::collections::HashMap;
+
+use diagram_ir::{
+    LayoutedSequenceDiagram, LayoutedSequenceItem, SequenceDiagram, SequenceEvent,
+    SequenceNotePlacement,
+};
+
+pub const VERSION: &str = "0.1.0";
+
+const MARGIN: f64 = 28.0;
+const HEADER_Y: f64 = 42.0;
+const HEADER_H: f64 = 44.0;
+const MIN_LANE_W: f64 = 150.0;
+const EVENT_H: f64 = 58.0;
+const NOTE_H: f64 = 38.0;
+const ACTIVATION_W: f64 = 12.0;
+
+/// Lay out an ordered sequence diagram. Participant order is semantic and is
+/// therefore retained exactly rather than optimized by the layout engine.
+pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDiagram {
+    let lane_widths: Vec<f64> = diagram
+        .participants
+        .iter()
+        .map(|participant| {
+            ((participant.label.text.chars().count() as f64 * 8.0) + 36.0).max(MIN_LANE_W)
+        })
+        .collect();
+    let width = lane_widths.iter().sum::<f64>() + MARGIN * 2.0;
+    let mut centers = HashMap::new();
+    let mut items = Vec::new();
+    let mut x = MARGIN;
+
+    for (participant, lane_width) in diagram.participants.iter().zip(&lane_widths) {
+        let box_width = (*lane_width - 24.0).max(100.0);
+        let center = x + *lane_width / 2.0;
+        centers.insert(participant.id.clone(), center);
+        items.push(LayoutedSequenceItem::ParticipantBox {
+            id: participant.id.clone(),
+            label: participant.label.text.clone(),
+            kind: participant.kind.clone(),
+            x: center - box_width / 2.0,
+            y: HEADER_Y,
+            width: box_width,
+            height: HEADER_H,
+        });
+        x += *lane_width;
+    }
+
+    let event_start = HEADER_Y + HEADER_H + 36.0;
+    let mut y = event_start;
+    let mut activation_starts: HashMap<String, Vec<f64>> = HashMap::new();
+    let mut message_number = 0usize;
+
+    for event in &diagram.events {
+        match event {
+            SequenceEvent::Message {
+                from,
+                to,
+                label,
+                line_style,
+                arrowhead,
+                bidirectional,
+                activate,
+                deactivate,
+            } => {
+                let Some(&from_x) = centers.get(from) else {
+                    continue;
+                };
+                let Some(&to_x) = centers.get(to) else {
+                    continue;
+                };
+                message_number += 1;
+                items.push(LayoutedSequenceItem::Message {
+                    from_x,
+                    to_x,
+                    y,
+                    label: label.clone(),
+                    line_style: line_style.clone(),
+                    arrowhead: arrowhead.clone(),
+                    bidirectional: *bidirectional,
+                    number: diagram.auto_number.then_some(message_number),
+                });
+                if *activate {
+                    activation_starts.entry(to.clone()).or_default().push(y);
+                }
+                if *deactivate {
+                    close_activation(&mut items, &mut activation_starts, from, from_x, y);
+                }
+                y += EVENT_H;
+            }
+            SequenceEvent::Activation {
+                participant,
+                active,
+            } => {
+                let Some(&participant_x) = centers.get(participant) else {
+                    continue;
+                };
+                if *active {
+                    activation_starts
+                        .entry(participant.clone())
+                        .or_default()
+                        .push(y);
+                } else {
+                    close_activation(
+                        &mut items,
+                        &mut activation_starts,
+                        participant,
+                        participant_x,
+                        y,
+                    );
+                }
+                y += EVENT_H / 2.0;
+            }
+            SequenceEvent::Note {
+                participants,
+                placement,
+                text,
+            } => {
+                let participant_centers: Vec<f64> = participants
+                    .iter()
+                    .filter_map(|id| centers.get(id).copied())
+                    .collect();
+                if participant_centers.is_empty() {
+                    continue;
+                }
+                let min_x = participant_centers
+                    .iter()
+                    .copied()
+                    .fold(f64::INFINITY, f64::min);
+                let max_x = participant_centers
+                    .iter()
+                    .copied()
+                    .fold(f64::NEG_INFINITY, f64::max);
+                let note_width = ((text.chars().count() as f64 * 7.5) + 28.0)
+                    .max(100.0)
+                    .min((width - MARGIN * 2.0).max(100.0));
+                let note_x = match placement {
+                    SequenceNotePlacement::LeftOf => min_x - note_width - 14.0,
+                    SequenceNotePlacement::RightOf => max_x + 14.0,
+                    SequenceNotePlacement::Over => (min_x + max_x - note_width) / 2.0,
+                }
+                .clamp(MARGIN, (width - MARGIN - note_width).max(MARGIN));
+                items.push(LayoutedSequenceItem::Note {
+                    x: note_x,
+                    y: y - 10.0,
+                    width: note_width,
+                    height: NOTE_H,
+                    text: text.clone(),
+                });
+                y += NOTE_H + 20.0;
+            }
+        }
+    }
+
+    let height = (y + 36.0).max(180.0);
+    for participant in &diagram.participants {
+        if let Some(&center) = centers.get(&participant.id) {
+            items.push(LayoutedSequenceItem::Lifeline {
+                participant: participant.id.clone(),
+                x: center,
+                y1: HEADER_Y + HEADER_H,
+                y2: height - 20.0,
+            });
+            if let Some(starts) = activation_starts.remove(&participant.id) {
+                for start in starts {
+                    items.push(LayoutedSequenceItem::Activation {
+                        participant: participant.id.clone(),
+                        x: center - ACTIVATION_W / 2.0,
+                        y1: start,
+                        y2: height - 20.0,
+                    });
+                }
+            }
+        }
+    }
+
+    LayoutedSequenceDiagram {
+        width,
+        height,
+        title: diagram.title.clone(),
+        items,
+    }
+}
+
+fn close_activation(
+    items: &mut Vec<LayoutedSequenceItem>,
+    starts: &mut HashMap<String, Vec<f64>>,
+    participant: &str,
+    center: f64,
+    y: f64,
+) {
+    if let Some(start) = starts.get_mut(participant).and_then(Vec::pop) {
+        items.push(LayoutedSequenceItem::Activation {
+            participant: participant.to_string(),
+            x: center - ACTIVATION_W / 2.0,
+            y1: start,
+            y2: y,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diagram_ir::{
+        DiagramLabel, SequenceArrowhead, SequenceLineStyle, SequenceParticipant,
+        SequenceParticipantKind,
+    };
+
+    fn participant(id: &str) -> SequenceParticipant {
+        SequenceParticipant {
+            id: id.into(),
+            label: DiagramLabel::new(id),
+            kind: SequenceParticipantKind::Participant,
+            style: None,
+        }
+    }
+
+    #[test]
+    fn lays_out_messages_and_lifelines() {
+        let diagram = SequenceDiagram {
+            title: None,
+            auto_number: true,
+            participants: vec![participant("Alice"), participant("Bob")],
+            events: vec![SequenceEvent::Message {
+                from: "Alice".into(),
+                to: "Bob".into(),
+                label: "Hello".into(),
+                line_style: SequenceLineStyle::Solid,
+                arrowhead: SequenceArrowhead::Filled,
+                bidirectional: false,
+                activate: false,
+                deactivate: false,
+            }],
+        };
+        let layout = layout_sequence_diagram(&diagram);
+        assert_eq!(
+            layout
+                .items
+                .iter()
+                .filter(|item| matches!(item, LayoutedSequenceItem::ParticipantBox { .. }))
+                .count(),
+            2
+        );
+        assert_eq!(
+            layout
+                .items
+                .iter()
+                .filter(|item| matches!(item, LayoutedSequenceItem::Lifeline { .. }))
+                .count(),
+            2
+        );
+        assert!(layout.items.iter().any(|item| matches!(
+            item,
+            LayoutedSequenceItem::Message {
+                number: Some(1),
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn closes_activation_on_deactivation_event() {
+        let diagram = SequenceDiagram {
+            title: None,
+            auto_number: false,
+            participants: vec![participant("Bob")],
+            events: vec![
+                SequenceEvent::Activation {
+                    participant: "Bob".into(),
+                    active: true,
+                },
+                SequenceEvent::Activation {
+                    participant: "Bob".into(),
+                    active: false,
+                },
+            ],
+        };
+        let layout = layout_sequence_diagram(&diagram);
+        assert!(layout.items.iter().any(
+            |item| matches!(item, LayoutedSequenceItem::Activation { y1, y2, .. } if y2 > y1)
+        ));
+    }
+}

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added a Mermaid Pie -> chart layout -> PaintScene -> Metal PNG example and
   Apple end-to-end test.
+- Added sequence lowering for participant headers, lifelines, messages,
+  arrowheads, notes, activation bars, and shaped labels, plus a Metal PNG test.
 
 ## 0.1.2 — Fix text coordinate-space mismatch (text now inside nodes)
 

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 
@@ -21,5 +21,6 @@ text-native-coretext = { path = "../text-native-coretext" }
 layout-ir = { path = "../layout-ir" }
 diagram-layout-chart = { path = "../diagram-layout-chart" }
 diagram-layout-structural = { path = "../diagram-layout-structural" }
+diagram-layout-sequence = { path = "../diagram-layout-sequence" }
 diagram-layout-temporal = { path = "../diagram-layout-temporal" }
 diagram-layout-geometric = { path = "../diagram-layout-geometric" }

--- a/code/packages/rust/diagram-to-paint/README.md
+++ b/code/packages/rust/diagram-to-paint/README.md
@@ -1,7 +1,8 @@
 # diagram-to-paint
 
-DG03 — Converts a `LayoutedGraphDiagram` into a `PaintScene` for rendering by
-`paint-metal` and other backends. Text rendering is **delegated to `layout-to-paint`**
+DG03 — Converts layouted graph, chart, structural, temporal, sequence, and
+geometric diagrams into a `PaintScene` for rendering by `paint-metal` and other
+backends. Text rendering is **delegated to `layout-to-paint`**
 so every paint backend receives real glyph IDs from the TXT00 shaping pipeline.
 
 ## Usage
@@ -49,6 +50,8 @@ println!("Scene: {}×{} with {} instructions",
 | Arrowhead        | `PaintPath` (filled triangle)                    |
 | Edge label       | `PaintGlyphRun` (real glyph IDs via TXT00)       |
 | Diagram title    | `PaintGlyphRun` (real glyph IDs via TXT00)       |
+| Sequence lifeline/message | `PaintPath` (solid or dashed)             |
+| Sequence note/activation  | `PaintRect`                               |
 
 ## Painter's algorithm order
 

--- a/code/packages/rust/diagram-to-paint/examples/class_diagram.rs
+++ b/code/packages/rust/diagram-to-paint/examples/class_diagram.rs
@@ -22,19 +22,28 @@ fn main() {
   Shape <|-- Circle
   Shape <|-- Rectangle";
 
-    let diagram  = parse_class_diagram(src).expect("class parse failed");
-    let layout   = layout_structural_diagram(&diagram);
-    let shaper   = CoreTextShaper;
-    let metrics  = CoreTextMetrics;
+    let diagram = parse_class_diagram(src).expect("class parse failed");
+    let layout = layout_structural_diagram(&diagram);
+    let shaper = CoreTextShaper;
+    let metrics = CoreTextMetrics;
     let resolver = CoreTextResolver::new();
 
     let scene = diagram_to_paint_structural(
         &layout,
         &DiagramToPaintOptions {
-            background: layout_ir::Color { r: 255, g: 255, b: 255, a: 255 },
+            background: layout_ir::Color {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 255,
+            },
             device_pixel_ratio: 2.0,
             label_font: font_spec("Helvetica", 12.0),
-            title_font: { let mut f = font_spec("Helvetica", 14.0); f.weight = 700; f },
+            title_font: {
+                let mut f = font_spec("Helvetica", 14.0);
+                f.weight = 700;
+                f
+            },
             shaper: &shaper,
             metrics: &metrics,
             resolver: &resolver,
@@ -44,9 +53,16 @@ fn main() {
     let path = "/tmp/class_diagram.png";
     write_png(&render(&scene), path).expect("PNG write failed");
     println!("Rendered class diagram to {path}");
-    println!("Scene: {}×{} px, {} nodes, {} relationships",
-        scene.width, scene.height, layout.nodes.len(), layout.relationships.len());
+    println!(
+        "Scene: {}×{} px, {} nodes, {} relationships",
+        scene.width,
+        scene.height,
+        layout.nodes.len(),
+        layout.relationships.len()
+    );
 }
 
 #[cfg(not(target_vendor = "apple"))]
-fn main() { panic!("class_diagram example requires an Apple target (paint-metal)"); }
+fn main() {
+    panic!("class_diagram example requires an Apple target (paint-metal)");
+}

--- a/code/packages/rust/diagram-to-paint/examples/gantt.rs
+++ b/code/packages/rust/diagram-to-paint/examples/gantt.rs
@@ -27,24 +27,33 @@ fn main() {
     layout-chart  :i2, after i1, 5d
     diagram-paint :i3, after i2, 3d";
 
-    let gantt    = parse_gantt(src).expect("gantt parse failed");
+    let gantt = parse_gantt(src).expect("gantt parse failed");
     let temporal = TemporalDiagram {
         kind: TemporalKind::Gantt,
         title: Some("Diagram Pipeline".into()),
         body: TemporalBody::Gantt(gantt),
     };
-    let layout   = layout_temporal_diagram(&temporal, 900.0);
-    let shaper   = CoreTextShaper;
-    let metrics  = CoreTextMetrics;
+    let layout = layout_temporal_diagram(&temporal, 900.0);
+    let shaper = CoreTextShaper;
+    let metrics = CoreTextMetrics;
     let resolver = CoreTextResolver::new();
 
     let scene = diagram_to_paint_temporal(
         &layout,
         &DiagramToPaintOptions {
-            background: layout_ir::Color { r: 255, g: 255, b: 255, a: 255 },
+            background: layout_ir::Color {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 255,
+            },
             device_pixel_ratio: 2.0,
             label_font: font_spec("Helvetica", 11.0),
-            title_font: { let mut f = font_spec("Helvetica", 13.0); f.weight = 700; f },
+            title_font: {
+                let mut f = font_spec("Helvetica", 13.0);
+                f.weight = 700;
+                f
+            },
             shaper: &shaper,
             metrics: &metrics,
             resolver: &resolver,
@@ -54,8 +63,15 @@ fn main() {
     let path = "/tmp/gantt.png";
     write_png(&render(&scene), path).expect("PNG write failed");
     println!("Rendered Gantt chart to {path}");
-    println!("Scene: {}×{} px, {} items", scene.width, scene.height, layout.items.len());
+    println!(
+        "Scene: {}×{} px, {} items",
+        scene.width,
+        scene.height,
+        layout.items.len()
+    );
 }
 
 #[cfg(not(target_vendor = "apple"))]
-fn main() { panic!("gantt example requires an Apple target (paint-metal)"); }
+fn main() {
+    panic!("gantt example requires an Apple target (paint-metal)");
+}

--- a/code/packages/rust/diagram-to-paint/examples/geometric.rs
+++ b/code/packages/rust/diagram-to-paint/examples/geometric.rs
@@ -23,48 +23,87 @@ fn main() {
         height: None,
         elements: vec![
             GeoElement::Box {
-                id: "input".into(), x: 50.0, y: 100.0, w: 120.0, h: 60.0,
-                corner_radius: 6.0, label: Some("Input".into()),
-                fill: Some("#dbeafe".into()), stroke: Some("#2563eb".into()),
+                id: "input".into(),
+                x: 50.0,
+                y: 100.0,
+                w: 120.0,
+                h: 60.0,
+                corner_radius: 6.0,
+                label: Some("Input".into()),
+                fill: Some("#dbeafe".into()),
+                stroke: Some("#2563eb".into()),
             },
             GeoElement::Line {
-                id: "l1".into(), x1: 170.0, y1: 130.0, x2: 260.0, y2: 130.0,
-                arrow_end: true, arrow_start: false, stroke: None,
+                id: "l1".into(),
+                x1: 170.0,
+                y1: 130.0,
+                x2: 260.0,
+                y2: 130.0,
+                arrow_end: true,
+                arrow_start: false,
+                stroke: None,
             },
             GeoElement::Circle {
-                id: "proc".into(), cx: 300.0, cy: 130.0, r: 40.0,
+                id: "proc".into(),
+                cx: 300.0,
+                cy: 130.0,
+                r: 40.0,
                 label: Some("Process".into()),
-                fill: Some("#dcfce7".into()), stroke: Some("#16a34a".into()),
+                fill: Some("#dcfce7".into()),
+                stroke: Some("#16a34a".into()),
             },
             GeoElement::Line {
-                id: "l2".into(), x1: 340.0, y1: 130.0, x2: 420.0, y2: 130.0,
-                arrow_end: true, arrow_start: false, stroke: None,
+                id: "l2".into(),
+                x1: 340.0,
+                y1: 130.0,
+                x2: 420.0,
+                y2: 130.0,
+                arrow_end: true,
+                arrow_start: false,
+                stroke: None,
             },
             GeoElement::Box {
-                id: "output".into(), x: 420.0, y: 100.0, w: 120.0, h: 60.0,
-                corner_radius: 6.0, label: Some("Output".into()),
-                fill: Some("#fef9c3".into()), stroke: Some("#ca8a04".into()),
+                id: "output".into(),
+                x: 420.0,
+                y: 100.0,
+                w: 120.0,
+                h: 60.0,
+                corner_radius: 6.0,
+                label: Some("Output".into()),
+                fill: Some("#fef9c3".into()),
+                stroke: Some("#ca8a04".into()),
             },
             GeoElement::Text {
-                id: "t1".into(), x: 270.0, y: 60.0,
+                id: "t1".into(),
+                x: 270.0,
+                y: 60.0,
                 text: "Data Flow Pipeline".into(),
                 align: TextAlign::Center,
             },
         ],
     };
 
-    let layout   = layout_geometric_diagram(&diagram);
-    let shaper   = CoreTextShaper;
-    let metrics  = CoreTextMetrics;
+    let layout = layout_geometric_diagram(&diagram);
+    let shaper = CoreTextShaper;
+    let metrics = CoreTextMetrics;
     let resolver = CoreTextResolver::new();
 
     let scene = diagram_to_paint_geometric(
         &layout,
         &DiagramToPaintOptions {
-            background: layout_ir::Color { r: 255, g: 255, b: 255, a: 255 },
+            background: layout_ir::Color {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 255,
+            },
             device_pixel_ratio: 2.0,
             label_font: font_spec("Helvetica", 13.0),
-            title_font: { let mut f = font_spec("Helvetica", 16.0); f.weight = 700; f },
+            title_font: {
+                let mut f = font_spec("Helvetica", 16.0);
+                f.weight = 700;
+                f
+            },
             shaper: &shaper,
             metrics: &metrics,
             resolver: &resolver,
@@ -74,8 +113,15 @@ fn main() {
     let path = "/tmp/geometric.png";
     write_png(&render(&scene), path).expect("PNG write failed");
     println!("Rendered geometric diagram to {path}");
-    println!("Scene: {}×{} px, {} elements", scene.width, scene.height, layout.elements.len());
+    println!(
+        "Scene: {}×{} px, {} elements",
+        scene.width,
+        scene.height,
+        layout.elements.len()
+    );
 }
 
 #[cfg(not(target_vendor = "apple"))]
-fn main() { panic!("geometric example requires an Apple target (paint-metal)"); }
+fn main() {
+    panic!("geometric example requires an Apple target (paint-metal)");
+}

--- a/code/packages/rust/diagram-to-paint/examples/xychart.rs
+++ b/code/packages/rust/diagram-to-paint/examples/xychart.rs
@@ -22,19 +22,28 @@ fn main() {
   bar [45, 62, 38, 71, 85, 94]
   line [40, 58, 42, 68, 79, 90]"#;
 
-    let diagram  = parse_xychart(src).expect("xychart parse failed");
-    let layout   = layout_chart_diagram(&diagram, 700.0, 420.0);
-    let shaper   = CoreTextShaper;
-    let metrics  = CoreTextMetrics;
+    let diagram = parse_xychart(src).expect("xychart parse failed");
+    let layout = layout_chart_diagram(&diagram, 700.0, 420.0);
+    let shaper = CoreTextShaper;
+    let metrics = CoreTextMetrics;
     let resolver = CoreTextResolver::new();
 
     let scene = diagram_to_paint_chart(
         &layout,
         &DiagramToPaintOptions {
-            background: layout_ir::Color { r: 255, g: 255, b: 255, a: 255 },
+            background: layout_ir::Color {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 255,
+            },
             device_pixel_ratio: 2.0,
             label_font: font_spec("Helvetica", 11.0),
-            title_font: { let mut f = font_spec("Helvetica", 16.0); f.weight = 700; f },
+            title_font: {
+                let mut f = font_spec("Helvetica", 16.0);
+                f.weight = 700;
+                f
+            },
             shaper: &shaper,
             metrics: &metrics,
             resolver: &resolver,
@@ -44,9 +53,15 @@ fn main() {
     let path = "/tmp/xychart.png";
     write_png(&render(&scene), path).expect("PNG write failed");
     println!("Rendered XY chart to {path}");
-    println!("Scene: {}×{} px, {} chart items",
-        scene.width, scene.height, layout.items.len());
+    println!(
+        "Scene: {}×{} px, {} chart items",
+        scene.width,
+        scene.height,
+        layout.items.len()
+    );
 }
 
 #[cfg(not(target_vendor = "apple"))]
-fn main() { panic!("xychart example requires an Apple target (paint-metal)"); }
+fn main() {
+    panic!("xychart example requires an Apple target (paint-metal)");
+}

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,18 +26,19 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.3.0";
+pub const VERSION: &str = "0.4.0";
 
 use std::collections::HashMap;
 
 use diagram_ir::{
     DiagramShape, EdgeKind, GeoElement, LayoutedChartDiagram, LayoutedChartItem,
     LayoutedGeometricDiagram, LayoutedGraphDiagram, LayoutedGraphEdge, LayoutedGraphNode,
-    LayoutedStructuralDiagram, LayoutedTemporalDiagram, LayoutedTemporalItem, Orientation,
-    Point, RelKind, TaskStatus, TextAlign as GeoTextAlign,
+    LayoutedSequenceDiagram, LayoutedSequenceItem, LayoutedStructuralDiagram,
+    LayoutedTemporalDiagram, LayoutedTemporalItem, Orientation, Point, RelKind, SequenceArrowhead,
+    SequenceLineStyle, SequenceParticipantKind, TaskStatus, TextAlign as GeoTextAlign,
 };
 use layout_ir::{Color, Content, FontSpec, PositionedNode, TextAlign, TextContent};
-use layout_to_paint::{LayoutToPaintOptions, layout_to_paint};
+use layout_to_paint::{layout_to_paint, LayoutToPaintOptions};
 use paint_instructions::{
     PaintBase, PaintEllipse, PaintInstruction, PaintPath, PaintRect, PaintScene, PathCommand,
     StrokeCap, StrokeJoin,
@@ -65,8 +66,8 @@ where
     pub label_font: FontSpec,
     /// Font for the diagram title (default: Helvetica 18 pt 700).
     pub title_font: FontSpec,
-    pub shaper:   &'a S,
-    pub metrics:  &'a M,
+    pub shaper: &'a S,
+    pub metrics: &'a M,
     pub resolver: &'a R,
 }
 
@@ -94,10 +95,16 @@ fn node_shape_instruction(node: &LayoutedGraphNode) -> PaintInstruction {
             PaintInstruction::Path(PaintPath {
                 base: PaintBase::default(),
                 commands: vec![
-                    PathCommand::MoveTo { x: cx,                   y: node.y },
-                    PathCommand::LineTo { x: node.x + node.width,  y: cy },
-                    PathCommand::LineTo { x: cx,                   y: node.y + node.height },
-                    PathCommand::LineTo { x: node.x,               y: cy },
+                    PathCommand::MoveTo { x: cx, y: node.y },
+                    PathCommand::LineTo {
+                        x: node.x + node.width,
+                        y: cy,
+                    },
+                    PathCommand::LineTo {
+                        x: cx,
+                        y: node.y + node.height,
+                    },
+                    PathCommand::LineTo { x: node.x, y: cy },
                     PathCommand::Close,
                 ],
                 fill: Some(node.style.fill.clone()),
@@ -181,7 +188,7 @@ fn arrowhead(edge: &LayoutedGraphEdge) -> Option<PaintPath> {
         return None;
     }
 
-    let end  = &edge.points[edge.points.len() - 1];
+    let end = &edge.points[edge.points.len() - 1];
     let prev = &edge.points[edge.points.len() - 2];
 
     let dx = end.x - prev.x;
@@ -193,20 +200,26 @@ fn arrowhead(edge: &LayoutedGraphEdge) -> Option<PaintPath> {
 
     let ux = dx / len;
     let uy = dy / len;
-    let size   = 10.0;
+    let size = 10.0;
     let half_w = size * 0.6;
 
     let base_x = end.x - ux * size;
     let base_y = end.y - uy * size;
     let px = -uy;
-    let py =  ux;
+    let py = ux;
 
     Some(PaintPath {
         base: PaintBase::default(),
         commands: vec![
             PathCommand::MoveTo { x: end.x, y: end.y },
-            PathCommand::LineTo { x: base_x + px * half_w, y: base_y + py * half_w },
-            PathCommand::LineTo { x: base_x - px * half_w, y: base_y - py * half_w },
+            PathCommand::LineTo {
+                x: base_x + px * half_w,
+                y: base_y + py * half_w,
+            },
+            PathCommand::LineTo {
+                x: base_x - px * half_w,
+                y: base_y - py * half_w,
+            },
             PathCommand::Close,
         ],
         fill: Some(edge.style.stroke.clone()),
@@ -237,7 +250,12 @@ fn css_to_color(css: &str) -> Color {
             return Color { r, g, b, a: 255 };
         }
     }
-    Color { r: 0, g: 0, b: 0, a: 255 } // opaque black fallback
+    Color {
+        r: 0,
+        g: 0,
+        b: 0,
+        a: 255,
+    } // opaque black fallback
 }
 
 fn text_node(
@@ -310,10 +328,10 @@ where
     // Build one PositionedNode per text item, collect them as children of a
     // transparent synthetic root spanning the full canvas, then call
     // layout_to_paint once. Append the resulting PaintGlyphRun instructions.
-    let label_font   = options.label_font.clone();
-    let title_font   = options.title_font.clone();
-    let label_size   = label_font.size;
-    let title_size   = title_font.size;
+    let label_font = options.label_font.clone();
+    let title_font = options.title_font.clone();
+    let label_size = label_font.size;
+    let title_size = title_font.size;
 
     let mut text_children: Vec<PositionedNode> = Vec::new();
 
@@ -326,7 +344,12 @@ where
             diagram.width,
             title_size * 1.2,
             title_font,
-            Color { r: 17, g: 24, b: 39, a: 255 }, // #111827
+            Color {
+                r: 17,
+                g: 24,
+                b: 39,
+                a: 255,
+            }, // #111827
         ));
     }
 
@@ -388,10 +411,15 @@ where
     let text_opts = LayoutToPaintOptions {
         width: diagram.width,
         height: diagram.height,
-        background: Color { r: 0, g: 0, b: 0, a: 0 }, // transparent root
+        background: Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 0,
+        }, // transparent root
         device_pixel_ratio: 1.0,
-        shaper:   options.shaper,
-        metrics:  options.metrics,
+        shaper: options.shaper,
+        metrics: options.metrics,
         resolver: options.resolver,
     };
     let text_scene = layout_to_paint(&text_root, &text_opts);
@@ -438,8 +466,18 @@ where
 
     if let Some(ref tb) = diagram.title_box {
         text_children.push(text_node(
-            &tb.text, tb.x - diagram.width / 2.0, tb.y - ls, diagram.width, ls * 1.4,
-            options.title_font.clone(), Color { r: 17, g: 24, b: 39, a: 255 },
+            &tb.text,
+            tb.x - diagram.width / 2.0,
+            tb.y - ls,
+            diagram.width,
+            ls * 1.4,
+            options.title_font.clone(),
+            Color {
+                r: 17,
+                g: 24,
+                b: 39,
+                a: 255,
+            },
         ));
     }
 
@@ -448,7 +486,8 @@ where
             LayoutedChartItem::AxisSpine { x1, y1, x2, y2, .. } => {
                 instructions.push(PaintInstruction::Path(line_path(
                     &[Point { x: *x1, y: *y1 }, Point { x: *x2, y: *y2 }],
-                    "#374151", 1.5,
+                    "#374151",
+                    1.5,
                 )));
             }
             LayoutedChartItem::GridLine { x1, y1, x2, y2 } => {
@@ -458,18 +497,35 @@ where
                         PathCommand::MoveTo { x: *x1, y: *y1 },
                         PathCommand::LineTo { x: *x2, y: *y2 },
                     ],
-                    fill: Some("none".into()), fill_rule: None,
-                    stroke: Some("#e5e7eb".into()), stroke_width: Some(1.0),
-                    stroke_cap: None, stroke_join: None,
-                    stroke_dash: Some(vec![4.0, 4.0]), stroke_dash_offset: None,
+                    fill: Some("none".into()),
+                    fill_rule: None,
+                    stroke: Some("#e5e7eb".into()),
+                    stroke_width: Some(1.0),
+                    stroke_cap: None,
+                    stroke_join: None,
+                    stroke_dash: Some(vec![4.0, 4.0]),
+                    stroke_dash_offset: None,
                 }));
             }
-            LayoutedChartItem::Bar { x, y, width, height, color } => {
+            LayoutedChartItem::Bar {
+                x,
+                y,
+                width,
+                height,
+                color,
+            } => {
                 instructions.push(PaintInstruction::Rect(PaintRect {
                     base: PaintBase::default(),
-                    x: *x, y: *y, width: *width, height: *height,
-                    fill: Some(color.clone()), stroke: None, stroke_width: None,
-                    corner_radius: Some(2.0), stroke_dash: None, stroke_dash_offset: None,
+                    x: *x,
+                    y: *y,
+                    width: *width,
+                    height: *height,
+                    fill: Some(color.clone()),
+                    stroke: None,
+                    stroke_width: None,
+                    corner_radius: Some(2.0),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
                 }));
             }
             LayoutedChartItem::LinePath { points, color } => {
@@ -477,48 +533,108 @@ where
                     instructions.push(PaintInstruction::Path(line_path(points, color, 2.0)));
                 }
             }
-            LayoutedChartItem::PieArc { cx, cy, r, start_angle, end_angle, color, label } => {
+            LayoutedChartItem::PieArc {
+                cx,
+                cy,
+                r,
+                start_angle,
+                end_angle,
+                color,
+                label,
+            } => {
                 let cmds = pie_slice_commands(*cx, *cy, *r, *start_angle, *end_angle);
                 instructions.push(PaintInstruction::Path(PaintPath {
                     base: PaintBase::default(),
                     commands: cmds,
-                    fill: Some(color.clone()), fill_rule: None,
-                    stroke: Some("#ffffff".into()), stroke_width: Some(1.5),
-                    stroke_cap: None, stroke_join: None,
-                    stroke_dash: None, stroke_dash_offset: None,
+                    fill: Some(color.clone()),
+                    fill_rule: None,
+                    stroke: Some("#ffffff".into()),
+                    stroke_width: Some(1.5),
+                    stroke_cap: None,
+                    stroke_join: None,
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
                 }));
                 // Label at midpoint of arc
                 let mid = (start_angle + end_angle) / 2.0;
                 let lx = cx + (r * 0.65) * mid.cos();
                 let ly = cy + (r * 0.65) * mid.sin();
                 text_children.push(text_node(
-                    label, lx - 40.0, ly - ls / 2.0, 80.0, ls * 1.2,
-                    lf.clone(), Color { r: 255, g: 255, b: 255, a: 255 },
+                    label,
+                    lx - 40.0,
+                    ly - ls / 2.0,
+                    80.0,
+                    ls * 1.2,
+                    lf.clone(),
+                    Color {
+                        r: 255,
+                        g: 255,
+                        b: 255,
+                        a: 255,
+                    },
                 ));
             }
-            LayoutedChartItem::SankeyBand { from_x, from_y, to_x, width, color, .. } => {
+            LayoutedChartItem::SankeyBand {
+                from_x,
+                from_y,
+                to_x,
+                width,
+                color,
+                ..
+            } => {
                 instructions.push(PaintInstruction::Rect(PaintRect {
                     base: PaintBase::default(),
-                    x: *from_x, y: *from_y,
-                    width: to_x - from_x, height: *width,
-                    fill: Some(color.clone()), stroke: None, stroke_width: None,
-                    corner_radius: None, stroke_dash: None, stroke_dash_offset: None,
+                    x: *from_x,
+                    y: *from_y,
+                    width: to_x - from_x,
+                    height: *width,
+                    fill: Some(color.clone()),
+                    stroke: None,
+                    stroke_width: None,
+                    corner_radius: None,
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
                 }));
             }
             LayoutedChartItem::DataLabel { x, y, text } => {
                 text_children.push(text_node(
-                    text, x - 40.0, y - ls / 2.0, 80.0, ls * 1.2,
-                    lf.clone(), Color { r: 55, g: 65, b: 81, a: 255 },
+                    text,
+                    x - 40.0,
+                    y - ls / 2.0,
+                    80.0,
+                    ls * 1.2,
+                    lf.clone(),
+                    Color {
+                        r: 55,
+                        g: 65,
+                        b: 81,
+                        a: 255,
+                    },
                 ));
             }
-            LayoutedChartItem::AxisTick { x, y, label, orientation } => {
+            LayoutedChartItem::AxisTick {
+                x,
+                y,
+                label,
+                orientation,
+            } => {
                 let (tx, ty, tw) = match orientation {
                     Orientation::Horizontal => (x - 30.0, y - ls / 2.0, 60.0),
-                    Orientation::Vertical   => (x - 30.0, y + 2.0,       60.0),
+                    Orientation::Vertical => (x - 30.0, y + 2.0, 60.0),
                 };
                 text_children.push(text_node(
-                    label, tx, ty, tw, ls * 1.2,
-                    lf.clone(), Color { r: 107, g: 114, b: 128, a: 255 },
+                    label,
+                    tx,
+                    ty,
+                    tw,
+                    ls * 1.2,
+                    lf.clone(),
+                    Color {
+                        r: 107,
+                        g: 114,
+                        b: 128,
+                        a: 255,
+                    },
                 ));
             }
             LayoutedChartItem::Legend { x, y, entries } => {
@@ -526,13 +642,30 @@ where
                 for e in entries {
                     instructions.push(PaintInstruction::Rect(PaintRect {
                         base: PaintBase::default(),
-                        x: ex, y: y - ls / 2.0, width: ls, height: ls,
-                        fill: Some(e.color.clone()), stroke: None, stroke_width: None,
-                        corner_radius: None, stroke_dash: None, stroke_dash_offset: None,
+                        x: ex,
+                        y: y - ls / 2.0,
+                        width: ls,
+                        height: ls,
+                        fill: Some(e.color.clone()),
+                        stroke: None,
+                        stroke_width: None,
+                        corner_radius: None,
+                        stroke_dash: None,
+                        stroke_dash_offset: None,
                     }));
                     text_children.push(text_node(
-                        &e.label, ex + ls + 4.0, y - ls / 2.0, 80.0, ls * 1.2,
-                        lf.clone(), Color { r: 55, g: 65, b: 81, a: 255 },
+                        &e.label,
+                        ex + ls + 4.0,
+                        y - ls / 2.0,
+                        80.0,
+                        ls * 1.2,
+                        lf.clone(),
+                        Color {
+                            r: 55,
+                            g: 65,
+                            b: 81,
+                            a: 255,
+                        },
                     ));
                     ex += ls + 4.0 + 88.0;
                 }
@@ -541,33 +674,51 @@ where
     }
 
     let text_root = PositionedNode {
-        x: 0.0, y: 0.0, width: diagram.width, height: diagram.height,
-        id: None, content: None, children: text_children, ext: HashMap::new(),
+        x: 0.0,
+        y: 0.0,
+        width: diagram.width,
+        height: diagram.height,
+        id: None,
+        content: None,
+        children: text_children,
+        ext: HashMap::new(),
     };
     let text_opts = LayoutToPaintOptions {
-        width: diagram.width, height: diagram.height,
-        background: Color { r: 0, g: 0, b: 0, a: 0 },
+        width: diagram.width,
+        height: diagram.height,
+        background: Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 0,
+        },
         device_pixel_ratio: 1.0,
-        shaper: options.shaper, metrics: options.metrics, resolver: options.resolver,
+        shaper: options.shaper,
+        metrics: options.metrics,
+        resolver: options.resolver,
     };
     let text_scene = layout_to_paint(&text_root, &text_opts);
     instructions.extend(text_scene.instructions);
 
     let bg = options.background;
     PaintScene {
-        width: diagram.width, height: diagram.height,
+        width: diagram.width,
+        height: diagram.height,
         background: format!("rgb({},{},{})", bg.r, bg.g, bg.b),
-        instructions, id: None, metadata: None,
+        instructions,
+        id: None,
+        metadata: None,
     }
 }
 
 /// Build `PathCommand`s for a filled pie slice (center → arc → close).
-fn pie_slice_commands(
-    cx: f64, cy: f64, r: f64, start: f64, end: f64,
-) -> Vec<PathCommand> {
+fn pie_slice_commands(cx: f64, cy: f64, r: f64, start: f64, end: f64) -> Vec<PathCommand> {
     let mut cmds = vec![
         PathCommand::MoveTo { x: cx, y: cy },
-        PathCommand::LineTo { x: cx + r * start.cos(), y: cy + r * start.sin() },
+        PathCommand::LineTo {
+            x: cx + r * start.cos(),
+            y: cy + r * start.sin(),
+        },
     ];
     // Split arc into ≤ 90° segments.
     let total = end - start;
@@ -584,8 +735,8 @@ fn pie_slice_commands(
             cy1: cy + r * (c0s + k * c0c),
             cx2: cx + r * (c1c + k * c1s),
             cy2: cy + r * (c1s - k * c1c),
-            x:    cx + r * c1c,
-            y:    cy + r * c1s,
+            x: cx + r * c1c,
+            y: cy + r * c1s,
         });
     }
     cmds.push(PathCommand::Close);
@@ -617,36 +768,66 @@ where
     for group in &diagram.groups {
         instructions.push(PaintInstruction::Rect(PaintRect {
             base: PaintBase::default(),
-            x: group.x, y: group.y, width: group.width, height: group.height,
-            fill: Some("#f8fafc".into()), stroke: Some("#94a3b8".into()),
-            stroke_width: Some(1.5), corner_radius: Some(8.0),
-            stroke_dash: Some(vec![6.0, 4.0]), stroke_dash_offset: None,
+            x: group.x,
+            y: group.y,
+            width: group.width,
+            height: group.height,
+            fill: Some("#f8fafc".into()),
+            stroke: Some("#94a3b8".into()),
+            stroke_width: Some(1.5),
+            corner_radius: Some(8.0),
+            stroke_dash: Some(vec![6.0, 4.0]),
+            stroke_dash_offset: None,
         }));
         let label = match &group.stereotype {
             Some(stereotype) => format!("«{stereotype}» {}", group.label),
             None => group.label.clone(),
         };
         text_children.push(text_node(
-            &label, group.x + 10.0, group.y + 6.0, group.width - 20.0, ls * 1.3,
-            lf.clone(), Color { r: 71, g: 85, b: 105, a: 255 },
+            &label,
+            group.x + 10.0,
+            group.y + 6.0,
+            group.width - 20.0,
+            ls * 1.3,
+            lf.clone(),
+            Color {
+                r: 71,
+                g: 85,
+                b: 105,
+                a: 255,
+            },
         ));
     }
 
     // ── Relationships (drawn behind nodes) ───────────────────────────────────
     for rel in &diagram.relationships {
-        instructions.push(PaintInstruction::Path(line_path(&rel.points, "#6b7280", 1.5)));
+        instructions.push(PaintInstruction::Path(line_path(
+            &rel.points,
+            "#6b7280",
+            1.5,
+        )));
         // Arrowhead on the last segment
         if rel.points.len() >= 2 {
-            let tip  = &rel.points[rel.points.len() - 1];
+            let tip = &rel.points[rel.points.len() - 1];
             let prev = &rel.points[rel.points.len() - 2];
-            instructions.push(PaintInstruction::Path(
-                structural_arrowhead(prev, tip, &rel.kind),
-            ));
+            instructions.push(PaintInstruction::Path(structural_arrowhead(
+                prev, tip, &rel.kind,
+            )));
         }
         if let Some((ref pos, ref lbl)) = rel.label {
             text_children.push(text_node(
-                lbl, pos.x - 40.0, pos.y - ls / 2.0, 80.0, ls * 1.2,
-                lf.clone(), Color { r: 55, g: 65, b: 81, a: 255 },
+                lbl,
+                pos.x - 40.0,
+                pos.y - ls / 2.0,
+                80.0,
+                ls * 1.2,
+                lf.clone(),
+                Color {
+                    r: 55,
+                    g: 65,
+                    b: 81,
+                    a: 255,
+                },
             ));
         }
         if rel.points.len() >= 2 {
@@ -659,14 +840,34 @@ where
             let uy = dy / len;
             if let Some(ref multiplicity) = rel.from_mult {
                 text_children.push(text_node(
-                    multiplicity, start.x + ux * 18.0 - 20.0, start.y + uy * 18.0 + 4.0,
-                    40.0, ls * 1.2, lf.clone(), Color { r: 55, g: 65, b: 81, a: 255 },
+                    multiplicity,
+                    start.x + ux * 18.0 - 20.0,
+                    start.y + uy * 18.0 + 4.0,
+                    40.0,
+                    ls * 1.2,
+                    lf.clone(),
+                    Color {
+                        r: 55,
+                        g: 65,
+                        b: 81,
+                        a: 255,
+                    },
                 ));
             }
             if let Some(ref multiplicity) = rel.to_mult {
                 text_children.push(text_node(
-                    multiplicity, end.x - ux * 18.0 - 20.0, end.y - uy * 18.0 + 4.0,
-                    40.0, ls * 1.2, lf.clone(), Color { r: 55, g: 65, b: 81, a: 255 },
+                    multiplicity,
+                    end.x - ux * 18.0 - 20.0,
+                    end.y - uy * 18.0 + 4.0,
+                    40.0,
+                    ls * 1.2,
+                    lf.clone(),
+                    Color {
+                        r: 55,
+                        g: 65,
+                        b: 81,
+                        a: 255,
+                    },
                 ));
             }
         }
@@ -677,18 +878,31 @@ where
         // Outer rect
         instructions.push(PaintInstruction::Rect(PaintRect {
             base: PaintBase::default(),
-            x: node.x, y: node.y, width: node.width, height: node.height,
-            fill: Some("#f9fafb".into()), stroke: Some("#374151".into()),
-            stroke_width: Some(1.5), corner_radius: Some(4.0),
-            stroke_dash: None, stroke_dash_offset: None,
+            x: node.x,
+            y: node.y,
+            width: node.width,
+            height: node.height,
+            fill: Some("#f9fafb".into()),
+            stroke: Some("#374151".into()),
+            stroke_width: Some(1.5),
+            corner_radius: Some(4.0),
+            stroke_dash: None,
+            stroke_dash_offset: None,
         }));
         // Header divider
         instructions.push(PaintInstruction::Path(line_path(
             &[
-                Point { x: node.x, y: node.y + HEADER_H },
-                Point { x: node.x + node.width, y: node.y + HEADER_H },
+                Point {
+                    x: node.x,
+                    y: node.y + HEADER_H,
+                },
+                Point {
+                    x: node.x + node.width,
+                    y: node.y + HEADER_H,
+                },
             ],
-            "#d1d5db", 1.0,
+            "#d1d5db",
+            1.0,
         )));
         // Header text (with optional stereotype)
         let header_label = if let Some(ref st) = node.stereotype {
@@ -698,8 +912,17 @@ where
         };
         text_children.push(text_node(
             &header_label,
-            node.x, node.y + 8.0, node.width, HEADER_H - 8.0,
-            options.title_font.clone(), Color { r: 17, g: 24, b: 39, a: 255 },
+            node.x,
+            node.y + 8.0,
+            node.width,
+            HEADER_H - 8.0,
+            options.title_font.clone(),
+            Color {
+                r: 17,
+                g: 24,
+                b: 39,
+                a: 255,
+            },
         ));
         // Compartments
         for comp in &node.compartments {
@@ -707,10 +930,17 @@ where
             // Compartment divider
             instructions.push(PaintInstruction::Path(line_path(
                 &[
-                    Point { x: node.x, y: comp_y },
-                    Point { x: node.x + node.width, y: comp_y },
+                    Point {
+                        x: node.x,
+                        y: comp_y,
+                    },
+                    Point {
+                        x: node.x + node.width,
+                        y: comp_y,
+                    },
                 ],
-                "#e5e7eb", 1.0,
+                "#e5e7eb",
+                1.0,
             )));
             // Row text
             for (i, row) in comp.rows.iter().enumerate() {
@@ -721,30 +951,52 @@ where
                     node.width - 16.0,
                     ls * 1.2,
                     lf.clone(),
-                    Color { r: 55, g: 65, b: 81, a: 255 },
+                    Color {
+                        r: 55,
+                        g: 65,
+                        b: 81,
+                        a: 255,
+                    },
                 ));
             }
         }
     }
 
     let text_root = PositionedNode {
-        x: 0.0, y: 0.0, width: diagram.width, height: diagram.height,
-        id: None, content: None, children: text_children, ext: HashMap::new(),
+        x: 0.0,
+        y: 0.0,
+        width: diagram.width,
+        height: diagram.height,
+        id: None,
+        content: None,
+        children: text_children,
+        ext: HashMap::new(),
     };
     let text_opts = LayoutToPaintOptions {
-        width: diagram.width, height: diagram.height,
-        background: Color { r: 0, g: 0, b: 0, a: 0 },
+        width: diagram.width,
+        height: diagram.height,
+        background: Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 0,
+        },
         device_pixel_ratio: 1.0,
-        shaper: options.shaper, metrics: options.metrics, resolver: options.resolver,
+        shaper: options.shaper,
+        metrics: options.metrics,
+        resolver: options.resolver,
     };
     let text_scene = layout_to_paint(&text_root, &text_opts);
     instructions.extend(text_scene.instructions);
 
     let bg = options.background;
     PaintScene {
-        width: diagram.width, height: diagram.height,
+        width: diagram.width,
+        height: diagram.height,
         background: format!("rgb({},{},{})", bg.r, bg.g, bg.b),
-        instructions, id: None, metadata: None,
+        instructions,
+        id: None,
+        metadata: None,
     }
 }
 
@@ -754,12 +1006,12 @@ fn structural_arrowhead(prev: &Point, tip: &Point, kind: &RelKind) -> PaintPath 
     let len = (dx * dx + dy * dy).sqrt().max(1e-9);
     let ux = dx / len;
     let uy = dy / len;
-    let size  = 10.0;
-    let hw    = size * 0.5;
-    let bx    = tip.x - ux * size;
-    let by    = tip.y - uy * size;
+    let size = 10.0;
+    let hw = size * 0.5;
+    let bx = tip.x - ux * size;
+    let by = tip.y - uy * size;
     let px = -uy;
-    let py =  ux;
+    let py = ux;
     let (fill, open) = match kind {
         RelKind::Inheritance | RelKind::Realization => ("#ffffff", true),
         RelKind::Composition => ("#374151", false),
@@ -768,27 +1020,418 @@ fn structural_arrowhead(prev: &Point, tip: &Point, kind: &RelKind) -> PaintPath 
     let commands = if open {
         vec![
             PathCommand::MoveTo { x: tip.x, y: tip.y },
-            PathCommand::LineTo { x: bx + px * hw, y: by + py * hw },
+            PathCommand::LineTo {
+                x: bx + px * hw,
+                y: by + py * hw,
+            },
             PathCommand::MoveTo { x: tip.x, y: tip.y },
-            PathCommand::LineTo { x: bx - px * hw, y: by - py * hw },
+            PathCommand::LineTo {
+                x: bx - px * hw,
+                y: by - py * hw,
+            },
         ]
     } else {
         vec![
             PathCommand::MoveTo { x: tip.x, y: tip.y },
-            PathCommand::LineTo { x: bx + px * hw, y: by + py * hw },
-            PathCommand::LineTo { x: bx - px * hw, y: by - py * hw },
+            PathCommand::LineTo {
+                x: bx + px * hw,
+                y: by + py * hw,
+            },
+            PathCommand::LineTo {
+                x: bx - px * hw,
+                y: by - py * hw,
+            },
             PathCommand::Close,
         ]
     };
     PaintPath {
         base: PaintBase::default(),
         commands,
-        fill: if open { Some("none".into()) } else { Some(fill.into()) },
+        fill: if open {
+            Some("none".into())
+        } else {
+            Some(fill.into())
+        },
         fill_rule: None,
-        stroke: Some("#374151".into()), stroke_width: Some(1.5),
-        stroke_cap: None, stroke_join: None,
-        stroke_dash: None, stroke_dash_offset: None,
+        stroke: Some("#374151".into()),
+        stroke_width: Some(1.5),
+        stroke_cap: None,
+        stroke_join: None,
+        stroke_dash: None,
+        stroke_dash_offset: None,
     }
+}
+
+// ============================================================================
+// Sequence family (DG04)
+// ============================================================================
+
+/// Lower a layouted sequence diagram into backend-neutral PaintInstructions.
+pub fn diagram_to_paint_sequence<S, M, R>(
+    diagram: &LayoutedSequenceDiagram,
+    options: &DiagramToPaintOptions<'_, S, M, R>,
+) -> PaintScene
+where
+    S: TextShaper,
+    M: FontMetrics<Handle = S::Handle>,
+    R: FontResolver<Handle = S::Handle>,
+{
+    let mut instructions = Vec::new();
+    let mut text_children = Vec::new();
+    let label_font = options.label_font.clone();
+    let text_color = Color {
+        r: 30,
+        g: 41,
+        b: 59,
+        a: 255,
+    };
+
+    // Lifelines and messages sit behind activation bars, notes, and headers.
+    for item in &diagram.items {
+        match item {
+            LayoutedSequenceItem::Lifeline { x, y1, y2, .. } => {
+                instructions.push(PaintInstruction::Path(PaintPath {
+                    base: PaintBase::default(),
+                    commands: vec![
+                        PathCommand::MoveTo { x: *x, y: *y1 },
+                        PathCommand::LineTo { x: *x, y: *y2 },
+                    ],
+                    fill: None,
+                    fill_rule: None,
+                    stroke: Some("#94a3b8".into()),
+                    stroke_width: Some(1.25),
+                    stroke_cap: Some(StrokeCap::Round),
+                    stroke_join: None,
+                    stroke_dash: Some(vec![5.0, 5.0]),
+                    stroke_dash_offset: None,
+                }));
+            }
+            LayoutedSequenceItem::Message {
+                from_x,
+                to_x,
+                y,
+                label,
+                line_style,
+                arrowhead,
+                bidirectional,
+                number,
+            } => {
+                let (commands, start, end, label_x, label_width) = if (*from_x - *to_x).abs() < 0.1
+                {
+                    let loop_width = 46.0;
+                    (
+                        vec![
+                            PathCommand::MoveTo { x: *from_x, y: *y },
+                            PathCommand::LineTo {
+                                x: *from_x + loop_width,
+                                y: *y,
+                            },
+                            PathCommand::LineTo {
+                                x: *from_x + loop_width,
+                                y: *y + 26.0,
+                            },
+                            PathCommand::LineTo {
+                                x: *from_x,
+                                y: *y + 26.0,
+                            },
+                        ],
+                        Point {
+                            x: *from_x + loop_width,
+                            y: *y + 26.0,
+                        },
+                        Point {
+                            x: *from_x,
+                            y: *y + 26.0,
+                        },
+                        *from_x + 8.0,
+                        loop_width + 80.0,
+                    )
+                } else {
+                    let left = from_x.min(*to_x);
+                    (
+                        vec![
+                            PathCommand::MoveTo { x: *from_x, y: *y },
+                            PathCommand::LineTo { x: *to_x, y: *y },
+                        ],
+                        Point { x: *from_x, y: *y },
+                        Point { x: *to_x, y: *y },
+                        left,
+                        (*to_x - *from_x).abs(),
+                    )
+                };
+                instructions.push(PaintInstruction::Path(PaintPath {
+                    base: PaintBase::default(),
+                    commands,
+                    fill: None,
+                    fill_rule: None,
+                    stroke: Some("#334155".into()),
+                    stroke_width: Some(1.5),
+                    stroke_cap: Some(StrokeCap::Round),
+                    stroke_join: Some(StrokeJoin::Round),
+                    stroke_dash: match line_style {
+                        SequenceLineStyle::Solid => None,
+                        SequenceLineStyle::Dotted => Some(vec![5.0, 4.0]),
+                    },
+                    stroke_dash_offset: None,
+                }));
+                instructions.extend(sequence_arrowhead(&start, &end, arrowhead));
+                if *bidirectional {
+                    instructions.extend(sequence_arrowhead(&end, &start, arrowhead));
+                }
+                let rendered_label = match number {
+                    Some(number) => format!("{number}. {label}"),
+                    None => label.clone(),
+                };
+                text_children.push(text_node(
+                    &rendered_label,
+                    label_x,
+                    *y - options.label_font.size - 6.0,
+                    label_width.max(80.0),
+                    options.label_font.size * 1.35,
+                    label_font.clone(),
+                    text_color,
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    for item in &diagram.items {
+        match item {
+            LayoutedSequenceItem::Activation { x, y1, y2, .. } => {
+                instructions.push(PaintInstruction::Rect(PaintRect {
+                    base: PaintBase::default(),
+                    x: *x,
+                    y: *y1,
+                    width: 12.0,
+                    height: (*y2 - *y1).max(4.0),
+                    fill: Some("#dbeafe".into()),
+                    stroke: Some("#2563eb".into()),
+                    stroke_width: Some(1.0),
+                    corner_radius: Some(1.0),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
+                }));
+            }
+            LayoutedSequenceItem::Note {
+                x,
+                y,
+                width,
+                height,
+                text,
+            } => {
+                instructions.push(PaintInstruction::Rect(PaintRect {
+                    base: PaintBase::default(),
+                    x: *x,
+                    y: *y,
+                    width: *width,
+                    height: *height,
+                    fill: Some("#fef9c3".into()),
+                    stroke: Some("#ca8a04".into()),
+                    stroke_width: Some(1.25),
+                    corner_radius: Some(3.0),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
+                }));
+                text_children.push(text_node(
+                    text,
+                    *x + 8.0,
+                    *y + 8.0,
+                    *width - 16.0,
+                    *height - 12.0,
+                    label_font.clone(),
+                    text_color,
+                ));
+            }
+            LayoutedSequenceItem::ParticipantBox {
+                label,
+                kind,
+                x,
+                y,
+                width,
+                height,
+                ..
+            } => {
+                instructions.push(PaintInstruction::Rect(PaintRect {
+                    base: PaintBase::default(),
+                    x: *x,
+                    y: *y,
+                    width: *width,
+                    height: *height,
+                    fill: Some(match kind {
+                        SequenceParticipantKind::Participant => "#eff6ff".into(),
+                        SequenceParticipantKind::Actor => "#f0fdf4".into(),
+                    }),
+                    stroke: Some(match kind {
+                        SequenceParticipantKind::Participant => "#2563eb".into(),
+                        SequenceParticipantKind::Actor => "#16a34a".into(),
+                    }),
+                    stroke_width: Some(1.5),
+                    corner_radius: Some(match kind {
+                        SequenceParticipantKind::Participant => 5.0,
+                        SequenceParticipantKind::Actor => *height / 2.0,
+                    }),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
+                }));
+                text_children.push(text_node(
+                    label,
+                    *x + 8.0,
+                    *y + 11.0,
+                    *width - 16.0,
+                    *height - 12.0,
+                    label_font.clone(),
+                    text_color,
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(title) = &diagram.title {
+        text_children.push(text_node(
+            title,
+            20.0,
+            10.0,
+            diagram.width - 40.0,
+            26.0,
+            options.title_font.clone(),
+            text_color,
+        ));
+    }
+
+    let text_root = PositionedNode {
+        x: 0.0,
+        y: 0.0,
+        width: diagram.width,
+        height: diagram.height,
+        id: None,
+        content: None,
+        children: text_children,
+        ext: HashMap::new(),
+    };
+    let text_scene = layout_to_paint(
+        &text_root,
+        &LayoutToPaintOptions {
+            width: diagram.width,
+            height: diagram.height,
+            background: Color {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 0,
+            },
+            device_pixel_ratio: 1.0,
+            shaper: options.shaper,
+            metrics: options.metrics,
+            resolver: options.resolver,
+        },
+    );
+    instructions.extend(text_scene.instructions);
+
+    let background = options.background;
+    PaintScene {
+        width: diagram.width,
+        height: diagram.height,
+        background: format!("rgb({},{},{})", background.r, background.g, background.b),
+        instructions,
+        id: None,
+        metadata: None,
+    }
+}
+
+fn sequence_arrowhead(
+    previous: &Point,
+    tip: &Point,
+    arrowhead: &SequenceArrowhead,
+) -> Vec<PaintInstruction> {
+    let dx = tip.x - previous.x;
+    let dy = tip.y - previous.y;
+    let length = (dx * dx + dy * dy).sqrt().max(1e-9);
+    let ux = dx / length;
+    let uy = dy / length;
+    let px = -uy;
+    let py = ux;
+    let back_x = tip.x - ux * 10.0;
+    let back_y = tip.y - uy * 10.0;
+    let left = Point {
+        x: back_x + px * 5.0,
+        y: back_y + py * 5.0,
+    };
+    let right = Point {
+        x: back_x - px * 5.0,
+        y: back_y - py * 5.0,
+    };
+    let commands = match arrowhead {
+        SequenceArrowhead::Open => vec![
+            PathCommand::MoveTo {
+                x: left.x,
+                y: left.y,
+            },
+            PathCommand::LineTo { x: tip.x, y: tip.y },
+            PathCommand::LineTo {
+                x: right.x,
+                y: right.y,
+            },
+        ],
+        SequenceArrowhead::Filled => vec![
+            PathCommand::MoveTo { x: tip.x, y: tip.y },
+            PathCommand::LineTo {
+                x: left.x,
+                y: left.y,
+            },
+            PathCommand::LineTo {
+                x: right.x,
+                y: right.y,
+            },
+            PathCommand::Close,
+        ],
+        SequenceArrowhead::Cross => vec![
+            PathCommand::MoveTo {
+                x: left.x,
+                y: left.y,
+            },
+            PathCommand::LineTo {
+                x: right.x,
+                y: right.y,
+            },
+            PathCommand::MoveTo {
+                x: back_x + px * 5.0,
+                y: back_y + py * 5.0,
+            },
+            PathCommand::LineTo {
+                x: tip.x - px * 5.0,
+                y: tip.y - py * 5.0,
+            },
+        ],
+        SequenceArrowhead::Point => vec![
+            PathCommand::MoveTo {
+                x: left.x,
+                y: left.y,
+            },
+            PathCommand::LineTo { x: tip.x, y: tip.y },
+            PathCommand::LineTo {
+                x: right.x,
+                y: right.y,
+            },
+            PathCommand::Close,
+        ],
+    };
+    vec![PaintInstruction::Path(PaintPath {
+        base: PaintBase::default(),
+        commands,
+        fill: match arrowhead {
+            SequenceArrowhead::Filled | SequenceArrowhead::Point => Some("#334155".into()),
+            _ => None,
+        },
+        fill_rule: None,
+        stroke: Some("#334155".into()),
+        stroke_width: Some(1.5),
+        stroke_cap: Some(StrokeCap::Round),
+        stroke_join: Some(StrokeJoin::Round),
+        stroke_dash: None,
+        stroke_dash_offset: None,
+    })]
 }
 
 // ============================================================================
@@ -815,43 +1458,101 @@ where
             LayoutedTemporalItem::TimeAxisSpine { x1, y1, x2, y2 } => {
                 instructions.push(PaintInstruction::Path(line_path(
                     &[Point { x: *x1, y: *y1 }, Point { x: *x2, y: *y2 }],
-                    "#374151", 1.5,
+                    "#374151",
+                    1.5,
                 )));
             }
             LayoutedTemporalItem::TimeAxisTick { x, y, label } => {
                 instructions.push(PaintInstruction::Path(line_path(
                     &[Point { x: *x, y: *y - 4.0 }, Point { x: *x, y: *y }],
-                    "#374151", 1.0,
+                    "#374151",
+                    1.0,
                 )));
                 text_children.push(text_node(
-                    label, x - 20.0, *y + 2.0, 40.0, ls * 1.2,
-                    lf.clone(), Color { r: 107, g: 114, b: 128, a: 255 },
+                    label,
+                    x - 20.0,
+                    *y + 2.0,
+                    40.0,
+                    ls * 1.2,
+                    lf.clone(),
+                    Color {
+                        r: 107,
+                        g: 114,
+                        b: 128,
+                        a: 255,
+                    },
                 ));
             }
-            LayoutedTemporalItem::SectionHeader { x, y, width, height, label } => {
+            LayoutedTemporalItem::SectionHeader {
+                x,
+                y,
+                width,
+                height,
+                label,
+            } => {
                 instructions.push(PaintInstruction::Rect(PaintRect {
                     base: PaintBase::default(),
-                    x: *x, y: *y, width: *width, height: *height,
-                    fill: Some("#f3f4f6".into()), stroke: None, stroke_width: None,
-                    corner_radius: None, stroke_dash: None, stroke_dash_offset: None,
+                    x: *x,
+                    y: *y,
+                    width: *width,
+                    height: *height,
+                    fill: Some("#f3f4f6".into()),
+                    stroke: None,
+                    stroke_width: None,
+                    corner_radius: None,
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
                 }));
                 text_children.push(text_node(
-                    label, *x + 8.0, *y + (*height - ls) / 2.0, *width - 16.0, ls * 1.2,
-                    options.title_font.clone(), Color { r: 17, g: 24, b: 39, a: 255 },
+                    label,
+                    *x + 8.0,
+                    *y + (*height - ls) / 2.0,
+                    *width - 16.0,
+                    ls * 1.2,
+                    options.title_font.clone(),
+                    Color {
+                        r: 17,
+                        g: 24,
+                        b: 39,
+                        a: 255,
+                    },
                 ));
             }
-            LayoutedTemporalItem::TaskBar { x, y, width, height, status, label } => {
+            LayoutedTemporalItem::TaskBar {
+                x,
+                y,
+                width,
+                height,
+                status,
+                label,
+            } => {
                 let color = task_status_color(status);
                 instructions.push(PaintInstruction::Rect(PaintRect {
                     base: PaintBase::default(),
-                    x: *x, y: *y, width: *width, height: *height,
-                    fill: Some(color.into()), stroke: None, stroke_width: None,
-                    corner_radius: Some(2.0), stroke_dash: None, stroke_dash_offset: None,
+                    x: *x,
+                    y: *y,
+                    width: *width,
+                    height: *height,
+                    fill: Some(color.into()),
+                    stroke: None,
+                    stroke_width: None,
+                    corner_radius: Some(2.0),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
                 }));
                 text_children.push(text_node(
-                    label, *x + 4.0, *y + (*height - ls) / 2.0,
-                    (*width - 8.0).max(8.0), ls * 1.2,
-                    lf.clone(), Color { r: 255, g: 255, b: 255, a: 255 },
+                    label,
+                    *x + 4.0,
+                    *y + (*height - ls) / 2.0,
+                    (*width - 8.0).max(8.0),
+                    ls * 1.2,
+                    lf.clone(),
+                    Color {
+                        r: 255,
+                        g: 255,
+                        b: 255,
+                        a: 255,
+                    },
                 ));
             }
             LayoutedTemporalItem::MilestoneMarker { x, y, label } => {
@@ -859,20 +1560,34 @@ where
                 instructions.push(PaintInstruction::Path(PaintPath {
                     base: PaintBase::default(),
                     commands: vec![
-                        PathCommand::MoveTo { x: *x,     y: y - s },
-                        PathCommand::LineTo { x: x + s,  y: *y },
-                        PathCommand::LineTo { x: *x,     y: y + s },
-                        PathCommand::LineTo { x: x - s,  y: *y },
+                        PathCommand::MoveTo { x: *x, y: y - s },
+                        PathCommand::LineTo { x: x + s, y: *y },
+                        PathCommand::LineTo { x: *x, y: y + s },
+                        PathCommand::LineTo { x: x - s, y: *y },
                         PathCommand::Close,
                     ],
-                    fill: Some("#111827".into()), fill_rule: None,
-                    stroke: None, stroke_width: None,
-                    stroke_cap: None, stroke_join: None,
-                    stroke_dash: None, stroke_dash_offset: None,
+                    fill: Some("#111827".into()),
+                    fill_rule: None,
+                    stroke: None,
+                    stroke_width: None,
+                    stroke_cap: None,
+                    stroke_join: None,
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
                 }));
                 text_children.push(text_node(
-                    label, x - 40.0, y + s + 2.0, 80.0, ls * 1.2,
-                    lf.clone(), Color { r: 17, g: 24, b: 39, a: 255 },
+                    label,
+                    x - 40.0,
+                    y + s + 2.0,
+                    80.0,
+                    ls * 1.2,
+                    lf.clone(),
+                    Color {
+                        r: 17,
+                        g: 24,
+                        b: 39,
+                        a: 255,
+                    },
                 ));
             }
             LayoutedTemporalItem::TodayMarker { x, y1, y2 } => {
@@ -882,91 +1597,175 @@ where
                         PathCommand::MoveTo { x: *x, y: *y1 },
                         PathCommand::LineTo { x: *x, y: *y2 },
                     ],
-                    fill: Some("none".into()), fill_rule: None,
-                    stroke: Some("#ef4444".into()), stroke_width: Some(2.0),
-                    stroke_cap: None, stroke_join: None,
-                    stroke_dash: Some(vec![6.0, 3.0]), stroke_dash_offset: None,
+                    fill: Some("none".into()),
+                    fill_rule: None,
+                    stroke: Some("#ef4444".into()),
+                    stroke_width: Some(2.0),
+                    stroke_cap: None,
+                    stroke_join: None,
+                    stroke_dash: Some(vec![6.0, 3.0]),
+                    stroke_dash_offset: None,
                 }));
             }
             LayoutedTemporalItem::BranchLane { y, color, label } => {
                 instructions.push(PaintInstruction::Path(line_path(
-                    &[Point { x: 0.0, y: *y }, Point { x: diagram.width, y: *y }],
-                    color, 1.0,
+                    &[
+                        Point { x: 0.0, y: *y },
+                        Point {
+                            x: diagram.width,
+                            y: *y,
+                        },
+                    ],
+                    color,
+                    1.0,
                 )));
                 text_children.push(text_node(
-                    label, 4.0, y - ls / 2.0, 56.0, ls * 1.2,
-                    lf.clone(), Color { r: 55, g: 65, b: 81, a: 255 },
+                    label,
+                    4.0,
+                    y - ls / 2.0,
+                    56.0,
+                    ls * 1.2,
+                    lf.clone(),
+                    Color {
+                        r: 55,
+                        g: 65,
+                        b: 81,
+                        a: 255,
+                    },
                 ));
             }
-            LayoutedTemporalItem::CommitNode { x, y, id: _, message, tag } => {
+            LayoutedTemporalItem::CommitNode {
+                x,
+                y,
+                id: _,
+                message,
+                tag,
+            } => {
                 instructions.push(PaintInstruction::Ellipse(PaintEllipse {
                     base: PaintBase::default(),
-                    cx: *x, cy: *y, rx: 8.0, ry: 8.0,
+                    cx: *x,
+                    cy: *y,
+                    rx: 8.0,
+                    ry: 8.0,
                     fill: Some("#3b82f6".into()),
-                    stroke: Some("#1d4ed8".into()), stroke_width: Some(2.0),
-                    stroke_dash: None, stroke_dash_offset: None,
+                    stroke: Some("#1d4ed8".into()),
+                    stroke_width: Some(2.0),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
                 }));
                 if let Some(ref msg) = message {
                     text_children.push(text_node(
-                        msg, x - 40.0, y - ls - 10.0, 80.0, ls * 1.2,
-                        lf.clone(), Color { r: 55, g: 65, b: 81, a: 255 },
+                        msg,
+                        x - 40.0,
+                        y - ls - 10.0,
+                        80.0,
+                        ls * 1.2,
+                        lf.clone(),
+                        Color {
+                            r: 55,
+                            g: 65,
+                            b: 81,
+                            a: 255,
+                        },
                     ));
                 }
                 if let Some(ref t) = tag {
                     text_children.push(text_node(
-                        t, x - 24.0, y + 12.0, 48.0, ls * 1.2,
-                        lf.clone(), Color { r: 34, g: 197, b: 94, a: 255 },
+                        t,
+                        x - 24.0,
+                        y + 12.0,
+                        48.0,
+                        ls * 1.2,
+                        lf.clone(),
+                        Color {
+                            r: 34,
+                            g: 197,
+                            b: 94,
+                            a: 255,
+                        },
                     ));
                 }
             }
-            LayoutedTemporalItem::MergeArc { from_x, from_y, to_x, to_y } => {
+            LayoutedTemporalItem::MergeArc {
+                from_x,
+                from_y,
+                to_x,
+                to_y,
+            } => {
                 let cpx = (from_x + to_x) / 2.0;
                 instructions.push(PaintInstruction::Path(PaintPath {
                     base: PaintBase::default(),
                     commands: vec![
-                        PathCommand::MoveTo { x: *from_x, y: *from_y },
+                        PathCommand::MoveTo {
+                            x: *from_x,
+                            y: *from_y,
+                        },
                         PathCommand::CubicTo {
-                            cx1: cpx, cy1: *from_y,
-                            cx2: cpx, cy2: *to_y,
-                            x: *to_x, y: *to_y,
+                            cx1: cpx,
+                            cy1: *from_y,
+                            cx2: cpx,
+                            cy2: *to_y,
+                            x: *to_x,
+                            y: *to_y,
                         },
                     ],
-                    fill: Some("none".into()), fill_rule: None,
-                    stroke: Some("#6b7280".into()), stroke_width: Some(2.0),
-                    stroke_cap: Some(StrokeCap::Round), stroke_join: Some(StrokeJoin::Round),
-                    stroke_dash: None, stroke_dash_offset: None,
+                    fill: Some("none".into()),
+                    fill_rule: None,
+                    stroke: Some("#6b7280".into()),
+                    stroke_width: Some(2.0),
+                    stroke_cap: Some(StrokeCap::Round),
+                    stroke_join: Some(StrokeJoin::Round),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
                 }));
             }
         }
     }
 
     let text_root = PositionedNode {
-        x: 0.0, y: 0.0, width: diagram.width, height: diagram.height,
-        id: None, content: None, children: text_children, ext: HashMap::new(),
+        x: 0.0,
+        y: 0.0,
+        width: diagram.width,
+        height: diagram.height,
+        id: None,
+        content: None,
+        children: text_children,
+        ext: HashMap::new(),
     };
     let text_opts = LayoutToPaintOptions {
-        width: diagram.width, height: diagram.height,
-        background: Color { r: 0, g: 0, b: 0, a: 0 },
+        width: diagram.width,
+        height: diagram.height,
+        background: Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 0,
+        },
         device_pixel_ratio: 1.0,
-        shaper: options.shaper, metrics: options.metrics, resolver: options.resolver,
+        shaper: options.shaper,
+        metrics: options.metrics,
+        resolver: options.resolver,
     };
     let text_scene = layout_to_paint(&text_root, &text_opts);
     instructions.extend(text_scene.instructions);
 
     let bg = options.background;
     PaintScene {
-        width: diagram.width, height: diagram.height,
+        width: diagram.width,
+        height: diagram.height,
         background: format!("rgb({},{},{})", bg.r, bg.g, bg.b),
-        instructions, id: None, metadata: None,
+        instructions,
+        id: None,
+        metadata: None,
     }
 }
 
 fn task_status_color(status: &TaskStatus) -> &'static str {
     match status {
-        TaskStatus::Normal    => "#3b82f6",
-        TaskStatus::Done      => "#22c55e",
-        TaskStatus::Active    => "#f59e0b",
-        TaskStatus::Crit      => "#ef4444",
+        TaskStatus::Normal => "#3b82f6",
+        TaskStatus::Done => "#22c55e",
+        TaskStatus::Active => "#f59e0b",
+        TaskStatus::Crit => "#ef4444",
         TaskStatus::Milestone => "#111827",
     }
 }
@@ -992,66 +1791,138 @@ where
 
     for el in &diagram.elements {
         match el {
-            GeoElement::Box { x, y, w, h, corner_radius, label, fill, stroke, .. } => {
+            GeoElement::Box {
+                x,
+                y,
+                w,
+                h,
+                corner_radius,
+                label,
+                fill,
+                stroke,
+                ..
+            } => {
                 instructions.push(PaintInstruction::Rect(PaintRect {
                     base: PaintBase::default(),
-                    x: *x, y: *y, width: *w, height: *h,
+                    x: *x,
+                    y: *y,
+                    width: *w,
+                    height: *h,
                     fill: Some(fill.clone().unwrap_or_else(|| "#f9fafb".into())),
                     stroke: Some(stroke.clone().unwrap_or_else(|| "#374151".into())),
                     stroke_width: Some(1.5),
                     corner_radius: Some(*corner_radius),
-                    stroke_dash: None, stroke_dash_offset: None,
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
                 }));
                 if let Some(ref lbl) = label {
                     text_children.push(text_node(
-                        lbl, *x + 4.0, y + (h - ls) / 2.0, w - 8.0, ls * 1.2,
-                        lf.clone(), Color { r: 17, g: 24, b: 39, a: 255 },
+                        lbl,
+                        *x + 4.0,
+                        y + (h - ls) / 2.0,
+                        w - 8.0,
+                        ls * 1.2,
+                        lf.clone(),
+                        Color {
+                            r: 17,
+                            g: 24,
+                            b: 39,
+                            a: 255,
+                        },
                     ));
                 }
             }
-            GeoElement::Circle { cx, cy, r, label, fill, stroke, .. } => {
+            GeoElement::Circle {
+                cx,
+                cy,
+                r,
+                label,
+                fill,
+                stroke,
+                ..
+            } => {
                 instructions.push(PaintInstruction::Ellipse(PaintEllipse {
                     base: PaintBase::default(),
-                    cx: *cx, cy: *cy, rx: *r, ry: *r,
+                    cx: *cx,
+                    cy: *cy,
+                    rx: *r,
+                    ry: *r,
                     fill: Some(fill.clone().unwrap_or_else(|| "#f9fafb".into())),
                     stroke: Some(stroke.clone().unwrap_or_else(|| "#374151".into())),
                     stroke_width: Some(1.5),
-                    stroke_dash: None, stroke_dash_offset: None,
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
                 }));
                 if let Some(ref lbl) = label {
                     text_children.push(text_node(
-                        lbl, cx - r * 0.7, cy - ls / 2.0, r * 1.4, ls * 1.2,
-                        lf.clone(), Color { r: 17, g: 24, b: 39, a: 255 },
+                        lbl,
+                        cx - r * 0.7,
+                        cy - ls / 2.0,
+                        r * 1.4,
+                        ls * 1.2,
+                        lf.clone(),
+                        Color {
+                            r: 17,
+                            g: 24,
+                            b: 39,
+                            a: 255,
+                        },
                     ));
                 }
             }
-            GeoElement::Line { x1, y1, x2, y2, arrow_end, arrow_start, stroke, .. } => {
+            GeoElement::Line {
+                x1,
+                y1,
+                x2,
+                y2,
+                arrow_end,
+                arrow_start,
+                stroke,
+                ..
+            } => {
                 let stroke_color = stroke.as_deref().unwrap_or("#374151");
                 instructions.push(PaintInstruction::Path(line_path(
                     &[Point { x: *x1, y: *y1 }, Point { x: *x2, y: *y2 }],
-                    stroke_color, 1.5,
+                    stroke_color,
+                    1.5,
                 )));
                 if *arrow_end {
                     let prev = Point { x: *x1, y: *y1 };
-                    let tip  = Point { x: *x2, y: *y2 };
-                    instructions.push(PaintInstruction::Path(simple_arrowhead(&prev, &tip, stroke_color)));
+                    let tip = Point { x: *x2, y: *y2 };
+                    instructions.push(PaintInstruction::Path(simple_arrowhead(
+                        &prev,
+                        &tip,
+                        stroke_color,
+                    )));
                 }
                 if *arrow_start {
                     let prev = Point { x: *x2, y: *y2 };
-                    let tip  = Point { x: *x1, y: *y1 };
-                    instructions.push(PaintInstruction::Path(simple_arrowhead(&prev, &tip, stroke_color)));
+                    let tip = Point { x: *x1, y: *y1 };
+                    instructions.push(PaintInstruction::Path(simple_arrowhead(
+                        &prev,
+                        &tip,
+                        stroke_color,
+                    )));
                 }
             }
-            GeoElement::Arc { cx, cy, r, start_deg, end_deg, stroke, .. } => {
+            GeoElement::Arc {
+                cx,
+                cy,
+                r,
+                start_deg,
+                end_deg,
+                stroke,
+                ..
+            } => {
                 let start = start_deg.to_radians();
-                let end   = end_deg.to_radians();
-                let n = (((end - start).abs() / std::f64::consts::FRAC_PI_2).ceil() as usize).max(1);
+                let end = end_deg.to_radians();
+                let n =
+                    (((end - start).abs() / std::f64::consts::FRAC_PI_2).ceil() as usize).max(1);
                 let step = (end - start) / n as f64;
-                let mut cmds = vec![
-                    PathCommand::MoveTo {
-                        x: cx + r * start.cos(), y: cy + r * start.sin(),
-                    }
-                ];
+                let mut cmds = vec![PathCommand::MoveTo {
+                    x: cx + r * start.cos(),
+                    y: cy + r * start.sin(),
+                }];
                 for i in 0..n {
                     let a0 = start + i as f64 * step;
                     let a1 = a0 + step;
@@ -1063,35 +1934,48 @@ where
                         cy1: cy + r * (c0s + k * c0c),
                         cx2: cx + r * (c1c + k * c1s),
                         cy2: cy + r * (c1s - k * c1c),
-                        x:    cx + r * c1c,
-                        y:    cy + r * c1s,
+                        x: cx + r * c1c,
+                        y: cy + r * c1s,
                     });
                 }
                 instructions.push(PaintInstruction::Path(PaintPath {
                     base: PaintBase::default(),
                     commands: cmds,
-                    fill: Some("none".into()), fill_rule: None,
+                    fill: Some("none".into()),
+                    fill_rule: None,
                     stroke: Some(stroke.clone().unwrap_or_else(|| "#374151".into())),
                     stroke_width: Some(1.5),
-                    stroke_cap: Some(StrokeCap::Round), stroke_join: Some(StrokeJoin::Round),
-                    stroke_dash: None, stroke_dash_offset: None,
+                    stroke_cap: Some(StrokeCap::Round),
+                    stroke_join: Some(StrokeJoin::Round),
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
                 }));
             }
-            GeoElement::Text { x, y, text, align, .. } => {
+            GeoElement::Text {
+                x, y, text, align, ..
+            } => {
                 use layout_ir::TextAlign as LTextAlign;
                 let ta = match align {
-                    GeoTextAlign::Left   => LTextAlign::Start,
+                    GeoTextAlign::Left => LTextAlign::Start,
                     GeoTextAlign::Center => LTextAlign::Center,
-                    GeoTextAlign::Right  => LTextAlign::End,
+                    GeoTextAlign::Right => LTextAlign::End,
                 };
                 let est_w = text.len() as f64 * 7.5 + 8.0;
                 text_children.push(PositionedNode {
-                    x: *x, y: y - ls, width: est_w, height: ls * 1.4,
+                    x: *x,
+                    y: y - ls,
+                    width: est_w,
+                    height: ls * 1.4,
                     id: None,
                     content: Some(layout_ir::Content::Text(layout_ir::TextContent {
                         value: text.clone(),
                         font: lf.clone(),
-                        color: Color { r: 17, g: 24, b: 39, a: 255 },
+                        color: Color {
+                            r: 17,
+                            g: 24,
+                            b: 39,
+                            a: 255,
+                        },
                         max_lines: None,
                         text_align: ta,
                     })),
@@ -1103,23 +1987,40 @@ where
     }
 
     let text_root = PositionedNode {
-        x: 0.0, y: 0.0, width: diagram.width, height: diagram.height,
-        id: None, content: None, children: text_children, ext: HashMap::new(),
+        x: 0.0,
+        y: 0.0,
+        width: diagram.width,
+        height: diagram.height,
+        id: None,
+        content: None,
+        children: text_children,
+        ext: HashMap::new(),
     };
     let text_opts = LayoutToPaintOptions {
-        width: diagram.width, height: diagram.height,
-        background: Color { r: 0, g: 0, b: 0, a: 0 },
+        width: diagram.width,
+        height: diagram.height,
+        background: Color {
+            r: 0,
+            g: 0,
+            b: 0,
+            a: 0,
+        },
         device_pixel_ratio: 1.0,
-        shaper: options.shaper, metrics: options.metrics, resolver: options.resolver,
+        shaper: options.shaper,
+        metrics: options.metrics,
+        resolver: options.resolver,
     };
     let text_scene = layout_to_paint(&text_root, &text_opts);
     instructions.extend(text_scene.instructions);
 
     let bg = options.background;
     PaintScene {
-        width: diagram.width, height: diagram.height,
+        width: diagram.width,
+        height: diagram.height,
         background: format!("rgb({},{},{})", bg.r, bg.g, bg.b),
-        instructions, id: None, metadata: None,
+        instructions,
+        id: None,
+        metadata: None,
     }
 }
 
@@ -1130,26 +2031,35 @@ fn simple_arrowhead(prev: &Point, tip: &Point, stroke: &str) -> PaintPath {
     let ux = dx / len;
     let uy = dy / len;
     let size = 10.0;
-    let hw   = size * 0.5;
-    let bx   = tip.x - ux * size;
-    let by   = tip.y - uy * size;
-    let px   = -uy;
-    let py   =  ux;
+    let hw = size * 0.5;
+    let bx = tip.x - ux * size;
+    let by = tip.y - uy * size;
+    let px = -uy;
+    let py = ux;
     PaintPath {
         base: PaintBase::default(),
         commands: vec![
             PathCommand::MoveTo { x: tip.x, y: tip.y },
-            PathCommand::LineTo { x: bx + px * hw, y: by + py * hw },
-            PathCommand::LineTo { x: bx - px * hw, y: by - py * hw },
+            PathCommand::LineTo {
+                x: bx + px * hw,
+                y: by + py * hw,
+            },
+            PathCommand::LineTo {
+                x: bx - px * hw,
+                y: by - py * hw,
+            },
             PathCommand::Close,
         ],
-        fill: Some(stroke.into()), fill_rule: None,
-        stroke: None, stroke_width: None,
-        stroke_cap: None, stroke_join: None,
-        stroke_dash: None, stroke_dash_offset: None,
+        fill: Some(stroke.into()),
+        fill_rule: None,
+        stroke: None,
+        stroke_width: None,
+        stroke_cap: None,
+        stroke_join: None,
+        stroke_dash: None,
+        stroke_dash_offset: None,
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -1180,13 +2090,27 @@ mod tests {
     struct FakeMetrics;
     impl FontMetrics for FakeMetrics {
         type Handle = FakeHandle;
-        fn units_per_em(&self, _: &FakeHandle) -> u32 { 1000 }
-        fn ascent(&self, _: &FakeHandle) -> i32 { 800 }
-        fn descent(&self, _: &FakeHandle) -> i32 { 200 }
-        fn line_gap(&self, _: &FakeHandle) -> i32 { 0 }
-        fn x_height(&self, _: &FakeHandle) -> Option<i32> { Some(500) }
-        fn cap_height(&self, _: &FakeHandle) -> Option<i32> { Some(700) }
-        fn family_name(&self, _: &FakeHandle) -> String { "Fake".into() }
+        fn units_per_em(&self, _: &FakeHandle) -> u32 {
+            1000
+        }
+        fn ascent(&self, _: &FakeHandle) -> i32 {
+            800
+        }
+        fn descent(&self, _: &FakeHandle) -> i32 {
+            200
+        }
+        fn line_gap(&self, _: &FakeHandle) -> i32 {
+            0
+        }
+        fn x_height(&self, _: &FakeHandle) -> Option<i32> {
+            Some(500)
+        }
+        fn cap_height(&self, _: &FakeHandle) -> Option<i32> {
+            Some(700)
+        }
+        fn family_name(&self, _: &FakeHandle) -> String {
+            "Fake".into()
+        }
     }
 
     struct FakeShaper;
@@ -1222,7 +2146,9 @@ mod tests {
                 font_ref: "fake:test".into(),
             }))
         }
-        fn font_ref(&self, _h: &FakeHandle) -> String { "fake:test".into() }
+        fn font_ref(&self, _h: &FakeHandle) -> String {
+            "fake:test".into()
+        }
     }
 
     fn make_opts<'a>(
@@ -1231,7 +2157,12 @@ mod tests {
         resolver: &'a FakeResolver,
     ) -> DiagramToPaintOptions<'a, FakeShaper, FakeMetrics, FakeResolver> {
         DiagramToPaintOptions {
-            background: Color { r: 255, g: 255, b: 255, a: 255 },
+            background: Color {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 255,
+            },
             device_pixel_ratio: 1.0,
             label_font: font_spec("Helvetica", 14.0),
             title_font: FontSpec {
@@ -1253,11 +2184,11 @@ mod tests {
 
     fn edge_style() -> ResolvedDiagramStyle {
         ResolvedDiagramStyle {
-            fill:          "none".to_string(),
-            stroke:        "#4b5563".to_string(),
-            stroke_width:  2.0,
-            text_color:    "#374151".to_string(),
-            font_size:     12.0,
+            fill: "none".to_string(),
+            stroke: "#4b5563".to_string(),
+            stroke_width: 2.0,
+            text_color: "#374151".to_string(),
+            font_size: 12.0,
             corner_radius: 0.0,
         }
     }
@@ -1273,16 +2204,20 @@ mod tests {
                     id: "A".to_string(),
                     label: DiagramLabel::new("Start"),
                     shape: DiagramShape::RoundedRect,
-                    x: 24.0, y: 24.0,
-                    width: 96.0, height: 52.0,
+                    x: 24.0,
+                    y: 24.0,
+                    width: 96.0,
+                    height: 52.0,
                     style: default_style(),
                 },
                 LayoutedGraphNode {
                     id: "B".to_string(),
                     label: DiagramLabel::new("End"),
                     shape: DiagramShape::RoundedRect,
-                    x: 216.0, y: 24.0,
-                    width: 96.0, height: 52.0,
+                    x: 216.0,
+                    y: 24.0,
+                    width: 96.0,
+                    height: 52.0,
                     style: default_style(),
                 },
             ],
@@ -1291,10 +2226,7 @@ mod tests {
                 from_node_id: "A".to_string(),
                 to_node_id: "B".to_string(),
                 kind: EdgeKind::Directed,
-                points: vec![
-                    Point { x: 120.0, y: 50.0 },
-                    Point { x: 216.0, y: 50.0 },
-                ],
+                points: vec![Point { x: 120.0, y: 50.0 }, Point { x: 216.0, y: 50.0 }],
                 label: None,
                 label_position: None,
                 style: edge_style(),
@@ -1304,7 +2236,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.3.0");
+        assert_eq!(crate::VERSION, "0.4.0");
     }
 
     #[test]
@@ -1345,10 +2277,15 @@ mod tests {
         let resolver = FakeResolver;
         let opts = make_opts(&shaper, &metrics, &resolver);
         let scene = diagram_to_paint(&simple_layout(), &opts);
-        let rects = scene.instructions.iter()
+        let rects = scene
+            .instructions
+            .iter()
             .filter(|i| matches!(i, PaintInstruction::Rect(_)))
             .count();
-        assert_eq!(rects, 2, "two RoundedRect nodes → two PaintRect instructions");
+        assert_eq!(
+            rects, 2,
+            "two RoundedRect nodes → two PaintRect instructions"
+        );
     }
 
     #[test]
@@ -1358,11 +2295,17 @@ mod tests {
         let resolver = FakeResolver;
         let opts = make_opts(&shaper, &metrics, &resolver);
         let scene = diagram_to_paint(&simple_layout(), &opts);
-        let runs = scene.instructions.iter()
+        let runs = scene
+            .instructions
+            .iter()
             .filter(|i| matches!(i, PaintInstruction::GlyphRun(_)))
             .count();
         // "Start" (5 chars) and "End" (3 chars) each produce one PaintGlyphRun.
-        assert!(runs >= 2, "expected at least 2 PaintGlyphRuns for node labels, got {}", runs);
+        assert!(
+            runs >= 2,
+            "expected at least 2 PaintGlyphRuns for node labels, got {}",
+            runs
+        );
     }
 
     #[test]
@@ -1372,7 +2315,9 @@ mod tests {
         let resolver = FakeResolver;
         let opts = make_opts(&shaper, &metrics, &resolver);
         let scene = diagram_to_paint(&simple_layout(), &opts);
-        let paths = scene.instructions.iter()
+        let paths = scene
+            .instructions
+            .iter()
             .filter(|i| matches!(i, PaintInstruction::Path(_)))
             .count();
         // 1 edge polyline + 1 arrowhead
@@ -1388,7 +2333,9 @@ mod tests {
         let resolver = FakeResolver;
         let opts = make_opts(&shaper, &metrics, &resolver);
         let scene = diagram_to_paint(&layout, &opts);
-        let paths = scene.instructions.iter()
+        let paths = scene
+            .instructions
+            .iter()
             .filter(|i| matches!(i, PaintInstruction::Path(_)))
             .count();
         assert_eq!(paths, 1, "undirected edge: only the polyline, no arrowhead");
@@ -1403,7 +2350,9 @@ mod tests {
         let resolver = FakeResolver;
         let opts = make_opts(&shaper, &metrics, &resolver);
         let scene = diagram_to_paint(&layout, &opts);
-        let ellipses = scene.instructions.iter()
+        let ellipses = scene
+            .instructions
+            .iter()
             .filter(|i| matches!(i, PaintInstruction::Ellipse(_)))
             .count();
         assert_eq!(ellipses, 1);
@@ -1418,11 +2367,22 @@ mod tests {
         let resolver = FakeResolver;
         let opts = make_opts(&shaper, &metrics, &resolver);
         let scene = diagram_to_paint(&layout, &opts);
-        let diamond_paths: Vec<_> = scene.instructions.iter()
-            .filter_map(|i| if let PaintInstruction::Path(p) = i { Some(p) } else { None })
+        let diamond_paths: Vec<_> = scene
+            .instructions
+            .iter()
+            .filter_map(|i| {
+                if let PaintInstruction::Path(p) = i {
+                    Some(p)
+                } else {
+                    None
+                }
+            })
             .filter(|p| p.commands.len() == 5)
             .collect();
-        assert!(!diamond_paths.is_empty(), "expected a diamond PaintPath with 5 commands");
+        assert!(
+            !diamond_paths.is_empty(),
+            "expected a diamond PaintPath with 5 commands"
+        );
     }
 
     #[test]
@@ -1433,17 +2393,26 @@ mod tests {
         let metrics = FakeMetrics;
         let resolver = FakeResolver;
         let opts = make_opts(&shaper, &metrics, &resolver);
-        let scene_with    = diagram_to_paint(&layout, &opts);
+        let scene_with = diagram_to_paint(&layout, &opts);
 
         let layout_no = simple_layout();
         let opts2 = make_opts(&shaper, &metrics, &resolver);
         let scene_without = diagram_to_paint(&layout_no, &opts2);
 
-        let runs_with    = scene_with.instructions.iter()
-            .filter(|i| matches!(i, PaintInstruction::GlyphRun(_))).count();
-        let runs_without = scene_without.instructions.iter()
-            .filter(|i| matches!(i, PaintInstruction::GlyphRun(_))).count();
-        assert!(runs_with > runs_without, "title should add at least one glyph run");
+        let runs_with = scene_with
+            .instructions
+            .iter()
+            .filter(|i| matches!(i, PaintInstruction::GlyphRun(_)))
+            .count();
+        let runs_without = scene_without
+            .instructions
+            .iter()
+            .filter(|i| matches!(i, PaintInstruction::GlyphRun(_)))
+            .count();
+        assert!(
+            runs_with > runs_without,
+            "title should add at least one glyph run"
+        );
     }
 
     #[test]
@@ -1453,12 +2422,16 @@ mod tests {
         let resolver = FakeResolver;
         let opts = make_opts(&shaper, &metrics, &resolver);
         let scene = diagram_to_paint(&simple_layout(), &opts);
-        let run = scene.instructions.iter()
+        let run = scene
+            .instructions
+            .iter()
             .find(|i| matches!(i, PaintInstruction::GlyphRun(_)));
         if let Some(PaintInstruction::GlyphRun(gr)) = run {
             // The FakeShaper always returns "fake:test" as font_ref.
-            assert_eq!(gr.font_ref, "fake:test",
-                "font_ref should come from the shaper, not a hardcoded string");
+            assert_eq!(
+                gr.font_ref, "fake:test",
+                "font_ref should come from the shaper, not a hardcoded string"
+            );
         }
     }
 
@@ -1474,21 +2447,54 @@ mod tests {
 
         let scene_with_label = diagram_to_paint(&layout, &opts);
         let opts2 = make_opts(&shaper, &metrics, &resolver);
-        let scene_no_label   = diagram_to_paint(&simple_layout(), &opts2);
+        let scene_no_label = diagram_to_paint(&simple_layout(), &opts2);
 
-        let runs_with = scene_with_label.instructions.iter()
-            .filter(|i| matches!(i, PaintInstruction::GlyphRun(_))).count();
-        let runs_without = scene_no_label.instructions.iter()
-            .filter(|i| matches!(i, PaintInstruction::GlyphRun(_))).count();
-        assert!(runs_with > runs_without, "edge label should produce at least one extra glyph run");
+        let runs_with = scene_with_label
+            .instructions
+            .iter()
+            .filter(|i| matches!(i, PaintInstruction::GlyphRun(_)))
+            .count();
+        let runs_without = scene_no_label
+            .instructions
+            .iter()
+            .filter(|i| matches!(i, PaintInstruction::GlyphRun(_)))
+            .count();
+        assert!(
+            runs_with > runs_without,
+            "edge label should produce at least one extra glyph run"
+        );
     }
 
     #[test]
     fn css_to_color_parses_hex() {
-        assert_eq!(css_to_color("#4b5563"), Color { r: 0x4b, g: 0x55, b: 0x63, a: 255 });
-        assert_eq!(css_to_color("#ffffff"), Color { r: 255, g: 255, b: 255, a: 255 });
+        assert_eq!(
+            css_to_color("#4b5563"),
+            Color {
+                r: 0x4b,
+                g: 0x55,
+                b: 0x63,
+                a: 255
+            }
+        );
+        assert_eq!(
+            css_to_color("#ffffff"),
+            Color {
+                r: 255,
+                g: 255,
+                b: 255,
+                a: 255
+            }
+        );
         // Invalid/unsupported → opaque black
-        assert_eq!(css_to_color("none"), Color { r: 0, g: 0, b: 0, a: 255 });
+        assert_eq!(
+            css_to_color("none"),
+            Color {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 255
+            }
+        );
     }
 
     #[test]
@@ -1501,8 +2507,14 @@ mod tests {
         let opts = make_opts(&shaper, &metrics, &resolver);
         let scene = diagram_to_paint(&simple_layout(), &opts);
 
-        let last_path_idx = scene.instructions.iter().rposition(|i| matches!(i, PaintInstruction::Path(_)));
-        let first_rect_idx = scene.instructions.iter().position(|i| matches!(i, PaintInstruction::Rect(_)));
+        let last_path_idx = scene
+            .instructions
+            .iter()
+            .rposition(|i| matches!(i, PaintInstruction::Path(_)));
+        let first_rect_idx = scene
+            .instructions
+            .iter()
+            .position(|i| matches!(i, PaintInstruction::Rect(_)));
         if let (Some(lp), Some(fr)) = (last_path_idx, first_rect_idx) {
             assert!(lp < fr, "all edge paths should appear before node rects");
         }

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -11,17 +11,18 @@
 mod apple {
     use diagram_layout_chart::layout_chart_diagram;
     use diagram_layout_graph::layout_graph_diagram;
+    use diagram_layout_sequence::layout_sequence_diagram;
     use diagram_layout_structural::layout_structural_diagram;
     use diagram_layout_temporal::layout_temporal_diagram;
     use diagram_to_paint::{
-        diagram_to_paint, diagram_to_paint_chart, diagram_to_paint_structural,
-        diagram_to_paint_temporal, DiagramToPaintOptions,
+        diagram_to_paint, diagram_to_paint_chart, diagram_to_paint_sequence,
+        diagram_to_paint_structural, diagram_to_paint_temporal, DiagramToPaintOptions,
     };
     use dot_parser::parse_to_diagram;
     use layout_ir::font_spec;
     use mermaid_parser::{
         parse_c4_diagram, parse_er_diagram, parse_gitgraph, parse_pie, parse_sankey,
-        parse_to_diagram as parse_mermaid_to_diagram,
+        parse_sequence_diagram, parse_to_diagram as parse_mermaid_to_diagram,
     };
     use paint_codec_png::write_png;
     use paint_metal::render;
@@ -341,6 +342,45 @@ mod apple {
         assert!(scene.instructions.iter().any(|instruction| matches!(
             instruction,
             paint_instructions::PaintInstruction::Rect(rect) if rect.stroke_dash.is_some()
+        )));
+    }
+
+    #[test]
+    fn render_mermaid_sequence_to_png() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\ntitle Native Mermaid sequence\nautonumber\nactor User\nparticipant API as Banking API\nparticipant DB as Ledger\nUser->>+API: Submit transfer\nAPI->>DB: Record transaction\nDB-->>API: Committed\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete",
+        )
+        .expect("Mermaid sequence parse failed");
+        let layout = layout_sequence_diagram(&diagram);
+
+        let shaper = CoreTextShaper;
+        let metrics = CoreTextMetrics;
+        let resolver = CoreTextResolver::new();
+        let scene = diagram_to_paint_sequence(
+            &layout,
+            &DiagramToPaintOptions {
+                background: layout_ir::Color {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                    a: 255,
+                },
+                device_pixel_ratio: 2.0,
+                label_font: font_spec("Helvetica", 12.0),
+                title_font: font_spec("Helvetica", 17.0),
+                shaper: &shaper,
+                metrics: &metrics,
+                resolver: &resolver,
+            },
+        );
+
+        let pixels = render(&scene);
+        write_png(&pixels, "/tmp/mermaid_sequence_e2e.png").expect("PNG write failed");
+        assert!(pixels.width > 0);
+        assert!(pixels.height > 0);
+        assert!(scene.instructions.iter().any(|instruction| matches!(
+            instruction,
+            paint_instructions::PaintInstruction::Path(path) if path.stroke_dash.is_some()
         )));
     }
 }

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+- Added a portable Mermaid 11.16.1 sequence token grammar and lexer entrypoint.
+
 ## 0.2.0
 
 - Added the shared Mermaid 11.16.0 pie-chart token grammar and lexer entrypoint.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.2.0";
+pub const VERSION: &str = "0.3.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -14,6 +14,8 @@ const GITGRAPH_TOKEN_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/gitgraph.tokens");
 const ER_TOKEN_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/er.tokens");
 const C4_TOKEN_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/c4.tokens");
+const SEQUENCE_TOKEN_GRAMMAR_SOURCE: &str =
+    include_str!("../../../../grammars/mermaid/sequence.tokens");
 
 fn create_lexer<'a>(source: &'a str, grammar_source: &str, grammar_name: &str) -> GrammarLexer<'a> {
     let grammar = parse_token_grammar(grammar_source)
@@ -43,6 +45,10 @@ pub fn create_mermaid_er_lexer(source: &str) -> GrammarLexer<'_> {
 
 pub fn create_mermaid_c4_lexer(source: &str) -> GrammarLexer<'_> {
     create_lexer(source, C4_TOKEN_GRAMMAR_SOURCE, "c4.tokens")
+}
+
+pub fn create_mermaid_sequence_lexer(source: &str) -> GrammarLexer<'_> {
+    create_lexer(source, SEQUENCE_TOKEN_GRAMMAR_SOURCE, "sequence.tokens")
 }
 
 pub fn tokenize_mermaid(source: &str) -> Vec<Token> {
@@ -87,6 +93,13 @@ pub fn tokenize_mermaid_c4(source: &str) -> Vec<Token> {
         .unwrap_or_else(|e| panic!("Mermaid C4 tokenization failed: {e}"))
 }
 
+pub fn tokenize_mermaid_sequence(source: &str) -> Vec<Token> {
+    let mut lexer = create_mermaid_sequence_lexer(source);
+    lexer
+        .tokenize()
+        .unwrap_or_else(|e| panic!("Mermaid sequence tokenization failed: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -98,7 +111,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.2.0");
+        assert_eq!(VERSION, "0.3.0");
     }
 
     #[test]
@@ -261,5 +274,23 @@ mod tests {
         assert!(values.contains(&"Person"));
         assert!(values.contains(&"$sprite"));
         assert!(values.contains(&"Rel"));
+    }
+
+    #[test]
+    fn tokenizes_sequence_participants_messages_and_notes() {
+        let tokens = tokenize_mermaid_sequence(
+            "sequenceDiagram\nparticipant A as Alice\nA->>+Bob: Hello Bob\nnote right of Bob: Ready\n",
+        );
+        let values: Vec<&str> = tokens
+            .iter()
+            .filter(|token| token.type_ != TokenType::Eof)
+            .map(|token| token.value.as_str())
+            .collect();
+
+        assert!(values.contains(&"sequenceDiagram"));
+        assert!(values.contains(&"->>"));
+        assert!(values.contains(&"+"));
+        assert!(values.contains(&"note"));
+        assert!(values.contains(&"Ready"));
     }
 }

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.0
+
+- Added grammar-backed sequence parsing for participants, actors, aliases,
+  messages, notes, activations, titles, and automatic numbering.
+- Added sequence dispatch into the shared semantic IR and marked the family partial.
+
 ## 0.3.0
 
 - Pinned the compatibility target to Mermaid 11.16.1.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -11,8 +11,13 @@ The current native pipeline supports documented subsets of:
 
 - `flowchart` / `graph`
 - `classDiagram`
+- `sequenceDiagram`
+- `erDiagram`
+- `C4Context` / `C4Container` / `C4Component` / `C4Dynamic` / `C4Deployment`
 - `gantt`
+- `gitGraph`
 - `pie`
+- `sankey`
 - `xychart`
 
 Each supported family lowers into the shared Diagram IR and can continue
@@ -27,6 +32,11 @@ Mermaid
   -> PaintScene
   -> Metal / SVG / Direct2D / other Paint VM backends
 ```
+
+The sequence subset includes participants and actors, aliases, standard solid
+and dotted message arrows, bidirectional/cross/point arrowheads, notes,
+activations, titles, and automatic numbering. Control blocks and advanced
+participant metadata remain explicit compatibility gaps.
 
 All other Mermaid 11.16.1 family headers are recognized and return an explicit
 `recognized but not implemented` error until their grammar, lowering, layout,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.3.0";
+pub const VERSION: &str = "0.4.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -18,7 +18,7 @@ use grammar_tools::parser_grammar::parse_parser_grammar;
 use lexer::token::{Token, TokenType};
 use mermaid_lexer::{
     tokenize_mermaid, tokenize_mermaid_c4, tokenize_mermaid_er, tokenize_mermaid_gitgraph,
-    tokenize_mermaid_pie, tokenize_mermaid_sankey,
+    tokenize_mermaid_pie, tokenize_mermaid_sankey, tokenize_mermaid_sequence,
 };
 use parser::grammar_parser::{GrammarASTNode, GrammarParser, DEFAULT_MAX_RULE_DEPTH};
 
@@ -30,6 +30,8 @@ const GITGRAPH_PARSER_GRAMMAR_SOURCE: &str =
     include_str!("../../../../grammars/mermaid/gitgraph.grammar");
 const ER_PARSER_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/er.grammar");
 const C4_PARSER_GRAMMAR_SOURCE: &str = include_str!("../../../../grammars/mermaid/c4.grammar");
+const SEQUENCE_PARSER_GRAMMAR_SOURCE: &str =
+    include_str!("../../../../grammars/mermaid/sequence.grammar");
 
 /// Recursion-depth cap for the Mermaid [`GrammarParser`] — see
 /// [`GrammarParser::with_max_depth`] for why this guard exists at all (deep
@@ -246,6 +248,18 @@ pub fn parse_mermaid_c4_ast(source: &str) -> Result<GrammarASTNode, ParseError> 
     })
 }
 
+pub fn parse_mermaid_sequence_ast(source: &str) -> Result<GrammarASTNode, ParseError> {
+    let tokens = tokenize_mermaid_sequence(source);
+    let grammar = parse_parser_grammar(SEQUENCE_PARSER_GRAMMAR_SOURCE)
+        .unwrap_or_else(|e| panic!("Failed to parse sequence.grammar: {e}"));
+    let mut parser = GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH);
+    parser.parse().map_err(|e| ParseError {
+        message: e.message,
+        line: e.token.line,
+        col: e.token.column,
+    })
+}
+
 pub fn parse_to_diagram(source: &str) -> Result<GraphDiagram, ParseError> {
     let mut cursor = TokenCursor::new(tokenize_mermaid(source));
     cursor.skip_terminators();
@@ -408,6 +422,8 @@ fn token_name(token: &Token) -> &str {
         TokenType::Number => "NUMBER",
         TokenType::String => "STRING",
         TokenType::Keyword => "KEYWORD",
+        TokenType::Plus => "PLUS",
+        TokenType::Minus => "MINUS",
         TokenType::Colon => "COLON",
         TokenType::Comma => "COMMA",
         TokenType::Equals => "EQUALS",
@@ -431,9 +447,11 @@ fn token_name(token: &Token) -> &str {
 use diagram_ir::{
     Axis, AxisKind, ChartDiagram, ChartKind, ChartOrientation, ChartSeries, Compartment,
     CompartmentKind, GanttDiagram, GanttSection, GanttTask, GitBranch, GitCommitType, GitDiagram,
-    GitEvent, PieSlice, RelKind, SankeyFlow, SankeyNode, SeriesKind, StructuralDiagram,
-    StructuralGroup, StructuralKind, StructuralNode, StructuralNodeKind, StructuralRelationship,
-    TaskStart, TaskStatus, TemporalBody, TemporalDiagram, TemporalKind,
+    GitEvent, PieSlice, RelKind, SankeyFlow, SankeyNode, SequenceArrowhead, SequenceDiagram,
+    SequenceEvent, SequenceLineStyle, SequenceNotePlacement, SequenceParticipant,
+    SequenceParticipantKind, SeriesKind, StructuralDiagram, StructuralGroup, StructuralKind,
+    StructuralNode, StructuralNodeKind, StructuralRelationship, TaskStart, TaskStatus,
+    TemporalBody, TemporalDiagram, TemporalKind,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -520,6 +538,7 @@ impl MermaidDiagramType {
                 | Self::Gantt
                 | Self::GitGraph
                 | Self::Pie
+                | Self::Sequence
                 | Self::Sankey
                 | Self::XyChart
         )
@@ -530,6 +549,7 @@ impl MermaidDiagramType {
 pub enum MermaidDiagram {
     Graph(GraphDiagram),
     Chart(ChartDiagram),
+    Sequence(SequenceDiagram),
     Structural(StructuralDiagram),
     Temporal(TemporalDiagram),
 }
@@ -600,6 +620,9 @@ pub fn parse_any_mermaid(source: &str) -> Result<MermaidDiagram, ParseError> {
         MermaidDiagramType::Er => parse_er_diagram(source).map(MermaidDiagram::Structural),
         MermaidDiagramType::XyChart => parse_xychart(source).map(MermaidDiagram::Chart),
         MermaidDiagramType::Pie => parse_pie(source).map(MermaidDiagram::Chart),
+        MermaidDiagramType::Sequence => {
+            parse_sequence_diagram(source).map(MermaidDiagram::Sequence)
+        }
         MermaidDiagramType::Sankey => parse_sankey(source).map(MermaidDiagram::Chart),
         MermaidDiagramType::GitGraph => parse_gitgraph(source).map(|git| {
             MermaidDiagram::Temporal(TemporalDiagram {
@@ -989,6 +1012,243 @@ fn parse_data_list(s: &str) -> Vec<f64> {
         .split(',')
         .filter_map(|x| x.trim().parse().ok())
         .collect()
+}
+
+// ── sequence parser ──────────────────────────────────────────────────────
+
+/// Parse the grammar-backed core of Mermaid sequence diagrams into the
+/// shared sequence IR. Unsupported control blocks fail grammar validation
+/// instead of being silently discarded.
+pub fn parse_sequence_diagram(source: &str) -> Result<SequenceDiagram, ParseError> {
+    parse_mermaid_sequence_ast(source)?;
+
+    let mut cursor = TokenCursor::new(tokenize_mermaid_sequence(source));
+    cursor.skip_terminators();
+    cursor
+        .consume_if("HEADER")
+        .ok_or_else(|| token_error(cursor.current(), "expected sequenceDiagram header"))?;
+    cursor.skip_terminators();
+
+    let mut diagram = SequenceDiagram {
+        title: None,
+        auto_number: false,
+        participants: Vec::new(),
+        events: Vec::new(),
+    };
+    let mut participant_indices: HashMap<String, usize> = HashMap::new();
+
+    while !cursor.at_eof() {
+        match cursor.current().value.as_str() {
+            "participant" | "actor" => {
+                let kind = if cursor.advance().value == "actor" {
+                    SequenceParticipantKind::Actor
+                } else {
+                    SequenceParticipantKind::Participant
+                };
+                let id = take_sequence_identifier(&mut cursor)?;
+                let label = if cursor.current().value == "as" {
+                    cursor.advance();
+                    take_sequence_line_text(&mut cursor)
+                } else {
+                    id.clone()
+                };
+                upsert_sequence_participant(
+                    &mut diagram,
+                    &mut participant_indices,
+                    id,
+                    label,
+                    kind,
+                );
+            }
+            "activate" | "deactivate" => {
+                let active = cursor.advance().value == "activate";
+                let participant = take_sequence_identifier(&mut cursor)?;
+                ensure_sequence_participant(&mut diagram, &mut participant_indices, &participant);
+                diagram.events.push(SequenceEvent::Activation {
+                    participant,
+                    active,
+                });
+            }
+            "note" => parse_sequence_note(&mut cursor, &mut diagram, &mut participant_indices)?,
+            "title" => {
+                cursor.advance();
+                diagram.title = Some(take_sequence_line_text(&mut cursor));
+            }
+            "autonumber" => {
+                cursor.advance();
+                diagram.auto_number = cursor.current().value != "off";
+                while !cursor.at_eof() && token_name(cursor.current()) != "NEWLINE" {
+                    cursor.advance();
+                }
+            }
+            _ => parse_sequence_message(&mut cursor, &mut diagram, &mut participant_indices)?,
+        }
+        cursor.skip_terminators();
+    }
+
+    Ok(diagram)
+}
+
+fn parse_sequence_message(
+    cursor: &mut TokenCursor,
+    diagram: &mut SequenceDiagram,
+    participant_indices: &mut HashMap<String, usize>,
+) -> Result<(), ParseError> {
+    let from = take_sequence_identifier(cursor)?;
+    let arrow = cursor.advance().clone();
+    let (line_style, arrowhead, bidirectional) = match token_name(&arrow) {
+        "SOLID_OPEN_ARROW" => (SequenceLineStyle::Solid, SequenceArrowhead::Open, false),
+        "DOTTED_OPEN_ARROW" => (SequenceLineStyle::Dotted, SequenceArrowhead::Open, false),
+        "SOLID_FILLED_ARROW" => (SequenceLineStyle::Solid, SequenceArrowhead::Filled, false),
+        "DOTTED_FILLED_ARROW" => (SequenceLineStyle::Dotted, SequenceArrowhead::Filled, false),
+        "BIDIRECTIONAL_SOLID" => (SequenceLineStyle::Solid, SequenceArrowhead::Filled, true),
+        "BIDIRECTIONAL_DOTTED" => (SequenceLineStyle::Dotted, SequenceArrowhead::Filled, true),
+        "SOLID_CROSS_ARROW" => (SequenceLineStyle::Solid, SequenceArrowhead::Cross, false),
+        "DOTTED_CROSS_ARROW" => (SequenceLineStyle::Dotted, SequenceArrowhead::Cross, false),
+        "SOLID_POINT_ARROW" => (SequenceLineStyle::Solid, SequenceArrowhead::Point, false),
+        "DOTTED_POINT_ARROW" => (SequenceLineStyle::Dotted, SequenceArrowhead::Point, false),
+        other => {
+            return Err(token_error(
+                &arrow,
+                format!("unsupported sequence arrow {other}"),
+            ))
+        }
+    };
+    let activate = cursor.consume_if("PLUS").is_some();
+    let deactivate = if activate {
+        false
+    } else {
+        cursor.consume_if("MINUS").is_some()
+    };
+    let to = take_sequence_identifier(cursor)?;
+    cursor
+        .consume_if("COLON")
+        .ok_or_else(|| token_error(cursor.current(), "expected ':' before sequence message"))?;
+    let label = take_sequence_line_text(cursor);
+    ensure_sequence_participant(diagram, participant_indices, &from);
+    ensure_sequence_participant(diagram, participant_indices, &to);
+    diagram.events.push(SequenceEvent::Message {
+        from,
+        to,
+        label,
+        line_style,
+        arrowhead,
+        bidirectional,
+        activate,
+        deactivate,
+    });
+    Ok(())
+}
+
+fn parse_sequence_note(
+    cursor: &mut TokenCursor,
+    diagram: &mut SequenceDiagram,
+    participant_indices: &mut HashMap<String, usize>,
+) -> Result<(), ParseError> {
+    cursor.advance();
+    let placement_token = cursor.advance().clone();
+    let placement = match placement_token.value.as_str() {
+        "left" => {
+            consume_sequence_word(cursor, "of")?;
+            SequenceNotePlacement::LeftOf
+        }
+        "right" => {
+            consume_sequence_word(cursor, "of")?;
+            SequenceNotePlacement::RightOf
+        }
+        "over" => SequenceNotePlacement::Over,
+        other => {
+            return Err(token_error(
+                &placement_token,
+                format!("invalid note placement {other:?}"),
+            ))
+        }
+    };
+    let mut participants = vec![take_sequence_identifier(cursor)?];
+    if cursor.consume_if("COMMA").is_some() {
+        participants.push(take_sequence_identifier(cursor)?);
+    }
+    cursor
+        .consume_if("COLON")
+        .ok_or_else(|| token_error(cursor.current(), "expected ':' before note text"))?;
+    let text = take_sequence_line_text(cursor);
+    for participant in &participants {
+        ensure_sequence_participant(diagram, participant_indices, participant);
+    }
+    diagram.events.push(SequenceEvent::Note {
+        participants,
+        placement,
+        text,
+    });
+    Ok(())
+}
+
+fn consume_sequence_word(cursor: &mut TokenCursor, expected: &str) -> Result<(), ParseError> {
+    if cursor.current().value == expected {
+        cursor.advance();
+        Ok(())
+    } else {
+        Err(token_error(
+            cursor.current(),
+            format!("expected sequence word {expected:?}"),
+        ))
+    }
+}
+
+fn take_sequence_identifier(cursor: &mut TokenCursor) -> Result<String, ParseError> {
+    if matches!(token_name(cursor.current()), "IDENTIFIER" | "WORD") {
+        Ok(cursor.advance().value.clone())
+    } else {
+        Err(token_error(
+            cursor.current(),
+            "expected sequence participant identifier",
+        ))
+    }
+}
+
+fn take_sequence_line_text(cursor: &mut TokenCursor) -> String {
+    let mut words = Vec::new();
+    while !cursor.at_eof() && token_name(cursor.current()) != "NEWLINE" {
+        words.push(cursor.advance().value.clone());
+    }
+    words.join(" ")
+}
+
+fn ensure_sequence_participant(
+    diagram: &mut SequenceDiagram,
+    participant_indices: &mut HashMap<String, usize>,
+    id: &str,
+) {
+    if !participant_indices.contains_key(id) {
+        upsert_sequence_participant(
+            diagram,
+            participant_indices,
+            id.to_string(),
+            id.to_string(),
+            SequenceParticipantKind::Participant,
+        );
+    }
+}
+
+fn upsert_sequence_participant(
+    diagram: &mut SequenceDiagram,
+    participant_indices: &mut HashMap<String, usize>,
+    id: String,
+    label: String,
+    kind: SequenceParticipantKind,
+) {
+    if let Some(&index) = participant_indices.get(&id) {
+        diagram.participants[index].label = DiagramLabel::new(label);
+        diagram.participants[index].kind = kind;
+        return;
+    }
+    participant_indices.insert(id.clone(), diagram.participants.len());
+    diagram.participants.push(SequenceParticipant {
+        id,
+        label: DiagramLabel::new(label),
+        kind,
+        style: None,
+    });
 }
 
 // ── pie parser ───────────────────────────────────────────────────────────
@@ -2248,6 +2508,41 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
             _ => panic!("expected Structural"),
         }
     }
+
+    #[test]
+    fn sequence_parses_core_events_and_implicit_participants() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\nautonumber\nparticipant A as Alice\nA->>+Bob: Hello Bob\nnote right of Bob: Ready\ndeactivate Bob\n",
+        )
+        .unwrap();
+        assert!(diagram.auto_number);
+        assert_eq!(diagram.participants.len(), 2);
+        assert_eq!(diagram.participants[0].label.text, "Alice");
+        assert!(matches!(
+            &diagram.events[0],
+            SequenceEvent::Message { from, to, activate: true, .. }
+                if from == "A" && to == "Bob"
+        ));
+        assert!(matches!(
+            &diagram.events[1],
+            SequenceEvent::Note {
+                placement: SequenceNotePlacement::RightOf,
+                ..
+            }
+        ));
+        assert!(matches!(
+            &diagram.events[2],
+            SequenceEvent::Activation { participant, active: false } if participant == "Bob"
+        ));
+    }
+
+    #[test]
+    fn dispatch_sequence() {
+        match parse_any_mermaid("sequenceDiagram\nAlice-->>Bob: Hello").unwrap() {
+            MermaidDiagram::Sequence(diagram) => assert_eq!(diagram.events.len(), 1),
+            _ => panic!("expected Sequence"),
+        }
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -2264,7 +2559,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.3.0");
+        assert_eq!(crate::VERSION, "0.4.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/tests/compatibility.rs
+++ b/code/packages/rust/mermaid-parser/tests/compatibility.rs
@@ -57,9 +57,9 @@ Alice->>Bob: Hello
 
 #[test]
 fn recognized_but_unimplemented_family_is_not_reported_as_unknown() {
-    let error = parse_any_mermaid("sequenceDiagram\nAlice->>Bob: Hello")
+    let error = parse_any_mermaid("stateDiagram-v2\n[*] --> Ready")
         .err()
-        .expect("sequence support is not implemented yet");
+        .expect("state support is not implemented yet");
     assert!(error.message.contains("recognized but not implemented"));
     assert!(error.message.contains(MERMAID_COMPATIBILITY_BASELINE));
 }

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -103,6 +103,21 @@ Sharing a domain IR does not require sharing a source AST. For example,
 Sequence Diagram and ZenUML should have different parsers but may lower into
 the same participant/message/lifeline IR.
 
+### Sequence Native Slice
+
+The first sequence vertical slice is grammar-backed and covers participant and
+actor declarations, aliases, implicit participants, solid and dotted message
+arrows, open/filled/cross/point arrowheads, bidirectional messages, notes,
+activation/deactivation, titles, and automatic numbering. It lowers through
+`diagram-layout-sequence` to existing path, rectangle, dashed-stroke, and glyph
+PaintInstructions and is exercised by a Mermaid-to-Metal-to-PNG fixture.
+
+The Mermaid 11.16.1 control blocks (`loop`, `opt`, `alt`, `par`, `critical`,
+`break`, and `rect`), participant creation/destruction and metadata, links, and
+advanced arrow variants remain compatibility work. The family remains partial
+until those forms and the pinned upstream corpus pass; unsupported forms must
+fail grammar validation rather than degrade silently.
+
 ### Structural Groups
 
 Nested containers such as C4 boundaries are semantic structural groups, not


### PR DESCRIPTION
## Summary
- add portable Mermaid 11.16.1 sequence token and parser grammars
- add shared sequence semantic/layout IR and a dedicated layout package
- lower participants, lifelines, messages, notes, activations, and shaped text to existing PaintInstructions
- verify Mermaid -> PaintScene -> Metal -> PNG and mark sequence compatibility partial

## Supported slice
Participants/actors and aliases, implicit participants, solid/dotted/open/filled/cross/point and bidirectional messages, activation/deactivation, notes, titles, and autonumber.

Control blocks, create/destroy, links/properties/details, and advanced arrow variants remain explicitly documented compatibility gaps.

## Verification
- `cargo test -p diagram-ir -p diagram-layout-sequence -p mermaid-lexer -p mermaid-parser -p diagram-to-paint -- --nocapture`
- `cargo clippy -p diagram-ir -p diagram-layout-sequence -p mermaid-lexer -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- build-tool BUILD validation dry run
- visually inspected `/tmp/mermaid_sequence_e2e.png`
