### PR TITLE
Fix Qt styled wrapper dimensions

### DIFF
--- a/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-qt/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed - duplicate fixed wrapper dimensions
+
+Painted or padded `Row` and `Column` wrappers no longer emit a second,
+content-derived `implicitWidth` or `implicitHeight` when MSL already provides a
+fixed dimension. Complete generated applications therefore remain valid QML
+when a styled native layout combines width or height with paint or padding.
+
 ### Added - native multiline legacy Input lowering
 
 The still-supported UI25 `Input ( multiline: true )` primitive now lowers to

--- a/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-qt/src/pipeline.rs
@@ -959,21 +959,31 @@ fn emit_styled_layout_container_qml(
 
     let inset = qml_padding(props).unwrap_or_else(|| "0".to_string());
     let paint_lines = qml_rectangle_paint_lines(props);
+    let has_fixed_width = style_prop(props, "width")
+        .and_then(qml_px_or_none)
+        .is_some();
+    let has_fixed_height = style_prop(props, "height")
+        .and_then(qml_px_or_none)
+        .is_some();
     let mut out = String::new();
     writeln!(out, "{pad}Rectangle {{").unwrap();
     for line in qml_layout_size_lines(props) {
         writeln!(out, "{inner_pad}{line}").unwrap();
     }
-    writeln!(
-        out,
-        "{inner_pad}implicitWidth: childrenRect.x + childrenRect.width + {inset}"
-    )
-    .unwrap();
-    writeln!(
-        out,
-        "{inner_pad}implicitHeight: childrenRect.y + childrenRect.height + {inset}"
-    )
-    .unwrap();
+    if !has_fixed_width {
+        writeln!(
+            out,
+            "{inner_pad}implicitWidth: childrenRect.x + childrenRect.width + {inset}"
+        )
+        .unwrap();
+    }
+    if !has_fixed_height {
+        writeln!(
+            out,
+            "{inner_pad}implicitHeight: childrenRect.y + childrenRect.height + {inset}"
+        )
+        .unwrap();
+    }
     if paint_lines.iter().all(|line| !line.starts_with("color:")) {
         writeln!(out, "{inner_pad}color: \"transparent\"").unwrap();
     }
@@ -8409,6 +8419,56 @@ mod tests {
             out.contains("spacing: 16"),
             "missing native spacing:\n{out}"
         );
+    }
+
+    #[test]
+    fn styled_wrapper_does_not_assign_fixed_dimensions_twice() {
+        let style = StyleDef {
+            component_name: "Sidebar".to_string(),
+            parts: vec![PartStyle {
+                name: "sidebar".to_string(),
+                base: vec![
+                    sp("width", "236px"),
+                    sp("height", "480px"),
+                    sp("padding", "20px"),
+                    sp("background", "#1a1714"),
+                ],
+                transitions: vec![],
+                states: vec![],
+            }],
+        };
+        let layout = LayoutDef {
+            component_name: "Sidebar".to_string(),
+            root: LayoutNode {
+                tag: "Column".to_string(),
+                part_name: Some("sidebar".to_string()),
+                props: vec![],
+                children: vec![LayoutNode {
+                    tag: "Text".to_string(),
+                    part_name: None,
+                    props: vec![lp("content", LayoutPropValue::String("Menu".to_string()))],
+                    children: vec![],
+                }],
+            },
+        };
+        let out = from_pipeline(&component("Sidebar", vec![], vec![]), &layout, &style)
+            .unwrap()
+            .output;
+
+        assert_eq!(
+            out.matches("implicitWidth:").count(),
+            1,
+            "fixed width and content-derived width must not both be emitted:\n{out}"
+        );
+        assert_eq!(
+            out.matches("implicitHeight:").count(),
+            1,
+            "fixed height and content-derived height must not both be emitted:\n{out}"
+        );
+        assert!(out.contains("implicitWidth: 236"));
+        assert!(out.contains("Layout.preferredWidth: 236"));
+        assert!(out.contains("implicitHeight: 480"));
+        assert!(out.contains("Layout.preferredHeight: 480"));
     }
 
     #[test]

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -309,13 +309,14 @@ unblocks multiple downstream targets; never count source generation as completio
   only focused fixtures; SwiftUI still needs type-correct truthiness lowering and
   collision-safe generated member names, while Flutter still needs boolean
   truthiness lowering and required input values. Qt's plain multiline `Input`
-  lowering is complete; the complete TaskApp now reaches Qt's QML compiler, which
-  rejects styled fixed-width `Box` output because it assigns `implicitWidth` once
-  for the fixed width and again for content-derived wrapper sizing. Deduplicate
-  those generated size bindings before the Qt full-app gate can pass. Standalone
-  Qt package compilation also needs collision-safe signal names: Notes' `onDelete`
-  currently lowers to QML's reserved `signal delete()` identifier, although the
-  composed TaskApp's namespaced `onDeleteNote` avoids that collision.
+  lowering and fixed-dimension wrapper deduplication are complete, and the complete
+  TaskApp now passes Qt's QML compiler, AUTOMOC, C++ compiler, and linker. Its first
+  headless launch reaches the QML engine but fails because fractional MSL font size
+  `10.5` lowers to `font.pixelSize: 10.5`, while Qt requires that property to be an
+  integer; make fractional font sizing type-correct before the Qt launch gate can
+  pass. Standalone Qt package compilation also needs collision-safe signal names:
+  Notes' `onDelete` currently lowers to QML's reserved `signal delete()` identifier,
+  although the composed TaskApp's namespaced `onDeleteNote` avoids that collision.
 
 ### P1 — reusable application vocabulary
 


### PR DESCRIPTION
## Summary

- avoid content-derived `implicitWidth` when a painted or padded Row/Column already has a fixed MSL width
- apply the same rule to fixed height
- add a regression proving each QML dimension is assigned exactly once
- update UI38 with the now-green full TaskApp build and the next launch blocker

## Validation

- `cargo fmt -p mosaic-emit-qt -- --check`
- `cargo test -p mosaic-emit-qt` (121 passed)
- `cargo clippy -p mosaic-emit-qt --all-targets -- -D warnings`
- `cargo test -p mosaic-package-artifact-builder` (55 unit + 1 doctest passed)
- complete TaskApp Qt package generation
- real Qt CMake configure, QML compile, AUTOMOC, C++ compile, and link (100% built)
- headless executable launch reaches the QML engine; the next pre-existing blocker is fractional `font.pixelSize`, recorded in UI38
