### PR TITLE
Add authorized Axis snapshot host

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -954,6 +954,7 @@ members = [
     "smart-home-kasa-lan-integration",
     "smart-home-reolink-integration",
     "smart-home-axis-vapix-integration",
+    "smart-home-axis-snapshot-host",
     "smart-home-blue-iris-integration",
     "smart-home-frigate-integration",
     "smart-home-synology-surveillance-integration",

--- a/code/packages/rust/smart-home-axis-snapshot-host/BUILD
+++ b/code/packages/rust/smart-home-axis-snapshot-host/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-axis-snapshot-host -- --nocapture

--- a/code/packages/rust/smart-home-axis-snapshot-host/CHANGELOG.md
+++ b/code/packages/rust/smart-home-axis-snapshot-host/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0
+
+- Add exact Human Approval preflight for installed Axis camera-1 snapshots.
+- Resolve bounded sealed-Vault credentials into zeroizing process-local state.
+- Register one reviewed-address-pinned VAPIX JPEG endpoint and Basic/Digest
+  credential lifetime around delivery, with cleanup on success and failure.
+- Cover denial-before-Vault, exact target correspondence, cleanup after failures,
+  repeated sealed-record use, and native authenticated JPEG delivery.

--- a/code/packages/rust/smart-home-axis-snapshot-host/Cargo.toml
+++ b/code/packages/rust/smart-home-axis-snapshot-host/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "smart-home-axis-snapshot-host"
+version = "0.1.0"
+edition = "2021"
+description = "Authorized Axis VAPIX snapshot delivery host for the smart-home runtime"
+license = "MIT"
+
+[dependencies]
+coding_adventures_csprng = { path = "../csprng" }
+coding_adventures_vault_leases = { path = "../vault-leases" }
+coding_adventures_vault_sealed_store = { path = "../vault-sealed-store" }
+coding_adventures_zeroize = { path = "../zeroize" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+smart-home-axis-vapix-integration = { path = "../smart-home-axis-vapix-integration" }
+smart-home-camera-media = { path = "../smart-home-camera-media" }
+smart-home-camera-media-http-executor = { path = "../smart-home-camera-media-http-executor" }
+smart-home-core = { path = "../smart-home-core" }
+smart-home-runtime = { path = "../smart-home-runtime" }
+url-parser = { path = "../url-parser" }
+
+[dev-dependencies]
+storage-core = { path = "../storage-core" }
+tls-platform = { path = "../tls-platform" }

--- a/code/packages/rust/smart-home-axis-snapshot-host/README.md
+++ b/code/packages/rust/smart-home-axis-snapshot-host/README.md
@@ -1,0 +1,14 @@
+# smart-home-axis-snapshot-host
+
+Production composition for one bounded Axis VAPIX camera snapshot.
+
+The host requires exact D23 Human Approval before Vault or network access,
+validates the installed Axis camera-1 entity and its probed JPEG capability,
+resolves one bounded versioned credential envelope, and registers the
+documented `/axis-cgi/jpg/image.cgi?camera=1` endpoint against a reviewed
+canonical host and pinned socket. Basic or Digest credentials and the endpoint
+remain process-local and are removed after every delivery outcome.
+
+Production delivery is HTTPS-only. Plain HTTP is available solely to explicit
+loopback fixtures. Streams, recordings, playback, source enumeration, and
+broader media transfer remain outside this host.

--- a/code/packages/rust/smart-home-axis-snapshot-host/src/lib.rs
+++ b/code/packages/rust/smart-home-axis-snapshot-host/src/lib.rs
@@ -1,0 +1,499 @@
+//! Authorized production host for bounded Axis camera snapshots.
+
+#![forbid(unsafe_code)]
+
+use coding_adventures_csprng::random_array;
+use coding_adventures_vault_leases::LeasePayload;
+use coding_adventures_vault_sealed_store::SealedStore;
+use coding_adventures_zeroize::Zeroizing;
+use serde::{Deserialize, Deserializer, Serialize};
+use smart_home_axis_vapix_integration::{
+    AxisConfig, INTEGRATION_ID, JPEG_SNAPSHOT_PATH, MAX_CREDENTIAL_FIELD_BYTES,
+};
+use smart_home_camera_media::{
+    CameraMediaAccessRequest, CameraMediaClock, CameraMediaConnectionTarget,
+    CameraMediaCredentialRegistry, CameraMediaDelivery, CameraMediaError, CameraMediaExecutor,
+    CameraMediaKind, CameraMediaNonceError, CameraMediaNonceSource, CameraMediaPolicy,
+    CameraMediaPrincipalSource, CameraMediaService,
+};
+use smart_home_camera_media_http_executor::{
+    CameraMediaHttpCredentialError, CameraMediaHttpCredentials, CameraMediaHttpExecutor,
+};
+use smart_home_core::{
+    BridgeId, CapabilityId, CapabilityMode, EntityId, EntityKind, IntegrationId, VaultRef,
+};
+use smart_home_runtime::SmartHomeRuntime;
+use std::fmt;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use url_parser::Url;
+
+pub const VERSION: &str = "0.1.0";
+pub const AXIS_VAULT_NAMESPACE: &str = "smart_home.axis_vapix.credentials";
+pub const AXIS_VAULT_REF_PREFIX: &str = "vault://smart-home/axis-vapix/";
+pub const MAX_CREDENTIAL_PAYLOAD_BYTES: usize = MAX_CREDENTIAL_FIELD_BYTES * 2 + 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AxisCredentialSourceError;
+
+pub trait AxisCredentialSource {
+    fn resolve(&self, vault_ref: &VaultRef) -> Result<LeasePayload, AxisCredentialSourceError>;
+}
+
+pub struct AxisSealedStoreCredentialSource {
+    vault: Arc<SealedStore>,
+}
+
+impl AxisSealedStoreCredentialSource {
+    pub fn new(vault: Arc<SealedStore>) -> Self {
+        Self { vault }
+    }
+}
+
+impl AxisCredentialSource for AxisSealedStoreCredentialSource {
+    fn resolve(&self, vault_ref: &VaultRef) -> Result<LeasePayload, AxisCredentialSourceError> {
+        let key = axis_vault_record_key(vault_ref).ok_or(AxisCredentialSourceError)?;
+        let record = self
+            .vault
+            .get(AXIS_VAULT_NAMESPACE, key)
+            .map_err(|_| AxisCredentialSourceError)?
+            .ok_or(AxisCredentialSourceError)?;
+        Ok(LeasePayload::new(record.plaintext.into_inner()))
+    }
+}
+
+pub fn axis_vault_record_key(vault_ref: &VaultRef) -> Option<&str> {
+    vault_ref
+        .as_str()
+        .strip_prefix(AXIS_VAULT_REF_PREFIX)
+        .filter(|key| !key.is_empty())
+}
+
+#[derive(Clone)]
+pub struct AxisSnapshotEndpoint {
+    bridge_id: BridgeId,
+    connection_target: CameraMediaConnectionTarget,
+}
+
+impl AxisSnapshotEndpoint {
+    pub fn new(bridge_id: BridgeId, connection_target: CameraMediaConnectionTarget) -> Self {
+        Self {
+            bridge_id,
+            connection_target,
+        }
+    }
+}
+
+impl fmt::Debug for AxisSnapshotEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AxisSnapshotEndpoint")
+            .field("bridge_id", &self.bridge_id)
+            .field("connection_target", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AxisSnapshotRequest {
+    pub entity_id: EntityId,
+    pub purpose: String,
+    pub ttl_ms: u64,
+}
+
+impl AxisSnapshotRequest {
+    pub fn new(entity_id: EntityId, purpose: impl Into<String>, ttl_ms: u64) -> Self {
+        Self {
+            entity_id,
+            purpose: purpose.into(),
+            ttl_ms,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AxisSnapshotHostError {
+    InvalidRequest,
+    InvalidTarget,
+    MissingCredentialReference,
+    CredentialResolutionRejected,
+    InvalidCredentialPayload,
+    CredentialRegistrationRejected,
+    CredentialRemovalFailed,
+    EndpointAlreadyRegistered,
+    EndpointRegistrationRejected,
+    EndpointRemovalFailed,
+    Media(CameraMediaError),
+}
+
+impl fmt::Display for AxisSnapshotHostError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidRequest => "invalid Axis snapshot request",
+            Self::InvalidTarget => "snapshot target is not an installed Axis camera 1",
+            Self::MissingCredentialReference => "Axis bridge has no credential reference",
+            Self::CredentialResolutionRejected => "Axis credential lookup was rejected",
+            Self::InvalidCredentialPayload => "Axis credential payload is invalid",
+            Self::CredentialRegistrationRejected => {
+                "Axis snapshot credentials could not be registered"
+            }
+            Self::CredentialRemovalFailed => "Axis snapshot credentials could not be removed",
+            Self::EndpointAlreadyRegistered => "Axis snapshot endpoint is already registered",
+            Self::EndpointRegistrationRejected => "Axis snapshot endpoint registration failed",
+            Self::EndpointRemovalFailed => "Axis snapshot endpoint removal failed",
+            Self::Media(error) => return error.fmt(formatter),
+        })
+    }
+}
+
+impl std::error::Error for AxisSnapshotHostError {}
+
+impl From<CameraMediaError> for AxisSnapshotHostError {
+    fn from(value: CameraMediaError) -> Self {
+        Self::Media(value)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CredentialEnvelope {
+    schema_version: u64,
+    #[serde(deserialize_with = "deserialize_secret_string")]
+    username: Zeroizing<String>,
+    #[serde(deserialize_with = "deserialize_secret_string")]
+    password: Zeroizing<String>,
+}
+
+#[derive(Serialize)]
+struct BorrowedCredentialEnvelope<'a> {
+    schema_version: u64,
+    username: &'a str,
+    password: &'a str,
+}
+
+pub fn encode_axis_credentials(
+    username: &str,
+    password: &str,
+) -> Result<LeasePayload, AxisSnapshotHostError> {
+    validate_credential_fields(username, password)?;
+    let bytes = Zeroizing::new(
+        serde_json::to_vec(&BorrowedCredentialEnvelope {
+            schema_version: 1,
+            username,
+            password,
+        })
+        .map_err(|_| AxisSnapshotHostError::InvalidCredentialPayload)?,
+    );
+    if bytes.len() > MAX_CREDENTIAL_PAYLOAD_BYTES {
+        return Err(AxisSnapshotHostError::InvalidCredentialPayload);
+    }
+    Ok(LeasePayload::new(bytes.into_inner()))
+}
+
+pub struct SystemCameraMediaClock;
+
+impl CameraMediaClock for SystemCameraMediaClock {
+    fn now_ms(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX)
+    }
+}
+
+pub struct OsCameraMediaNonceSource;
+
+impl CameraMediaNonceSource for OsCameraMediaNonceSource {
+    fn fill_nonce(&mut self, output: &mut [u8; 16]) -> Result<(), CameraMediaNonceError> {
+        *output = random_array().map_err(|_| CameraMediaNonceError)?;
+        Ok(())
+    }
+}
+
+pub struct AxisSnapshotHost<Clock, Nonce, Principals, Executor, Credentials>
+where
+    Clock: CameraMediaClock,
+    Nonce: CameraMediaNonceSource,
+    Principals: CameraMediaPrincipalSource,
+    Executor: CameraMediaExecutor
+        + CameraMediaCredentialRegistry<
+            Credentials = CameraMediaHttpCredentials,
+            Error = CameraMediaHttpCredentialError,
+        >,
+    Credentials: AxisCredentialSource,
+{
+    media: CameraMediaService<Clock, Nonce, Principals, Executor>,
+    credentials: Credentials,
+    endpoint: AxisSnapshotEndpoint,
+    max_snapshot_ttl_ms: u64,
+}
+
+impl<Clock, Nonce, Principals, Executor, Credentials>
+    AxisSnapshotHost<Clock, Nonce, Principals, Executor, Credentials>
+where
+    Clock: CameraMediaClock,
+    Nonce: CameraMediaNonceSource,
+    Principals: CameraMediaPrincipalSource,
+    Executor: CameraMediaExecutor
+        + CameraMediaCredentialRegistry<
+            Credentials = CameraMediaHttpCredentials,
+            Error = CameraMediaHttpCredentialError,
+        >,
+    Credentials: AxisCredentialSource,
+{
+    pub fn new(
+        policy: CameraMediaPolicy,
+        clock: Clock,
+        nonce_source: Nonce,
+        principal_source: Principals,
+        executor: Executor,
+        credentials: Credentials,
+        endpoint: AxisSnapshotEndpoint,
+    ) -> Self {
+        let max_snapshot_ttl_ms = policy.max_snapshot_ttl_ms;
+        Self {
+            media: CameraMediaService::new(policy, clock, nonce_source, principal_source, executor),
+            credentials,
+            endpoint,
+            max_snapshot_ttl_ms,
+        }
+    }
+
+    pub fn deliver_snapshot(
+        &mut self,
+        runtime: &SmartHomeRuntime,
+        request: AxisSnapshotRequest,
+    ) -> Result<CameraMediaDelivery, AxisSnapshotHostError> {
+        self.validate_request(&request)?;
+        self.media
+            .authorize_access(runtime, &request.entity_id, CameraMediaKind::Snapshot)?;
+        if self
+            .media
+            .has_endpoint(&request.entity_id, CameraMediaKind::Snapshot)
+        {
+            return Err(AxisSnapshotHostError::EndpointAlreadyRegistered);
+        }
+        let target = installed_target(runtime, &request.entity_id, &self.endpoint)?;
+        let payload = self
+            .credentials
+            .resolve(&target.credential_ref)
+            .map_err(|_| AxisSnapshotHostError::CredentialResolutionRejected)?;
+        let credentials = decode_credentials(payload.as_bytes())?;
+        drop(payload);
+
+        self.media
+            .register_pinned_endpoint(
+                request.entity_id.clone(),
+                CameraMediaKind::Snapshot,
+                &target.snapshot_uri,
+                self.endpoint.connection_target.clone(),
+            )
+            .map_err(|_| AxisSnapshotHostError::EndpointRegistrationRejected)?;
+        if self
+            .media
+            .register_executor_credentials(request.entity_id.clone(), credentials)
+            .is_err()
+        {
+            if !self
+                .media
+                .unregister_endpoint(&request.entity_id, CameraMediaKind::Snapshot)
+            {
+                return Err(AxisSnapshotHostError::EndpointRemovalFailed);
+            }
+            return Err(AxisSnapshotHostError::CredentialRegistrationRejected);
+        }
+
+        let delivery = (|| {
+            let lease = self.media.issue_lease(
+                runtime,
+                CameraMediaAccessRequest::new(
+                    request.entity_id.clone(),
+                    CameraMediaKind::Snapshot,
+                    request.purpose,
+                    request.ttl_ms,
+                ),
+            )?;
+            self.media
+                .deliver_lease(runtime, &lease.lease_id)
+                .map_err(Into::into)
+        })();
+        let credentials_removed = self
+            .media
+            .unregister_executor_credentials(&request.entity_id);
+        let endpoint_removed = self
+            .media
+            .unregister_endpoint(&request.entity_id, CameraMediaKind::Snapshot);
+        if !credentials_removed {
+            return Err(AxisSnapshotHostError::CredentialRemovalFailed);
+        }
+        if !endpoint_removed {
+            return Err(AxisSnapshotHostError::EndpointRemovalFailed);
+        }
+        delivery
+    }
+
+    pub fn media_snapshot(&self) -> smart_home_camera_media::CameraMediaBrokerSnapshot {
+        self.media.snapshot()
+    }
+
+    fn validate_request(&self, request: &AxisSnapshotRequest) -> Result<(), AxisSnapshotHostError> {
+        if request.purpose.trim().is_empty()
+            || request.ttl_ms == 0
+            || request.ttl_ms > self.max_snapshot_ttl_ms
+        {
+            return Err(AxisSnapshotHostError::InvalidRequest);
+        }
+        Ok(())
+    }
+}
+
+impl<Principals, Credentials>
+    AxisSnapshotHost<
+        SystemCameraMediaClock,
+        OsCameraMediaNonceSource,
+        Principals,
+        CameraMediaHttpExecutor,
+        Credentials,
+    >
+where
+    Principals: CameraMediaPrincipalSource,
+    Credentials: AxisCredentialSource,
+{
+    pub fn production(
+        principal_source: Principals,
+        credentials: Credentials,
+        endpoint: AxisSnapshotEndpoint,
+    ) -> Self {
+        Self::new(
+            CameraMediaPolicy::default(),
+            SystemCameraMediaClock,
+            OsCameraMediaNonceSource,
+            principal_source,
+            CameraMediaHttpExecutor::default(),
+            credentials,
+            endpoint,
+        )
+    }
+}
+
+struct InstalledTarget {
+    credential_ref: VaultRef,
+    snapshot_uri: String,
+}
+
+fn installed_target(
+    runtime: &SmartHomeRuntime,
+    entity_id: &EntityId,
+    endpoint: &AxisSnapshotEndpoint,
+) -> Result<InstalledTarget, AxisSnapshotHostError> {
+    let registry = runtime.registry();
+    let entity = registry
+        .entity(entity_id)
+        .ok_or(AxisSnapshotHostError::InvalidTarget)?;
+    let device = registry
+        .device(&entity.device_id)
+        .ok_or(AxisSnapshotHostError::InvalidTarget)?;
+    let bridge = registry
+        .bridge(&device.bridge_id)
+        .ok_or(AxisSnapshotHostError::InvalidTarget)?;
+    let snapshot_capability = entity.capabilities.iter().any(|capability| {
+        capability.capability_id == CapabilityId::trusted("camera.snapshot")
+            && capability.mode == CapabilityMode::Command
+    });
+    let exact_channel = entity
+        .metadata
+        .iter()
+        .any(|metadata| metadata.key == "axis.video_channel" && metadata.value == "1");
+    let expected_entity_id = EntityId::trusted(format!("{}:camera", device.device_id.as_str()));
+    if entity.kind != EntityKind::Camera
+        || *entity_id != expected_entity_id
+        || !device.entity_ids.contains(entity_id)
+        || bridge.bridge_id != endpoint.bridge_id
+        || bridge.integration_id != IntegrationId::trusted(INTEGRATION_ID)
+        || !snapshot_capability
+        || !exact_channel
+    {
+        return Err(AxisSnapshotHostError::InvalidTarget);
+    }
+    let credential_ref = bridge
+        .auth_ref
+        .clone()
+        .ok_or(AxisSnapshotHostError::MissingCredentialReference)?;
+    let base_url = bridge
+        .address
+        .clone()
+        .ok_or(AxisSnapshotHostError::InvalidTarget)?;
+    let config = AxisConfig::new(bridge.bridge_id.clone(), base_url, credential_ref.clone())
+        .map_err(|_| AxisSnapshotHostError::InvalidTarget)?;
+    validate_connection_target(&config.base_url, &endpoint.connection_target)?;
+    Ok(InstalledTarget {
+        credential_ref,
+        snapshot_uri: format!("{}{JPEG_SNAPSHOT_PATH}", config.base_url),
+    })
+}
+
+fn validate_connection_target(
+    base_url: &str,
+    connection_target: &CameraMediaConnectionTarget,
+) -> Result<(), AxisSnapshotHostError> {
+    let parsed = Url::parse(base_url).map_err(|_| AxisSnapshotHostError::InvalidTarget)?;
+    let host = parsed
+        .host
+        .as_deref()
+        .ok_or(AxisSnapshotHostError::InvalidTarget)?;
+    if !host.eq_ignore_ascii_case(connection_target.canonical_host())
+        || parsed.effective_port() != Some(connection_target.pinned_address().port())
+        || (parsed.scheme == "http"
+            && (!is_loopback_host(host) || !connection_target.pinned_address().ip().is_loopback()))
+    {
+        return Err(AxisSnapshotHostError::InvalidTarget);
+    }
+    Ok(())
+}
+
+fn decode_credentials(bytes: &[u8]) -> Result<CameraMediaHttpCredentials, AxisSnapshotHostError> {
+    if bytes.len() > MAX_CREDENTIAL_PAYLOAD_BYTES {
+        return Err(AxisSnapshotHostError::InvalidCredentialPayload);
+    }
+    let envelope: CredentialEnvelope = serde_json::from_slice(bytes)
+        .map_err(|_| AxisSnapshotHostError::InvalidCredentialPayload)?;
+    if envelope.schema_version != 1 {
+        return Err(AxisSnapshotHostError::InvalidCredentialPayload);
+    }
+    validate_credential_fields(&envelope.username, &envelope.password)?;
+    CameraMediaHttpCredentials::new(
+        envelope.username.into_inner(),
+        envelope.password.into_inner(),
+    )
+    .map_err(|_| AxisSnapshotHostError::InvalidCredentialPayload)
+}
+
+fn deserialize_secret_string<'de, D>(deserializer: D) -> Result<Zeroizing<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer).map(Zeroizing::new)
+}
+
+fn validate_credential_fields(username: &str, password: &str) -> Result<(), AxisSnapshotHostError> {
+    if username.trim().is_empty()
+        || password.is_empty()
+        || username.len() > MAX_CREDENTIAL_FIELD_BYTES
+        || password.len() > MAX_CREDENTIAL_FIELD_BYTES
+        || username.contains(':')
+        || username.contains(['\r', '\n', '\0'])
+        || password.contains(['\r', '\n', '\0'])
+    {
+        return Err(AxisSnapshotHostError::InvalidCredentialPayload);
+    }
+    Ok(())
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
+        || host == "127.0.0.1"
+        || host == "::1"
+        || host.starts_with("127.")
+}

--- a/code/packages/rust/smart-home-axis-snapshot-host/tests/host.rs
+++ b/code/packages/rust/smart-home-axis-snapshot-host/tests/host.rs
@@ -1,0 +1,667 @@
+use coding_adventures_vault_leases::LeasePayload;
+use coding_adventures_vault_sealed_store::{InitOptions, SealedStore};
+use smart_home_axis_snapshot_host::{
+    encode_axis_credentials, AxisCredentialSource, AxisCredentialSourceError,
+    AxisSealedStoreCredentialSource, AxisSnapshotEndpoint, AxisSnapshotHost, AxisSnapshotHostError,
+    AxisSnapshotRequest, AXIS_VAULT_NAMESPACE, AXIS_VAULT_REF_PREFIX,
+};
+use smart_home_camera_media::{
+    CameraMediaClock, CameraMediaConnectionTarget, CameraMediaCredentialRegistry,
+    CameraMediaExecution, CameraMediaExecutionError, CameraMediaExecutionResult,
+    CameraMediaExecutor, CameraMediaNonceError, CameraMediaNonceSource, CameraMediaPolicy,
+    CameraMediaPrincipalSource,
+};
+use smart_home_camera_media_http_executor::{
+    CameraMediaHttpCredentialError, CameraMediaHttpCredentials, CameraMediaHttpExecutor,
+    CameraMediaHttpPolicy,
+};
+use smart_home_core::{
+    AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityGrant, CapabilityGrantId,
+    CapabilityMode, Device, DeviceId, Entity, EntityId, EntityKind, Health, IntegrationId,
+    Metadata, PrivilegeTier, ValueKind, VaultRef,
+};
+use smart_home_runtime::SmartHomeRuntime;
+use std::cell::{Cell, RefCell};
+use std::collections::{BTreeSet, VecDeque};
+use std::io::{Cursor, Read, Write};
+use std::net::SocketAddr;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+use storage_core::{InMemoryStorageBackend, StorageBackend};
+use tls_platform::{
+    TlsConfig, TlsConnectionSummary, TlsConnector, TlsError, TlsStream, TlsVersion,
+};
+
+#[derive(Clone)]
+struct FixedClock(u64);
+
+impl CameraMediaClock for FixedClock {
+    fn now_ms(&self) -> u64 {
+        self.0
+    }
+}
+
+struct TestNonce(u8);
+
+impl CameraMediaNonceSource for TestNonce {
+    fn fill_nonce(&mut self, output: &mut [u8; 16]) -> Result<(), CameraMediaNonceError> {
+        output.fill(self.0);
+        self.0 = self.0.wrapping_add(1);
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct FixedPrincipal(Option<AgentId>);
+
+impl CameraMediaPrincipalSource for FixedPrincipal {
+    fn current_principal(&self) -> Option<AgentId> {
+        self.0.clone()
+    }
+}
+
+#[derive(Clone)]
+struct TestCredentials {
+    state: Rc<CredentialState>,
+}
+
+struct CredentialState {
+    resolve_count: Cell<usize>,
+    payload: LeasePayload,
+}
+
+impl TestCredentials {
+    fn new(payload: LeasePayload) -> Self {
+        Self {
+            state: Rc::new(CredentialState {
+                resolve_count: Cell::new(0),
+                payload,
+            }),
+        }
+    }
+
+    fn resolve_count(&self) -> usize {
+        self.state.resolve_count.get()
+    }
+}
+
+impl AxisCredentialSource for TestCredentials {
+    fn resolve(&self, _vault_ref: &VaultRef) -> Result<LeasePayload, AxisCredentialSourceError> {
+        self.state
+            .resolve_count
+            .set(self.state.resolve_count.get() + 1);
+        Ok(self.state.payload.clone())
+    }
+}
+
+#[derive(Default)]
+struct ExecutorState {
+    registered: BTreeSet<EntityId>,
+    register_count: usize,
+    unregister_count: usize,
+    delivery_count: usize,
+    last_endpoint: Option<String>,
+    fail_registration: bool,
+    fail_delivery: bool,
+}
+
+struct TestExecutor(Rc<RefCell<ExecutorState>>);
+
+impl CameraMediaCredentialRegistry for TestExecutor {
+    type Credentials = CameraMediaHttpCredentials;
+    type Error = CameraMediaHttpCredentialError;
+
+    fn register_credentials(
+        &mut self,
+        entity_id: EntityId,
+        _credentials: Self::Credentials,
+    ) -> Result<(), Self::Error> {
+        let mut state = self.0.borrow_mut();
+        state.register_count += 1;
+        if state.fail_registration {
+            return Err(CameraMediaHttpCredentialError::CredentialAlreadyRegistered);
+        }
+        state.registered.insert(entity_id);
+        Ok(())
+    }
+
+    fn unregister_credentials(&mut self, entity_id: &EntityId) -> bool {
+        let mut state = self.0.borrow_mut();
+        state.unregister_count += 1;
+        state.registered.remove(entity_id)
+    }
+}
+
+impl CameraMediaExecutor for TestExecutor {
+    type Stream = ();
+
+    fn deliver(
+        &mut self,
+        execution: CameraMediaExecution<'_>,
+    ) -> Result<CameraMediaExecutionResult<Self::Stream>, CameraMediaExecutionError> {
+        let mut state = self.0.borrow_mut();
+        assert!(state.registered.contains(execution.entity_id()));
+        assert!(execution.connection_target().is_some());
+        state.delivery_count += 1;
+        state.last_endpoint = Some(execution.endpoint_uri().to_string());
+        if state.fail_delivery {
+            return Err(CameraMediaExecutionError::Unavailable);
+        }
+        Ok(CameraMediaExecutionResult::snapshot(vec![
+            0xff, 0xd8, 0xff, 0xd9,
+        ]))
+    }
+
+    fn close_stream(
+        &mut self,
+        _stream: &mut Self::Stream,
+    ) -> Result<(), CameraMediaExecutionError> {
+        Err(CameraMediaExecutionError::Rejected)
+    }
+}
+
+type TestHost =
+    AxisSnapshotHost<FixedClock, TestNonce, FixedPrincipal, TestExecutor, TestCredentials>;
+
+struct Fixture {
+    runtime: SmartHomeRuntime,
+    entity_id: EntityId,
+    credentials: TestCredentials,
+    state: Rc<RefCell<ExecutorState>>,
+    host: TestHost,
+}
+
+fn fixture_runtime(granted: bool, base_url: &str) -> (SmartHomeRuntime, EntityId, AgentId) {
+    let mut runtime = SmartHomeRuntime::new();
+    let bridge_id = BridgeId::trusted("bridge:axis:test");
+    let device_id = DeviceId::trusted("axis:accc8eaf8c30");
+    let entity_id = EntityId::trusted("axis:accc8eaf8c30:camera");
+    let principal_id = AgentId::trusted("operator");
+    let mut bridge = Bridge::new(
+        bridge_id.clone(),
+        IntegrationId::trusted("axis_vapix"),
+        BridgeTransport::LanHttp,
+    );
+    bridge.address = Some(base_url.to_string());
+    bridge.auth_ref = Some(VaultRef::trusted("vault://fixture/axis"));
+    runtime.upsert_bridge(bridge).unwrap();
+    runtime
+        .upsert_device(Device {
+            device_id: device_id.clone(),
+            bridge_id,
+            manufacturer: "AXIS".to_string(),
+            model: "Q1785-LE".to_string(),
+            name: "AXIS Camera".to_string(),
+            serial: Some("ACCC8EAF8C30".to_string()),
+            firmware_version: Some("12.1.0".to_string()),
+            room_id: None,
+            entity_ids: vec![entity_id.clone()],
+            identifiers: Vec::new(),
+            health: Health::Online,
+            metadata: Vec::new(),
+        })
+        .unwrap();
+    runtime
+        .upsert_entity(Entity {
+            entity_id: entity_id.clone(),
+            device_id,
+            kind: EntityKind::Camera,
+            name: "AXIS Camera".to_string(),
+            capabilities: vec![Capability::new(
+                smart_home_camera_media::CameraMediaKind::Snapshot.capability_id(),
+                CapabilityMode::Command,
+                ValueKind::Text,
+            )],
+            state: None,
+            metadata: vec![Metadata::new("axis.video_channel", "1")],
+        })
+        .unwrap();
+    if granted {
+        runtime
+            .registry_mut()
+            .upsert_capability_grant(CapabilityGrant::for_entity_capability(
+                CapabilityGrantId::trusted("grant:axis-snapshot"),
+                principal_id.clone(),
+                entity_id.clone(),
+                smart_home_camera_media::CameraMediaKind::Snapshot.capability_id(),
+                PrivilegeTier::HumanApproval,
+                "user",
+                1,
+            ));
+    }
+    (runtime, entity_id, principal_id)
+}
+
+fn test_host(granted: bool, fail_registration: bool, fail_delivery: bool) -> Fixture {
+    let address: SocketAddr = "192.0.2.25:443".parse().unwrap();
+    let (runtime, entity_id, principal_id) = fixture_runtime(granted, "https://axis.home");
+    let credentials =
+        TestCredentials::new(encode_axis_credentials("camera-user", "camera-secret").unwrap());
+    let state = Rc::new(RefCell::new(ExecutorState {
+        fail_registration,
+        fail_delivery,
+        ..ExecutorState::default()
+    }));
+    let policy = CameraMediaPolicy {
+        allow_plaintext_loopback: true,
+        ..CameraMediaPolicy::default()
+    };
+    let host = AxisSnapshotHost::new(
+        policy,
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        TestExecutor(state.clone()),
+        credentials.clone(),
+        AxisSnapshotEndpoint::new(
+            BridgeId::trusted("bridge:axis:test"),
+            CameraMediaConnectionTarget::new("axis.home", address),
+        ),
+    );
+    Fixture {
+        runtime,
+        entity_id,
+        credentials,
+        state,
+        host,
+    }
+}
+
+#[test]
+fn authorized_delivery_uses_exact_camera_one_endpoint_and_cleans_resources() {
+    let mut fixture = test_host(true, false, false);
+    let delivery = fixture
+        .host
+        .deliver_snapshot(
+            &fixture.runtime,
+            AxisSnapshotRequest::new(fixture.entity_id, "operator preview", 5_000),
+        )
+        .unwrap();
+
+    assert_eq!(
+        delivery.snapshot_bytes(),
+        Some(&[0xff, 0xd8, 0xff, 0xd9][..])
+    );
+    assert_eq!(fixture.credentials.resolve_count(), 1);
+    let state = fixture.state.borrow();
+    assert_eq!(state.register_count, 1);
+    assert_eq!(state.unregister_count, 1);
+    assert_eq!(state.delivery_count, 1);
+    assert_eq!(
+        state.last_endpoint.as_deref(),
+        Some("https://axis.home/axis-cgi/jpg/image.cgi?camera=1")
+    );
+    assert!(state.registered.is_empty());
+    drop(state);
+    assert_eq!(fixture.host.media_snapshot().endpoint_count, 0);
+}
+
+#[test]
+fn denial_happens_before_vault_endpoint_or_delivery() {
+    let mut fixture = test_host(false, false, false);
+    let error = fixture
+        .host
+        .deliver_snapshot(
+            &fixture.runtime,
+            AxisSnapshotRequest::new(fixture.entity_id, "operator preview", 5_000),
+        )
+        .unwrap_err();
+
+    assert!(matches!(error, AxisSnapshotHostError::Media(_)));
+    assert_eq!(fixture.credentials.resolve_count(), 0);
+    assert_eq!(fixture.state.borrow().register_count, 0);
+    assert_eq!(fixture.host.media_snapshot().endpoint_count, 0);
+}
+
+#[test]
+fn failed_delivery_still_removes_credentials_and_endpoint() {
+    let mut fixture = test_host(true, false, true);
+    let error = fixture
+        .host
+        .deliver_snapshot(
+            &fixture.runtime,
+            AxisSnapshotRequest::new(fixture.entity_id, "operator preview", 5_000),
+        )
+        .unwrap_err();
+
+    assert!(matches!(error, AxisSnapshotHostError::Media(_)));
+    let state = fixture.state.borrow();
+    assert_eq!(state.unregister_count, 1);
+    assert!(state.registered.is_empty());
+    drop(state);
+    assert_eq!(fixture.host.media_snapshot().endpoint_count, 0);
+}
+
+#[test]
+fn credential_registration_failure_removes_temporary_endpoint() {
+    let mut fixture = test_host(true, true, false);
+    let error = fixture
+        .host
+        .deliver_snapshot(
+            &fixture.runtime,
+            AxisSnapshotRequest::new(fixture.entity_id, "operator preview", 5_000),
+        )
+        .unwrap_err();
+
+    assert_eq!(error, AxisSnapshotHostError::CredentialRegistrationRejected);
+    assert_eq!(fixture.state.borrow().delivery_count, 0);
+    assert_eq!(fixture.host.media_snapshot().endpoint_count, 0);
+}
+
+#[test]
+fn invalid_camera_correspondence_is_rejected_before_vault() {
+    let mut fixture = test_host(true, false, false);
+    let mut entity = fixture
+        .runtime
+        .registry()
+        .entity(&fixture.entity_id)
+        .unwrap()
+        .clone();
+    entity.metadata = vec![Metadata::new("axis.video_channel", "2")];
+    fixture.runtime.upsert_entity(entity).unwrap();
+
+    assert_eq!(
+        fixture
+            .host
+            .deliver_snapshot(
+                &fixture.runtime,
+                AxisSnapshotRequest::new(fixture.entity_id, "operator preview", 5_000),
+            )
+            .unwrap_err(),
+        AxisSnapshotHostError::InvalidTarget
+    );
+    assert_eq!(fixture.credentials.resolve_count(), 0);
+}
+
+#[test]
+fn malformed_credentials_are_redacted_and_never_registered() {
+    let address: SocketAddr = "192.0.2.25:443".parse().unwrap();
+    let (runtime, entity_id, principal_id) = fixture_runtime(true, "https://axis.home");
+    let secret = "raw-axis-password";
+    let credentials = TestCredentials::new(LeasePayload::new(
+        format!(r#"{{"username":"camera","password":"{secret}","extra":true}}"#).into_bytes(),
+    ));
+    let state = Rc::new(RefCell::new(ExecutorState::default()));
+    let mut host = AxisSnapshotHost::new(
+        CameraMediaPolicy {
+            allow_plaintext_loopback: true,
+            ..CameraMediaPolicy::default()
+        },
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        TestExecutor(state.clone()),
+        credentials,
+        AxisSnapshotEndpoint::new(
+            BridgeId::trusted("bridge:axis:test"),
+            CameraMediaConnectionTarget::new("axis.home", address),
+        ),
+    );
+
+    let error = host
+        .deliver_snapshot(
+            &runtime,
+            AxisSnapshotRequest::new(entity_id, "operator preview", 5_000),
+        )
+        .unwrap_err();
+    let diagnostics = format!("{error:?} {error}");
+    assert!(!diagnostics.contains(secret));
+    assert_eq!(state.borrow().register_count, 0);
+    assert_eq!(host.media_snapshot().endpoint_count, 0);
+}
+
+#[test]
+fn sealed_vault_record_supports_repeated_approved_deliveries() {
+    let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryStorageBackend::default());
+    backend.initialize().unwrap();
+    let vault = Arc::new(SealedStore::new(backend));
+    vault
+        .init(
+            b"fixture-password",
+            &InitOptions {
+                argon2id_time_cost: 1,
+                argon2id_memory_kib: 32,
+                argon2id_parallelism: 1,
+                salt_override: Some(vec![9; 16]),
+            },
+        )
+        .unwrap();
+    let payload = encode_axis_credentials("camera-user", "camera-secret").unwrap();
+    vault
+        .put(
+            AXIS_VAULT_NAMESPACE,
+            "bridge/main",
+            payload.as_bytes(),
+            None,
+        )
+        .unwrap();
+
+    let address: SocketAddr = "192.0.2.25:443".parse().unwrap();
+    let (mut runtime, entity_id, principal_id) = fixture_runtime(true, "https://axis.home");
+    let bridge_id = BridgeId::trusted("bridge:axis:test");
+    let mut bridge = runtime.registry().bridge(&bridge_id).unwrap().clone();
+    bridge.auth_ref = Some(VaultRef::trusted(format!(
+        "{AXIS_VAULT_REF_PREFIX}bridge/main"
+    )));
+    runtime.upsert_bridge(bridge).unwrap();
+    let state = Rc::new(RefCell::new(ExecutorState::default()));
+    let mut host = AxisSnapshotHost::new(
+        CameraMediaPolicy {
+            allow_plaintext_loopback: true,
+            ..CameraMediaPolicy::default()
+        },
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        TestExecutor(state.clone()),
+        AxisSealedStoreCredentialSource::new(vault),
+        AxisSnapshotEndpoint::new(
+            bridge_id,
+            CameraMediaConnectionTarget::new("axis.home", address),
+        ),
+    );
+
+    for purpose in ["first preview", "second preview"] {
+        host.deliver_snapshot(
+            &runtime,
+            AxisSnapshotRequest::new(entity_id.clone(), purpose, 5_000),
+        )
+        .unwrap();
+    }
+    let state = state.borrow();
+    assert_eq!(state.register_count, 2);
+    assert_eq!(state.unregister_count, 2);
+    assert_eq!(state.delivery_count, 2);
+    assert!(state.registered.is_empty());
+    drop(state);
+    assert_eq!(host.media_snapshot().endpoint_count, 0);
+}
+
+#[test]
+fn native_http_executor_delivers_one_basic_authenticated_axis_jpeg() {
+    let address: SocketAddr = "192.0.2.25:443".parse().unwrap();
+    let capture = Arc::new(Mutex::new(TlsCapture::default()));
+    let connector = RecordingConnector::new(
+        VecDeque::from(vec![
+            b"HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: Basic realm=\"AXIS\"\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_vec(),
+            wire_response("image/jpeg", &[0xff, 0xd8, 0xff, 0xd9]),
+        ]),
+        Arc::clone(&capture),
+    );
+    let (runtime, entity_id, principal_id) = fixture_runtime(true, "https://axis.home");
+    let credentials = TestCredentials::new(encode_axis_credentials("user", "secret").unwrap());
+    let executor = CameraMediaHttpExecutor::new(
+        Box::new(connector),
+        TlsConfig::https_default(),
+        CameraMediaHttpPolicy::default(),
+    );
+    let mut host = AxisSnapshotHost::new(
+        CameraMediaPolicy::default(),
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        executor,
+        credentials,
+        AxisSnapshotEndpoint::new(
+            BridgeId::trusted("bridge:axis:test"),
+            CameraMediaConnectionTarget::new("axis.home", address),
+        ),
+    );
+
+    let delivery = host
+        .deliver_snapshot(
+            &runtime,
+            AxisSnapshotRequest::new(entity_id, "operator preview", 5_000),
+        )
+        .unwrap();
+    assert_eq!(
+        delivery.snapshot_bytes(),
+        Some(&[0xff, 0xd8, 0xff, 0xd9][..])
+    );
+    assert_eq!(host.media_snapshot().endpoint_count, 0);
+    let capture = capture.lock().unwrap();
+    assert_eq!(capture.requests.len(), 2);
+    let first = String::from_utf8(capture.requests[0].clone()).unwrap();
+    assert!(first.starts_with("GET /axis-cgi/jpg/image.cgi?camera=1 HTTP/1.1\r\n"));
+    assert!(!first.contains("Authorization:"));
+    let second = String::from_utf8(capture.requests[1].clone()).unwrap();
+    assert!(second.starts_with("GET /axis-cgi/jpg/image.cgi?camera=1 HTTP/1.1\r\n"));
+    assert!(second.contains("Authorization: Basic dXNlcjpzZWNyZXQ="));
+    assert_eq!(
+        capture.pinned_connections,
+        vec![
+            ("axis.home".to_string(), address),
+            ("axis.home".to_string(), address)
+        ]
+    );
+}
+
+#[derive(Default)]
+struct TlsCapture {
+    pinned_connections: Vec<(String, SocketAddr)>,
+    requests: Vec<Vec<u8>>,
+}
+
+struct RecordingConnector {
+    responses: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    capture: Arc<Mutex<TlsCapture>>,
+}
+
+impl RecordingConnector {
+    fn new(responses: VecDeque<Vec<u8>>, capture: Arc<Mutex<TlsCapture>>) -> Self {
+        Self {
+            responses: Arc::new(Mutex::new(responses)),
+            capture,
+        }
+    }
+
+    fn stream(&self) -> Result<Box<dyn TlsStream>, TlsError> {
+        let response = self
+            .responses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or_else(|| TlsError::Io {
+                phase: "fixture response",
+                source: std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "missing fixture response",
+                ),
+            })?;
+        Ok(Box::new(RecordingTlsStream {
+            response: Cursor::new(response),
+            request: Vec::new(),
+            capture: Arc::clone(&self.capture),
+        }))
+    }
+}
+
+impl TlsConnector for RecordingConnector {
+    fn connect(
+        &self,
+        _host: &str,
+        _port: u16,
+        _config: &TlsConfig,
+    ) -> Result<Box<dyn TlsStream>, TlsError> {
+        self.stream()
+    }
+
+    fn connect_addr(
+        &self,
+        server_name: &str,
+        address: SocketAddr,
+        _config: &TlsConfig,
+    ) -> Result<Box<dyn TlsStream>, TlsError> {
+        self.capture
+            .lock()
+            .unwrap()
+            .pinned_connections
+            .push((server_name.to_string(), address));
+        self.stream()
+    }
+}
+
+struct RecordingTlsStream {
+    response: Cursor<Vec<u8>>,
+    request: Vec<u8>,
+    capture: Arc<Mutex<TlsCapture>>,
+}
+
+impl Drop for RecordingTlsStream {
+    fn drop(&mut self) {
+        self.capture
+            .lock()
+            .unwrap()
+            .requests
+            .push(std::mem::take(&mut self.request));
+    }
+}
+
+impl Read for RecordingTlsStream {
+    fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+        self.response.read(output)
+    }
+}
+
+impl Write for RecordingTlsStream {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.request.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl TlsStream for RecordingTlsStream {
+    fn peer_certificates(&self) -> Result<Vec<Vec<u8>>, TlsError> {
+        Ok(Vec::new())
+    }
+
+    fn negotiated_alpn(&self) -> Option<String> {
+        Some("http/1.1".to_string())
+    }
+
+    fn negotiated_version(&self) -> TlsVersion {
+        TlsVersion::Tls13
+    }
+
+    fn close_notify(&mut self) -> Result<(), TlsError> {
+        Ok(())
+    }
+
+    fn summary(&self) -> TlsConnectionSummary {
+        panic!("summary is not used by the snapshot host")
+    }
+}
+
+fn wire_response(content_type: &str, body: &[u8]) -> Vec<u8> {
+    let mut response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )
+    .into_bytes();
+    response.extend_from_slice(body);
+    response
+}

--- a/code/packages/rust/smart-home-axis-vapix-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-axis-vapix-integration/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.0
+
+- Probe the bounded VAPIX image parameter inventory during authenticated
+  inspection.
+- Advertise `camera.snapshot` only for an enabled camera-1 channel with VAPIX
+  HTTP version 3 and native JPEG support.
+
 ## 0.3.0
 
 - Probe Axis endpoints without credentials and select advertised Basic or

--- a/code/packages/rust/smart-home-axis-vapix-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-axis-vapix-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smart-home-axis-vapix-integration"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Authenticated Axis VAPIX discovery, inspection, and bounded PTZ control"
 license = "MIT"

--- a/code/packages/rust/smart-home-axis-vapix-integration/README.md
+++ b/code/packages/rust/smart-home-axis-vapix-integration/README.md
@@ -17,6 +17,9 @@ The package:
 - materializes Basic and Digest authorization values only inside the bounded
   transport, with credentials and derived response values in zeroizing memory;
 - calls the authenticated Basic Device Information and API Discovery JSON CGIs;
+- probes the documented image parameter inventory for VAPIX HTTP version 3,
+  JPEG support, camera-1 availability, and camera-1 enablement before
+  advertising `camera.snapshot`;
 - probes the documented PTZ command inventory, current position, server presets,
   native speed control, and `CtlQueueing` mode before advertising `camera.ptz`;
 - recalls only probed presets and bounds continuous directional movement to five
@@ -27,14 +30,14 @@ The package:
 - normalizes Axis identity, firmware, product type, and the supported VAPIX API
   list into one confirmed camera entity; and
 - authorizes D23 reads and human-approved PTZ commands before credentials or
-  transport are touched; and
+  transport are touched;
 - preserves confirmed position from inspection instead of inventing optimistic
   orientation after movement.
 
-The production path intentionally targets VAPIX camera 1. Event
-streaming, snapshots, media transfer, multi-channel enumeration, and advanced
-zoom/guard-tour control remain separate slices with additional host or
-capability prerequisites.
+The production path intentionally targets VAPIX camera 1. Snapshot execution
+is composed by `smart-home-axis-snapshot-host`; event streaming, broader media
+transfer, multi-channel enumeration, and advanced zoom/guard-tour control
+remain separate slices with additional host or capability prerequisites.
 
 Protocol references:
 
@@ -43,3 +46,5 @@ Protocol references:
 - [Axis API Discovery](https://developer.axis.com/vapix/network-video/api-discovery-service/)
 - [Axis mDNS-SD](https://developer.axis.com/vapix/network-video/mdns-sd-api/)
 - [Axis PTZ API](https://developer.axis.com/vapix/network-video/pantiltzoom-api/)
+- [Axis video streaming API](https://developer.axis.com/vapix/network-video/video-streaming/)
+- [Axis image parameters](https://developer.axis.com/vapix/network-video/parameter-management/image-api/)

--- a/code/packages/rust/smart-home-axis-vapix-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-axis-vapix-integration/src/lib.rs
@@ -33,7 +33,7 @@ use std::time::Duration;
 use tls_platform::{default_connector, TlsConfig, TlsConnector};
 use url_parser::{Url, UrlError};
 
-pub const VERSION: &str = "0.3.0";
+pub const VERSION: &str = "0.4.0";
 pub const INTEGRATION_ID: &str = "axis_vapix";
 pub const PROTOCOL_ID: &str = "axis_vapix";
 pub const VIDEO_MDNS_SERVICE_TYPE: &str = "_axis-video._tcp.local";
@@ -43,8 +43,11 @@ pub const API_DISCOVERY_PATH: &str = "/axis-cgi/apidiscovery.cgi";
 pub const PTZ_CONTROL_PATH: &str = "/axis-cgi/com/ptz.cgi";
 pub const PTZ_QUEUE_PATH: &str = "/axis-cgi/com/ptzqueue.cgi";
 pub const PARAM_PATH: &str = "/axis-cgi/param.cgi";
+pub const JPEG_SNAPSHOT_PATH: &str = "/axis-cgi/jpg/image.cgi?camera=1";
+pub const VIDEO_CAPABILITY_PATH: &str = "/axis-cgi/param.cgi?action=list&responseformat=rfc&group=Properties.API.HTTP.Version,Properties.Image.Format,Image.NbrOfConfigs,Image.I0.Enabled";
 pub const DEFAULT_MAX_DISCOVERY_RESPONSES: usize = 128;
 pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
+pub const MAX_CREDENTIAL_FIELD_BYTES: usize = 1_024;
 pub const MIN_PTZ_SPEED: u32 = 1;
 pub const MAX_PTZ_SPEED: u32 = 100;
 pub const MAX_PTZ_DURATION_MS: u64 = 5_000;
@@ -175,9 +178,13 @@ impl AxisCredentials {
     ) -> Result<Self, AxisError> {
         let username = username.into();
         let password = password.into();
-        if username.trim().is_empty() || password.is_empty() {
+        if username.trim().is_empty()
+            || password.is_empty()
+            || username.len() > MAX_CREDENTIAL_FIELD_BYTES
+            || password.len() > MAX_CREDENTIAL_FIELD_BYTES
+        {
             return Err(AxisError::Validation(
-                "username and password must not be empty".to_string(),
+                "username and password must be non-empty and bounded".to_string(),
             ));
         }
         if has_unsafe_http_text(&username) || has_unsafe_http_text(&password) {
@@ -291,7 +298,30 @@ pub struct AxisApi {
 pub struct AxisSnapshot {
     pub device: AxisDeviceInformation,
     pub apis: Vec<AxisApi>,
+    pub video: Option<AxisVideoSnapshot>,
     pub ptz: Option<AxisPtzSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AxisVideoSnapshot {
+    pub channel: u32,
+    pub http_api_version: String,
+    pub formats: Vec<String>,
+    pub channel_count: u32,
+    pub enabled: bool,
+}
+
+impl AxisVideoSnapshot {
+    pub fn supports_jpeg_snapshot(&self) -> bool {
+        self.channel == 1
+            && self.http_api_version == "3"
+            && self.channel_count >= self.channel
+            && self.enabled
+            && self
+                .formats
+                .iter()
+                .any(|format| format.eq_ignore_ascii_case("jpeg"))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -670,10 +700,16 @@ impl<T: AxisTransport> AxisClient<T> {
             &json!({"apiVersion":"1.0","context":"smart-home","method":"getApiList"}),
         )?;
         let mut snapshot = parse_snapshot(&properties, &apis)?;
+        snapshot.video = self.inspect_video()?;
         if snapshot.apis.iter().any(|api| api.id == "ptz-control") {
             snapshot.ptz = Some(self.inspect_ptz(PTZ_CAMERA)?);
         }
         Ok(snapshot)
+    }
+
+    fn inspect_video(&mut self) -> Result<Option<AxisVideoSnapshot>, AxisError> {
+        let response = self.get_text(VIDEO_CAPABILITY_PATH, None)?;
+        parse_video_snapshot(response_text(&response.body)?)
     }
 
     fn post_json(&mut self, path: &str, body: &JsonValue) -> Result<JsonValue, AxisError> {
@@ -1089,6 +1125,17 @@ pub fn install_snapshot(
         ValueKind::Object,
     )];
     if snapshot
+        .video
+        .as_ref()
+        .is_some_and(AxisVideoSnapshot::supports_jpeg_snapshot)
+    {
+        capabilities.push(Capability::new(
+            CapabilityId::trusted("camera.snapshot"),
+            CapabilityMode::Command,
+            ValueKind::Text,
+        ));
+    }
+    if snapshot
         .ptz
         .as_ref()
         .is_some_and(AxisPtzSnapshot::commandable)
@@ -1110,7 +1157,10 @@ pub fn install_snapshot(
             expires_at_ms: None,
             confidence: StateConfidence::Confirmed,
         }),
-        metadata: vec![Metadata::new("axis.protocol", PROTOCOL_ID)],
+        metadata: vec![
+            Metadata::new("axis.protocol", PROTOCOL_ID),
+            Metadata::new("axis.video_channel", PTZ_CAMERA.to_string()),
+        ],
     })?;
 
     Ok(InstalledAxisDevice {
@@ -1174,8 +1224,58 @@ fn parse_snapshot(properties: &JsonValue, apis: &JsonValue) -> Result<AxisSnapsh
     Ok(AxisSnapshot {
         device,
         apis: parsed_apis,
+        video: None,
         ptz: None,
     })
+}
+
+fn parse_video_snapshot(text: &str) -> Result<Option<AxisVideoSnapshot>, AxisError> {
+    let values = parse_key_values(text);
+    let value = |name: &str| {
+        values.get(name).copied().or_else(|| {
+            values.iter().find_map(|(key, value)| {
+                key.strip_prefix("root.")
+                    .is_some_and(|key| key == name)
+                    .then_some(*value)
+            })
+        })
+    };
+    let Some(http_api_version) = value("Properties.API.HTTP.Version") else {
+        return Ok(None);
+    };
+    let Some(formats) = value("Properties.Image.Format") else {
+        return Ok(None);
+    };
+    let Some(channel_count) = value("Image.NbrOfConfigs") else {
+        return Ok(None);
+    };
+    let Some(enabled) = value("Image.I0.Enabled") else {
+        return Ok(None);
+    };
+    let channel_count = channel_count.parse::<u32>().map_err(|_| {
+        AxisError::Validation("Axis video channel count is not an integer".to_string())
+    })?;
+    let enabled = match enabled.to_ascii_lowercase().as_str() {
+        "yes" | "true" | "1" => true,
+        "no" | "false" | "0" => false,
+        _ => {
+            return Err(AxisError::Validation(
+                "Axis video channel enabled state is invalid".to_string(),
+            ))
+        }
+    };
+    Ok(Some(AxisVideoSnapshot {
+        channel: 1,
+        http_api_version: http_api_version.to_string(),
+        formats: formats
+            .split(',')
+            .map(str::trim)
+            .filter(|format| !format.is_empty())
+            .map(str::to_string)
+            .collect(),
+        channel_count,
+        enabled,
+    }))
 }
 
 fn required_string(
@@ -1227,6 +1327,21 @@ fn snapshot_value(snapshot: &AxisSnapshot) -> Value {
     ];
     if let Some(ptz) = &snapshot.ptz {
         fields.push(("ptz".to_string(), ptz_value(ptz)));
+    }
+    if let Some(video) = &snapshot.video {
+        fields.push((
+            "video".to_string(),
+            Value::Object(vec![
+                (
+                    "channel".to_string(),
+                    Value::Integer(i64::from(video.channel)),
+                ),
+                (
+                    "jpeg_snapshot".to_string(),
+                    Value::Bool(video.supports_jpeg_snapshot()),
+                ),
+            ]),
+        ));
     }
     Value::Object(fields)
 }
@@ -1798,6 +1913,7 @@ mod tests {
     const DEVICE_INFO: &str = r#"{"apiVersion":"1.0","context":"smart-home","data":{"propertyList":{"Brand":"AXIS","ProdFullName":"AXIS Q1785-LE Network Camera","ProdNbr":"Q1785-LE","ProdType":"Network Camera","SerialNumber":"ACCC8EAF8C30","Version":"12.1.0"}}}"#;
     const API_LIST: &str = r#"{"apiVersion":"1.0","context":"smart-home","data":{"apiList":[{"id":"systemready","version":"1.0","status":"released"},{"id":"basic-device-info","version":"1.2","status":"released"}]}}"#;
     const PTZ_API_LIST: &str = r#"{"apiVersion":"1.0","context":"smart-home","data":{"apiList":[{"id":"ptz-control","version":"1.0","status":"released"},{"id":"basic-device-info","version":"1.2","status":"released"}]}}"#;
+    const VIDEO_CAPABILITY: &str = "root.Properties.API.HTTP.Version=3\nroot.Properties.Image.Format=jpeg,mjpeg,h264\nroot.Image.NbrOfConfigs=1\nroot.Image.I0.Enabled=yes\n";
 
     fn response(body: &str) -> Vec<u8> {
         format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).into_bytes()
@@ -2037,6 +2153,7 @@ mod tests {
             response(DEVICE_INFO),
             auth_challenge(stale_digest_value),
             response(API_LIST),
+            text_response(VIDEO_CAPABILITY),
         ]);
         let client =
             AxisClient::new(config(port), credentials(), AxisLanTransport::default()).unwrap();
@@ -2062,6 +2179,13 @@ mod tests {
             camera.state.as_ref().unwrap().confidence,
             StateConfidence::Confirmed
         );
+        assert!(
+            camera
+                .capabilities
+                .iter()
+                .any(|capability| capability.capability_id
+                    == CapabilityId::trusted("camera.snapshot"))
+        );
         let bridge = runtime.registry().bridge(&installed.bridge_id).unwrap();
         assert_eq!(
             bridge.auth_ref.as_ref().unwrap().as_str(),
@@ -2069,12 +2193,13 @@ mod tests {
         );
 
         let requests = requests.lock().unwrap();
-        assert_eq!(requests.len(), 4);
+        assert_eq!(requests.len(), 5);
         assert!(requests[0].contains(&format!("POST {BASIC_DEVICE_INFO_PATH} HTTP/1.1")));
         assert!(request_header(&requests[0], "Authorization").is_none());
         assert!(requests[1].contains(&format!("POST {BASIC_DEVICE_INFO_PATH} HTTP/1.1")));
         assert!(requests[2].contains(&format!("POST {API_DISCOVERY_PATH} HTTP/1.1")));
         assert!(requests[3].contains(&format!("POST {API_DISCOVERY_PATH} HTTP/1.1")));
+        assert!(requests[4].contains(&format!("GET {VIDEO_CAPABILITY_PATH} HTTP/1.1")));
         let challenge = DigestChallenge::parse(digest_value).unwrap();
         for (request, uri, nonce_count) in [
             (&requests[1], BASIC_DEVICE_INFO_PATH, 1),
@@ -2101,6 +2226,19 @@ mod tests {
             )
             .unwrap();
         assert_eq!(authorization, expected.as_str());
+        let authorization = request_header(&requests[4], "Authorization").unwrap();
+        let client_nonce = quoted_directive(authorization, "cnonce").unwrap();
+        let expected = stale_challenge
+            .authorization(
+                "root",
+                "secret",
+                "GET",
+                VIDEO_CAPABILITY_PATH,
+                client_nonce,
+                2,
+            )
+            .unwrap();
+        assert_eq!(authorization, expected.as_str());
         assert!(requests.iter().all(|request| !request.contains("vault://")));
         assert!(requests.iter().all(|request| !request.contains("secret")));
     }
@@ -2112,6 +2250,7 @@ mod tests {
             auth_challenge(r#"Basic realm="AXIS""#),
             response(DEVICE_INFO),
             response(PTZ_API_LIST),
+            text_response(VIDEO_CAPABILITY),
             text_response("continuouspantiltmove=-100..100,-100..100\ngotoserverpresetno=integer\nspeed=integer\nquery=position\n"),
             text_response("pan=12.5\ntilt=-3.0\nzoom=2200\n"),
             text_response("Preset Positions for camera 1\npresetposno1=Home\npresetposno3=Driveway\n"),
@@ -2220,17 +2359,18 @@ mod tests {
             .as_deref()
             .is_some_and(|message| message.contains("bounded PTZ left")));
         let requests = requests.lock().unwrap();
-        assert_eq!(requests.len(), 14);
+        assert_eq!(requests.len(), 15);
         assert!(request_header(&requests[0], "Authorization").is_none());
-        assert!(requests[3].starts_with(&format!("GET {PTZ_CONTROL_PATH}?info=1&camera=1 ")));
-        assert!(requests[6].contains("group=PTZ.Various.V1.CtlQueueing"));
-        assert!(requests[7].contains("control=request&camera=1"));
-        assert!(requests[8].contains("gotoserverpresetno=3&speed=50&camera=1"));
-        assert!(requests[8].contains("Cookie: ptz=lease-token"));
-        assert!(requests[9].contains("control=drop&camera=1"));
-        assert!(requests[11].contains("continuouspantiltmove=-25,0&camera=1"));
-        assert!(requests[12].contains("continuouspantiltmove=0,0&camera=1"));
-        assert!(requests[13].contains("control=drop&camera=1"));
+        assert!(requests[3].contains(&format!("GET {VIDEO_CAPABILITY_PATH} HTTP/1.1")));
+        assert!(requests[4].starts_with(&format!("GET {PTZ_CONTROL_PATH}?info=1&camera=1 ")));
+        assert!(requests[7].contains("group=PTZ.Various.V1.CtlQueueing"));
+        assert!(requests[8].contains("control=request&camera=1"));
+        assert!(requests[9].contains("gotoserverpresetno=3&speed=50&camera=1"));
+        assert!(requests[9].contains("Cookie: ptz=lease-token"));
+        assert!(requests[10].contains("control=drop&camera=1"));
+        assert!(requests[12].contains("continuouspantiltmove=-25,0&camera=1"));
+        assert!(requests[13].contains("continuouspantiltmove=0,0&camera=1"));
+        assert!(requests[14].contains("control=drop&camera=1"));
         assert!(requests
             .iter()
             .skip(1)
@@ -2287,6 +2427,22 @@ mod tests {
         assert_eq!(snapshot.device.product_number, "Q1785-LE");
         assert_eq!(snapshot.apis[0].id, "basic-device-info");
         assert_eq!(snapshot.apis[1].id, "systemready");
+    }
+
+    #[test]
+    fn video_probe_requires_http_v3_jpeg_and_enabled_channel_one() {
+        let supported = parse_video_snapshot(VIDEO_CAPABILITY).unwrap().unwrap();
+        assert!(supported.supports_jpeg_snapshot());
+
+        let disabled = parse_video_snapshot(
+            "Properties.API.HTTP.Version=3\nProperties.Image.Format=jpeg\nImage.NbrOfConfigs=1\nImage.I0.Enabled=no\n",
+        )
+        .unwrap()
+        .unwrap();
+        assert!(!disabled.supports_jpeg_snapshot());
+        assert!(parse_video_snapshot("Properties.API.HTTP.Version=3\n")
+            .unwrap()
+            .is_none());
     }
 
     #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1432,19 +1432,47 @@ camera-media policy and pinned native HTTPS executor:
   events, streams, recordings, export, playback, PTZ, and configuration
   mutations remain prerequisite-gated.
 
+## Current Axis VAPIX Snapshot Host Slice
+
+This slice composes the installed Axis camera-1 identity with the completed
+camera-media policy and pinned native HTTPS executor:
+
+- Authenticated Axis inspection now probes the bounded VAPIX image parameter
+  inventory and advertises `camera.snapshot` only when camera 1 is enabled,
+  VAPIX HTTP version 3 is present, and JPEG is supported.
+- `smart-home-axis-snapshot-host` performs exact Human Approval preflight
+  before Vault access, endpoint registration, credential registration, or
+  media I/O. The target must be the exact camera entity installed by the
+  reviewed Axis bridge and carry the probed camera-1 metadata and capability.
+- One bounded, versioned sealed-Vault credential envelope is decoded into
+  zeroizing process-local state. The host registers the documented
+  `/axis-cgi/jpg/image.cgi?camera=1` endpoint against the reviewed canonical
+  host and pinned socket, then registers only temporary Basic or Digest
+  credentials for one bounded delivery.
+- Credentials and the endpoint are removed after success, lease failure,
+  executor failure, and registration failure. Neither credential material nor
+  the authenticated endpoint enters runtime state, errors, audit records, or
+  debug output.
+- Tests cover denial before Vault, exact installed-target correspondence,
+  malformed credential redaction, repeated sealed-record use, cleanup after
+  failure, and a strict pinned-TLS Basic challenge-to-JPEG exchange.
+- Automated credential provisioning remains an explicit pairing-flow
+  responsibility. Event streams, source enumeration, recordings, playback,
+  exports, and broader media transfer remain prerequisite-gated.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
-The strongest next executable candidate is bounded Axis camera-1 snapshot
-delivery: the production integration already has explicit local HTTPS intake,
-an installed camera-1 identity, sealed credential references, and completed
-Basic/SHA-256 Digest support, while the camera-media executor supports the same
-authentication schemes. A fresh post-merge audit must verify the official VAPIX
-JPEG endpoint, prove exact camera-1 correspondence and native capability, and
-wire host-owned credential registration/removal before implementation. Broader
-video-source enumeration, streams, recordings, and playback remain
+The strongest next executable candidate is bounded Blue Iris snapshot delivery:
+the production integration already has an explicit local HTTPS origin, exact
+camera identities, isolated challenge-response sessions, and explicit logout.
+A fresh post-merge audit must verify the documented native image request,
+prove exact camera correspondence and snapshot permission, and define the
+process-local session-bearing endpoint lifetime before implementation. Frigate
+snapshot delivery remains blocked on a cookie-capable media authentication
+boundary; broader streams, recordings, export, and playback remain
 prerequisite-gated.
 
 1. Add automated ONVIF credential provisioning only through an explicit pairing
@@ -1539,36 +1567,32 @@ prerequisite-gated.
 29. Add Axis event streaming only after the existing WebSocket protocol core has
    a concrete authenticated host using the completed Digest primitive or a
    short-lived session token, plus subscription supervision.
-30. Add bounded Axis snapshots through the completed camera-media HTTPS executor
-    after process-local endpoint registration and credential lifetime are
-    wired; broader media transfer still requires a concrete supervised resource
-    executor.
-31. Enumerate Axis video sources/channels before extending PTZ beyond the current
-   capability-probed VAPIX camera 1 boundary.
-32. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
-   only when each operation has a specific capability probe and readable state.
-33. Add bounded Reolink snapshots through the completed camera-media HTTPS
+30. Enumerate Axis video sources/channels before extending PTZ beyond the current
+    capability-probed VAPIX camera 1 boundary.
+31. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
+    only when each operation has a specific capability probe and readable state.
+32. Add bounded Reolink snapshots through the completed camera-media HTTPS
     executor after process-local endpoint registration and credential lifetime
     are wired; recording search/download and playback still require a concrete
     supervised resource executor.
-34. Add Reolink current-position, zoom, guard-point, or patrol controls only when
-   each operation has a capability-specific probe and the firmware exposes the
-   native state needed to avoid invented orientation claims.
-35. Add Reolink push events only after a concrete webhook or event-stream host
-   and subscription lifecycle exist.
-36. Add authenticated KLAP/Tapo devices and other broader-device families only
-   after their authentication and session prerequisites are concrete.
-37. Add ONVIF PullPoint events once a concrete event host and subscription
-   lifecycle exist.
-38. Add RTSP media transfer and recording once concrete media transfer and
-   recorder host primitives exist.
-39. Add a production Matter commissioning, secure-session, and network host only
-   after certificate, fabric, Interaction Model encoding, subscription, and
-   transport prerequisites exist.
-40. Add a Thread border-router host only after an actual host transport exists.
-41. Add a production Zigbee coordinator, join, and security host only after
-   concrete coordinator transport and security primitives exist.
-42. Add production Z-Wave inclusion and S2 only after concrete host transport
+33. Add Reolink current-position, zoom, guard-point, or patrol controls only when
+    each operation has a capability-specific probe and the firmware exposes the
+    native state needed to avoid invented orientation claims.
+34. Add Reolink push events only after a concrete webhook or event-stream host
+    and subscription lifecycle exist.
+35. Add authenticated KLAP/Tapo devices and other broader-device families only
+    after their authentication and session prerequisites are concrete.
+36. Add ONVIF PullPoint events once a concrete event host and subscription
+    lifecycle exist.
+37. Add RTSP media transfer and recording once concrete media transfer and
+    recorder host primitives exist.
+38. Add a production Matter commissioning, secure-session, and network host only
+    after certificate, fabric, Interaction Model encoding, subscription, and
+    transport prerequisites exist.
+39. Add a Thread border-router host only after an actual host transport exists.
+40. Add a production Zigbee coordinator, join, and security host only after
+    concrete coordinator transport and security primitives exist.
+41. Add production Z-Wave inclusion and S2 only after concrete host transport
    and security primitives exist.
 
 ## End-To-End Definition


### PR DESCRIPTION
## Summary
- capability-probe Axis camera 1 for VAPIX HTTP v3, JPEG support, and an enabled native channel before advertising snapshots
- add an exact D23 Human Approval host around sealed credentials, reviewed-address-pinned HTTPS, and temporary Basic/Digest registration
- remove credentials and the camera-1 endpoint after every outcome, with redaction, correspondence, repeat-use, and native TLS challenge coverage
- record the completed slice and reprioritize the D18-D23 Smart Home backlog

## Validation
- `cargo test -p smart-home-axis-vapix-integration -p smart-home-axis-snapshot-host`
- `cargo clippy -p smart-home-axis-vapix-integration -p smart-home-axis-snapshot-host --all-targets --all-features -- -D warnings`
- `bash BUILD` in both impacted packages
- `cargo fmt -p smart-home-axis-vapix-integration -p smart-home-axis-snapshot-host -- --check`
- `git diff --check`
