### PR TITLE
Add Mermaid sequence actor links

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -3,7 +3,7 @@
 
 document = { NEWLINE } HEADER body EOF ;
 body = { NEWLINE | statement } ;
-statement = participant_stmt | participant_box | destroy_stmt | message_stmt | activation_stmt | note_stmt | title_stmt | autonumber_stmt | control_block ;
+statement = participant_stmt | participant_box | destroy_stmt | message_stmt | activation_stmt | note_stmt | link_stmt | links_stmt | title_stmt | autonumber_stmt | control_block ;
 
 participant_stmt = [ "create" ] participant_decl ;
 participant_decl = ( "participant" | "actor" ) identifier [ CONFIG ] [ "as" text ] ;
@@ -12,6 +12,8 @@ destroy_stmt = "destroy" identifier ;
 message_stmt = identifier [ CENTRAL ] message_arrow [ CENTRAL ] [ PLUS | MINUS ] identifier COLON [ text ] ;
 activation_stmt = ( "activate" | "deactivate" ) identifier ;
 note_stmt = "note" ( ( "left" | "right" ) "of" identifier | "over" actor_pair ) COLON text ;
+link_stmt = "link" identifier COLON text AT URL ;
+links_stmt = "links" identifier COLON JSON_OBJECT ;
 title_stmt = "title" text ;
 autonumber_stmt = "autonumber" [ "off" | NUMBER [ NUMBER ] ] ;
 

--- a/code/grammars/mermaid/sequence.tokens
+++ b/code/grammars/mermaid/sequence.tokens
@@ -38,7 +38,10 @@ CENTRAL                  = "()"
 COLON                    = ":"
 COLOR                    = /rgba?\([^\)\r\n]*\)/
 CONFIG                   = /@\{[^\}\r\n]*\}/
+JSON_OBJECT              = /\{[^\}\r\n]*\}/
+URL                      = /https?:\/\/[^ \t\r\n]+/
 COMMA                    = ","
+AT                       = "@"
 PLUS                     = "+"
 MINUS                    = "-"
 NUMBER                   = /(?:[0-9]+(?:\.[0-9]{1,2})?|\.[0-9]{1,2})/
@@ -50,6 +53,8 @@ keywords:
   actor
   create
   destroy
+  link
+  links
   box
   as
   activate

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.13.0
+
+- Added labeled sequence participant links to semantic and layout IR.
+
 ## 0.12.0
 
 - Added optional sequence block fills for background highlights.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.7.0 — DG00/DG04 semantic IR
+//! diagram-ir v0.13.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.12.0";
+pub const VERSION: &str = "0.13.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -173,6 +173,13 @@ pub struct SequenceParticipant {
     pub kind: SequenceParticipantKind,
     pub style: Option<DiagramStyle>,
     pub group_id: Option<String>,
+    pub links: Vec<SequenceLink>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SequenceLink {
+    pub label: String,
+    pub url: String,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -298,6 +305,7 @@ pub enum LayoutedSequenceItem {
         id: String,
         label: String,
         kind: SequenceParticipantKind,
+        links: Vec<SequenceLink>,
         x: f64,
         y: f64,
         width: f64,
@@ -907,8 +915,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_is_0_12_0() {
-        assert_eq!(VERSION, "0.12.0");
+    fn version_is_0_13_0() {
+        assert_eq!(VERSION, "0.13.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.0 - 2026-08-09
+
+- Preserve actor links on participant layout items for backend-neutral lowering.
+
 ## 0.8.0 - 2026-08-09
 
 - Preserve nested rect fills without reserving a control-block label band.

--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-sequence"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
 

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -7,7 +7,7 @@ use diagram_ir::{
     SequenceEvent, SequenceNotePlacement,
 };
 
-pub const VERSION: &str = "0.8.0";
+pub const VERSION: &str = "0.9.0";
 
 const MARGIN: f64 = 28.0;
 const HEADER_Y: f64 = 42.0;
@@ -74,6 +74,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                 id: participant.id.clone(),
                 label: participant.label.text.clone(),
                 kind: participant.kind.clone(),
+                links: participant.links.clone(),
                 x: center - box_width / 2.0,
                 y: header_y,
                 width: box_width,
@@ -170,6 +171,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                         id: definition.id.clone(),
                         label: definition.label.text.clone(),
                         kind: definition.kind.clone(),
+                        links: definition.links.clone(),
                         x: center - box_width / 2.0,
                         y,
                         width: box_width,
@@ -367,6 +369,7 @@ mod tests {
             kind: SequenceParticipantKind::Participant,
             style: None,
             group_id: None,
+            links: vec![],
         }
     }
 

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Export sequence actor links as PaintScene hit-test metadata.
 - Paint sequence rect blocks with their declared functional colors.
 - Format decimal sequence numbers without redundant trailing zeroes.
 - Added central-connection endpoint circles layered above activation bars.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.12.0";
+pub const VERSION: &str = "0.13.0";
 
 use std::collections::HashMap;
 
@@ -1080,6 +1080,7 @@ where
     let mut instructions = Vec::new();
     let mut text_children = Vec::new();
     let mut central_markers = Vec::new();
+    let mut scene_metadata = HashMap::new();
     let label_font = options.label_font.clone();
     let text_color = Color {
         r: 30,
@@ -1424,14 +1425,22 @@ where
                 ));
             }
             LayoutedSequenceItem::ParticipantBox {
+                id,
                 label,
                 kind,
+                links,
                 x,
                 y,
                 width,
                 height,
                 ..
             } => {
+                for link in links {
+                    scene_metadata.insert(
+                        format!("sequence.participant.{id}.link.{}", link.label),
+                        link.url.clone(),
+                    );
+                }
                 let specialized = !matches!(
                     kind,
                     SequenceParticipantKind::Participant | SequenceParticipantKind::Actor
@@ -1545,7 +1554,7 @@ where
         background: format!("rgb({},{},{})", background.r, background.g, background.b),
         instructions,
         id: None,
-        metadata: None,
+        metadata: (!scene_metadata.is_empty()).then_some(scene_metadata),
     }
 }
 
@@ -2646,7 +2655,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.12.0");
+        assert_eq!(crate::VERSION, "0.13.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -9,7 +9,7 @@
 
 #[cfg(target_vendor = "apple")]
 mod apple {
-    use diagram_ir::{SequenceBlockKind, SequenceEvent};
+    use diagram_ir::{SequenceBlockKind, SequenceEvent, SequenceLink};
     use diagram_layout_chart::layout_chart_diagram;
     use diagram_layout_graph::layout_graph_diagram;
     use diagram_layout_sequence::layout_sequence_diagram;
@@ -365,6 +365,10 @@ mod apple {
         diagram.events.push(SequenceEvent::BlockEnd {
             kind: SequenceBlockKind::Rect,
         });
+        diagram.participants[0].links.push(SequenceLink {
+            label: "Dashboard".into(),
+            url: "https://example.com/dashboard".into(),
+        });
         let layout = layout_sequence_diagram(&diagram);
 
         let shaper = CoreTextShaper;
@@ -396,6 +400,14 @@ mod apple {
             instruction,
             paint_instructions::PaintInstruction::Path(path) if path.stroke_dash.is_some()
         )));
+        assert_eq!(
+            scene
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("sequence.participant.User.link.Dashboard"))
+                .map(String::as_str),
+            Some("https://example.com/dashboard")
+        );
         assert!(scene.instructions.iter().any(|instruction| matches!(
             instruction,
             paint_instructions::PaintInstruction::Path(path)

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.0
+
+- Tokenize sequence actor-link URLs and JSON link maps.
+
 ## 0.11.0
 
 - Reuse functional color tokens for sequence `rect` highlights.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.11.0";
+pub const VERSION: &str = "0.12.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.11.0");
+        assert_eq!(VERSION, "0.12.0");
     }
 
     #[test]
@@ -393,5 +393,18 @@ A\\-B: reverse stick bottom
             .map(|token| token.value.as_str())
             .collect();
         assert_eq!(numbers, vec!["10.5", "2.25"]);
+    }
+
+    #[test]
+    fn tokenizes_sequence_actor_links() {
+        let tokens = tokenize_mermaid_sequence(
+            "sequenceDiagram\nlink Alice: Dashboard @ https://example.com/alice\nlinks Bob: {\"Wiki\": \"https://example.com/wiki\"}\n",
+        );
+        assert!(tokens
+            .iter()
+            .any(|token| token.type_name.as_deref() == Some("URL")));
+        assert!(tokens
+            .iter()
+            .any(|token| token.type_name.as_deref() == Some("JSON_OBJECT")));
     }
 }

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.0
+
+- Parse singular and JSON-map sequence actor links into semantic IR.
+
 ## 0.12.0
 
 - Parse nested `rect` blocks with required `rgb` or `rgba` fills.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 
@@ -10,6 +10,4 @@ grammar-tools = { path = "../grammar-tools" }
 lexer = { path = "../lexer" }
 mermaid-lexer = { path = "../mermaid-lexer" }
 parser = { path = "../parser" }
-
-[dev-dependencies]
 serde_json = "1"

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -38,7 +38,9 @@ and dotted message arrows, bidirectional/cross/point arrowheads, notes,
 activations, titles, automatic numbering, and nested control blocks with branch
 separators. Participant creation and destruction are lifecycle events consumed
 by layout. Participant `box` declarations preserve group labels, fills, and
-membership. Actor-menu links, properties, and details remain explicit compatibility gaps.
+membership. Singular and JSON-map actor-menu links survive as PaintScene
+metadata for interactive backends. Properties and details remain explicit
+compatibility gaps.
 All Mermaid 11.16.1 solid/dotted, normal/reverse filled and stick half-arrow
 forms preserve their line style, half orientation, and endpoint through Paint.
 Central connection markers before and/or after an arrow preserve source,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.12.0";
+pub const VERSION: &str = "0.13.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -448,7 +448,7 @@ use diagram_ir::{
     Axis, AxisKind, ChartDiagram, ChartKind, ChartOrientation, ChartSeries, Compartment,
     CompartmentKind, GanttDiagram, GanttSection, GanttTask, GitBranch, GitCommitType, GitDiagram,
     GitEvent, PieSlice, RelKind, SankeyFlow, SankeyNode, SequenceArrowhead, SequenceBlockKind,
-    SequenceCentralConnection, SequenceDiagram, SequenceEvent, SequenceLineStyle,
+    SequenceCentralConnection, SequenceDiagram, SequenceEvent, SequenceLineStyle, SequenceLink,
     SequenceNotePlacement, SequenceParticipant, SequenceParticipantGroup, SequenceParticipantKind,
     SeriesKind, StructuralDiagram, StructuralGroup, StructuralKind, StructuralNode,
     StructuralNodeKind, StructuralRelationship, TaskStart, TaskStatus, TemporalBody,
@@ -1081,6 +1081,7 @@ fn parse_sequence_body(
                 });
             }
             "note" => parse_sequence_note(cursor, diagram, participant_indices)?,
+            "link" | "links" => parse_sequence_links(cursor, diagram, participant_indices)?,
             "title" => {
                 cursor.advance();
                 diagram.title = Some(take_sequence_line_text(cursor));
@@ -1122,6 +1123,48 @@ fn take_sequence_number(cursor: &mut TokenCursor) -> Result<Option<f64>, ParseEr
         ));
     }
     Ok(Some(value))
+}
+
+fn parse_sequence_links(
+    cursor: &mut TokenCursor,
+    diagram: &mut SequenceDiagram,
+    participant_indices: &mut HashMap<String, usize>,
+) -> Result<(), ParseError> {
+    let plural = cursor.advance().value == "links";
+    let participant = take_sequence_identifier(cursor)?;
+    ensure_sequence_participant(diagram, participant_indices, &participant);
+    cursor
+        .consume_if("COLON")
+        .ok_or_else(|| token_error(cursor.current(), "expected ':' before actor links"))?;
+    let links = if plural {
+        let token = cursor.advance().clone();
+        if token_name(&token) != "JSON_OBJECT" {
+            return Err(token_error(&token, "expected a JSON object of actor links"));
+        }
+        serde_json::from_str::<HashMap<String, String>>(&token.value)
+            .map_err(|error| token_error(&token, format!("invalid actor links JSON: {error}")))?
+            .into_iter()
+            .map(|(label, url)| SequenceLink { label, url })
+            .collect()
+    } else {
+        let mut label = Vec::new();
+        while !cursor.at_eof() && token_name(cursor.current()) != "AT" {
+            label.push(cursor.advance().value.clone());
+        }
+        cursor
+            .consume_if("AT")
+            .ok_or_else(|| token_error(cursor.current(), "expected '@' before actor link URL"))?;
+        let url = cursor
+            .consume_if("URL")
+            .ok_or_else(|| token_error(cursor.current(), "expected an http(s) actor link URL"))?;
+        vec![SequenceLink {
+            label: label.join(" "),
+            url: url.value,
+        }]
+    };
+    let index = participant_indices[&participant];
+    diagram.participants[index].links.extend(links);
+    Ok(())
 }
 
 fn parse_sequence_participant(
@@ -1607,6 +1650,7 @@ fn upsert_sequence_participant(
         kind,
         style: None,
         group_id: None,
+        links: Vec::new(),
     });
 }
 
@@ -3113,6 +3157,21 @@ B//-A: reverse stick top
             .collect();
         assert_eq!(fills, vec!["rgba(0, 0, 255, .1)", "rgb(200, 150, 255)"]);
     }
+
+    #[test]
+    fn sequence_parses_simple_and_json_actor_links() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\nparticipant Alice\nlink Alice: Health Dashboard @ https://example.com/health\nlinks Alice: {\"Wiki\": \"https://example.com/wiki\", \"Repo\": \"https://example.com/repo\"}\n",
+        )
+        .unwrap();
+        let alice = &diagram.participants[0];
+        assert_eq!(alice.links.len(), 3);
+        assert!(alice.links.iter().any(
+            |link| link.label == "Health Dashboard" && link.url == "https://example.com/health"
+        ));
+        assert!(alice.links.iter().any(|link| link.label == "Wiki"));
+        assert!(alice.links.iter().any(|link| link.label == "Repo"));
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -3129,7 +3188,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.12.0");
+        assert_eq!(crate::VERSION, "0.13.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -118,8 +118,9 @@ block events. Sequence layout resolves those events into nested frames and
 branch dividers before existing PaintInstructions render them. Participant
 `create` and `destroy` statements lower into lifecycle events; layout uses them
 to place dynamic participant headers, bound lifelines, and emit destruction
-markers. Actor-menu links, properties, and details
-remain compatibility work. Participant `box` declarations now lower into
+markers. Singular and JSON-map actor-menu links lower through semantic IR and
+layout into PaintScene metadata. Properties and details remain compatibility
+work. Participant `box` declarations now lower into
 semantic groups, lane-enclosing layout geometry, and backend-neutral Paint
 rectangles and labels, including the supported named and `rgb`/`rgba` color
 forms. The family remains partial until those forms and the


### PR DESCRIPTION
## Summary
- add grammar-backed singular and JSON-map sequence actor links
- preserve actor link semantics through diagram IR and sequence layout
- expose links through PaintScene metadata while retaining Metal-to-PNG rendering

## Verification
- `cargo test -p diagram-ir -p mermaid-lexer -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint -- --nocapture`
- `cargo clippy -p diagram-ir -p mermaid-lexer -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `git diff --check`
- visually inspected `/tmp/mermaid_sequence_e2e.png`