### PR TITLE
Add Mermaid sequence participant boxes

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -3,9 +3,11 @@
 
 document = { NEWLINE } HEADER body EOF ;
 body = { NEWLINE | statement } ;
-statement = participant_stmt | destroy_stmt | message_stmt | activation_stmt | note_stmt | title_stmt | autonumber_stmt | control_block ;
+statement = participant_stmt | participant_box | destroy_stmt | message_stmt | activation_stmt | note_stmt | title_stmt | autonumber_stmt | control_block ;
 
-participant_stmt = [ "create" ] ( "participant" | "actor" ) identifier [ "as" text ] ;
+participant_stmt = [ "create" ] participant_decl ;
+participant_decl = ( "participant" | "actor" ) identifier [ "as" text ] ;
+participant_box = "box" [ text ] NEWLINE { NEWLINE | participant_decl } "end" ;
 destroy_stmt = "destroy" identifier ;
 message_stmt = identifier message_arrow [ PLUS | MINUS ] identifier COLON [ text ] ;
 activation_stmt = ( "activate" | "deactivate" ) identifier ;
@@ -21,5 +23,5 @@ critical_block = "critical" [ text ] NEWLINE body { "option" [ text ] NEWLINE bo
 
 actor_pair = identifier [ COMMA identifier ] ;
 message_arrow = SOLID_OPEN_ARROW | DOTTED_OPEN_ARROW | SOLID_FILLED_ARROW | DOTTED_FILLED_ARROW | BIDIRECTIONAL_SOLID | BIDIRECTIONAL_DOTTED | SOLID_CROSS_ARROW | DOTTED_CROSS_ARROW | SOLID_POINT_ARROW | DOTTED_POINT_ARROW ;
-identifier = IDENTIFIER | WORD ;
+identifier = IDENTIFIER | WORD | COLOR ;
 text = identifier { identifier } ;

--- a/code/grammars/mermaid/sequence.tokens
+++ b/code/grammars/mermaid/sequence.tokens
@@ -19,6 +19,7 @@ SOLID_OPEN_ARROW         = "->"
 SOLID_CROSS_ARROW        = "-x"
 SOLID_POINT_ARROW        = "-)"
 COLON                    = ":"
+COLOR                    = /rgba?\([^\)\r\n]*\)/
 COMMA                    = ","
 PLUS                     = "+"
 MINUS                    = "-"
@@ -30,6 +31,7 @@ keywords:
   actor
   create
   destroy
+  box
   as
   activate
   deactivate

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.7.0
+
+- Added semantic and layout IR primitives for sequence participant groups.
+
 ## 0.6.0
 
 - Added sequence participant creation/destruction events and destruction geometry.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.6.0 — DG00/DG04 semantic IR
+//! diagram-ir v0.7.0 — DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.6.0";
+pub const VERSION: &str = "0.7.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -166,6 +166,14 @@ pub struct SequenceParticipant {
     pub label: DiagramLabel,
     pub kind: SequenceParticipantKind,
     pub style: Option<DiagramStyle>,
+    pub group_id: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SequenceParticipantGroup {
+    pub id: String,
+    pub label: Option<String>,
+    pub fill: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -245,11 +253,21 @@ pub struct SequenceDiagram {
     pub title: Option<String>,
     pub auto_number: bool,
     pub participants: Vec<SequenceParticipant>,
+    pub participant_groups: Vec<SequenceParticipantGroup>,
     pub events: Vec<SequenceEvent>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum LayoutedSequenceItem {
+    ParticipantGroup {
+        id: String,
+        label: Option<String>,
+        fill: Option<String>,
+        x: f64,
+        y: f64,
+        width: f64,
+        height: f64,
+    },
     ParticipantBox {
         id: String,
         label: String,
@@ -861,8 +879,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_is_0_6_0() {
-        assert_eq!(VERSION, "0.6.0");
+    fn version_is_0_7_0() {
+        assert_eq!(VERSION, "0.7.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0 - 2026-08-09
+
+- Lay out sequence participant groups around their member lanes.
+
 ## 0.3.0 - 2026-08-09
 
 - Place created participant headers at their event and bound lifelines at destruction.

--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-sequence"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
 

--- a/code/packages/rust/diagram-layout-sequence/README.md
+++ b/code/packages/rust/diagram-layout-sequence/README.md
@@ -6,3 +6,5 @@ activation bars for `diagram-to-paint`. Nested control-block events become
 depth-aware frames and labeled branch dividers without introducing paint or
 backend concepts into semantic IR. Participant lifecycle events place dynamic
 headers and bound their lifelines to explicit destruction markers.
+Participant-group geometry encloses the lanes declared in Mermaid `box`
+blocks and carries backend-neutral labels and optional fills into PaintScene.

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -7,7 +7,7 @@ use diagram_ir::{
     SequenceEvent, SequenceNotePlacement,
 };
 
-pub const VERSION: &str = "0.3.0";
+pub const VERSION: &str = "0.4.0";
 
 const MARGIN: f64 = 28.0;
 const HEADER_Y: f64 = 42.0;
@@ -34,6 +34,12 @@ struct BlockFrameState {
 /// Lay out an ordered sequence diagram. Participant order is semantic and is
 /// therefore retained exactly rather than optimized by the layout engine.
 pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDiagram {
+    let header_y = HEADER_Y
+        + if diagram.participant_groups.is_empty() {
+            0.0
+        } else {
+            28.0
+        };
     let lane_widths: Vec<f64> = diagram
         .participants
         .iter()
@@ -55,8 +61,10 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
     let mut lifeline_ends = HashMap::new();
     let mut items = Vec::new();
     let mut x = MARGIN;
+    let mut lane_lefts = Vec::with_capacity(lane_widths.len());
 
     for (participant, lane_width) in diagram.participants.iter().zip(&lane_widths) {
+        lane_lefts.push(x);
         let box_width = (*lane_width - 24.0).max(100.0);
         let center = x + *lane_width / 2.0;
         centers.insert(participant.id.clone(), center);
@@ -66,16 +74,16 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                 label: participant.label.text.clone(),
                 kind: participant.kind.clone(),
                 x: center - box_width / 2.0,
-                y: HEADER_Y,
+                y: header_y,
                 width: box_width,
                 height: HEADER_H,
             });
-            lifeline_starts.insert(participant.id.clone(), HEADER_Y + HEADER_H);
+            lifeline_starts.insert(participant.id.clone(), header_y + HEADER_H);
         }
         x += *lane_width;
     }
 
-    let event_start = HEADER_Y + HEADER_H + 36.0;
+    let event_start = header_y + HEADER_H + 36.0;
     let mut y = event_start;
     let mut activation_starts: HashMap<String, Vec<f64>> = HashMap::new();
     let mut message_number = 0usize;
@@ -262,6 +270,29 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
     }
 
     let height = (y + 36.0).max(180.0);
+    for group in &diagram.participant_groups {
+        let indexes: Vec<usize> = diagram
+            .participants
+            .iter()
+            .enumerate()
+            .filter_map(|(index, participant)| {
+                (participant.group_id.as_deref() == Some(group.id.as_str())).then_some(index)
+            })
+            .collect();
+        if let (Some(first), Some(last)) = (indexes.first(), indexes.last()) {
+            let group_x = lane_lefts[*first] + 4.0;
+            let group_right = lane_lefts[*last] + lane_widths[*last] - 4.0;
+            items.push(LayoutedSequenceItem::ParticipantGroup {
+                id: group.id.clone(),
+                label: group.label.clone(),
+                fill: group.fill.clone(),
+                x: group_x,
+                y: HEADER_Y - 6.0,
+                width: group_right - group_x,
+                height: height - 22.0,
+            });
+        }
+    }
     for participant in &diagram.participants {
         if let Some(&center) = centers.get(&participant.id) {
             items.push(LayoutedSequenceItem::Lifeline {
@@ -270,7 +301,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                 y1: lifeline_starts
                     .get(&participant.id)
                     .copied()
-                    .unwrap_or(HEADER_Y + HEADER_H),
+                    .unwrap_or(header_y + HEADER_H),
                 y2: lifeline_ends
                     .get(&participant.id)
                     .copied()
@@ -328,6 +359,7 @@ mod tests {
             label: DiagramLabel::new(id),
             kind: SequenceParticipantKind::Participant,
             style: None,
+            group_id: None,
         }
     }
 
@@ -337,6 +369,7 @@ mod tests {
             title: None,
             auto_number: true,
             participants: vec![participant("Alice"), participant("Bob")],
+            participant_groups: vec![],
             events: vec![SequenceEvent::Message {
                 from: "Alice".into(),
                 to: "Bob".into(),
@@ -380,6 +413,7 @@ mod tests {
             title: None,
             auto_number: false,
             participants: vec![participant("Bob")],
+            participant_groups: vec![],
             events: vec![
                 SequenceEvent::Activation {
                     participant: "Bob".into(),
@@ -403,6 +437,7 @@ mod tests {
             title: None,
             auto_number: false,
             participants: vec![participant("Alice"), participant("Bob")],
+            participant_groups: vec![],
             events: vec![
                 SequenceEvent::BlockStart {
                     kind: SequenceBlockKind::Alt,
@@ -456,6 +491,7 @@ mod tests {
             title: None,
             auto_number: false,
             participants: vec![participant("Alice"), participant("Worker")],
+            participant_groups: vec![],
             events: vec![
                 SequenceEvent::Message {
                     from: "Alice".into(),
@@ -522,5 +558,42 @@ mod tests {
         assert_eq!(lifeline_y1, worker_box_y + HEADER_H);
         assert_eq!(lifeline_y2, destruction_y);
         assert!(worker_box_y > HEADER_Y);
+    }
+
+    #[test]
+    fn participant_group_encloses_only_member_lanes() {
+        let mut alice = participant("Alice");
+        alice.group_id = Some("client".into());
+        let mut bob = participant("Bob");
+        bob.group_id = Some("client".into());
+        let diagram = SequenceDiagram {
+            title: None,
+            auto_number: false,
+            participants: vec![alice, bob, participant("Database")],
+            participant_groups: vec![diagram_ir::SequenceParticipantGroup {
+                id: "client".into(),
+                label: Some("Client tier".into()),
+                fill: Some("aqua".into()),
+            }],
+            events: vec![],
+        };
+        let layout = layout_sequence_diagram(&diagram);
+        let (group_x, group_width) = layout
+            .items
+            .iter()
+            .find_map(|item| match item {
+                LayoutedSequenceItem::ParticipantGroup { x, width, .. } => Some((*x, *width)),
+                _ => None,
+            })
+            .unwrap();
+        let database_x = layout
+            .items
+            .iter()
+            .find_map(|item| match item {
+                LayoutedSequenceItem::ParticipantBox { id, x, .. } if id == "Database" => Some(*x),
+                _ => None,
+            })
+            .unwrap();
+        assert!(group_x + group_width < database_x);
     }
 }

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added sequence participant-group backgrounds and labels.
 - Added a Mermaid Pie -> chart layout -> PaintScene -> Metal PNG example and
   Apple end-to-end test.
 - Added sequence lowering for participant headers, lifelines, messages,

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.6.0";
+pub const VERSION: &str = "0.7.0";
 
 use std::collections::HashMap;
 
@@ -1087,6 +1087,45 @@ where
         a: 255,
     };
 
+    // Participant groups form the rear-most layer around their member lanes.
+    for item in &diagram.items {
+        if let LayoutedSequenceItem::ParticipantGroup {
+            label,
+            fill,
+            x,
+            y,
+            width,
+            height,
+            ..
+        } = item
+        {
+            instructions.push(PaintInstruction::Rect(PaintRect {
+                base: PaintBase::default(),
+                x: *x,
+                y: *y,
+                width: *width,
+                height: *height,
+                fill: fill.clone(),
+                stroke: Some("#94a3b8".into()),
+                stroke_width: Some(1.25),
+                corner_radius: Some(6.0),
+                stroke_dash: None,
+                stroke_dash_offset: None,
+            }));
+            if let Some(label) = label {
+                text_children.push(text_node(
+                    label,
+                    *x + 8.0,
+                    *y + 6.0,
+                    *width - 16.0,
+                    20.0,
+                    label_font.clone(),
+                    text_color,
+                ));
+            }
+        }
+    }
+
     // Block frames are backgrounds. Paint outer frames before nested frames
     // regardless of the order in which their closing events were laid out.
     let mut frames: Vec<&LayoutedSequenceItem> = diagram
@@ -1476,7 +1515,7 @@ fn sequence_block_colors(kind: &SequenceBlockKind) -> (&'static str, &'static st
         SequenceBlockKind::Break => ("#fff1f2", "#e11d48"),
         SequenceBlockKind::Critical => ("#fefce8", "#ca8a04"),
         SequenceBlockKind::Par | SequenceBlockKind::ParOver => ("#f0fdfa", "#0f766e"),
-        _ => ("#f8fafc", "#64748b"),
+        _ => ("transparent", "#64748b"),
     }
 }
 
@@ -2376,7 +2415,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.6.0");
+        assert_eq!(crate::VERSION, "0.7.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -348,7 +348,7 @@ mod apple {
     #[test]
     fn render_mermaid_sequence_to_png() {
         let diagram = parse_sequence_diagram(
-            "sequenceDiagram\ntitle Native Mermaid sequence\nautonumber\nactor User\nparticipant API as Banking API\nparticipant DB as Ledger\nalt Transfer accepted\nUser->>+API: Submit transfer\ncreate participant Worker as Audit Worker\nAPI->>Worker: Start audit\nWorker-->>API: Audit complete\ndestroy Worker\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete\nelse Transfer rejected\nAPI-->>User: Validation failed\nend",
+            "sequenceDiagram\ntitle Native Mermaid sequence\nautonumber\nbox aqua Client tier\nactor User\nparticipant API as Banking API\nend\nbox Services\nparticipant DB as Ledger\nend\nalt Transfer accepted\nUser->>+API: Submit transfer\ncreate participant Worker as Audit Worker\nAPI->>Worker: Start audit\nWorker-->>API: Audit complete\ndestroy Worker\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete\nelse Transfer rejected\nAPI-->>User: Validation failed\nend",
         )
         .expect("Mermaid sequence parse failed");
         let layout = layout_sequence_diagram(&diagram);
@@ -391,6 +391,11 @@ mod apple {
             instruction,
             paint_instructions::PaintInstruction::Rect(rect)
                 if rect.stroke.as_deref() == Some("#64748b")
+        )));
+        assert!(scene.instructions.iter().any(|instruction| matches!(
+            instruction,
+            paint_instructions::PaintInstruction::Rect(rect)
+                if rect.stroke.as_deref() == Some("#94a3b8")
         )));
     }
 }

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+- Tokenize sequence participant boxes and CSS functional colors.
+
 ## 0.5.0
 
 - Added Mermaid sequence participant lifecycle tokens.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.5.0";
+pub const VERSION: &str = "0.6.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.5.0");
+        assert_eq!(VERSION, "0.6.0");
     }
 
     #[test]
@@ -323,5 +323,15 @@ mod tests {
         assert!(values.contains(&"create"));
         assert!(values.contains(&"destroy"));
         assert!(values.contains(&"Worker"));
+    }
+
+    #[test]
+    fn tokenizes_sequence_box_color_as_one_token() {
+        let tokens = tokenize_mermaid_sequence(
+            "sequenceDiagram\nbox rgba(33,66,99,0.5) Services\nparticipant API\nend\n",
+        );
+        assert!(tokens
+            .iter()
+            .any(|token| token.value == "rgba(33,66,99,0.5)"));
     }
 }

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0
+
+- Parse Mermaid sequence `box` declarations into participant-group IR.
+
 ## 0.6.0
 
 - Added grammar-backed `create participant`, `create actor`, and `destroy` lowering.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -37,7 +37,8 @@ The sequence subset includes participants and actors, aliases, standard solid
 and dotted message arrows, bidirectional/cross/point arrowheads, notes,
 activations, titles, automatic numbering, and nested control blocks with branch
 separators. Participant creation and destruction are lifecycle events consumed
-by layout. Advanced participant metadata remains an explicit compatibility gap.
+by layout. Participant `box` declarations preserve group labels, fills, and
+membership. Advanced participant metadata remains an explicit compatibility gap.
 
 All other Mermaid 11.16.1 family headers are recognized and return an explicit
 `recognized but not implemented` error until their grammar, lowering, layout,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.6.0";
+pub const VERSION: &str = "0.7.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -449,9 +449,9 @@ use diagram_ir::{
     CompartmentKind, GanttDiagram, GanttSection, GanttTask, GitBranch, GitCommitType, GitDiagram,
     GitEvent, PieSlice, RelKind, SankeyFlow, SankeyNode, SequenceArrowhead, SequenceBlockKind,
     SequenceDiagram, SequenceEvent, SequenceLineStyle, SequenceNotePlacement, SequenceParticipant,
-    SequenceParticipantKind, SeriesKind, StructuralDiagram, StructuralGroup, StructuralKind,
-    StructuralNode, StructuralNodeKind, StructuralRelationship, TaskStart, TaskStatus,
-    TemporalBody, TemporalDiagram, TemporalKind,
+    SequenceParticipantGroup, SequenceParticipantKind, SeriesKind, StructuralDiagram,
+    StructuralGroup, StructuralKind, StructuralNode, StructuralNodeKind, StructuralRelationship,
+    TaskStart, TaskStatus, TemporalBody, TemporalDiagram, TemporalKind,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1033,6 +1033,7 @@ pub fn parse_sequence_diagram(source: &str) -> Result<SequenceDiagram, ParseErro
         title: None,
         auto_number: false,
         participants: Vec::new(),
+        participant_groups: Vec::new(),
         events: Vec::new(),
     };
     let mut participant_indices: HashMap<String, usize> = HashMap::new();
@@ -1052,12 +1053,13 @@ fn parse_sequence_body(
     while !cursor.at_eof() && !terminators.contains(&cursor.current().value.as_str()) {
         match cursor.current().value.as_str() {
             "participant" | "actor" => {
-                parse_sequence_participant(cursor, diagram, participant_indices, false)?
+                parse_sequence_participant(cursor, diagram, participant_indices, false)?;
             }
             "create" => {
                 cursor.advance();
                 parse_sequence_participant(cursor, diagram, participant_indices, true)?;
             }
+            "box" => parse_sequence_participant_box(cursor, diagram, participant_indices)?,
             "destroy" => {
                 cursor.advance();
                 let participant = take_sequence_identifier(cursor)?;
@@ -1102,7 +1104,7 @@ fn parse_sequence_participant(
     diagram: &mut SequenceDiagram,
     participant_indices: &mut HashMap<String, usize>,
     created: bool,
-) -> Result<(), ParseError> {
+) -> Result<String, ParseError> {
     let declaration = cursor.advance().clone();
     let kind = match declaration.value.as_str() {
         "actor" => SequenceParticipantKind::Actor,
@@ -1123,11 +1125,85 @@ fn parse_sequence_participant(
     };
     upsert_sequence_participant(diagram, participant_indices, id.clone(), label, kind);
     if created {
-        diagram
-            .events
-            .push(SequenceEvent::ParticipantCreated { participant: id });
+        diagram.events.push(SequenceEvent::ParticipantCreated {
+            participant: id.clone(),
+        });
     }
+    Ok(id)
+}
+
+fn parse_sequence_participant_box(
+    cursor: &mut TokenCursor,
+    diagram: &mut SequenceDiagram,
+    participant_indices: &mut HashMap<String, usize>,
+) -> Result<(), ParseError> {
+    cursor.advance();
+    let (fill, label) = parse_sequence_box_header(&take_sequence_line_text(cursor));
+    let group_id = format!("box-{}", diagram.participant_groups.len() + 1);
+    diagram.participant_groups.push(SequenceParticipantGroup {
+        id: group_id.clone(),
+        label,
+        fill,
+    });
+    cursor.skip_terminators();
+    while !cursor.at_eof() && cursor.current().value != "end" {
+        if !matches!(cursor.current().value.as_str(), "participant" | "actor") {
+            return Err(token_error(
+                cursor.current(),
+                "sequence box may only contain participant declarations",
+            ));
+        }
+        let id = parse_sequence_participant(cursor, diagram, participant_indices, false)?;
+        let index = participant_indices[&id];
+        diagram.participants[index].group_id = Some(group_id.clone());
+        cursor.skip_terminators();
+    }
+    if cursor.at_eof() {
+        return Err(token_error(cursor.current(), "unterminated sequence box"));
+    }
+    cursor.advance();
     Ok(())
+}
+
+fn parse_sequence_box_header(raw: &str) -> (Option<String>, Option<String>) {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return (None, None);
+    }
+    let split = raw.find(char::is_whitespace).unwrap_or(raw.len());
+    let first = &raw[..split];
+    let is_function_color = ["rgb(", "rgba("]
+        .iter()
+        .any(|prefix| first.to_ascii_lowercase().starts_with(prefix));
+    let is_named_color = matches!(
+        first.to_ascii_lowercase().as_str(),
+        "aqua"
+            | "black"
+            | "blue"
+            | "fuchsia"
+            | "gray"
+            | "grey"
+            | "green"
+            | "lime"
+            | "maroon"
+            | "navy"
+            | "olive"
+            | "orange"
+            | "purple"
+            | "red"
+            | "silver"
+            | "teal"
+            | "transparent"
+            | "white"
+            | "yellow"
+    );
+    if is_function_color || is_named_color {
+        let label = raw[split..].trim();
+        let fill = (!first.eq_ignore_ascii_case("transparent")).then(|| first.to_string());
+        (fill, (!label.is_empty()).then(|| label.to_string()))
+    } else {
+        (None, Some(raw.to_string()))
+    }
 }
 
 fn parse_sequence_control_block(
@@ -1350,6 +1426,7 @@ fn upsert_sequence_participant(
         label: DiagramLabel::new(label),
         kind,
         style: None,
+        group_id: None,
     });
 }
 
@@ -2702,6 +2779,39 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
             SequenceEvent::ParticipantDestroyed { participant } if participant == "Worker"
         )));
     }
+
+    #[test]
+    fn sequence_parses_participant_boxes() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\nbox Purple Client tier\nactor User\nparticipant API as Banking API\nend\nbox Services\nparticipant DB\nend\n",
+        )
+        .unwrap();
+        assert_eq!(diagram.participant_groups.len(), 2);
+        assert_eq!(
+            diagram.participant_groups[0].fill.as_deref(),
+            Some("Purple")
+        );
+        assert_eq!(
+            diagram.participant_groups[0].label.as_deref(),
+            Some("Client tier")
+        );
+        assert_eq!(diagram.participant_groups[1].fill, None);
+        assert_eq!(
+            diagram.participant_groups[1].label.as_deref(),
+            Some("Services")
+        );
+        assert_eq!(diagram.participants[0].group_id.as_deref(), Some("box-1"));
+        assert_eq!(diagram.participants[2].group_id.as_deref(), Some("box-2"));
+    }
+
+    #[test]
+    fn sequence_rejects_messages_inside_participant_boxes() {
+        let error = parse_sequence_diagram(
+            "sequenceDiagram\nbox Services\nparticipant API\nAPI->>DB: Query\nend\n",
+        )
+        .expect_err("box bodies only allow participant declarations");
+        assert!(!error.message.is_empty());
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -2718,7 +2828,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.6.0");
+        assert_eq!(crate::VERSION, "0.7.0");
     }
 
     #[test]

--- a/code/packages/rust/paint-metal/CHANGELOG.md
+++ b/code/packages/rust/paint-metal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — paint-metal
 
+## 0.3.0 — 2026-08-09
+
+- Added CSS named-color support for backend-neutral PaintInstructions.
+
 ## 0.2.0 — 2026-04-23
 
 ### Added

--- a/code/packages/rust/paint-metal/Cargo.toml
+++ b/code/packages/rust/paint-metal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paint-metal"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Metal GPU renderer for paint-instructions scenes (P2D01): PaintScene → PixelContainer via Apple's Metal API"
 

--- a/code/packages/rust/paint-metal/src/lib.rs
+++ b/code/packages/rust/paint-metal/src/lib.rs
@@ -76,7 +76,7 @@
 // Platform-conditional: code for the non-native platform is intentionally inactive; allow the resulting dead_code/unused lints only where it does not compile in.
 #![cfg_attr(not(target_vendor = "apple"), allow(dead_code, unused_imports))]
 
-pub const VERSION: &str = "0.2.0";
+pub const VERSION: &str = "0.3.0";
 
 pub use paint_instructions::PixelContainer;
 
@@ -172,6 +172,9 @@ fn parse_hex_color(s: &str) -> (f64, f64, f64, f64) {
     if s == "transparent" {
         return (0.0, 0.0, 0.0, 0.0);
     }
+    if let Some(hex) = css_named_color(s) {
+        return parse_hex_color(hex);
+    }
     // CSS rgb()/rgba() support — layout-to-paint emits these.
     if let Some(inner) = s.strip_prefix("rgba(").and_then(|t| t.strip_suffix(')')) {
         return parse_rgb_components(inner, true);
@@ -202,6 +205,29 @@ fn parse_hex_color(s: &str) -> (f64, f64, f64, f64) {
         1.0
     };
     (r, g, b, a)
+}
+
+fn css_named_color(name: &str) -> Option<&'static str> {
+    Some(match name.to_ascii_lowercase().as_str() {
+        "aqua" => "#00ffff",
+        "black" => "#000000",
+        "blue" => "#0000ff",
+        "fuchsia" => "#ff00ff",
+        "gray" | "grey" => "#808080",
+        "green" => "#008000",
+        "lime" => "#00ff00",
+        "maroon" => "#800000",
+        "navy" => "#000080",
+        "olive" => "#808000",
+        "orange" => "#ffa500",
+        "purple" => "#800080",
+        "red" => "#ff0000",
+        "silver" => "#c0c0c0",
+        "teal" => "#008080",
+        "white" => "#ffffff",
+        "yellow" => "#ffff00",
+        _ => return None,
+    })
 }
 
 /// Parse the comma-separated r,g,b(,a) components from inside an
@@ -351,8 +377,14 @@ fn add_rect_vertices(rect: &PaintRect, positions: &mut Vec<f32>, colors: &mut Ve
 /// Emit a filled axis-aligned rectangle as two triangles (helper).
 #[allow(clippy::too_many_arguments)] // geometry + color + buffers; signature kept as-is
 fn emit_filled_rect(
-    x: f32, y: f32, w: f32, h: f32,
-    r: f32, g: f32, b: f32, a: f32,
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+    r: f32,
+    g: f32,
+    b: f32,
+    a: f32,
     positions: &mut Vec<f32>,
     colors: &mut Vec<f32>,
 ) {
@@ -395,10 +427,14 @@ fn add_line_vertices(line: &PaintLine, positions: &mut Vec<f32>, colors: &mut Ve
     let nx = -dy / len * half_w;
     let ny = dx / len * half_w;
 
-    let p0x = x1 + nx; let p0y = y1 + ny;
-    let p1x = x1 - nx; let p1y = y1 - ny;
-    let p2x = x2 + nx; let p2y = y2 + ny;
-    let p3x = x2 - nx; let p3y = y2 - ny;
+    let p0x = x1 + nx;
+    let p0y = y1 + ny;
+    let p1x = x1 - nx;
+    let p1y = y1 - ny;
+    let p2x = x2 + nx;
+    let p2y = y2 + ny;
+    let p3x = x2 - nx;
+    let p3y = y2 - ny;
 
     positions.extend_from_slice(&[p0x, p0y, p2x, p2y, p1x, p1y]);
     colors.extend_from_slice(&[r, g, b, a, r, g, b, a, r, g, b, a]);
@@ -442,10 +478,7 @@ fn add_ellipse_vertices(ellipse: &PaintEllipse, positions: &mut Vec<f32>, colors
     let mut pts: Vec<(f32, f32)> = Vec::with_capacity(ELLIPSE_SEGMENTS);
     for i in 0..ELLIPSE_SEGMENTS {
         let angle = (i as f64 / ELLIPSE_SEGMENTS as f64) * TAU;
-        pts.push((
-            cx + rx * angle.cos() as f32,
-            cy + ry * angle.sin() as f32,
-        ));
+        pts.push((cx + rx * angle.cos() as f32, cy + ry * angle.sin() as f32));
     }
 
     // Fill: fan from centre
@@ -552,11 +585,19 @@ fn add_path_vertices(path: &PaintPath, positions: &mut Vec<f32>, colors: &mut Ve
                 cy = *y as f32;
                 current.push((cx, cy));
             }
-            PathCommand::QuadTo { cx: qcx, cy: qcy, x, y } => {
+            PathCommand::QuadTo {
+                cx: qcx,
+                cy: qcy,
+                x,
+                y,
+            } => {
                 // De Casteljau — 8 linear segments
-                let p0x = cx; let p0y = cy;
-                let p1x = *qcx as f32; let p1y = *qcy as f32;
-                let p2x = *x as f32;   let p2y = *y as f32;
+                let p0x = cx;
+                let p0y = cy;
+                let p1x = *qcx as f32;
+                let p1y = *qcy as f32;
+                let p2x = *x as f32;
+                let p2y = *y as f32;
                 for k in 1..=8u32 {
                     let t = k as f32 / 8.0;
                     let u = 1.0 - t;
@@ -564,22 +605,41 @@ fn add_path_vertices(path: &PaintPath, positions: &mut Vec<f32>, colors: &mut Ve
                     let qy = u * u * p0y + 2.0 * u * t * p1y + t * t * p2y;
                     current.push((qx, qy));
                 }
-                cx = p2x; cy = p2y;
+                cx = p2x;
+                cy = p2y;
             }
-            PathCommand::CubicTo { cx1, cy1, cx2, cy2, x, y } => {
+            PathCommand::CubicTo {
+                cx1,
+                cy1,
+                cx2,
+                cy2,
+                x,
+                y,
+            } => {
                 // De Casteljau — 8 linear segments
-                let p0x = cx; let p0y = cy;
-                let p1x = *cx1 as f32; let p1y = *cy1 as f32;
-                let p2x = *cx2 as f32; let p2y = *cy2 as f32;
-                let p3x = *x as f32;   let p3y = *y as f32;
+                let p0x = cx;
+                let p0y = cy;
+                let p1x = *cx1 as f32;
+                let p1y = *cy1 as f32;
+                let p2x = *cx2 as f32;
+                let p2y = *cy2 as f32;
+                let p3x = *x as f32;
+                let p3y = *y as f32;
                 for k in 1..=8u32 {
                     let t = k as f32 / 8.0;
                     let u = 1.0 - t;
-                    let qx = u*u*u*p0x + 3.0*u*u*t*p1x + 3.0*u*t*t*p2x + t*t*t*p3x;
-                    let qy = u*u*u*p0y + 3.0*u*u*t*p1y + 3.0*u*t*t*p2y + t*t*t*p3y;
+                    let qx = u * u * u * p0x
+                        + 3.0 * u * u * t * p1x
+                        + 3.0 * u * t * t * p2x
+                        + t * t * t * p3x;
+                    let qy = u * u * u * p0y
+                        + 3.0 * u * u * t * p1y
+                        + 3.0 * u * t * t * p2y
+                        + t * t * t * p3y;
                     current.push((qx, qy));
                 }
-                cx = p3x; cy = p3y;
+                cx = p3x;
+                cy = p3y;
             }
             PathCommand::ArcTo { .. } => {
                 // ArcTo: not tessellated yet — skip. Diagrams don't use arcs.
@@ -728,17 +788,34 @@ unsafe fn render_unsafe(scene: &PaintScene) -> PixelContainer {
     let (cr, cg, cb, ca) = parse_hex_color(&scene.background);
 
     msg!(attachment0, "setTexture:", texture);
-    msg!(attachment0, "setLoadAction:", MTL_LOAD_ACTION_CLEAR as usize);
-    msg!(attachment0, "setStoreAction:", MTL_STORE_ACTION_STORE as usize);
+    msg!(
+        attachment0,
+        "setLoadAction:",
+        MTL_LOAD_ACTION_CLEAR as usize
+    );
+    msg!(
+        attachment0,
+        "setStoreAction:",
+        MTL_STORE_ACTION_STORE as usize
+    );
 
     // MTLClearColor is 4 doubles — passed as HFA in d0-d3 on arm64
-    let clear_color = MTLClearColor { red: cr, green: cg, blue: cb, alpha: ca };
+    let clear_color = MTLClearColor {
+        red: cr,
+        green: cg,
+        blue: cb,
+        alpha: ca,
+    };
     let set_clear_color: unsafe extern "C" fn(Id, Sel, MTLClearColor) =
         std::mem::transmute(objc_msgSend as *const ());
     set_clear_color(attachment0, sel("setClearColor:"), clear_color);
 
     let command_buffer = msg_send_id(command_queue, "commandBuffer");
-    let encoder: Id = msg!(command_buffer, "renderCommandEncoderWithDescriptor:", pass_desc);
+    let encoder: Id = msg!(
+        command_buffer,
+        "renderCommandEncoderWithDescriptor:",
+        pass_desc
+    );
 
     let viewport_size: [f32; 2] = [width as f32, height as f32];
 
@@ -750,14 +827,37 @@ unsafe fn render_unsafe(scene: &PaintScene) -> PixelContainer {
         let color_buffer = create_buffer(device, &colors);
 
         msg!(encoder, "setRenderPipelineState:", rect_pipeline);
-        msg!(encoder, "setVertexBuffer:offset:atIndex:", pos_buffer, 0usize, 0usize);
-        msg!(encoder, "setVertexBuffer:offset:atIndex:", color_buffer, 0usize, 1usize);
+        msg!(
+            encoder,
+            "setVertexBuffer:offset:atIndex:",
+            pos_buffer,
+            0usize,
+            0usize
+        );
+        msg!(
+            encoder,
+            "setVertexBuffer:offset:atIndex:",
+            color_buffer,
+            0usize,
+            1usize
+        );
 
         let vp_ptr = viewport_size.as_ptr() as *const std::ffi::c_void as Id;
-        msg!(encoder, "setVertexBytes:length:atIndex:", vp_ptr, 8usize, 2usize);
+        msg!(
+            encoder,
+            "setVertexBytes:length:atIndex:",
+            vp_ptr,
+            8usize,
+            2usize
+        );
 
-        msg!(encoder, "drawPrimitives:vertexStart:vertexCount:",
-            MTL_PRIMITIVE_TYPE_TRIANGLE as usize, 0usize, vertex_count);
+        msg!(
+            encoder,
+            "drawPrimitives:vertexStart:vertexCount:",
+            MTL_PRIMITIVE_TYPE_TRIANGLE as usize,
+            0usize,
+            vertex_count
+        );
 
         release(pos_buffer);
         release(color_buffer);
@@ -788,7 +888,11 @@ unsafe fn create_offscreen_texture(device: Id, width: u32, height: u32) -> Id {
     let desc = alloc_init("MTLTextureDescriptor");
 
     // MTLPixelFormatRGBA8Unorm = 70
-    msg!(desc, "setPixelFormat:", MTL_PIXEL_FORMAT_RGBA8_UNORM as usize);
+    msg!(
+        desc,
+        "setPixelFormat:",
+        MTL_PIXEL_FORMAT_RGBA8_UNORM as usize
+    );
     msg!(desc, "setWidth:", width as usize);
     msg!(desc, "setHeight:", height as usize);
     // MTLTextureType2D = 2
@@ -809,8 +913,11 @@ unsafe fn compile_shader_library(device: Id, source: &str) -> Id {
     let options: Id = ptr::null_mut();
     let mut error: Id = ptr::null_mut();
     let library: Id = msg!(
-        device, "newLibraryWithSource:options:error:",
-        source_ns, options, &mut error as *mut Id
+        device,
+        "newLibraryWithSource:options:error:",
+        source_ns,
+        options,
+        &mut error as *mut Id
     );
     CFRelease(source_ns);
 
@@ -842,8 +949,10 @@ unsafe fn create_rect_pipeline(device: Id) -> Id {
 
     let mut error: Id = ptr::null_mut();
     let pipeline: Id = msg!(
-        device, "newRenderPipelineStateWithDescriptor:error:",
-        desc, &mut error as *mut Id
+        device,
+        "newRenderPipelineStateWithDescriptor:error:",
+        desc,
+        &mut error as *mut Id
     );
 
     release(vertex_fn);
@@ -851,7 +960,10 @@ unsafe fn create_rect_pipeline(device: Id) -> Id {
     release(library);
     release(desc);
 
-    assert!(!pipeline.is_null(), "Failed to create rect render pipeline state");
+    assert!(
+        !pipeline.is_null(),
+        "Failed to create rect render pipeline state"
+    );
     pipeline
 }
 
@@ -859,14 +971,18 @@ unsafe fn create_rect_pipeline(device: Id) -> Id {
 unsafe fn setup_pipeline_color_attachment(desc: Id) {
     let attachments = msg_send_id(desc, "colorAttachments");
     let att0: Id = msg!(attachments, "objectAtIndexedSubscript:", 0usize);
-    msg!(att0, "setPixelFormat:", MTL_PIXEL_FORMAT_RGBA8_UNORM as usize);
+    msg!(
+        att0,
+        "setPixelFormat:",
+        MTL_PIXEL_FORMAT_RGBA8_UNORM as usize
+    );
 
     // Enable standard src-over alpha blending so transparent pixels composite correctly.
     // The formula is:  dst = src.rgb * src.a + dst.rgb * (1 - src.a)
     msg!(att0, "setBlendingEnabled:", 1usize);
-    msg!(att0, "setSourceRGBBlendFactor:", 4usize);        // sourceAlpha
-    msg!(att0, "setDestinationRGBBlendFactor:", 5usize);   // oneMinusSourceAlpha
-    msg!(att0, "setSourceAlphaBlendFactor:", 1usize);       // one
+    msg!(att0, "setSourceRGBBlendFactor:", 4usize); // sourceAlpha
+    msg!(att0, "setDestinationRGBBlendFactor:", 5usize); // oneMinusSourceAlpha
+    msg!(att0, "setSourceAlphaBlendFactor:", 1usize); // one
     msg!(att0, "setDestinationAlphaBlendFactor:", 5usize); // oneMinusSourceAlpha
 }
 
@@ -875,8 +991,11 @@ unsafe fn create_buffer(device: Id, data: &[f32]) -> Id {
     let byte_len = std::mem::size_of_val(data);
     // MTLResourceStorageModeShared = 0
     let buffer: Id = msg!(
-        device, "newBufferWithBytes:length:options:",
-        data.as_ptr() as Id, byte_len, 0usize
+        device,
+        "newBufferWithBytes:length:options:",
+        data.as_ptr() as Id,
+        byte_len,
+        0usize
     );
     assert!(!buffer.is_null(), "Failed to create Metal buffer");
     buffer
@@ -901,21 +1020,24 @@ unsafe fn read_back_pixels(texture: Id, width: u32, height: u32) -> PixelContain
     // MTLRegion is 48 bytes, so we use a typed function pointer that lets the
     // compiler generate the correct ABI (pass by value triggers indirect passing).
     let get_bytes: unsafe extern "C" fn(
-        Id, Sel,
+        Id,
+        Sel,
         *mut u8,   // bytes pointer
         usize,     // bytesPerRow
         MTLRegion, // region (compiler passes indirectly on arm64)
         usize,     // mipmapLevel
     ) = std::mem::transmute(objc_msgSend as *const ());
     get_bytes(
-        texture, sel("getBytes:bytesPerRow:fromRegion:mipmapLevel:"),
-        data.as_mut_ptr(), bytes_per_row,
-        region, 0,
+        texture,
+        sel("getBytes:bytesPerRow:fromRegion:mipmapLevel:"),
+        data.as_mut_ptr(),
+        bytes_per_row,
+        region,
+        0,
     );
 
     PixelContainer::from_data(width, height, data)
 }
-
 
 // ---------------------------------------------------------------------------
 // CoreText glyph-run overlay (Apple only)
@@ -936,15 +1058,13 @@ unsafe fn read_back_pixels(texture: Id, width: u32, height: u32) -> PixelContain
 mod glyph_run_overlay {
     use objc_bridge::{
         cfstring_checked, CFRelease, CGAffineTransform, CGBitmapContextCreate,
-        CGColorSpaceCreateDeviceRGB, CGColorSpaceRelease, CGContextRelease,
+        CGColorSpaceCreateDeviceRGB, CGColorSpaceRelease, CGContextRef, CGContextRelease,
         CGContextRestoreGState, CGContextSaveGState, CGContextSetRGBFillColor,
         CGContextSetShouldAntialias, CGContextSetShouldSmoothFonts, CGContextSetTextMatrix,
-        CGPoint, CTFontCreateWithName, CTFontDrawGlyphs, CGContextRef, Id,
-        K_CG_IMAGE_ALPHA_PREMULTIPLIED_FIRST, K_CG_BITMAP_BYTE_ORDER_32_LITTLE, NIL,
+        CGPoint, CTFontCreateWithName, CTFontDrawGlyphs, Id, K_CG_BITMAP_BYTE_ORDER_32_LITTLE,
+        K_CG_IMAGE_ALPHA_PREMULTIPLIED_FIRST, NIL,
     };
-    use paint_instructions::{
-        PaintGlyphRun, PaintInstruction, PaintScene, PixelContainer,
-    };
+    use paint_instructions::{PaintGlyphRun, PaintInstruction, PaintScene, PixelContainer};
 
     pub(super) unsafe fn overlay_coretext_glyph_runs(
         scene: &PaintScene,
@@ -998,20 +1118,13 @@ mod glyph_run_overlay {
         CGContextRelease(ctx);
     }
 
-    fn collect_coretext_runs(
-        instructions: &[PaintInstruction],
-    ) -> Vec<&PaintGlyphRun> {
+    fn collect_coretext_runs(instructions: &[PaintInstruction]) -> Vec<&PaintGlyphRun> {
         let mut out: Vec<&PaintGlyphRun> = Vec::new();
-        fn walk<'a>(
-            ins: &'a [PaintInstruction],
-            out: &mut Vec<&'a PaintGlyphRun>,
-        ) {
+        fn walk<'a>(ins: &'a [PaintInstruction], out: &mut Vec<&'a PaintGlyphRun>) {
             for i in ins {
                 match i {
-                    PaintInstruction::GlyphRun(g) => {
-                        if g.font_ref.starts_with("coretext:") {
-                            out.push(g);
-                        }
+                    PaintInstruction::GlyphRun(g) if g.font_ref.starts_with("coretext:") => {
+                        out.push(g);
                     }
                     PaintInstruction::Group(grp) => walk(&grp.children, out),
                     PaintInstruction::Clip(c) => walk(&c.children, out),
@@ -1078,13 +1191,14 @@ mod glyph_run_overlay {
     /// Parse a subset of CSS colours into (r, g, b, a) in 0..=1.
     fn parse_css_color(s: &str) -> (f64, f64, f64, f64) {
         let s = s.trim();
-        let (inner, has_alpha) = if let Some(i) = s.strip_prefix("rgba(").and_then(|x| x.strip_suffix(")")) {
-            (i, true)
-        } else if let Some(i) = s.strip_prefix("rgb(").and_then(|x| x.strip_suffix(")")) {
-            (i, false)
-        } else {
-            return (0.0, 0.0, 0.0, 1.0);
-        };
+        let (inner, has_alpha) =
+            if let Some(i) = s.strip_prefix("rgba(").and_then(|x| x.strip_suffix(")")) {
+                (i, true)
+            } else if let Some(i) = s.strip_prefix("rgb(").and_then(|x| x.strip_suffix(")")) {
+                (i, false)
+            } else {
+                return (0.0, 0.0, 0.0, 1.0);
+            };
         let parts: Vec<&str> = inner.split(',').map(|p| p.trim()).collect();
         if parts.len() < 3 {
             return (0.0, 0.0, 0.0, 1.0);
@@ -1097,7 +1211,12 @@ mod glyph_run_overlay {
         } else {
             1.0
         };
-        (r.clamp(0.0, 1.0), g.clamp(0.0, 1.0), b.clamp(0.0, 1.0), a.clamp(0.0, 1.0))
+        (
+            r.clamp(0.0, 1.0),
+            g.clamp(0.0, 1.0),
+            b.clamp(0.0, 1.0),
+            a.clamp(0.0, 1.0),
+        )
     }
 
     #[cfg(test)]
@@ -1192,10 +1311,7 @@ impl std::error::Error for PaintMetalError {}
 
 #[cfg(target_vendor = "apple")]
 mod live_present {
-    use objc_bridge::{
-        msg, MTLOrigin, MTLRegion, MTLSize,
-        Id, NIL,
-    };
+    use objc_bridge::{msg, Id, MTLOrigin, MTLRegion, MTLSize, NIL};
     use paint_instructions::PixelContainer;
 
     use super::PaintMetalError;
@@ -1287,13 +1403,12 @@ mod live_present {
 mod tests {
     use super::*;
     use paint_instructions::{
-        PaintBase, PaintEllipse, PaintInstruction, PaintPath, PaintRect, PaintScene,
-        PathCommand,
+        PaintBase, PaintEllipse, PaintInstruction, PaintPath, PaintRect, PaintScene, PathCommand,
     };
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.2.0");
+        assert_eq!(VERSION, "0.3.0");
     }
 
     // ─── Color parser tests ──────────────────────────────────────────────────
@@ -1332,6 +1447,12 @@ mod tests {
         assert_eq!(b, 0.0);
     }
 
+    #[test]
+    fn parse_css_named_color() {
+        let (r, g, b, a) = parse_hex_color("Aqua");
+        assert_eq!((r, g, b, a), (0.0, 1.0, 1.0, 1.0));
+    }
+
     // ─── Vertex generation tests ─────────────────────────────────────────────
 
     #[test]
@@ -1352,7 +1473,10 @@ mod tests {
         let mut positions = Vec::new();
         let mut colors = Vec::new();
         collect_geometry(&[rect], &mut positions, &mut colors, 0);
-        assert!(positions.is_empty(), "transparent rect should produce no vertices");
+        assert!(
+            positions.is_empty(),
+            "transparent rect should produce no vertices"
+        );
     }
 
     #[test]
@@ -1416,7 +1540,11 @@ mod tests {
         collect_geometry(&[ellipse], &mut positions, &mut colors, 0);
         // fill: 64 * 3 verts, stroke ring: 64 quads * 2 tris * 3 verts = 384
         let expected = (ELLIPSE_SEGMENTS * 3 + ELLIPSE_SEGMENTS * 2 * 3) * 2; // × 2 for x,y
-        assert_eq!(positions.len(), expected, "ellipse fill+stroke vertex count");
+        assert_eq!(
+            positions.len(),
+            expected,
+            "ellipse fill+stroke vertex count"
+        );
     }
 
     #[test]
@@ -1425,10 +1553,10 @@ mod tests {
         let diamond = PaintInstruction::Path(PaintPath {
             base: PaintBase::default(),
             commands: vec![
-                PathCommand::MoveTo { x: 50.0, y: 10.0 },  // top
-                PathCommand::LineTo { x: 90.0, y: 50.0 },  // right
-                PathCommand::LineTo { x: 50.0, y: 90.0 },  // bottom
-                PathCommand::LineTo { x: 10.0, y: 50.0 },  // left
+                PathCommand::MoveTo { x: 50.0, y: 10.0 }, // top
+                PathCommand::LineTo { x: 90.0, y: 50.0 }, // right
+                PathCommand::LineTo { x: 50.0, y: 90.0 }, // bottom
+                PathCommand::LineTo { x: 10.0, y: 50.0 }, // left
                 PathCommand::Close,
             ],
             fill: Some("#ffff00".to_string()),
@@ -1446,7 +1574,10 @@ mod tests {
         // Subpath has 5 points (top, right, bottom, left, top-again from close).
         // Fan: pivot=pts[0], triangles for i in 1..4 → 3 triangles
         // Each triangle: 3 vertices × 2 floats = 6 floats → 18 total
-        assert!(positions.len() >= 18, "diamond fill should have at least 3 triangles");
+        assert!(
+            positions.len() >= 18,
+            "diamond fill should have at least 3 triangles"
+        );
     }
 
     #[test]
@@ -1465,8 +1596,14 @@ mod tests {
         let mut positions = Vec::new();
         let mut colors = Vec::new();
         collect_geometry(&[text_instr], &mut positions, &mut colors, 0);
-        assert!(positions.is_empty(), "PaintText should not generate triangle vertices");
-        assert!(colors.is_empty(), "PaintText should not generate color vertices");
+        assert!(
+            positions.is_empty(),
+            "PaintText should not generate triangle vertices"
+        );
+        assert!(
+            colors.is_empty(),
+            "PaintText should not generate color vertices"
+        );
     }
 
     #[test]
@@ -1482,9 +1619,11 @@ mod tests {
     #[test]
     fn render_red_rect_on_white() {
         let mut scene = PaintScene::new(100.0, 100.0);
-        scene.instructions.push(PaintInstruction::Rect(
-            PaintRect::filled(10.0, 10.0, 80.0, 80.0, "#ff0000"),
-        ));
+        scene
+            .instructions
+            .push(PaintInstruction::Rect(PaintRect::filled(
+                10.0, 10.0, 80.0, 80.0, "#ff0000",
+            )));
 
         let pixels = render(&scene);
         assert_eq!(pixels.width, 100);
@@ -1493,8 +1632,8 @@ mod tests {
         // Centre of the red rectangle should be red
         let (r, g, b, a) = pixels.pixel_at(50, 50);
         assert_eq!(r, 255, "red channel at centre");
-        assert_eq!(g, 0,   "green channel at centre");
-        assert_eq!(b, 0,   "blue channel at centre");
+        assert_eq!(g, 0, "green channel at centre");
+        assert_eq!(b, 0, "blue channel at centre");
         assert_eq!(a, 255, "alpha at centre");
 
         // Top-left corner is outside the rect → white background
@@ -1509,25 +1648,27 @@ mod tests {
     #[test]
     fn render_blue_ellipse() {
         let mut scene = PaintScene::new(100.0, 100.0);
-        scene.instructions.push(PaintInstruction::Ellipse(PaintEllipse {
-            base: PaintBase::default(),
-            cx: 50.0,
-            cy: 50.0,
-            rx: 30.0,
-            ry: 30.0,
-            fill: Some("#0000ff".to_string()),
-            stroke: None,
-            stroke_width: None,
-            stroke_dash: None,
-            stroke_dash_offset: None,
-        }));
+        scene
+            .instructions
+            .push(PaintInstruction::Ellipse(PaintEllipse {
+                base: PaintBase::default(),
+                cx: 50.0,
+                cy: 50.0,
+                rx: 30.0,
+                ry: 30.0,
+                fill: Some("#0000ff".to_string()),
+                stroke: None,
+                stroke_width: None,
+                stroke_dash: None,
+                stroke_dash_offset: None,
+            }));
 
         let pixels = render(&scene);
 
         // Centre of the ellipse should be blue
         let (r, g, b, _a) = pixels.pixel_at(50, 50);
-        assert_eq!(r, 0,   "red channel at ellipse centre should be 0");
-        assert_eq!(g, 0,   "green channel at ellipse centre should be 0");
+        assert_eq!(r, 0, "red channel at ellipse centre should be 0");
+        assert_eq!(g, 0, "green channel at ellipse centre should be 0");
         assert_eq!(b, 255, "blue channel at ellipse centre should be 255");
 
         // Pixel well outside the ellipse should be white background
@@ -1544,10 +1685,10 @@ mod tests {
         scene.instructions.push(PaintInstruction::Path(PaintPath {
             base: PaintBase::default(),
             commands: vec![
-                PathCommand::MoveTo { x: 50.0, y: 10.0 },  // top
-                PathCommand::LineTo { x: 90.0, y: 50.0 },  // right
-                PathCommand::LineTo { x: 50.0, y: 90.0 },  // bottom
-                PathCommand::LineTo { x: 10.0, y: 50.0 },  // left
+                PathCommand::MoveTo { x: 50.0, y: 10.0 }, // top
+                PathCommand::LineTo { x: 90.0, y: 50.0 }, // right
+                PathCommand::LineTo { x: 50.0, y: 90.0 }, // bottom
+                PathCommand::LineTo { x: 10.0, y: 50.0 }, // left
                 PathCommand::Close,
             ],
             fill: Some("#ffff00".to_string()),
@@ -1566,7 +1707,7 @@ mod tests {
         let (r, g, b, _a) = pixels.pixel_at(50, 50);
         assert_eq!(r, 255, "yellow: r=255 at diamond centre");
         assert_eq!(g, 255, "yellow: g=255 at diamond centre");
-        assert_eq!(b, 0,   "yellow: b=0 at diamond centre");
+        assert_eq!(b, 0, "yellow: b=0 at diamond centre");
 
         // Corner (2, 2) is well outside the diamond → white
         let (r, g, b, _a) = pixels.pixel_at(2, 2);
@@ -1584,13 +1725,15 @@ mod tests {
         for row in 0..4u32 {
             for col in 0..4u32 {
                 if (row + col) % 2 == 0 {
-                    scene.instructions.push(PaintInstruction::Rect(PaintRect::filled(
-                        col as f64 * module_size,
-                        row as f64 * module_size,
-                        module_size,
-                        module_size,
-                        "#000000",
-                    )));
+                    scene
+                        .instructions
+                        .push(PaintInstruction::Rect(PaintRect::filled(
+                            col as f64 * module_size,
+                            row as f64 * module_size,
+                            module_size,
+                            module_size,
+                            "#000000",
+                        )));
                 }
             }
         }

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -119,7 +119,10 @@ branch dividers before existing PaintInstructions render them. Participant
 `create` and `destroy` statements lower into lifecycle events; layout uses them
 to place dynamic participant headers, bound lifelines, and emit destruction
 markers. Participant configuration metadata, links, and advanced arrow variants
-remain compatibility work. The family remains partial until those forms and the
+remain compatibility work. Participant `box` declarations now lower into
+semantic groups, lane-enclosing layout geometry, and backend-neutral Paint
+rectangles and labels, including the supported named and `rgb`/`rgba` color
+forms. The family remains partial until those forms and the
 pinned upstream corpus pass; unsupported forms must fail grammar validation
 rather than degrade silently.
 


### PR DESCRIPTION
## Summary
- add grammar-backed Mermaid sequence `box` parsing with named and rgb/rgba colors
- carry participant groups through semantic IR, lane layout, and backend-neutral PaintInstructions
- validate the complete path with Metal-to-PNG coverage and add named-color support to Metal

## Verification
- `cargo test -p mermaid-lexer -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint -p paint-metal`
- `cargo clippy -p diagram-ir -p diagram-layout-sequence -p mermaid-lexer -p mermaid-parser -p diagram-to-paint -p paint-metal --all-targets --no-deps -- -D warnings`
- visually inspected `/tmp/mermaid_sequence_e2e.png`