### PR TITLE
Report hidden input starts in tables

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Hidden `input` start tags processed in table structure now report the
+  required parse error, covering 4 previously silent malformed corpus cases
+  without changing DOM recovery or undeclared-diagnostic coverage.
 - Head-content start tags processed after an explicit head end tag and before
   the body has started now report the required after-head parse error.
 - A `dt` or `dd` start tag now reports the in-body parse error when

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the post-head head-content start-tag diagnostic slice, 2,080 of those
-cases emit at least one lexer or parser diagnostic and 103 remain
+After the hidden-input-in-table diagnostic slice, 2,084 of those cases emit at
+least one lexer or parser diagnostic and 99 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -66,7 +66,7 @@ open table blocks adoption-agency recovery. Description-list item start tags
 now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
 without flagging adjacent description-list items.
 
-The fresh 103-case residual inventory keeps the next concrete groups in the
+The fresh 99-case residual inventory keeps the next concrete groups in the
 existing priority order: remaining table foster-parenting and table-scope
 boundaries;
 select/template recovery; script-tokenizer EOF recovery; plaintext/frameset
@@ -81,7 +81,9 @@ Prioritized work items:
    Non-whitespace table text now reports when it is foster-parented. The
    specialized SVG and MathML start-tag path now reports when table insertion
    mode foster-parents foreign content, and table-context end tags now report
-   when they force recovery from foreign content. The
+   when they force recovery from foreign content. Hidden `input` start tags in
+   table structure now report their required parse error while retaining their
+   special in-table insertion behavior. The
    remaining fragment EOF inventory includes fostered-anchor `eof-in-table`
    rows and MathML/SVG table-boundary scope recovery.
 3. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5335,6 +5335,10 @@ impl HtmlParser {
             if attribute_value(&attributes, "type")
                 .is_some_and(|value| value.eq_ignore_ascii_case("hidden"))
             {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-hidden-input-start-tag-in-table",
+                    "hidden input start tag in a table context was inserted with a parse error",
+                ));
                 self.append_node(Node::element(name, attributes));
             } else {
                 self.insert_node_before_open_table(Node::element(name, attributes));
@@ -33462,6 +33466,36 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| diagnostic.code != "unexpected-character-in-table"));
+    }
+
+    #[test]
+    fn reports_hidden_input_start_tags_in_tables() {
+        for source in [
+            "<!doctype html><table><input type=hidDEN></table>",
+            "<!doctype html><table> \n<input type='HIDDEN'></table>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic
+                        == &ParserDiagnostic::new(
+                            "unexpected-hidden-input-start-tag-in-table",
+                            "hidden input start tag in a table context was inserted with a parse error",
+                        )
+                }),
+                "source {source:?}"
+            );
+        }
+
+        for source in [
+            "<!doctype html><input type=hidden>",
+            "<!doctype html><table><input type=text></table>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-hidden-input-start-tag-in-table"
+            }));
+        }
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 103);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2080);
+    assert_eq!(missing_diagnostic_cases, 99);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2084);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the WHATWG-required parse error for hidden `input` starts in table structure
- preserve the existing special in-table insertion behavior
- ratchet malformed tree cases without diagnostics from 103 to 99

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- live WPT/html5lib coverage audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing, 7,242 normalized, zero skipped
- WHATWG audit coverage, manifest, Rust-test, smoke-metadata, and Python audit guards
- `git diff --check`

`cargo fmt --package coding-adventures-html-parser -- --check` is not included because current rustfmt produces broad pre-existing churn outside this focused change; the changed hunks are style-clean.