### PR TITLE
Verify Tamil ந handwriting ductus

### DIFF
--- a/code/learning/human-languages/BACKLOG.md
+++ b/code/learning/human-languages/BACKLOG.md
@@ -70,10 +70,11 @@ activities, and back matter. The twelve former handwritten entries are protected
 generated targets with checked hashes, titles, labels, order, and output. HL-C19
 is already complete; HL-C09A through HL-C09G verified Tamil அ, ஆ, இ, க, வ, ல,
 and ற in #10222, #10223, #10226, #10228, #10230, #10234, and #10240. HL-C09H
-verified Tamil ன from Frame 13's first row in #10244. HL-C09I verifies the
-adjacent three-loop ண row from the same source page. HL-C09J is the next
-bounded stroke-order tranche: verify Tamil ந from Frame 12 before widening
-DUCTUS across scripts.
+verified Tamil ன from Frame 13's first row in #10244, and HL-C09I verified the
+adjacent three-loop ண row in #10249. HL-C09J verifies Tamil ந from Frame 12,
+completing the Tamil starter inventory. HL-C09K is the next bounded tranche:
+source and verify Persian ا before expanding through the smallest remaining
+script inventory.
 The index audit found **2,075** canonical candidates across the corpus: **1,426**
 word and phrase lessons for English-first lookup, **136** dedicated grammar,
 writing, etymology, culture, and pronunciation lessons, **427** chapter
@@ -233,7 +234,7 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C06 | Complete (#10219) | Add the figure pipeline: SVG generation, `graphicx`, SVG→PDF in CI, and a `--check` hash gate. | A generated figure round-trips from canonical data into a compiled PDF and fails CI on drift, reusing `paint-vm-svg`'s `renderToSvgString`. |
 | HL-C07 | Complete (#9963) | Add the log-scanning warning gate with recorded per-track baselines. | Overfull/underfull boxes, missing glyphs, hyperref warnings, duplicate destinations, and font substitutions are machine-checked by `scan_latex_log_warnings.py` after the `latexmk` loop, against `core/latex-warning-baseline.json`. Baselines ship unseeded — `null` means unmeasured, never zero — so the gate reports today and fails the moment a seeded track regresses. The first CI run on main emits the real counts into the job summary for a human to paste back. |
 | HL-C08 | Complete (#9974) | Render the ductus in Language Ladder. | `penPathD`/`penTip` drive the tested SVG stroke build-up in the app; the currently authored ductus is shared with validation and script practice. |
-| HL-C09 | Queued — 10 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 218 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
+| HL-C09 | Queued — 11 of 228 verified | Expand `DUCTUS` to cover the ten scripts with prose stroke-order entries. | Add cited, font-checked ductus and verified pen-lift metadata for the remaining 217 entries measured by HL-C19; each passes the on-ink, join-tolerance, coverage, citation, and source-agreement invariants. |
 | HL-C09A | Complete (#10222) | Verify Tamil அ as the first post-HL-C19 expansion tranche, using the primer already cited for Tamil handwriting. | அ carries a source-aligned two-stroke path with exactly one lift; its five movements, learner prose, source metadata, font-outline geometry, and rendered filmstrip agree. |
 | HL-C09B | Complete (#10223) | Verify Tamil ஆ as the next source-backed expansion tranche from Frame 4 of the same primer. | ஆ carries a font-checked path for the அ body plus its long-vowel right-hand loop; its learner prose states every verified lift, and source, geometry, and filmstrip tests agree. |
 | HL-C09C | Complete (#10226) | Verify Tamil இ as Frame 4's third source-backed vowel tranche. | இ carries a seven-movement, font-checked path whose learner prose states each evidenced lift; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
@@ -243,7 +244,8 @@ direction, and no gate may penalise page, lesson, or chapter count.
 | HL-C09G | Complete (#10240) | Verify Tamil ற from the source-adjacent Frame 10 row. | ற carries a five-movement, font-checked three-stroke path whose learner prose states the two evidenced lifts; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C09H | Complete (#10244) | Verify Tamil ன from Frame 13's first source-backed nasal row. | ன carries a six-movement, font-checked two-stroke path whose first five movements stay joined before the separate right upright; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
 | HL-C09I | Complete (#10249) | Verify Tamil ண from Frame 13's adjacent source-backed three-loop nasal row. | ண carries a seven-movement, font-checked two-stroke path whose first six movements stay joined through both inner arches and the top bar before the separate right upright; the cited order, Noto outline geometry, source metadata, and real filmstrip agree. |
-| HL-C09J | Queued — next | Verify Tamil ந from Frame 12's source-backed dental-nasal row. | Preserve the cited six-movement order, verify every lift against an authored Noto-backed path, and keep the learner prose, source metadata, and real filmstrip in agreement. |
+| HL-C09J | Complete (#10252) | Verify Tamil ந from Frame 12's source-backed dental-nasal row. | ந carries a six-movement, font-checked three-stroke path adapted to the vendored Noto form: its first three movements stay joined, one lift precedes the rising middle stem and top bar, and a second precedes the right-hand descent; source, geometry, prose, and filmstrip agree. |
+| HL-C09K | Queued — next | Source and verify Persian ا as the first path in the smallest remaining script inventory. | Select a primary Naskh handwriting source, preserve its right-to-left teaching context and evidenced lifts, and keep the isolated Noto outline, learner prose, source metadata, and real filmstrip in agreement. |
 | HL-C10 | Complete (#10010, #10013, #10067) | Complete A1 and add the A2-through-C2 spine tranches with all registered realization ledgers. | All seven declared stages carry nodes; every one of the 22 registered tracks has a non-drifting ledger entry for every node. |
 | HL-C11 | Queued — capability and closure coverage complete | Finish representative chapter payoffs across all 22 tracks. | #10128 brought all 513 chapters to an authored `canDo`, spine mapping, known payoff lesson, and closed assessment. Remediate the remaining 27 payoffs below the 0.5 representativeness floor across ten tracks, then enforce the clean tracks instead of leaving their gates report-only. |
 | HL-C12 | Queued — licensing decided, pipeline outstanding | Add the Class C illustration pipeline with provenance sidecars and a size budget. Licensing is settled and recorded in [`_assets/LICENSE.md`](./_assets/LICENSE.md); the remaining work is the pipeline itself. | Every asset carries `license`, `rightsAsserted`, `generator`, `model`, `prompt`, `date`, and `sha256`; CI fails any asset without a provenance sidecar or a recorded licence, and enforces the per-track size budget. |
@@ -2646,7 +2648,7 @@ problem.
   **61 glyph violations plus five multi-system Japanese openings**. The current
   corpus is 91% core-drivable, not the historical 84% recorded before later work.
 - HL-C19 supersedes HL-C09's old estimate. There are **228** prose stroke-order
-  entries across ten scripts: ten verified ductus paths and 218 entries still needing cited,
+  entries across ten scripts: eleven verified ductus paths and 217 entries still needing cited,
   font-checked pen-lift evidence.
 
 ## Findings from HL-C05

--- a/code/learning/human-languages/data/scripts/README.md
+++ b/code/learning/human-languages/data/scripts/README.md
@@ -130,7 +130,7 @@ and given the same citation.
 4. Where no ductus exists, do not invent lifts — keep the steps as part order and
    leave `penLifts` out.
 
-Tamil **அ**, **ஆ**, **இ**, **க**, **வ**, **ல**, **ற**, **ன**, and **ண** now join **ம** with authored ductus paths. The primer's
+Tamil **அ**, **ஆ**, **இ**, **க**, **வ**, **ல**, **ற**, **ன**, **ண**, and **ந** now join **ம** with authored ductus paths. The primer's
 Frame 4 shows four connected movements for their shared curl-and-loop body,
 followed by one lift and the separate right upright; ஆ then continues without
 another lift into its long-vowel loop. Frame 4's next row gives இ five joined
@@ -146,11 +146,13 @@ the below-baseline sweep and descender: five movements, three runs, and two
 lifts. Frame 13's first row joins ன's left spiral, single inner arch, and top
 bar as five movements, then lifts once before the separate right upright. Its
 next row keeps the analogous ண path joined through an extra inner arch and the
-top bar for six movements before the same one lift and separate upright. The
-remaining **218** prose part
-orders across ten scripts (`arabic` 21, `chinese` 24, `cyrillic` 33,
+top bar for six movements before the same one lift and separate upright. Frame
+12 gives ந three joined opening movements, one lift before its joined rising
+middle stem and top bar, then a second lift before the right-hand descent. The
+Tamil starter inventory is now fully verified. The remaining **217** prose part
+orders across nine scripts (`arabic` 21, `chinese` 24, `cyrillic` 33,
 `devanagari` 28, `gujarati` 33, `hebrew` 22, `japanese` 34,
-`perso-arabic` 9, `tamil` 1, `urdu-nastaliq` 13) are explicitly **unverified for
+`perso-arabic` 9, `urdu-nastaliq` 13) are explicitly **unverified for
 pen lifts**. The data validator rejects a lift count without a citation (or a
 citation without a count), and Language Ladder's ductus test proves every verified
 claim has the same cited, font-checked path. That closes `HL-C19`; future entries

--- a/code/learning/human-languages/data/scripts/tamil.json
+++ b/code/learning/human-languages/data/scripts/tamil.json
@@ -7,7 +7,7 @@
   "signature": "Curvy and loopy with flat top-bars on many letters, repeated arches, and no continuous head-line.",
   "complete": false,
   "combination": "A consonant carries an inherent 'a' (க = ka). A vowel sign replaces that vowel (க + ா → கா = kā). The puḷḷi ் — a DOT above the letter — removes the vowel entirely (க் = k). Unlike Devanagari, Tamil does NOT fuse the bare consonant into a conjunct: the dot stays visible and both letters keep their full shape. (A handful of Sanskrit-borrowed ligatures are the exception — க்ஷ kṣa and ஸ்ரீ śrī.)",
-  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. அ, ஆ, இ, க, ம, வ, ண, ன, ல, and ற have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ, ஆ, இ, ண, and ன each have two pen-down runs with one verified lift; ஆ continues from its upright into the long-vowel loop, இ joins its outer-left climb to the final arch, and ண and ன join their loop-and-arch bodies to the top bar before the separate right upright. க and ற each use three pen-down runs with two verified lifts. ம, வ, and ல are each a single unbroken stroke even though their parts have separate names. The remaining letter here has no verified pen path, so read its steps as part order only, and do not add or assume lifts until a cited ductus exists. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
+  "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. IMPORTANT for authors: a `strokeOrder` list names the PARTS of a letter in writing order; it does NOT by itself say where the pen lifts. All eleven letters in this starter inventory have authored, font-checked pen paths (`DUCTUS` in language-ladder's `strokes.ts`). அ, ஆ, இ, ண, and ன each have two pen-down runs with one verified lift; ஆ continues from its upright into the long-vowel loop, இ joins its outer-left climb to the final arch, and ண and ன join their loop-and-arch bodies to the top bar before the separate right upright. க, ந, and ற each use three pen-down runs with two verified lifts. ம, வ, and ல are each a single unbroken stroke even though their parts have separate names. There are no unverified letters in this starter inventory. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",
   "letters": [
     {
       "glyph": "அ",
@@ -172,9 +172,22 @@
       "role": "consonant",
       "inherentVowel": "a",
       "components": ["a straight top bar", "a vertical on the left", "a second vertical in the middle", "a right stroke that curls below the baseline and sweeps left into a descender"],
-      "strokeOrder": ["top bar", "left vertical", "middle vertical", "right stroke, curl and sweep"],
-      "strokeOrderNote": "conventional",
-      "notes": "The dental n, tongue against the teeth. Contrast ன (alveolar) and ண (retroflex)."
+      "strokeOrder": [
+        "start at the lower-left tail and sweep around the low bowl to its upper junction",
+        "without lifting, climb to the top and carry left along the bar to the first descent",
+        "without lifting, draw the first upright straight down — then lift once",
+        "set the pen at the bottom of the adjacent middle upright and rise to the top",
+        "without lifting again, carry the top bar to the right edge — then lift a second time",
+        "set the pen at the upper right curve, descend around it and sweep left into the below-baseline tail — and only now lift"
+      ],
+      "strokeOrderNote": "three strokes — three joined opening movements, one lift, the joined middle rise and top bar, a second lift, then the right-hand descent and tail; cited to Radhakrishnan, Tamil Script Learners Manual, Frame 12, ந",
+      "penLifts": 2,
+      "strokeOrderSource": {
+        "citation": "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 12, ந (Univ. of Texas at Austin), p. 195",
+        "url": "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+        "variation": "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. Frame 12 uses a looped handwritten form; the vendored Noto face straightens that family resemblance into two stems and a curled right descent, so the evidenced order is adapted to the rendered outline without inventing lifts."
+      },
+      "notes": "The dental n, tongue against the teeth. Contrast ன (alveolar) and ண (retroflex). Frame 12 numbers six movements, not six strokes: the first three stay joined, one lift precedes the rising middle stem and top bar, and a second precedes the right-hand descent. The Noto-backed path keeps that order while honestly following the font's straighter typographic form."
     },
     {
       "glyph": "ன",

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -62,6 +62,13 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
   six movements, then one lift precedes the separate right upright, matching
   Language Ladder's font-checked path.
 
+### Added - verified Tamil ந handwriting
+
+- Record Frame 12's cited six-movement order for Tamil ந as three pen-down
+  runs adapted to the vendored Noto form: three opening movements stay joined,
+  one lift precedes the middle rise and top bar, and a second precedes the
+  right-hand descent and tail.
+
 ### Added - generated lesson figures
 
 - Generate deterministic etymology-route SVGs from the canonical lesson `roots`

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -75,6 +75,15 @@
 - Check all seven movements against the Noto Sans Tamil outline and pin the sole
   lift transition in the real filmstrip and learner prose.
 
+### Added — cited three-stroke ductus for Tamil ந (HL-C09J)
+
+- Add Frame 12's Tamil dental nasal, ந: three joined opening movements, one
+  verified lift before the joined middle rise and top bar, and a second before
+  the right-hand descent and below-baseline tail.
+- Adapt the primer's looped handwritten form to the vendored Noto outline and
+  pin all six movements, both lift transitions, and the source variation in
+  geometry, prose, and filmstrip tests.
+
 ### Added — canonical lesson figures
 
 - Preserve standalone Markdown images as typed lesson blocks instead of flattening

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -165,8 +165,9 @@ in font units, and `ductusview.ts` flips them together with exactly **one**
 `scale(1,-1)` group — so a mistake cannot leave a plausible-looking stroke
 sitting upside down on a correct letter.
 
-**Tamil அ, ஆ, இ, க, ம, வ, ல, ற, ன, and ண have authored pen paths today.** `DUCTUS` admits no letter
-without a citation for its stroke order, and hand-drawing a letter is forbidden
+**All eleven starter Tamil letters — அ, ஆ, இ, க, ம, வ, ல, ற, ன, ண, and ந —
+have authored pen paths today.** `DUCTUS` admits no letter without a citation
+for its stroke order, and hand-drawing a letter is forbidden
 outright (a subtly wrong Tamil ண looks perfect to exactly the audience that
 cannot yet read Tamil, so the error would ship *as the lesson*). அ and ஆ exercise
 real two-stroke paths with one lift; ஆ keeps its upright and long-vowel loop in
@@ -182,9 +183,13 @@ second lift precedes the right arch's joined sweep and descender. ன joins its
 left spiral, single inner arch, and top bar through five movements before one
 lift precedes its separate right upright. ண follows the same two-run pattern,
 keeping its extra inner arch joined to the rest of the body and top bar before
-the sole lift.
-Every other letter falls back to the numbered prose list, unchanged. Extending
-the coverage is HL-C09, and it needs a cited source per letter.
+the sole lift. ந uses three runs: its opening three movements stay joined, the
+middle rise joins the top bar after one lift, and a second lift precedes its
+right-hand descent and tail. Frame 12's looped handwritten form differs from
+Noto's straighter typographic form, so the source records that adaptation while
+the mechanical gates keep every authored point on the actual font. Every other
+script still falls back to the numbered prose list, unchanged. Extending the
+coverage is HL-C09, and it needs a cited source per letter.
 
 ## Where it fits
 

--- a/code/programs/typescript/language-ladder/src/strokes.ts
+++ b/code/programs/typescript/language-ladder/src/strokes.ts
@@ -207,6 +207,10 @@ const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n);
 // ற is Frame 10: movements 1-2 make the left arch and first middle descent,
 // movement 3 restarts on the adjacent middle descent, and movements 4-5 join
 // the right arch to the below-baseline sweep and descender.
+// ந is Frame 12: movements 1-3 stay joined through the opening body and first
+// descent; movements 4-5 restart on the middle rise and continue through the
+// top bar; movement 6 restarts on the right-hand descent and tail. The cited
+// looped handwriting is fitted to Noto's straighter typographic form.
 // ன is Frame 13's first row: movements 1-5 join its left spiral, single inner
 // arch, and top bar; movement 6 restarts on the separate right upright. ண is
 // the adjacent row: movements 1-6 stay joined through the added inner arch and
@@ -881,6 +885,108 @@ export const DUCTUS: Record<string, LetterDuctus> = {
       url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
       variation:
         "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",
+    },
+  },
+  ந: {
+    glyph: "ந",
+    strokes: [
+      {
+        segments: [
+          {
+            label: "sweep from the lower-left tail around the low bowl",
+            path: [
+              { x: 92, y: -300 },
+              { x: 92, y: -235 },
+              { x: 110, y: -185 },
+              { x: 160, y: -140 },
+              { x: 250, y: -120 },
+              { x: 360, y: -120 },
+              { x: 470, y: -105 },
+              { x: 570, y: -70 },
+              { x: 640, y: -15 },
+              { x: 690, y: 75 },
+              { x: 698, y: 160 },
+              { x: 680, y: 235 },
+              { x: 625, y: 300 },
+              { x: 550, y: 325 },
+              { x: 430, y: 300 },
+            ],
+          },
+          {
+            label: "climb to the top and carry left to the first descent",
+            path: [
+              { x: 430, y: 300 },
+              { x: 390, y: 350 },
+              { x: 390, y: 420 },
+              { x: 390, y: 518 },
+              { x: 300, y: 518 },
+              { x: 210, y: 518 },
+              { x: 130, y: 518 },
+            ],
+          },
+          {
+            label: "descend the first upright",
+            path: [
+              { x: 130, y: 518 },
+              { x: 130, y: 380 },
+              { x: 130, y: 220 },
+              { x: 130, y: 25 },
+            ],
+          },
+        ],
+      },
+      {
+        segments: [
+          {
+            label: "rise on the adjacent middle upright",
+            path: [
+              { x: 390, y: 25 },
+              { x: 390, y: 180 },
+              { x: 390, y: 350 },
+              { x: 390, y: 518 },
+            ],
+          },
+          {
+            label: "carry the top bar right",
+            path: [
+              { x: 390, y: 518 },
+              { x: 470, y: 518 },
+              { x: 540, y: 518 },
+              { x: 605, y: 518 },
+            ],
+          },
+        ],
+      },
+      {
+        segments: [
+          {
+            label: "descend the right curve and sweep into the tail",
+            path: [
+              { x: 540, y: 325 },
+              { x: 620, y: 300 },
+              { x: 675, y: 235 },
+              { x: 700, y: 155 },
+              { x: 690, y: 75 },
+              { x: 645, y: -10 },
+              { x: 575, y: -70 },
+              { x: 470, y: -105 },
+              { x: 360, y: -120 },
+              { x: 250, y: -120 },
+              { x: 160, y: -140 },
+              { x: 110, y: -185 },
+              { x: 92, y: -235 },
+              { x: 92, y: -300 },
+            ],
+          },
+        ],
+      },
+    ],
+    source: {
+      citation:
+        "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 12, ந (Univ. of Texas at Austin), p. 195",
+      url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+      variation:
+        "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. Frame 12 uses a looped handwritten form; the vendored Noto face straightens that family resemblance into two stems and a curled right descent, so the evidenced order is adapted to the rendered outline without inventing lifts.",
     },
   },
   ன: {

--- a/code/programs/typescript/language-ladder/tests/ductusview.test.ts
+++ b/code/programs/typescript/language-ladder/tests/ductusview.test.ts
@@ -67,6 +67,8 @@ const NNA = DUCTUS["ன"];
 const nnaOutline = tamilOutline("ன");
 const RETROFLEX_NNA = DUCTUS["ண"];
 const retroflexNnaOutline = tamilOutline("ண");
+const DENTAL_NA = DUCTUS["ந"];
+const dentalNaOutline = tamilOutline("ந");
 
 /** Walk a node tree, collecting every node the predicate accepts. */
 function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = []): SvgNode[] {
@@ -78,7 +80,7 @@ function collect(node: SvgNode, pick: (n: SvgNode) => boolean, out: SvgNode[] = 
 const byTag = (node: SvgNode, tag: string) => collect(node, (n) => n.tag === tag);
 
 describe("ductusFor — only cited letters have a ductus", () => {
-  it("finds all ten authored Tamil letters", () => {
+  it("finds all eleven authored Tamil letters", () => {
     expect(ductusFor("ம")?.glyph).toBe("ம");
     expect(ductusFor("அ")?.glyph).toBe("அ");
     expect(ductusFor("ஆ")?.glyph).toBe("ஆ");
@@ -89,12 +91,13 @@ describe("ductusFor — only cited letters have a ductus", () => {
     expect(ductusFor("ற")?.glyph).toBe("ற");
     expect(ductusFor("ன")?.glyph).toBe("ன");
     expect(ductusFor("ண")?.glyph).toBe("ண");
+    expect(ductusFor("ந")?.glyph).toBe("ந");
   });
 
   it("returns undefined for a letter nobody has authored a stroke order for", () => {
-    // ந is a real Tamil letter with prose stroke order in the curriculum but no
-    // authored pen path. It must come back empty rather than borrow ம's.
-    expect(ductusFor("ந")).toBeUndefined();
+    // Persian ا has prose stroke order in the curriculum but no authored pen
+    // path yet. It must come back empty rather than borrow Tamil ம's.
+    expect(ductusFor("ا")).toBeUndefined();
     expect(ductusFor("A")).toBeUndefined();
     expect(ductusFor("")).toBeUndefined();
   });
@@ -515,6 +518,34 @@ describe("ண — a real cited two-stroke seven-movement filmstrip", () => {
     expect(done).toHaveLength(1);
     expect(done[0].attrs.d).toBe(penPathD(RETROFLEX_NNA.strokes[0], 1));
     expect(pen.attrs.d).toBe(penPathD(RETROFLEX_NNA.strokes[1], 1));
+  });
+});
+
+describe("ந — a real cited three-stroke six-movement filmstrip", () => {
+  const steps = ductusSteps(DENTAL_NA);
+  const strip = ductusFilmstrip(DENTAL_NA, dentalNaOutline);
+
+  it("marks the two source-backed lift transitions", () => {
+    expect(steps.map((step) => step.startsAfterLift)).toEqual([false, false, false, true, false, true]);
+    expect(steps.map((step) => step.strokeIndex)).toEqual([0, 0, 0, 1, 1, 2]);
+  });
+
+  it("reports six movements in three strokes with two lifts", () => {
+    expect(strip.frames).toHaveLength(6);
+    expect(strip.penLifts).toBe(2);
+    expect(strip.summary).toBe("3 strokes · 2 pen lifts · 6 movements");
+  });
+
+  it("keeps both completed strokes visible during the right-hand descent", () => {
+    const last = strip.frames[5];
+    const done = byTag(last, "path").filter((path) => path.attrs.class === "ductus__done");
+    const pen = byTag(last, "path").find((path) => path.attrs.class === "ductus__pen")!;
+    expect(done).toHaveLength(2);
+    expect(done.map((path) => path.attrs.d)).toEqual([
+      penPathD(DENTAL_NA.strokes[0], 1),
+      penPathD(DENTAL_NA.strokes[1], 1),
+    ]);
+    expect(pen.attrs.d).toBe(penPathD(DENTAL_NA.strokes[2], 1));
   });
 });
 

--- a/code/programs/typescript/language-ladder/tests/strokes.test.ts
+++ b/code/programs/typescript/language-ladder/tests/strokes.test.ts
@@ -228,6 +228,12 @@ describe("handwriting ductus", () => {
     expect(DUCTUS["ண"].strokes.map((stroke) => stroke.segments.length)).toEqual([6, 1]);
   });
 
+  it("ந lifts between its three pen-down runs", () => {
+    expect(penLifts(DUCTUS["ந"])).toBe(2);
+    expect(DUCTUS["ந"].strokes).toHaveLength(3);
+    expect(DUCTUS["ந"].strokes.map((stroke) => stroke.segments.length)).toEqual([3, 2, 1]);
+  });
+
   // The PROVENANCE GATE. A stroke's SHAPE is checked against the font above;
   // its ORDER cannot be — so it must trace to a cited source, or it does not
   // ship. This is the counterpart, for hand-authored order, of "facts enter
@@ -330,6 +336,13 @@ describe("handwriting ductus", () => {
     expect(src.url).toContain("tamilscript");
     expect(src.citation).toMatch(/Appendix I.*Frame 13.*ண/);
     expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
+  });
+
+  it("ந's stroke order traces to Frame 12 and records the Noto adaptation", () => {
+    const src = DUCTUS["ந"].source;
+    expect(src.url).toContain("tamilscript");
+    expect(src.citation).toMatch(/Appendix I.*Frame 12.*ந/);
+    expect(src.variation).toMatch(/looped handwritten form.*Noto/i);
   });
 });
 


### PR DESCRIPTION
## What changed

- add the cited six-movement Tamil ந ductus from Frame 12 of the UT Austin handwriting primer
- preserve three pen-down runs and two evidenced lifts while adapting the source’s looped handwritten form to the vendored Noto outline
- add geometry, filmstrip, lift, provenance, and source-agreement tests
- mark the Tamil starter inventory fully verified and queue Persian ا as HL-C09K

## Why

HL-C09 requires every prose stroke-order entry to gain source-backed pen-lift metadata and a font-checked path before Language Ladder renders it. ந was the final unverified Tamil starter entry.

## Validation

- focused ductus and filmstrip tests: 136 passed
- human-language-data: 460 tests passed
- language-ladder: typecheck, production build, bundle check, and 615 tests passed
- `bash code/scripts/verify-human-languages.sh --fast`: all local checks passed
- `git diff --check`