### PR TITLE
Verify Tamil ற handwriting ductus

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -70,9 +70,9 @@ activities, and back matter. The twelve former handwritten entries are protected
 generated targets with checked hashes, titles, labels, order, and output. HL-C19
 is already complete; HL-C09A verified Tamil அ in #10222, HL-C09B verified
 Tamil ஆ in #10223, HL-C09C verified Tamil இ in #10226, HL-C09D verified
-Tamil க in #10228, and HL-C09E verified Tamil வ in #10230. HL-C09F is the next
-bounded stroke-order tranche: verify Tamil ல from Frame 9 of the cited primer
-before widening DUCTUS across scripts.
+Tamil க in #10228, HL-C09E verified Tamil வ in #10230, and HL-C09F verified
+Tamil ல in #10234. HL-C09G is the next bounded stroke-order tranche: verify
+Tamil ற from Frame 10 of the cited primer before widening DUCTUS across scripts.
 The index audit found **2,075** canonical candidates across the corpus: **1,426**
 word and phrase lessons for English-first lookup, **136** dedicated grammar,
 writing, etymology, culture, and pronunciation lessons, **427** chapter
@@ -232,13 +232,14 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C06 | Complete (#10219) | Add the figure pipeline: SVG generation, `graphicx`, SVG→PDF in CI, and a `--check` hash gate. | A generated figure round-trips from canonical data into a compiled PDF and fails CI on drift, reusing `paint-vm-svg`'s `renderToSvgString`. |
 | HL-C07 | Complete (#9963) | Add the log-scanning warning gate with recorded per-track baselines. | Overfull/underfull boxes, missing glyphs, hyperref warnings, duplicate destinations, and font substitutions are machine-checked by `scan_latex_log_warnings.py` after the `latexmk` loop, against `core/latex-warning-baseline.json`. Baselines ship unseeded — `null` means unmeasured, never zero — so the gate reports today and fails the moment a seeded track regresses. The first CI run on main emits the real counts into the job summary for a human to paste back. |
 | HL-C08 | Complete (#9974) | Render the ductus in Language Ladder. | `penPathD`/`penTip` drive the tested SVG stroke build-up in the app; the currently authored ductus is shared with validation and script practice. |
-| HL-C09 | Queued — 7 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 221 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
+| HL-C09 | Queued — 8 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 220 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
 | HL-C09A | Complete (#10222) | Verify Tamil அ as the first post-HL-C19 expansion tranche, using the primer already cited for Tamil handwriting. | அ carries a source-aligned two-stroke path with exactly one lift; its five movements, learner prose, source metadata, font-outline geometry, and rendered filmstrip agree. |
 | HL-C09B | Complete (#10223) | Verify Tamil ஆ as the next source-backed expansion tranche from Frame 4 of the same primer. | ஆ carries a font-checked path for the அ body plus its long-vowel right-hand loop; its learner prose states every verified lift, and source, geometry, and filmstrip tests agree. |
 | HL-C09C | Complete (#10226) | Verify Tamil இ as Frame 4's third source-backed vowel tranche. | இ carries a seven-movement, font-checked path whose learner prose states each evidenced lift; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C09D | Complete (#10228) | Verify Tamil க from Frame 3's final source-backed consonant row. | க carries a six-movement, font-checked three-stroke path whose learner prose states its two evidenced lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C09E | Complete (#10230) | Verify Tamil வ from Frame 9's first source-backed consonant row. | வ carries a five-movement, font-checked unbroken path whose learner prose states the evidenced zero lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C09F | Complete (#10234) | Verify Tamil ல from Frame 9's second source-backed consonant row. | ல carries a four-movement, font-checked unbroken path whose learner prose states the evidenced zero lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
+| HL-C09G | Complete (#10240) | Verify Tamil ற from the source-adjacent Frame 10 row. | ற carries a five-movement, font-checked three-stroke path whose learner prose states the two evidenced lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C10 | Complete (#10010, #10013, #10067) | Complete A1 and add the A2-through-C2 spine tranches with all registered realization ledgers. | All seven declared stages carry nodes; every one of the 22 registered tracks has a non-drifting ledger entry for every node. |
 | HL-C11 | Queued — capability and closure coverage complete | Finish representative chapter payoffs across all 22 tracks. | #10128 brought all 513 chapters to an authored `canDo`, spine mapping, known payoff lesson, and closed assessment. Remediate the remaining 27 payoffs below the 0.5 representativeness floor across ten tracks, then enforce the clean tracks instead of leaving their gates report-only. |
 | HL-C12 | Queued — licensing decided, pipeline outstanding | Add the Class C illustration pipeline with provenance sidecars and a size budget. Licensing is settled and recorded in [`_assets/LICENSE.md`](./_assets/LICENSE.md); the remaining work is the pipeline itself. | Every asset carries `license`, `rightsAsserted`, `generator`, `model`, `prompt`, `date`, and `sha256`; CI fails any asset without a provenance sidecar or a recorded licence, and enforces the per-track size budget. |
@@ -2641,7 +2642,7 @@ problem.
   **61 glyph violations plus five multi-system Japanese openings**. The current
   corpus is 91% core-drivable, not the historical 84% recorded before later work.
 - HL-C19 supersedes HL-C09's old estimate. There are **228** prose stroke-order
-  entries across ten scripts: seven verified ductus paths and 221 entries still needing cited,
+  entries across ten scripts: eight verified ductus paths and 220 entries still needing cited,
   font-checked pen-lift evidence.
 
 ## Findings from HL-C05

--- a/code/learning/human-languages/data/scripts/README.md
+++ b/code/learning/human-languages/data/scripts/README.md
@@ -130,7 +130,7 @@ and given the same citation.
 4. Where no ductus exists, do not invent lifts — keep the steps as part order and
    leave `penLifts` out.
 
-Tamil **அ**, **ஆ**, **இ**, **க**, **வ**, and **ல** now join **ம** with authored ductus paths. The primer's
+Tamil **அ**, **ஆ**, **இ**, **க**, **வ**, **ல**, and **ற** now join **ம** with authored ductus paths. The primer's
 Frame 4 shows four connected movements for their shared curl-and-loop body,
 followed by one lift and the separate right upright; ஆ then continues without
 another lift into its long-vowel loop. Frame 4's next row gives இ five joined
@@ -140,10 +140,13 @@ Frame 3 row for க separates its upper frame and two lower bowls into three
 pen-down runs with two verified lifts. Frame 9 joins வ's spiral body, bottom
 bar, and right upright as five movements in one unbroken run; its next row
 traces ல's outward spiral, middle descent, deep right-hand turn, and open tip
-as four movements without lifting. The remaining **221** prose part
+as four movements without lifting. Frame 10 joins ற's left arch to its first
+middle descent, restarts for the adjacent descent, then joins the right arch to
+the below-baseline sweep and descender: five movements, three runs, and two
+lifts. The remaining **220** prose part
 orders across ten scripts (`arabic` 21, `chinese` 24, `cyrillic` 33,
 `devanagari` 28, `gujarati` 33, `hebrew` 22, `japanese` 34,
-`perso-arabic` 9, `tamil` 4, `urdu-nastaliq` 13) are explicitly **unverified for
+`perso-arabic` 9, `tamil` 3, `urdu-nastaliq` 13) are explicitly **unverified for
 pen lifts**. The data validator rejects a lift count without a citation (or a
 citation without a count), and Language Ladder's ductus test proves every verified
 claim has the same cited, font-checked path. That closes `HL-C19`; future entries

--- a/code/learning/human-languages/data/scripts/tamil.json
+++ b/code/learning/human-languages/data/scripts/tamil.json
@@ -7,7 +7,7 @@
   "signature": "Curvy and loopy with flat top-bars on many letters, repeated arches, and no continuous head-line.",
   "complete": false,
   "combination": "A consonant carries an inherent 'a' (க = ka). A vowel sign replaces that vowel (க + ா → கா = kā). The puḷḷi ் — a DOT above the letter — removes the vowel entirely (க் = k). Unlike Devanagari, Tamil does NOT fuse the bare consonant into a conjunct: the dot stays visible and both letters keep their full shape. (A handful of Sanskrit-borrowed ligatures are the exception — க்ஷ kṣa and ஸ்ரீ śrī.)",
-  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, இ, க, ம, வ, and ல have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ and ஆ each have two pen-down runs with one lift before the separate right upright; ஆ then continues into its long-vowel loop without another lift. இ keeps its first five movements joined, lifts once before the outer-left climb, and joins that climb to the final arch. க uses three pen-down runs: its upper frame, lower-left bowl, and lower-right bowl. ம, வ, and ல are each a single unbroken stroke even though their parts have separate names. The other four letters here have no verified pen path, so read their steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
+  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, இ, க, ம, வ, ல, and ற have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ and ஆ each have two pen-down runs with one lift before the separate right upright; ஆ then continues into its long-vowel loop without another lift. இ keeps its first five movements joined, lifts once before the outer-left climb, and joins that climb to the final arch. க and ற each use three pen-down runs with two verified lifts. ம, வ, and ல are each a single unbroken stroke even though their parts have separate names. The other three letters here have no verified pen path, so read their steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
   "letters": [
     {
       "glyph": "அ",
@@ -199,9 +199,21 @@
       "role": "consonant",
       "inherentVowel": "a",
       "components": ["two arches side by side, giving three legs down to the baseline", "the right leg continues BELOW the baseline, sweeps left, and drops into a long descender"],
-      "strokeOrder": ["first arch", "second arch", "right leg", "the sweep left below the baseline and the descender"],
-      "strokeOrderNote": "conventional",
-      "notes": "The hard/trilled r, distinct from ர. In நன்றி the pair ன் + ற is said as a single cluster."
+      "strokeOrder": [
+        "start at the lower left, climb the left side, and arch to the middle",
+        "without lifting, descend the first middle upright — then lift once",
+        "set the pen at the adjacent middle upright and descend — then lift a second time",
+        "set the pen at the middle top, arch over, and descend the right side",
+        "without lifting again, sweep left below the baseline and drop into the long descender — and only now lift"
+      ],
+      "strokeOrderNote": "three strokes — two joined movements, one pen lift, the adjacent middle descent, a second lift, then two joined movements; cited to Radhakrishnan, Tamil Script Learners Manual, Frame 10, ற",
+      "penLifts": 2,
+      "strokeOrderSource": {
+        "citation": "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 10, ற (Univ. of Texas at Austin), p. 194",
+        "url": "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+        "variation": "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order."
+      },
+      "notes": "The hard/trilled r, distinct from ர. Frame 10's five numbered movements form three pen-down runs: movements 1–2 join, movement 3 restarts on the neighboring middle descent, and movements 4–5 join the right arch to the sweep and descender. In நன்றி the pair ன் + ற is said as a single cluster."
     }
   ],
   "marks": [

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -41,6 +41,13 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
   with zero lifts, matching the next row of Frame 9 and Language Ladder's
   font-checked path.
 
+### Added - verified Tamil ற handwriting
+
+- Record the cited five-movement order for Tamil ற as three pen-down runs: its
+  left arch joins the first middle descent, the adjacent descent restarts after
+  one lift, and a second lift precedes the right arch's joined below-baseline
+  sweep and descender, matching Frame 10 and Language Ladder's font-checked path.
+
 ### Added - generated lesson figures
 
 - Generate deterministic etymology-route SVGs from the canonical lesson `roots`

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -51,6 +51,14 @@
 - Check the complete path against the Noto Sans Tamil outline and pin its zero
   lifts in the real four-frame filmstrip and learner prose.
 
+### Added — cited three-stroke ductus for Tamil ற (HL-C09G)
+
+- Add Frame 10's Tamil ற row: two joined movements form the left arch and first
+  middle descent, movement 3 restarts on the adjacent descent, and movements
+  4–5 join the right arch to the below-baseline sweep and descender.
+- Check all five movements against the Noto Sans Tamil outline and pin both
+  lift transitions in the real filmstrip and learner prose.
+
 ### Added — canonical lesson figures
 
 - Preserve standalone Markdown images as typed lesson blocks instead of flattening

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -165,7 +165,7 @@ in font units, and `ductusview.ts` flips them together with exactly **one**
 `scale(1,-1)` group — so a mistake cannot leave a plausible-looking stroke
 sitting upside down on a correct letter.
 
-**Tamil அ, ஆ, இ, க, ம, வ, and ல have authored pen paths today.** `DUCTUS` admits no letter
+**Tamil அ, ஆ, இ, க, ம, வ, ல, and ற have authored pen paths today.** `DUCTUS` admits no letter
 without a citation for its stroke order, and hand-drawing a letter is forbidden
 outright (a subtly wrong Tamil ண looks perfect to exactly the audience that
 cannot yet read Tamil, so the error would ship *as the lesson*). அ and ஆ exercise
@@ -176,7 +176,9 @@ stroke. க exercises a real three-stroke path: its upper frame and two lower bo
 are separated by two verified lifts. வ joins its spiral body, bottom bar, and
 right upright in one five-movement run with no lift. ல carries its outward
 spiral through a middle descent and deep right-hand turn to the open tip in one
-four-movement run with no lift. Every other
+four-movement run with no lift. ற uses three pen-down runs: its left arch joins
+the first middle descent, the adjacent descent restarts after one lift, and a
+second lift precedes the right arch's joined sweep and descender. Every other
 letter falls back to the numbered prose list, unchanged. Extending the coverage
 is HL-C09, and it needs a cited source per letter.
 

--- a/code/programs/typescript/language-ladder/src/strokes.ts
+++ b/code/programs/typescript/language-ladder/src/strokes.ts
@@ -204,6 +204,9 @@ const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n);
 // bottom bar and right upright without a pen lift.
 // ல is Frame 9's second row: all four movements join its spiral body to the
 // deep right-hand turn and rising finish without a pen lift.
+// ற is Frame 10: movements 1-2 make the left arch and first middle descent,
+// movement 3 restarts on the adjacent middle descent, and movements 4-5 join
+// the right arch to the below-baseline sweep and descender.
 // ம is Frame 1's third row: all five movements join into one unbroken stroke.
 // ---------------------------------------------------------------------------
 
@@ -786,6 +789,91 @@ export const DUCTUS: Record<string, LetterDuctus> = {
     source: {
       citation:
         "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 9, ல (Univ. of Texas at Austin), p. 194",
+      url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+      variation:
+        "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",
+    },
+  },
+  ற: {
+    glyph: "ற",
+    strokes: [
+      {
+        segments: [
+          {
+            label: "climb the left and arch to the middle",
+            path: [
+              { x: 105, y: 40 },
+              { x: 105, y: 200 },
+              { x: 105, y: 400 },
+              { x: 135, y: 485 },
+              { x: 215, y: 535 },
+              { x: 300, y: 530 },
+              { x: 370, y: 485 },
+              { x: 405, y: 430 },
+            ],
+          },
+          {
+            label: "descend the first middle upright",
+            path: [
+              { x: 405, y: 430 },
+              { x: 405, y: 300 },
+              { x: 405, y: 150 },
+              { x: 405, y: 35 },
+            ],
+          },
+        ],
+      },
+      {
+        segments: [
+          {
+            label: "descend the second middle upright",
+            path: [
+              { x: 405, y: 430 },
+              { x: 405, y: 300 },
+              { x: 405, y: 150 },
+              { x: 405, y: 35 },
+            ],
+          },
+        ],
+      },
+      {
+        segments: [
+          {
+            label: "arch over and descend the right side",
+            path: [
+              { x: 420, y: 450 },
+              { x: 455, y: 510 },
+              { x: 540, y: 540 },
+              { x: 640, y: 520 },
+              { x: 710, y: 460 },
+              { x: 755, y: 380 },
+              { x: 760, y: 260 },
+              { x: 760, y: 130 },
+              { x: 750, y: 50 },
+            ],
+          },
+          {
+            label: "sweep left below the baseline and down",
+            path: [
+              { x: 750, y: 50 },
+              { x: 730, y: 0 },
+              { x: 690, y: -40 },
+              { x: 620, y: -75 },
+              { x: 520, y: -100 },
+              { x: 400, y: -115 },
+              { x: 280, y: -120 },
+              { x: 160, y: -125 },
+              { x: 105, y: -155 },
+              { x: 105, y: -230 },
+              { x: 105, y: -315 },
+            ],
+          },
+        ],
+      },
+    ],
+    source: {
+      citation:
+        "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 10, ற (Univ. of Texas at Austin), p. 194",
       url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
       variation:
         "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",

--- a/code/programs/typescript/language-ladder/tests/ductusview.test.ts
+++ b/code/programs/typescript/language-ladder/tests/ductusview.test.ts
@@ -61,6 +61,8 @@ const VA = DUCTUS["வ"];
 const vaOutline = tamilOutline("வ");
 const LA = DUCTUS["ல"];
 const laOutline = tamilOutline("ல");
+const RRA = DUCTUS["ற"];
+const rraOutline = tamilOutline("ற");
 
 /** Walk a node tree, collecting every node the predicate accepts. */
 function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = []): SvgNode[] {
@@ -72,7 +74,7 @@ function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = 
 const byTag = (node: SvgNode, tag: string) => collect(node, (n) => n.tag === tag);
 
 describe("ductusFor — only cited letters have a ductus", () => {
-  it("finds all seven authored Tamil letters", () => {
+  it("finds all eight authored Tamil letters", () => {
     expect(ductusFor("ம")?.glyph).toBe("ம");
     expect(ductusFor("அ")?.glyph).toBe("அ");
     expect(ductusFor("ஆ")?.glyph).toBe("ஆ");
@@ -80,6 +82,7 @@ describe("ductusFor — only cited letters have a ductus", () => {
     expect(ductusFor("க")?.glyph).toBe("க");
     expect(ductusFor("வ")?.glyph).toBe("வ");
     expect(ductusFor("ல")?.glyph).toBe("ல");
+    expect(ductusFor("ற")?.glyph).toBe("ற");
   });
 
   it("returns undefined for a letter nobody has authored a stroke order for", () => {
@@ -431,6 +434,31 @@ describe("ல — a real cited unbroken four-movement filmstrip", () => {
     const pen = byTag(last, "path").find((path) => path.attrs.class === "ductus__pen")!;
     expect(done).toHaveLength(0);
     expect(pen.attrs.d).toBe(penPathD(LA.strokes[0], 1));
+  });
+});
+
+describe("ற — a real cited three-stroke five-movement filmstrip", () => {
+  const steps = ductusSteps(RRA);
+  const strip = ductusFilmstrip(RRA, rraOutline);
+
+  it("marks exactly the two source-backed lift transitions", () => {
+    expect(steps.map((step) => step.startsAfterLift)).toEqual([false, false, true, true, false]);
+    expect(steps.map((step) => step.strokeIndex)).toEqual([0, 0, 1, 2, 2]);
+  });
+
+  it("reports five movements in three strokes with two lifts", () => {
+    expect(strip.frames).toHaveLength(5);
+    expect(strip.penLifts).toBe(2);
+    expect(strip.summary).toBe("3 strokes · 2 pen lifts · 5 movements");
+  });
+
+  it("keeps both completed strokes visible while drawing the joined sweep", () => {
+    const last = strip.frames[4];
+    const done = byTag(last, "path").filter((path) => path.attrs.class === "ductus__done");
+    const pen = byTag(last, "path").find((path) => path.attrs.class === "ductus__pen")!;
+    expect(done).toHaveLength(2);
+    expect(done.map((path) => path.attrs.d)).toEqual([penPathD(RRA.strokes[0], 1), penPathD(RRA.strokes[1], 1)]);
+    expect(pen.attrs.d).toBe(penPathD(RRA.strokes[2], 1));
   });
 });
 

--- a/code/programs/typescript/language-ladder/tests/strokes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/strokes.test.ts
@@ -210,6 +210,12 @@ describe("handwriting ductus", () => {
     expect(DUCTUS["ல"].strokes[0].segments).toHaveLength(4);
   });
 
+  it("ற lifts between its three pen-down runs", () => {
+    expect(penLifts(DUCTUS["ற"])).toBe(2);
+    expect(DUCTUS["ற"].strokes).toHaveLength(3);
+    expect(DUCTUS["ற"].strokes.map((stroke) => stroke.segments.length)).toEqual([2, 1, 2]);
+  });
+
   // The PROVENANCE GATE. A stroke's SHAPE is checked against the font above;
   // its ORDER cannot be — so it must trace to a cited source, or it does not
   // ship. This is the counterpart, for hand-authored order, of "facts enter
@@ -290,6 +296,13 @@ describe("handwriting ductus", () => {
     const src = DUCTUS["ல"].source;
     expect(src.url).toContain("tamilscript");
     expect(src.citation).toMatch(/Appendix I.*Frame 9.*ல/);
+    expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
+  });
+
+  it("ற's stroke order traces to Frame 10", () => {
+    const src = DUCTUS["ற"].source;
+    expect(src.url).toContain("tamilscript");
+    expect(src.citation).toMatch(/Appendix I.*Frame 10.*ற/);
     expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
   });
 });


### PR DESCRIPTION
## What changed

- replace Tamil ற's prose-only placeholder with a cited five-movement handwriting order from Frame 10 of the UT Austin primer
- add a font-checked three-stroke `DUCTUS` path and real five-frame Language Ladder filmstrip coverage
- update the HL-C09 inventory to 8 of 228 verified entries, with 220 remaining

## Why

Frame 10 shows ற as three pen-down runs, but the curriculum previously had no verified pen-lift claim or renderable ductus. This tranche preserves movements 1–2 as the joined left arch and first middle descent, restarts movement 3 on the adjacent descent, and joins movements 4–5 from the right arch through the below-baseline sweep and descender.

## Learner impact

Language Ladder can now animate ற with the same cited path that backs its learner prose, while validators keep the source, two lift transitions, font geometry, and filmstrip in agreement.

## Validation

- `npx vitest run tests/strokes.test.ts tests/ductusview.test.ts` (112 tests)
- `bash BUILD` in `code/packages/typescript/human-language-data` (460 tests)
- `bash BUILD` in `code/programs/typescript/language-ladder` (typecheck, production build, bundle check, 591 tests)
- `bash code/scripts/verify-human-languages.sh --fast`
- `git diff --check`