### PR TITLE
Redact vault record debug output

### DIFF
--- a/code/packages/rust/vault-records/CHANGELOG.md
+++ b/code/packages/rust/vault-records/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   record family, secret-field counts, optional/list shape, lease/expiry flags,
   and opaque content/payload lengths.
 
+### Security
+
+- Replaced derived `Debug` on all secret-bearing record types and `AnyRecord`
+  with closed value-redacted implementations. Opaque content types and payload
+  bytes are also suppressed.
+- Added a closed `VaultRecordError::Debug` implementation so diagnostic and
+  assertion formatting cannot emit attacker-controlled content types.
+
 ## [0.1.0] — 2026-05-04
 
 ### Added

--- a/code/packages/rust/vault-records/README.md
+++ b/code/packages/rust/vault-records/README.md
@@ -84,13 +84,17 @@ Every type that carries secrets (`Login.password`, `Card.cvv`,
 `DatabaseCredential.password`) implements `Zeroize`. Higher layers
 wrap held records in `Zeroizing<T>`.
 
+Diagnostic formatting is closed and value-redacted. `Debug` for each typed
+record emits only its type name and `<redacted>`; `AnyRecord` retains only the
+variant name and the same marker. Opaque content types, opaque payload bytes,
+display metadata, and secret fields are never formatted.
+
 ## Errors are inert
 
-`VaultRecordError`'s `Display` strings come exclusively from
-literals in this crate. The `ContentTypeMismatch` variant
-deliberately suppresses the attacker-controlled `actual` content
-type from its Display output; callers that need it can match on
-the variant.
+`VaultRecordError`'s `Display` and `Debug` strings come exclusively from
+literals in this crate. The `ContentTypeMismatch` variant deliberately
+suppresses the attacker-controlled `actual` content type from both outputs;
+callers that need it can match on the variant.
 
 ## Where it fits
 

--- a/code/packages/rust/vault-records/src/lib.rs
+++ b/code/packages/rust/vault-records/src/lib.rs
@@ -26,6 +26,9 @@
 //!       `Login`, `SecureNote`, `Card`, `TotpSeed`.
 //!     - **Machine-secret store** (HashiCorp Vault class):
 //!       `ApiKey`, `DatabaseCredential`.
+//! * Keep ordinary diagnostic formatting inert: typed records and
+//!   [`AnyRecord`] retain only their type or variant name plus a fixed
+//!   `<redacted>` marker, and [`VaultRecordError`] suppresses input values.
 //!
 //! Apps register custom types as they need.
 //!
@@ -142,7 +145,6 @@ pub trait VaultRecord: Sized {
 ///
 /// `Display` strings come from this crate's literals — never from
 /// the input bytes — to avoid log-injection from malicious payloads.
-#[derive(Debug)]
 pub enum VaultRecordError {
     /// Underlying canonical-CBOR codec failed.
     Cbor(CborError),
@@ -164,6 +166,19 @@ pub enum VaultRecordError {
         /// Static description of the violation, e.g. `"Login.username missing"`.
         what: &'static str,
     },
+}
+
+impl core::fmt::Debug for VaultRecordError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let variant = match self {
+            Self::Cbor(_) => "VaultRecordError::Cbor",
+            Self::NotARecord => "VaultRecordError::NotARecord",
+            Self::BadEnvelope => "VaultRecordError::BadEnvelope",
+            Self::ContentTypeMismatch { .. } => "VaultRecordError::ContentTypeMismatch",
+            Self::SchemaMismatch { .. } => "VaultRecordError::SchemaMismatch",
+        };
+        f.write_str(variant)
+    }
 }
 
 impl core::fmt::Display for VaultRecordError {
@@ -287,7 +302,7 @@ fn split_envelope(v: CborValue) -> Result<(String, CborValue), VaultRecordError>
 
 /// One of the known record types, or an opaque pass-through for
 /// content types this crate doesn't recognise.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum AnyRecord {
     /// `vault/login/v1`
     Login(Login),
@@ -311,6 +326,21 @@ pub enum AnyRecord {
         /// The canonical-CBOR-encoded payload bytes.
         payload_bytes: Vec<u8>,
     },
+}
+
+impl core::fmt::Debug for AnyRecord {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let variant = match self {
+            Self::Login(_) => "AnyRecord::Login(<redacted>)",
+            Self::SecureNote(_) => "AnyRecord::SecureNote(<redacted>)",
+            Self::Card(_) => "AnyRecord::Card(<redacted>)",
+            Self::TotpSeed(_) => "AnyRecord::TotpSeed(<redacted>)",
+            Self::ApiKey(_) => "AnyRecord::ApiKey(<redacted>)",
+            Self::DatabaseCredential(_) => "AnyRecord::DatabaseCredential(<redacted>)",
+            Self::Opaque { .. } => "AnyRecord::Opaque(<redacted>)",
+        };
+        f.write_str(variant)
+    }
 }
 
 /// Known high-level record kind without carrying record values.
@@ -581,7 +611,7 @@ pub fn encode_opaque(
 /// A login (username + password + URLs) in the password-manager use
 /// case. Reference shape: Bitwarden's `Login` / 1Password's
 /// `LoginItem`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Login {
     /// Display title for the entry.
     pub title: String,
@@ -676,7 +706,7 @@ impl VaultRecord for Login {
 }
 
 /// A free-form encrypted note.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct SecureNote {
     /// Display title.
     pub title: String,
@@ -720,7 +750,7 @@ impl VaultRecord for SecureNote {
 }
 
 /// A credit-card / payment-method record.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Card {
     /// Display title (e.g. "Personal Visa").
     pub title: String,
@@ -818,7 +848,7 @@ impl VaultRecord for Card {
 /// A TOTP / HOTP seed (the shared secret an authenticator app stores
 /// for one account). Useful when the vault is also acting as the
 /// user's authenticator.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct TotpSeed {
     /// Display label (e.g. "GitHub : ada@example.com").
     pub label: String,
@@ -909,7 +939,7 @@ impl VaultRecord for TotpSeed {
 }
 
 /// An API key — the machine-secret-store equivalent of `Login`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ApiKey {
     /// Display label.
     pub label: String,
@@ -1007,7 +1037,7 @@ impl VaultRecord for ApiKey {
 /// metadata. Often a *dynamic* credential issued by VLT08; the
 /// record schema is identical whether the credential is static or
 /// dynamic.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct DatabaseCredential {
     /// Display label.
     pub label: String,
@@ -1120,6 +1150,30 @@ impl VaultRecord for DatabaseCredential {
         })
     }
 }
+
+macro_rules! impl_redacted_record_debug {
+    ($($record:ident),+ $(,)?) => {
+        $(
+            impl core::fmt::Debug for $record {
+                fn fmt(
+                    &self,
+                    f: &mut core::fmt::Formatter<'_>,
+                ) -> core::fmt::Result {
+                    f.write_str(concat!(stringify!($record), "(<redacted>)"))
+                }
+            }
+        )+
+    };
+}
+
+impl_redacted_record_debug!(
+    Login,
+    SecureNote,
+    Card,
+    TotpSeed,
+    ApiKey,
+    DatabaseCredential
+);
 
 // ─────────────────────────────────────────────────────────────────────
 // 5. Map-walking helpers
@@ -1335,6 +1389,68 @@ mod tests {
         SecureNote {
             title: "WiFi password".into(),
             body: "SSID: HomeNet\nKey: hunter2".into(),
+        }
+    }
+
+    #[test]
+    fn record_debug_is_value_redacted() {
+        let cases = [
+            (format!("{:?}", sample_login()), "Login(<redacted>)"),
+            (format!("{:?}", sample_note()), "SecureNote(<redacted>)"),
+            (format!("{:?}", sample_card()), "Card(<redacted>)"),
+            (format!("{:?}", sample_totp()), "TotpSeed(<redacted>)"),
+            (format!("{:?}", sample_api_key()), "ApiKey(<redacted>)"),
+            (
+                format!("{:?}", sample_db()),
+                "DatabaseCredential(<redacted>)",
+            ),
+        ];
+
+        for (actual, expected) in cases {
+            assert_eq!(actual, expected);
+        }
+        assert_eq!(format!("{:#?}", sample_login()), "Login(<redacted>)");
+    }
+
+    #[test]
+    fn any_record_debug_is_value_redacted() {
+        let cases = [
+            (
+                AnyRecord::Login(sample_login()),
+                "AnyRecord::Login(<redacted>)",
+            ),
+            (
+                AnyRecord::SecureNote(sample_note()),
+                "AnyRecord::SecureNote(<redacted>)",
+            ),
+            (
+                AnyRecord::Card(sample_card()),
+                "AnyRecord::Card(<redacted>)",
+            ),
+            (
+                AnyRecord::TotpSeed(sample_totp()),
+                "AnyRecord::TotpSeed(<redacted>)",
+            ),
+            (
+                AnyRecord::ApiKey(sample_api_key()),
+                "AnyRecord::ApiKey(<redacted>)",
+            ),
+            (
+                AnyRecord::DatabaseCredential(sample_db()),
+                "AnyRecord::DatabaseCredential(<redacted>)",
+            ),
+            (
+                AnyRecord::Opaque {
+                    content_type: "vault/private-token/v1".into(),
+                    payload_bytes: b"raw opaque secret".to_vec(),
+                },
+                "AnyRecord::Opaque(<redacted>)",
+            ),
+        ];
+
+        for (record, expected) in cases {
+            assert_eq!(format!("{record:?}"), expected);
+            assert_eq!(format!("{record:#?}"), expected);
         }
     }
 
@@ -1762,6 +1878,39 @@ mod tests {
             if let VaultRecordError::ContentTypeMismatch { .. } = e {
                 assert!(!s.contains("ATTACKER"));
             }
+        }
+    }
+
+    #[test]
+    fn error_debug_strings_are_static() {
+        let cases = [
+            (
+                VaultRecordError::Cbor(CborError::UnexpectedEof),
+                "VaultRecordError::Cbor",
+            ),
+            (VaultRecordError::NotARecord, "VaultRecordError::NotARecord"),
+            (
+                VaultRecordError::BadEnvelope,
+                "VaultRecordError::BadEnvelope",
+            ),
+            (
+                VaultRecordError::ContentTypeMismatch {
+                    expected: LOGIN_V1,
+                    actual: "ATTACKER-CONTROLLED-CONTENT-TYPE".into(),
+                },
+                "VaultRecordError::ContentTypeMismatch",
+            ),
+            (
+                VaultRecordError::SchemaMismatch {
+                    what: "static schema detail",
+                },
+                "VaultRecordError::SchemaMismatch",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(format!("{error:?}"), expected);
+            assert_eq!(format!("{error:#?}"), expected);
         }
     }
 }

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1244,10 +1244,10 @@ changelog, focused build, and downstream validation.
    including closure of VLT01's existing measured line-coverage gap against its
    declared 95% target (88.2% under Tarpaulin LLVM after the root-KEK seam),
    and fixed wire/GC bounds for accumulated observed-set tombstones and
-   operation IDs before domain state is decoded from persistent objects. The
-   review must also replace or contain VLT02's derived secret-bearing `Debug`
-   implementations, which can currently emit raw record fields if a caller
-   bypasses the VLT-PM03 redacted view API.
+   operation IDs before domain state is decoded from persistent objects.
+   VLT02's record, opaque-payload, and error diagnostics use closed redacted
+   `Debug` implementations, so callers that bypass VLT-PM03 views do not emit
+   raw record fields through ordinary diagnostic formatting.
 
 ### Phase 1A — local CLI
 

--- a/code/specs/VLT02-vault-records.md
+++ b/code/specs/VLT02-vault-records.md
@@ -120,9 +120,17 @@ Every type carrying a secret implements `Zeroize` manually:
 `ApiKey.token`, `DatabaseCredential.password`. Higher Vault layers
 hold records inside `Zeroizing<T>` so drops always wipe.
 
+Every first-party record type also implements a closed, value-redacted
+`Debug`. The output contains only the Rust type name and a fixed `<redacted>`
+marker. It never formats display metadata, secret fields, list contents, or
+optional values. `AnyRecord` applies the same rule while retaining only its
+variant name; the opaque variant does not format its attacker-controlled
+content type or canonical payload bytes. These guarantees apply even when a
+caller bypasses the higher-level VLT-PM03 redacted view API.
+
 ## Errors are inert
 
-`VaultRecordError`'s `Display` strings come exclusively from this
+`VaultRecordError`'s `Display` and `Debug` strings come exclusively from this
 crate's literals. Specifically:
 
 - `Cbor` reports the underlying CBOR error variant tag, not bytes.
@@ -133,6 +141,10 @@ crate's literals. Specifically:
   literal — so log lines never contain attacker-controlled bytes.
 - `SchemaMismatch { what }` uses a `&'static str` from a fixed
   per-field table.
+
+`Debug` exposes only the variant name and suppresses the
+attacker-controlled `actual` content type. This keeps diagnostic and assertion
+formatting at the same trust boundary as `Display`.
 
 This matches VLT01's discipline.
 
@@ -150,6 +162,8 @@ This matches VLT01's discipline.
 | Top-level value other than the `{t, d}` map                     | `NotARecord`                                                          | `decode_rejects_top_level_array`, `…_with_extra_field`          |
 | `"t"` is not text                                               | `BadEnvelope`                                                         | `decode_rejects_envelope_with_t_not_text`                       |
 | Attacker-controlled bytes in error messages                     | `Display` strings static literals only; `actual` field hidden         | `error_display_strings_are_static`                              |
+| Plaintext record values leak through diagnostic formatting      | Closed custom `Debug` on records and `AnyRecord`                       | `record_debug_is_value_redacted`, `any_record_debug_is_value_redacted` |
+| Attacker content type leaks through error diagnostic formatting | Closed custom `Debug` on `VaultRecordError`                            | `error_debug_strings_are_static`                                |
 | Forward incompatibility breaks v1 readers                       | Unknown payload fields tolerated                                      | `extra_unknown_fields_in_payload_are_ignored`                   |
 
 ## Non-goals


### PR DESCRIPTION
## Summary

- replace derived `Debug` on all six VLT02 record types with closed type-only redaction
- redact `AnyRecord` while retaining only its variant, including opaque content types and payload bytes
- make `VaultRecordError::Debug` suppress attacker-controlled content types just like `Display`
- tighten VLT02 and the password-manager Phase 0 security contract, with exact regression tests for normal and pretty diagnostic formatting

## Security impact

Before this change, ordinary `{:?}` formatting could emit plaintext passwords, card data, TOTP seeds, API tokens, database credentials, notes, and opaque payload bytes. After this change, record diagnostics contain only a fixed type or variant name plus `<redacted>`. Error diagnostics contain only a fixed variant name.

## Validation

- `cargo test -p coding_adventures_vault_records` — 27 passed
- `cargo clippy -p coding_adventures_vault_records --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p coding_adventures_vault_records --no-deps`
- package `BUILD` — passed
- capability taxonomy — 7 passed
- affected build tool — 4 of 4 packages built
- tarpaulin baseline — 376/458 lines, 82.1%; all new diagnostic branches are covered