### PR TITLE
Report template table text recovery

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Non-whitespace text after a template row now reports the required template
+  table-mode parse error, covering 2 previously silent malformed corpus cases
+  without changing DOM recovery or undeclared-diagnostic coverage.
 - Nested `select` and `input` start tags processed with an open `select` now
   report the required select insertion-mode parse error, covering 4 previously
   silent malformed corpus cases without changing DOM recovery or

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the select-start-tag recovery diagnostic slice, 2,090 of those cases emit
-at least one lexer or parser diagnostic and 93 remain
+After the template table-mode text diagnostic slice, 2,092 of those cases emit
+at least one lexer or parser diagnostic and 91 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -66,7 +66,7 @@ open table blocks adoption-agency recovery. Description-list item start tags
 now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
 without flagging adjacent description-list items.
 
-The fresh 93-case residual inventory keeps the next concrete groups in the
+The fresh 91-case residual inventory keeps the next concrete groups in the
 existing priority order: remaining table foster-parenting and table-scope
 boundaries;
 select/template recovery; script-tokenizer EOF recovery; plaintext/frameset
@@ -85,7 +85,9 @@ Prioritized work items:
    table structure now report their required parse error while retaining their
    special in-table insertion behavior. Foster-parented `title` and `meta`
    start tags now report the general in-table parse error. Nested `select` and
-   `input` start tags now report when they force recovery from select mode. The
+   `input` start tags now report when they force recovery from select mode.
+   Non-whitespace text after a template row now reports when it forces recovery
+   from template table mode. The
    remaining fragment EOF inventory includes fostered-anchor `eof-in-table`
    rows and MathML/SVG table-boundary scope recovery.
 3. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5689,6 +5689,18 @@ impl HtmlParser {
             return;
         }
 
+        if self.has_open_element("template")
+            && !self.has_open_element("table")
+            && self.current_element_is("template")
+            && self.current_has_child_element("tr")
+            && !is_html_whitespace_text(&text)
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-character-in-template-table-mode",
+                "non-whitespace character data forced recovery from template table mode",
+            ));
+        }
+
         if self.open_elements.is_empty()
             && is_html_whitespace_text(&text)
             && !self.has_document_element()
@@ -33495,6 +33507,31 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| diagnostic.code != "unexpected-start-tag-in-select"));
+    }
+
+    #[test]
+    fn reports_non_whitespace_text_that_leaves_template_table_mode() {
+        let output = parse_html_with_diagnostics(
+            "<!DOCTYPE HTML><template><tr><td>cell</td></tr>a</template>",
+        )
+        .unwrap();
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-character-in-template-table-mode",
+                "non-whitespace character data forced recovery from template table mode"
+            )]
+        );
+
+        for source in [
+            "<!doctype html><template>text</template>",
+            "<!doctype html><template><tr><td>cell</td></tr> </template>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-character-in-template-table-mode"
+            }));
+        }
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 93);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2090);
+    assert_eq!(missing_diagnostic_cases, 91);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2092);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the required parse error when non-whitespace text forces recovery from template table mode
- preserve existing template DOM recovery and keep ordinary template text and whitespace quiet
- ratchet malformed tree cases without diagnostics from 93 to 91 and reprioritize the conformance backlog

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- live WPT/html5lib audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing, 7,242 normalized cases, zero skipped
- `check_whatwg_audit_coverage.py --check`
- `check_whatwg_audit_manifest.py`
- `check_whatwg_audit_rust_tests.py`
- `check_html5lib_tree_construction_smoke.py`
- `test_html_conformance_coverage_audit.py`
- `git diff --check`

The package-wide rustfmt check still reports pre-existing formatting drift outside this patch; this slice introduces no whitespace errors and keeps the diff scoped.