### PR TITLE
Report seeded fragment context errors

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Start and end tags rejected against seeded fragment-context elements now
+  report their required parse errors, covering 37 previously silent table,
+  select, frameset, document-shell, and foreign fragment cases without changing
+  DOM recovery or undeclared-diagnostic coverage.
 - Formatting start tags foster-parented out of table structure now report the
   required in-table parse error, covering 16 previously silent malformed corpus
   cases without changing DOM recovery or undeclared-diagnostic coverage.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the foster-parented formatting start-tag diagnostic slice, 2,108 of those
-cases emit at least one lexer or parser diagnostic and 75 remain
+After the seeded fragment-context boundary diagnostic slice, 2,145 of those
+cases emit at least one lexer or parser diagnostic and 38 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -66,16 +66,25 @@ open table blocks adoption-agency recovery. Description-list item start tags
 now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
 without flagging adjacent description-list items.
 
-The fresh 75-case residual inventory keeps the next concrete groups in this
-priority order: remaining table fragment scope and shell boundaries;
-script-tokenizer EOF recovery; plaintext/frameset and document-tail boundaries;
-and foreign-fragment stray tags plus MathML/SVG table integration. The current
-corpus no longer has a silent formatting-only or general in-body group.
+The fresh 38-case residual inventory keeps the next concrete groups in this
+priority order: script-tokenizer EOF recovery; plaintext/frameset and
+document-tail boundaries; and the final fragment-context rows for colgroup
+text, an after-body token, and an HTML start tag in a seeded SVG context. The
+current corpus no longer has a silent table-shell, foreign end-tag,
+formatting-only, or general in-body group.
 
 Prioritized work items:
 
-1. **Table, select, and template insertion modes.** Cover the remaining foster
-   parenting, table scopes, select recovery, and template mode-stack errors.
+1. **Script-tokenizer EOF recovery.** Cover malformed script end tags that
+   reach EOF while the lexer is still assembling the tag.
+2. **Plaintext, frameset, and document-tail boundaries.** Cover EOF and stray
+   content diagnostics after plaintext and frameset transitions.
+3. **Fragment-context parsing.** Cover the final colgroup text, after-body, and
+   foreign HTML start-tag rows. Invalid start and end tags targeting seeded
+   fragment-context elements now report without mutating their synthetic
+   shells.
+4. **Table, select, and template insertion modes.** Continue the algorithm
+   audit beyond the currently exercised diagnostic corpus.
    Non-whitespace table text now reports when it is foster-parented. The
    specialized SVG and MathML start-tag path now reports when table insertion
    mode foster-parents foreign content, and table-context end tags now report
@@ -87,17 +96,9 @@ Prioritized work items:
    Non-whitespace text after a template row now reports when it forces recovery
    from template table mode. Formatting start tags now report when table
    structure foster-parents them, covering the remaining silent fostered-anchor
-   starts. The
-   remaining fragment EOF inventory includes fostered-anchor `eof-in-table`
-   rows and MathML/SVG table-boundary scope recovery.
-2. **Script-tokenizer EOF recovery.** Cover malformed script end tags that
-   reach EOF while the lexer is still assembling the tag.
-3. **Plaintext, frameset, and document-tail boundaries.** Cover EOF and stray
-   content diagnostics after plaintext and frameset transitions.
-4. **Foreign content and fragment parsing.** Cover SVG/MathML integration
-   boundaries and context-sensitive fragment errors. HTML start tags that force
-   recovery from foreign content now report their parse error; remaining work
-   includes foreign end-tag and fragment-shell recovery.
+   starts. Seeded table and foreign fragment-shell boundaries now report their
+   required parse errors. The only silent table fragment row is non-whitespace
+   text in a seeded `colgroup` context.
 5. **Adoption agency and active formatting.** Cover malformed formatting cases
    without changing their now-conforming DOM output.
 6. **Diagnostic positions and error taxonomy.** Carry source positions into

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5085,6 +5085,12 @@ impl HtmlParser {
             self.close_fostered_formatting_before_table_context(&name);
             self.pop_fostered_content_before_table_context(&name);
             if self.fragment_context_ignores_table_start_tag(&name) {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-table-start-tag-in-fragment",
+                    format!(
+                        "start tag `<{name}>` was ignored by the seeded table fragment context"
+                    ),
+                ));
                 return;
             }
             if self.has_open_element("select")
@@ -6747,10 +6753,13 @@ impl HtmlParser {
             self.append_text_to_current("</script>".to_string());
             return;
         }
-        if name != "html" && self.current_element_is_marked_fragment_context(name) {
-            return;
-        }
-        if self.open_marked_fragment_shell_element_matches(name) {
+        if (name != "html" && self.current_element_is_marked_fragment_context(name))
+            || self.open_marked_fragment_shell_element_matches(name)
+        {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-fragment-context-end-tag",
+                format!("end tag `</{name}>` targeted a seeded fragment context element"),
+            ));
             return;
         }
         if self.has_open_svg_html_integration_point()
@@ -33491,6 +33500,66 @@ mod tests {
                 diagnostic.code != "unexpected-formatting-start-tag-in-table"
             }));
         }
+    }
+
+    #[test]
+    fn reports_start_tags_ignored_by_seeded_table_fragment_contexts() {
+        for (source, context, name) in [
+            ("<table><tr>", "table", "table"),
+            ("<caption><td>", "tr", "caption"),
+            ("<tbody><td>", "tr", "tbody"),
+        ] {
+            let output = parse_html_fragment_for_context_with_diagnostics(source, context).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic
+                        == &ParserDiagnostic::new(
+                            "unexpected-table-start-tag-in-fragment",
+                            format!(
+                                "start tag `<{name}>` was ignored by the seeded table fragment context"
+                            ),
+                        )
+                }),
+                "source {source:?} in context {context:?}"
+            );
+        }
+
+        let valid = parse_html_fragment_for_context_with_diagnostics("<tr><td>x", "table").unwrap();
+        assert!(valid
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-table-start-tag-in-fragment"));
+    }
+
+    #[test]
+    fn reports_end_tags_targeting_seeded_fragment_shells() {
+        for (source, context, name) in [
+            ("</table><tr>", "table", "table"),
+            ("</tr><td>", "tr", "tr"),
+            ("</table><tr>", "tbody", "table"),
+            ("</select><option>", "select", "select"),
+            ("</svg>x", "svg svg", "svg"),
+        ] {
+            let output = parse_html_fragment_for_context_with_diagnostics(source, context).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic
+                        == &ParserDiagnostic::new(
+                            "unexpected-fragment-context-end-tag",
+                            format!(
+                                "end tag `</{name}>` targeted a seeded fragment context element"
+                            ),
+                        )
+                }),
+                "source {source:?} in context {context:?}"
+            );
+        }
+
+        let valid = parse_html_fragment_for_context_with_diagnostics("<td>x", "tr").unwrap();
+        assert!(valid
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "unexpected-fragment-context-end-tag"));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 75);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2108);
+    assert_eq!(missing_diagnostic_cases, 38);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2145);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report parse errors when table-only start tags are rejected by seeded table fragment contexts
- report parse errors when end tags target synthetic table, select, frameset, document-shell, or foreign fragment elements
- reduce malformed tree cases without diagnostics from 75 to 38 and reprioritize the backlog

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- focused post-rebase fragment-shell test and diagnostic ratchet
- live WPT/html5lib audit: 1,934 tree cases, 6,806 tokenizer cases, zero missing, zero normalized skips
- WHATWG audit coverage, manifest, Rust-test, smoke-metadata, and Python audit tests
- `git diff --check`

## Formatting note
- `cargo fmt -p coding-adventures-html-parser -- --check` still reports broad pre-existing formatting drift in this package; new lines were aligned with rustfmt output and unrelated files were left untouched.