### PR TITLE
Report fostered formatting starts in tables

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Formatting start tags foster-parented out of table structure now report the
+  required in-table parse error, covering 16 previously silent malformed corpus
+  cases without changing DOM recovery or undeclared-diagnostic coverage.
 - Non-whitespace text after a template row now reports the required template
   table-mode parse error, covering 2 previously silent malformed corpus cases
   without changing DOM recovery or undeclared-diagnostic coverage.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the template table-mode text diagnostic slice, 2,092 of those cases emit
-at least one lexer or parser diagnostic and 91 remain
+After the foster-parented formatting start-tag diagnostic slice, 2,108 of those
+cases emit at least one lexer or parser diagnostic and 75 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -66,17 +66,15 @@ open table blocks adoption-agency recovery. Description-list item start tags
 now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
 without flagging adjacent description-list items.
 
-The fresh 91-case residual inventory keeps the next concrete groups in the
-existing priority order: remaining table foster-parenting and table-scope
-boundaries;
-select/template recovery; script-tokenizer EOF recovery; plaintext/frameset
-boundaries; and foreign-fragment stray tags plus MathML/SVG table integration.
+The fresh 75-case residual inventory keeps the next concrete groups in this
+priority order: remaining table fragment scope and shell boundaries;
+script-tokenizer EOF recovery; plaintext/frameset and document-tail boundaries;
+and foreign-fragment stray tags plus MathML/SVG table integration. The current
+corpus no longer has a silent formatting-only or general in-body group.
 
 Prioritized work items:
 
-1. **In-body insertion mode.** Cover the remaining formatting-reconstruction
-   and stray-tag diagnostics.
-2. **Table, select, and template insertion modes.** Cover the remaining foster
+1. **Table, select, and template insertion modes.** Cover the remaining foster
    parenting, table scopes, select recovery, and template mode-stack errors.
    Non-whitespace table text now reports when it is foster-parented. The
    specialized SVG and MathML start-tag path now reports when table insertion
@@ -87,21 +85,27 @@ Prioritized work items:
    start tags now report the general in-table parse error. Nested `select` and
    `input` start tags now report when they force recovery from select mode.
    Non-whitespace text after a template row now reports when it forces recovery
-   from template table mode. The
+   from template table mode. Formatting start tags now report when table
+   structure foster-parents them, covering the remaining silent fostered-anchor
+   starts. The
    remaining fragment EOF inventory includes fostered-anchor `eof-in-table`
    rows and MathML/SVG table-boundary scope recovery.
-3. **Adoption agency and active formatting.** Cover malformed formatting cases
-   without changing their now-conforming DOM output.
+2. **Script-tokenizer EOF recovery.** Cover malformed script end tags that
+   reach EOF while the lexer is still assembling the tag.
+3. **Plaintext, frameset, and document-tail boundaries.** Cover EOF and stray
+   content diagnostics after plaintext and frameset transitions.
 4. **Foreign content and fragment parsing.** Cover SVG/MathML integration
    boundaries and context-sensitive fragment errors. HTML start tags that force
    recovery from foreign content now report their parse error; remaining work
    includes foreign end-tag and fragment-shell recovery.
-5. **Diagnostic positions and error taxonomy.** Carry source positions into
+5. **Adoption agency and active formatting.** Cover malformed formatting cases
+   without changing their now-conforming DOM output.
+6. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.
-6. **Input boundary review.** Document the Unicode-code-point parser boundary
+7. **Input boundary review.** Document the Unicode-code-point parser boundary
    and either add or explicitly separate byte decoding and encoding sniffing.
-7. **Algorithm and differential audit.** Map implemented states/modes to the
+8. **Algorithm and differential audit.** Map implemented states/modes to the
    current HTML Standard and add deterministic differential/fuzz coverage for
    branches not exercised by the upstream corpora.
 

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -6258,6 +6258,17 @@ impl HtmlParser {
             return false;
         }
 
+        if self.current_element_is_table_structure()
+            && (incoming_name == "a" || is_formatting_element(incoming_name))
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-formatting-start-tag-in-table",
+                format!(
+                    "formatting start tag `<{incoming_name}>` in a table context was foster parented"
+                ),
+            ));
+        }
+
         if !self.current_element_is_table_structure()
             && self.current_parent_is_fostered_before_open_table()
             && incoming_name == "nobr" {
@@ -33441,6 +33452,45 @@ mod tests {
                 "end tag `</font>` could not close a formatting element across table scope"
             )]
         );
+    }
+
+    #[test]
+    fn reports_formatting_start_tags_fostered_from_table_structure() {
+        for (source, name) in [
+            ("<!doctype html><table><a>x</table>", "a"),
+            ("<!doctype html><table><tbody><b>x</table>", "b"),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic
+                        == &ParserDiagnostic::new(
+                            "unexpected-formatting-start-tag-in-table",
+                            format!(
+                                "formatting start tag `<{name}>` in a table context was foster parented"
+                            ),
+                        )
+                }),
+                "source {source:?}"
+            );
+        }
+
+        let fragment =
+            parse_html_fragment_for_context_with_diagnostics("<a><tr>", "table").unwrap();
+        assert_eq!(
+            fragment.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-formatting-start-tag-in-table",
+                "formatting start tag `<a>` in a table context was foster parented"
+            )]
+        );
+
+        for source in ["<!doctype html><a>x", "<!doctype html><table><tr><td><b>x"] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-formatting-start-tag-in-table"
+            }));
+        }
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 91);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2092);
+    assert_eq!(missing_diagnostic_cases, 75);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2108);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the required in-table parse error when formatting start tags are foster-parented from table structure
- add full-document, fragment, and negative diagnostic coverage
- reduce malformed tree cases without diagnostics from 91 to 75 and reprioritize the remaining backlog

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- focused post-rebase unit and tree diagnostic ratchet tests
- live WPT/html5lib audit: 1,934 tree cases, 6,806 tokenizer cases, zero missing, 7,242 normalized, zero skipped
- WHATWG audit coverage, manifest, Rust-test, tree-smoke, and conformance audit checks
- `git diff --check`

## Formatting note
- workspace and package-wide `cargo fmt -- --check` remain blocked by broad pre-existing formatting drift outside this patch; the new lines follow rustfmt output.