### PR TITLE
Add bounded Reolink snapshot delivery

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -954,6 +954,7 @@ members = [
     "smart-home-lifx-lan-integration",
     "smart-home-kasa-lan-integration",
     "smart-home-reolink-integration",
+    "smart-home-reolink-snapshot-host",
     "smart-home-axis-vapix-integration",
     "smart-home-axis-snapshot-host",
     "smart-home-blue-iris-integration",

--- a/code/packages/rust/smart-home-reolink-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-reolink-integration/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.0
+
+- Advertise the documented JPEG snapshot capability only for awake, online
+  `RLC-*` physical camera channels so the bounded snapshot host can require an
+  exact installed-device proof.
+
 ## 0.3.0
 
 - Added capability-probed `GetPtzPreset` support, authorized preset recall, and

--- a/code/packages/rust/smart-home-reolink-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-reolink-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smart-home-reolink-integration"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Authenticated Reolink camera and NVR CGI inspection and recording control for the smart-home runtime"
 license = "MIT"

--- a/code/packages/rust/smart-home-reolink-integration/README.md
+++ b/code/packages/rust/smart-home-reolink-integration/README.md
@@ -7,6 +7,8 @@ local HTTP/HTTPS CGI API:
 - bounded login-token, device-information, channel-status, motion-state, and
   logout exchanges;
 - normalized camera-channel and motion-sensor entities;
+- documented JPEG snapshot capability for awake, online `RLC-*` physical
+  channels, composed by `smart-home-reolink-snapshot-host`;
 - capability-probed `GetRecV20` state plus authorized `SetRecV20` recording
   enable/disable with exact readback verification; and
 - capability-probed `GetPtzPreset` support plus authorized preset recall and
@@ -16,10 +18,11 @@ local HTTP/HTTPS CGI API:
 Credentials are zeroized after use and are represented in D23 only by a
 `VaultRef`. Session tokens are redacted and never enter normalized state.
 
-This package does not infer a current PTZ position where firmware offers no
-portable readback. Recording search/download, RTSP media transfer, autonomous
-guard/patrol behavior, webhook events, and ONVIF PullPoint events remain
-separate transport/runtime work.
+This package does not infer snapshot support for NVRs, battery cameras, or
+logical channels, and it does not infer a current PTZ position where firmware
+offers no portable readback. Recording search/download, RTSP media transfer,
+autonomous guard/patrol behavior, webhook events, and ONVIF PullPoint events
+remain separate transport/runtime work.
 
 Set `REOLINK_USERNAME`, `REOLINK_PASSWORD`, and `REOLINK_CREDENTIAL_REF`, then
 run `cargo run -p smart-home-reolink-integration -- inspect <base-url>` to emit

--- a/code/packages/rust/smart-home-reolink-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-reolink-integration/src/lib.rs
@@ -25,9 +25,10 @@ use std::time::Duration;
 use tls_platform::{default_connector, TlsConfig, TlsConnector};
 use url_parser::{Url, UrlError};
 
-pub const VERSION: &str = "0.3.0";
+pub const VERSION: &str = "0.4.0";
 pub const INTEGRATION_ID: &str = "reolink";
 pub const PROTOCOL_ID: &str = "reolink_cgi";
+pub const SNAPSHOT_PATH: &str = "/cgi-bin/api.cgi";
 pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
 pub const MIN_PTZ_SPEED: u32 = 1;
 pub const MAX_PTZ_SPEED: u32 = 64;
@@ -278,6 +279,10 @@ impl ReolinkPtzDirection {
 pub struct ReolinkSnapshot {
     pub device: ReolinkDeviceInformation,
     pub channels: Vec<ReolinkChannelStatus>,
+}
+
+pub fn supports_documented_jpeg_snapshot(model: &str, channel: &ReolinkChannelStatus) -> bool {
+    model.trim().to_ascii_uppercase().starts_with("RLC-") && channel.online && !channel.sleeping
 }
 
 pub trait ReolinkTransport {
@@ -886,6 +891,13 @@ pub fn install_snapshot(
             CapabilityMode::Observe,
             ValueKind::Object,
         )];
+        if supports_documented_jpeg_snapshot(&snapshot.device.model, channel) {
+            camera_capabilities.push(Capability::new(
+                CapabilityId::trusted("camera.snapshot"),
+                CapabilityMode::Command,
+                ValueKind::Text,
+            ));
+        }
         if channel.recording_enabled.is_some() {
             camera_capabilities.push(Capability::camera_recording());
             installed.recording_entity_ids.push(camera_id.clone());
@@ -1797,5 +1809,29 @@ mod tests {
         assert_eq!(record.confidence, DiscoveryConfidence::Paired);
         assert_eq!(record.pairing_requirement, PairingRequirement::Credentials);
         assert_eq!(record.native_bridge_id, "abc123");
+    }
+
+    #[test]
+    fn documented_snapshot_capability_is_limited_to_awake_online_rlc_channels() {
+        let channel = ReolinkChannelStatus {
+            channel: 0,
+            name: "Porch".to_string(),
+            online: true,
+            sleeping: false,
+            motion: None,
+            recording_enabled: None,
+            ptz_presets: None,
+        };
+        assert!(supports_documented_jpeg_snapshot("RLC-520A", &channel));
+
+        let mut offline = channel.clone();
+        offline.online = false;
+        assert!(!supports_documented_jpeg_snapshot("RLC-520A", &offline));
+
+        let mut sleeping = channel.clone();
+        sleeping.sleeping = true;
+        assert!(!supports_documented_jpeg_snapshot("RLC-520A", &sleeping));
+        assert!(!supports_documented_jpeg_snapshot("RLN8-410", &channel));
+        assert!(!supports_documented_jpeg_snapshot("E1 Pro", &channel));
     }
 }

--- a/code/packages/rust/smart-home-reolink-snapshot-host/BUILD
+++ b/code/packages/rust/smart-home-reolink-snapshot-host/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-reolink-snapshot-host -- --nocapture

--- a/code/packages/rust/smart-home-reolink-snapshot-host/CHANGELOG.md
+++ b/code/packages/rust/smart-home-reolink-snapshot-host/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.1.0
+
+- Add exact Human Approval preflight for installed Reolink RLC snapshots.
+- Resolve bounded sealed-Vault credentials into a zeroizing, operation-scoped
+  HTTPS snapshot endpoint.
+- Pin canonical TLS identity and socket address, then remove the endpoint after
+  success and failure.
+- Cover denial-before-Vault, exact channel correspondence, redaction, repeated
+  sealed-record use, and native pinned-TLS JPEG delivery.

--- a/code/packages/rust/smart-home-reolink-snapshot-host/Cargo.toml
+++ b/code/packages/rust/smart-home-reolink-snapshot-host/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "smart-home-reolink-snapshot-host"
+version = "0.1.0"
+edition = "2021"
+description = "Authorized Reolink JPEG snapshot delivery host for the smart-home runtime"
+license = "MIT"
+
+[dependencies]
+coding_adventures_csprng = { path = "../csprng" }
+coding_adventures_vault_leases = { path = "../vault-leases" }
+coding_adventures_vault_sealed_store = { path = "../vault-sealed-store" }
+coding_adventures_zeroize = { path = "../zeroize" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+smart-home-camera-media = { path = "../smart-home-camera-media" }
+smart-home-camera-media-http-executor = { path = "../smart-home-camera-media-http-executor" }
+smart-home-core = { path = "../smart-home-core" }
+smart-home-reolink-integration = { path = "../smart-home-reolink-integration" }
+smart-home-runtime = { path = "../smart-home-runtime" }
+url-parser = { path = "../url-parser" }
+
+[dev-dependencies]
+storage-core = { path = "../storage-core" }
+tls-platform = { path = "../tls-platform" }

--- a/code/packages/rust/smart-home-reolink-snapshot-host/README.md
+++ b/code/packages/rust/smart-home-reolink-snapshot-host/README.md
@@ -1,0 +1,14 @@
+# smart-home-reolink-snapshot-host
+
+Production composition for one bounded Reolink RLC physical-channel snapshot.
+
+The host requires exact D23 Human Approval before Vault or network access,
+validates the installed online and awake RLC camera entity, resolves one bounded
+versioned credential envelope, and registers the documented
+`/cgi-bin/api.cgi?cmd=Snap` HTTPS endpoint against a reviewed canonical host and
+pinned socket. Percent-encoded credentials and the complete endpoint remain in
+zeroizing process-local memory and are removed after every delivery outcome.
+
+The host does not infer support for NVR channels, battery cameras, or excluded
+model families. Streams, recordings, playback, logical-channel snapshots, and
+broader media transfer remain outside this package.

--- a/code/packages/rust/smart-home-reolink-snapshot-host/src/lib.rs
+++ b/code/packages/rust/smart-home-reolink-snapshot-host/src/lib.rs
@@ -1,0 +1,507 @@
+//! Authorized production host for bounded Reolink camera snapshots.
+
+#![forbid(unsafe_code)]
+
+use coding_adventures_csprng::random_array;
+use coding_adventures_vault_leases::LeasePayload;
+use coding_adventures_vault_sealed_store::SealedStore;
+use coding_adventures_zeroize::Zeroizing;
+use serde::{Deserialize, Deserializer, Serialize};
+use smart_home_camera_media::{
+    CameraMediaAccessRequest, CameraMediaClock, CameraMediaConnectionTarget, CameraMediaDelivery,
+    CameraMediaError, CameraMediaExecutor, CameraMediaKind, CameraMediaNonceError,
+    CameraMediaNonceSource, CameraMediaPolicy, CameraMediaPrincipalSource, CameraMediaService,
+};
+use smart_home_camera_media_http_executor::CameraMediaHttpExecutor;
+use smart_home_core::{
+    BridgeId, CapabilityId, CapabilityMode, EntityId, EntityKind, Health, IntegrationId, Value,
+    VaultRef,
+};
+use smart_home_reolink_integration::{ReolinkConfig, INTEGRATION_ID, SNAPSHOT_PATH};
+use smart_home_runtime::SmartHomeRuntime;
+use std::fmt::{self, Write as _};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use url_parser::Url;
+
+pub const VERSION: &str = "0.1.0";
+pub const REOLINK_VAULT_NAMESPACE: &str = "smart_home.reolink.credentials";
+pub const REOLINK_VAULT_REF_PREFIX: &str = "vault://smart-home/reolink/";
+pub const MAX_CREDENTIAL_FIELD_BYTES: usize = 1_024;
+pub const MAX_CREDENTIAL_PAYLOAD_BYTES: usize = MAX_CREDENTIAL_FIELD_BYTES * 2 + 256;
+const SNAPSHOT_REQUEST_TAG: &str = "smart-home-d23";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReolinkCredentialSourceError;
+
+pub trait ReolinkCredentialSource {
+    fn resolve(&self, vault_ref: &VaultRef) -> Result<LeasePayload, ReolinkCredentialSourceError>;
+}
+
+pub struct ReolinkSealedStoreCredentialSource {
+    vault: Arc<SealedStore>,
+}
+
+impl ReolinkSealedStoreCredentialSource {
+    pub fn new(vault: Arc<SealedStore>) -> Self {
+        Self { vault }
+    }
+}
+
+impl ReolinkCredentialSource for ReolinkSealedStoreCredentialSource {
+    fn resolve(&self, vault_ref: &VaultRef) -> Result<LeasePayload, ReolinkCredentialSourceError> {
+        let key = reolink_vault_record_key(vault_ref).ok_or(ReolinkCredentialSourceError)?;
+        let record = self
+            .vault
+            .get(REOLINK_VAULT_NAMESPACE, key)
+            .map_err(|_| ReolinkCredentialSourceError)?
+            .ok_or(ReolinkCredentialSourceError)?;
+        Ok(LeasePayload::new(record.plaintext.into_inner()))
+    }
+}
+
+pub fn reolink_vault_record_key(vault_ref: &VaultRef) -> Option<&str> {
+    vault_ref
+        .as_str()
+        .strip_prefix(REOLINK_VAULT_REF_PREFIX)
+        .filter(|key| !key.is_empty())
+}
+
+#[derive(Clone)]
+pub struct ReolinkSnapshotEndpoint {
+    bridge_id: BridgeId,
+    connection_target: CameraMediaConnectionTarget,
+}
+
+impl ReolinkSnapshotEndpoint {
+    pub fn new(bridge_id: BridgeId, connection_target: CameraMediaConnectionTarget) -> Self {
+        Self {
+            bridge_id,
+            connection_target,
+        }
+    }
+}
+
+impl fmt::Debug for ReolinkSnapshotEndpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ReolinkSnapshotEndpoint")
+            .field("bridge_id", &self.bridge_id)
+            .field("connection_target", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReolinkSnapshotRequest {
+    pub entity_id: EntityId,
+    pub purpose: String,
+    pub ttl_ms: u64,
+}
+
+impl ReolinkSnapshotRequest {
+    pub fn new(entity_id: EntityId, purpose: impl Into<String>, ttl_ms: u64) -> Self {
+        Self {
+            entity_id,
+            purpose: purpose.into(),
+            ttl_ms,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReolinkSnapshotHostError {
+    InvalidRequest,
+    InvalidTarget,
+    MissingCredentialReference,
+    CredentialResolutionRejected,
+    InvalidCredentialPayload,
+    EndpointAlreadyRegistered,
+    EndpointRegistrationRejected,
+    EndpointRemovalFailed,
+    Media(CameraMediaError),
+}
+
+impl fmt::Display for ReolinkSnapshotHostError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidRequest => "invalid Reolink snapshot request",
+            Self::InvalidTarget => "snapshot target is not an installed Reolink RLC channel",
+            Self::MissingCredentialReference => "Reolink bridge has no credential reference",
+            Self::CredentialResolutionRejected => "Reolink credential lookup was rejected",
+            Self::InvalidCredentialPayload => "Reolink credential payload is invalid",
+            Self::EndpointAlreadyRegistered => "Reolink snapshot endpoint is already registered",
+            Self::EndpointRegistrationRejected => "Reolink snapshot endpoint registration failed",
+            Self::EndpointRemovalFailed => "Reolink snapshot endpoint removal failed",
+            Self::Media(error) => return error.fmt(formatter),
+        })
+    }
+}
+
+impl std::error::Error for ReolinkSnapshotHostError {}
+
+impl From<CameraMediaError> for ReolinkSnapshotHostError {
+    fn from(value: CameraMediaError) -> Self {
+        Self::Media(value)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CredentialEnvelope {
+    schema_version: u64,
+    #[serde(deserialize_with = "deserialize_secret_string")]
+    username: Zeroizing<String>,
+    #[serde(deserialize_with = "deserialize_secret_string")]
+    password: Zeroizing<String>,
+}
+
+#[derive(Serialize)]
+struct BorrowedCredentialEnvelope<'a> {
+    schema_version: u64,
+    username: &'a str,
+    password: &'a str,
+}
+
+pub fn encode_reolink_credentials(
+    username: &str,
+    password: &str,
+) -> Result<LeasePayload, ReolinkSnapshotHostError> {
+    validate_credential_fields(username, password)?;
+    let bytes = Zeroizing::new(
+        serde_json::to_vec(&BorrowedCredentialEnvelope {
+            schema_version: 1,
+            username,
+            password,
+        })
+        .map_err(|_| ReolinkSnapshotHostError::InvalidCredentialPayload)?,
+    );
+    if bytes.len() > MAX_CREDENTIAL_PAYLOAD_BYTES {
+        return Err(ReolinkSnapshotHostError::InvalidCredentialPayload);
+    }
+    Ok(LeasePayload::new(bytes.into_inner()))
+}
+
+pub struct SystemCameraMediaClock;
+
+impl CameraMediaClock for SystemCameraMediaClock {
+    fn now_ms(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX)
+    }
+}
+
+pub struct OsCameraMediaNonceSource;
+
+impl CameraMediaNonceSource for OsCameraMediaNonceSource {
+    fn fill_nonce(&mut self, output: &mut [u8; 16]) -> Result<(), CameraMediaNonceError> {
+        *output = random_array().map_err(|_| CameraMediaNonceError)?;
+        Ok(())
+    }
+}
+
+pub struct ReolinkSnapshotHost<Clock, Nonce, Principals, Executor, Credentials>
+where
+    Clock: CameraMediaClock,
+    Nonce: CameraMediaNonceSource,
+    Principals: CameraMediaPrincipalSource,
+    Executor: CameraMediaExecutor,
+    Credentials: ReolinkCredentialSource,
+{
+    media: CameraMediaService<Clock, Nonce, Principals, Executor>,
+    credentials: Credentials,
+    endpoint: ReolinkSnapshotEndpoint,
+    max_snapshot_ttl_ms: u64,
+}
+
+impl<Clock, Nonce, Principals, Executor, Credentials>
+    ReolinkSnapshotHost<Clock, Nonce, Principals, Executor, Credentials>
+where
+    Clock: CameraMediaClock,
+    Nonce: CameraMediaNonceSource,
+    Principals: CameraMediaPrincipalSource,
+    Executor: CameraMediaExecutor,
+    Credentials: ReolinkCredentialSource,
+{
+    pub fn new(
+        policy: CameraMediaPolicy,
+        clock: Clock,
+        nonce_source: Nonce,
+        principal_source: Principals,
+        executor: Executor,
+        credentials: Credentials,
+        endpoint: ReolinkSnapshotEndpoint,
+    ) -> Self {
+        let max_snapshot_ttl_ms = policy.max_snapshot_ttl_ms;
+        Self {
+            media: CameraMediaService::new(policy, clock, nonce_source, principal_source, executor),
+            credentials,
+            endpoint,
+            max_snapshot_ttl_ms,
+        }
+    }
+
+    pub fn deliver_snapshot(
+        &mut self,
+        runtime: &SmartHomeRuntime,
+        request: ReolinkSnapshotRequest,
+    ) -> Result<CameraMediaDelivery, ReolinkSnapshotHostError> {
+        self.validate_request(&request)?;
+        self.media
+            .authorize_access(runtime, &request.entity_id, CameraMediaKind::Snapshot)?;
+        if self
+            .media
+            .has_endpoint(&request.entity_id, CameraMediaKind::Snapshot)
+        {
+            return Err(ReolinkSnapshotHostError::EndpointAlreadyRegistered);
+        }
+        let target = installed_target(runtime, &request.entity_id, &self.endpoint)?;
+        let payload = self
+            .credentials
+            .resolve(&target.credential_ref)
+            .map_err(|_| ReolinkSnapshotHostError::CredentialResolutionRejected)?;
+        let credentials = decode_credentials(payload.as_bytes())?;
+        drop(payload);
+        let snapshot_uri = build_snapshot_uri(&target.base_url, target.channel, &credentials);
+        drop(credentials);
+
+        self.media
+            .register_pinned_endpoint(
+                request.entity_id.clone(),
+                CameraMediaKind::Snapshot,
+                snapshot_uri,
+                self.endpoint.connection_target.clone(),
+            )
+            .map_err(|_| ReolinkSnapshotHostError::EndpointRegistrationRejected)?;
+
+        let delivery = (|| {
+            let lease = self.media.issue_lease(
+                runtime,
+                CameraMediaAccessRequest::new(
+                    request.entity_id.clone(),
+                    CameraMediaKind::Snapshot,
+                    request.purpose,
+                    request.ttl_ms,
+                ),
+            )?;
+            self.media
+                .deliver_lease(runtime, &lease.lease_id)
+                .map_err(Into::into)
+        })();
+        if !self
+            .media
+            .unregister_endpoint(&request.entity_id, CameraMediaKind::Snapshot)
+        {
+            return Err(ReolinkSnapshotHostError::EndpointRemovalFailed);
+        }
+        delivery
+    }
+
+    pub fn media_snapshot(&self) -> smart_home_camera_media::CameraMediaBrokerSnapshot {
+        self.media.snapshot()
+    }
+
+    fn validate_request(
+        &self,
+        request: &ReolinkSnapshotRequest,
+    ) -> Result<(), ReolinkSnapshotHostError> {
+        if request.purpose.trim().is_empty()
+            || request.ttl_ms == 0
+            || request.ttl_ms > self.max_snapshot_ttl_ms
+        {
+            return Err(ReolinkSnapshotHostError::InvalidRequest);
+        }
+        Ok(())
+    }
+}
+
+impl<Principals, Credentials>
+    ReolinkSnapshotHost<
+        SystemCameraMediaClock,
+        OsCameraMediaNonceSource,
+        Principals,
+        CameraMediaHttpExecutor,
+        Credentials,
+    >
+where
+    Principals: CameraMediaPrincipalSource,
+    Credentials: ReolinkCredentialSource,
+{
+    pub fn production(
+        principal_source: Principals,
+        credentials: Credentials,
+        endpoint: ReolinkSnapshotEndpoint,
+    ) -> Self {
+        Self::new(
+            CameraMediaPolicy::default(),
+            SystemCameraMediaClock,
+            OsCameraMediaNonceSource,
+            principal_source,
+            CameraMediaHttpExecutor::default(),
+            credentials,
+            endpoint,
+        )
+    }
+}
+
+struct InstalledTarget {
+    credential_ref: VaultRef,
+    base_url: String,
+    channel: u32,
+}
+
+fn installed_target(
+    runtime: &SmartHomeRuntime,
+    entity_id: &EntityId,
+    endpoint: &ReolinkSnapshotEndpoint,
+) -> Result<InstalledTarget, ReolinkSnapshotHostError> {
+    let registry = runtime.registry();
+    let entity = registry
+        .entity(entity_id)
+        .ok_or(ReolinkSnapshotHostError::InvalidTarget)?;
+    let device = registry
+        .device(&entity.device_id)
+        .ok_or(ReolinkSnapshotHostError::InvalidTarget)?;
+    let bridge = registry
+        .bridge(&device.bridge_id)
+        .ok_or(ReolinkSnapshotHostError::InvalidTarget)?;
+    let channel = entity
+        .metadata
+        .iter()
+        .find(|metadata| metadata.key == "reolink.channel")
+        .and_then(|metadata| metadata.value.parse::<u32>().ok())
+        .ok_or(ReolinkSnapshotHostError::InvalidTarget)?;
+    let snapshot_capability = entity.capabilities.iter().any(|capability| {
+        capability.capability_id == CapabilityId::trusted("camera.snapshot")
+            && capability.mode == CapabilityMode::Command
+    });
+    let expected_entity_id = EntityId::trusted(format!("{}:camera", device.device_id.as_str()));
+    let current_channel = matches!(
+        entity.state.as_ref().map(|state| &state.value),
+        Some(Value::Object(fields))
+            if fields.iter().any(|(key, value)| key == "online" && *value == Value::Bool(true))
+                && fields.iter().any(|(key, value)| key == "sleeping" && *value == Value::Bool(false))
+    );
+    if entity.kind != EntityKind::Camera
+        || *entity_id != expected_entity_id
+        || !device.entity_ids.contains(entity_id)
+        || device.health != Health::Online
+        || !device.model.trim().to_ascii_uppercase().starts_with("RLC-")
+        || bridge.bridge_id != endpoint.bridge_id
+        || bridge.integration_id != IntegrationId::trusted(INTEGRATION_ID)
+        || !snapshot_capability
+        || !current_channel
+    {
+        return Err(ReolinkSnapshotHostError::InvalidTarget);
+    }
+    let credential_ref = bridge
+        .auth_ref
+        .clone()
+        .ok_or(ReolinkSnapshotHostError::MissingCredentialReference)?;
+    let base_url = bridge
+        .address
+        .clone()
+        .ok_or(ReolinkSnapshotHostError::InvalidTarget)?;
+    let config = ReolinkConfig::new(bridge.bridge_id.clone(), base_url, credential_ref.clone())
+        .map_err(|_| ReolinkSnapshotHostError::InvalidTarget)?;
+    validate_connection_target(&config.base_url, &endpoint.connection_target)?;
+    Ok(InstalledTarget {
+        credential_ref,
+        base_url: config.base_url,
+        channel,
+    })
+}
+
+fn validate_connection_target(
+    base_url: &str,
+    connection_target: &CameraMediaConnectionTarget,
+) -> Result<(), ReolinkSnapshotHostError> {
+    let parsed = Url::parse(base_url).map_err(|_| ReolinkSnapshotHostError::InvalidTarget)?;
+    let host = parsed
+        .host
+        .as_deref()
+        .ok_or(ReolinkSnapshotHostError::InvalidTarget)?;
+    if !host.eq_ignore_ascii_case(connection_target.canonical_host())
+        || parsed.effective_port() != Some(connection_target.pinned_address().port())
+        || !matches!(parsed.path.as_str(), "" | "/")
+        || parsed.query.is_some()
+        || parsed.fragment.is_some()
+        || (parsed.scheme != "https"
+            && (parsed.scheme != "http"
+                || !is_loopback_host(host)
+                || !connection_target.pinned_address().ip().is_loopback()))
+    {
+        return Err(ReolinkSnapshotHostError::InvalidTarget);
+    }
+    Ok(())
+}
+
+fn build_snapshot_uri(base_url: &str, channel: u32, credentials: &CredentialEnvelope) -> String {
+    let username = encode_query_secret(&credentials.username);
+    let password = encode_query_secret(&credentials.password);
+    let origin = base_url.trim_end_matches('/');
+    format!(
+        "{origin}{SNAPSHOT_PATH}?cmd=Snap&channel={channel}&rs={SNAPSHOT_REQUEST_TAG}&user={}&password={}",
+        username.as_str(),
+        password.as_str()
+    )
+}
+
+fn decode_credentials(bytes: &[u8]) -> Result<CredentialEnvelope, ReolinkSnapshotHostError> {
+    if bytes.len() > MAX_CREDENTIAL_PAYLOAD_BYTES {
+        return Err(ReolinkSnapshotHostError::InvalidCredentialPayload);
+    }
+    let envelope: CredentialEnvelope = serde_json::from_slice(bytes)
+        .map_err(|_| ReolinkSnapshotHostError::InvalidCredentialPayload)?;
+    if envelope.schema_version != 1 {
+        return Err(ReolinkSnapshotHostError::InvalidCredentialPayload);
+    }
+    validate_credential_fields(&envelope.username, &envelope.password)?;
+    Ok(envelope)
+}
+
+fn deserialize_secret_string<'de, D>(deserializer: D) -> Result<Zeroizing<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(deserializer).map(Zeroizing::new)
+}
+
+fn validate_credential_fields(
+    username: &str,
+    password: &str,
+) -> Result<(), ReolinkSnapshotHostError> {
+    if username.trim().is_empty()
+        || password.is_empty()
+        || username.len() > MAX_CREDENTIAL_FIELD_BYTES
+        || password.len() > MAX_CREDENTIAL_FIELD_BYTES
+        || username.chars().any(char::is_control)
+        || password.chars().any(char::is_control)
+    {
+        return Err(ReolinkSnapshotHostError::InvalidCredentialPayload);
+    }
+    Ok(())
+}
+
+fn encode_query_secret(value: &str) -> Zeroizing<String> {
+    let mut encoded = Zeroizing::new(String::with_capacity(value.len()));
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            write!(&mut *encoded, "%{byte:02X}").expect("writing to a String cannot fail");
+        }
+    }
+    encoded
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
+        || host == "127.0.0.1"
+        || host == "::1"
+        || host.starts_with("127.")
+}

--- a/code/packages/rust/smart-home-reolink-snapshot-host/tests/host.rs
+++ b/code/packages/rust/smart-home-reolink-snapshot-host/tests/host.rs
@@ -1,0 +1,655 @@
+use coding_adventures_vault_leases::LeasePayload;
+use coding_adventures_vault_sealed_store::{InitOptions, SealedStore};
+use smart_home_camera_media::{
+    CameraMediaClock, CameraMediaConnectionTarget, CameraMediaExecution, CameraMediaExecutionError,
+    CameraMediaExecutionResult, CameraMediaExecutor, CameraMediaNonceError, CameraMediaNonceSource,
+    CameraMediaPolicy, CameraMediaPrincipalSource,
+};
+use smart_home_camera_media_http_executor::{CameraMediaHttpExecutor, CameraMediaHttpPolicy};
+use smart_home_core::{
+    AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityGrant, CapabilityGrantId,
+    CapabilityMode, Device, DeviceId, Entity, EntityId, EntityKind, Health, IntegrationId,
+    Metadata, PrivilegeTier, StateConfidence, StateSnapshot, StateSource, Value, ValueKind,
+    VaultRef,
+};
+use smart_home_reolink_snapshot_host::{
+    encode_reolink_credentials, ReolinkCredentialSource, ReolinkCredentialSourceError,
+    ReolinkSealedStoreCredentialSource, ReolinkSnapshotEndpoint, ReolinkSnapshotHost,
+    ReolinkSnapshotHostError, ReolinkSnapshotRequest, REOLINK_VAULT_NAMESPACE,
+    REOLINK_VAULT_REF_PREFIX,
+};
+use smart_home_runtime::SmartHomeRuntime;
+use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
+use std::io::{Cursor, Read, Write};
+use std::net::SocketAddr;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+use storage_core::{InMemoryStorageBackend, StorageBackend};
+use tls_platform::{
+    TlsConfig, TlsConnectionSummary, TlsConnector, TlsError, TlsStream, TlsVersion,
+};
+
+#[derive(Clone)]
+struct FixedClock(u64);
+
+impl CameraMediaClock for FixedClock {
+    fn now_ms(&self) -> u64 {
+        self.0
+    }
+}
+
+struct TestNonce(u8);
+
+impl CameraMediaNonceSource for TestNonce {
+    fn fill_nonce(&mut self, output: &mut [u8; 16]) -> Result<(), CameraMediaNonceError> {
+        output.fill(self.0);
+        self.0 = self.0.wrapping_add(1);
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct FixedPrincipal(Option<AgentId>);
+
+impl CameraMediaPrincipalSource for FixedPrincipal {
+    fn current_principal(&self) -> Option<AgentId> {
+        self.0.clone()
+    }
+}
+
+#[derive(Clone)]
+struct TestCredentials {
+    resolve_count: Rc<Cell<usize>>,
+    payload: LeasePayload,
+}
+
+impl TestCredentials {
+    fn new(payload: LeasePayload) -> Self {
+        Self {
+            resolve_count: Rc::new(Cell::new(0)),
+            payload,
+        }
+    }
+
+    fn resolve_count(&self) -> usize {
+        self.resolve_count.get()
+    }
+}
+
+impl ReolinkCredentialSource for TestCredentials {
+    fn resolve(&self, _vault_ref: &VaultRef) -> Result<LeasePayload, ReolinkCredentialSourceError> {
+        self.resolve_count.set(self.resolve_count.get() + 1);
+        Ok(self.payload.clone())
+    }
+}
+
+#[derive(Default)]
+struct ExecutorState {
+    delivery_count: usize,
+    last_endpoint: Option<String>,
+    fail_delivery: bool,
+}
+
+struct TestExecutor(Rc<RefCell<ExecutorState>>);
+
+impl CameraMediaExecutor for TestExecutor {
+    type Stream = ();
+
+    fn deliver(
+        &mut self,
+        execution: CameraMediaExecution<'_>,
+    ) -> Result<CameraMediaExecutionResult<Self::Stream>, CameraMediaExecutionError> {
+        let mut state = self.0.borrow_mut();
+        assert!(execution.connection_target().is_some());
+        state.delivery_count += 1;
+        state.last_endpoint = Some(execution.endpoint_uri().to_string());
+        if state.fail_delivery {
+            return Err(CameraMediaExecutionError::Unavailable);
+        }
+        Ok(CameraMediaExecutionResult::snapshot(vec![
+            0xff, 0xd8, 0xff, 0xd9,
+        ]))
+    }
+
+    fn close_stream(
+        &mut self,
+        _stream: &mut Self::Stream,
+    ) -> Result<(), CameraMediaExecutionError> {
+        Err(CameraMediaExecutionError::Rejected)
+    }
+}
+
+type TestHost =
+    ReolinkSnapshotHost<FixedClock, TestNonce, FixedPrincipal, TestExecutor, TestCredentials>;
+
+struct Fixture {
+    runtime: SmartHomeRuntime,
+    entity_id: EntityId,
+    credentials: TestCredentials,
+    state: Rc<RefCell<ExecutorState>>,
+    host: TestHost,
+}
+
+fn fixture_runtime(granted: bool, base_url: &str) -> (SmartHomeRuntime, EntityId, AgentId) {
+    let mut runtime = SmartHomeRuntime::new();
+    let bridge_id = BridgeId::trusted("bridge:reolink:test");
+    let device_id = DeviceId::trusted("reolink:abc123:ch0");
+    let entity_id = EntityId::trusted("reolink:abc123:ch0:camera");
+    let principal_id = AgentId::trusted("operator");
+    let mut bridge = Bridge::new(
+        bridge_id.clone(),
+        IntegrationId::trusted("reolink"),
+        BridgeTransport::LanHttp,
+    );
+    bridge.address = Some(base_url.to_string());
+    bridge.auth_ref = Some(VaultRef::trusted("vault://fixture/reolink"));
+    runtime.upsert_bridge(bridge).unwrap();
+    runtime
+        .upsert_device(Device {
+            device_id: device_id.clone(),
+            bridge_id,
+            manufacturer: "Reolink".to_string(),
+            model: "RLC-520A".to_string(),
+            name: "Driveway".to_string(),
+            serial: None,
+            firmware_version: Some("v3.1".to_string()),
+            room_id: None,
+            entity_ids: vec![entity_id.clone()],
+            identifiers: Vec::new(),
+            health: Health::Online,
+            metadata: Vec::new(),
+        })
+        .unwrap();
+    runtime
+        .upsert_entity(Entity {
+            entity_id: entity_id.clone(),
+            device_id,
+            kind: EntityKind::Camera,
+            name: "Driveway".to_string(),
+            capabilities: vec![
+                Capability::new(
+                    smart_home_camera_media::CameraMediaKind::Snapshot.capability_id(),
+                    CapabilityMode::Command,
+                    ValueKind::Text,
+                ),
+                Capability::new(
+                    smart_home_core::CapabilityId::trusted("camera.health"),
+                    CapabilityMode::Observe,
+                    ValueKind::Object,
+                ),
+            ],
+            state: Some(StateSnapshot {
+                entity_id: entity_id.clone(),
+                value: Value::Object(vec![
+                    ("online".to_string(), Value::Bool(true)),
+                    ("sleeping".to_string(), Value::Bool(false)),
+                ]),
+                source: StateSource::Poll,
+                observed_at_ms: 1,
+                received_at_ms: 1,
+                expires_at_ms: None,
+                confidence: StateConfidence::Confirmed,
+            }),
+            metadata: vec![Metadata::new("reolink.channel", "0")],
+        })
+        .unwrap();
+    if granted {
+        runtime
+            .registry_mut()
+            .upsert_capability_grant(CapabilityGrant::for_entity_capability(
+                CapabilityGrantId::trusted("grant:reolink-snapshot"),
+                principal_id.clone(),
+                entity_id.clone(),
+                smart_home_camera_media::CameraMediaKind::Snapshot.capability_id(),
+                PrivilegeTier::HumanApproval,
+                "user",
+                1,
+            ));
+    }
+    (runtime, entity_id, principal_id)
+}
+
+fn test_host(granted: bool, fail_delivery: bool) -> Fixture {
+    let address: SocketAddr = "192.0.2.25:443".parse().unwrap();
+    let (runtime, entity_id, principal_id) = fixture_runtime(granted, "https://reolink.home");
+    let credentials =
+        TestCredentials::new(encode_reolink_credentials("camera-user", "camera-secret").unwrap());
+    let state = Rc::new(RefCell::new(ExecutorState {
+        fail_delivery,
+        ..ExecutorState::default()
+    }));
+    let host = ReolinkSnapshotHost::new(
+        CameraMediaPolicy::default(),
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        TestExecutor(state.clone()),
+        credentials.clone(),
+        ReolinkSnapshotEndpoint::new(
+            BridgeId::trusted("bridge:reolink:test"),
+            CameraMediaConnectionTarget::new("reolink.home", address),
+        ),
+    );
+    Fixture {
+        runtime,
+        entity_id,
+        credentials,
+        state,
+        host,
+    }
+}
+
+#[test]
+fn authorized_delivery_uses_exact_channel_endpoint_and_cleans_it() {
+    let mut fixture = test_host(true, false);
+    let delivery = fixture
+        .host
+        .deliver_snapshot(
+            &fixture.runtime,
+            ReolinkSnapshotRequest::new(fixture.entity_id, "operator preview", 5_000),
+        )
+        .unwrap();
+
+    assert_eq!(
+        delivery.snapshot_bytes(),
+        Some(&[0xff, 0xd8, 0xff, 0xd9][..])
+    );
+    assert_eq!(fixture.credentials.resolve_count(), 1);
+    let state = fixture.state.borrow();
+    assert_eq!(state.delivery_count, 1);
+    assert_eq!(
+        state.last_endpoint.as_deref(),
+        Some("https://reolink.home/cgi-bin/api.cgi?cmd=Snap&channel=0&rs=smart-home-d23&user=camera-user&password=camera-secret")
+    );
+    drop(state);
+    assert_eq!(fixture.host.media_snapshot().endpoint_count, 0);
+}
+
+#[test]
+fn denial_happens_before_vault_endpoint_or_delivery() {
+    let mut fixture = test_host(false, false);
+    let error = fixture
+        .host
+        .deliver_snapshot(
+            &fixture.runtime,
+            ReolinkSnapshotRequest::new(fixture.entity_id, "operator preview", 5_000),
+        )
+        .unwrap_err();
+
+    assert!(matches!(error, ReolinkSnapshotHostError::Media(_)));
+    assert_eq!(fixture.credentials.resolve_count(), 0);
+    assert_eq!(fixture.state.borrow().delivery_count, 0);
+    assert_eq!(fixture.host.media_snapshot().endpoint_count, 0);
+}
+
+#[test]
+fn failed_delivery_still_removes_the_token_bearing_endpoint() {
+    let mut fixture = test_host(true, true);
+    let error = fixture
+        .host
+        .deliver_snapshot(
+            &fixture.runtime,
+            ReolinkSnapshotRequest::new(fixture.entity_id, "operator preview", 5_000),
+        )
+        .unwrap_err();
+
+    assert!(matches!(error, ReolinkSnapshotHostError::Media(_)));
+    assert_eq!(fixture.state.borrow().delivery_count, 1);
+    assert_eq!(fixture.host.media_snapshot().endpoint_count, 0);
+}
+
+#[test]
+fn unsupported_or_stale_channel_is_rejected_before_vault() {
+    let mut fixture = test_host(true, false);
+    let mut device = fixture
+        .runtime
+        .registry()
+        .device(&DeviceId::trusted("reolink:abc123:ch0"))
+        .unwrap()
+        .clone();
+    device.model = "RLN8-410".to_string();
+    fixture.runtime.upsert_device(device).unwrap();
+
+    assert_eq!(
+        fixture
+            .host
+            .deliver_snapshot(
+                &fixture.runtime,
+                ReolinkSnapshotRequest::new(fixture.entity_id, "operator preview", 5_000),
+            )
+            .unwrap_err(),
+        ReolinkSnapshotHostError::InvalidTarget
+    );
+    assert_eq!(fixture.credentials.resolve_count(), 0);
+}
+
+#[test]
+fn malformed_credentials_are_redacted_and_never_delivered() {
+    let address: SocketAddr = "192.0.2.25:443".parse().unwrap();
+    let (runtime, entity_id, principal_id) = fixture_runtime(true, "https://reolink.home");
+    let secret = "raw-reolink-password";
+    let credentials = TestCredentials::new(LeasePayload::new(
+        format!(r#"{{"username":"camera","password":"{secret}","extra":true}}"#).into_bytes(),
+    ));
+    let state = Rc::new(RefCell::new(ExecutorState::default()));
+    let mut host = ReolinkSnapshotHost::new(
+        CameraMediaPolicy::default(),
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        TestExecutor(state.clone()),
+        credentials,
+        ReolinkSnapshotEndpoint::new(
+            BridgeId::trusted("bridge:reolink:test"),
+            CameraMediaConnectionTarget::new("reolink.home", address),
+        ),
+    );
+
+    let error = host
+        .deliver_snapshot(
+            &runtime,
+            ReolinkSnapshotRequest::new(entity_id, "operator preview", 5_000),
+        )
+        .unwrap_err();
+    let diagnostics = format!("{error:?} {error}");
+    assert!(!diagnostics.contains(secret));
+    assert_eq!(state.borrow().delivery_count, 0);
+    assert_eq!(host.media_snapshot().endpoint_count, 0);
+}
+
+#[test]
+fn sealed_vault_record_supports_repeated_approved_deliveries() {
+    let backend: Arc<dyn StorageBackend> = Arc::new(InMemoryStorageBackend::default());
+    backend.initialize().unwrap();
+    let vault = Arc::new(SealedStore::new(backend));
+    vault
+        .init(
+            b"fixture-password",
+            &InitOptions {
+                argon2id_time_cost: 1,
+                argon2id_memory_kib: 32,
+                argon2id_parallelism: 1,
+                salt_override: Some(vec![9; 16]),
+            },
+        )
+        .unwrap();
+    let payload = encode_reolink_credentials("camera-user", "camera-secret").unwrap();
+    vault
+        .put(
+            REOLINK_VAULT_NAMESPACE,
+            "bridge/main",
+            payload.as_bytes(),
+            None,
+        )
+        .unwrap();
+
+    let address: SocketAddr = "192.0.2.25:443".parse().unwrap();
+    let (mut runtime, entity_id, principal_id) = fixture_runtime(true, "https://reolink.home");
+    let bridge_id = BridgeId::trusted("bridge:reolink:test");
+    let mut bridge = runtime.registry().bridge(&bridge_id).unwrap().clone();
+    bridge.auth_ref = Some(VaultRef::trusted(format!(
+        "{REOLINK_VAULT_REF_PREFIX}bridge/main"
+    )));
+    runtime.upsert_bridge(bridge).unwrap();
+    let state = Rc::new(RefCell::new(ExecutorState::default()));
+    let mut host = ReolinkSnapshotHost::new(
+        CameraMediaPolicy::default(),
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        TestExecutor(state.clone()),
+        ReolinkSealedStoreCredentialSource::new(vault),
+        ReolinkSnapshotEndpoint::new(
+            bridge_id,
+            CameraMediaConnectionTarget::new("reolink.home", address),
+        ),
+    );
+
+    for purpose in ["first preview", "second preview"] {
+        host.deliver_snapshot(
+            &runtime,
+            ReolinkSnapshotRequest::new(entity_id.clone(), purpose, 5_000),
+        )
+        .unwrap();
+    }
+    assert_eq!(state.borrow().delivery_count, 2);
+    assert_eq!(host.media_snapshot().endpoint_count, 0);
+}
+
+#[test]
+fn native_http_executor_uses_pinned_tls_and_percent_encoded_query_credentials() {
+    let address: SocketAddr = "192.0.2.25:443".parse().unwrap();
+    let capture = Arc::new(Mutex::new(TlsCapture::default()));
+    let connector = RecordingConnector::new(
+        VecDeque::from(vec![wire_response("image/jpeg", &[0xff, 0xd8, 0xff, 0xd9])]),
+        Arc::clone(&capture),
+    );
+    let (runtime, entity_id, principal_id) = fixture_runtime(true, "https://reolink.home");
+    let credentials =
+        TestCredentials::new(encode_reolink_credentials("operator+home", "s&ecret/1").unwrap());
+    let executor = CameraMediaHttpExecutor::new(
+        Box::new(connector),
+        TlsConfig::https_default(),
+        CameraMediaHttpPolicy::default(),
+    );
+    let mut host = ReolinkSnapshotHost::new(
+        CameraMediaPolicy::default(),
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        executor,
+        credentials,
+        ReolinkSnapshotEndpoint::new(
+            BridgeId::trusted("bridge:reolink:test"),
+            CameraMediaConnectionTarget::new("reolink.home", address),
+        ),
+    );
+
+    let delivery = host
+        .deliver_snapshot(
+            &runtime,
+            ReolinkSnapshotRequest::new(entity_id, "operator preview", 5_000),
+        )
+        .unwrap();
+    assert_eq!(
+        delivery.snapshot_bytes(),
+        Some(&[0xff, 0xd8, 0xff, 0xd9][..])
+    );
+    assert_eq!(host.media_snapshot().endpoint_count, 0);
+    let capture = capture.lock().unwrap();
+    assert_eq!(capture.requests.len(), 1);
+    let request = String::from_utf8(capture.requests[0].clone()).unwrap();
+    assert!(request.starts_with(
+        "GET /cgi-bin/api.cgi?cmd=Snap&channel=0&rs=smart-home-d23&user=operator%2Bhome&password=s%26ecret%2F1 HTTP/1.1\r\n"
+    ));
+    assert!(!request.contains("s&ecret/1"));
+    assert_eq!(
+        capture.pinned_connections,
+        vec![("reolink.home".to_string(), address)]
+    );
+}
+
+#[test]
+fn root_slash_is_normalized_and_preconfigured_query_data_is_rejected() {
+    let address: SocketAddr = "192.0.2.25:443".parse().unwrap();
+    let (runtime, entity_id, principal_id) = fixture_runtime(true, "https://reolink.home/");
+    let credentials =
+        TestCredentials::new(encode_reolink_credentials("camera-user", "camera-secret").unwrap());
+    let state = Rc::new(RefCell::new(ExecutorState::default()));
+    let mut host = ReolinkSnapshotHost::new(
+        CameraMediaPolicy::default(),
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        TestExecutor(state.clone()),
+        credentials.clone(),
+        ReolinkSnapshotEndpoint::new(
+            BridgeId::trusted("bridge:reolink:test"),
+            CameraMediaConnectionTarget::new("reolink.home", address),
+        ),
+    );
+    host.deliver_snapshot(
+        &runtime,
+        ReolinkSnapshotRequest::new(entity_id, "operator preview", 5_000),
+    )
+    .unwrap();
+    assert_eq!(
+        state.borrow().last_endpoint.as_deref(),
+        Some("https://reolink.home/cgi-bin/api.cgi?cmd=Snap&channel=0&rs=smart-home-d23&user=camera-user&password=camera-secret")
+    );
+
+    let (runtime, entity_id, principal_id) =
+        fixture_runtime(true, "https://reolink.home/?unexpected=true");
+    let mut host = ReolinkSnapshotHost::new(
+        CameraMediaPolicy::default(),
+        FixedClock(10),
+        TestNonce(1),
+        FixedPrincipal(Some(principal_id)),
+        TestExecutor(Rc::new(RefCell::new(ExecutorState::default()))),
+        credentials.clone(),
+        ReolinkSnapshotEndpoint::new(
+            BridgeId::trusted("bridge:reolink:test"),
+            CameraMediaConnectionTarget::new("reolink.home", address),
+        ),
+    );
+    assert_eq!(
+        host.deliver_snapshot(
+            &runtime,
+            ReolinkSnapshotRequest::new(entity_id, "operator preview", 5_000),
+        )
+        .unwrap_err(),
+        ReolinkSnapshotHostError::InvalidTarget
+    );
+    assert_eq!(credentials.resolve_count(), 1);
+}
+
+#[derive(Default)]
+struct TlsCapture {
+    pinned_connections: Vec<(String, SocketAddr)>,
+    requests: Vec<Vec<u8>>,
+}
+
+struct RecordingConnector {
+    responses: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    capture: Arc<Mutex<TlsCapture>>,
+}
+
+impl RecordingConnector {
+    fn new(responses: VecDeque<Vec<u8>>, capture: Arc<Mutex<TlsCapture>>) -> Self {
+        Self {
+            responses: Arc::new(Mutex::new(responses)),
+            capture,
+        }
+    }
+
+    fn stream(&self) -> Result<Box<dyn TlsStream>, TlsError> {
+        let response = self
+            .responses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or_else(|| TlsError::Io {
+                phase: "fixture response",
+                source: std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "missing fixture response",
+                ),
+            })?;
+        Ok(Box::new(RecordingTlsStream {
+            response: Cursor::new(response),
+            request: Vec::new(),
+            capture: Arc::clone(&self.capture),
+        }))
+    }
+}
+
+impl TlsConnector for RecordingConnector {
+    fn connect(
+        &self,
+        _host: &str,
+        _port: u16,
+        _config: &TlsConfig,
+    ) -> Result<Box<dyn TlsStream>, TlsError> {
+        self.stream()
+    }
+
+    fn connect_addr(
+        &self,
+        server_name: &str,
+        address: SocketAddr,
+        _config: &TlsConfig,
+    ) -> Result<Box<dyn TlsStream>, TlsError> {
+        self.capture
+            .lock()
+            .unwrap()
+            .pinned_connections
+            .push((server_name.to_string(), address));
+        self.stream()
+    }
+}
+
+struct RecordingTlsStream {
+    response: Cursor<Vec<u8>>,
+    request: Vec<u8>,
+    capture: Arc<Mutex<TlsCapture>>,
+}
+
+impl Drop for RecordingTlsStream {
+    fn drop(&mut self) {
+        self.capture
+            .lock()
+            .unwrap()
+            .requests
+            .push(std::mem::take(&mut self.request));
+    }
+}
+
+impl Read for RecordingTlsStream {
+    fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+        self.response.read(output)
+    }
+}
+
+impl Write for RecordingTlsStream {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.request.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl TlsStream for RecordingTlsStream {
+    fn peer_certificates(&self) -> Result<Vec<Vec<u8>>, TlsError> {
+        Ok(Vec::new())
+    }
+
+    fn negotiated_alpn(&self) -> Option<String> {
+        Some("http/1.1".to_string())
+    }
+
+    fn negotiated_version(&self) -> TlsVersion {
+        TlsVersion::Tls13
+    }
+
+    fn close_notify(&mut self) -> Result<(), TlsError> {
+        Ok(())
+    }
+
+    fn summary(&self) -> TlsConnectionSummary {
+        panic!("summary is not used by the snapshot host")
+    }
+}
+
+fn wire_response(content_type: &str, body: &[u8]) -> Vec<u8> {
+    let mut response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )
+    .into_bytes();
+    response.extend_from_slice(body);
+    response
+}

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1460,25 +1460,55 @@ camera-media policy and pinned native HTTPS executor:
   responsibility. Event streams, source enumeration, recordings, playback,
   exports, and broader media transfer remain prerequisite-gated.
 
+## Current Reolink HTTPS Snapshot Host Slice
+
+This slice composes the exact installed Reolink physical-channel identity with
+the completed camera-media policy and pinned native HTTPS executor:
+
+- Authenticated Reolink inspection advertises `camera.snapshot` only for an
+  awake, online `RLC-*` channel. NVR, battery-camera, logical-channel, and
+  unsupported-family snapshot claims remain excluded.
+- `smart-home-reolink-snapshot-host` performs exact Human Approval preflight
+  before Vault access, endpoint registration, or media I/O. The target must be
+  the exact camera entity installed by the reviewed bridge, remain online and
+  awake, and retain its exact physical-channel metadata and capability.
+- One bounded, versioned sealed-Vault credential envelope is decoded into
+  zeroizing process-local state. The host percent-encodes the credentials into
+  the documented `/cgi-bin/api.cgi?cmd=Snap` HTTPS request and registers that
+  endpoint only against the reviewed canonical host and pinned socket.
+- The credential envelope is disposed before delivery and the complete
+  token-bearing endpoint is removed after success, lease failure, executor
+  failure, or registration failure. It never enters normalized state, errors,
+  audit records, or debug output.
+- Tests cover denial before Vault, exact installed-target correspondence,
+  malformed credential redaction, repeated sealed-record use, cleanup after
+  failure, and a strict pinned-TLS JPEG request with percent-encoded query
+  credentials.
+- Automated credential provisioning remains an explicit pairing-flow
+  responsibility. Streams, recordings, playback, NVR channels, logical
+  channels, and broader media transfer remain prerequisite-gated.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
 and then by prerequisite readiness:
 
-The strongest next executable candidate is bounded Blue Iris snapshot delivery:
-the production integration already has an explicit local HTTPS origin, exact
-camera identities, isolated challenge-response sessions, and explicit logout.
-A fresh post-merge audit must verify the documented native image request,
-prove exact camera correspondence and snapshot permission, and define the
-process-local session-bearing endpoint lifetime before implementation. Frigate
-snapshot delivery remains blocked on a cookie-capable media authentication
-boundary; broader streams, recordings, export, and playback remain
-prerequisite-gated.
+No additional camera snapshot slice is currently executable without a concrete
+authentication prerequisite. Blue Iris documents `/image/{camera}` and secure
+JSON sessions independently, but does not document how a secure session binds
+to that image request; the only documented direct URL credentials require
+disabling secure sessions and are rejected. Frigate snapshot delivery remains
+blocked on a cookie-capable media authentication boundary. The strongest next
+post-merge audit is the explicit sealed-Vault camera credential pairing flow,
+which must prove D23 pairing authorization, versioned envelope creation, opaque
+reference installation, replacement semantics, and failure cleanup before any
+host becomes an implicit credential writer.
 
-1. Add automated ONVIF credential provisioning only through an explicit pairing
-   flow that writes the versioned envelope into the dedicated sealed-Vault
-   namespace and installs only its opaque reference. Snapshot delivery itself is
-   complete and must not become an implicit credential writer.
+1. Add automated ONVIF, ZoneMinder, Axis, and Reolink credential provisioning
+   only through explicit D23 pairing flows that write each host's versioned
+   envelope into its dedicated sealed-Vault namespace and install only opaque
+   references. Snapshot delivery itself is complete and must not become an
+   implicit credential writer.
 2. Add authenticated AirGradient MQTT only after official firmware removes
    plaintext credential logging and one-shot Vault-leased credential injection
    can be proven without request-plan or normalized-state exposure.
@@ -1550,10 +1580,11 @@ prerequisite-gated.
 24. Add Frigate commands or configuration mutations only with operation-specific
    D23 contracts, least-privilege role checks, and readable postcondition
    verification.
-25. Add bounded Blue Iris snapshots through the completed camera-media HTTPS
-    executor after process-local endpoint registration and credential lifetime
-    are wired; alert/clip search, export, and playback still require a concrete
-    supervised resource executor.
+25. Add bounded Blue Iris snapshots only after an official interface documents
+    how an isolated secure JSON session authenticates `/image/{camera}`, or a
+    concrete cookie/session-bound media executor exists. Never disable secure
+    sessions or place reusable Blue Iris credentials in a URL. Alert/clip
+    search, export, and playback still require a supervised resource executor.
 26. Add broader Blue Iris `camconfig` or administrative mutations only with
    operation-specific D23 contracts, least-privilege permissions, and readable
    postcondition verification; do not persist the license value returned at
@@ -1571,29 +1602,25 @@ prerequisite-gated.
     capability-probed VAPIX camera 1 boundary.
 31. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
     only when each operation has a specific capability probe and readable state.
-32. Add bounded Reolink snapshots through the completed camera-media HTTPS
-    executor after process-local endpoint registration and credential lifetime
-    are wired; recording search/download and playback still require a concrete
-    supervised resource executor.
-33. Add Reolink current-position, zoom, guard-point, or patrol controls only when
+32. Add Reolink current-position, zoom, guard-point, or patrol controls only when
     each operation has a capability-specific probe and the firmware exposes the
     native state needed to avoid invented orientation claims.
-34. Add Reolink push events only after a concrete webhook or event-stream host
+33. Add Reolink push events only after a concrete webhook or event-stream host
     and subscription lifecycle exist.
-35. Add authenticated KLAP/Tapo devices and other broader-device families only
+34. Add authenticated KLAP/Tapo devices and other broader-device families only
     after their authentication and session prerequisites are concrete.
-36. Add ONVIF PullPoint events once a concrete event host and subscription
+35. Add ONVIF PullPoint events once a concrete event host and subscription
     lifecycle exist.
-37. Add RTSP media transfer and recording once concrete media transfer and
+36. Add RTSP media transfer and recording once concrete media transfer and
     recorder host primitives exist.
-38. Add a production Matter commissioning, secure-session, and network host only
+37. Add a production Matter commissioning, secure-session, and network host only
     after certificate, fabric, Interaction Model encoding, subscription, and
     transport prerequisites exist.
-39. Add a Thread border-router host only after an actual host transport exists.
-40. Add a production Zigbee coordinator, join, and security host only after
+38. Add a Thread border-router host only after an actual host transport exists.
+39. Add a production Zigbee coordinator, join, and security host only after
     concrete coordinator transport and security primitives exist.
-41. Add production Z-Wave inclusion and S2 only after concrete host transport
-   and security primitives exist.
+40. Add production Z-Wave inclusion and S2 only after concrete host transport
+    and security primitives exist.
 
 ## End-To-End Definition
 


### PR DESCRIPTION
## Summary

- advertise documented JPEG snapshots only for awake, online Reolink RLC physical channels
- add exact D23 Human Approval, sealed-Vault credential resolution, reviewed-address-pinned HTTPS delivery, and operation-scoped endpoint cleanup
- record the Blue Iris secure-session media-binding blocker and reprioritize the remaining Smart Home backlog

## Validation

- `cargo test -p smart-home-reolink-integration -p smart-home-reolink-snapshot-host`
- `cargo clippy -p smart-home-reolink-integration -p smart-home-reolink-snapshot-host --all-targets --all-features -- -D warnings`
- `bash code/packages/rust/smart-home-reolink-integration/BUILD`
- `bash code/packages/rust/smart-home-reolink-snapshot-host/BUILD`
- `cargo fmt -p smart-home-reolink-integration -p smart-home-reolink-snapshot-host -- --check`
- `git diff --check`