### PR TITLE
Add Mermaid sequence actor properties

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -3,7 +3,7 @@
 
 document = { NEWLINE } HEADER body EOF ;
 body = { NEWLINE | statement } ;
-statement = participant_stmt | participant_box | destroy_stmt | message_stmt | activation_stmt | note_stmt | link_stmt | links_stmt | title_stmt | autonumber_stmt | control_block ;
+statement = participant_stmt | participant_box | destroy_stmt | message_stmt | activation_stmt | note_stmt | link_stmt | links_stmt | properties_stmt | title_stmt | autonumber_stmt | control_block ;
 
 participant_stmt = [ "create" ] participant_decl ;
 participant_decl = ( "participant" | "actor" ) identifier [ CONFIG ] [ "as" text ] ;
@@ -14,6 +14,7 @@ activation_stmt = ( "activate" | "deactivate" ) identifier ;
 note_stmt = "note" ( ( "left" | "right" ) "of" identifier | "over" actor_pair ) COLON text ;
 link_stmt = "link" identifier COLON text AT URL ;
 links_stmt = "links" identifier COLON JSON_OBJECT ;
+properties_stmt = "properties" identifier COLON JSON_OBJECT ;
 title_stmt = "title" text ;
 autonumber_stmt = "autonumber" [ "off" | NUMBER [ NUMBER ] ] ;
 

--- a/code/grammars/mermaid/sequence.tokens
+++ b/code/grammars/mermaid/sequence.tokens
@@ -38,7 +38,7 @@ CENTRAL                  = "()"
 COLON                    = ":"
 COLOR                    = /rgba?\([^\)\r\n]*\)/
 CONFIG                   = /@\{[^\}\r\n]*\}/
-JSON_OBJECT              = /\{[^\}\r\n]*\}/
+JSON_OBJECT              = /\{[^\r\n]*\}/
 URL                      = /https?:\/\/[^ \t\r\n]+/
 COMMA                    = ","
 AT                       = "@"
@@ -55,6 +55,7 @@ keywords:
   destroy
   link
   links
+  properties
   box
   as
   activate

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.14.0
+
+- Added arbitrary JSON-valued properties to sequence participants and layout IR.
+
 ## 0.13.0
 
 - Added labeled sequence participant links to semantic and layout IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.13.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.14.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.13.0";
+pub const VERSION: &str = "0.14.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -174,12 +174,20 @@ pub struct SequenceParticipant {
     pub style: Option<DiagramStyle>,
     pub group_id: Option<String>,
     pub links: Vec<SequenceLink>,
+    pub properties: Vec<SequenceProperty>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SequenceLink {
     pub label: String,
     pub url: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SequenceProperty {
+    pub name: String,
+    /// Canonical JSON preserves Mermaid's arbitrary property value types.
+    pub value_json: String,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -306,6 +314,7 @@ pub enum LayoutedSequenceItem {
         label: String,
         kind: SequenceParticipantKind,
         links: Vec<SequenceLink>,
+        properties: Vec<SequenceProperty>,
         x: f64,
         y: f64,
         width: f64,
@@ -915,8 +924,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_is_0_13_0() {
-        assert_eq!(VERSION, "0.13.0");
+    fn version_is_0_14_0() {
+        assert_eq!(VERSION, "0.14.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.0 - 2026-08-09
+
+- Preserve actor properties on participant layout items.
+
 ## 0.9.0 - 2026-08-09
 
 - Preserve actor links on participant layout items for backend-neutral lowering.

--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-sequence"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
 

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -7,7 +7,7 @@ use diagram_ir::{
     SequenceEvent, SequenceNotePlacement,
 };
 
-pub const VERSION: &str = "0.9.0";
+pub const VERSION: &str = "0.10.0";
 
 const MARGIN: f64 = 28.0;
 const HEADER_Y: f64 = 42.0;
@@ -75,6 +75,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                 label: participant.label.text.clone(),
                 kind: participant.kind.clone(),
                 links: participant.links.clone(),
+                properties: participant.properties.clone(),
                 x: center - box_width / 2.0,
                 y: header_y,
                 width: box_width,
@@ -172,6 +173,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                         label: definition.label.text.clone(),
                         kind: definition.kind.clone(),
                         links: definition.links.clone(),
+                        properties: definition.properties.clone(),
                         x: center - box_width / 2.0,
                         y,
                         width: box_width,
@@ -370,6 +372,7 @@ mod tests {
             style: None,
             group_id: None,
             links: vec![],
+            properties: vec![],
         }
     }
 

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Export JSON-valued sequence actor properties as PaintScene metadata.
 - Export sequence actor links as PaintScene hit-test metadata.
 - Paint sequence rect blocks with their declared functional colors.
 - Format decimal sequence numbers without redundant trailing zeroes.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.13.0";
+pub const VERSION: &str = "0.14.0";
 
 use std::collections::HashMap;
 
@@ -1429,6 +1429,7 @@ where
                 label,
                 kind,
                 links,
+                properties,
                 x,
                 y,
                 width,
@@ -1439,6 +1440,12 @@ where
                     scene_metadata.insert(
                         format!("sequence.participant.{id}.link.{}", link.label),
                         link.url.clone(),
+                    );
+                }
+                for property in properties {
+                    scene_metadata.insert(
+                        format!("sequence.participant.{id}.property.{}", property.name),
+                        property.value_json.clone(),
                     );
                 }
                 let specialized = !matches!(
@@ -2655,7 +2662,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.13.0");
+        assert_eq!(crate::VERSION, "0.14.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -9,7 +9,7 @@
 
 #[cfg(target_vendor = "apple")]
 mod apple {
-    use diagram_ir::{SequenceBlockKind, SequenceEvent, SequenceLink};
+    use diagram_ir::{SequenceBlockKind, SequenceEvent, SequenceLink, SequenceProperty};
     use diagram_layout_chart::layout_chart_diagram;
     use diagram_layout_graph::layout_graph_diagram;
     use diagram_layout_sequence::layout_sequence_diagram;
@@ -369,6 +369,10 @@ mod apple {
             label: "Dashboard".into(),
             url: "https://example.com/dashboard".into(),
         });
+        diagram.participants[0].properties.push(SequenceProperty {
+            name: "role".into(),
+            value_json: "\"administrator\"".into(),
+        });
         let layout = layout_sequence_diagram(&diagram);
 
         let shaper = CoreTextShaper;
@@ -407,6 +411,14 @@ mod apple {
                 .and_then(|metadata| metadata.get("sequence.participant.User.link.Dashboard"))
                 .map(String::as_str),
             Some("https://example.com/dashboard")
+        );
+        assert_eq!(
+            scene
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("sequence.participant.User.property.role"))
+                .map(String::as_str),
+            Some("\"administrator\"")
         );
         assert!(scene.instructions.iter().any(|instruction| matches!(
             instruction,

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.0
+
+- Tokenize sequence actor property objects, including nested JSON values.
+
 ## 0.12.0
 
 - Tokenize sequence actor-link URLs and JSON link maps.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.12.0";
+pub const VERSION: &str = "0.13.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.12.0");
+        assert_eq!(VERSION, "0.13.0");
     }
 
     #[test]
@@ -403,6 +403,17 @@ A\\-B: reverse stick bottom
         assert!(tokens
             .iter()
             .any(|token| token.type_name.as_deref() == Some("URL")));
+        assert!(tokens
+            .iter()
+            .any(|token| token.type_name.as_deref() == Some("JSON_OBJECT")));
+    }
+
+    #[test]
+    fn tokenizes_sequence_actor_properties() {
+        let tokens = tokenize_mermaid_sequence(
+            "sequenceDiagram\nproperties Alice: {\"role\": \"admin\", \"active\": true}\n",
+        );
+        assert!(tokens.iter().any(|token| token.value == "properties"));
         assert!(tokens
             .iter()
             .any(|token| token.type_name.as_deref() == Some("JSON_OBJECT")));

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.14.0
+
+- Parse and merge arbitrary JSON-valued sequence actor properties.
+
 ## 0.13.0
 
 - Parse singular and JSON-map sequence actor links into semantic IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -39,8 +39,9 @@ activations, titles, automatic numbering, and nested control blocks with branch
 separators. Participant creation and destruction are lifecycle events consumed
 by layout. Participant `box` declarations preserve group labels, fills, and
 membership. Singular and JSON-map actor-menu links survive as PaintScene
-metadata for interactive backends. Properties and details remain explicit
-compatibility gaps.
+metadata for interactive backends. Arbitrary JSON-valued actor properties are
+also preserved in scene metadata. DOM-referenced `details` remain an explicit
+compatibility gap.
 All Mermaid 11.16.1 solid/dotted, normal/reverse filled and stick half-arrow
 forms preserve their line style, half orientation, and endpoint through Paint.
 Central connection markers before and/or after an arrow preserve source,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.13.0";
+pub const VERSION: &str = "0.14.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -450,9 +450,9 @@ use diagram_ir::{
     GitEvent, PieSlice, RelKind, SankeyFlow, SankeyNode, SequenceArrowhead, SequenceBlockKind,
     SequenceCentralConnection, SequenceDiagram, SequenceEvent, SequenceLineStyle, SequenceLink,
     SequenceNotePlacement, SequenceParticipant, SequenceParticipantGroup, SequenceParticipantKind,
-    SeriesKind, StructuralDiagram, StructuralGroup, StructuralKind, StructuralNode,
-    StructuralNodeKind, StructuralRelationship, TaskStart, TaskStatus, TemporalBody,
-    TemporalDiagram, TemporalKind,
+    SequenceProperty, SeriesKind, StructuralDiagram, StructuralGroup, StructuralKind,
+    StructuralNode, StructuralNodeKind, StructuralRelationship, TaskStart, TaskStatus,
+    TemporalBody, TemporalDiagram, TemporalKind,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1082,6 +1082,7 @@ fn parse_sequence_body(
             }
             "note" => parse_sequence_note(cursor, diagram, participant_indices)?,
             "link" | "links" => parse_sequence_links(cursor, diagram, participant_indices)?,
+            "properties" => parse_sequence_properties(cursor, diagram, participant_indices)?,
             "title" => {
                 cursor.advance();
                 diagram.title = Some(take_sequence_line_text(cursor));
@@ -1164,6 +1165,46 @@ fn parse_sequence_links(
     };
     let index = participant_indices[&participant];
     diagram.participants[index].links.extend(links);
+    Ok(())
+}
+
+fn parse_sequence_properties(
+    cursor: &mut TokenCursor,
+    diagram: &mut SequenceDiagram,
+    participant_indices: &mut HashMap<String, usize>,
+) -> Result<(), ParseError> {
+    cursor.advance();
+    let participant = take_sequence_identifier(cursor)?;
+    ensure_sequence_participant(diagram, participant_indices, &participant);
+    cursor
+        .consume_if("COLON")
+        .ok_or_else(|| token_error(cursor.current(), "expected ':' before actor properties"))?;
+    let token = cursor.advance().clone();
+    if token_name(&token) != "JSON_OBJECT" {
+        return Err(token_error(
+            &token,
+            "expected a JSON object of actor properties",
+        ));
+    }
+    let properties = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(
+        &token.value,
+    )
+    .map_err(|error| token_error(&token, format!("invalid actor properties JSON: {error}")))?;
+    let target = &mut diagram.participants[participant_indices[&participant]].properties;
+    for (name, value) in properties {
+        let property = SequenceProperty {
+            name,
+            value_json: value.to_string(),
+        };
+        if let Some(existing) = target
+            .iter_mut()
+            .find(|existing| existing.name == property.name)
+        {
+            *existing = property;
+        } else {
+            target.push(property);
+        }
+    }
     Ok(())
 }
 
@@ -1651,6 +1692,7 @@ fn upsert_sequence_participant(
         style: None,
         group_id: None,
         links: Vec::new(),
+        properties: Vec::new(),
     });
 }
 
@@ -3172,6 +3214,25 @@ B//-A: reverse stick top
         assert!(alice.links.iter().any(|link| link.label == "Wiki"));
         assert!(alice.links.iter().any(|link| link.label == "Repo"));
     }
+
+    #[test]
+    fn sequence_parses_and_merges_actor_properties() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\nparticipant Alice\nproperties Alice: {\"role\": \"admin\", \"active\": true, \"limits\": {\"daily\": 5}}\nproperties Alice: {\"role\": \"owner\"}\n",
+        )
+        .unwrap();
+        let properties = &diagram.participants[0].properties;
+        assert_eq!(properties.len(), 3);
+        assert!(properties
+            .iter()
+            .any(|property| property.name == "role" && property.value_json == "\"owner\""));
+        assert!(properties
+            .iter()
+            .any(|property| property.name == "active" && property.value_json == "true"));
+        assert!(properties.iter().any(|property| {
+            property.name == "limits" && property.value_json == "{\"daily\":5}"
+        }));
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -3188,7 +3249,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.13.0");
+        assert_eq!(crate::VERSION, "0.14.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -119,7 +119,8 @@ branch dividers before existing PaintInstructions render them. Participant
 `create` and `destroy` statements lower into lifecycle events; layout uses them
 to place dynamic participant headers, bound lifelines, and emit destruction
 markers. Singular and JSON-map actor-menu links lower through semantic IR and
-layout into PaintScene metadata. Properties and details remain compatibility
+layout into PaintScene metadata. Actor `properties` preserve arbitrary JSON
+values through the same pipeline. DOM-referenced `details` remain compatibility
 work. Participant `box` declarations now lower into
 semantic groups, lane-enclosing layout geometry, and backend-neutral Paint
 rectangles and labels, including the supported named and `rgb`/`rgba` color


### PR DESCRIPTION
## Summary
- add grammar-backed Mermaid sequence actor `properties` statements
- preserve arbitrary JSON-valued properties through semantic IR and sequence layout
- expose canonical JSON values through PaintScene metadata with Metal PNG coverage

## Verification
- `cargo test -p diagram-ir -p mermaid-lexer -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint -- --nocapture`
- `cargo clippy -p diagram-ir -p mermaid-lexer -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `git diff --check`
- visually inspected `/tmp/mermaid_sequence_e2e.png`