### PR TITLE
Implement password manager object storage V1

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1050,4 +1050,5 @@ members = [
   "chief-of-staff-host",
   "chief-of-staff-agent-stdio-protocol",
   "chief-of-staff-agent-stdio-host",
+  "vault-pm-storage",
 ]

--- a/code/packages/rust/vault-pm-storage/BUILD
+++ b/code/packages/rust/vault-pm-storage/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding_adventures_vault_pm_storage -- --nocapture

--- a/code/packages/rust/vault-pm-storage/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-storage/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this package are documented here.
+
+## [0.1.0] - 2026-08-09
+
+### Added
+
+- The bounded, provider-neutral `VaultObjectStore` V1 contract.
+- Redacted identifiers, bodies, cursors, provider revisions, and typed errors.
+- Capability reporting for consistency, conditional operations, change feeds,
+  checksums, upload/read optimizations, deletion, sharing, and provider limits.
+- A thread-safe deterministic in-memory backend with immutable writes, exact
+  reads/stats, ordered cursor pagination, deletion, and change hints.
+- A one-shot deterministic fault wrapper for provider errors, corrupt reads,
+  stale or duplicate listings, and ambiguous committed writes.
+- A reusable conformance runner and embedded language-neutral fixture.
+
+### Security
+
+- Conflicting bytes under one logical object ID fail as corruption.
+- Store instances bind idempotently to exactly one vault locator.
+- Debug and display output omit bodies, identifiers, cursors, revisions, and
+  attacker-controlled provider messages.
+- All V1 body, cursor, revision, list, and change-page bounds are explicit.

--- a/code/packages/rust/vault-pm-storage/Cargo.toml
+++ b/code/packages/rust/vault-pm-storage/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "coding_adventures_vault_pm_storage"
+version = "0.1.0"
+edition = "2021"
+description = "VLT-PM02 immutable object-store contract, conformance model, and deterministic fault injection"
+
+[dependencies]
+coding_adventures_sha256 = { path = "../sha256" }
+coding_adventures_vault_pm_format = { path = "../vault-pm-format" }

--- a/code/packages/rust/vault-pm-storage/README.md
+++ b/code/packages/rust/vault-pm-storage/README.md
@@ -1,0 +1,74 @@
+# `coding_adventures_vault_pm_storage`
+
+The provider-neutral immutable object-store contract for the local-first
+password manager described by VLT-PM02.
+
+The crate keeps product logic independent from local folders, Google Drive,
+WebDAV, S3, browser storage, and future providers. Storage sees only opaque
+32-byte bucket/object identifiers and bounded ciphertext bytes. Repository code
+above this layer remains responsible for verifying hashes, signatures, commit
+ancestry, and rollback anchors.
+
+## Included
+
+- `VaultObjectStore`, with initialize, exact get/stat, immutable put, ordered
+  pagination, optional deletion, and optional change hints;
+- closed, redacted value and error types;
+- `BackendCapabilities`, used only to select optimization paths;
+- a deterministic thread-safe `InMemoryObjectStore`;
+- `FaultInjectingObjectStore`, including ambiguous-after-commit, stale-list,
+  duplicate-list, typed-error, and corrupt-read actions;
+- `run_conformance_suite`, reusable by every future adapter; and
+- the embedded language-neutral `vault-pm-storage-v1.json` fixture.
+
+## Example
+
+```rust
+use coding_adventures_vault_pm_storage::{
+    BucketId, InMemoryObjectStore, ObjectBytes, ObjectId, PutImmutableOutcome,
+    VaultLocator, VaultObjectStore,
+};
+
+let store = InMemoryObjectStore::new();
+store.initialize(&VaultLocator::new([1; 32]))?;
+
+let bucket = BucketId::new([2; 32]);
+let object = ObjectId::new([3; 32]);
+let bytes = ObjectBytes::new(b"opaque encrypted frame".to_vec())?;
+
+assert_eq!(
+    store.put_immutable(&bucket, &object, &bytes)?,
+    PutImmutableOutcome::Created,
+);
+assert_eq!(store.get(&bucket, &object)?, Some(bytes));
+# Ok::<(), coding_adventures_vault_pm_storage::StoreError>(())
+```
+
+## Adapter conformance
+
+An adapter's integration test constructs a clean configured store and delegates
+to the common runner:
+
+```rust,ignore
+let report = run_conformance_suite(|| MyProviderStore::for_test_account())?;
+assert!(report.checks >= 19);
+```
+
+The suite checks the baseline contract and compares optional operation behavior
+to the adapter's own capability report. Provider-specific sandbox tests remain
+necessary for authentication, quotas, and native consistency behavior.
+
+## Deliberate exclusions
+
+This package has no filesystem, network, clock, process, environment, entropy,
+or key access. The `storage-core` bridge and concrete provider adapters belong
+in separate packages. Retry, caching, metrics, replica selection, commit
+publication, merge, and garbage collection also live above or beside this
+contract.
+
+## Development
+
+```bash
+bash BUILD
+cargo clippy -p coding_adventures_vault_pm_storage -- -D warnings
+```

--- a/code/packages/rust/vault-pm-storage/required_capabilities.json
+++ b/code/packages/rust/vault-pm-storage/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/vault-pm-storage",
+  "capabilities": [],
+  "justification": "Pure contract and deterministic in-memory model over caller-provided opaque bytes. No filesystem, network, process, environment, clock, CSPRNG, or secret-key access."
+}

--- a/code/packages/rust/vault-pm-storage/src/lib.rs
+++ b/code/packages/rust/vault-pm-storage/src/lib.rs
@@ -1,0 +1,1560 @@
+//! # `vault-pm-storage`
+//!
+//! VLT-PM02's storage layer is intentionally boring: opaque bucket names,
+//! opaque object names, and immutable byte strings. “Boring” is a security
+//! feature here. A Google Drive adapter must not need to know whether bytes are
+//! a login item, a commit, or random padding.
+//!
+//! The crate contains three things:
+//!
+//! 1. [`VaultObjectStore`], the provider-neutral contract;
+//! 2. [`InMemoryObjectStore`], the deterministic executable model; and
+//! 3. [`FaultInjectingObjectStore`], which makes hostile storage behavior
+//!    repeatable in repository tests.
+//!
+//! The implementation has no I/O authority. Filesystem and cloud adapters live
+//! in separate packages and run [`run_conformance_suite`] against the same
+//! public behavior.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fmt::{self, Debug, Display, Formatter};
+use std::sync::Mutex;
+
+use coding_adventures_sha256::sha256;
+use coding_adventures_vault_pm_format::ObjectId as FormatObjectId;
+
+/// V1's absolute body bound, aligned with VLT-PM01 object frames.
+pub const MAX_OBJECT_BYTES: usize = 64 * 1024 * 1024;
+/// Largest page a caller may request.
+pub const MAX_LIST_LIMIT: usize = 10_000;
+/// Largest backend-owned continuation token accepted at the boundary.
+pub const MAX_CURSOR_BYTES: usize = 256;
+/// Largest provider revision token accepted at the boundary.
+pub const MAX_REVISION_BYTES: usize = 256;
+/// Upper bound for one optional change-feed page.
+pub const MAX_CHANGE_EVENTS: usize = 1_000;
+/// Language-neutral operation vector consumed by every adapter implementation.
+pub const CONFORMANCE_FIXTURE_V1: &str =
+    include_str!("../../../../specs/fixtures/vault-pm-storage-v1.json");
+
+macro_rules! private_fixed_bytes {
+    ($name:ident, $size:expr, $label:literal) => {
+        #[doc = $label]
+        #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name([u8; $size]);
+
+        impl $name {
+            /// Construct the opaque value from exact bytes.
+            pub const fn new(bytes: [u8; $size]) -> Self {
+                Self(bytes)
+            }
+
+            /// Borrow bytes for a provider adapter's lossless name encoding.
+            pub const fn as_bytes(&self) -> &[u8; $size] {
+                &self.0
+            }
+
+            /// Consume the wrapper and return its exact bytes.
+            pub const fn into_bytes(self) -> [u8; $size] {
+                self.0
+            }
+        }
+
+        impl Debug for $name {
+            fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+                formatter.write_str(concat!($label, "(<redacted>)"))
+            }
+        }
+    };
+}
+
+private_fixed_bytes!(VaultLocator, 32, "VaultLocator");
+private_fixed_bytes!(BucketId, 32, "BucketId");
+private_fixed_bytes!(ObjectId, 32, "ObjectId");
+
+impl From<FormatObjectId> for ObjectId {
+    fn from(value: FormatObjectId) -> Self {
+        Self::new(value.into_bytes())
+    }
+}
+
+impl From<ObjectId> for FormatObjectId {
+    fn from(value: ObjectId) -> Self {
+        Self::new(value.into_bytes())
+    }
+}
+
+/// A bounded opaque body. Debug output reports length, never content.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ObjectBytes(Vec<u8>);
+
+impl ObjectBytes {
+    /// Validate and own an object body.
+    pub fn new(bytes: Vec<u8>) -> Result<Self, StoreError> {
+        if bytes.len() > MAX_OBJECT_BYTES {
+            return Err(StoreError::InvalidInput(InputViolation::ObjectTooLarge));
+        }
+        Ok(Self(bytes))
+    }
+
+    /// Borrow exact bytes for transport or verification.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Return the body length.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Report whether the body is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Consume the wrapper.
+    pub fn into_vec(self) -> Vec<u8> {
+        self.0
+    }
+
+    fn corrupted_clone(&self) -> Self {
+        let mut bytes = self.0.clone();
+        if let Some(first) = bytes.first_mut() {
+            *first ^= 0x80;
+        } else {
+            bytes.push(0x80);
+        }
+        Self(bytes)
+    }
+}
+
+impl Debug for ObjectBytes {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ObjectBytes")
+            .field("len", &self.len())
+            .field("bytes", &"<redacted>")
+            .finish()
+    }
+}
+
+macro_rules! private_token {
+    ($name:ident, $label:literal) => {
+        #[doc = $label]
+        #[derive(Clone, PartialEq, Eq)]
+        pub struct $name(Vec<u8>);
+
+        impl $name {
+            /// Restore an opaque token previously returned by a backend.
+            pub fn new(bytes: Vec<u8>) -> Result<Self, StoreError> {
+                if bytes.is_empty() {
+                    return Err(StoreError::InvalidInput(InputViolation::CursorMalformed));
+                }
+                if bytes.len() > MAX_CURSOR_BYTES {
+                    return Err(StoreError::InvalidInput(InputViolation::CursorTooLarge));
+                }
+                Ok(Self(bytes))
+            }
+
+            /// Borrow exact bytes for persistence between calls.
+            pub fn as_bytes(&self) -> &[u8] {
+                &self.0
+            }
+
+            fn trusted(bytes: Vec<u8>) -> Self {
+                debug_assert!(!bytes.is_empty() && bytes.len() <= MAX_CURSOR_BYTES);
+                Self(bytes)
+            }
+        }
+
+        impl Debug for $name {
+            fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+                formatter
+                    .debug_struct($label)
+                    .field("len", &self.0.len())
+                    .field("bytes", &"<redacted>")
+                    .finish()
+            }
+        }
+    };
+}
+
+private_token!(ListCursor, "ListCursor");
+private_token!(ChangeCursor, "ChangeCursor");
+
+/// Opaque, bounded provider revision. Its value is redacted from Debug.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ProviderRevision(String);
+
+impl ProviderRevision {
+    /// Validate a non-empty, single-line provider revision.
+    pub fn new(value: impl Into<String>) -> Result<Self, StoreError> {
+        let value = value.into();
+        if value.is_empty()
+            || value.len() > MAX_REVISION_BYTES
+            || value.chars().any(char::is_control)
+        {
+            return Err(StoreError::InvalidInput(InputViolation::RevisionMalformed));
+        }
+        Ok(Self(value))
+    }
+
+    /// Borrow the exact revision for a conditional provider request.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Debug for ProviderRevision {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ProviderRevision(<redacted>)")
+    }
+}
+
+/// Body-free advisory metadata for one committed object.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObjectStat {
+    pub body_len: u64,
+    pub revision: Option<ProviderRevision>,
+    pub server_checksum: Option<[u8; 32]>,
+}
+
+/// One logical object in an ordered listing.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObjectEntry {
+    pub object: ObjectId,
+    pub stat: ObjectStat,
+}
+
+/// One page of unique, ascending logical objects.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObjectPage {
+    pub entries: Vec<ObjectEntry>,
+    pub next_cursor: Option<ListCursor>,
+}
+
+/// Result of an immutable put.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PutImmutableOutcome {
+    Created,
+    AlreadyPresent,
+}
+
+/// Result of an optional physical delete.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeleteOutcome {
+    Deleted,
+    Missing,
+}
+
+/// Change-feed event kind. Events are discovery hints, never authority.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChangeKind {
+    Put,
+    Delete,
+}
+
+/// One backend-local monotonically sequenced change hint.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChangeEvent {
+    pub sequence: u64,
+    pub bucket: BucketId,
+    pub object: ObjectId,
+    pub kind: ChangeKind,
+}
+
+/// One bounded page from an optional change feed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChangePage {
+    pub events: Vec<ChangeEvent>,
+    /// Watermark to persist even when `events` is empty.
+    pub cursor: ChangeCursor,
+}
+
+/// Optimization capabilities. None weakens repository verification.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BackendCapabilities {
+    pub strong_read_after_write: bool,
+    pub strong_list_after_write: bool,
+    pub conditional_create: bool,
+    pub conditional_replace: bool,
+    pub change_feed: bool,
+    pub push_notifications: bool,
+    pub resumable_upload: bool,
+    pub range_read: bool,
+    pub server_checksum: bool,
+    pub physical_delete: bool,
+    pub shareable_container: bool,
+    pub max_object_size: Option<u64>,
+    pub preferred_pack_size: u64,
+}
+
+impl BackendCapabilities {
+    /// Capabilities of the full in-memory executable model.
+    pub const fn in_memory() -> Self {
+        Self {
+            strong_read_after_write: true,
+            strong_list_after_write: true,
+            conditional_create: true,
+            conditional_replace: false,
+            change_feed: true,
+            push_notifications: false,
+            resumable_upload: false,
+            range_read: false,
+            server_checksum: true,
+            physical_delete: true,
+            shareable_container: false,
+            max_object_size: Some(MAX_OBJECT_BYTES as u64),
+            preferred_pack_size: 0,
+        }
+    }
+
+    /// The weakest conforming baseline: immutable bytes plus complete listing.
+    pub const fn baseline() -> Self {
+        Self {
+            strong_read_after_write: false,
+            strong_list_after_write: false,
+            conditional_create: false,
+            conditional_replace: false,
+            change_feed: false,
+            push_notifications: false,
+            resumable_upload: false,
+            range_read: false,
+            server_checksum: false,
+            physical_delete: false,
+            shareable_container: false,
+            max_object_size: None,
+            preferred_pack_size: 0,
+        }
+    }
+}
+
+/// Machine-comparable invalid-input reasons without attacker-controlled text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InputViolation {
+    ObjectTooLarge,
+    ListLimit,
+    CursorTooLarge,
+    CursorMalformed,
+    CursorScope,
+    RevisionMalformed,
+    FaultOperationMismatch,
+}
+
+/// Closed storage error taxonomy. Display and Debug contain no input bytes.
+#[derive(Clone, PartialEq, Eq)]
+pub enum StoreError {
+    InvalidInput(InputViolation),
+    NotInitialized,
+    Authorization,
+    Quota,
+    RateLimited { retry_after_ms: Option<u64> },
+    Network,
+    Corruption,
+    Conflict,
+    Unsupported,
+    Provider,
+}
+
+impl Debug for StoreError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidInput(reason) => {
+                formatter.debug_tuple("InvalidInput").field(reason).finish()
+            }
+            Self::RateLimited { retry_after_ms } => formatter
+                .debug_struct("RateLimited")
+                .field("retry_after_ms", retry_after_ms)
+                .finish(),
+            other => formatter.write_str(other.label()),
+        }
+    }
+}
+
+impl StoreError {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::InvalidInput(_) => "InvalidInput",
+            Self::NotInitialized => "NotInitialized",
+            Self::Authorization => "Authorization",
+            Self::Quota => "Quota",
+            Self::RateLimited { .. } => "RateLimited",
+            Self::Network => "Network",
+            Self::Corruption => "Corruption",
+            Self::Conflict => "Conflict",
+            Self::Unsupported => "Unsupported",
+            Self::Provider => "Provider",
+        }
+    }
+}
+
+impl Display for StoreError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("vault-pm-storage: ")?;
+        formatter.write_str(match self {
+            Self::InvalidInput(_) => "invalid input",
+            Self::NotInitialized => "store is not initialized",
+            Self::Authorization => "authorization failed",
+            Self::Quota => "provider quota exhausted",
+            Self::RateLimited { .. } => "provider rate limited the operation",
+            Self::Network => "network operation failed",
+            Self::Corruption => "immutable storage corruption detected",
+            Self::Conflict => "storage identity conflict",
+            Self::Unsupported => "operation is unsupported",
+            Self::Provider => "provider operation failed",
+        })
+    }
+}
+
+impl std::error::Error for StoreError {}
+
+/// Provider-neutral immutable object storage.
+pub trait VaultObjectStore: Send + Sync {
+    fn initialize(&self, locator: &VaultLocator) -> Result<(), StoreError>;
+    fn capabilities(&self) -> BackendCapabilities;
+    fn get(&self, bucket: &BucketId, object: &ObjectId) -> Result<Option<ObjectBytes>, StoreError>;
+    fn stat(&self, bucket: &BucketId, object: &ObjectId) -> Result<Option<ObjectStat>, StoreError>;
+    fn put_immutable(
+        &self,
+        bucket: &BucketId,
+        object: &ObjectId,
+        bytes: &ObjectBytes,
+    ) -> Result<PutImmutableOutcome, StoreError>;
+    fn list(
+        &self,
+        bucket: &BucketId,
+        cursor: Option<&ListCursor>,
+        limit: usize,
+    ) -> Result<ObjectPage, StoreError>;
+    fn delete_unreferenced(
+        &self,
+        bucket: &BucketId,
+        object: &ObjectId,
+    ) -> Result<DeleteOutcome, StoreError>;
+    fn changes(&self, cursor: Option<&ChangeCursor>) -> Result<Option<ChangePage>, StoreError>;
+}
+
+#[derive(Clone)]
+struct StoredObject {
+    bytes: ObjectBytes,
+    revision: u64,
+}
+
+#[derive(Default)]
+struct MemoryState {
+    locator: Option<VaultLocator>,
+    revision: u64,
+    objects: BTreeMap<(BucketId, ObjectId), StoredObject>,
+    changes: Vec<ChangeEvent>,
+}
+
+/// Thread-safe deterministic reference backend.
+pub struct InMemoryObjectStore {
+    capabilities: BackendCapabilities,
+    state: Mutex<MemoryState>,
+}
+
+impl Default for InMemoryObjectStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InMemoryObjectStore {
+    /// Construct the fully featured in-memory model.
+    pub fn new() -> Self {
+        Self::with_capabilities(BackendCapabilities::in_memory())
+    }
+
+    /// Construct a model with optional features enabled exactly as reported.
+    pub fn with_capabilities(capabilities: BackendCapabilities) -> Self {
+        Self {
+            capabilities,
+            state: Mutex::new(MemoryState::default()),
+        }
+    }
+
+    fn lock_state(&self) -> Result<std::sync::MutexGuard<'_, MemoryState>, StoreError> {
+        self.state.lock().map_err(|_| StoreError::Provider)
+    }
+
+    fn require_initialized(state: &MemoryState) -> Result<(), StoreError> {
+        if state.locator.is_none() {
+            Err(StoreError::NotInitialized)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn stat_for(&self, object: &StoredObject) -> Result<ObjectStat, StoreError> {
+        Ok(ObjectStat {
+            body_len: u64::try_from(object.bytes.len())
+                .map_err(|_| StoreError::InvalidInput(InputViolation::ObjectTooLarge))?,
+            revision: Some(ProviderRevision::new(object.revision.to_string())?),
+            server_checksum: self
+                .capabilities
+                .server_checksum
+                .then(|| sha256(object.bytes.as_slice())),
+        })
+    }
+
+    fn next_revision(state: &mut MemoryState) -> Result<u64, StoreError> {
+        state.revision = state.revision.checked_add(1).ok_or(StoreError::Provider)?;
+        Ok(state.revision)
+    }
+
+    fn record_change(
+        state: &mut MemoryState,
+        sequence: u64,
+        bucket: BucketId,
+        object: ObjectId,
+        kind: ChangeKind,
+    ) {
+        state.changes.push(ChangeEvent {
+            sequence,
+            bucket,
+            object,
+            kind,
+        });
+    }
+}
+
+impl VaultObjectStore for InMemoryObjectStore {
+    fn initialize(&self, locator: &VaultLocator) -> Result<(), StoreError> {
+        let mut state = self.lock_state()?;
+        match state.locator {
+            None => {
+                state.locator = Some(*locator);
+                Ok(())
+            }
+            Some(existing) if existing == *locator => Ok(()),
+            Some(_) => Err(StoreError::Conflict),
+        }
+    }
+
+    fn capabilities(&self) -> BackendCapabilities {
+        self.capabilities.clone()
+    }
+
+    fn get(&self, bucket: &BucketId, object: &ObjectId) -> Result<Option<ObjectBytes>, StoreError> {
+        let state = self.lock_state()?;
+        Self::require_initialized(&state)?;
+        Ok(state
+            .objects
+            .get(&(*bucket, *object))
+            .map(|entry| entry.bytes.clone()))
+    }
+
+    fn stat(&self, bucket: &BucketId, object: &ObjectId) -> Result<Option<ObjectStat>, StoreError> {
+        let state = self.lock_state()?;
+        Self::require_initialized(&state)?;
+        state
+            .objects
+            .get(&(*bucket, *object))
+            .map(|entry| self.stat_for(entry))
+            .transpose()
+    }
+
+    fn put_immutable(
+        &self,
+        bucket: &BucketId,
+        object: &ObjectId,
+        bytes: &ObjectBytes,
+    ) -> Result<PutImmutableOutcome, StoreError> {
+        let mut state = self.lock_state()?;
+        Self::require_initialized(&state)?;
+        if let Some(max) = self.capabilities.max_object_size {
+            if u64::try_from(bytes.len())
+                .map_err(|_| StoreError::InvalidInput(InputViolation::ObjectTooLarge))?
+                > max
+            {
+                return Err(StoreError::InvalidInput(InputViolation::ObjectTooLarge));
+            }
+        }
+        let key = (*bucket, *object);
+        if let Some(existing) = state.objects.get(&key) {
+            return if existing.bytes == *bytes {
+                Ok(PutImmutableOutcome::AlreadyPresent)
+            } else {
+                Err(StoreError::Corruption)
+            };
+        }
+
+        let revision = Self::next_revision(&mut state)?;
+        state.objects.insert(
+            key,
+            StoredObject {
+                bytes: bytes.clone(),
+                revision,
+            },
+        );
+        Self::record_change(&mut state, revision, *bucket, *object, ChangeKind::Put);
+        Ok(PutImmutableOutcome::Created)
+    }
+
+    fn list(
+        &self,
+        bucket: &BucketId,
+        cursor: Option<&ListCursor>,
+        limit: usize,
+    ) -> Result<ObjectPage, StoreError> {
+        let state = self.lock_state()?;
+        Self::require_initialized(&state)?;
+        if !(1..=MAX_LIST_LIMIT).contains(&limit) {
+            return Err(StoreError::InvalidInput(InputViolation::ListLimit));
+        }
+        let after = cursor
+            .map(|value| decode_list_cursor(value, bucket))
+            .transpose()?;
+
+        let mut candidates = state
+            .objects
+            .iter()
+            .filter(|((entry_bucket, object), _)| {
+                entry_bucket == bucket && after.is_none_or(|position| *object > position)
+            })
+            .take(limit + 1)
+            .map(|((_, object), stored)| {
+                Ok(ObjectEntry {
+                    object: *object,
+                    stat: self.stat_for(stored)?,
+                })
+            })
+            .collect::<Result<Vec<_>, StoreError>>()?;
+
+        let has_more = candidates.len() > limit;
+        if has_more {
+            candidates.truncate(limit);
+        }
+        let next_cursor = if has_more {
+            candidates
+                .last()
+                .map(|entry| encode_list_cursor(bucket, &entry.object))
+        } else {
+            None
+        };
+        Ok(ObjectPage {
+            entries: candidates,
+            next_cursor,
+        })
+    }
+
+    fn delete_unreferenced(
+        &self,
+        bucket: &BucketId,
+        object: &ObjectId,
+    ) -> Result<DeleteOutcome, StoreError> {
+        let mut state = self.lock_state()?;
+        Self::require_initialized(&state)?;
+        if !self.capabilities.physical_delete {
+            return Err(StoreError::Unsupported);
+        }
+        if state.objects.remove(&(*bucket, *object)).is_none() {
+            return Ok(DeleteOutcome::Missing);
+        }
+        let revision = Self::next_revision(&mut state)?;
+        Self::record_change(&mut state, revision, *bucket, *object, ChangeKind::Delete);
+        Ok(DeleteOutcome::Deleted)
+    }
+
+    fn changes(&self, cursor: Option<&ChangeCursor>) -> Result<Option<ChangePage>, StoreError> {
+        let state = self.lock_state()?;
+        Self::require_initialized(&state)?;
+        if !self.capabilities.change_feed {
+            return Err(StoreError::Unsupported);
+        }
+        let locator = state.locator.ok_or(StoreError::NotInitialized)?;
+        let after = cursor
+            .map(|value| decode_change_cursor(value, &locator))
+            .transpose()?
+            .unwrap_or(0);
+        if after > state.revision {
+            return Err(StoreError::InvalidInput(InputViolation::CursorMalformed));
+        }
+        let events = state
+            .changes
+            .iter()
+            .filter(|event| event.sequence > after)
+            .take(MAX_CHANGE_EVENTS)
+            .cloned()
+            .collect::<Vec<_>>();
+        let watermark = events.last().map_or(after, |event| event.sequence);
+        if events.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(ChangePage {
+                events,
+                cursor: encode_change_cursor(&locator, watermark),
+            }))
+        }
+    }
+}
+
+const LIST_CURSOR_VERSION: u8 = 1;
+const LIST_CURSOR_LEN: usize = 1 + 32 + 32;
+
+fn encode_list_cursor(bucket: &BucketId, object: &ObjectId) -> ListCursor {
+    let mut bytes = Vec::with_capacity(LIST_CURSOR_LEN);
+    bytes.push(LIST_CURSOR_VERSION);
+    bytes.extend_from_slice(bucket.as_bytes());
+    bytes.extend_from_slice(object.as_bytes());
+    ListCursor::trusted(bytes)
+}
+
+fn decode_list_cursor(cursor: &ListCursor, bucket: &BucketId) -> Result<ObjectId, StoreError> {
+    let bytes = cursor.as_bytes();
+    if bytes.len() != LIST_CURSOR_LEN || bytes[0] != LIST_CURSOR_VERSION {
+        return Err(StoreError::InvalidInput(InputViolation::CursorMalformed));
+    }
+    if &bytes[1..33] != bucket.as_bytes() {
+        return Err(StoreError::InvalidInput(InputViolation::CursorScope));
+    }
+    let mut object = [0_u8; 32];
+    object.copy_from_slice(&bytes[33..]);
+    Ok(ObjectId::new(object))
+}
+
+const CHANGE_CURSOR_VERSION: u8 = 1;
+const CHANGE_CURSOR_LEN: usize = 1 + 32 + 8;
+
+fn encode_change_cursor(locator: &VaultLocator, sequence: u64) -> ChangeCursor {
+    let mut bytes = Vec::with_capacity(CHANGE_CURSOR_LEN);
+    bytes.push(CHANGE_CURSOR_VERSION);
+    bytes.extend_from_slice(locator.as_bytes());
+    bytes.extend_from_slice(&sequence.to_be_bytes());
+    ChangeCursor::trusted(bytes)
+}
+
+fn decode_change_cursor(cursor: &ChangeCursor, locator: &VaultLocator) -> Result<u64, StoreError> {
+    let bytes = cursor.as_bytes();
+    if bytes.len() != CHANGE_CURSOR_LEN || bytes[0] != CHANGE_CURSOR_VERSION {
+        return Err(StoreError::InvalidInput(InputViolation::CursorMalformed));
+    }
+    if &bytes[1..33] != locator.as_bytes() {
+        return Err(StoreError::InvalidInput(InputViolation::CursorScope));
+    }
+    let mut sequence = [0_u8; 8];
+    sequence.copy_from_slice(&bytes[33..]);
+    Ok(u64::from_be_bytes(sequence))
+}
+
+/// Operations addressable by deterministic faults.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StoreOperation {
+    Initialize,
+    Get,
+    Stat,
+    PutImmutable,
+    List,
+    DeleteUnreferenced,
+    Changes,
+}
+
+/// One-shot fault effect. Input bytes cannot be embedded in an effect.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FaultEffect {
+    Return(StoreError),
+    CorruptGet,
+    OmitLastListEntry,
+    DuplicateFirstListEntry,
+    CommitPutThenNetwork,
+}
+
+/// One operation-scoped fault action.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FaultAction {
+    pub operation: StoreOperation,
+    pub effect: FaultEffect,
+}
+
+/// Transparent-by-default wrapper with deterministic one-shot faults.
+pub struct FaultInjectingObjectStore<S> {
+    inner: S,
+    faults: Mutex<VecDeque<FaultAction>>,
+}
+
+impl<S> FaultInjectingObjectStore<S> {
+    /// Wrap a store with an initially empty fault queue.
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            faults: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    /// Borrow the wrapped store for assertions or configuration.
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+
+    /// Consume the wrapper and return the store.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+
+    /// Enqueue one validated operation-specific action.
+    pub fn enqueue(&self, action: FaultAction) -> Result<(), StoreError> {
+        if !effect_matches(action.operation, &action.effect) {
+            return Err(StoreError::InvalidInput(
+                InputViolation::FaultOperationMismatch,
+            ));
+        }
+        self.faults
+            .lock()
+            .map_err(|_| StoreError::Provider)?
+            .push_back(action);
+        Ok(())
+    }
+
+    /// Return the number of actions not yet consumed.
+    pub fn pending_faults(&self) -> Result<usize, StoreError> {
+        Ok(self.faults.lock().map_err(|_| StoreError::Provider)?.len())
+    }
+
+    fn take_fault(&self, operation: StoreOperation) -> Result<Option<FaultEffect>, StoreError> {
+        let mut faults = self.faults.lock().map_err(|_| StoreError::Provider)?;
+        let Some(position) = faults
+            .iter()
+            .position(|action| action.operation == operation)
+        else {
+            return Ok(None);
+        };
+        Ok(faults.remove(position).map(|action| action.effect))
+    }
+}
+
+fn effect_matches(operation: StoreOperation, effect: &FaultEffect) -> bool {
+    match effect {
+        FaultEffect::Return(_) => true,
+        FaultEffect::CorruptGet => operation == StoreOperation::Get,
+        FaultEffect::OmitLastListEntry | FaultEffect::DuplicateFirstListEntry => {
+            operation == StoreOperation::List
+        }
+        FaultEffect::CommitPutThenNetwork => operation == StoreOperation::PutImmutable,
+    }
+}
+
+fn immediate_error(effect: Option<FaultEffect>) -> Result<Option<FaultEffect>, StoreError> {
+    match effect {
+        Some(FaultEffect::Return(error)) => Err(error),
+        other => Ok(other),
+    }
+}
+
+impl<S: VaultObjectStore> VaultObjectStore for FaultInjectingObjectStore<S> {
+    fn initialize(&self, locator: &VaultLocator) -> Result<(), StoreError> {
+        immediate_error(self.take_fault(StoreOperation::Initialize)?)?;
+        self.inner.initialize(locator)
+    }
+
+    fn capabilities(&self) -> BackendCapabilities {
+        self.inner.capabilities()
+    }
+
+    fn get(&self, bucket: &BucketId, object: &ObjectId) -> Result<Option<ObjectBytes>, StoreError> {
+        let effect = immediate_error(self.take_fault(StoreOperation::Get)?)?;
+        let result = self.inner.get(bucket, object)?;
+        match effect {
+            Some(FaultEffect::CorruptGet) => Ok(result.map(|bytes| bytes.corrupted_clone())),
+            _ => Ok(result),
+        }
+    }
+
+    fn stat(&self, bucket: &BucketId, object: &ObjectId) -> Result<Option<ObjectStat>, StoreError> {
+        immediate_error(self.take_fault(StoreOperation::Stat)?)?;
+        self.inner.stat(bucket, object)
+    }
+
+    fn put_immutable(
+        &self,
+        bucket: &BucketId,
+        object: &ObjectId,
+        bytes: &ObjectBytes,
+    ) -> Result<PutImmutableOutcome, StoreError> {
+        let effect = immediate_error(self.take_fault(StoreOperation::PutImmutable)?)?;
+        if effect == Some(FaultEffect::CommitPutThenNetwork) {
+            self.inner.put_immutable(bucket, object, bytes)?;
+            return Err(StoreError::Network);
+        }
+        self.inner.put_immutable(bucket, object, bytes)
+    }
+
+    fn list(
+        &self,
+        bucket: &BucketId,
+        cursor: Option<&ListCursor>,
+        limit: usize,
+    ) -> Result<ObjectPage, StoreError> {
+        let effect = immediate_error(self.take_fault(StoreOperation::List)?)?;
+        let mut page = self.inner.list(bucket, cursor, limit)?;
+        match effect {
+            Some(FaultEffect::OmitLastListEntry) => {
+                page.entries.pop();
+            }
+            Some(FaultEffect::DuplicateFirstListEntry) => {
+                if let Some(first) = page.entries.first().cloned() {
+                    page.entries.insert(0, first);
+                }
+            }
+            _ => {}
+        }
+        Ok(page)
+    }
+
+    fn delete_unreferenced(
+        &self,
+        bucket: &BucketId,
+        object: &ObjectId,
+    ) -> Result<DeleteOutcome, StoreError> {
+        immediate_error(self.take_fault(StoreOperation::DeleteUnreferenced)?)?;
+        self.inner.delete_unreferenced(bucket, object)
+    }
+
+    fn changes(&self, cursor: Option<&ChangeCursor>) -> Result<Option<ChangePage>, StoreError> {
+        immediate_error(self.take_fault(StoreOperation::Changes)?)?;
+        self.inner.changes(cursor)
+    }
+}
+
+/// Summary returned by a successful adapter conformance run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConformanceReport {
+    pub checks: usize,
+    pub capabilities: BackendCapabilities,
+}
+
+/// A static step label plus the typed error that failed it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConformanceFailure {
+    pub step: &'static str,
+    pub error: Option<StoreError>,
+}
+
+impl Display for ConformanceFailure {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "vault-pm-storage conformance failed at {}",
+            self.step
+        )
+    }
+}
+
+impl std::error::Error for ConformanceFailure {}
+
+fn failed(step: &'static str) -> ConformanceFailure {
+    ConformanceFailure { step, error: None }
+}
+
+fn failed_with(step: &'static str, error: StoreError) -> ConformanceFailure {
+    ConformanceFailure {
+        step,
+        error: Some(error),
+    }
+}
+
+fn expect<T>(result: Result<T, StoreError>, step: &'static str) -> Result<T, ConformanceFailure> {
+    result.map_err(|error| failed_with(step, error))
+}
+
+/// Exercise the public baseline contract against a newly constructed adapter.
+///
+/// Optional behavior is checked against the adapter's own capability report.
+/// Provider packages call this function from their integration tests.
+pub fn run_conformance_suite<S, F>(factory: F) -> Result<ConformanceReport, ConformanceFailure>
+where
+    S: VaultObjectStore,
+    F: FnOnce() -> S,
+{
+    let store = factory();
+    let locator = VaultLocator::new([0x11; 32]);
+    let other_locator = VaultLocator::new([0x12; 32]);
+    let bucket = BucketId::new([0x21; 32]);
+    let other_bucket = BucketId::new([0x22; 32]);
+    let absent = ObjectId::new([0x31; 32]);
+    let first_body = ObjectBytes::new(b"vault-pm-storage-fixture".to_vec())
+        .map_err(|error| failed_with("fixture body", error))?;
+    let conflicting_body = ObjectBytes::new(b"different".to_vec())
+        .map_err(|error| failed_with("conflict body", error))?;
+    let mut checks = 0;
+
+    if store.get(&bucket, &absent) != Err(StoreError::NotInitialized)
+        || store.stat(&bucket, &absent) != Err(StoreError::NotInitialized)
+        || store.put_immutable(&bucket, &absent, &first_body) != Err(StoreError::NotInitialized)
+        || store.list(&bucket, None, 0) != Err(StoreError::NotInitialized)
+        || store.delete_unreferenced(&bucket, &absent) != Err(StoreError::NotInitialized)
+        || store.changes(None) != Err(StoreError::NotInitialized)
+    {
+        return Err(failed("pre-initialization operations"));
+    }
+    checks += 6;
+    expect(store.initialize(&locator), "initialize")?;
+    expect(store.initialize(&locator), "idempotent initialize")?;
+    if store.initialize(&other_locator) != Err(StoreError::Conflict) {
+        return Err(failed("locator binding"));
+    }
+    checks += 3;
+
+    if expect(store.get(&bucket, &absent), "absent get")?.is_some()
+        || expect(store.stat(&bucket, &absent), "absent stat")?.is_some()
+    {
+        return Err(failed("absent point operations"));
+    }
+    checks += 2;
+
+    if expect(
+        store.put_immutable(&bucket, &absent, &first_body),
+        "first immutable put",
+    )? != PutImmutableOutcome::Created
+    {
+        return Err(failed("created outcome"));
+    }
+    if expect(
+        store.put_immutable(&bucket, &absent, &first_body),
+        "idempotent immutable put",
+    )? != PutImmutableOutcome::AlreadyPresent
+    {
+        return Err(failed("already-present outcome"));
+    }
+    if store.put_immutable(&bucket, &absent, &conflicting_body) != Err(StoreError::Corruption) {
+        return Err(failed("immutable conflict"));
+    }
+    checks += 3;
+
+    if expect(store.get(&bucket, &absent), "exact get")? != Some(first_body.clone()) {
+        return Err(failed("exact body"));
+    }
+    let stat = expect(store.stat(&bucket, &absent), "exact stat")?
+        .ok_or_else(|| failed("present stat"))?;
+    if stat.body_len != first_body.len() as u64 {
+        return Err(failed("stat length"));
+    }
+    checks += 2;
+
+    let mut expected = BTreeSet::from([absent]);
+    for byte in [0x01_u8, 0x20, 0x40, 0x80, 0xf0] {
+        let object = ObjectId::new([byte; 32]);
+        let body = ObjectBytes::new(vec![byte]).map_err(|error| failed_with("page body", error))?;
+        expect(
+            store.put_immutable(&bucket, &object, &body),
+            "page fixture put",
+        )?;
+        expected.insert(object);
+    }
+
+    let first_page = expect(store.list(&bucket, None, 2), "first list page")?;
+    let cross_bucket_cursor = first_page
+        .next_cursor
+        .clone()
+        .ok_or_else(|| failed("first continuation"))?;
+    if store.list(&other_bucket, Some(&cross_bucket_cursor), 2)
+        != Err(StoreError::InvalidInput(InputViolation::CursorScope))
+    {
+        return Err(failed("cursor bucket scope"));
+    }
+    if store.list(&bucket, None, 0) != Err(StoreError::InvalidInput(InputViolation::ListLimit))
+        || store.list(&bucket, None, MAX_LIST_LIMIT + 1)
+            != Err(StoreError::InvalidInput(InputViolation::ListLimit))
+    {
+        return Err(failed("list bounds"));
+    }
+    checks += 3;
+
+    let mut observed = Vec::new();
+    let mut cursor = None;
+    loop {
+        let page = expect(store.list(&bucket, cursor.as_ref(), 2), "paginated list")?;
+        observed.extend(page.entries.into_iter().map(|entry| entry.object));
+        cursor = page.next_cursor;
+        if cursor.is_none() {
+            break;
+        }
+    }
+    let observed_set = observed.iter().copied().collect::<BTreeSet<_>>();
+    if observed.windows(2).any(|pair| pair[0] >= pair[1])
+        || observed_set.len() != observed.len()
+        || observed_set != expected
+    {
+        return Err(failed("ordered exhaustive pagination"));
+    }
+    checks += 1;
+
+    let capabilities = store.capabilities();
+    let delete_result = store.delete_unreferenced(&bucket, &absent);
+    if capabilities.physical_delete {
+        if expect(delete_result, "supported delete")? != DeleteOutcome::Deleted
+            || expect(
+                store.delete_unreferenced(&bucket, &absent),
+                "idempotent delete",
+            )? != DeleteOutcome::Missing
+        {
+            return Err(failed("delete outcomes"));
+        }
+    } else if delete_result != Err(StoreError::Unsupported) {
+        return Err(failed("unsupported delete"));
+    }
+    checks += 1;
+
+    if capabilities.change_feed {
+        let changes = expect(store.changes(None), "change feed")?;
+        let page = changes.ok_or_else(|| failed("advertised change feed"))?;
+        if page
+            .events
+            .windows(2)
+            .any(|pair| pair[0].sequence >= pair[1].sequence)
+        {
+            return Err(failed("change ordering"));
+        }
+        expect(store.changes(Some(&page.cursor)), "change resume")?;
+    } else if store.changes(None) != Err(StoreError::Unsupported) {
+        return Err(failed("unsupported change feed"));
+    }
+    checks += 2;
+
+    let debug = format!("{locator:?} {bucket:?} {absent:?} {first_body:?}");
+    if debug.contains("17, 17")
+        || debug.contains("33, 33")
+        || debug.contains("49, 49")
+        || debug.contains("vault-pm-storage-fixture")
+    {
+        return Err(failed("redacted debug"));
+    }
+    checks += 1;
+
+    Ok(ConformanceReport {
+        checks,
+        capabilities,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn initialized() -> InMemoryObjectStore {
+        let store = InMemoryObjectStore::new();
+        store.initialize(&VaultLocator::new([1; 32])).unwrap();
+        store
+    }
+
+    #[test]
+    fn in_memory_model_passes_shared_conformance() {
+        let report = run_conformance_suite(InMemoryObjectStore::new).unwrap();
+        assert_eq!(report.checks, 24);
+        assert!(report.capabilities.change_feed);
+    }
+
+    #[test]
+    fn shared_fixture_is_embedded_and_versioned() {
+        assert!(CONFORMANCE_FIXTURE_V1.contains("VLT-PM-STORAGE-CONFORMANCE"));
+        assert!(CONFORMANCE_FIXTURE_V1.contains("\"version\": 1"));
+        assert!(CONFORMANCE_FIXTURE_V1.contains("CommitPutThenNetwork"));
+        assert!(CONFORMANCE_FIXTURE_V1.len() < 16 * 1024);
+    }
+
+    #[test]
+    fn baseline_optional_capabilities_pass_shared_conformance() {
+        let report = run_conformance_suite(|| {
+            InMemoryObjectStore::with_capabilities(BackendCapabilities::baseline())
+        })
+        .unwrap();
+        assert!(!report.capabilities.change_feed);
+        assert!(!report.capabilities.physical_delete);
+    }
+
+    #[test]
+    fn format_object_ids_round_trip_without_exposing_bytes() {
+        let format = FormatObjectId::new([0xa5; 32]);
+        let storage = ObjectId::from(format);
+        assert_eq!(FormatObjectId::from(storage), format);
+        assert_eq!(format!("{storage:?}"), "ObjectId(<redacted>)");
+    }
+
+    #[test]
+    fn value_bounds_and_debug_redaction_are_enforced() {
+        assert_eq!(
+            ListCursor::new(vec![]),
+            Err(StoreError::InvalidInput(InputViolation::CursorMalformed))
+        );
+        assert_eq!(
+            ChangeCursor::new(vec![0; MAX_CURSOR_BYTES + 1]),
+            Err(StoreError::InvalidInput(InputViolation::CursorTooLarge))
+        );
+        assert_eq!(
+            ProviderRevision::new("line\nbreak"),
+            Err(StoreError::InvalidInput(InputViolation::RevisionMalformed))
+        );
+        let secret = ObjectBytes::new(b"do-not-print-me".to_vec()).unwrap();
+        assert!(!format!("{secret:?}").contains("do-not-print-me"));
+        assert_eq!(
+            StoreError::Corruption.to_string(),
+            "vault-pm-storage: immutable storage corruption detected"
+        );
+    }
+
+    #[test]
+    fn public_value_helpers_are_lossless_and_redacted() {
+        let locator = VaultLocator::new([7; 32]);
+        assert_eq!(*locator.as_bytes(), [7; 32]);
+        assert_eq!(locator.into_bytes(), [7; 32]);
+        let bucket = BucketId::new([8; 32]);
+        assert_eq!(*bucket.as_bytes(), [8; 32]);
+        assert_eq!(bucket.into_bytes(), [8; 32]);
+        let object = ObjectId::new([9; 32]);
+        assert_eq!(*object.as_bytes(), [9; 32]);
+        assert_eq!(object.into_bytes(), [9; 32]);
+
+        let empty = ObjectBytes::new(Vec::new()).unwrap();
+        assert!(empty.is_empty());
+        assert_eq!(empty.into_vec(), Vec::<u8>::new());
+
+        let list = ListCursor::new(vec![1, 2, 3]).unwrap();
+        assert_eq!(list.as_bytes(), &[1, 2, 3]);
+        assert!(!format!("{list:?}").contains("1, 2, 3"));
+        let change = ChangeCursor::new(vec![4, 5, 6]).unwrap();
+        assert_eq!(change.as_bytes(), &[4, 5, 6]);
+        assert!(!format!("{change:?}").contains("4, 5, 6"));
+
+        let revision = ProviderRevision::new("provider-etag").unwrap();
+        assert_eq!(revision.as_str(), "provider-etag");
+        assert_eq!(format!("{revision:?}"), "ProviderRevision(<redacted>)");
+        assert_eq!(
+            ProviderRevision::new(""),
+            Err(StoreError::InvalidInput(InputViolation::RevisionMalformed))
+        );
+        assert_eq!(
+            ProviderRevision::new("x".repeat(MAX_REVISION_BYTES + 1)),
+            Err(StoreError::InvalidInput(InputViolation::RevisionMalformed))
+        );
+
+        assert_eq!(
+            InMemoryObjectStore::default().capabilities(),
+            BackendCapabilities::in_memory()
+        );
+    }
+
+    #[test]
+    fn every_error_variant_has_stable_redacted_formatting() {
+        let errors = [
+            StoreError::InvalidInput(InputViolation::ListLimit),
+            StoreError::NotInitialized,
+            StoreError::Authorization,
+            StoreError::Quota,
+            StoreError::RateLimited {
+                retry_after_ms: Some(250),
+            },
+            StoreError::Network,
+            StoreError::Corruption,
+            StoreError::Conflict,
+            StoreError::Unsupported,
+            StoreError::Provider,
+        ];
+        for error in errors {
+            let debug = format!("{error:?}");
+            let display = error.to_string();
+            assert!(!debug.is_empty());
+            assert!(display.starts_with("vault-pm-storage: "));
+        }
+        assert_eq!(
+            format!(
+                "{:?}",
+                StoreError::RateLimited {
+                    retry_after_ms: None
+                }
+            ),
+            "RateLimited { retry_after_ms: None }"
+        );
+    }
+
+    #[test]
+    fn provider_size_cap_is_enforced_without_mutation() {
+        let mut capabilities = BackendCapabilities::in_memory();
+        capabilities.max_object_size = Some(2);
+        let store = InMemoryObjectStore::with_capabilities(capabilities);
+        store.initialize(&VaultLocator::new([1; 32])).unwrap();
+        let result = store.put_immutable(
+            &BucketId::new([2; 32]),
+            &ObjectId::new([3; 32]),
+            &ObjectBytes::new(vec![1, 2, 3]).unwrap(),
+        );
+        assert_eq!(
+            result,
+            Err(StoreError::InvalidInput(InputViolation::ObjectTooLarge))
+        );
+        assert!(store
+            .list(&BucketId::new([2; 32]), None, 10)
+            .unwrap()
+            .entries
+            .is_empty());
+    }
+
+    #[test]
+    fn cursor_encoding_rejects_tampering_and_future_change_positions() {
+        let store = initialized();
+        let bucket = BucketId::new([2; 32]);
+        for byte in 1..=2 {
+            store
+                .put_immutable(
+                    &bucket,
+                    &ObjectId::new([byte; 32]),
+                    &ObjectBytes::new(vec![byte]).unwrap(),
+                )
+                .unwrap();
+        }
+        let cursor = store.list(&bucket, None, 1).unwrap().next_cursor.unwrap();
+        let mut malformed = cursor.as_bytes().to_vec();
+        malformed[0] = 99;
+        let malformed = ListCursor::new(malformed).unwrap();
+        assert_eq!(
+            store.list(&bucket, Some(&malformed), 1),
+            Err(StoreError::InvalidInput(InputViolation::CursorMalformed))
+        );
+
+        let future = encode_change_cursor(&VaultLocator::new([1; 32]), 99);
+        assert_eq!(
+            store.changes(Some(&future)),
+            Err(StoreError::InvalidInput(InputViolation::CursorMalformed))
+        );
+        let malformed_change = ChangeCursor::new(vec![99]).unwrap();
+        assert_eq!(
+            store.changes(Some(&malformed_change)),
+            Err(StoreError::InvalidInput(InputViolation::CursorMalformed))
+        );
+
+        let other_store_cursor = encode_change_cursor(&VaultLocator::new([9; 32]), 0);
+        assert_eq!(
+            store.changes(Some(&other_store_cursor)),
+            Err(StoreError::InvalidInput(InputViolation::CursorScope))
+        );
+    }
+
+    #[test]
+    fn deterministic_generated_set_lists_in_sorted_pages() {
+        let store = initialized();
+        let bucket = BucketId::new([8; 32]);
+        let mut state = 0x9e37_79b9_u32;
+        let mut expected = BTreeSet::new();
+        for _ in 0..257 {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            let mut id = [0_u8; 32];
+            for chunk in id.chunks_exact_mut(4) {
+                chunk.copy_from_slice(&state.to_be_bytes());
+                state = state.rotate_left(7).wrapping_add(0x7f4a_7c15);
+            }
+            let object = ObjectId::new(id);
+            let body = ObjectBytes::new(state.to_be_bytes().to_vec()).unwrap();
+            let expected_outcome = if expected.insert(object) {
+                PutImmutableOutcome::Created
+            } else {
+                PutImmutableOutcome::AlreadyPresent
+            };
+            assert_eq!(
+                store.put_immutable(&bucket, &object, &body).unwrap(),
+                expected_outcome
+            );
+        }
+
+        for limit in [1, 2, 17, MAX_LIST_LIMIT] {
+            let mut cursor = None;
+            let mut actual = Vec::new();
+            loop {
+                let page = store.list(&bucket, cursor.as_ref(), limit).unwrap();
+                actual.extend(page.entries.into_iter().map(|entry| entry.object));
+                cursor = page.next_cursor;
+                if cursor.is_none() {
+                    break;
+                }
+            }
+            assert_eq!(actual, expected.iter().copied().collect::<Vec<_>>());
+        }
+    }
+
+    #[test]
+    fn queued_return_fault_is_one_shot_and_operation_scoped() {
+        let faulty = FaultInjectingObjectStore::new(InMemoryObjectStore::new());
+        faulty
+            .enqueue(FaultAction {
+                operation: StoreOperation::Get,
+                effect: FaultEffect::Return(StoreError::Authorization),
+            })
+            .unwrap();
+        faulty.initialize(&VaultLocator::new([1; 32])).unwrap();
+        let bucket = BucketId::new([2; 32]);
+        let object = ObjectId::new([3; 32]);
+        assert_eq!(faulty.get(&bucket, &object), Err(StoreError::Authorization));
+        assert_eq!(faulty.get(&bucket, &object), Ok(None));
+        assert_eq!(faulty.pending_faults().unwrap(), 0);
+    }
+
+    #[test]
+    fn invalid_fault_pair_is_rejected() {
+        let faulty = FaultInjectingObjectStore::new(InMemoryObjectStore::new());
+        assert_eq!(
+            faulty.enqueue(FaultAction {
+                operation: StoreOperation::Stat,
+                effect: FaultEffect::CorruptGet,
+            }),
+            Err(StoreError::InvalidInput(
+                InputViolation::FaultOperationMismatch
+            ))
+        );
+    }
+
+    #[test]
+    fn corrupt_get_does_not_mutate_inner_store() {
+        let faulty = FaultInjectingObjectStore::new(initialized());
+        let bucket = BucketId::new([2; 32]);
+        let object = ObjectId::new([3; 32]);
+        let body = ObjectBytes::new(b"ciphertext".to_vec()).unwrap();
+        faulty.put_immutable(&bucket, &object, &body).unwrap();
+        faulty
+            .enqueue(FaultAction {
+                operation: StoreOperation::Get,
+                effect: FaultEffect::CorruptGet,
+            })
+            .unwrap();
+        assert_ne!(faulty.get(&bucket, &object).unwrap(), Some(body.clone()));
+        assert_eq!(faulty.get(&bucket, &object).unwrap(), Some(body));
+    }
+
+    #[test]
+    fn ambiguous_committed_put_converges_on_retry() {
+        let faulty = FaultInjectingObjectStore::new(initialized());
+        let bucket = BucketId::new([2; 32]);
+        let object = ObjectId::new([3; 32]);
+        let body = ObjectBytes::new(b"ciphertext".to_vec()).unwrap();
+        faulty
+            .enqueue(FaultAction {
+                operation: StoreOperation::PutImmutable,
+                effect: FaultEffect::CommitPutThenNetwork,
+            })
+            .unwrap();
+        assert_eq!(
+            faulty.put_immutable(&bucket, &object, &body),
+            Err(StoreError::Network)
+        );
+        assert_eq!(
+            faulty.put_immutable(&bucket, &object, &body).unwrap(),
+            PutImmutableOutcome::AlreadyPresent
+        );
+    }
+
+    #[test]
+    fn stale_and_duplicate_list_faults_are_explicitly_adversarial() {
+        let faulty = FaultInjectingObjectStore::new(initialized());
+        let bucket = BucketId::new([2; 32]);
+        for byte in 1..=2 {
+            faulty
+                .put_immutable(
+                    &bucket,
+                    &ObjectId::new([byte; 32]),
+                    &ObjectBytes::new(vec![byte]).unwrap(),
+                )
+                .unwrap();
+        }
+        faulty
+            .enqueue(FaultAction {
+                operation: StoreOperation::List,
+                effect: FaultEffect::OmitLastListEntry,
+            })
+            .unwrap();
+        assert_eq!(faulty.list(&bucket, None, 10).unwrap().entries.len(), 1);
+        faulty
+            .enqueue(FaultAction {
+                operation: StoreOperation::List,
+                effect: FaultEffect::DuplicateFirstListEntry,
+            })
+            .unwrap();
+        let duplicate = faulty.list(&bucket, None, 10).unwrap();
+        assert_eq!(duplicate.entries.len(), 3);
+        assert_eq!(duplicate.entries[0].object, duplicate.entries[1].object);
+        assert_eq!(faulty.list(&bucket, None, 10).unwrap().entries.len(), 2);
+    }
+
+    #[test]
+    fn fault_wrapper_delegates_every_unfaulted_operation() {
+        let faulty = FaultInjectingObjectStore::new(InMemoryObjectStore::new());
+        assert_eq!(faulty.capabilities(), BackendCapabilities::in_memory());
+        let locator = VaultLocator::new([1; 32]);
+        faulty.initialize(&locator).unwrap();
+        let bucket = BucketId::new([2; 32]);
+        let object = ObjectId::new([3; 32]);
+        let body = ObjectBytes::new(vec![4]).unwrap();
+        faulty.put_immutable(&bucket, &object, &body).unwrap();
+        assert!(faulty.stat(&bucket, &object).unwrap().is_some());
+        assert!(faulty.changes(None).unwrap().is_some());
+        assert_eq!(
+            faulty.delete_unreferenced(&bucket, &object).unwrap(),
+            DeleteOutcome::Deleted
+        );
+        assert_eq!(faulty.inner().get(&bucket, &object).unwrap(), None);
+        let inner = faulty.into_inner();
+        assert_eq!(inner.capabilities(), BackendCapabilities::in_memory());
+    }
+
+    #[test]
+    fn empty_body_corruption_and_empty_list_duplication_are_deterministic() {
+        let faulty = FaultInjectingObjectStore::new(initialized());
+        let bucket = BucketId::new([2; 32]);
+        let object = ObjectId::new([3; 32]);
+        let empty = ObjectBytes::new(Vec::new()).unwrap();
+        faulty.put_immutable(&bucket, &object, &empty).unwrap();
+        faulty
+            .enqueue(FaultAction {
+                operation: StoreOperation::Get,
+                effect: FaultEffect::CorruptGet,
+            })
+            .unwrap();
+        assert_eq!(
+            faulty.get(&bucket, &object).unwrap().unwrap().into_vec(),
+            vec![0x80]
+        );
+
+        let empty_bucket = BucketId::new([9; 32]);
+        faulty
+            .enqueue(FaultAction {
+                operation: StoreOperation::List,
+                effect: FaultEffect::DuplicateFirstListEntry,
+            })
+            .unwrap();
+        assert!(faulty
+            .list(&empty_bucket, None, 1)
+            .unwrap()
+            .entries
+            .is_empty());
+    }
+
+    #[test]
+    fn conformance_failures_are_static_and_redacted() {
+        let plain = failed("example step");
+        assert_eq!(plain.error, None);
+        assert_eq!(
+            plain.to_string(),
+            "vault-pm-storage conformance failed at example step"
+        );
+        let typed = failed_with("provider step", StoreError::Provider);
+        assert_eq!(typed.error, Some(StoreError::Provider));
+        assert!(!typed.to_string().contains("Provider"));
+    }
+
+    #[test]
+    fn change_feed_resumes_after_watermark_and_records_deletes() {
+        let store = initialized();
+        let bucket = BucketId::new([2; 32]);
+        let first = ObjectId::new([3; 32]);
+        let second = ObjectId::new([4; 32]);
+        let body = ObjectBytes::new(vec![5]).unwrap();
+        store.put_immutable(&bucket, &first, &body).unwrap();
+        let page = store.changes(None).unwrap().unwrap();
+        assert_eq!(page.events.len(), 1);
+        store.put_immutable(&bucket, &second, &body).unwrap();
+        store.delete_unreferenced(&bucket, &first).unwrap();
+        let resumed = store.changes(Some(&page.cursor)).unwrap().unwrap();
+        assert_eq!(resumed.events.len(), 2);
+        assert_eq!(resumed.events[0].kind, ChangeKind::Put);
+        assert_eq!(resumed.events[1].kind, ChangeKind::Delete);
+        assert!(resumed.events[0].sequence < resumed.events[1].sequence);
+    }
+}

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1233,7 +1233,7 @@ changelog, focused build, and downstream validation.
 1. `vault-pm-format`: bootstrap, object frame, device certificate, commit, and
    signed announcement canonical structures and vectors.
 2. `vault-pm-storage`: semantic contract, capability report, conformance and
-   fault-injection backend.
+   fault-injection backend, specified by `VLT-PM02-storage.md`.
 3. Extend VLT01/custody seam to accept an injected random root KEK.
 4. `vault-pm-domain`: product IDs, documents, conflicts, redacted views.
 5. Security review of format/key hierarchy before persistent user data exists.
@@ -1299,6 +1299,8 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
 - `VLT09-vault-audit-log.md` — audit chain.
 - `VLT10-vault-sync-engine.md` — version vectors and conflict semantics.
 - `VLT11-transports.md` — current CLI transport contract.
+- `VLT-PM01-format.md` and `VLT-PM02-storage.md` — product repository wire and
+  object-store contracts.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM02-storage.md
+++ b/code/specs/VLT-PM02-storage.md
@@ -157,11 +157,12 @@ unreferenced; the backend does not decide reachability.
 
 ### 5.5 Change hints
 
-`changes` is optional and returns `Ok(None)` when no change-feed capability is
-present. When supported, events carry a monotonically increasing backend-local
-sequence, bucket, object ID, and `Put` or `Delete` kind. Events are hints: they
-may be duplicated or delayed, and consumers still perform periodic full list
-scans. A cursor resumes strictly after its last sequence.
+`changes` is optional and returns `Unsupported` when no change-feed capability
+is present. A supported feed returns `Ok(None)` when no events exist after the
+requested cursor. Otherwise events carry a monotonically increasing
+backend-local sequence, bucket, object ID, and `Put` or `Delete` kind. Events
+are hints: they may be duplicated or delayed, and consumers still perform
+periodic full list scans. A cursor resumes strictly after its last sequence.
 
 ## 6. Capability report
 
@@ -296,4 +297,3 @@ Later packages own:
 - the monorepo build graph recognizes the new package and affected closure;
 - no filesystem, network, process, environment, clock, CSPRNG, or secret-key
   capability is declared or used.
-

--- a/code/specs/VLT-PM02-storage.md
+++ b/code/specs/VLT-PM02-storage.md
@@ -1,7 +1,7 @@
 # VLT-PM02 — Password-manager object storage contract
 
-**Status:** Draft V1  
-**Parent:** VLT-PM00 §11 and §23 Phase 0  
+**Status:** Draft V1
+**Parent:** VLT-PM00 §11 and §23 Phase 0
 **Depends on:** VLT-PM01 object identifiers
 
 ## 1. Purpose

--- a/code/specs/VLT-PM02-storage.md
+++ b/code/specs/VLT-PM02-storage.md
@@ -1,0 +1,299 @@
+# VLT-PM02 — Password-manager object storage contract
+
+**Status:** Draft V1  
+**Parent:** VLT-PM00 §11 and §23 Phase 0  
+**Depends on:** VLT-PM01 object identifiers
+
+## 1. Purpose
+
+This specification defines the smallest storage contract shared by the local
+repository, cloud replicas, browser hosts, and test doubles. A conforming store
+persists and enumerates opaque immutable bytes. It does not understand vault
+records, keys, commits, signatures, or plaintext.
+
+The contract deliberately targets the weakest useful provider semantics. Strong
+conditional writes, checksums, range reads, change feeds, notifications, and
+physical deletion are reported capabilities and optimization hints. They are
+never prerequisites for correctness.
+
+## 2. Security boundary
+
+Storage is hostile. A provider or fault-injection backend may omit, replay,
+duplicate, reorder, truncate, or corrupt data and may lie about optional
+metadata. Repository code above this contract verifies content-derived object
+IDs, signatures, ancestry, and pinned heads before accepting data.
+
+A backend MUST:
+
+- treat bucket IDs, object IDs, cursors, revisions, and bodies as opaque;
+- never log or place object bodies in errors or debug output;
+- never transform, compress, index, import, or interpret object bodies;
+- enforce configured size and page bounds before allocating or issuing I/O;
+- distinguish absent objects from authorization, withholding, corruption, and
+  provider failures;
+- return only committed complete bodies.
+
+The contract does not hide access timing, object sizes, bucket membership, or
+the fact that opaque objects belong to one configured provider account.
+
+## 3. Primitive values and bounds
+
+| Value | V1 representation | Bound or rule |
+|---|---|---|
+| `VaultLocator` | 32 opaque bytes | binds one store instance to one vault locator |
+| `BucketId` | 32 opaque bytes | compared bytewise; no caller-readable names |
+| `ObjectId` | VLT-PM01 32-byte ID | compared bytewise; storage does not recompute it |
+| `ObjectBytes` | opaque byte string | at most 64 MiB |
+| `ListCursor` | backend-owned byte string | at most 256 bytes; bound to one bucket |
+| `ChangeCursor` | backend-owned byte string | at most 256 bytes; bound to one store |
+| provider revision | UTF-8 single-line token | 1–256 bytes |
+| list limit | positive integer | at most 10,000 entries |
+| change page | backend selected | at most 1,000 events |
+
+Fixed-width identifiers have value semantics. Their `Debug` representation MAY
+show a short type label but MUST NOT reveal their bytes. Bodies and cursors MUST
+use redacted `Debug` output.
+
+## 4. Store lifecycle
+
+`initialize(locator)` is idempotent. The first successful call binds a store
+instance and its configured container to that locator. Repeating the same call
+succeeds without replacing data. Initializing the same instance with a different
+locator returns `Conflict`.
+
+All data operations before successful initialization return `NotInitialized`.
+Initialization may create provider-owned container metadata, but MUST NOT write
+plaintext vault names or user data.
+
+## 5. Normative operations
+
+```rust
+pub trait VaultObjectStore: Send + Sync {
+    fn initialize(&self, locator: &VaultLocator) -> Result<(), StoreError>;
+    fn capabilities(&self) -> BackendCapabilities;
+    fn get(
+        &self,
+        bucket: &BucketId,
+        object: &ObjectId,
+    ) -> Result<Option<ObjectBytes>, StoreError>;
+    fn stat(
+        &self,
+        bucket: &BucketId,
+        object: &ObjectId,
+    ) -> Result<Option<ObjectStat>, StoreError>;
+    fn put_immutable(
+        &self,
+        bucket: &BucketId,
+        object: &ObjectId,
+        bytes: &ObjectBytes,
+    ) -> Result<PutImmutableOutcome, StoreError>;
+    fn list(
+        &self,
+        bucket: &BucketId,
+        cursor: Option<&ListCursor>,
+        limit: usize,
+    ) -> Result<ObjectPage, StoreError>;
+    fn delete_unreferenced(
+        &self,
+        bucket: &BucketId,
+        object: &ObjectId,
+    ) -> Result<DeleteOutcome, StoreError>;
+    fn changes(
+        &self,
+        cursor: Option<&ChangeCursor>,
+    ) -> Result<Option<ChangePage>, StoreError>;
+}
+```
+
+### 5.1 Exact reads
+
+`get` returns the exact committed bytes or `None`. `stat` returns the exact body
+length plus an optional opaque provider revision and optional provider checksum.
+Metadata is advisory; object-ID verification remains repository-owned.
+
+A body shorter or longer than the committed stat, a checksum disagreement, or
+different bytes observed for the same `(bucket, object)` is `Corruption`, not
+`NotFound` or `Conflict`.
+
+### 5.2 Immutable put
+
+`put_immutable` is the only V1 write:
+
+| Prior logical state | Requested bytes | Outcome |
+|---|---|---|
+| absent | any bounded bytes | `Created` |
+| present | byte-for-byte identical | `AlreadyPresent` |
+| present | different | `Corruption` |
+
+The outcome is idempotent across retries. A provider without atomic
+create-if-absent may upload to a temporary physical name, race publication,
+re-read all contenders, and collapse identical duplicates. It MUST never report
+success until a subsequent exact read can return the requested complete bytes.
+
+### 5.3 Listing and cursors
+
+Each page contains unique logical object IDs in ascending bytewise order. A
+cursor is an exclusive continuation position and is scoped to its originating
+bucket. Reusing it with another bucket or passing a malformed/oversized cursor
+returns `InvalidInput`.
+
+For an unchanged store, following `next_cursor` to exhaustion returns every
+object in the bucket exactly once. Concurrent additions MAY appear in the
+current traversal when their ID is after the cursor. Additions at or before the
+cursor may wait until the next complete traversal. Consequently, correctness
+uses repeated complete scans; change feeds and strong list-after-write only
+reduce latency.
+
+`next_cursor` is present exactly when another page may exist. A conforming store
+MUST NOT return an empty page with a continuation cursor for an unchanged
+bucket.
+
+### 5.4 Deletion
+
+Physical deletion is optional. Unsupported stores return `Unsupported` without
+side effects. A supported store returns `Deleted` or `Missing` idempotently.
+The method name is an assertion by repository GC that the object is
+unreferenced; the backend does not decide reachability.
+
+### 5.5 Change hints
+
+`changes` is optional and returns `Ok(None)` when no change-feed capability is
+present. When supported, events carry a monotonically increasing backend-local
+sequence, bucket, object ID, and `Put` or `Delete` kind. Events are hints: they
+may be duplicated or delayed, and consumers still perform periodic full list
+scans. A cursor resumes strictly after its last sequence.
+
+## 6. Capability report
+
+```rust
+pub struct BackendCapabilities {
+    pub strong_read_after_write: bool,
+    pub strong_list_after_write: bool,
+    pub conditional_create: bool,
+    pub conditional_replace: bool,
+    pub change_feed: bool,
+    pub push_notifications: bool,
+    pub resumable_upload: bool,
+    pub range_read: bool,
+    pub server_checksum: bool,
+    pub physical_delete: bool,
+    pub shareable_container: bool,
+    pub max_object_size: Option<u64>,
+    pub preferred_pack_size: u64,
+}
+```
+
+`max_object_size`, when present, MUST be no greater than the provider's tested
+limit. V1 callers also enforce the contract-wide 64 MiB limit. A preferred pack
+size of zero means no provider preference. Capability reports are stable for
+one configured backend session; a changed report triggers a new storage health
+check, not weaker verification.
+
+## 7. Error taxonomy
+
+| Error | Meaning | Default retry behavior |
+|---|---|---|
+| `InvalidInput` | invalid bound, token, cursor, or argument | never retry unchanged |
+| `NotInitialized` | lifecycle violation | initialize first |
+| `Authorization` | credentials absent, expired, or rejected | reauthorize |
+| `Quota` | account/container quota exhausted | user action |
+| `RateLimited` | provider request budget exhausted | retry after bounded delay |
+| `Network` | transport unavailable/interrupted | bounded retry |
+| `Corruption` | immutable identity or bytes contradicted | stop and surface |
+| `Conflict` | locator/container identity conflict | stop and surface |
+| `Unsupported` | optional operation unavailable | select baseline path |
+| `Provider` | typed provider failure not covered above | bounded retry or surface |
+
+Errors MUST NOT contain body bytes, identifiers, provider tokens, paths, or raw
+provider response bodies in `Display` or `Debug`. Provider adapters may retain a
+redacted stable reason code and retry delay in private telemetry.
+
+## 8. Reference in-memory backend
+
+Phase 0 ships a deterministic, thread-safe `InMemoryObjectStore` with:
+
+- atomic immutable puts;
+- exact point reads and stats;
+- ascending cursor pagination;
+- optional deletion and change-feed support reflected in capabilities;
+- monotonically increasing revisions and change sequences;
+- no clock, filesystem, network, environment, process, entropy, or secret-key
+  authority.
+
+The reference backend is the executable model for adapter conformance. Its
+default configuration implements every optional capability that can be modeled
+in memory except notifications, range reads, resumable uploads, and sharing.
+
+## 9. Deterministic fault injection
+
+`FaultInjectingObjectStore<S>` wraps any store. Tests enqueue one-shot actions
+for a specific operation. Actions are consumed in FIFO order and can:
+
+- return a typed authorization, quota, rate-limit, network, corruption,
+  conflict, unsupported, or provider error;
+- corrupt one successful `get` body without changing the inner store;
+- omit the last entry from one successful list page to model a stale listing;
+- duplicate the first entry in one successful list page to model a broken or
+  adversarial provider adapter;
+- commit one put in the inner store and then return `Network` to model an
+  ambiguous response.
+
+Faults contain no attacker-controlled message. With an empty fault queue the
+wrapper is transparent and conforming. Some injected successful responses are
+intentionally non-conforming so repository verification and retry logic can be
+tested against hostile storage.
+
+## 10. Conformance suite and fixture
+
+The language-neutral fixture is
+`code/specs/fixtures/vault-pm-storage-v1.json`. It fixes identifiers, byte
+payloads, bounds, operations, and expected outcomes. Implementations MUST run
+the equivalent sequence through their public interface.
+
+The reusable conformance runner verifies at minimum:
+
+1. initialization is idempotent and locator-bound;
+2. pre-initialization operations fail closed;
+3. absent `get` and `stat` return `None`;
+4. immutable put distinguishes create, replay, and conflicting bytes;
+5. get returns exact bytes and stat returns exact length;
+6. pagination is ordered, unique, cursor-bound, and exhaustive;
+7. invalid limits and cursors fail without backend mutation;
+8. optional deletion behavior matches its capability;
+9. optional change-feed behavior matches its capability;
+10. bodies and identifier bytes are absent from debug/errors;
+11. ambiguous-after-commit retry converges to `AlreadyPresent`;
+12. stale and corrupted reads remain detectable by the repository-facing test.
+
+An adapter passes only when the baseline suite succeeds with its optional
+capabilities both enabled where supported and disabled/fallback where not.
+
+## 11. Package boundary
+
+`vault-pm-storage` owns only values, the trait, the reusable conformance runner,
+the in-memory model, and deterministic fault injection. It MUST NOT import a
+filesystem, HTTP client, OAuth SDK, provider SDK, record codec, custody provider,
+clock, or randomness source.
+
+Later packages own:
+
+- `vault-pm-storage-storage-core`: mapping bucket/object IDs to opaque
+  `storage-core` namespace/key values;
+- provider adapters such as Google Drive, WebDAV, and S3;
+- caching, retry, rate limiting, metrics, and replica-set decorators;
+- repository verification, publication ordering, discovery, merge, and GC.
+
+## 12. Acceptance gates
+
+- the spec, fixture, Rust model, README, changelog, and capability manifest agree;
+- the reference backend passes the reusable suite with pagination limits of 1,
+  2, and the maximum allowed value;
+- property-style generated object sets preserve sorted exhaustive listing and
+  immutable replay behavior;
+- fault actions are one-shot, deterministic, and cannot leak bodies;
+- line and branch coverage exceed 90%;
+- clippy passes with warnings denied;
+- the monorepo build graph recognizes the new package and affected closure;
+- no filesystem, network, process, environment, clock, CSPRNG, or secret-key
+  capability is declared or used.
+

--- a/code/specs/fixtures/vault-pm-storage-v1.json
+++ b/code/specs/fixtures/vault-pm-storage-v1.json
@@ -1,0 +1,54 @@
+{
+  "fixture": "VLT-PM-STORAGE-CONFORMANCE",
+  "version": 1,
+  "encoding": {
+    "fixed_bytes": "lowercase hexadecimal",
+    "body": "lowercase hexadecimal",
+    "ordering": "ascending unsigned bytewise"
+  },
+  "limits": {
+    "object_bytes": 67108864,
+    "list_limit": 10000,
+    "cursor_bytes": 256,
+    "provider_revision_bytes": 256,
+    "change_events": 1000
+  },
+  "values": {
+    "locator": "1111111111111111111111111111111111111111111111111111111111111111",
+    "other_locator": "1212121212121212121212121212121212121212121212121212121212121212",
+    "bucket": "2121212121212121212121212121212121212121212121212121212121212121",
+    "other_bucket": "2222222222222222222222222222222222222222222222222222222222222222",
+    "object": "3131313131313131313131313131313131313131313131313131313131313131",
+    "body": "7661756c742d706d2d73746f726167652d66697874757265",
+    "conflicting_body": "646966666572656e74"
+  },
+  "operations": [
+    { "call": "get", "before_initialize": true, "expect_error": "NotInitialized" },
+    { "call": "initialize", "locator": "locator", "expect": "Ok" },
+    { "call": "initialize", "locator": "locator", "expect": "Ok" },
+    { "call": "initialize", "locator": "other_locator", "expect_error": "Conflict" },
+    { "call": "get", "object": "object", "expect": null },
+    { "call": "stat", "object": "object", "expect": null },
+    { "call": "put_immutable", "object": "object", "body": "body", "expect": "Created" },
+    { "call": "put_immutable", "object": "object", "body": "body", "expect": "AlreadyPresent" },
+    { "call": "put_immutable", "object": "object", "body": "conflicting_body", "expect_error": "Corruption" },
+    { "call": "get", "object": "object", "expect_body": "body" },
+    { "call": "stat", "object": "object", "expect_body_len": 24 },
+    { "call": "list", "limit": 0, "expect_error": "InvalidInput.ListLimit" },
+    { "call": "list", "limit": 10001, "expect_error": "InvalidInput.ListLimit" }
+  ],
+  "pagination_objects": [
+    "0101010101010101010101010101010101010101010101010101010101010101",
+    "2020202020202020202020202020202020202020202020202020202020202020",
+    "4040404040404040404040404040404040404040404040404040404040404040",
+    "8080808080808080808080808080808080808080808080808080808080808080",
+    "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"
+  ],
+  "faults": [
+    { "operation": "get", "effect": "Return.Authorization", "one_shot": true },
+    { "operation": "get", "effect": "CorruptGet", "mutates_inner": false },
+    { "operation": "list", "effect": "OmitLastListEntry", "conforming_response": false },
+    { "operation": "list", "effect": "DuplicateFirstListEntry", "conforming_response": false },
+    { "operation": "put_immutable", "effect": "CommitPutThenNetwork", "retry_expect": "AlreadyPresent" }
+  ]
+}


### PR DESCRIPTION
## Summary

- specify the VLT-PM02 provider-neutral immutable object-store contract and shared V1 fixture
- add redacted bounded storage values, capability reporting, typed errors, and VLT-PM01 object-ID conversion
- implement a deterministic thread-safe in-memory backend with exact reads, immutable writes, ordered pagination, optional deletion, and change hints
- add deterministic hostile-storage fault injection and a reusable adapter conformance suite
- bind list cursors to buckets and change cursors to their originating vault locator

## Why

This is Phase 0 item 2 from VLT-PM00. It gives the local repository and future Google Drive, WebDAV, S3, browser, and filesystem adapters one exact baseline contract without giving core product code provider-specific authority.

## Validation

- `cargo test -p coding_adventures_vault_pm_storage` — 19 passed
- `cargo clippy -p coding_adventures_vault_pm_storage -- -D warnings`
- targeted Tarpaulin — 422/447 lines, 94.41%
- capability taxonomy — 7 passed
- language-neutral JSON fixture parsed and cross-checked
- monorepo affected build with clippy — 4/4 packages built
- `git diff --check origin/main...HEAD`

## Security review

- no filesystem, network, process, environment, clock, entropy, or key authority
- object bodies, identifiers, cursors, revisions, and provider messages are absent from Display/Debug errors
- conflicting bytes under one logical object ID fail as corruption
- initialization is locator-bound and all data operations fail closed before it
- cursor scope is validated before traversal/resume

## Backlog

No new product slice was inserted ahead of the existing sequence. After merge, the next prioritization compares the injected random root-KEK custody seam with `vault-pm-domain`.