### PR TITLE
Report select start-tag recovery

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Nested `select` and `input` start tags processed with an open `select` now
+  report the required select insertion-mode parse error, covering 4 previously
+  silent malformed corpus cases without changing DOM recovery or
+  undeclared-diagnostic coverage.
 - `title` and `meta` start tags foster-parented out of table structure now
   report the required in-table parse error, covering 2 previously silent
   malformed corpus cases without changing DOM recovery or

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the head-content-in-table diagnostic slice, 2,086 of those cases emit at
-least one lexer or parser diagnostic and 97 remain
+After the select-start-tag recovery diagnostic slice, 2,090 of those cases emit
+at least one lexer or parser diagnostic and 93 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -66,7 +66,7 @@ open table blocks adoption-agency recovery. Description-list item start tags
 now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
 without flagging adjacent description-list items.
 
-The fresh 97-case residual inventory keeps the next concrete groups in the
+The fresh 93-case residual inventory keeps the next concrete groups in the
 existing priority order: remaining table foster-parenting and table-scope
 boundaries;
 select/template recovery; script-tokenizer EOF recovery; plaintext/frameset
@@ -84,7 +84,8 @@ Prioritized work items:
    when they force recovery from foreign content. Hidden `input` start tags in
    table structure now report their required parse error while retaining their
    special in-table insertion behavior. Foster-parented `title` and `meta`
-   start tags now report the general in-table parse error. The
+   start tags now report the general in-table parse error. Nested `select` and
+   `input` start tags now report when they force recovery from select mode. The
    remaining fragment EOF inventory includes fostered-anchor `eof-in-table`
    rows and MathML/SVG table-boundary scope recovery.
 3. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7371,6 +7371,11 @@ impl HtmlParser {
             return false;
         }
 
+        self.diagnostics.push(ParserDiagnostic::new(
+            "unexpected-start-tag-in-select",
+            format!("start tag `<{incoming_name}>` forced recovery from an open select element"),
+        ));
+
         if incoming_name == "input" && self.current_element_is_marked_fragment_context("select") {
             return true;
         }
@@ -33447,6 +33452,49 @@ mod tests {
 
         let matching = parse_html_with_diagnostics("<!doctype html><menuitem></menuitem>").unwrap();
         assert!(matching.parser_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_start_tags_that_force_recovery_from_selects() {
+        for (source, name) in [
+            ("<!doctype html><select><input>X", "input"),
+            ("<!doctype html><select><select>X", "select"),
+            (
+                "<!doctype html><select><optgroup><option></optgroup><option><select><option>",
+                "select",
+            ),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic
+                        == &ParserDiagnostic::new(
+                            "unexpected-start-tag-in-select",
+                            format!(
+                                "start tag `<{name}>` forced recovery from an open select element"
+                            ),
+                        )
+                }),
+                "source {source:?}"
+            );
+        }
+
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics("<input><option>", "select")
+                .unwrap();
+        assert_eq!(
+            fragment.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-start-tag-in-select",
+                "start tag `<input>` forced recovery from an open select element"
+            )]
+        );
+
+        let outside = parse_html_with_diagnostics("<!doctype html><input><select>").unwrap();
+        assert!(outside
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-start-tag-in-select"));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 97);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2086);
+    assert_eq!(missing_diagnostic_cases, 93);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2090);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the required parse error when nested `select` or `input` start tags force recovery from an open select
- preserve existing full-document and fragment DOM recovery behavior
- ratchet malformed tree cases without diagnostics from 97 to 93 and reprioritize the conformance backlog

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- live WPT/html5lib audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing, 7,242 normalized cases, zero skipped
- `check_whatwg_audit_coverage.py --check`
- `check_whatwg_audit_manifest.py`
- `check_whatwg_audit_rust_tests.py`
- `check_html5lib_tree_construction_smoke.py`
- `test_html_conformance_coverage_audit.py`
- `git diff --check`

The package-wide rustfmt check still reports pre-existing formatting drift outside this patch; this slice introduces no whitespace errors and keeps the diff scoped.