### PR TITLE
Add revision-guarded pairing completion

### DIFF
--- a/code/packages/rust/smart-home-runtime-store/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime-store/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add D23-authorized, revision-guarded pairing completion that persists a
+  candidate runtime before swapping live state and reports the prior opaque
+  Vault reference for explicit credential replacement cleanup.
 - Add revision-guarded retained identity migration that persists a complete
   migrated candidate before swapping the caller's live runtime.
 - Reject automation definitions and execution state that still contain an

--- a/code/packages/rust/smart-home-runtime-store/Cargo.toml
+++ b/code/packages/rust/smart-home-runtime-store/Cargo.toml
@@ -8,9 +8,9 @@ license = "MIT"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+smart-home-core = { path = "../smart-home-core" }
 smart-home-runtime = { path = "../smart-home-runtime" }
 storage-core = { path = "../storage-core" }
 
 [dev-dependencies]
-smart-home-core = { path = "../smart-home-core" }
 storage-local-folder = { path = "../storage-local-folder" }

--- a/code/packages/rust/smart-home-runtime-store/README.md
+++ b/code/packages/rust/smart-home-runtime-store/README.md
@@ -16,3 +16,11 @@ after that write succeeds. A stale revision leaves both the live runtime and
 the durable record unchanged. Supplied automation definitions and execution
 state must already use destination identities; exact source-ID references are
 rejected before either runtime or storage mutation.
+
+Pairing completion follows the same persist-before-swap rule. It executes the
+D23 `CompletePairing` authorization and mutation against a cloned runtime,
+persists the complete candidate only at the caller's expected revision, and
+then swaps live state. The API accepts only an opaque `VaultRef` and returns the
+prior bridge reference for explicit post-commit credential cleanup. Coordinating
+the separate sealed-Vault write and crash-recoverable old-record deletion
+remains the credential host's responsibility.

--- a/code/packages/rust/smart-home-runtime-store/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime-store/src/lib.rs
@@ -3,9 +3,11 @@
 #![forbid(unsafe_code)]
 
 use serde::{Deserialize, Serialize};
+use smart_home_core::{AgentId, VaultRef};
 use smart_home_runtime::{
-    RuntimeDurableSnapshot, RuntimeError, RuntimeRetainedIdentityMigration,
-    RuntimeRetainedIdentityMigrationReport, SmartHomeRuntime,
+    RuntimeCompletePairingToolOutput, RuntimeCompletePairingToolRequest, RuntimeDurableSnapshot,
+    RuntimeError, RuntimeRetainedIdentityMigration, RuntimeRetainedIdentityMigrationReport,
+    SmartHomeRuntime,
 };
 use std::fmt;
 use storage_core::{Revision, StorageBackend, StorageError, StorageMetadata, StoragePutInput};
@@ -247,6 +249,67 @@ impl<B: StorageBackend> SmartHomeRuntimeStore<B> {
         Ok((report, revision))
     }
 
+    /// Completes one authorized pairing session as a revision-guarded durable
+    /// runtime mutation.
+    ///
+    /// The caller must have already sealed the credential payload and supplies
+    /// only its opaque `VaultRef`. The completion runs against a cloned runtime,
+    /// including D23 Human Approval authorization, then persists that complete
+    /// candidate with compare-and-swap. Live state changes only after the write
+    /// succeeds. The prior bridge reference is returned so a credential host
+    /// can perform explicit replacement cleanup after the durable commit.
+    pub fn complete_pairing(
+        &self,
+        runtime: &mut SmartHomeRuntime,
+        principal_id: AgentId,
+        request: RuntimeCompletePairingToolRequest,
+        automation_definitions: &[DurableAutomationDefinition],
+        automation_state: Option<serde_json::Value>,
+        expected_revision: Revision,
+    ) -> Result<(RuntimeCompletePairingToolOutput, Option<VaultRef>, Revision), RuntimeStoreError>
+    {
+        validate_automation_definitions(automation_definitions)?;
+        if automation_state
+            .as_ref()
+            .is_some_and(|state| !state.is_object())
+        {
+            return Err(RuntimeStoreError::Validation {
+                field: "automation_state",
+                message: "must be a JSON object".to_string(),
+            });
+        }
+
+        let mut candidate = runtime.clone();
+        let completed_at_ms = request.completion.completed_at_ms;
+        let output =
+            candidate.execute_complete_pairing_tool(principal_id, request, completed_at_ms)?;
+        let previous_vault_ref = runtime
+            .registry()
+            .bridge(&output.session.bridge_id)
+            .and_then(|bridge| bridge.auth_ref.clone());
+        let envelope = RuntimeStoreEnvelope {
+            schema_version: SCHEMA_VERSION,
+            saved_at_ms: completed_at_ms,
+            runtime: candidate.durable_snapshot(),
+            automation_definitions: automation_definitions.to_vec(),
+            automation_state,
+        };
+        let body = serde_json::to_vec(&envelope)
+            .map_err(|error| RuntimeStoreError::Encode(error.to_string()))?;
+        self.backend.initialize()?;
+        let input = StoragePutInput::new(
+            self.namespace.clone(),
+            self.key.clone(),
+            CONTENT_TYPE,
+            StorageMetadata::Object(Default::default()),
+            body,
+        )?
+        .with_if_revision(Some(expected_revision));
+        let revision = self.backend.put(input)?.revision;
+        *runtime = candidate;
+        Ok((output, previous_vault_ref, revision))
+    }
+
     pub fn load(&self) -> Result<Option<RestoredSmartHomeRuntime>, RuntimeStoreError> {
         self.backend.initialize()?;
         let Some(record) = self.backend.get(&self.namespace, &self.key)? else {
@@ -338,9 +401,9 @@ fn json_references_any(
         serde_json::Value::Object(fields) => fields.iter().any(|(key, value)| {
             source_ids.contains(key.as_str()) || json_references_any(value, source_ids)
         }),
-        serde_json::Value::Null
-        | serde_json::Value::Bool(_)
-        | serde_json::Value::Number(_) => false,
+        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {
+            false
+        }
     }
 }
 
@@ -348,13 +411,15 @@ fn json_references_any(
 mod tests {
     use super::*;
     use smart_home_core::{
-        AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CommandId,
-        CommandResult, CommandStatus, CorrelationId, Device, DeviceEvent, DeviceEventType,
-        DeviceId, Entity, EntityId, EntityKind, EventId, Health, IntegrationId, StateDelta, Value,
+        AgentId, AuthorizationOutcome, Bridge, BridgeId, BridgeTransport, Capability,
+        CapabilityGrant, CapabilityGrantId, CapabilityId, CommandId, CommandResult, CommandStatus,
+        CorrelationId, Device, DeviceEvent, DeviceEventType, DeviceId, Entity, EntityId,
+        EntityKind, EventId, Health, IntegrationId, PrivilegeTier, StateDelta, Value, VaultRef,
     };
     use smart_home_runtime::{
-        DesiredEntityState, DesiredStateQuery, RetainedDeviceIdentityReplacement,
-        RetainedEntityIdentityReplacement, RuntimeCommandResultQuery, RuntimeEvent,
+        DesiredEntityState, DesiredStateQuery, PairingSessionStatus,
+        RetainedDeviceIdentityReplacement, RetainedEntityIdentityReplacement,
+        RuntimeCommandResultQuery, RuntimeCompletePairingToolRequest, RuntimeEvent,
         RuntimePairingSession, RuntimePairingSessionId, RuntimePairingSessionQuery,
         RuntimeRetainedIdentityMigration,
     };
@@ -491,6 +556,20 @@ mod tests {
         )])
     }
 
+    fn grant_pairing(runtime: &mut SmartHomeRuntime, principal: &AgentId) {
+        runtime.registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_capability(
+                CapabilityGrantId::trusted("grant-pair"),
+                principal.clone(),
+                CapabilityId::trusted("smart_home.pair"),
+                PrivilegeTier::HumanApproval,
+                "test",
+                400,
+            )
+            .with_expiry(1_000),
+        );
+    }
+
     #[test]
     fn local_folder_restart_restores_runtime_and_automation_definitions() {
         let root = temp_root("restart");
@@ -556,6 +635,174 @@ mod tests {
                 .len(),
             1
         );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn pairing_completion_persists_before_swapping_live_runtime() {
+        let root = temp_root("pairing-completion");
+        let principal = AgentId::trusted("agent:test");
+        let old_vault_ref = VaultRef::trusted("vault://smart-home/hue/bridge-1/old");
+        let new_vault_ref = VaultRef::trusted("vault://smart-home/hue/bridge-1/new");
+        let mut runtime = runtime_fixture();
+        let mut bridge = runtime
+            .registry()
+            .bridge(&BridgeId::trusted("bridge-1"))
+            .unwrap()
+            .clone();
+        bridge.auth_ref = Some(old_vault_ref.clone());
+        runtime.upsert_bridge(bridge).unwrap();
+        grant_pairing(&mut runtime, &principal);
+        let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+        let initial_revision = store.save(&runtime, &[], 500).unwrap();
+
+        let (output, previous_vault_ref, completed_revision) = store
+            .complete_pairing(
+                &mut runtime,
+                principal.clone(),
+                RuntimeCompletePairingToolRequest::new(
+                    RuntimePairingSessionId::trusted("pairing-1"),
+                    new_vault_ref.clone(),
+                    600,
+                ),
+                &[],
+                None,
+                initial_revision,
+            )
+            .unwrap();
+
+        assert_eq!(output.session.status, PairingSessionStatus::Completed);
+        assert_eq!(previous_vault_ref, Some(old_vault_ref));
+        assert_eq!(
+            runtime
+                .registry()
+                .bridge(&BridgeId::trusted("bridge-1"))
+                .unwrap()
+                .auth_ref,
+            Some(new_vault_ref.clone())
+        );
+        assert!(runtime
+            .registry()
+            .authorization_decisions_for_principal(&principal)
+            .iter()
+            .any(|decision| decision.outcome == AuthorizationOutcome::Allowed));
+
+        let restored = store.load().unwrap().unwrap();
+        assert_eq!(restored.revision, completed_revision);
+        assert_eq!(restored.saved_at_ms, 600);
+        assert_eq!(
+            restored
+                .runtime
+                .pairing_session(&RuntimePairingSessionId::trusted("pairing-1"))
+                .unwrap()
+                .status,
+            PairingSessionStatus::Completed
+        );
+        assert_eq!(
+            restored
+                .runtime
+                .registry()
+                .bridge(&BridgeId::trusted("bridge-1"))
+                .unwrap()
+                .auth_ref,
+            Some(new_vault_ref)
+        );
+        assert!(restored
+            .runtime
+            .registry()
+            .authorization_decisions_for_principal(&principal)
+            .iter()
+            .any(|decision| decision.outcome == AuthorizationOutcome::Allowed));
+        assert!(restored.runtime.registry().events().any(|event| {
+            event.metadata.iter().any(|metadata| {
+                metadata.key == "smart_home.pairing_session" && metadata.value == "pairing-1"
+            })
+        }));
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn pairing_completion_storage_conflict_keeps_live_session_pending() {
+        let root = temp_root("pairing-conflict");
+        let principal = AgentId::trusted("agent:test");
+        let mut runtime = runtime_fixture();
+        grant_pairing(&mut runtime, &principal);
+        let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+        let stale_revision = store.save(&runtime, &[], 500).unwrap();
+        let current_revision = store.save(&runtime, &[], 550).unwrap();
+        let before = runtime.durable_snapshot();
+
+        let error = store
+            .complete_pairing(
+                &mut runtime,
+                principal,
+                RuntimeCompletePairingToolRequest::new(
+                    RuntimePairingSessionId::trusted("pairing-1"),
+                    VaultRef::trusted("vault://smart-home/hue/bridge-1/new"),
+                    600,
+                ),
+                &[],
+                None,
+                stale_revision,
+            )
+            .unwrap_err();
+
+        assert!(matches!(error, RuntimeStoreError::Storage(_)));
+        assert_eq!(runtime.durable_snapshot(), before);
+        let restored = store.load().unwrap().unwrap();
+        assert_eq!(restored.revision, current_revision);
+        assert_eq!(
+            restored
+                .runtime
+                .pairing_session(&RuntimePairingSessionId::trusted("pairing-1"))
+                .unwrap()
+                .status,
+            PairingSessionStatus::PendingUserPresence
+        );
+        assert_eq!(
+            restored
+                .runtime
+                .registry()
+                .bridge(&BridgeId::trusted("bridge-1"))
+                .unwrap()
+                .auth_ref,
+            None
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn pairing_completion_denial_writes_no_candidate() {
+        let root = temp_root("pairing-denial");
+        let mut runtime = runtime_fixture();
+        let before = runtime.durable_snapshot();
+        let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+        let initial_revision = store.save(&runtime, &[], 500).unwrap();
+
+        let error = store
+            .complete_pairing(
+                &mut runtime,
+                AgentId::trusted("agent:unauthorized"),
+                RuntimeCompletePairingToolRequest::new(
+                    RuntimePairingSessionId::trusted("pairing-1"),
+                    VaultRef::trusted("vault://smart-home/hue/bridge-1/new"),
+                    600,
+                ),
+                &[],
+                None,
+                initial_revision.clone(),
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RuntimeStoreError::Runtime(RuntimeError::UnauthorizedTool { .. })
+        ));
+        assert_eq!(runtime.durable_snapshot(), before);
+        assert_eq!(store.load().unwrap().unwrap().revision, initial_revision);
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1488,6 +1488,32 @@ the completed camera-media policy and pinned native HTTPS executor:
   responsibility. Streams, recordings, playback, NVR channels, logical
   channels, and broader media transfer remain prerequisite-gated.
 
+## Current Revision-Guarded Pairing Completion Slice
+
+This slice closes the durable-runtime half of credential pairing without
+claiming cross-store atomicity:
+
+- `smart-home-runtime-store` accepts an already sealed opaque `VaultRef`, a D23
+  principal, one exact pending pairing completion, and the caller's expected
+  runtime revision.
+- Completion runs against a cloned runtime through the existing
+  `smart_home.complete_pairing` Human Approval authorization path. The complete
+  candidate snapshot is persisted with compare-and-swap before live state is
+  replaced.
+- Authorization denial, invalid pairing state, encoding failure, or a stale
+  storage revision leaves the live pairing session and bridge reference
+  unchanged. Successful restart recovery restores the completed session,
+  bridge reference, authorization decision, health event, and metadata.
+- The API returns the previous opaque bridge `VaultRef` after commit so a
+  credential host can distinguish first installation from replacement without
+  reading credential material.
+- Tests prove authorized replacement and restart recovery, denial without a
+  durable candidate, and stale-revision rollback with both live and durable
+  pairing state still pending.
+- Sealed-Vault write/rollback and old-record deletion are deliberately not
+  presented as atomic with runtime persistence. A recoverable transaction
+  journal remains required before automated credential provisioning can ship.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
@@ -1498,17 +1524,21 @@ authentication prerequisite. Blue Iris documents `/image/{camera}` and secure
 JSON sessions independently, but does not document how a secure session binds
 to that image request; the only documented direct URL credentials require
 disabling secure sessions and are rejected. Frigate snapshot delivery remains
-blocked on a cookie-capable media authentication boundary. The strongest next
-post-merge audit is the explicit sealed-Vault camera credential pairing flow,
-which must prove D23 pairing authorization, versioned envelope creation, opaque
-reference installation, replacement semantics, and failure cleanup before any
-host becomes an implicit credential writer.
+blocked on a cookie-capable media authentication boundary. Revision-guarded
+D23 pairing completion is now available, but the sealed Vault and runtime store
+remain independent commit domains. The strongest next prerequisite is a
+secret-free durable prepare/commit/cleanup journal that can recover a crash or
+rollback failure around new-record creation, runtime CAS, and old-record
+deletion before any host becomes an implicit credential writer.
 
-1. Add automated ONVIF, ZoneMinder, Axis, and Reolink credential provisioning
-   only through explicit D23 pairing flows that write each host's versioned
-   envelope into its dedicated sealed-Vault namespace and install only opaque
-   references. Snapshot delivery itself is complete and must not become an
-   implicit credential writer.
+1. Add a secret-free, recoverable pairing transaction protocol spanning sealed
+   Vault and runtime-store commit domains. It must journal prepare, new opaque
+   reference, previous opaque reference, expected runtime revision, commit, and
+   cleanup status; recover crashes; bind rollback/deletion to exact revisions;
+   and migrate the existing Hue pairing service before enabling automated
+   ONVIF, ZoneMinder, Axis, or Reolink credential provisioning. Snapshot
+   delivery itself is complete and must not become an implicit credential
+   writer.
 2. Add authenticated AirGradient MQTT only after official firmware removes
    plaintext credential logging and one-shot Vault-leased credential injection
    can be proven without request-plan or normalized-state exposure.


### PR DESCRIPTION
## Summary
- complete D23-authorized pairing against a cloned runtime and persist the full candidate with expected-revision CAS before swapping live state
- accept only an opaque Vault reference, return the previous reference for explicit replacement cleanup, and preserve live/durable pending state on denial or storage conflict
- record the remaining secret-free cross-store transaction journal prerequisite in the D18-D23 completion inventory

## Validation
- `cargo fmt -p smart-home-runtime-store -- --check`
- `cargo test -p smart-home-runtime-store`
- `cargo clippy -p smart-home-runtime-store --all-targets --all-features -- -D warnings`
- `bash smart-home-runtime-store/BUILD`