### PR TITLE
Report head content starts in tables

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- `title` and `meta` start tags foster-parented out of table structure now
+  report the required in-table parse error, covering 2 previously silent
+  malformed corpus cases without changing DOM recovery or
+  undeclared-diagnostic coverage.
 - Hidden `input` start tags processed in table structure now report the
   required parse error, covering 4 previously silent malformed corpus cases
   without changing DOM recovery or undeclared-diagnostic coverage.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the hidden-input-in-table diagnostic slice, 2,084 of those cases emit at
-least one lexer or parser diagnostic and 99 remain
+After the head-content-in-table diagnostic slice, 2,086 of those cases emit at
+least one lexer or parser diagnostic and 97 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -66,7 +66,7 @@ open table blocks adoption-agency recovery. Description-list item start tags
 now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
 without flagging adjacent description-list items.
 
-The fresh 99-case residual inventory keeps the next concrete groups in the
+The fresh 97-case residual inventory keeps the next concrete groups in the
 existing priority order: remaining table foster-parenting and table-scope
 boundaries;
 select/template recovery; script-tokenizer EOF recovery; plaintext/frameset
@@ -83,7 +83,8 @@ Prioritized work items:
    mode foster-parents foreign content, and table-context end tags now report
    when they force recovery from foreign content. Hidden `input` start tags in
    table structure now report their required parse error while retaining their
-   special in-table insertion behavior. The
+   special in-table insertion behavior. Foster-parented `title` and `meta`
+   start tags now report the general in-table parse error. The
    remaining fragment EOF inventory includes fostered-anchor `eof-in-table`
    rows and MathML/SVG table-boundary scope recovery.
 3. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5305,11 +5305,19 @@ impl HtmlParser {
         }
 
         if !in_foreign_content && name == "meta" && self.current_element_is_table_structure() {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-head-content-start-tag-in-table",
+                "head-content start tag `<meta>` in a table context was foster parented",
+            ));
             self.insert_node_before_open_table(Node::element(name, attributes));
             return;
         }
 
         if !in_foreign_content && name == "title" && self.current_element_is_table_structure() {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-head-content-start-tag-in-table",
+                "head-content start tag `<title>` in a table context was foster parented",
+            ));
             if let Some(path) = self.insert_node_before_open_table(Node::element(name, attributes))
             {
                 self.open_elements.push(path);
@@ -33496,6 +33504,36 @@ mod tests {
                 diagnostic.code != "unexpected-hidden-input-start-tag-in-table"
             }));
         }
+    }
+
+    #[test]
+    fn reports_head_content_start_tags_fostered_from_tables() {
+        for (source, name) in [
+            ("<!doctype html><table><title>X</title></table>", "title"),
+            ("<!doctype html><table><meta></table>", "meta"),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic
+                        == &ParserDiagnostic::new(
+                            "unexpected-head-content-start-tag-in-table",
+                            format!(
+                                "head-content start tag `<{name}>` in a table context was foster parented"
+                            ),
+                        )
+                }),
+                "source {source:?}"
+            );
+        }
+
+        let head = parse_html_with_diagnostics(
+            "<!doctype html><head><title>X</title><meta></head><body></body>",
+        )
+        .unwrap();
+        assert!(head.parser_diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != "unexpected-head-content-start-tag-in-table"
+        }));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 99);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2084);
+    assert_eq!(missing_diagnostic_cases, 97);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2086);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the required in-table parse error for foster-parented `title` and `meta` starts
- preserve the existing DOM insertion behavior
- ratchet malformed tree cases without diagnostics from 99 to 97

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- live WPT/html5lib coverage audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing, 7,242 normalized, zero skipped
- WHATWG audit coverage, manifest, Rust-test, smoke-metadata, and Python audit guards
- `git diff --check`

`cargo fmt --package coding-adventures-html-parser -- --check` is not included because current rustfmt produces broad pre-existing churn outside this focused change; the changed hunks are style-clean.