### PR TITLE
fix(mosaic): emit multiline Input natively

### DIFF
--- a/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-swiftui/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed - Native multiline Input compatibility
+
+The still-supported UI25 `Input` primitive now lowers to an accessible SwiftUI
+`TextEditor` when `multiline: true`, including visible placeholder text,
+dispatch-driven editing, maximum-length enforcement, and the authored MLL part
+identifier. Trestle Notes can therefore compile without collapsing its body
+editor into a single-line field.
+
 ### Added - optional generated-shell interaction acceptance
 
 Generated SwiftUI applications now call an optional package-host interaction

--- a/code/packages/rust/mosaic-emit-swiftui/README.md
+++ b/code/packages/rust/mosaic-emit-swiftui/README.md
@@ -116,6 +116,7 @@ does not install automatic press tracking.
 | `Divider`        | `Divider()`                                   |
 | `Stack`          | `ZStack { ... }` *(v0.2.0; UI29 kernel)*      |
 | `HostScroll`     | `ScrollView { ... }` *(v0.2.0; UI29 kernel)*  |
+| `Input`          | `TextEditor` when `multiline: true`; otherwise the native `TextField` path *(UI25 compatibility)* |
 | `HostInput`      | `TextField` with a dispatching `Binding` when `onChange` is wired *(UI29 kernel)* |
 | `HostButton`     | `Button(action: { dispatch(.tap) }) { Text(label) }` *(v0.2.0; UI29 kernel)* |
 | `HostSurface`    | Host-supplied `AnyView` from a `node` slot          |

--- a/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/src/pipeline.rs
@@ -2156,6 +2156,11 @@ fn emit_view_tree(
         // primitives backed by SwiftUI's `TextField` and `Button`
         // respectively. They read slot/emit refs off the node props; see
         // the per-function doc comments below for the full mapping.
+        // UI25's legacy `Input` remains the only authored primitive with a
+        // multiline contract. Keep accepting it until the kernel grows a
+        // dedicated multiline control; single-line Input shares HostInput's
+        // native lowering while multiline Input uses TextEditor.
+        "Input" => emit_legacy_input(node, indent)?,
         "HostInput" => emit_host_input(node, indent)?,
         "HostButton" => emit_host_button(node, indent, emits, for_payload)?,
         "HostSurface" => emit_host_surface(node, indent),
@@ -2617,6 +2622,85 @@ fn swift_text_expression(node: &LayoutNode) -> String {
 // =====================================================================
 // UI29 kernel partial — HostInput / HostButton emitters
 // =====================================================================
+
+/// Lower the still-supported UI25 `Input` primitive. `HostInput` deliberately
+/// covers only the single-line kernel surface, while UI25 `Input` also carries
+/// the multiline text-editor contract used by Trestle Notes.
+fn emit_legacy_input(node: &LayoutNode, indent: usize) -> Result<String, PipelineEmitError> {
+    if find_keyword_prop(node, "multiline") != Some("true") {
+        return emit_host_input(node, indent);
+    }
+
+    let pad = " ".repeat(indent);
+    let child_pad = " ".repeat(indent + 4);
+    let placeholder = find_string_prop(node, "placeholder").unwrap_or("");
+    let placeholder_lit = format!("\"{}\"", escape_swift_string(placeholder));
+
+    let value_expr = match node.props.iter().find(|p| p.name == "value") {
+        Some(p) => match &p.value {
+            LayoutPropValue::SlotRef(slot) => {
+                let camel = to_camel_case_first_lower(slot);
+                validate_slot_or_field_name(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
+                camel
+            }
+            LayoutPropValue::Expr(text) => text.clone(),
+            LayoutPropValue::String(text) => format!("\"{}\"", escape_swift_string(text)),
+            _ => "\"\"".to_string(),
+        },
+        None => "\"\"".to_string(),
+    };
+
+    let max_length = node.props.iter().find_map(|prop| {
+        if prop.name == "max-length" {
+            if let LayoutPropValue::Number(value) = &prop.value {
+                return Some(value.max(0.0) as u64);
+            }
+        }
+        None
+    });
+
+    let text_binding = match find_emit_ref_prop(node, "onChange") {
+        Some(emit_name) if find_slot_ref_prop(node, "value").is_some() => {
+            let case_name = to_camel_case_first_lower(&strip_on_prefix(emit_name));
+            validate_emit_name(&case_name)?;
+            let new_value = max_length
+                .map(|limit| format!("String($0.prefix({limit}))"))
+                .unwrap_or_else(|| "$0".to_string());
+            format!(
+                "Binding(get: {{ {value_expr} }}, set: {{ dispatch(.{case_name}(value: {new_value})) }})"
+            )
+        }
+        _ => format!(".constant({value_expr})"),
+    };
+
+    let mut output = format!("{pad}ZStack(alignment: .topLeading) {{\n");
+    if !placeholder.is_empty() {
+        output.push_str(&format!(
+            "{child_pad}if {value_expr}.isEmpty {{\n{child_pad}    Text({placeholder_lit})\n{child_pad}        .foregroundColor(.secondary)\n{child_pad}        .padding(.horizontal, 5)\n{child_pad}        .padding(.vertical, 8)\n{child_pad}        .allowsHitTesting(false)\n{child_pad}        .accessibilityHidden(true)\n{child_pad}}}\n"
+        ));
+    }
+    output.push_str(&format!("{child_pad}TextEditor(text: {text_binding})"));
+    if !placeholder.is_empty() {
+        output.push_str(&format!(".accessibilityLabel({placeholder_lit})"));
+    }
+    if let Some(part_name) = &node.part_name {
+        output.push_str(&format!(
+            ".accessibilityIdentifier(\"{}\")",
+            escape_swift_string(part_name)
+        ));
+    }
+    if let Some(slot) = find_slot_ref_prop(node, "read-only") {
+        let camel = to_camel_case_first_lower(slot);
+        validate_slot_or_field_name(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
+        output.push_str(&format!(".disabled({camel})"));
+    } else if let Some(keyword) = find_keyword_prop(node, "read-only") {
+        if keyword == "true" || keyword == "false" {
+            output.push_str(&format!(".disabled({keyword})"));
+        }
+    }
+    output.push_str(&format!("\n{pad}}}\n"));
+    Ok(output)
+}
 
 /// Lower a UI29 `HostInput` node to a SwiftUI `TextField`.
 ///
@@ -5081,6 +5165,46 @@ mod tests {
             !out.contains(".onChange(of:"),
             "the setter is the dispatch path; no separate .onChange modifier, got:\n{out}"
         );
+    }
+
+    #[test]
+    fn legacy_multiline_input_emits_accessible_text_editor() {
+        let input = LayoutNode {
+            tag: "Input".to_string(),
+            part_name: Some("notes-body-input".to_string()),
+            props: vec![
+                prop_string("placeholder", "Write something…"),
+                prop_slot_ref("value", "body-value"),
+                prop_keyword("multiline", "true"),
+                LayoutProp {
+                    name: "max-length".to_string(),
+                    value: LayoutPropValue::Number(2_000.0),
+                },
+                prop_emit_ref("onChange", "onBodyChange"),
+            ],
+            children: vec![],
+        };
+        let layout = layout_with("Notes", container_node("Box", vec![input]));
+        let out = from_pipeline(
+            &component(
+                "Notes",
+                vec![slot("body-value", SlotType::Text, true)],
+                vec![emit(
+                    "onBodyChange",
+                    vec![param("value", EmitPayloadType::Text)],
+                )],
+            ),
+            &layout,
+            &empty_style("Notes"),
+        )
+        .unwrap()
+        .output;
+
+        assert!(out.contains("TextEditor(text: Binding(get: { bodyValue }"));
+        assert!(out.contains("String($0.prefix(2000))"));
+        assert!(out.contains("Text(\"Write something…\")"));
+        assert!(out.contains(".accessibilityLabel(\"Write something…\")"));
+        assert!(out.contains(".accessibilityIdentifier(\"notes-body-input\")"));
     }
 
     // ---------------------------------------------------------------------

--- a/code/packages/rust/mosaic-emit-swiftui/tests/task_app_focus_compiles_to_swiftui.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/tests/task_app_focus_compiles_to_swiftui.rs
@@ -1,8 +1,9 @@
-//! Complex-app acceptance gate for native MSL focus activation.
+//! Reusable ProjectNav acceptance gate for native MSL focus activation.
 //!
-//! Task App authors its project composer focus ring in Mosaic. The SwiftUI
-//! backend must connect that shared `state focused` block to native focus
-//! without app-specific AppKit code.
+//! Trestle's ProjectNav package authors its project composer focus ring in
+//! Mosaic. The SwiftUI backend must connect that shared `state focused` block
+//! to native focus without app-specific AppKit code. Trestle itself is also
+//! compiled below to pin its package-expanded multiline Notes editor.
 
 use std::fs;
 use std::path::PathBuf;
@@ -32,6 +33,13 @@ fn task_app_src_root() -> PathBuf {
         .expect("derive Task App source root from CARGO_MANIFEST_DIR")
 }
 
+fn project_nav_src_root() -> PathBuf {
+    code_packages_root()
+        .join("mosaic")
+        .join("mosaic-pkg-project-nav")
+        .join("src")
+}
+
 /// Resolve every `pkg::P::C` reference in `layout` in place — the same step
 /// `mosaic-compile`'s CLI runs before handing a layout to any backend
 /// emitter (UI34 §5). Every emitter's entry point assumes this has already
@@ -45,32 +53,32 @@ fn resolve_packages(layout: &mut moslayout_compiler::LayoutDef) {
 }
 
 #[test]
-fn task_app_focused_state_lowers_to_native_swiftui_focus() {
-    let root = task_app_src_root();
-    let mil = fs::read_to_string(root.join("TaskApp.mil")).expect("read TaskApp.mil");
-    let mll = fs::read_to_string(root.join("TaskApp.mll")).expect("read TaskApp.mll");
-    let msl = fs::read_to_string(root.join("TaskApp.light.msl")).expect("read TaskApp.light.msl");
+fn project_nav_focused_state_lowers_to_native_swiftui_focus() {
+    let root = project_nav_src_root();
+    let mil = fs::read_to_string(root.join("ProjectNav.mil")).expect("read ProjectNav.mil");
+    let mll = fs::read_to_string(root.join("ProjectNav.mll")).expect("read ProjectNav.mll");
+    let msl =
+        fs::read_to_string(root.join("ProjectNav.light.msl")).expect("read ProjectNav.light.msl");
 
-    let interface = mosmodel_compiler::compile(&mil).expect("compile Task App interface");
-    let mut layout = moslayout_compiler::compile(&mll, Some(&interface.descriptor_json))
-        .expect("compile Task App layout");
-    resolve_packages(&mut layout.def);
+    let interface = mosmodel_compiler::compile(&mil).expect("compile ProjectNav interface");
+    let layout = moslayout_compiler::compile(&mll, Some(&interface.descriptor_json))
+        .expect("compile ProjectNav layout");
     let style = mosstyle_compiler::compile(&msl, Some(&layout.part_map_json))
-        .expect("compile Task App light style");
+        .expect("compile ProjectNav light style");
     let output = mosaic_emit_swiftui::from_pipeline(&interface.component, &layout.def, &style.def)
-        .expect("emit Task App SwiftUI")
+        .expect("emit ProjectNav SwiftUI")
         .output;
 
     assert!(
         output.contains("private struct _MosaicFocusState<Content: View>: View"),
-        "Task App must generate native focus support:\n{output}"
+        "ProjectNav must generate native focus support:\n{output}"
     );
     assert_eq!(
         output
             .matches("_MosaicFocusState { __mosaicFocusActive in")
             .count(),
         1,
-        "Task App has one authored focused surface:\n{output}"
+        "ProjectNav has one authored focused surface:\n{output}"
     );
     assert!(
         output.contains(".focused($isFocused)"),
@@ -88,6 +96,33 @@ fn task_app_focused_state_lowers_to_native_swiftui_focus() {
     assert!(
         focus_region.contains("__mosaicFocusActive"),
         "the authored focus border must consume native focus state:\n{focus_region}"
+    );
+}
+
+#[test]
+fn task_app_package_graph_lowers_notes_to_native_multiline_swiftui() {
+    let root = task_app_src_root();
+    let mil = fs::read_to_string(root.join("TaskApp.mil")).expect("read TaskApp.mil");
+    let mll = fs::read_to_string(root.join("TaskApp.mll")).expect("read TaskApp.mll");
+    let msl = fs::read_to_string(root.join("TaskApp.light.msl")).expect("read TaskApp.light.msl");
+
+    let interface = mosmodel_compiler::compile(&mil).expect("compile Task App interface");
+    let mut layout = moslayout_compiler::compile(&mll, Some(&interface.descriptor_json))
+        .expect("compile Task App layout");
+    resolve_packages(&mut layout.def);
+    let style = mosstyle_compiler::compile(&msl, Some(&layout.part_map_json))
+        .expect("compile Task App light style");
+    let output = mosaic_emit_swiftui::from_pipeline(&interface.component, &layout.def, &style.def)
+        .expect("emit Task App SwiftUI")
+        .output;
+
+    assert!(
+        output.contains("TextEditor(text: Binding(get: { noteBodyValue }"),
+        "Trestle's Notes body must use a native multiline editor:\n{output}"
+    );
+    assert!(
+        output.contains(".accessibilityIdentifier(\"notes-body-input\")"),
+        "the authored Notes body identity must reach SwiftUI:\n{output}"
     );
 }
 
@@ -148,6 +183,59 @@ style FocusField {
     assert!(
         result.status.success(),
         "generated native focus wrapper must typecheck:\n{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn native_multiline_input_typechecks_with_swiftui() {
+    let interface = mosmodel_compiler::compile(
+        r#"
+component NotesEditor {
+  slot value : text ;
+  emit onBodyChange ( value : text ) ;
+}
+"#,
+    )
+    .expect("compile multiline fixture interface");
+    let layout = moslayout_compiler::compile(
+        r#"
+layout NotesEditor {
+  Input [ body ] (
+    value : slot: value ,
+    placeholder : "Write something…" ,
+    multiline : true ,
+    max-length : 2000 ,
+    onChange : emit: onBodyChange
+  )
+}
+"#,
+        Some(&interface.descriptor_json),
+    )
+    .expect("compile multiline fixture layout");
+    let style = mosstyle_compiler::compile(
+        "style NotesEditor { part body { min-height: 200; } }",
+        Some(&layout.part_map_json),
+    )
+    .expect("compile multiline fixture style");
+    let output = mosaic_emit_swiftui::from_pipeline(&interface.component, &layout.def, &style.def)
+        .expect("emit multiline fixture SwiftUI")
+        .output;
+
+    let source_path =
+        std::env::temp_dir().join(format!("mosaic-multiline-{}.swift", std::process::id()));
+    fs::write(&source_path, output).expect("write generated multiline fixture");
+    let result = Command::new("swiftc")
+        .arg("-typecheck")
+        .arg(&source_path)
+        .output()
+        .expect("run swiftc");
+    let _ = fs::remove_file(&source_path);
+
+    assert!(
+        result.status.success(),
+        "generated native multiline editor must typecheck:\n{}",
         String::from_utf8_lossy(&result.stderr)
     );
 }

--- a/code/packages/rust/mosaic-emit-swiftui/tests/task_app_press_compiles_to_swiftui.rs
+++ b/code/packages/rust/mosaic-emit-swiftui/tests/task_app_press_compiles_to_swiftui.rs
@@ -69,22 +69,24 @@ fn task_app_pressed_state_lowers_to_native_swiftui_press_state() {
             output
                 .matches("_MosaicPressState { __mosaicPressActive in")
                 .count(),
-            1,
-            "{theme} has one authored pressed surface:\n{output}"
+            2,
+            "{theme} has two authored pressed surfaces:\n{output}"
         );
-        let press_start = output
-            .find("_MosaicPressState { __mosaicPressActive in")
-            .expect("press wrapper");
-        let press_region = &output[press_start..output.len().min(press_start + 2_500)];
-        assert!(
-            press_region.contains("Button(action: { dispatch(.addTask) })")
-                && press_region.contains("Text(\"Add task\")"),
-            "the primary action must own the {theme} native press wrapper:\n{press_region}"
-        );
-        assert!(
-            press_region.contains("__mosaicPressActive"),
-            "the {theme} pressed background must consume native press state:\n{press_region}"
-        );
+        for action in ["dispatch(.addLabel)", "dispatch(.addTask)"] {
+            let action_start = output.find(action).expect("pressed action");
+            let wrapper_start = output[..action_start]
+                .rfind("_MosaicPressState { __mosaicPressActive in")
+                .expect("nearest press wrapper");
+            assert!(
+                action_start - wrapper_start < 500,
+                "{action} must be owned by a nearby {theme} native press wrapper"
+            );
+            let press_region = &output[wrapper_start..output.len().min(wrapper_start + 1_500)];
+            assert!(
+                press_region.contains("__mosaicPressActive"),
+                "the {theme} pressed background must consume native press state:\n{press_region}"
+            );
+        }
     }
 }
 

--- a/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-xaml/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased] — VC2-xaml Grid: WinUI value translation + nested-For + per-column widths
 
+### Fixed - Native multiline Input compatibility
+
+The still-supported UI25 `Input` primitive now shares the complete native
+`TextBox` lowering, including `AcceptsReturn`, text wrapping, dispatch, and
+automation identity. Trestle Notes can therefore compile to WinUI without
+losing its multiline body editor.
+
 ### Fixed - Live native disabled state
 
 Slot-backed `disabled` properties now lower to one-way WinUI `IsEnabled`

--- a/code/packages/rust/mosaic-emit-xaml/README.md
+++ b/code/packages/rust/mosaic-emit-xaml/README.md
@@ -26,6 +26,7 @@ mosstyle base styling:
 | `Icon`      | `<FontIcon Glyph="..."/>` |
 | `If` / `Else` | `<ContentControl>` with bound visibility |
 | `For` | `<ItemsRepeater>` with generated row view-models |
+| `Input` | `<TextBox>` with `AcceptsReturn` and wrapping for `multiline: true` |
 | `HostInput` | `<TextBox>` |
 | `HostButton` | `<Button>` |
 | `HostSurface` | Styled `<Border>` containing a node-bound `<ContentPresenter>` |

--- a/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-xaml/src/pipeline.rs
@@ -2015,7 +2015,10 @@ fn emit_xaml_node(
         )),
 
         // PR-3: Host* primitives (single-element host-native controls).
-        "HostInput" => emit_host_input(node, indent, part_styles, ctx),
+        // UI25 `Input` remains the multiline text primitive used by the
+        // Notes package. WinUI TextBox already implements its complete
+        // property surface, so it shares HostInput's native lowering.
+        "Input" | "HostInput" => emit_host_input(node, indent, part_styles, ctx),
         "HostButton" => emit_host_button(node, indent, part_styles, ctx),
         "HostSurface" => emit_host_surface(node, indent, part_styles, ctx),
 
@@ -8324,6 +8327,15 @@ mod tests {
         }
     }
 
+    fn legacy_input_node(part: Option<&str>, props: Vec<LayoutProp>) -> LayoutNode {
+        LayoutNode {
+            tag: "Input".to_string(),
+            part_name: part.map(String::from),
+            props,
+            children: Vec::new(),
+        }
+    }
+
     fn host_button_node(part: Option<&str>, props: Vec<LayoutProp>) -> LayoutNode {
         LayoutNode {
             tag: "HostButton".to_string(),
@@ -8462,6 +8474,41 @@ mod tests {
         assert!(
             r.xaml
                 .contains("AcceptsReturn=\"True\" TextWrapping=\"Wrap\""),
+            "got:\n{}",
+            r.xaml
+        );
+    }
+
+    #[test]
+    fn legacy_multiline_input_uses_native_textbox_contract() {
+        let c = component("Notes", vec![], vec![]);
+        let l = layout_with_root(
+            "Notes",
+            legacy_input_node(
+                Some("notes-body-input"),
+                vec![
+                    LayoutProp {
+                        name: "placeholder".to_string(),
+                        value: LayoutPropValue::String("Write something…".to_string()),
+                    },
+                    LayoutProp {
+                        name: "multiline".to_string(),
+                        value: LayoutPropValue::Keyword("true".to_string()),
+                    },
+                ],
+            ),
+        );
+        let r = compile(&c, &l, &empty_style("Notes"));
+        assert!(r.xaml.contains("<TextBox"), "got:\n{}", r.xaml);
+        assert!(
+            r.xaml
+                .contains("AcceptsReturn=\"True\" TextWrapping=\"Wrap\""),
+            "got:\n{}",
+            r.xaml
+        );
+        assert!(
+            r.xaml
+                .contains("AutomationProperties.AutomationId=\"notes-body-input\""),
             "got:\n{}",
             r.xaml
         );

--- a/code/packages/rust/mosaic-emit-xaml/tests/task_app_focus_compiles_to_xaml.rs
+++ b/code/packages/rust/mosaic-emit-xaml/tests/task_app_focus_compiles_to_xaml.rs
@@ -1,8 +1,9 @@
-//! Complex-app acceptance gate for native MSL focus activation.
+//! Reusable ProjectNav acceptance gate for native MSL focus activation.
 //!
-//! Task App authors its project-composer focus ring in Mosaic. The XAML
-//! backend must connect that shared `state focused` block to WinUI focus
-//! without app-specific code-behind.
+//! Trestle's ProjectNav package authors its project-composer focus ring in
+//! Mosaic. The XAML backend must connect that shared `state focused` block to
+//! WinUI focus without app-specific code-behind. Trestle itself is also
+//! compiled below to pin its package-expanded multiline Notes editor.
 
 use std::fs;
 use std::path::PathBuf;
@@ -30,6 +31,13 @@ fn task_app_src_root() -> PathBuf {
         .expect("derive Task App source root from CARGO_MANIFEST_DIR")
 }
 
+fn project_nav_src_root() -> PathBuf {
+    code_packages_root()
+        .join("mosaic")
+        .join("mosaic-pkg-project-nav")
+        .join("src")
+}
+
 /// Resolve every `pkg::P::C` reference in `layout` in place — the same step
 /// `mosaic-compile`'s CLI runs before handing a layout to any backend
 /// emitter (UI34 §5). Every emitter's entry point assumes this has already
@@ -43,7 +51,66 @@ fn resolve_packages(layout: &mut moslayout_compiler::LayoutDef) {
 }
 
 #[test]
-fn task_app_focused_state_lowers_to_native_xaml_focus() {
+fn project_nav_focused_state_lowers_to_native_xaml_focus() {
+    let root = project_nav_src_root();
+    let mil = fs::read_to_string(root.join("ProjectNav.mil")).expect("read ProjectNav.mil");
+    let mll = fs::read_to_string(root.join("ProjectNav.mll")).expect("read ProjectNav.mll");
+    let msl =
+        fs::read_to_string(root.join("ProjectNav.light.msl")).expect("read ProjectNav.light.msl");
+
+    let interface = mosmodel_compiler::compile(&mil).expect("compile ProjectNav interface");
+    let layout = moslayout_compiler::compile(&mll, Some(&interface.descriptor_json))
+        .expect("compile ProjectNav layout");
+    let style = mosstyle_compiler::compile(&msl, Some(&layout.part_map_json))
+        .expect("compile ProjectNav light style");
+    let result = mosaic_emit_xaml::from_pipeline(
+        &interface.component,
+        &layout.def,
+        &style.def,
+        None,
+        &mosaic_emit_xaml::EmitOptions::default(),
+    )
+    .expect("emit ProjectNav XAML");
+
+    assert_eq!(
+        result
+            .xaml
+            .matches("<local:FocusStateToBoolConverter x:Key=")
+            .count(),
+        1,
+        "ProjectNav must declare one native focus converter:\n{}",
+        result.xaml
+    );
+    assert_eq!(
+        result
+            .xaml
+            .matches("Binding FocusState, ElementName=ProjectInput")
+            .count(),
+        1,
+        "ProjectNav has one property-scoped focused override:\n{}",
+        result.xaml
+    );
+    assert!(
+        result.xaml.contains(
+            "<Setter Target=\"ProjectInput.(Control.BorderBrush).(SolidColorBrush.Color)\" Value=\"#e0942a\"/>"
+        ),
+        "the shared project-input focus ring must target the native TextBox:\n{}",
+        result.xaml
+    );
+    let helper = result
+        .if_helpers
+        .iter()
+        .find(|file| file.filename == "FocusStateToBoolConverter.cs")
+        .expect("Task App focus converter helper");
+    assert!(
+        helper.source.contains("state != FocusState.Unfocused"),
+        "native pointer, keyboard, and programmatic focus must activate the shared state:\n{}",
+        helper.source
+    );
+}
+
+#[test]
+fn task_app_package_graph_lowers_notes_to_native_multiline_xaml() {
     let root = task_app_src_root();
     let mil = fs::read_to_string(root.join("TaskApp.mil")).expect("read TaskApp.mil");
     let mll = fs::read_to_string(root.join("TaskApp.mll")).expect("read TaskApp.mll");
@@ -64,39 +131,14 @@ fn task_app_focused_state_lowers_to_native_xaml_focus() {
     )
     .expect("emit Task App XAML");
 
-    assert_eq!(
-        result
-            .xaml
-            .matches("<local:FocusStateToBoolConverter x:Key=")
-            .count(),
-        1,
-        "Task App must declare one native focus converter:\n{}",
-        result.xaml
-    );
-    assert_eq!(
-        result
-            .xaml
-            .matches("Binding FocusState, ElementName=ProjectInput")
-            .count(),
-        1,
-        "Task App has one property-scoped focused override:\n{}",
-        result.xaml
-    );
+    let body_input = result
+        .xaml
+        .lines()
+        .find(|line| line.contains("AutomationProperties.AutomationId=\"notes-body-input\""))
+        .expect("Trestle Notes body TextBox");
     assert!(
-        result.xaml.contains(
-            "<Setter Target=\"ProjectInput.(Control.BorderBrush).(SolidColorBrush.Color)\" Value=\"#e0942a\"/>"
-        ),
-        "the shared project-input focus ring must target the native TextBox:\n{}",
-        result.xaml
-    );
-    let helper = result
-        .if_helpers
-        .iter()
-        .find(|file| file.filename == "FocusStateToBoolConverter.cs")
-        .expect("Task App focus converter helper");
-    assert!(
-        helper.source.contains("state != FocusState.Unfocused"),
-        "native pointer, keyboard, and programmatic focus must activate the shared state:\n{}",
-        helper.source
+        body_input.contains("AcceptsReturn=\"True\"")
+            && body_input.contains("TextWrapping=\"Wrap\""),
+        "Trestle's Notes body must use an identified multiline TextBox:\n{body_input}"
     );
 }

--- a/code/packages/rust/mosaic-emit-xaml/tests/task_app_hover_compiles_to_xaml.rs
+++ b/code/packages/rust/mosaic-emit-xaml/tests/task_app_hover_compiles_to_xaml.rs
@@ -1,7 +1,7 @@
 //! Complex-app acceptance gate for native MSL hover activation.
 //!
 //! Task App deliberately authors all interaction styling in Mosaic. Its light
-//! theme exercises nineteen independently named HostButton hover surfaces,
+//! theme exercises thirty-seven authored hover state blocks,
 //! including controls inside repeated project and task DataTemplates. (The
 //! board view's HostDraggable card hover, and the sheet view's Grid/Select/
 //! toolbar hover states from mosaic-pkg-sheet/mosaic-pkg-grid/mosaic-pkg-
@@ -75,13 +75,10 @@ fn task_app_hover_states_lower_to_native_row_local_xaml() {
 
     assert_eq!(
         output.matches("Binding IsPointerOver").count(),
-        22,
+        38,
         "each property-scoped hover state must use native pointer state:\n{output}"
     );
     for target in [
-        "ProjectOff",
-        "ProjectAdd",
-        "ProjectSub",
         "SegListOff",
         "SegListOff2",
         "SegListOff3",


### PR DESCRIPTION
## Summary
- lower UI25 `Input(multiline: true)` to an accessible SwiftUI `TextEditor`
- route legacy `Input` through the complete native WinUI `TextBox` lowering
- pin Trestle's package-expanded Notes body to multiline native controls on both backends
- repair stale Trestle focus, press, and hover acceptance assertions after ProjectNav extraction and app growth

This is the focused prerequisite for #10257: changing the package artifact builder caused CI to exercise the full SwiftUI/XAML emitter graph, exposing that Trestle Notes could not compile natively because its deliberate multiline `Input` was rejected.

## Validation
- `cargo fmt -p mosaic-emit-swiftui -p mosaic-emit-xaml -- --check`
- `cargo test -p mosaic-emit-swiftui -p mosaic-emit-xaml`
  - 150 SwiftUI unit tests + 9 integration/compiler tests
  - 194 XAML unit tests + 10 integration tests + 1 ignored doctest
- `cargo clippy -p mosaic-emit-swiftui -p mosaic-emit-xaml --all-targets -- -D warnings`
- generated multiline SwiftUI fixture type-checked with `swiftc`
