### PR TITLE
Report non-current description list item starts

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- A `dt` or `dd` start tag now reports the in-body parse error when
+  implied-end-tag recovery closes a non-current description-list item,
+  covering the remaining silent in-body list case without changing DOM
+  recovery or adjacent description-list diagnostics.
 - Table-context end tags that force recovery from SVG or MathML foreign
   content now report the foreign-content parse error, covering 4 previously
   silent malformed corpus cases without changing DOM recovery or

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -1,6 +1,6 @@
 # HTML Parser Conformance Backlog
 
-Last audited: 2026-08-03
+Last audited: 2026-08-09
 
 ## Completion Boundary
 
@@ -21,15 +21,15 @@ exact upstream commits used for the latest completed audit.
 
 ## Prioritized Queue
 
-The 2026-08-03 upstream audit at WPT
-`82c3d9069cf2e93e5528a1f428fa122bd9af651d` and html5lib-tests
+The 2026-08-09 upstream audit at WPT
+`54f8f933629e7c010ae98a246729af01f8abcda5` and html5lib-tests
 `224991ec10db04f056a89eed8b0bd8695fd2950e` covered all 1,934 WPT
 tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the foreign-content table-end-tag breakout diagnostic slice, 2,074 of
-those cases emit at least one lexer or parser diagnostic and 109 remain
+After the non-current description-list item start-tag diagnostic slice, 2,075
+of those cases emit at least one lexer or parser diagnostic and 108 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -61,9 +61,11 @@ the specialized parse error when no heading is in scope or the current heading
 does not match the token. A `li` start tag reports when its implied-end-tag
 recovery closes a non-current list item, and a paragraph end tag reports when it
 breaks out of MathML foreign content. A formatting end tag also reports when an
-open table blocks adoption-agency recovery.
+open table blocks adoption-agency recovery. Description-list item start tags
+now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
+without flagging adjacent description-list items.
 
-The fresh 109-case residual inventory keeps the next concrete groups in the
+The fresh 108-case residual inventory keeps the next concrete groups in the
 existing priority order: remaining table foster-parenting and table-scope
 boundaries;
 select/template recovery; script-tokenizer EOF recovery; plaintext/frameset

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7236,6 +7236,21 @@ impl HtmlParser {
         } else if incoming_name == "dt" || incoming_name == "dd" {
             if !self.current_parent_has_element_ancestor("button") {
                 self.close_open_element_if(|name| name == "p");
+                if !self.current_element_is("dt")
+                    && !self.current_element_is("dd")
+                    && !self.current_element_is("optgroup")
+                    && self.open_elements.iter().any(|path| {
+                        element_at_path(&self.document, path)
+                            .is_some_and(|name| name == "dt" || name == "dd")
+                    })
+                {
+                    self.diagnostics.push(ParserDiagnostic::new(
+                        "unexpected-description-list-item-start-tag",
+                        format!(
+                            "start tag `<{incoming_name}>` implied the end of a non-current description-list item"
+                        ),
+                    ));
+                }
                 self.close_open_element_if(|name| name == "dt" || name == "dd");
             }
         } else if incoming_name == "option"
@@ -33308,6 +33323,29 @@ mod tests {
             .parser_diagnostics
             .iter()
             .any(|diagnostic| diagnostic.code == "unexpected-li-start-tag"));
+    }
+
+    #[test]
+    fn reports_description_list_item_start_tags_that_close_non_current_items() {
+        let output = parse_html_with_diagnostics("<!DOCTYPE html><dt><div><dd>").unwrap();
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-description-list-item-start-tag",
+                "start tag `<dd>` implied the end of a non-current description-list item"
+            )]
+        );
+
+        for source in [
+            "<!doctype html><dl><dt>term<dd>description",
+            "<!doctype html><dl><dd>description<dt>term",
+            "<!doctype html><dd><optgroup><dd>",
+        ] {
+            let adjacent = parse_html_with_diagnostics(source).unwrap();
+            assert!(adjacent.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-description-list-item-start-tag"
+            }));
+        }
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
@@ -14,7 +14,7 @@
     "missing": 0,
     "missing_sources": [],
     "upstream_cases": 1934,
-    "upstream_revision": "82c3d9069cf2e93e5528a1f428fa122bd9af651d",
+    "upstream_revision": "54f8f933629e7c010ae98a246729af01f8abcda5",
     "upstream_source": "wpt/html/syntax/parsing/resources"
   }
 }

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 109);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2074);
+    assert_eq!(missing_diagnostic_cases, 108);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2075);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the in-body parse error when a `dt` or `dd` start closes a non-current description-list item
- preserve diagnostic-free adjacent items and the existing `optgroup` recovery case
- ratchet silent malformed tree cases from 109 to 108 and refresh the pinned live WPT revision

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- live WPT/html5lib coverage audit: 1,934 tree cases, 6,806 tokenizer cases, zero missing, zero normalized skips
- generated HTML fixture guard
- WHATWG audit coverage, manifest, Rust-test, and tree-smoke guards
- Python conformance audit unit tests
- `git diff --check`