### PR TITLE
Verify Tamil ன handwriting ductus

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -68,11 +68,11 @@ HL-C77 closes that migration boundary: all 41 Spanish book chapters now generate
 from the same canonical lesson ASTs used by Language Ladder, narration, objective
 activities, and back matter. The twelve former handwritten entries are protected
 generated targets with checked hashes, titles, labels, order, and output. HL-C19
-is already complete; HL-C09A verified Tamil அ in #10222, HL-C09B verified
-Tamil ஆ in #10223, HL-C09C verified Tamil இ in #10226, HL-C09D verified
-Tamil க in #10228, HL-C09E verified Tamil வ in #10230, and HL-C09F verified
-Tamil ல in #10234. HL-C09G is the next bounded stroke-order tranche: verify
-Tamil ற from Frame 10 of the cited primer before widening DUCTUS across scripts.
+is already complete; HL-C09A through HL-C09G verified Tamil அ, ஆ, இ, க, வ, ல,
+and ற in #10222, #10223, #10226, #10228, #10230, #10234, and #10240. HL-C09H
+verifies Tamil ன from Frame 13's first row in #10244. HL-C09I is the next
+bounded stroke-order tranche: verify the adjacent three-loop ண row from the
+same source page before widening DUCTUS across scripts.
 The index audit found **2,075** canonical candidates across the corpus: **1,426**
 word and phrase lessons for English-first lookup, **136** dedicated grammar,
 writing, etymology, culture, and pronunciation lessons, **427** chapter
@@ -232,7 +232,7 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C06 | Complete (#10219) | Add the figure pipeline: SVG generation, `graphicx`, SVG→PDF in CI, and a `--check` hash gate. | A generated figure round-trips from canonical data into a compiled PDF and fails CI on drift, reusing `paint-vm-svg`'s `renderToSvgString`. |
 | HL-C07 | Complete (#9963) | Add the log-scanning warning gate with recorded per-track baselines. | Overfull/underfull boxes, missing glyphs, hyperref warnings, duplicate destinations, and font substitutions are machine-checked by `scan_latex_log_warnings.py` after the `latexmk` loop, against `core/latex-warning-baseline.json`. Baselines ship unseeded — `null` means unmeasured, never zero — so the gate reports today and fails the moment a seeded track regresses. The first CI run on main emits the real counts into the job summary for a human to paste back. |
 | HL-C08 | Complete (#9974) | Render the ductus in Language Ladder. | `penPathD`/`penTip` drive the tested SVG stroke build-up in the app; the currently authored ductus is shared with validation and script practice. |
-| HL-C09 | Queued — 8 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 220 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
+| HL-C09 | Queued — 9 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 219 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
 | HL-C09A | Complete (#10222) | Verify Tamil அ as the first post-HL-C19 expansion tranche, using the primer already cited for Tamil handwriting. | அ carries a source-aligned two-stroke path with exactly one lift; its five movements, learner prose, source metadata, font-outline geometry, and rendered filmstrip agree. |
 | HL-C09B | Complete (#10223) | Verify Tamil ஆ as the next source-backed expansion tranche from Frame 4 of the same primer. | ஆ carries a font-checked path for the அ body plus its long-vowel right-hand loop; its learner prose states every verified lift, and source, geometry, and filmstrip tests agree. |
 | HL-C09C | Complete (#10226) | Verify Tamil இ as Frame 4's third source-backed vowel tranche. | இ carries a seven-movement, font-checked path whose learner prose states each evidenced lift; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
@@ -240,6 +240,8 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C09E | Complete (#10230) | Verify Tamil வ from Frame 9's first source-backed consonant row. | வ carries a five-movement, font-checked unbroken path whose learner prose states the evidenced zero lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C09F | Complete (#10234) | Verify Tamil ல from Frame 9's second source-backed consonant row. | ல carries a four-movement, font-checked unbroken path whose learner prose states the evidenced zero lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C09G | Complete (#10240) | Verify Tamil ற from the source-adjacent Frame 10 row. | ற carries a five-movement, font-checked three-stroke path whose learner prose states the two evidenced lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
+| HL-C09H | Complete (#10244) | Verify Tamil ன from Frame 13's first source-backed nasal row. | ன carries a six-movement, font-checked two-stroke path whose first five movements stay joined before the separate right upright; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
+| HL-C09I | Queued — next | Verify Tamil ண from Frame 13's adjacent source-backed three-loop nasal row. | Preserve the cited seven-movement order, verify every lift against an authored Noto-backed path, and keep the learner prose, source metadata, and real filmstrip in agreement. |
 | HL-C10 | Complete (#10010, #10013, #10067) | Complete A1 and add the A2-through-C2 spine tranches with all registered realization ledgers. | All seven declared stages carry nodes; every one of the 22 registered tracks has a non-drifting ledger entry for every node. |
 | HL-C11 | Queued — capability and closure coverage complete | Finish representative chapter payoffs across all 22 tracks. | #10128 brought all 513 chapters to an authored `canDo`, spine mapping, known payoff lesson, and closed assessment. Remediate the remaining 27 payoffs below the 0.5 representativeness floor across ten tracks, then enforce the clean tracks instead of leaving their gates report-only. |
 | HL-C12 | Queued — licensing decided, pipeline outstanding | Add the Class C illustration pipeline with provenance sidecars and a size budget. Licensing is settled and recorded in [`_assets/LICENSE.md`](./_assets/LICENSE.md); the remaining work is the pipeline itself. | Every asset carries `license`, `rightsAsserted`, `generator`, `model`, `prompt`, `date`, and `sha256`; CI fails any asset without a provenance sidecar or a recorded licence, and enforces the per-track size budget. |
@@ -2642,7 +2644,7 @@ problem.
   **61 glyph violations plus five multi-system Japanese openings**. The current
   corpus is 91% core-drivable, not the historical 84% recorded before later work.
 - HL-C19 supersedes HL-C09's old estimate. There are **228** prose stroke-order
-  entries across ten scripts: eight verified ductus paths and 220 entries still needing cited,
+  entries across ten scripts: nine verified ductus paths and 219 entries still needing cited,
   font-checked pen-lift evidence.
 
 ## Findings from HL-C05

--- a/code/learning/human-languages/data/scripts/README.md
+++ b/code/learning/human-languages/data/scripts/README.md
@@ -130,7 +130,7 @@ and given the same citation.
 4. Where no ductus exists, do not invent lifts — keep the steps as part order and
    leave `penLifts` out.
 
-Tamil **அ**, **ஆ**, **இ**, **க**, **வ**, **ல**, and **ற** now join **ம** with authored ductus paths. The primer's
+Tamil **அ**, **ஆ**, **இ**, **க**, **வ**, **ல**, **ற**, and **ன** now join **ம** with authored ductus paths. The primer's
 Frame 4 shows four connected movements for their shared curl-and-loop body,
 followed by one lift and the separate right upright; ஆ then continues without
 another lift into its long-vowel loop. Frame 4's next row gives இ five joined
@@ -143,10 +143,12 @@ traces ல's outward spiral, middle descent, deep right-hand turn, and open tip
 as four movements without lifting. Frame 10 joins ற's left arch to its first
 middle descent, restarts for the adjacent descent, then joins the right arch to
 the below-baseline sweep and descender: five movements, three runs, and two
-lifts. The remaining **220** prose part
+lifts. Frame 13's first row joins ன's left spiral, single inner arch, and top
+bar as five movements, then lifts once before the separate right upright. The
+remaining **219** prose part
 orders across ten scripts (`arabic` 21, `chinese` 24, `cyrillic` 33,
 `devanagari` 28, `gujarati` 33, `hebrew` 22, `japanese` 34,
-`perso-arabic` 9, `tamil` 3, `urdu-nastaliq` 13) are explicitly **unverified for
+`perso-arabic` 9, `tamil` 2, `urdu-nastaliq` 13) are explicitly **unverified for
 pen lifts**. The data validator rejects a lift count without a citation (or a
 citation without a count), and Language Ladder's ductus test proves every verified
 claim has the same cited, font-checked path. That closes `HL-C19`; future entries

--- a/code/learning/human-languages/data/scripts/tamil.json
+++ b/code/learning/human-languages/data/scripts/tamil.json
@@ -7,7 +7,7 @@
   "signature": "Curvy and loopy with flat top-bars on many letters, repeated arches, and no continuous head-line.",
   "complete": false,
   "combination": "A consonant carries an inherent 'a' (க = ka). A vowel sign replaces that vowel (க + ா → கா = kā). The puḷḷi ் — a DOT above the letter — removes the vowel entirely (க் = k). Unlike Devanagari, Tamil does NOT fuse the bare consonant into a conjunct: the dot stays visible and both letters keep their full shape. (A handful of Sanskrit-borrowed ligatures are the exception — க்ஷ kṣa and ஸ்ரீ śrī.)",
-  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, இ, க, ம, வ, ல, and ற have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ and ஆ each have two pen-down runs with one lift before the separate right upright; ஆ then continues into its long-vowel loop without another lift. இ keeps its first five movements joined, lifts once before the outer-left climb, and joins that climb to the final arch. க and ற each use three pen-down runs with two verified lifts. ம, வ, and ல are each a single unbroken stroke even though their parts have separate names. The other three letters here have no verified pen path, so read their steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
+  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, இ, க, ம, வ, ன, ல, and ற have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ, ஆ, இ, and ன each have two pen-down runs with one verified lift; ஆ continues from its upright into the long-vowel loop, இ joins its outer-left climb to the final arch, and ன joins its first five movements before the separate right upright. க and ற each use three pen-down runs with two verified lifts. ம, வ, and ல are each a single unbroken stroke even though their parts have separate names. The other two letters here have no verified pen path, so read their steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
   "letters": [
     {
       "glyph": "அ",
@@ -167,10 +167,23 @@
       "sound": "ṉa",
       "role": "consonant",
       "inherentVowel": "a",
-      "components": ["a straight top bar", "a loop on the left", "ONE arch", "a straight vertical on the right, down to the baseline"],
-      "strokeOrder": ["top bar", "left loop", "arch", "right vertical"],
-      "strokeOrderNote": "conventional",
-      "notes": "The alveolar n — and visibly ண MINUS ONE ARCH. ண has two arches between the loop and the final vertical; ன has one. Both end in the same straight vertical."
+      "components": ["a spiral loop on the left", "ONE rounded inner arch", "a straight top bar", "a separate straight vertical on the right, down to the baseline"],
+      "strokeOrder": [
+        "start in the lower-left curl and spiral outward, climbing the outer left side",
+        "without lifting, arch over the top of the left loop to the middle junction",
+        "without lifting, descend around the outside of the single inner arch",
+        "without lifting, turn through its bottom and climb the inside back to the top junction",
+        "without lifting, carry the top bar to the right edge — then lift once",
+        "set the pen at the top of the separate right upright and draw straight down — and only now lift"
+      ],
+      "strokeOrderNote": "two strokes — five joined loop, arch, and top-bar movements, one pen lift, then the right upright; cited to Radhakrishnan, Tamil Script Learners Manual, Frame 13, ன",
+      "penLifts": 1,
+      "strokeOrderSource": {
+        "citation": "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 13, ன (Univ. of Texas at Austin), p. 195",
+        "url": "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+        "variation": "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order."
+      },
+      "notes": "The alveolar n — and visibly ண minus one arch. Frame 13's first row numbers six movements, not six strokes: the first five stay connected through the left spiral, single arch, and top bar; only the separate right upright requires a lift."
     },
     {
       "glyph": "ல",

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -48,6 +48,13 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
   one lift, and a second lift precedes the right arch's joined below-baseline
   sweep and descender, matching Frame 10 and Language Ladder's font-checked path.
 
+### Added - verified Tamil ன handwriting
+
+- Record Frame 13's cited six-movement order for Tamil ன as two pen-down runs:
+  the left spiral, single inner arch, and top bar stay connected through five
+  movements, then one lift precedes the separate right upright, matching
+  Language Ladder's font-checked path.
+
 ### Added - generated lesson figures
 
 - Generate deterministic etymology-route SVGs from the canonical lesson `roots`

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -59,6 +59,14 @@
 - Check all five movements against the Noto Sans Tamil outline and pin both
   lift transitions in the real filmstrip and learner prose.
 
+### Added — cited two-stroke ductus for Tamil ன (HL-C09H)
+
+- Add Frame 13's first Tamil nasal row, ன: five joined movements carry its left
+  spiral through the single inner arch and top bar, then one verified lift
+  precedes the separate right upright.
+- Check all six movements against the Noto Sans Tamil outline and pin the sole
+  lift transition in the real filmstrip and learner prose.
+
 ### Added — canonical lesson figures
 
 - Preserve standalone Markdown images as typed lesson blocks instead of flattening

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -165,7 +165,7 @@ in font units, and `ductusview.ts` flips them together with exactly **one**
 `scale(1,-1)` group — so a mistake cannot leave a plausible-looking stroke
 sitting upside down on a correct letter.
 
-**Tamil அ, ஆ, இ, க, ம, வ, ல, and ற have authored pen paths today.** `DUCTUS` admits no letter
+**Tamil அ, ஆ, இ, க, ம, வ, ல, ற, and ன have authored pen paths today.** `DUCTUS` admits no letter
 without a citation for its stroke order, and hand-drawing a letter is forbidden
 outright (a subtly wrong Tamil ண looks perfect to exactly the audience that
 cannot yet read Tamil, so the error would ship *as the lesson*). அ and ஆ exercise
@@ -178,9 +178,11 @@ right upright in one five-movement run with no lift. ல carries its outward
 spiral through a middle descent and deep right-hand turn to the open tip in one
 four-movement run with no lift. ற uses three pen-down runs: its left arch joins
 the first middle descent, the adjacent descent restarts after one lift, and a
-second lift precedes the right arch's joined sweep and descender. Every other
-letter falls back to the numbered prose list, unchanged. Extending the coverage
-is HL-C09, and it needs a cited source per letter.
+second lift precedes the right arch's joined sweep and descender. ன joins its
+left spiral, single inner arch, and top bar through five movements before one
+lift precedes its separate right upright. Every other letter falls back to the
+numbered prose list, unchanged. Extending the coverage is HL-C09, and it needs a
+cited source per letter.
 
 ## Where it fits
 

--- a/code/programs/typescript/language-ladder/src/strokes.ts
+++ b/code/programs/typescript/language-ladder/src/strokes.ts
@@ -879,6 +879,110 @@ export const DUCTUS: Record<string, LetterDuctus> = {
         "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",
     },
   },
+  ன: {
+    glyph: "ன",
+    strokes: [
+      {
+        segments: [
+          {
+            label: "curl outward and climb the outer left",
+            path: [
+              { x: 300, y: 35 },
+              { x: 310, y: 55 },
+              { x: 350, y: 90 },
+              { x: 380, y: 145 },
+              { x: 380, y: 205 },
+              { x: 340, y: 260 },
+              { x: 285, y: 292 },
+              { x: 225, y: 290 },
+              { x: 170, y: 275 },
+              { x: 120, y: 275 },
+              { x: 95, y: 270 },
+              { x: 95, y: 180 },
+              { x: 115, y: 105 },
+              { x: 175, y: 45 },
+              { x: 250, y: 25 },
+              { x: 175, y: 45 },
+              { x: 115, y: 105 },
+              { x: 95, y: 180 },
+              { x: 95, y: 270 },
+              { x: 120, y: 360 },
+              { x: 180, y: 450 },
+            ],
+          },
+          {
+            label: "arch over the left loop to the middle",
+            path: [
+              { x: 180, y: 450 },
+              { x: 270, y: 520 },
+              { x: 370, y: 530 },
+              { x: 470, y: 520 },
+              { x: 560, y: 500 },
+              { x: 650, y: 495 },
+            ],
+          },
+          {
+            label: "descend around the single inner arch",
+            path: [
+              { x: 650, y: 495 },
+              { x: 700, y: 455 },
+              { x: 750, y: 400 },
+              { x: 785, y: 320 },
+              { x: 785, y: 230 },
+              { x: 770, y: 140 },
+              { x: 735, y: 75 },
+              { x: 690, y: 35 },
+              { x: 660, y: 25 },
+            ],
+          },
+          {
+            label: "turn through the bottom and climb inside",
+            path: [
+              { x: 660, y: 25 },
+              { x: 610, y: 45 },
+              { x: 555, y: 100 },
+              { x: 540, y: 180 },
+              { x: 545, y: 260 },
+              { x: 565, y: 350 },
+              { x: 600, y: 430 },
+              { x: 650, y: 495 },
+            ],
+          },
+          {
+            label: "carry the top bar right",
+            path: [
+              { x: 650, y: 495 },
+              { x: 720, y: 515 },
+              { x: 850, y: 518 },
+              { x: 1000, y: 518 },
+              { x: 1100, y: 518 },
+              { x: 1210, y: 518 },
+            ],
+          },
+        ],
+      },
+      {
+        segments: [
+          {
+            label: "descend the separate right upright",
+            path: [
+              { x: 1004, y: 480 },
+              { x: 1004, y: 350 },
+              { x: 1004, y: 180 },
+              { x: 1004, y: 25 },
+            ],
+          },
+        ],
+      },
+    ],
+    source: {
+      citation:
+        "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 13, ன (Univ. of Texas at Austin), p. 195",
+      url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+      variation:
+        "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",
+    },
+  },
   ம: {
     glyph: "ம",
     strokes: [

--- a/code/programs/typescript/language-ladder/tests/ductusview.test.ts
+++ b/code/programs/typescript/language-ladder/tests/ductusview.test.ts
@@ -63,6 +63,8 @@ const LA = DUCTUS["ல"];
 const laOutline = tamilOutline("ல");
 const RRA = DUCTUS["ற"];
 const rraOutline = tamilOutline("ற");
+const NNA = DUCTUS["ன"];
+const nnaOutline = tamilOutline("ன");
 
 /** Walk a node tree, collecting every node the predicate accepts. */
 function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = []): SvgNode[] {
@@ -74,7 +76,7 @@ function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = 
 const byTag = (node: SvgNode, tag: string) => collect(node, (n) => n.tag === tag);
 
 describe("ductusFor — only cited letters have a ductus", () => {
-  it("finds all eight authored Tamil letters", () => {
+  it("finds all nine authored Tamil letters", () => {
     expect(ductusFor("ம")?.glyph).toBe("ம");
     expect(ductusFor("அ")?.glyph).toBe("அ");
     expect(ductusFor("ஆ")?.glyph).toBe("ஆ");
@@ -83,6 +85,7 @@ describe("ductusFor — only cited letters have a ductus", () => {
     expect(ductusFor("வ")?.glyph).toBe("வ");
     expect(ductusFor("ல")?.glyph).toBe("ல");
     expect(ductusFor("ற")?.glyph).toBe("ற");
+    expect(ductusFor("ன")?.glyph).toBe("ன");
   });
 
   it("returns undefined for a letter nobody has authored a stroke order for", () => {
@@ -459,6 +462,31 @@ describe("ற — a real cited three-stroke five-movement filmstrip", () => {
     expect(done).toHaveLength(2);
     expect(done.map((path) => path.attrs.d)).toEqual([penPathD(RRA.strokes[0], 1), penPathD(RRA.strokes[1], 1)]);
     expect(pen.attrs.d).toBe(penPathD(RRA.strokes[2], 1));
+  });
+});
+
+describe("ன — a real cited two-stroke six-movement filmstrip", () => {
+  const steps = ductusSteps(NNA);
+  const strip = ductusFilmstrip(NNA, nnaOutline);
+
+  it("joins the loop, inner arch, and top bar before the sole lift", () => {
+    expect(steps.map((step) => step.startsAfterLift)).toEqual([false, false, false, false, false, true]);
+    expect(steps.map((step) => step.strokeIndex)).toEqual([0, 0, 0, 0, 0, 1]);
+  });
+
+  it("reports six movements in two strokes with one lift", () => {
+    expect(strip.frames).toHaveLength(6);
+    expect(strip.penLifts).toBe(1);
+    expect(strip.summary).toBe("2 strokes · 1 pen lift · 6 movements");
+  });
+
+  it("keeps the completed loop-and-bar stroke visible while drawing the upright", () => {
+    const last = strip.frames[5];
+    const done = byTag(last, "path").filter((path) => path.attrs.class === "ductus__done");
+    const pen = byTag(last, "path").find((path) => path.attrs.class === "ductus__pen")!;
+    expect(done).toHaveLength(1);
+    expect(done[0].attrs.d).toBe(penPathD(NNA.strokes[0], 1));
+    expect(pen.attrs.d).toBe(penPathD(NNA.strokes[1], 1));
   });
 });
 

--- a/code/programs/typescript/language-ladder/tests/strokes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/strokes.test.ts
@@ -216,6 +216,12 @@ describe("handwriting ductus", () => {
     expect(DUCTUS["ற"].strokes.map((stroke) => stroke.segments.length)).toEqual([2, 1, 2]);
   });
 
+  it("ன joins its first five movements before the right upright", () => {
+    expect(penLifts(DUCTUS["ன"])).toBe(1);
+    expect(DUCTUS["ன"].strokes).toHaveLength(2);
+    expect(DUCTUS["ன"].strokes.map((stroke) => stroke.segments.length)).toEqual([5, 1]);
+  });
+
   // The PROVENANCE GATE. A stroke's SHAPE is checked against the font above;
   // its ORDER cannot be — so it must trace to a cited source, or it does not
   // ship. This is the counterpart, for hand-authored order, of "facts enter
@@ -303,6 +309,13 @@ describe("handwriting ductus", () => {
     const src = DUCTUS["ற"].source;
     expect(src.url).toContain("tamilscript");
     expect(src.citation).toMatch(/Appendix I.*Frame 10.*ற/);
+    expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
+  });
+
+  it("ன's stroke order traces to Frame 13's first row", () => {
+    const src = DUCTUS["ன"].source;
+    expect(src.url).toContain("tamilscript");
+    expect(src.citation).toMatch(/Appendix I.*Frame 13.*ன/);
     expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
   });
 });


### PR DESCRIPTION
## Summary

- verify Tamil ன against Frame 13's first row in Sankaran Radhakrishnan's UT Austin *Tamil Script Learners Manual*
- add a six-movement, font-checked two-stroke ductus: five joined loop/arch/top-bar movements, one lift, then the separate right upright
- keep learner prose, source metadata, Noto geometry tests, and the real filmstrip in agreement
- advance HL-C09 coverage to 9 of 228 verified entries, with 219 remaining

## Validation

- `bash BUILD` in `code/packages/typescript/human-language-data` — 460 tests passed with coverage
- `bash BUILD` in `code/programs/typescript/language-ladder` — typecheck, production build, bundle gate, and 599 tests passed
- `bash code/scripts/verify-human-languages.sh --fast` — all drift gates, app/data tests, and Python helpers passed after rebasing onto current `origin/main`
- `git diff --check`