### PR TITLE
Report head content starts after head

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,8 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Head-content start tags processed after an explicit head end tag and before
+  the body has started now report the required after-head parse error.
 - A `dt` or `dd` start tag now reports the in-body parse error when
   implied-end-tag recovery closes a non-current description-list item,
   covering the remaining silent in-body list case without changing DOM

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the non-current description-list item start-tag diagnostic slice, 2,075
-of those cases emit at least one lexer or parser diagnostic and 108 remain
+After the post-head head-content start-tag diagnostic slice, 2,080 of those
+cases emit at least one lexer or parser diagnostic and 103 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -38,8 +38,9 @@ error, including the current processing-instruction cases.
 
 The concrete document-shell insertion-mode inventory is complete: missing and
 nonconforming doctypes, duplicate shell tags, body/html boundary errors,
-after-body and frameset modes, implied-shell paragraph end tags, and rejected
-frameset starts all report their current-Standard parse errors.
+post-head head-content starts, after-body and frameset modes, implied-shell
+paragraph end tags, and rejected frameset starts all report their
+current-Standard parse errors.
 
 Fragment in-body EOF diagnostics are also complete. Authored disallowed open
 elements now report the same error as full-document parsing, while synthetic
@@ -65,7 +66,7 @@ open table blocks adoption-agency recovery. Description-list item start tags
 now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
 without flagging adjacent description-list items.
 
-The fresh 108-case residual inventory keeps the next concrete groups in the
+The fresh 103-case residual inventory keeps the next concrete groups in the
 existing priority order: remaining table foster-parenting and table-scope
 boundaries;
 select/template recovery; script-tokenizer EOF recovery; plaintext/frameset

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4952,6 +4952,19 @@ impl HtmlParser {
         }
 
         if !in_foreign_content
+            && !self.is_fragment
+            && self.explicit_head_end_seen
+            && !self.has_open_element("head")
+            && !self.document_has_body_element()
+            && is_head_element(&name)
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-head-content-start-tag-after-head",
+                format!("start tag `<{name}>` was processed after the head had closed"),
+            ));
+        }
+
+        if !in_foreign_content
             && self.current_element_is("frameset")
             && !matches!(name.as_str(), "frame" | "frameset" | "noframes")
         {
@@ -33167,6 +33180,33 @@ mod tests {
                 )
             ]
         );
+    }
+
+    #[test]
+    fn reports_head_content_start_tags_after_an_explicit_head_end() {
+        for (source, tag_name) in [
+            ("<!doctype html><head></head><title>x</title>", "title"),
+            ("<!doctype html></head><base>", "base"),
+            ("<!doctype html></head><basefont>", "basefont"),
+            ("<!doctype html></head><bgsound>", "bgsound"),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().any(|diagnostic| {
+                diagnostic.code == "unexpected-head-content-start-tag-after-head"
+                    && diagnostic.message.contains(tag_name)
+            }));
+        }
+
+        for source in [
+            "<!doctype html><title>x</title>",
+            "<!doctype html><head><title>x</title></head>",
+            "<!doctype html><body><title>x</title>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-head-content-start-tag-after-head"
+            }));
+        }
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 108);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2075);
+    assert_eq!(missing_diagnostic_cases, 103);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2080);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the required after-head parse error for head-content start tags
- preserve valid in-head and in-body processing without new diagnostics
- ratchet tree-construction diagnostic coverage from 2,075 to 2,080 cases

## Validation
- cargo test -p coding-adventures-html-parser
- cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings
- live WPT/html5lib coverage audit with zero missing cases and zero normalized skips
- all focused WHATWG audit coverage, manifest, Rust-test, and smoke guards
- Python conformance audit tests
- git diff --check

`cargo fmt --check --package coding-adventures-html-parser` continues to propose broad pre-existing formatting changes in untouched parser files under the current local rustfmt, so this PR leaves that unrelated churn out.