### PR TITLE
Add nested Mermaid sequence control blocks

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -1,8 +1,9 @@
 # @version 1
 # Mermaid 11.16.1 sequence diagram parser grammar: initial native subset.
 
-document = { NEWLINE } HEADER { NEWLINE | statement } EOF ;
-statement = participant_stmt | message_stmt | activation_stmt | note_stmt | title_stmt | autonumber_stmt ;
+document = { NEWLINE } HEADER body EOF ;
+body = { NEWLINE | statement } ;
+statement = participant_stmt | message_stmt | activation_stmt | note_stmt | title_stmt | autonumber_stmt | control_block ;
 
 participant_stmt = ( "participant" | "actor" ) identifier [ "as" text ] ;
 message_stmt = identifier message_arrow [ PLUS | MINUS ] identifier COLON [ text ] ;
@@ -10,6 +11,12 @@ activation_stmt = ( "activate" | "deactivate" ) identifier ;
 note_stmt = "note" ( ( "left" | "right" ) "of" identifier | "over" actor_pair ) COLON text ;
 title_stmt = "title" text ;
 autonumber_stmt = "autonumber" [ "off" | identifier [ identifier ] ] ;
+
+control_block = simple_block | alt_block | par_block | critical_block ;
+simple_block = ( "loop" | "rect" | "opt" | "break" ) [ text ] NEWLINE body "end" ;
+alt_block = "alt" [ text ] NEWLINE body { "else" [ text ] NEWLINE body } "end" ;
+par_block = ( "par" | "par_over" ) [ text ] NEWLINE body { "and" [ text ] NEWLINE body } "end" ;
+critical_block = "critical" [ text ] NEWLINE body { "option" [ text ] NEWLINE body } "end" ;
 
 actor_pair = identifier [ COMMA identifier ] ;
 message_arrow = SOLID_OPEN_ARROW | DOTTED_OPEN_ARROW | SOLID_FILLED_ARROW | DOTTED_FILLED_ARROW | BIDIRECTIONAL_SOLID | BIDIRECTIONAL_DOTTED | SOLID_CROSS_ARROW | DOTTED_CROSS_ARROW | SOLID_POINT_ARROW | DOTTED_POINT_ARROW ;

--- a/code/grammars/mermaid/sequence.tokens
+++ b/code/grammars/mermaid/sequence.tokens
@@ -39,3 +39,15 @@ keywords:
   title
   autonumber
   off
+  loop
+  rect
+  opt
+  alt
+  else
+  par
+  par_over
+  and
+  critical
+  option
+  break
+  end

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog — diagram-ir
 
+## 0.5.0
+
+- Added nested sequence block start, branch, and end events.
+- Added layouted sequence frames and branch dividers.
+
 ## 0.4.0
 
 - Added semantic sequence participants, messages, notes, and activation events.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.4.0 — DG00/DG04 semantic IR
+//! diagram-ir v0.5.0 — DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.4.0";
+pub const VERSION: &str = "0.5.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -190,6 +190,18 @@ pub enum SequenceNotePlacement {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub enum SequenceBlockKind {
+    Loop,
+    Rect,
+    Opt,
+    Alt,
+    Par,
+    ParOver,
+    Critical,
+    Break,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub enum SequenceEvent {
     Message {
         from: String,
@@ -209,6 +221,16 @@ pub enum SequenceEvent {
         participants: Vec<String>,
         placement: SequenceNotePlacement,
         text: String,
+    },
+    BlockStart {
+        kind: SequenceBlockKind,
+        label: String,
+    },
+    BlockBranch {
+        label: String,
+    },
+    BlockEnd {
+        kind: SequenceBlockKind,
     },
 }
 
@@ -259,6 +281,21 @@ pub enum LayoutedSequenceItem {
         width: f64,
         height: f64,
         text: String,
+    },
+    BlockFrame {
+        kind: SequenceBlockKind,
+        label: String,
+        depth: usize,
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+    },
+    BlockDivider {
+        label: String,
+        x: f64,
+        y: f64,
+        width: f64,
     },
 }
 
@@ -813,8 +850,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_is_0_4_0() {
-        assert_eq!(VERSION, "0.4.0");
+    fn version_is_0_5_0() {
+        assert_eq!(VERSION, "0.5.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0 - 2026-08-09
+
+- Resolve nested sequence block events into frames and labeled branch dividers.
+
 ## 0.1.0 - 2026-08-09
 
 - Add the initial sequence layout pipeline for participants, messages, notes,

--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-sequence"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
 

--- a/code/packages/rust/diagram-layout-sequence/README.md
+++ b/code/packages/rust/diagram-layout-sequence/README.md
@@ -2,4 +2,6 @@
 
 Backend-neutral layout for sequence diagrams. It converts participants and
 ordered events into participant boxes, lifelines, message routes, notes, and
-activation bars for `diagram-to-paint`.
+activation bars for `diagram-to-paint`. Nested control-block events become
+depth-aware frames and labeled branch dividers without introducing paint or
+backend concepts into semantic IR.

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -3,11 +3,11 @@
 use std::collections::HashMap;
 
 use diagram_ir::{
-    LayoutedSequenceDiagram, LayoutedSequenceItem, SequenceDiagram, SequenceEvent,
-    SequenceNotePlacement,
+    LayoutedSequenceDiagram, LayoutedSequenceItem, SequenceBlockKind, SequenceDiagram,
+    SequenceEvent, SequenceNotePlacement,
 };
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 
 const MARGIN: f64 = 28.0;
 const HEADER_Y: f64 = 42.0;
@@ -16,6 +16,20 @@ const MIN_LANE_W: f64 = 150.0;
 const EVENT_H: f64 = 58.0;
 const NOTE_H: f64 = 38.0;
 const ACTIVATION_W: f64 = 12.0;
+const BLOCK_HEADER_H: f64 = 48.0;
+const BLOCK_BRANCH_H: f64 = 48.0;
+const BLOCK_BOTTOM_PAD: f64 = 14.0;
+const BLOCK_AFTER_GAP: f64 = 12.0;
+const BLOCK_INSET: f64 = 10.0;
+
+struct BlockFrameState {
+    kind: SequenceBlockKind,
+    label: String,
+    depth: usize,
+    x: f64,
+    y: f64,
+    width: f64,
+}
 
 /// Lay out an ordered sequence diagram. Participant order is semantic and is
 /// therefore retained exactly rather than optimized by the layout engine.
@@ -52,6 +66,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
     let mut y = event_start;
     let mut activation_starts: HashMap<String, Vec<f64>> = HashMap::new();
     let mut message_number = 0usize;
+    let mut block_stack: Vec<BlockFrameState> = Vec::new();
 
     for event in &diagram.events {
         match event {
@@ -150,6 +165,47 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                     text: text.clone(),
                 });
                 y += NOTE_H + 20.0;
+            }
+            SequenceEvent::BlockStart { kind, label } => {
+                let depth = block_stack.len();
+                let x = MARGIN + depth as f64 * BLOCK_INSET;
+                block_stack.push(BlockFrameState {
+                    kind: kind.clone(),
+                    label: label.clone(),
+                    depth,
+                    x,
+                    y,
+                    width: (width - x * 2.0).max(120.0),
+                });
+                y += BLOCK_HEADER_H;
+            }
+            SequenceEvent::BlockBranch { label } => {
+                if let Some(frame) = block_stack.last() {
+                    items.push(LayoutedSequenceItem::BlockDivider {
+                        label: label.clone(),
+                        x: frame.x,
+                        y,
+                        width: frame.width,
+                    });
+                }
+                y += BLOCK_BRANCH_H;
+            }
+            SequenceEvent::BlockEnd { kind } => {
+                if let Some(frame) = block_stack.pop() {
+                    debug_assert_eq!(&frame.kind, kind);
+                    y += BLOCK_BOTTOM_PAD;
+                    let frame_height = y - frame.y;
+                    items.push(LayoutedSequenceItem::BlockFrame {
+                        kind: frame.kind,
+                        label: frame.label,
+                        depth: frame.depth,
+                        x: frame.x,
+                        y: frame.y,
+                        width: frame.width,
+                        height: frame_height,
+                    });
+                    y += BLOCK_AFTER_GAP;
+                }
             }
         }
     }
@@ -282,5 +338,58 @@ mod tests {
         assert!(layout.items.iter().any(
             |item| matches!(item, LayoutedSequenceItem::Activation { y1, y2, .. } if y2 > y1)
         ));
+    }
+
+    #[test]
+    fn lays_out_nested_block_frames_and_branch_dividers() {
+        let diagram = SequenceDiagram {
+            title: None,
+            auto_number: false,
+            participants: vec![participant("Alice"), participant("Bob")],
+            events: vec![
+                SequenceEvent::BlockStart {
+                    kind: SequenceBlockKind::Alt,
+                    label: "Ready".into(),
+                },
+                SequenceEvent::BlockStart {
+                    kind: SequenceBlockKind::Loop,
+                    label: "Retry".into(),
+                },
+                SequenceEvent::Message {
+                    from: "Alice".into(),
+                    to: "Bob".into(),
+                    label: "Ping".into(),
+                    line_style: SequenceLineStyle::Solid,
+                    arrowhead: SequenceArrowhead::Filled,
+                    bidirectional: false,
+                    activate: false,
+                    deactivate: false,
+                },
+                SequenceEvent::BlockEnd {
+                    kind: SequenceBlockKind::Loop,
+                },
+                SequenceEvent::BlockBranch {
+                    label: "Fallback".into(),
+                },
+                SequenceEvent::BlockEnd {
+                    kind: SequenceBlockKind::Alt,
+                },
+            ],
+        };
+        let layout = layout_sequence_diagram(&diagram);
+        let frames: Vec<_> = layout
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                LayoutedSequenceItem::BlockFrame {
+                    depth, x, height, ..
+                } => Some((*depth, *x, *height)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(frames.len(), 2);
+        assert!(frames.iter().any(|(depth, _, _)| *depth == 1));
+        assert!(frames.iter().all(|(_, _, height)| *height > BLOCK_HEADER_H));
+        assert!(layout.items.iter().any(|item| matches!(item, LayoutedSequenceItem::BlockDivider { label, .. } if label == "Fallback")));
     }
 }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -6,6 +6,7 @@
   Apple end-to-end test.
 - Added sequence lowering for participant headers, lifelines, messages,
   arrowheads, notes, activation bars, and shaped labels, plus a Metal PNG test.
+- Added nested sequence frame and branch-divider lowering with visual Metal coverage.
 
 ## 0.1.2 — Fix text coordinate-space mismatch (text now inside nodes)
 

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.4.0";
+pub const VERSION: &str = "0.5.0";
 
 use std::collections::HashMap;
 
@@ -35,7 +35,8 @@ use diagram_ir::{
     LayoutedGeometricDiagram, LayoutedGraphDiagram, LayoutedGraphEdge, LayoutedGraphNode,
     LayoutedSequenceDiagram, LayoutedSequenceItem, LayoutedStructuralDiagram,
     LayoutedTemporalDiagram, LayoutedTemporalItem, Orientation, Point, RelKind, SequenceArrowhead,
-    SequenceLineStyle, SequenceParticipantKind, TaskStatus, TextAlign as GeoTextAlign,
+    SequenceBlockKind, SequenceLineStyle, SequenceParticipantKind, TaskStatus,
+    TextAlign as GeoTextAlign,
 };
 use layout_ir::{Color, Content, FontSpec, PositionedNode, TextAlign, TextContent};
 use layout_to_paint::{layout_to_paint, LayoutToPaintOptions};
@@ -1086,6 +1087,91 @@ where
         a: 255,
     };
 
+    // Block frames are backgrounds. Paint outer frames before nested frames
+    // regardless of the order in which their closing events were laid out.
+    let mut frames: Vec<&LayoutedSequenceItem> = diagram
+        .items
+        .iter()
+        .filter(|item| matches!(item, LayoutedSequenceItem::BlockFrame { .. }))
+        .collect();
+    frames.sort_by_key(|item| match item {
+        LayoutedSequenceItem::BlockFrame { depth, .. } => *depth,
+        _ => unreachable!(),
+    });
+    for frame in frames {
+        if let LayoutedSequenceItem::BlockFrame {
+            kind,
+            label,
+            x,
+            y,
+            width,
+            height,
+            ..
+        } = frame
+        {
+            let (fill, stroke) = sequence_block_colors(kind);
+            instructions.push(PaintInstruction::Rect(PaintRect {
+                base: PaintBase::default(),
+                x: *x,
+                y: *y,
+                width: *width,
+                height: *height,
+                fill: Some(fill.into()),
+                stroke: Some(stroke.into()),
+                stroke_width: Some(1.25),
+                corner_radius: Some(4.0),
+                stroke_dash: None,
+                stroke_dash_offset: None,
+            }));
+            let frame_label = if label.is_empty() {
+                sequence_block_name(kind).to_string()
+            } else {
+                format!("{}  {label}", sequence_block_name(kind))
+            };
+            text_children.push(text_node(
+                &frame_label,
+                *x + 8.0,
+                *y + 6.0,
+                *width - 16.0,
+                20.0,
+                label_font.clone(),
+                text_color,
+            ));
+        }
+    }
+
+    for item in &diagram.items {
+        if let LayoutedSequenceItem::BlockDivider { label, x, y, width } = item {
+            instructions.push(PaintInstruction::Path(PaintPath {
+                base: PaintBase::default(),
+                commands: vec![
+                    PathCommand::MoveTo { x: *x, y: *y },
+                    PathCommand::LineTo {
+                        x: *x + *width,
+                        y: *y,
+                    },
+                ],
+                fill: None,
+                fill_rule: None,
+                stroke: Some("#64748b".into()),
+                stroke_width: Some(1.0),
+                stroke_cap: None,
+                stroke_join: None,
+                stroke_dash: Some(vec![4.0, 3.0]),
+                stroke_dash_offset: None,
+            }));
+            text_children.push(text_node(
+                label,
+                *x + 8.0,
+                *y + 5.0,
+                *width - 16.0,
+                20.0,
+                label_font.clone(),
+                text_color,
+            ));
+        }
+    }
+
     // Lifelines and messages sit behind activation bars, notes, and headers.
     for item in &diagram.items {
         match item {
@@ -1337,6 +1423,29 @@ where
         instructions,
         id: None,
         metadata: None,
+    }
+}
+
+fn sequence_block_name(kind: &SequenceBlockKind) -> &'static str {
+    match kind {
+        SequenceBlockKind::Loop => "loop",
+        SequenceBlockKind::Rect => "rect",
+        SequenceBlockKind::Opt => "opt",
+        SequenceBlockKind::Alt => "alt",
+        SequenceBlockKind::Par => "par",
+        SequenceBlockKind::ParOver => "par_over",
+        SequenceBlockKind::Critical => "critical",
+        SequenceBlockKind::Break => "break",
+    }
+}
+
+fn sequence_block_colors(kind: &SequenceBlockKind) -> (&'static str, &'static str) {
+    match kind {
+        SequenceBlockKind::Rect => ("#fff7ed", "#ea580c"),
+        SequenceBlockKind::Break => ("#fff1f2", "#e11d48"),
+        SequenceBlockKind::Critical => ("#fefce8", "#ca8a04"),
+        SequenceBlockKind::Par | SequenceBlockKind::ParOver => ("#f0fdfa", "#0f766e"),
+        _ => ("#f8fafc", "#64748b"),
     }
 }
 
@@ -2236,7 +2345,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.4.0");
+        assert_eq!(crate::VERSION, "0.5.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -348,7 +348,7 @@ mod apple {
     #[test]
     fn render_mermaid_sequence_to_png() {
         let diagram = parse_sequence_diagram(
-            "sequenceDiagram\ntitle Native Mermaid sequence\nautonumber\nactor User\nparticipant API as Banking API\nparticipant DB as Ledger\nUser->>+API: Submit transfer\nAPI->>DB: Record transaction\nDB-->>API: Committed\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete",
+            "sequenceDiagram\ntitle Native Mermaid sequence\nautonumber\nactor User\nparticipant API as Banking API\nparticipant DB as Ledger\nalt Transfer accepted\nUser->>+API: Submit transfer\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete\nelse Transfer rejected\nAPI-->>User: Validation failed\nend",
         )
         .expect("Mermaid sequence parse failed");
         let layout = layout_sequence_diagram(&diagram);
@@ -381,6 +381,11 @@ mod apple {
         assert!(scene.instructions.iter().any(|instruction| matches!(
             instruction,
             paint_instructions::PaintInstruction::Path(path) if path.stroke_dash.is_some()
+        )));
+        assert!(scene.instructions.iter().any(|instruction| matches!(
+            instruction,
+            paint_instructions::PaintInstruction::Rect(rect)
+                if rect.stroke.as_deref() == Some("#64748b")
         )));
     }
 }

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+- Added tokens for every Mermaid 11.16.1 sequence control block and branch separator.
+
 ## 0.3.0
 
 - Added a portable Mermaid 11.16.1 sequence token grammar and lexer entrypoint.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.3.0";
+pub const VERSION: &str = "0.4.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.3.0");
+        assert_eq!(VERSION, "0.4.0");
     }
 
     #[test]
@@ -292,5 +292,21 @@ mod tests {
         assert!(values.contains(&"+"));
         assert!(values.contains(&"note"));
         assert!(values.contains(&"Ready"));
+    }
+
+    #[test]
+    fn tokenizes_sequence_control_blocks() {
+        let tokens = tokenize_mermaid_sequence(
+            "sequenceDiagram\nalt Ready\nA->>B: Go\nelse Waiting\nloop Retry\nB-->>A: Wait\nend\nend\n",
+        );
+        let values: Vec<&str> = tokens
+            .iter()
+            .filter(|token| token.type_ != TokenType::Eof)
+            .map(|token| token.value.as_str())
+            .collect();
+        assert!(values.contains(&"alt"));
+        assert!(values.contains(&"else"));
+        assert!(values.contains(&"loop"));
+        assert_eq!(values.iter().filter(|value| **value == "end").count(), 2);
     }
 }

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.0
+
+- Added recursive grammar and semantic lowering for nested sequence control blocks.
+- Rejects unterminated blocks instead of silently degrading their contents.
+
 ## 0.4.0
 
 - Added grammar-backed sequence parsing for participants, actors, aliases,

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -35,8 +35,8 @@ Mermaid
 
 The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,
-activations, titles, and automatic numbering. Control blocks and advanced
-participant metadata remain explicit compatibility gaps.
+activations, titles, automatic numbering, and nested control blocks with branch
+separators. Advanced participant metadata remains an explicit compatibility gap.
 
 All other Mermaid 11.16.1 family headers are recognized and return an explicit
 `recognized but not implemented` error until their grammar, lowering, layout,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.4.0";
+pub const VERSION: &str = "0.5.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -447,8 +447,8 @@ fn token_name(token: &Token) -> &str {
 use diagram_ir::{
     Axis, AxisKind, ChartDiagram, ChartKind, ChartOrientation, ChartSeries, Compartment,
     CompartmentKind, GanttDiagram, GanttSection, GanttTask, GitBranch, GitCommitType, GitDiagram,
-    GitEvent, PieSlice, RelKind, SankeyFlow, SankeyNode, SequenceArrowhead, SequenceDiagram,
-    SequenceEvent, SequenceLineStyle, SequenceNotePlacement, SequenceParticipant,
+    GitEvent, PieSlice, RelKind, SankeyFlow, SankeyNode, SequenceArrowhead, SequenceBlockKind,
+    SequenceDiagram, SequenceEvent, SequenceLineStyle, SequenceNotePlacement, SequenceParticipant,
     SequenceParticipantKind, SeriesKind, StructuralDiagram, StructuralGroup, StructuralKind,
     StructuralNode, StructuralNodeKind, StructuralRelationship, TaskStart, TaskStatus,
     TemporalBody, TemporalDiagram, TemporalKind,
@@ -1037,7 +1037,19 @@ pub fn parse_sequence_diagram(source: &str) -> Result<SequenceDiagram, ParseErro
     };
     let mut participant_indices: HashMap<String, usize> = HashMap::new();
 
-    while !cursor.at_eof() {
+    parse_sequence_body(&mut cursor, &mut diagram, &mut participant_indices, &[])?;
+
+    Ok(diagram)
+}
+
+fn parse_sequence_body(
+    cursor: &mut TokenCursor,
+    diagram: &mut SequenceDiagram,
+    participant_indices: &mut HashMap<String, usize>,
+    terminators: &[&str],
+) -> Result<(), ParseError> {
+    cursor.skip_terminators();
+    while !cursor.at_eof() && !terminators.contains(&cursor.current().value.as_str()) {
         match cursor.current().value.as_str() {
             "participant" | "actor" => {
                 let kind = if cursor.advance().value == "actor" {
@@ -1045,34 +1057,28 @@ pub fn parse_sequence_diagram(source: &str) -> Result<SequenceDiagram, ParseErro
                 } else {
                     SequenceParticipantKind::Participant
                 };
-                let id = take_sequence_identifier(&mut cursor)?;
+                let id = take_sequence_identifier(cursor)?;
                 let label = if cursor.current().value == "as" {
                     cursor.advance();
-                    take_sequence_line_text(&mut cursor)
+                    take_sequence_line_text(cursor)
                 } else {
                     id.clone()
                 };
-                upsert_sequence_participant(
-                    &mut diagram,
-                    &mut participant_indices,
-                    id,
-                    label,
-                    kind,
-                );
+                upsert_sequence_participant(diagram, participant_indices, id, label, kind);
             }
             "activate" | "deactivate" => {
                 let active = cursor.advance().value == "activate";
-                let participant = take_sequence_identifier(&mut cursor)?;
-                ensure_sequence_participant(&mut diagram, &mut participant_indices, &participant);
+                let participant = take_sequence_identifier(cursor)?;
+                ensure_sequence_participant(diagram, participant_indices, &participant);
                 diagram.events.push(SequenceEvent::Activation {
                     participant,
                     active,
                 });
             }
-            "note" => parse_sequence_note(&mut cursor, &mut diagram, &mut participant_indices)?,
+            "note" => parse_sequence_note(cursor, diagram, participant_indices)?,
             "title" => {
                 cursor.advance();
-                diagram.title = Some(take_sequence_line_text(&mut cursor));
+                diagram.title = Some(take_sequence_line_text(cursor));
             }
             "autonumber" => {
                 cursor.advance();
@@ -1081,12 +1087,75 @@ pub fn parse_sequence_diagram(source: &str) -> Result<SequenceDiagram, ParseErro
                     cursor.advance();
                 }
             }
-            _ => parse_sequence_message(&mut cursor, &mut diagram, &mut participant_indices)?,
+            "loop" | "rect" | "opt" | "alt" | "par" | "par_over" | "critical" | "break" => {
+                parse_sequence_control_block(cursor, diagram, participant_indices)?
+            }
+            _ => parse_sequence_message(cursor, diagram, participant_indices)?,
         }
         cursor.skip_terminators();
     }
+    Ok(())
+}
 
-    Ok(diagram)
+fn parse_sequence_control_block(
+    cursor: &mut TokenCursor,
+    diagram: &mut SequenceDiagram,
+    participant_indices: &mut HashMap<String, usize>,
+) -> Result<(), ParseError> {
+    let start = cursor.advance().clone();
+    let (kind, branch_keyword) = match start.value.as_str() {
+        "loop" => (SequenceBlockKind::Loop, None),
+        "rect" => (SequenceBlockKind::Rect, None),
+        "opt" => (SequenceBlockKind::Opt, None),
+        "alt" => (SequenceBlockKind::Alt, Some("else")),
+        "par" => (SequenceBlockKind::Par, Some("and")),
+        "par_over" => (SequenceBlockKind::ParOver, Some("and")),
+        "critical" => (SequenceBlockKind::Critical, Some("option")),
+        "break" => (SequenceBlockKind::Break, None),
+        other => {
+            return Err(token_error(
+                &start,
+                format!("unsupported sequence control block {other:?}"),
+            ))
+        }
+    };
+    let label = take_sequence_line_text(cursor);
+    diagram.events.push(SequenceEvent::BlockStart {
+        kind: kind.clone(),
+        label,
+    });
+    cursor.skip_terminators();
+
+    loop {
+        let terminators = match branch_keyword {
+            Some(branch) => vec![branch, "end"],
+            None => vec!["end"],
+        };
+        parse_sequence_body(cursor, diagram, participant_indices, &terminators)?;
+        if cursor.at_eof() {
+            return Err(token_error(
+                cursor.current(),
+                format!("unterminated {:?} sequence block", kind),
+            ));
+        }
+        if cursor.current().value == "end" {
+            cursor.advance();
+            diagram.events.push(SequenceEvent::BlockEnd { kind });
+            return Ok(());
+        }
+
+        let branch = cursor.advance().clone();
+        if Some(branch.value.as_str()) != branch_keyword {
+            return Err(token_error(
+                &branch,
+                format!("unexpected sequence block branch {:?}", branch.value),
+            ));
+        }
+        diagram.events.push(SequenceEvent::BlockBranch {
+            label: take_sequence_line_text(cursor),
+        });
+        cursor.skip_terminators();
+    }
 }
 
 fn parse_sequence_message(
@@ -2543,6 +2612,40 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
             _ => panic!("expected Sequence"),
         }
     }
+
+    #[test]
+    fn sequence_parses_nested_control_blocks_and_branches() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\nalt Authorized\nAlice->>Bob: Submit\nloop Retry\nBob-->>Alice: Pending\nend\nelse Rejected\nBob-->>Alice: Denied\nend\n",
+        )
+        .unwrap();
+        assert!(matches!(
+            &diagram.events[0],
+            SequenceEvent::BlockStart { kind: SequenceBlockKind::Alt, label } if label == "Authorized"
+        ));
+        assert!(matches!(
+            &diagram.events[2],
+            SequenceEvent::BlockStart { kind: SequenceBlockKind::Loop, label } if label == "Retry"
+        ));
+        assert!(matches!(
+            &diagram.events[5],
+            SequenceEvent::BlockBranch { label } if label == "Rejected"
+        ));
+        assert!(matches!(
+            diagram.events.last(),
+            Some(SequenceEvent::BlockEnd {
+                kind: SequenceBlockKind::Alt
+            })
+        ));
+    }
+
+    #[test]
+    fn sequence_rejects_unterminated_control_block() {
+        let error = parse_sequence_diagram("sequenceDiagram\nopt Available\nA->>B: Ping\n")
+            .expect_err("unterminated opt must fail");
+        assert!(!error.message.is_empty());
+        assert!(error.line >= 2);
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -2559,7 +2662,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.4.0");
+        assert_eq!(crate::VERSION, "0.5.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -112,11 +112,14 @@ activation/deactivation, titles, and automatic numbering. It lowers through
 `diagram-layout-sequence` to existing path, rectangle, dashed-stroke, and glyph
 PaintInstructions and is exercised by a Mermaid-to-Metal-to-PNG fixture.
 
-The Mermaid 11.16.1 control blocks (`loop`, `opt`, `alt`, `par`, `critical`,
-`break`, and `rect`), participant creation/destruction and metadata, links, and
-advanced arrow variants remain compatibility work. The family remains partial
-until those forms and the pinned upstream corpus pass; unsupported forms must
-fail grammar validation rather than degrade silently.
+Nested Mermaid 11.16.1 control blocks (`loop`, `opt`, `alt`/`else`, `par`/`and`,
+`par_over`, `critical`/`option`, `break`, and `rect`) lower into ordered semantic
+block events. Sequence layout resolves those events into nested frames and
+branch dividers before existing PaintInstructions render them. Participant
+creation/destruction and metadata, links, and advanced arrow variants remain
+compatibility work. The family remains partial until those forms and the pinned
+upstream corpus pass; unsupported forms must fail grammar validation rather
+than degrade silently.
 
 ### Structural Groups
 


### PR DESCRIPTION
## Summary
- extend the portable Mermaid 11.16.1 sequence grammar with every recursive control block and branch separator
- preserve nested blocks as semantic start/branch/end events in sequence IR
- resolve block spans into depth-aware frames and branch dividers during sequence layout
- lower frames through existing PaintRect, PaintPath, dashed-stroke, and glyph instructions
- validate nested `alt`/`else` plus `loop` through Metal-to-PNG

## Supported constructs
`loop`, `rect`, `opt`, `alt`/`else`, `par`/`and`, `par_over`, `critical`/`option`, and `break`, including arbitrary nesting.

## Verification
- `cargo test -p diagram-ir -p diagram-layout-sequence -p mermaid-lexer -p mermaid-parser -p diagram-to-paint -- --nocapture`
- `cargo clippy -p diagram-ir -p diagram-layout-sequence -p mermaid-lexer -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- visually inspected `/tmp/mermaid_sequence_e2e.png`
