### PR TITLE
Add Mermaid sequence participant stereotypes

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -6,7 +6,7 @@ body = { NEWLINE | statement } ;
 statement = participant_stmt | participant_box | destroy_stmt | message_stmt | activation_stmt | note_stmt | title_stmt | autonumber_stmt | control_block ;
 
 participant_stmt = [ "create" ] participant_decl ;
-participant_decl = ( "participant" | "actor" ) identifier [ "as" text ] ;
+participant_decl = ( "participant" | "actor" ) identifier [ CONFIG ] [ "as" text ] ;
 participant_box = "box" [ text ] NEWLINE { NEWLINE | participant_decl } "end" ;
 destroy_stmt = "destroy" identifier ;
 message_stmt = identifier message_arrow [ PLUS | MINUS ] identifier COLON [ text ] ;

--- a/code/grammars/mermaid/sequence.tokens
+++ b/code/grammars/mermaid/sequence.tokens
@@ -20,11 +20,12 @@ SOLID_CROSS_ARROW        = "-x"
 SOLID_POINT_ARROW        = "-)"
 COLON                    = ":"
 COLOR                    = /rgba?\([^\)\r\n]*\)/
+CONFIG                   = /@\{[^\}\r\n]*\}/
 COMMA                    = ","
 PLUS                     = "+"
 MINUS                    = "-"
-IDENTIFIER               = /[A-Za-z0-9_.$@]+/
-WORD                     = /[^ \t\r\n:,+-]+/
+IDENTIFIER               = /[A-Za-z0-9_.$]+/
+WORD                     = /[^ \t\r\n:,+-@]+/
 
 keywords:
   participant

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.8.0
+
+- Added Mermaid sequence participant stereotype kinds.
+
 ## 0.7.0
 
 - Added semantic and layout IR primitives for sequence participant groups.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.7.0 — DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.7.0";
+pub const VERSION: &str = "0.8.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -158,6 +158,12 @@ pub struct LayoutedGraphDiagram {
 pub enum SequenceParticipantKind {
     Participant,
     Actor,
+    Boundary,
+    Control,
+    Entity,
+    Database,
+    Collections,
+    Queue,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -879,8 +885,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_is_0_7_0() {
-        assert_eq!(VERSION, "0.7.0");
+    fn version_is_0_8_0() {
+        assert_eq!(VERSION, "0.8.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added backend-neutral sequence symbols for boundary, control, entity,
+  database, collections, and queue participants.
 - Added sequence participant-group backgrounds and labels.
 - Added a Mermaid Pie -> chart layout -> PaintScene -> Metal PNG example and
   Apple end-to-end test.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.7.0";
+pub const VERSION: &str = "0.8.0";
 
 use std::collections::HashMap;
 
@@ -1408,6 +1408,10 @@ where
                 height,
                 ..
             } => {
+                let specialized = !matches!(
+                    kind,
+                    SequenceParticipantKind::Participant | SequenceParticipantKind::Actor
+                );
                 instructions.push(PaintInstruction::Rect(PaintRect {
                     base: PaintBase::default(),
                     x: *x,
@@ -1417,24 +1421,34 @@ where
                     fill: Some(match kind {
                         SequenceParticipantKind::Participant => "#eff6ff".into(),
                         SequenceParticipantKind::Actor => "#f0fdf4".into(),
+                        _ => "#f0fdfa".into(),
                     }),
                     stroke: Some(match kind {
                         SequenceParticipantKind::Participant => "#2563eb".into(),
                         SequenceParticipantKind::Actor => "#16a34a".into(),
+                        _ => "#0f766e".into(),
                     }),
                     stroke_width: Some(1.5),
                     corner_radius: Some(match kind {
                         SequenceParticipantKind::Participant => 5.0,
                         SequenceParticipantKind::Actor => *height / 2.0,
+                        _ => 5.0,
                     }),
                     stroke_dash: None,
                     stroke_dash_offset: None,
                 }));
+                if specialized {
+                    instructions.extend(sequence_participant_icon(
+                        kind,
+                        *x + 24.0,
+                        *y + height / 2.0,
+                    ));
+                }
                 text_children.push(text_node(
                     label,
-                    *x + 8.0,
+                    *x + if specialized { 44.0 } else { 8.0 },
                     *y + 11.0,
-                    *width - 16.0,
+                    *width - if specialized { 50.0 } else { 16.0 },
                     *height - 12.0,
                     label_font.clone(),
                     text_color,
@@ -1506,6 +1520,134 @@ fn sequence_block_name(kind: &SequenceBlockKind) -> &'static str {
         SequenceBlockKind::ParOver => "par_over",
         SequenceBlockKind::Critical => "critical",
         SequenceBlockKind::Break => "break",
+    }
+}
+
+fn sequence_participant_icon(
+    kind: &SequenceParticipantKind,
+    cx: f64,
+    cy: f64,
+) -> Vec<PaintInstruction> {
+    let ellipse = |rx: f64, ry: f64| {
+        PaintInstruction::Ellipse(PaintEllipse {
+            base: PaintBase::default(),
+            cx,
+            cy,
+            rx,
+            ry,
+            fill: Some("#ffffff".into()),
+            stroke: Some("#0f766e".into()),
+            stroke_width: Some(1.5),
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        })
+    };
+    let path = |commands| {
+        PaintInstruction::Path(PaintPath {
+            base: PaintBase::default(),
+            commands,
+            fill: None,
+            fill_rule: None,
+            stroke: Some("#0f766e".into()),
+            stroke_width: Some(1.5),
+            stroke_cap: Some(StrokeCap::Round),
+            stroke_join: Some(StrokeJoin::Round),
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        })
+    };
+    match kind {
+        SequenceParticipantKind::Boundary => vec![
+            ellipse(9.0, 9.0),
+            path(vec![
+                PathCommand::MoveTo { x: cx + 9.0, y: cy },
+                PathCommand::LineTo {
+                    x: cx + 16.0,
+                    y: cy,
+                },
+                PathCommand::MoveTo {
+                    x: cx + 16.0,
+                    y: cy - 13.0,
+                },
+                PathCommand::LineTo {
+                    x: cx + 16.0,
+                    y: cy + 13.0,
+                },
+            ]),
+        ],
+        SequenceParticipantKind::Control => vec![
+            ellipse(11.0, 11.0),
+            path(vec![
+                PathCommand::MoveTo {
+                    x: cx - 8.0,
+                    y: cy - 10.0,
+                },
+                PathCommand::LineTo {
+                    x: cx - 1.0,
+                    y: cy - 15.0,
+                },
+                PathCommand::LineTo {
+                    x: cx + 1.0,
+                    y: cy - 8.0,
+                },
+            ]),
+        ],
+        SequenceParticipantKind::Entity => vec![
+            ellipse(10.0, 10.0),
+            path(vec![
+                PathCommand::MoveTo {
+                    x: cx - 12.0,
+                    y: cy + 13.0,
+                },
+                PathCommand::LineTo {
+                    x: cx + 12.0,
+                    y: cy + 13.0,
+                },
+            ]),
+        ],
+        SequenceParticipantKind::Database => vec![ellipse(12.0, 15.0)],
+        SequenceParticipantKind::Collections => vec![
+            PaintInstruction::Rect(PaintRect {
+                base: PaintBase::default(),
+                x: cx - 9.0,
+                y: cy - 13.0,
+                width: 20.0,
+                height: 22.0,
+                fill: Some("#ffffff".into()),
+                stroke: Some("#0f766e".into()),
+                stroke_width: Some(1.25),
+                corner_radius: Some(2.0),
+                stroke_dash: None,
+                stroke_dash_offset: None,
+            }),
+            PaintInstruction::Rect(PaintRect {
+                base: PaintBase::default(),
+                x: cx - 13.0,
+                y: cy - 9.0,
+                width: 20.0,
+                height: 22.0,
+                fill: None,
+                stroke: Some("#0f766e".into()),
+                stroke_width: Some(1.25),
+                corner_radius: Some(2.0),
+                stroke_dash: None,
+                stroke_dash_offset: None,
+            }),
+        ],
+        SequenceParticipantKind::Queue => vec![PaintInstruction::Rect(PaintRect {
+            base: PaintBase::default(),
+            x: cx - 14.0,
+            y: cy - 9.0,
+            width: 28.0,
+            height: 18.0,
+            fill: Some("#ffffff".into()),
+            stroke: Some("#0f766e".into()),
+            stroke_width: Some(1.5),
+            corner_radius: Some(9.0),
+            stroke_dash: None,
+            stroke_dash_offset: None,
+        })],
+        SequenceParticipantKind::Participant | SequenceParticipantKind::Actor => vec![],
     }
 }
 
@@ -2415,7 +2557,22 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.7.0");
+        assert_eq!(crate::VERSION, "0.8.0");
+    }
+
+    #[test]
+    fn sequence_stereotypes_emit_distinct_icon_geometry() {
+        let kinds = [
+            SequenceParticipantKind::Boundary,
+            SequenceParticipantKind::Control,
+            SequenceParticipantKind::Entity,
+            SequenceParticipantKind::Database,
+            SequenceParticipantKind::Collections,
+            SequenceParticipantKind::Queue,
+        ];
+        for kind in kinds {
+            assert!(!sequence_participant_icon(&kind, 20.0, 20.0).is_empty());
+        }
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -348,7 +348,7 @@ mod apple {
     #[test]
     fn render_mermaid_sequence_to_png() {
         let diagram = parse_sequence_diagram(
-            "sequenceDiagram\ntitle Native Mermaid sequence\nautonumber\nbox aqua Client tier\nactor User\nparticipant API as Banking API\nend\nbox Services\nparticipant DB as Ledger\nend\nalt Transfer accepted\nUser->>+API: Submit transfer\ncreate participant Worker as Audit Worker\nAPI->>Worker: Start audit\nWorker-->>API: Audit complete\ndestroy Worker\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete\nelse Transfer rejected\nAPI-->>User: Validation failed\nend",
+            "sequenceDiagram\ntitle Native Mermaid sequence\nautonumber\nbox aqua Client tier\nactor User\nparticipant API@{ \"type\": \"boundary\" } as Banking API\nend\nbox Services\nparticipant DB@{ \"type\": \"database\", \"alias\": \"Ledger\" }\nend\nalt Transfer accepted\nUser->>+API: Submit transfer\ncreate participant Worker as Audit Worker\nAPI->>Worker: Start audit\nWorker-->>API: Audit complete\ndestroy Worker\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete\nelse Transfer rejected\nAPI-->>User: Validation failed\nend",
         )
         .expect("Mermaid sequence parse failed");
         let layout = layout_sequence_diagram(&diagram);

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0
+
+- Tokenize inline sequence participant configuration objects.
+
 ## 0.6.0
 
 - Tokenize sequence participant boxes and CSS functional colors.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.6.0";
+pub const VERSION: &str = "0.7.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.6.0");
+        assert_eq!(VERSION, "0.7.0");
     }
 
     #[test]
@@ -333,5 +333,16 @@ mod tests {
         assert!(tokens
             .iter()
             .any(|token| token.value == "rgba(33,66,99,0.5)"));
+    }
+
+    #[test]
+    fn tokenizes_sequence_participant_configuration() {
+        let tokens = tokenize_mermaid_sequence(
+            "sequenceDiagram\nparticipant API@{ \"type\": \"boundary\", \"alias\": \"Public API\" }\n",
+        );
+        assert!(tokens.iter().any(|token| token.value == "API"));
+        assert!(tokens
+            .iter()
+            .any(|token| token.type_name.as_deref() == Some("CONFIG")));
     }
 }

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0
+
+- Parse participant `type` and `alias` configuration with external-alias precedence.
+
 ## 0.7.0
 
 - Parse Mermaid sequence `box` declarations into participant-group IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -38,7 +38,9 @@ and dotted message arrows, bidirectional/cross/point arrowheads, notes,
 activations, titles, automatic numbering, and nested control blocks with branch
 separators. Participant creation and destruction are lifecycle events consumed
 by layout. Participant `box` declarations preserve group labels, fills, and
-membership. Advanced participant metadata remains an explicit compatibility gap.
+membership. Actor-menu links, properties, and details remain explicit compatibility gaps.
+Inline participant configurations support Mermaid's `type` and `alias` fields,
+including boundary, control, entity, database, collections, and queue symbols.
 
 All other Mermaid 11.16.1 family headers are recognized and return an explicit
 `recognized but not implemented` error until their grammar, lowering, layout,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.7.0";
+pub const VERSION: &str = "0.8.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1106,7 +1106,7 @@ fn parse_sequence_participant(
     created: bool,
 ) -> Result<String, ParseError> {
     let declaration = cursor.advance().clone();
-    let kind = match declaration.value.as_str() {
+    let mut kind = match declaration.value.as_str() {
         "actor" => SequenceParticipantKind::Actor,
         "participant" => SequenceParticipantKind::Participant,
         other => {
@@ -1117,11 +1117,20 @@ fn parse_sequence_participant(
         }
     };
     let id = take_sequence_identifier(cursor)?;
+    let mut inline_alias = None;
+    if token_name(cursor.current()) == "CONFIG" {
+        let config = cursor.advance().clone();
+        let parsed = parse_sequence_participant_config(&config)?;
+        if let Some(config_kind) = parsed.0 {
+            kind = config_kind;
+        }
+        inline_alias = parsed.1;
+    }
     let label = if cursor.current().value == "as" {
         cursor.advance();
         take_sequence_line_text(cursor)
     } else {
-        id.clone()
+        inline_alias.unwrap_or_else(|| id.clone())
     };
     upsert_sequence_participant(diagram, participant_indices, id.clone(), label, kind);
     if created {
@@ -1130,6 +1139,58 @@ fn parse_sequence_participant(
         });
     }
     Ok(id)
+}
+
+fn parse_sequence_participant_config(
+    token: &Token,
+) -> Result<(Option<SequenceParticipantKind>, Option<String>), ParseError> {
+    let inner = token
+        .value
+        .strip_prefix("@{")
+        .and_then(|value| value.strip_suffix('}'))
+        .ok_or_else(|| token_error(token, "invalid sequence participant configuration"))?;
+    let mut kind = None;
+    let mut alias = None;
+    for field in inner.split(',') {
+        let field = field.trim();
+        if field.is_empty() {
+            continue;
+        }
+        let (key, value) = field.split_once(':').ok_or_else(|| {
+            token_error(token, "participant configuration fields require key: value")
+        })?;
+        let key = trim_sequence_config_string(key);
+        let value = trim_sequence_config_string(value);
+        match key {
+            "type" => {
+                kind = Some(match value.to_ascii_lowercase().as_str() {
+                    "participant" => SequenceParticipantKind::Participant,
+                    "actor" => SequenceParticipantKind::Actor,
+                    "boundary" => SequenceParticipantKind::Boundary,
+                    "control" => SequenceParticipantKind::Control,
+                    "entity" => SequenceParticipantKind::Entity,
+                    "database" => SequenceParticipantKind::Database,
+                    "collections" => SequenceParticipantKind::Collections,
+                    "queue" => SequenceParticipantKind::Queue,
+                    other => {
+                        return Err(token_error(
+                            token,
+                            format!("unsupported sequence participant type {other:?}"),
+                        ))
+                    }
+                });
+            }
+            "alias" => alias = Some(value.to_string()),
+            _ => {}
+        }
+    }
+    Ok((kind, alias))
+}
+
+fn trim_sequence_config_string(value: &str) -> &str {
+    value
+        .trim()
+        .trim_matches(|character| matches!(character, '\'' | '"'))
 }
 
 fn parse_sequence_participant_box(
@@ -2812,6 +2873,37 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
         .expect_err("box bodies only allow participant declarations");
         assert!(!error.message.is_empty());
     }
+
+    #[test]
+    fn sequence_parses_participant_stereotypes_and_alias_precedence() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\nparticipant API@{ \"type\": \"boundary\", \"alias\": \"Internal\" } as Public API\nparticipant C@{ type: control }\nparticipant E@{ type: entity }\nparticipant DB@{ type: 'database', alias: 'Ledger' }\nparticipant L@{ type: collections }\nparticipant Q@{ type: queue }\n",
+        )
+        .unwrap();
+        assert_eq!(
+            diagram.participants[0].kind,
+            SequenceParticipantKind::Boundary
+        );
+        assert_eq!(diagram.participants[0].label.text, "Public API");
+        assert_eq!(
+            diagram.participants[1].kind,
+            SequenceParticipantKind::Control
+        );
+        assert_eq!(
+            diagram.participants[2].kind,
+            SequenceParticipantKind::Entity
+        );
+        assert_eq!(
+            diagram.participants[3].kind,
+            SequenceParticipantKind::Database
+        );
+        assert_eq!(diagram.participants[3].label.text, "Ledger");
+        assert_eq!(
+            diagram.participants[4].kind,
+            SequenceParticipantKind::Collections
+        );
+        assert_eq!(diagram.participants[5].kind, SequenceParticipantKind::Queue);
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -2828,7 +2920,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.7.0");
+        assert_eq!(crate::VERSION, "0.8.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -118,13 +118,17 @@ block events. Sequence layout resolves those events into nested frames and
 branch dividers before existing PaintInstructions render them. Participant
 `create` and `destroy` statements lower into lifecycle events; layout uses them
 to place dynamic participant headers, bound lifelines, and emit destruction
-markers. Participant configuration metadata, links, and advanced arrow variants
+markers. Actor-menu links, properties, details, and advanced arrow variants
 remain compatibility work. Participant `box` declarations now lower into
 semantic groups, lane-enclosing layout geometry, and backend-neutral Paint
 rectangles and labels, including the supported named and `rgb`/`rgba` color
 forms. The family remains partial until those forms and the
 pinned upstream corpus pass; unsupported forms must fail grammar validation
 rather than degrade silently.
+
+Inline participant configuration now carries `type` and `alias` into semantic
+IR. Boundary, control, entity, database, collections, and queue kinds lower to
+backend-neutral path, ellipse, and rectangle symbols and have Metal PNG coverage.
 
 ### Structural Groups
 


### PR DESCRIPTION
## Summary
- extend the sequence grammar with inline participant configuration objects
- lower `type` and `alias` into semantic participant kinds with Mermaid alias precedence
- render boundary, control, entity, database, collections, and queue symbols through backend-neutral PaintInstructions
- exercise configured participants through Metal-to-PNG

## Verification
- `cargo test -p diagram-ir -p mermaid-lexer -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint`
- `cargo clippy -p diagram-ir -p mermaid-lexer -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- visually inspected `/tmp/mermaid_sequence_e2e.png`