### PR TITLE
Render Mermaid sequence rect colors

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -15,8 +15,9 @@ note_stmt = "note" ( ( "left" | "right" ) "of" identifier | "over" actor_pair ) 
 title_stmt = "title" text ;
 autonumber_stmt = "autonumber" [ "off" | NUMBER [ NUMBER ] ] ;
 
-control_block = simple_block | alt_block | par_block | critical_block ;
-simple_block = ( "loop" | "rect" | "opt" | "break" ) [ text ] NEWLINE body "end" ;
+control_block = simple_block | rect_block | alt_block | par_block | critical_block ;
+simple_block = ( "loop" | "opt" | "break" ) [ text ] NEWLINE body "end" ;
+rect_block = "rect" COLOR NEWLINE body "end" ;
 alt_block = "alt" [ text ] NEWLINE body { "else" [ text ] NEWLINE body } "end" ;
 par_block = ( "par" | "par_over" ) [ text ] NEWLINE body { "and" [ text ] NEWLINE body } "end" ;
 critical_block = "critical" [ text ] NEWLINE body { "option" [ text ] NEWLINE body } "end" ;

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.12.0
+
+- Added optional sequence block fills for background highlights.
+
 ## 0.11.0
 
 - Added decimal sequence-number start and increment values.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
 //! diagram-ir v0.7.0 — DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.11.0";
+pub const VERSION: &str = "0.12.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -262,6 +262,7 @@ pub enum SequenceEvent {
     BlockStart {
         kind: SequenceBlockKind,
         label: String,
+        fill: Option<String>,
     },
     BlockBranch {
         label: String,
@@ -340,6 +341,7 @@ pub enum LayoutedSequenceItem {
     BlockFrame {
         kind: SequenceBlockKind,
         label: String,
+        fill: Option<String>,
         depth: usize,
         x: f64,
         y: f64,
@@ -905,8 +907,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_is_0_11_0() {
-        assert_eq!(VERSION, "0.11.0");
+    fn version_is_0_12_0() {
+        assert_eq!(VERSION, "0.12.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0 - 2026-08-09
+
+- Preserve nested rect fills without reserving a control-block label band.
+
 ## 0.7.0 - 2026-08-09
 
 - Generate message numbers from configured decimal starts and increments.

--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-sequence"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
 

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -7,7 +7,7 @@ use diagram_ir::{
     SequenceEvent, SequenceNotePlacement,
 };
 
-pub const VERSION: &str = "0.7.0";
+pub const VERSION: &str = "0.8.0";
 
 const MARGIN: f64 = 28.0;
 const HEADER_Y: f64 = 42.0;
@@ -25,6 +25,7 @@ const BLOCK_INSET: f64 = 10.0;
 struct BlockFrameState {
     kind: SequenceBlockKind,
     label: String,
+    fill: Option<String>,
     depth: usize,
     x: f64,
     y: f64,
@@ -227,18 +228,21 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                 });
                 y += NOTE_H + 20.0;
             }
-            SequenceEvent::BlockStart { kind, label } => {
+            SequenceEvent::BlockStart { kind, label, fill } => {
                 let depth = block_stack.len();
                 let x = MARGIN + depth as f64 * BLOCK_INSET;
                 block_stack.push(BlockFrameState {
                     kind: kind.clone(),
                     label: label.clone(),
+                    fill: fill.clone(),
                     depth,
                     x,
                     y,
                     width: (width - x * 2.0).max(120.0),
                 });
-                y += BLOCK_HEADER_H;
+                if kind != &SequenceBlockKind::Rect {
+                    y += BLOCK_HEADER_H;
+                }
             }
             SequenceEvent::BlockBranch { label } => {
                 if let Some(frame) = block_stack.last() {
@@ -259,6 +263,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                     items.push(LayoutedSequenceItem::BlockFrame {
                         kind: frame.kind,
                         label: frame.label,
+                        fill: frame.fill,
                         depth: frame.depth,
                         x: frame.x,
                         y: frame.y,
@@ -484,10 +489,12 @@ mod tests {
                 SequenceEvent::BlockStart {
                     kind: SequenceBlockKind::Alt,
                     label: "Ready".into(),
+                    fill: None,
                 },
                 SequenceEvent::BlockStart {
                     kind: SequenceBlockKind::Loop,
                     label: "Retry".into(),
+                    fill: None,
                 },
                 SequenceEvent::Message {
                     from: "Alice".into(),

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Paint sequence rect blocks with their declared functional colors.
 - Format decimal sequence numbers without redundant trailing zeroes.
 - Added central-connection endpoint circles layered above activation bars.
 - Added normal and reverse filled/stick sequence half-arrow geometry.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.11.0";
+pub const VERSION: &str = "0.12.0";
 
 use std::collections::HashMap;
 
@@ -1142,6 +1142,7 @@ where
         if let LayoutedSequenceItem::BlockFrame {
             kind,
             label,
+            fill: frame_fill,
             x,
             y,
             width,
@@ -1156,27 +1157,29 @@ where
                 y: *y,
                 width: *width,
                 height: *height,
-                fill: Some(fill.into()),
-                stroke: Some(stroke.into()),
+                fill: Some(frame_fill.as_deref().unwrap_or(fill).into()),
+                stroke: (kind != &SequenceBlockKind::Rect).then(|| stroke.into()),
                 stroke_width: Some(1.25),
                 corner_radius: Some(4.0),
                 stroke_dash: None,
                 stroke_dash_offset: None,
             }));
-            let frame_label = if label.is_empty() {
-                sequence_block_name(kind).to_string()
-            } else {
-                format!("{}  {label}", sequence_block_name(kind))
-            };
-            text_children.push(text_node(
-                &frame_label,
-                *x + 8.0,
-                *y + 6.0,
-                *width - 16.0,
-                20.0,
-                label_font.clone(),
-                text_color,
-            ));
+            if kind != &SequenceBlockKind::Rect {
+                let frame_label = if label.is_empty() {
+                    sequence_block_name(kind).to_string()
+                } else {
+                    format!("{}  {label}", sequence_block_name(kind))
+                };
+                text_children.push(text_node(
+                    &frame_label,
+                    *x + 8.0,
+                    *y + 6.0,
+                    *width - 16.0,
+                    20.0,
+                    label_font.clone(),
+                    text_color,
+                ));
+            }
         }
     }
 
@@ -2643,7 +2646,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.11.0");
+        assert_eq!(crate::VERSION, "0.12.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -9,6 +9,7 @@
 
 #[cfg(target_vendor = "apple")]
 mod apple {
+    use diagram_ir::{SequenceBlockKind, SequenceEvent};
     use diagram_layout_chart::layout_chart_diagram;
     use diagram_layout_graph::layout_graph_diagram;
     use diagram_layout_sequence::layout_sequence_diagram;
@@ -353,6 +354,17 @@ mod apple {
         .expect("Mermaid sequence parse failed");
         diagram.auto_number_start = 10.5;
         diagram.auto_number_step = 2.25;
+        diagram.events.insert(
+            0,
+            SequenceEvent::BlockStart {
+                kind: SequenceBlockKind::Rect,
+                label: String::new(),
+                fill: Some("rgba(255, 200, 100, 0.12)".into()),
+            },
+        );
+        diagram.events.push(SequenceEvent::BlockEnd {
+            kind: SequenceBlockKind::Rect,
+        });
         let layout = layout_sequence_diagram(&diagram);
 
         let shaper = CoreTextShaper;
@@ -403,6 +415,11 @@ mod apple {
             instruction,
             paint_instructions::PaintInstruction::Ellipse(ellipse)
                 if ellipse.rx == 5.0 && ellipse.ry == 5.0
+        )));
+        assert!(scene.instructions.iter().any(|instruction| matches!(
+            instruction,
+            paint_instructions::PaintInstruction::Rect(rect)
+                if rect.fill.as_deref() == Some("rgba(255, 200, 100, 0.12)")
         )));
     }
 }

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.0
+
+- Reuse functional color tokens for sequence `rect` highlights.
+
 ## 0.10.0
 
 - Tokenize autonumber decimals with Mermaid's two-place precision limit.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.10.0";
+pub const VERSION: &str = "0.11.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.10.0");
+        assert_eq!(VERSION, "0.11.0");
     }
 
     #[test]

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.0
+
+- Parse nested `rect` blocks with required `rgb` or `rgba` fills.
+
 ## 0.11.0
 
 - Parse Mermaid 11.15+ autonumber start and increment values.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -45,6 +45,8 @@ Central connection markers before and/or after an arrow preserve source,
 destination, and dual endpoint semantics through layout and Paint.
 `autonumber` supports Mermaid 11.15+ decimal start and increment values with
 up to two decimal places.
+Nested `rect` background highlights preserve their declared `rgb`/`rgba` fills
+instead of being treated as labeled control frames.
 Inline participant configurations support Mermaid's `type` and `alias` fields,
 including boundary, control, entity, database, collections, and queue symbols.
 

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.11.0";
+pub const VERSION: &str = "0.12.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1314,10 +1314,16 @@ fn parse_sequence_control_block(
             ))
         }
     };
-    let label = take_sequence_line_text(cursor);
+    let block_text = take_sequence_line_text(cursor);
+    let (label, fill) = if kind == SequenceBlockKind::Rect {
+        (String::new(), Some(block_text))
+    } else {
+        (block_text, None)
+    };
     diagram.events.push(SequenceEvent::BlockStart {
         kind: kind.clone(),
         label,
+        fill,
     });
     cursor.skip_terminators();
 
@@ -2905,11 +2911,11 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
         .unwrap();
         assert!(matches!(
             &diagram.events[0],
-            SequenceEvent::BlockStart { kind: SequenceBlockKind::Alt, label } if label == "Authorized"
+            SequenceEvent::BlockStart { kind: SequenceBlockKind::Alt, label, .. } if label == "Authorized"
         ));
         assert!(matches!(
             &diagram.events[2],
-            SequenceEvent::BlockStart { kind: SequenceBlockKind::Loop, label } if label == "Retry"
+            SequenceEvent::BlockStart { kind: SequenceBlockKind::Loop, label, .. } if label == "Retry"
         ));
         assert!(matches!(
             &diagram.events[5],
@@ -3086,6 +3092,27 @@ B//-A: reverse stick top
         assert_eq!(diagram.auto_number_start, 10.5);
         assert_eq!(diagram.auto_number_step, 2.25);
     }
+
+    #[test]
+    fn sequence_parses_nested_rect_background_colors() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\nrect rgba(0, 0, 255, .1)\nAlice->>Bob: Outer\nrect rgb(200, 150, 255)\nBob->>Alice: Inner\nend\nend\n",
+        )
+        .unwrap();
+        let fills: Vec<_> = diagram
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                SequenceEvent::BlockStart {
+                    kind: SequenceBlockKind::Rect,
+                    fill,
+                    ..
+                } => fill.as_deref(),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(fills, vec!["rgba(0, 0, 255, .1)", "rgb(200, 150, 255)"]);
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -3102,7 +3129,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.11.0");
+        assert_eq!(crate::VERSION, "0.12.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -137,6 +137,8 @@ source/destination endpoint semantics and Paint ellipse markers layered above
 activation bars.
 Automatic numbering preserves Mermaid 11.15+ decimal start and increment
 values through semantic IR, layout, and shaped Paint labels.
+Nested `rect` background highlights require Mermaid `rgb`/`rgba` syntax and
+carry that fill through semantic block events, layout frames, and Paint.
 
 ### Structural Groups
 


### PR DESCRIPTION
## Summary
- make sequence `rect` a grammar-backed rgb/rgba background construct rather than a generic labeled block
- preserve nested block fills through semantic IR and sequence layout
- lower highlights to borderless Paint rectangles with Metal PNG coverage

## Verification
- `cargo test -p diagram-ir -p mermaid-lexer -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint`
- `cargo clippy -p diagram-ir -p mermaid-lexer -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- visually inspected `/tmp/mermaid_sequence_e2e.png`