### PR TITLE
Add Mermaid sequence participant lifecycles

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -3,9 +3,10 @@
 
 document = { NEWLINE } HEADER body EOF ;
 body = { NEWLINE | statement } ;
-statement = participant_stmt | message_stmt | activation_stmt | note_stmt | title_stmt | autonumber_stmt | control_block ;
+statement = participant_stmt | destroy_stmt | message_stmt | activation_stmt | note_stmt | title_stmt | autonumber_stmt | control_block ;
 
-participant_stmt = ( "participant" | "actor" ) identifier [ "as" text ] ;
+participant_stmt = [ "create" ] ( "participant" | "actor" ) identifier [ "as" text ] ;
+destroy_stmt = "destroy" identifier ;
 message_stmt = identifier message_arrow [ PLUS | MINUS ] identifier COLON [ text ] ;
 activation_stmt = ( "activate" | "deactivate" ) identifier ;
 note_stmt = "note" ( ( "left" | "right" ) "of" identifier | "over" actor_pair ) COLON text ;

--- a/code/grammars/mermaid/sequence.tokens
+++ b/code/grammars/mermaid/sequence.tokens
@@ -28,6 +28,8 @@ WORD                     = /[^ \t\r\n:,+-]+/
 keywords:
   participant
   actor
+  create
+  destroy
   as
   activate
   deactivate

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.6.0
+
+- Added sequence participant creation/destruction events and destruction geometry.
+
 ## 0.5.0
 
 - Added nested sequence block start, branch, and end events.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.5.0 — DG00/DG04 semantic IR
+//! diagram-ir v0.6.0 — DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.5.0";
+pub const VERSION: &str = "0.6.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -217,6 +217,12 @@ pub enum SequenceEvent {
         participant: String,
         active: bool,
     },
+    ParticipantCreated {
+        participant: String,
+    },
+    ParticipantDestroyed {
+        participant: String,
+    },
     Note {
         participants: Vec<String>,
         placement: SequenceNotePlacement,
@@ -274,6 +280,11 @@ pub enum LayoutedSequenceItem {
         x: f64,
         y1: f64,
         y2: f64,
+    },
+    Destruction {
+        participant: String,
+        x: f64,
+        y: f64,
     },
     Note {
         x: f64,
@@ -850,8 +861,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_is_0_5_0() {
-        assert_eq!(VERSION, "0.5.0");
+    fn version_is_0_6_0() {
+        assert_eq!(VERSION, "0.6.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0 - 2026-08-09
+
+- Place created participant headers at their event and bound lifelines at destruction.
+
 ## 0.2.0 - 2026-08-09
 
 - Resolve nested sequence block events into frames and labeled branch dividers.

--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-sequence"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
 

--- a/code/packages/rust/diagram-layout-sequence/README.md
+++ b/code/packages/rust/diagram-layout-sequence/README.md
@@ -4,4 +4,5 @@ Backend-neutral layout for sequence diagrams. It converts participants and
 ordered events into participant boxes, lifelines, message routes, notes, and
 activation bars for `diagram-to-paint`. Nested control-block events become
 depth-aware frames and labeled branch dividers without introducing paint or
-backend concepts into semantic IR.
+backend concepts into semantic IR. Participant lifecycle events place dynamic
+headers and bound their lifelines to explicit destruction markers.

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -1,13 +1,13 @@
 //! Backend-neutral sequence diagram layout.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use diagram_ir::{
     LayoutedSequenceDiagram, LayoutedSequenceItem, SequenceBlockKind, SequenceDiagram,
     SequenceEvent, SequenceNotePlacement,
 };
 
-pub const VERSION: &str = "0.2.0";
+pub const VERSION: &str = "0.3.0";
 
 const MARGIN: f64 = 28.0;
 const HEADER_Y: f64 = 42.0;
@@ -42,7 +42,17 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
         })
         .collect();
     let width = lane_widths.iter().sum::<f64>() + MARGIN * 2.0;
+    let created_participants: HashSet<&str> = diagram
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            SequenceEvent::ParticipantCreated { participant } => Some(participant.as_str()),
+            _ => None,
+        })
+        .collect();
     let mut centers = HashMap::new();
+    let mut lifeline_starts = HashMap::new();
+    let mut lifeline_ends = HashMap::new();
     let mut items = Vec::new();
     let mut x = MARGIN;
 
@@ -50,15 +60,18 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
         let box_width = (*lane_width - 24.0).max(100.0);
         let center = x + *lane_width / 2.0;
         centers.insert(participant.id.clone(), center);
-        items.push(LayoutedSequenceItem::ParticipantBox {
-            id: participant.id.clone(),
-            label: participant.label.text.clone(),
-            kind: participant.kind.clone(),
-            x: center - box_width / 2.0,
-            y: HEADER_Y,
-            width: box_width,
-            height: HEADER_H,
-        });
+        if !created_participants.contains(participant.id.as_str()) {
+            items.push(LayoutedSequenceItem::ParticipantBox {
+                id: participant.id.clone(),
+                label: participant.label.text.clone(),
+                kind: participant.kind.clone(),
+                x: center - box_width / 2.0,
+                y: HEADER_Y,
+                width: box_width,
+                height: HEADER_H,
+            });
+            lifeline_starts.insert(participant.id.clone(), HEADER_Y + HEADER_H);
+        }
         x += *lane_width;
     }
 
@@ -125,6 +138,44 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                         participant_x,
                         y,
                     );
+                }
+                y += EVENT_H / 2.0;
+            }
+            SequenceEvent::ParticipantCreated { participant } => {
+                if let (Some(&center), Some(definition)) = (
+                    centers.get(participant),
+                    diagram
+                        .participants
+                        .iter()
+                        .find(|item| item.id == *participant),
+                ) {
+                    let lane_index = diagram
+                        .participants
+                        .iter()
+                        .position(|item| item.id == *participant)
+                        .unwrap_or(0);
+                    let box_width = (lane_widths[lane_index] - 24.0).max(100.0);
+                    items.push(LayoutedSequenceItem::ParticipantBox {
+                        id: definition.id.clone(),
+                        label: definition.label.text.clone(),
+                        kind: definition.kind.clone(),
+                        x: center - box_width / 2.0,
+                        y,
+                        width: box_width,
+                        height: HEADER_H,
+                    });
+                    lifeline_starts.insert(participant.clone(), y + HEADER_H);
+                }
+                y += EVENT_H;
+            }
+            SequenceEvent::ParticipantDestroyed { participant } => {
+                if let Some(&center) = centers.get(participant) {
+                    items.push(LayoutedSequenceItem::Destruction {
+                        participant: participant.clone(),
+                        x: center,
+                        y,
+                    });
+                    lifeline_ends.insert(participant.clone(), y);
                 }
                 y += EVENT_H / 2.0;
             }
@@ -216,8 +267,14 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
             items.push(LayoutedSequenceItem::Lifeline {
                 participant: participant.id.clone(),
                 x: center,
-                y1: HEADER_Y + HEADER_H,
-                y2: height - 20.0,
+                y1: lifeline_starts
+                    .get(&participant.id)
+                    .copied()
+                    .unwrap_or(HEADER_Y + HEADER_H),
+                y2: lifeline_ends
+                    .get(&participant.id)
+                    .copied()
+                    .unwrap_or(height - 20.0),
             });
             if let Some(starts) = activation_starts.remove(&participant.id) {
                 for start in starts {
@@ -391,5 +448,79 @@ mod tests {
         assert!(frames.iter().any(|(depth, _, _)| *depth == 1));
         assert!(frames.iter().all(|(_, _, height)| *height > BLOCK_HEADER_H));
         assert!(layout.items.iter().any(|item| matches!(item, LayoutedSequenceItem::BlockDivider { label, .. } if label == "Fallback")));
+    }
+
+    #[test]
+    fn created_participant_has_bounded_lifeline() {
+        let diagram = SequenceDiagram {
+            title: None,
+            auto_number: false,
+            participants: vec![participant("Alice"), participant("Worker")],
+            events: vec![
+                SequenceEvent::Message {
+                    from: "Alice".into(),
+                    to: "Alice".into(),
+                    label: "Start".into(),
+                    line_style: SequenceLineStyle::Solid,
+                    arrowhead: SequenceArrowhead::Filled,
+                    bidirectional: false,
+                    activate: false,
+                    deactivate: false,
+                },
+                SequenceEvent::ParticipantCreated {
+                    participant: "Worker".into(),
+                },
+                SequenceEvent::Message {
+                    from: "Alice".into(),
+                    to: "Worker".into(),
+                    label: "Work".into(),
+                    line_style: SequenceLineStyle::Solid,
+                    arrowhead: SequenceArrowhead::Filled,
+                    bidirectional: false,
+                    activate: false,
+                    deactivate: false,
+                },
+                SequenceEvent::ParticipantDestroyed {
+                    participant: "Worker".into(),
+                },
+            ],
+        };
+        let layout = layout_sequence_diagram(&diagram);
+        let worker_box_y = layout
+            .items
+            .iter()
+            .find_map(|item| match item {
+                LayoutedSequenceItem::ParticipantBox { id, y, .. } if id == "Worker" => Some(*y),
+                _ => None,
+            })
+            .unwrap();
+        let (lifeline_y1, lifeline_y2) = layout
+            .items
+            .iter()
+            .find_map(|item| match item {
+                LayoutedSequenceItem::Lifeline {
+                    participant,
+                    y1,
+                    y2,
+                    ..
+                } if participant == "Worker" => Some((*y1, *y2)),
+                _ => None,
+            })
+            .unwrap();
+        let destruction_y = layout
+            .items
+            .iter()
+            .find_map(|item| match item {
+                LayoutedSequenceItem::Destruction { participant, y, .. }
+                    if participant == "Worker" =>
+                {
+                    Some(*y)
+                }
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(lifeline_y1, worker_box_y + HEADER_H);
+        assert_eq!(lifeline_y2, destruction_y);
+        assert!(worker_box_y > HEADER_Y);
     }
 }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added sequence lowering for participant headers, lifelines, messages,
   arrowheads, notes, activation bars, and shaped labels, plus a Metal PNG test.
 - Added nested sequence frame and branch-divider lowering with visual Metal coverage.
+- Added sequence destruction markers and dynamic participant Metal coverage.
 
 ## 0.1.2 — Fix text coordinate-space mismatch (text now inside nodes)
 

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.5.0";
+pub const VERSION: &str = "0.6.0";
 
 use std::collections::HashMap;
 
@@ -1299,6 +1299,37 @@ where
                     stroke_dash_offset: None,
                 }));
             }
+            LayoutedSequenceItem::Destruction { x, y, .. } => {
+                instructions.push(PaintInstruction::Path(PaintPath {
+                    base: PaintBase::default(),
+                    commands: vec![
+                        PathCommand::MoveTo {
+                            x: *x - 7.0,
+                            y: *y - 7.0,
+                        },
+                        PathCommand::LineTo {
+                            x: *x + 7.0,
+                            y: *y + 7.0,
+                        },
+                        PathCommand::MoveTo {
+                            x: *x + 7.0,
+                            y: *y - 7.0,
+                        },
+                        PathCommand::LineTo {
+                            x: *x - 7.0,
+                            y: *y + 7.0,
+                        },
+                    ],
+                    fill: None,
+                    fill_rule: None,
+                    stroke: Some("#dc2626".into()),
+                    stroke_width: Some(2.0),
+                    stroke_cap: Some(StrokeCap::Round),
+                    stroke_join: None,
+                    stroke_dash: None,
+                    stroke_dash_offset: None,
+                }));
+            }
             LayoutedSequenceItem::Note {
                 x,
                 y,
@@ -2345,7 +2376,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.5.0");
+        assert_eq!(crate::VERSION, "0.6.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -348,7 +348,7 @@ mod apple {
     #[test]
     fn render_mermaid_sequence_to_png() {
         let diagram = parse_sequence_diagram(
-            "sequenceDiagram\ntitle Native Mermaid sequence\nautonumber\nactor User\nparticipant API as Banking API\nparticipant DB as Ledger\nalt Transfer accepted\nUser->>+API: Submit transfer\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete\nelse Transfer rejected\nAPI-->>User: Validation failed\nend",
+            "sequenceDiagram\ntitle Native Mermaid sequence\nautonumber\nactor User\nparticipant API as Banking API\nparticipant DB as Ledger\nalt Transfer accepted\nUser->>+API: Submit transfer\ncreate participant Worker as Audit Worker\nAPI->>Worker: Start audit\nWorker-->>API: Audit complete\ndestroy Worker\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete\nelse Transfer rejected\nAPI-->>User: Validation failed\nend",
         )
         .expect("Mermaid sequence parse failed");
         let layout = layout_sequence_diagram(&diagram);
@@ -381,6 +381,11 @@ mod apple {
         assert!(scene.instructions.iter().any(|instruction| matches!(
             instruction,
             paint_instructions::PaintInstruction::Path(path) if path.stroke_dash.is_some()
+        )));
+        assert!(scene.instructions.iter().any(|instruction| matches!(
+            instruction,
+            paint_instructions::PaintInstruction::Path(path)
+                if path.stroke.as_deref() == Some("#dc2626")
         )));
         assert!(scene.instructions.iter().any(|instruction| matches!(
             instruction,

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0
+
+- Added Mermaid sequence participant lifecycle tokens.
+
 ## 0.4.0
 
 - Added tokens for every Mermaid 11.16.1 sequence control block and branch separator.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.4.0";
+pub const VERSION: &str = "0.5.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.4.0");
+        assert_eq!(VERSION, "0.5.0");
     }
 
     #[test]
@@ -308,5 +308,20 @@ mod tests {
         assert!(values.contains(&"else"));
         assert!(values.contains(&"loop"));
         assert_eq!(values.iter().filter(|value| **value == "end").count(), 2);
+    }
+
+    #[test]
+    fn tokenizes_sequence_participant_lifecycle() {
+        let tokens = tokenize_mermaid_sequence(
+            "sequenceDiagram\ncreate participant Worker as Background Worker\ndestroy Worker\n",
+        );
+        let values: Vec<&str> = tokens
+            .iter()
+            .filter(|token| token.type_ != TokenType::Eof)
+            .map(|token| token.value.as_str())
+            .collect();
+        assert!(values.contains(&"create"));
+        assert!(values.contains(&"destroy"));
+        assert!(values.contains(&"Worker"));
     }
 }

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+- Added grammar-backed `create participant`, `create actor`, and `destroy` lowering.
+
 ## 0.5.0
 
 - Added recursive grammar and semantic lowering for nested sequence control blocks.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -36,7 +36,8 @@ Mermaid
 The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,
 activations, titles, automatic numbering, and nested control blocks with branch
-separators. Advanced participant metadata remains an explicit compatibility gap.
+separators. Participant creation and destruction are lifecycle events consumed
+by layout. Advanced participant metadata remains an explicit compatibility gap.
 
 All other Mermaid 11.16.1 family headers are recognized and return an explicit
 `recognized but not implemented` error until their grammar, lowering, layout,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.5.0";
+pub const VERSION: &str = "0.6.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1052,19 +1052,19 @@ fn parse_sequence_body(
     while !cursor.at_eof() && !terminators.contains(&cursor.current().value.as_str()) {
         match cursor.current().value.as_str() {
             "participant" | "actor" => {
-                let kind = if cursor.advance().value == "actor" {
-                    SequenceParticipantKind::Actor
-                } else {
-                    SequenceParticipantKind::Participant
-                };
-                let id = take_sequence_identifier(cursor)?;
-                let label = if cursor.current().value == "as" {
-                    cursor.advance();
-                    take_sequence_line_text(cursor)
-                } else {
-                    id.clone()
-                };
-                upsert_sequence_participant(diagram, participant_indices, id, label, kind);
+                parse_sequence_participant(cursor, diagram, participant_indices, false)?
+            }
+            "create" => {
+                cursor.advance();
+                parse_sequence_participant(cursor, diagram, participant_indices, true)?;
+            }
+            "destroy" => {
+                cursor.advance();
+                let participant = take_sequence_identifier(cursor)?;
+                ensure_sequence_participant(diagram, participant_indices, &participant);
+                diagram
+                    .events
+                    .push(SequenceEvent::ParticipantDestroyed { participant });
             }
             "activate" | "deactivate" => {
                 let active = cursor.advance().value == "activate";
@@ -1093,6 +1093,39 @@ fn parse_sequence_body(
             _ => parse_sequence_message(cursor, diagram, participant_indices)?,
         }
         cursor.skip_terminators();
+    }
+    Ok(())
+}
+
+fn parse_sequence_participant(
+    cursor: &mut TokenCursor,
+    diagram: &mut SequenceDiagram,
+    participant_indices: &mut HashMap<String, usize>,
+    created: bool,
+) -> Result<(), ParseError> {
+    let declaration = cursor.advance().clone();
+    let kind = match declaration.value.as_str() {
+        "actor" => SequenceParticipantKind::Actor,
+        "participant" => SequenceParticipantKind::Participant,
+        other => {
+            return Err(token_error(
+                &declaration,
+                format!("expected participant or actor after create, got {other:?}"),
+            ))
+        }
+    };
+    let id = take_sequence_identifier(cursor)?;
+    let label = if cursor.current().value == "as" {
+        cursor.advance();
+        take_sequence_line_text(cursor)
+    } else {
+        id.clone()
+    };
+    upsert_sequence_participant(diagram, participant_indices, id.clone(), label, kind);
+    if created {
+        diagram
+            .events
+            .push(SequenceEvent::ParticipantCreated { participant: id });
     }
     Ok(())
 }
@@ -2646,6 +2679,29 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
         assert!(!error.message.is_empty());
         assert!(error.line >= 2);
     }
+
+    #[test]
+    fn sequence_parses_participant_lifecycle_events() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\nparticipant A as Alice\nA->>B: Start\ncreate actor Worker as Background Worker\nB->>Worker: Run\ndestroy Worker\n",
+        )
+        .unwrap();
+        let worker = diagram
+            .participants
+            .iter()
+            .find(|p| p.id == "Worker")
+            .unwrap();
+        assert_eq!(worker.kind, SequenceParticipantKind::Actor);
+        assert_eq!(worker.label.text, "Background Worker");
+        assert!(diagram.events.iter().any(|event| matches!(
+            event,
+            SequenceEvent::ParticipantCreated { participant } if participant == "Worker"
+        )));
+        assert!(diagram.events.iter().any(|event| matches!(
+            event,
+            SequenceEvent::ParticipantDestroyed { participant } if participant == "Worker"
+        )));
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -2662,7 +2718,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.5.0");
+        assert_eq!(crate::VERSION, "0.6.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -116,10 +116,12 @@ Nested Mermaid 11.16.1 control blocks (`loop`, `opt`, `alt`/`else`, `par`/`and`,
 `par_over`, `critical`/`option`, `break`, and `rect`) lower into ordered semantic
 block events. Sequence layout resolves those events into nested frames and
 branch dividers before existing PaintInstructions render them. Participant
-creation/destruction and metadata, links, and advanced arrow variants remain
-compatibility work. The family remains partial until those forms and the pinned
-upstream corpus pass; unsupported forms must fail grammar validation rather
-than degrade silently.
+`create` and `destroy` statements lower into lifecycle events; layout uses them
+to place dynamic participant headers, bound lifelines, and emit destruction
+markers. Participant configuration metadata, links, and advanced arrow variants
+remain compatibility work. The family remains partial until those forms and the
+pinned upstream corpus pass; unsupported forms must fail grammar validation
+rather than degrade silently.
 
 ### Structural Groups
 


### PR DESCRIPTION
## Summary
- extend the portable sequence grammar with `create participant`, `create actor`, and `destroy`
- lower lifecycle statements into semantic sequence events
- place dynamic participant headers and bound lifelines during layout
- render destruction markers through existing PaintPath instructions
- validate participant lifecycle through Metal-to-PNG

## Verification
- `cargo test -p diagram-ir -p diagram-layout-sequence -p mermaid-lexer -p mermaid-parser -p diagram-to-paint -- --nocapture`
- `cargo clippy -p diagram-ir -p diagram-layout-sequence -p mermaid-lexer -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- visually inspected `/tmp/mermaid_sequence_e2e.png`
