### PR TITLE
Verify Tamil ண handwriting ductus

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -70,9 +70,10 @@ activities, and back matter. The twelve former handwritten entries are protected
 generated targets with checked hashes, titles, labels, order, and output. HL-C19
 is already complete; HL-C09A through HL-C09G verified Tamil அ, ஆ, இ, க, வ, ல,
 and ற in #10222, #10223, #10226, #10228, #10230, #10234, and #10240. HL-C09H
-verifies Tamil ன from Frame 13's first row in #10244. HL-C09I is the next
-bounded stroke-order tranche: verify the adjacent three-loop ண row from the
-same source page before widening DUCTUS across scripts.
+verified Tamil ன from Frame 13's first row in #10244. HL-C09I verifies the
+adjacent three-loop ண row from the same source page. HL-C09J is the next
+bounded stroke-order tranche: verify Tamil ந from Frame 12 before widening
+DUCTUS across scripts.
 The index audit found **2,075** canonical candidates across the corpus: **1,426**
 word and phrase lessons for English-first lookup, **136** dedicated grammar,
 writing, etymology, culture, and pronunciation lessons, **427** chapter
@@ -232,7 +233,7 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C06 | Complete (#10219) | Add the figure pipeline: SVG generation, `graphicx`, SVG→PDF in CI, and a `--check` hash gate. | A generated figure round-trips from canonical data into a compiled PDF and fails CI on drift, reusing `paint-vm-svg`'s `renderToSvgString`. |
 | HL-C07 | Complete (#9963) | Add the log-scanning warning gate with recorded per-track baselines. | Overfull/underfull boxes, missing glyphs, hyperref warnings, duplicate destinations, and font substitutions are machine-checked by `scan_latex_log_warnings.py` after the `latexmk` loop, against `core/latex-warning-baseline.json`. Baselines ship unseeded — `null` means unmeasured, never zero — so the gate reports today and fails the moment a seeded track regresses. The first CI run on main emits the real counts into the job summary for a human to paste back. |
 | HL-C08 | Complete (#9974) | Render the ductus in Language Ladder. | `penPathD`/`penTip` drive the tested SVG stroke build-up in the app; the currently authored ductus is shared with validation and script practice. |
-| HL-C09 | Queued — 9 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 219 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
+| HL-C09 | Queued — 10 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 218 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
 | HL-C09A | Complete (#10222) | Verify Tamil அ as the first post-HL-C19 expansion tranche, using the primer already cited for Tamil handwriting. | அ carries a source-aligned two-stroke path with exactly one lift; its five movements, learner prose, source metadata, font-outline geometry, and rendered filmstrip agree. |
 | HL-C09B | Complete (#10223) | Verify Tamil ஆ as the next source-backed expansion tranche from Frame 4 of the same primer. | ஆ carries a font-checked path for the அ body plus its long-vowel right-hand loop; its learner prose states every verified lift, and source, geometry, and filmstrip tests agree. |
 | HL-C09C | Complete (#10226) | Verify Tamil இ as Frame 4's third source-backed vowel tranche. | இ carries a seven-movement, font-checked path whose learner prose states each evidenced lift; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
@@ -241,7 +242,8 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C09F | Complete (#10234) | Verify Tamil ல from Frame 9's second source-backed consonant row. | ல carries a four-movement, font-checked unbroken path whose learner prose states the evidenced zero lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C09G | Complete (#10240) | Verify Tamil ற from the source-adjacent Frame 10 row. | ற carries a five-movement, font-checked three-stroke path whose learner prose states the two evidenced lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C09H | Complete (#10244) | Verify Tamil ன from Frame 13's first source-backed nasal row. | ன carries a six-movement, font-checked two-stroke path whose first five movements stay joined before the separate right upright; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
-| HL-C09I | Queued — next | Verify Tamil ண from Frame 13's adjacent source-backed three-loop nasal row. | Preserve the cited seven-movement order, verify every lift against an authored Noto-backed path, and keep the learner prose, source metadata, and real filmstrip in agreement. |
+| HL-C09I | Complete (#10249) | Verify Tamil ண from Frame 13's adjacent source-backed three-loop nasal row. | ண carries a seven-movement, font-checked two-stroke path whose first six movements stay joined through both inner arches and the top bar before the separate right upright; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
+| HL-C09J | Queued — next | Verify Tamil ந from Frame 12's source-backed dental-nasal row. | Preserve the cited six-movement order, verify every lift against an authored Noto-backed path, and keep the learner prose, source metadata, and real filmstrip in agreement. |
 | HL-C10 | Complete (#10010, #10013, #10067) | Complete A1 and add the A2-through-C2 spine tranches with all registered realization ledgers. | All seven declared stages carry nodes; every one of the 22 registered tracks has a non-drifting ledger entry for every node. |
 | HL-C11 | Queued — capability and closure coverage complete | Finish representative chapter payoffs across all 22 tracks. | #10128 brought all 513 chapters to an authored `canDo`, spine mapping, known payoff lesson, and closed assessment. Remediate the remaining 27 payoffs below the 0.5 representativeness floor across ten tracks, then enforce the clean tracks instead of leaving their gates report-only. |
 | HL-C12 | Queued — licensing decided, pipeline outstanding | Add the Class C illustration pipeline with provenance sidecars and a size budget. Licensing is settled and recorded in [`_assets/LICENSE.md`](./_assets/LICENSE.md); the remaining work is the pipeline itself. | Every asset carries `license`, `rightsAsserted`, `generator`, `model`, `prompt`, `date`, and `sha256`; CI fails any asset without a provenance sidecar or a recorded licence, and enforces the per-track size budget. |
@@ -2644,7 +2646,7 @@ problem.
   **61 glyph violations plus five multi-system Japanese openings**. The current
   corpus is 91% core-drivable, not the historical 84% recorded before later work.
 - HL-C19 supersedes HL-C09's old estimate. There are **228** prose stroke-order
-  entries across ten scripts: nine verified ductus paths and 219 entries still needing cited,
+  entries across ten scripts: ten verified ductus paths and 218 entries still needing cited,
   font-checked pen-lift evidence.
 
 ## Findings from HL-C05

--- a/code/learning/human-languages/data/scripts/README.md
+++ b/code/learning/human-languages/data/scripts/README.md
@@ -130,7 +130,7 @@ and given the same citation.
 4. Where no ductus exists, do not invent lifts — keep the steps as part order and
    leave `penLifts` out.
 
-Tamil **அ**, **ஆ**, **இ**, **க**, **வ**, **ல**, **ற**, and **ன** now join **ம** with authored ductus paths. The primer's
+Tamil **அ**, **ஆ**, **இ**, **க**, **வ**, **ல**, **ற**, **ன**, and **ண** now join **ம** with authored ductus paths. The primer's
 Frame 4 shows four connected movements for their shared curl-and-loop body,
 followed by one lift and the separate right upright; ஆ then continues without
 another lift into its long-vowel loop. Frame 4's next row gives இ five joined
@@ -144,11 +144,13 @@ as four movements without lifting. Frame 10 joins ற's left arch to its first
 middle descent, restarts for the adjacent descent, then joins the right arch to
 the below-baseline sweep and descender: five movements, three runs, and two
 lifts. Frame 13's first row joins ன's left spiral, single inner arch, and top
-bar as five movements, then lifts once before the separate right upright. The
-remaining **219** prose part
+bar as five movements, then lifts once before the separate right upright. Its
+next row keeps the analogous ண path joined through an extra inner arch and the
+top bar for six movements before the same one lift and separate upright. The
+remaining **218** prose part
 orders across ten scripts (`arabic` 21, `chinese` 24, `cyrillic` 33,
 `devanagari` 28, `gujarati` 33, `hebrew` 22, `japanese` 34,
-`perso-arabic` 9, `tamil` 2, `urdu-nastaliq` 13) are explicitly **unverified for
+`perso-arabic` 9, `tamil` 1, `urdu-nastaliq` 13) are explicitly **unverified for
 pen lifts**. The data validator rejects a lift count without a citation (or a
 citation without a count), and Language Ladder's ductus test proves every verified
 claim has the same cited, font-checked path. That closes `HL-C19`; future entries

--- a/code/learning/human-languages/data/scripts/tamil.json
+++ b/code/learning/human-languages/data/scripts/tamil.json
@@ -7,7 +7,7 @@
   "signature": "Curvy and loopy with flat top-bars on many letters, repeated arches, and no continuous head-line.",
   "complete": false,
   "combination": "A consonant carries an inherent 'a' (க = ka). A vowel sign replaces that vowel (க + ா → கா = kā). The puḷḷi ் — a DOT above the letter — removes the vowel entirely (க் = k). Unlike Devanagari, Tamil does NOT fuse the bare consonant into a conjunct: the dot stays visible and both letters keep their full shape. (A handful of Sanskrit-borrowed ligatures are the exception — க்ஷ kṣa and ஸ்ரீ śrī.)",
-  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, இ, க, ம, வ, ன, ல, and ற have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ, ஆ, இ, and ன each have two pen-down runs with one verified lift; ஆ continues from its upright into the long-vowel loop, இ joins its outer-left climb to the final arch, and ன joins its first five movements before the separate right upright. க and ற each use three pen-down runs with two verified lifts. ம, வ, and ல are each a single unbroken stroke even though their parts have separate names. The other two letters here have no verified pen path, so read their steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
+  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, இ, க, ம, வ, ண, ன, ல, and ற have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ, ஆ, இ, ண, and ன each have two pen-down runs with one verified lift; ஆ continues from its upright into the long-vowel loop, இ joins its outer-left climb to the final arch, and ண and ன join their loop-and-arch bodies to the top bar before the separate right upright. க and ற each use three pen-down runs with two verified lifts. ம, வ, and ல are each a single unbroken stroke even though their parts have separate names. The remaining letter here has no verified pen path, so read its steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
   "letters": [
     {
       "glyph": "அ",
@@ -147,10 +147,24 @@
       "sound": "ṇa",
       "role": "consonant",
       "inherentVowel": "a",
-      "components": ["a straight top bar", "a loop on the left", "TWO arches", "a straight vertical on the right, down to the baseline"],
-      "strokeOrder": ["top bar", "left loop", "first arch", "second arch", "right vertical"],
-      "strokeOrderNote": "conventional",
-      "notes": "The RETROFLEX n — tongue curled back to the roof of the mouth. Learn it beside ன: ண is ன WITH ONE EXTRA ARCH. Both letters end in the same straight vertical; the extra arch is inserted before it. Tamil writes three n-sounds with three letters (ந, ன, ண)."
+      "components": ["a spiral loop on the left", "TWO rounded inner arches", "a straight top bar", "a separate straight vertical on the right, down to the baseline"],
+      "strokeOrder": [
+        "start in the lower-left curl and spiral outward, climbing the outer left side",
+        "without lifting, arch over the top of the left loop to the first junction",
+        "without lifting, descend around the outside of the first inner arch",
+        "without lifting, turn through its bottom and climb the inside back to the first junction",
+        "without lifting, sweep through the extra inner arch — over its top, around its outside and bottom, then up its inside to the right junction",
+        "without lifting, carry the top bar to the right edge — then lift once",
+        "set the pen at the top of the separate right upright and draw straight down — and only now lift"
+      ],
+      "strokeOrderNote": "two strokes — six joined loop, double-arch, and top-bar movements, one pen lift, then the right upright; cited to Radhakrishnan, Tamil Script Learners Manual, Frame 13, ண",
+      "penLifts": 1,
+      "strokeOrderSource": {
+        "citation": "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 13, ண (Univ. of Texas at Austin), p. 195",
+        "url": "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+        "variation": "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order."
+      },
+      "notes": "The RETROFLEX n — tongue curled back to the roof of the mouth. Learn it beside ன: ண is ன WITH ONE EXTRA ARCH. Frame 13's adjacent row numbers seven movements, not seven strokes: its first six stay connected through the left spiral, two inner arches, and top bar; only the separate right upright requires a lift. Tamil writes three n-sounds with three letters (ந, ன, ண)."
     },
     {
       "glyph": "ந",

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -55,6 +55,13 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
   movements, then one lift precedes the separate right upright, matching
   Language Ladder's font-checked path.
 
+### Added - verified Tamil ண handwriting
+
+- Record Frame 13's cited seven-movement order for Tamil ண as two pen-down
+  runs: the left spiral, both inner arches, and top bar stay connected through
+  six movements, then one lift precedes the separate right upright, matching
+  Language Ladder's font-checked path.
+
 ### Added - generated lesson figures
 
 - Generate deterministic etymology-route SVGs from the canonical lesson `roots`

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -67,6 +67,14 @@
 - Check all six movements against the Noto Sans Tamil outline and pin the sole
   lift transition in the real filmstrip and learner prose.
 
+### Added — cited two-stroke ductus for Tamil ண (HL-C09I)
+
+- Add Frame 13's adjacent Tamil nasal row, ண: six joined movements carry its
+  left spiral through both inner arches and the top bar, then one verified lift
+  precedes the separate right upright.
+- Check all seven movements against the Noto Sans Tamil outline and pin the sole
+  lift transition in the real filmstrip and learner prose.
+
 ### Added — canonical lesson figures
 
 - Preserve standalone Markdown images as typed lesson blocks instead of flattening

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -165,7 +165,7 @@ in font units, and `ductusview.ts` flips them together with exactly **one**
 `scale(1,-1)` group — so a mistake cannot leave a plausible-looking stroke
 sitting upside down on a correct letter.
 
-**Tamil அ, ஆ, இ, க, ம, வ, ல, ற, and ன have authored pen paths today.** `DUCTUS` admits no letter
+**Tamil அ, ஆ, இ, க, ம, வ, ல, ற, ன, and ண have authored pen paths today.** `DUCTUS` admits no letter
 without a citation for its stroke order, and hand-drawing a letter is forbidden
 outright (a subtly wrong Tamil ண looks perfect to exactly the audience that
 cannot yet read Tamil, so the error would ship *as the lesson*). அ and ஆ exercise
@@ -180,9 +180,11 @@ four-movement run with no lift. ற uses three pen-down runs: its left arch join
 the first middle descent, the adjacent descent restarts after one lift, and a
 second lift precedes the right arch's joined sweep and descender. ன joins its
 left spiral, single inner arch, and top bar through five movements before one
-lift precedes its separate right upright. Every other letter falls back to the
-numbered prose list, unchanged. Extending the coverage is HL-C09, and it needs a
-cited source per letter.
+lift precedes its separate right upright. ண follows the same two-run pattern,
+keeping its extra inner arch joined to the rest of the body and top bar before
+the sole lift.
+Every other letter falls back to the numbered prose list, unchanged. Extending
+the coverage is HL-C09, and it needs a cited source per letter.
 
 ## Where it fits
 

--- a/code/programs/typescript/language-ladder/src/strokes.ts
+++ b/code/programs/typescript/language-ladder/src/strokes.ts
@@ -207,6 +207,10 @@ const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n);
 // ற is Frame 10: movements 1-2 make the left arch and first middle descent,
 // movement 3 restarts on the adjacent middle descent, and movements 4-5 join
 // the right arch to the below-baseline sweep and descender.
+// ன is Frame 13's first row: movements 1-5 join its left spiral, single inner
+// arch, and top bar; movement 6 restarts on the separate right upright. ண is
+// the adjacent row: movements 1-6 stay joined through the added inner arch and
+// top bar, then movement 7 restarts on its separate right upright.
 // ம is Frame 1's third row: all five movements join into one unbroken stroke.
 // ---------------------------------------------------------------------------
 
@@ -978,6 +982,136 @@ export const DUCTUS: Record<string, LetterDuctus> = {
     source: {
       citation:
         "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 13, ன (Univ. of Texas at Austin), p. 195",
+      url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+      variation:
+        "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",
+    },
+  },
+  ண: {
+    glyph: "ண",
+    strokes: [
+      {
+        segments: [
+          {
+            label: "curl outward and climb the outer left",
+            path: [
+              { x: 300, y: 35 },
+              { x: 310, y: 55 },
+              { x: 350, y: 90 },
+              { x: 380, y: 145 },
+              { x: 380, y: 205 },
+              { x: 340, y: 260 },
+              { x: 285, y: 292 },
+              { x: 225, y: 290 },
+              { x: 170, y: 275 },
+              { x: 120, y: 275 },
+              { x: 95, y: 270 },
+              { x: 95, y: 180 },
+              { x: 115, y: 105 },
+              { x: 175, y: 45 },
+              { x: 250, y: 25 },
+              { x: 175, y: 45 },
+              { x: 115, y: 105 },
+              { x: 95, y: 180 },
+              { x: 95, y: 270 },
+              { x: 120, y: 360 },
+              { x: 180, y: 450 },
+            ],
+          },
+          {
+            label: "arch over the left loop to the first junction",
+            path: [
+              { x: 180, y: 450 },
+              { x: 270, y: 520 },
+              { x: 370, y: 530 },
+              { x: 470, y: 520 },
+              { x: 560, y: 500 },
+              { x: 650, y: 495 },
+            ],
+          },
+          {
+            label: "descend around the first inner arch",
+            path: [
+              { x: 650, y: 495 },
+              { x: 700, y: 455 },
+              { x: 750, y: 400 },
+              { x: 785, y: 320 },
+              { x: 785, y: 230 },
+              { x: 770, y: 140 },
+              { x: 735, y: 75 },
+              { x: 690, y: 35 },
+              { x: 660, y: 25 },
+            ],
+          },
+          {
+            label: "turn through the bottom and climb inside",
+            path: [
+              { x: 660, y: 25 },
+              { x: 610, y: 45 },
+              { x: 555, y: 100 },
+              { x: 540, y: 180 },
+              { x: 545, y: 260 },
+              { x: 565, y: 350 },
+              { x: 600, y: 430 },
+              { x: 650, y: 495 },
+            ],
+          },
+          {
+            label: "sweep through the extra inner arch",
+            path: [
+              { x: 650, y: 495 },
+              { x: 735, y: 525 },
+              { x: 825, y: 530 },
+              { x: 920, y: 515 },
+              { x: 1000, y: 500 },
+              { x: 1065, y: 495 },
+              { x: 1115, y: 455 },
+              { x: 1165, y: 400 },
+              { x: 1200, y: 320 },
+              { x: 1200, y: 230 },
+              { x: 1185, y: 140 },
+              { x: 1150, y: 75 },
+              { x: 1105, y: 35 },
+              { x: 1075, y: 25 },
+              { x: 1025, y: 45 },
+              { x: 970, y: 100 },
+              { x: 955, y: 180 },
+              { x: 960, y: 260 },
+              { x: 980, y: 350 },
+              { x: 1015, y: 430 },
+              { x: 1065, y: 495 },
+            ],
+          },
+          {
+            label: "carry the top bar right",
+            path: [
+              { x: 1065, y: 495 },
+              { x: 1135, y: 515 },
+              { x: 1260, y: 518 },
+              { x: 1380, y: 518 },
+              { x: 1500, y: 518 },
+              { x: 1625, y: 518 },
+            ],
+          },
+        ],
+      },
+      {
+        segments: [
+          {
+            label: "descend the separate right upright",
+            path: [
+              { x: 1418, y: 480 },
+              { x: 1418, y: 350 },
+              { x: 1418, y: 180 },
+              { x: 1418, y: 25 },
+            ],
+          },
+        ],
+      },
+    ],
+    source: {
+      citation:
+        "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 13, ண (Univ. of Texas at Austin), p. 195",
       url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
       variation:
         "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",

--- a/code/programs/typescript/language-ladder/tests/ductusview.test.ts
+++ b/code/programs/typescript/language-ladder/tests/ductusview.test.ts
@@ -65,6 +65,8 @@ const RRA = DUCTUS["ற"];
 const rraOutline = tamilOutline("ற");
 const NNA = DUCTUS["ன"];
 const nnaOutline = tamilOutline("ன");
+const RETROFLEX_NNA = DUCTUS["ண"];
+const retroflexNnaOutline = tamilOutline("ண");
 
 /** Walk a node tree, collecting every node the predicate accepts. */
 function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = []): SvgNode[] {
@@ -76,7 +78,7 @@ function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = 
 const byTag = (node: SvgNode, tag: string) => collect(node, (n) => n.tag === tag);
 
 describe("ductusFor — only cited letters have a ductus", () => {
-  it("finds all nine authored Tamil letters", () => {
+  it("finds all ten authored Tamil letters", () => {
     expect(ductusFor("ம")?.glyph).toBe("ம");
     expect(ductusFor("அ")?.glyph).toBe("அ");
     expect(ductusFor("ஆ")?.glyph).toBe("ஆ");
@@ -86,12 +88,13 @@ describe("ductusFor — only cited letters have a ductus", () => {
     expect(ductusFor("ல")?.glyph).toBe("ல");
     expect(ductusFor("ற")?.glyph).toBe("ற");
     expect(ductusFor("ன")?.glyph).toBe("ன");
+    expect(ductusFor("ண")?.glyph).toBe("ண");
   });
 
   it("returns undefined for a letter nobody has authored a stroke order for", () => {
-    // ண is a real Tamil letter with prose stroke order in the curriculum but no
+    // ந is a real Tamil letter with prose stroke order in the curriculum but no
     // authored pen path. It must come back empty rather than borrow ம's.
-    expect(ductusFor("ண")).toBeUndefined();
+    expect(ductusFor("ந")).toBeUndefined();
     expect(ductusFor("A")).toBeUndefined();
     expect(ductusFor("")).toBeUndefined();
   });
@@ -487,6 +490,31 @@ describe("ன — a real cited two-stroke six-movement filmstrip", () => {
     expect(done).toHaveLength(1);
     expect(done[0].attrs.d).toBe(penPathD(NNA.strokes[0], 1));
     expect(pen.attrs.d).toBe(penPathD(NNA.strokes[1], 1));
+  });
+});
+
+describe("ண — a real cited two-stroke seven-movement filmstrip", () => {
+  const steps = ductusSteps(RETROFLEX_NNA);
+  const strip = ductusFilmstrip(RETROFLEX_NNA, retroflexNnaOutline);
+
+  it("joins the loop, both inner arches, and top bar before the sole lift", () => {
+    expect(steps.map((step) => step.startsAfterLift)).toEqual([false, false, false, false, false, false, true]);
+    expect(steps.map((step) => step.strokeIndex)).toEqual([0, 0, 0, 0, 0, 0, 1]);
+  });
+
+  it("reports seven movements in two strokes with one lift", () => {
+    expect(strip.frames).toHaveLength(7);
+    expect(strip.penLifts).toBe(1);
+    expect(strip.summary).toBe("2 strokes · 1 pen lift · 7 movements");
+  });
+
+  it("keeps the completed double-arch stroke visible while drawing the upright", () => {
+    const last = strip.frames[6];
+    const done = byTag(last, "path").filter((path) => path.attrs.class === "ductus__done");
+    const pen = byTag(last, "path").find((path) => path.attrs.class === "ductus__pen")!;
+    expect(done).toHaveLength(1);
+    expect(done[0].attrs.d).toBe(penPathD(RETROFLEX_NNA.strokes[0], 1));
+    expect(pen.attrs.d).toBe(penPathD(RETROFLEX_NNA.strokes[1], 1));
   });
 });
 

--- a/code/programs/typescript/language-ladder/tests/strokes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/strokes.test.ts
@@ -222,6 +222,12 @@ describe("handwriting ductus", () => {
     expect(DUCTUS["ன"].strokes.map((stroke) => stroke.segments.length)).toEqual([5, 1]);
   });
 
+  it("ண joins its first six movements before the right upright", () => {
+    expect(penLifts(DUCTUS["ண"])).toBe(1);
+    expect(DUCTUS["ண"].strokes).toHaveLength(2);
+    expect(DUCTUS["ண"].strokes.map((stroke) => stroke.segments.length)).toEqual([6, 1]);
+  });
+
   // The PROVENANCE GATE. A stroke's SHAPE is checked against the font above;
   // its ORDER cannot be — so it must trace to a cited source, or it does not
   // ship. This is the counterpart, for hand-authored order, of "facts enter
@@ -316,6 +322,13 @@ describe("handwriting ductus", () => {
     const src = DUCTUS["ன"].source;
     expect(src.url).toContain("tamilscript");
     expect(src.citation).toMatch(/Appendix I.*Frame 13.*ன/);
+    expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
+  });
+
+  it("ண's stroke order traces to Frame 13's adjacent row", () => {
+    const src = DUCTUS["ண"].source;
+    expect(src.url).toContain("tamilscript");
+    expect(src.citation).toMatch(/Appendix I.*Frame 13.*ண/);
     expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
   });
 });


### PR DESCRIPTION
## What changed

- add the cited seven-movement Tamil ண ductus from Frame 13 of the UT Austin handwriting primer
- keep the first six movements joined through the left spiral, both inner arches, and top bar, with one lift before the separate right upright
- fit every authored point to the vendored Noto Sans Tamil outline and add filmstrip, lift, provenance, and source-agreement tests
- update the learner data, package/app documentation, changelogs, and HL-C09 backlog counts; queue Tamil ந as HL-C09J

## Why

HL-C09 requires every prose stroke-order entry to gain source-backed pen-lift metadata and a font-checked path before Language Ladder renders it. ண was the next adjacent source-backed row after ன.

## Validation

- focused ductus and filmstrip tests: 128 passed
- human-language-data: 460 tests passed
- language-ladder: typecheck, production build, bundle check, and 607 tests passed
- `bash code/scripts/verify-human-languages.sh --fast`: all local checks passed
- `git diff --check`