### PR TITLE
Bound password-manager observed-set retention

### DIFF
--- a/code/packages/rust/vault-pm-domain/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-domain/CHANGELOG.md
@@ -17,3 +17,8 @@ All notable changes to this package are documented here.
 - IDs, documents, conflicts, and views use custom redacted formatters.
 - Item and view drop paths wipe secret-bearing or sensitive string values.
 - Concurrent secret edits and delete/edit races are retained as conflicts.
+- Observed sets enforce hard retained-value, add-operation, and tombstone
+  limits during mutation, exact reconstruction, and merge.
+- Operation-ID collisions and dangling removal tombstones are rejected.
+- Tombstone compaction requires an explicit repository causal-stability
+  predicate and preserves concurrent or later adds.

--- a/code/packages/rust/vault-pm-domain/README.md
+++ b/code/packages/rust/vault-pm-domain/README.md
@@ -7,7 +7,7 @@ The crate composes VLT02 records into validated item documents and fixes the
 rules every future host shares:
 
 - opaque, explicitly rendered product identifiers;
-- observed-remove collection, tag, and attachment membership;
+- bounded observed-remove collection, tag, and attachment membership;
 - deterministic favorite-register merge;
 - whole-record and delete/edit conflict preservation;
 - tombstones and retained conflict resolution state; and
@@ -17,9 +17,19 @@ It deliberately owns no clock, entropy, storage, transport, cryptography, or
 device keys. Applications supply IDs and timestamps; repositories determine
 causal relations; hosts render the returned redacted views.
 
+Every observed set retains at most 256 distinct values, 1,024 add operations,
+and 1,024 removal tombstones. Its fallible mutation, exact-removal
+reconstruction, and merge APIs enforce those limits before insertion. Removed
+pairs remain until a repository supplies causal-stability proof to
+`compact_stable_removals`; elapsed time or observation by one head is not
+sufficient proof.
+
 ## Development
 
 ```bash
 bash BUILD
 cargo clippy -p coding_adventures_vault_pm_domain --all-targets -- -D warnings
 ```
+
+The Phase 0 suite contains 29 unit tests and covers 527/532 executable crate
+lines (99.06%) under Tarpaulin's LLVM engine.

--- a/code/packages/rust/vault-pm-domain/src/lib.rs
+++ b/code/packages/rust/vault-pm-domain/src/lib.rs
@@ -26,6 +26,12 @@ pub const MAX_TAG_LEN: usize = 128;
 pub const MAX_ATTACHMENTS: usize = 64;
 /// Maximum direct causal parents on one candidate.
 pub const MAX_CAUSAL_PARENTS: usize = 16;
+/// Maximum distinct values retained by one observed-remove set.
+pub const MAX_OBSERVED_VALUES: usize = 256;
+/// Maximum add-operation IDs retained by one observed-remove set.
+pub const MAX_OBSERVED_ADD_OPERATIONS: usize = 1024;
+/// Maximum removal tombstones retained by one observed-remove set.
+pub const MAX_OBSERVED_TOMBSTONES: usize = 1024;
 
 /// Closed, payload-free domain failures.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -40,6 +46,8 @@ pub enum DomainError {
     InvalidTag,
     /// A bounded collection exceeded its V1 limit.
     BoundExceeded,
+    /// Observed-set state reused an operation ID or referenced an unknown add.
+    InvalidObservedSet,
     /// An item's declared schema did not match its VLT02 record.
     SchemaMismatch,
     /// Candidate item identities or immutable schemas disagreed.
@@ -56,6 +64,7 @@ impl core::fmt::Display for DomainError {
             Self::InvalidTimestamp => "vault-pm-domain: invalid timestamp",
             Self::InvalidTag => "vault-pm-domain: invalid tag",
             Self::BoundExceeded => "vault-pm-domain: bound exceeded",
+            Self::InvalidObservedSet => "vault-pm-domain: invalid observed set",
             Self::SchemaMismatch => "vault-pm-domain: record schema mismatch",
             Self::IdentityMismatch => "vault-pm-domain: immutable identity mismatch",
             Self::InvalidConflict => "vault-pm-domain: invalid conflict operation",
@@ -233,8 +242,28 @@ impl<T: Ord + Clone> ObservedSet<T> {
     }
 
     /// Observe an idempotent add operation.
-    pub fn add(&mut self, value: T, operation: OperationId) {
-        self.adds.entry(value).or_default().insert(operation);
+    pub fn add(&mut self, value: T, operation: OperationId) -> Result<bool, DomainError> {
+        if self
+            .adds
+            .get(&value)
+            .is_some_and(|operations| operations.contains(&operation))
+        {
+            return Ok(false);
+        }
+        if self
+            .adds
+            .iter()
+            .any(|(candidate, operations)| candidate != &value && operations.contains(&operation))
+        {
+            return Err(DomainError::InvalidObservedSet);
+        }
+        if self.add_operation_count() == MAX_OBSERVED_ADD_OPERATIONS
+            || (!self.adds.contains_key(&value)
+                && self.retained_value_count() == MAX_OBSERVED_VALUES)
+        {
+            return Err(DomainError::BoundExceeded);
+        }
+        Ok(self.adds.entry(value).or_default().insert(operation))
     }
 
     /// Remove all add operations for `value` observed by this replica.
@@ -247,6 +276,40 @@ impl<T: Ord + Clone> ObservedSet<T> {
             .or_default()
             .extend(observed.iter().copied());
         true
+    }
+
+    /// Record one exact removal tombstone while reconstructing bounded state.
+    ///
+    /// The referenced add must already be present for the same value. This
+    /// lets a persistent decoder rebuild mixed removed/re-added state without
+    /// accepting dangling or cross-value operation IDs.
+    pub fn observe_removal(
+        &mut self,
+        value: &T,
+        operation: OperationId,
+    ) -> Result<bool, DomainError> {
+        if !self
+            .adds
+            .get(value)
+            .is_some_and(|operations| operations.contains(&operation))
+        {
+            return Err(DomainError::InvalidObservedSet);
+        }
+        if self
+            .removals
+            .get(value)
+            .is_some_and(|operations| operations.contains(&operation))
+        {
+            return Ok(false);
+        }
+        if self.tombstone_count() == MAX_OBSERVED_TOMBSTONES {
+            return Err(DomainError::BoundExceeded);
+        }
+        Ok(self
+            .removals
+            .entry(value.clone())
+            .or_default()
+            .insert(operation))
     }
 
     /// Return whether at least one add remains unremoved.
@@ -278,24 +341,67 @@ impl<T: Ord + Clone> ObservedSet<T> {
             .filter(|value| self.contains(value))
             .collect()
     }
+
+    /// Return the number of distinct values retained on wire, including absent values.
+    pub fn retained_value_count(&self) -> usize {
+        self.adds.len()
+    }
+
+    /// Return the number of retained add-operation IDs.
+    pub fn add_operation_count(&self) -> usize {
+        self.adds.values().map(BTreeSet::len).sum()
+    }
+
+    /// Return the number of retained removal tombstones.
+    pub fn tombstone_count(&self) -> usize {
+        self.removals.values().map(BTreeSet::len).sum()
+    }
+
     /// Merge by unioning add observations and removal tombstones.
-    pub fn merge(&self, other: &Self) -> Self {
+    pub fn merge(&self, other: &Self) -> Result<Self, DomainError> {
         let mut merged = self.clone();
         for (value, operations) in &other.adds {
-            merged
-                .adds
-                .entry(value.clone())
-                .or_default()
-                .extend(operations.iter().copied());
+            for operation in operations {
+                merged.add(value.clone(), *operation)?;
+            }
         }
         for (value, operations) in &other.removals {
-            merged
-                .removals
-                .entry(value.clone())
-                .or_default()
-                .extend(operations.iter().copied());
+            for operation in operations {
+                merged.observe_removal(value, *operation)?;
+            }
         }
-        merged
+        Ok(merged)
+    }
+
+    /// Compact removed add/tombstone pairs proven causally stable by the repository.
+    ///
+    /// The predicate may return `true` only when every retained head has
+    /// observed the removal and no authorized publisher can later reintroduce
+    /// the pre-removal add. Without that external proof, callers must retain
+    /// the pair. The return value is the number of compacted operation IDs.
+    pub fn compact_stable_removals(
+        &mut self,
+        mut is_causally_stable: impl FnMut(OperationId) -> bool,
+    ) -> usize {
+        let mut compacted = 0;
+        let removals = &mut self.removals;
+        self.adds.retain(|value, adds| {
+            let Some(tombstones) = removals.get_mut(value) else {
+                return true;
+            };
+            adds.retain(|operation| {
+                if tombstones.contains(operation) && is_causally_stable(*operation) {
+                    tombstones.remove(operation);
+                    compacted += 1;
+                    false
+                } else {
+                    true
+                }
+            });
+            !adds.is_empty()
+        });
+        self.removals.retain(|_, tombstones| !tombstones.is_empty());
+        compacted
     }
 }
 
@@ -326,11 +432,9 @@ impl<T: Ord + Clone> core::fmt::Debug for ObservedSet<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ObservedSet")
             .field("present_count", &self.len())
-            .field("value_count", &self.adds.len())
-            .field(
-                "removal_value_count",
-                &self.removals.values().filter(|set| !set.is_empty()).count(),
-            )
+            .field("retained_value_count", &self.retained_value_count())
+            .field("add_operation_count", &self.add_operation_count())
+            .field("tombstone_count", &self.tombstone_count())
             .finish()
     }
 }
@@ -847,10 +951,10 @@ fn merge_concurrent(
                 a.created_at_ms().min(b.created_at_ms()),
                 a.updated_at_ms().max(b.updated_at_ms()),
                 a.favorite().merge(b.favorite()),
-                a.collection_ids().merge(b.collection_ids()),
-                a.tags().merge(b.tags()),
+                a.collection_ids().merge(b.collection_ids())?,
+                a.tags().merge(b.tags())?,
                 a.payload().clone(),
-                a.attachments().merge(b.attachments()),
+                a.attachments().merge(b.attachments())?,
             )?;
             let candidate = ItemCandidate::new(
                 merge_revision,
@@ -1246,6 +1350,12 @@ mod tests {
         OperationId::new([byte; 32])
     }
 
+    fn indexed_operation(index: usize) -> OperationId {
+        let mut bytes = [0u8; 32];
+        bytes[..8].copy_from_slice(&(index as u64).to_be_bytes());
+        OperationId::new(bytes)
+    }
+
     fn login(password: &str) -> AnyRecord {
         AnyRecord::Login(Login {
             title: "Example".into(),
@@ -1258,7 +1368,7 @@ mod tests {
 
     fn document(id: u8, revision: u8, password: &str) -> ItemCandidate {
         let mut tags = ObservedSet::new();
-        tags.add("work".to_string(), operation(revision));
+        tags.add("work".to_string(), operation(revision)).unwrap();
         let document = ItemDocument::new(
             ItemId::new([id; 16]),
             ContentType::new(LOGIN_V1).unwrap(),
@@ -1336,11 +1446,11 @@ mod tests {
     #[test]
     fn observed_set_supports_remove_and_readd() {
         let mut set = ObservedSet::new();
-        set.add("a".to_string(), operation(1));
+        set.add("a".to_string(), operation(1)).unwrap();
         assert!(set.contains(&"a".to_string()));
         assert!(set.remove(&"a".to_string()));
         assert!(!set.contains(&"a".to_string()));
-        set.add("a".to_string(), operation(2));
+        set.add("a".to_string(), operation(2)).unwrap();
         assert!(set.contains(&"a".to_string()));
         assert_eq!(set.len(), 1);
     }
@@ -1348,23 +1458,139 @@ mod tests {
     #[test]
     fn observed_set_merge_obeys_crdt_laws() {
         let mut a = ObservedSet::new();
-        a.add("a".to_string(), operation(1));
+        a.add("a".to_string(), operation(1)).unwrap();
         let mut b = ObservedSet::new();
-        b.add("b".to_string(), operation(2));
+        b.add("b".to_string(), operation(2)).unwrap();
         let mut c = ObservedSet::new();
-        c.add("c".to_string(), operation(3));
-        assert_eq!(a.merge(&a), a);
-        assert_eq!(a.merge(&b), b.merge(&a));
-        assert_eq!(a.merge(&b).merge(&c), a.merge(&b.merge(&c)));
+        c.add("c".to_string(), operation(3)).unwrap();
+        assert_eq!(a.merge(&a).unwrap(), a);
+        assert_eq!(a.merge(&b).unwrap(), b.merge(&a).unwrap());
+        assert_eq!(
+            a.merge(&b).unwrap().merge(&c).unwrap(),
+            a.merge(&b.merge(&c).unwrap()).unwrap()
+        );
     }
 
     #[test]
     fn observed_remove_wins_for_observed_add_after_merge() {
         let mut source = ObservedSet::new();
-        source.add("a".to_string(), operation(1));
+        source.add("a".to_string(), operation(1)).unwrap();
         let mut removed = source.clone();
         removed.remove(&"a".to_string());
-        assert!(!source.merge(&removed).contains(&"a".to_string()));
+        assert!(!source.merge(&removed).unwrap().contains(&"a".to_string()));
+    }
+
+    #[test]
+    fn observed_set_enforces_retained_wire_bounds_and_operation_uniqueness() {
+        let mut values = ObservedSet::new();
+        for index in 0..MAX_OBSERVED_VALUES {
+            assert_eq!(
+                values.add(format!("value-{index}"), indexed_operation(index)),
+                Ok(true)
+            );
+        }
+        assert_eq!(values.retained_value_count(), MAX_OBSERVED_VALUES);
+        assert_eq!(
+            values.add(
+                "one-value-too-many".to_string(),
+                indexed_operation(MAX_OBSERVED_VALUES)
+            ),
+            Err(DomainError::BoundExceeded)
+        );
+
+        let mut operations = ObservedSet::new();
+        for index in 0..MAX_OBSERVED_ADD_OPERATIONS {
+            assert_eq!(
+                operations.add("value".to_string(), indexed_operation(index)),
+                Ok(true)
+            );
+        }
+        assert_eq!(
+            operations.add(
+                "value".to_string(),
+                indexed_operation(MAX_OBSERVED_ADD_OPERATIONS)
+            ),
+            Err(DomainError::BoundExceeded)
+        );
+        assert_eq!(
+            operations.add_operation_count(),
+            MAX_OBSERVED_ADD_OPERATIONS
+        );
+        assert!(operations.remove(&"value".to_string()));
+        assert_eq!(operations.tombstone_count(), MAX_OBSERVED_TOMBSTONES);
+
+        let mut collision = ObservedSet::new();
+        assert_eq!(collision.add("a".to_string(), operation(1)), Ok(true));
+        assert_eq!(collision.add("a".to_string(), operation(1)), Ok(false));
+        assert_eq!(
+            collision.add("b".to_string(), operation(1)),
+            Err(DomainError::InvalidObservedSet)
+        );
+    }
+
+    #[test]
+    fn exact_removal_reconstruction_rejects_dangling_operations() {
+        let mut set = ObservedSet::new();
+        set.add("a".to_string(), operation(1)).unwrap();
+        set.add("a".to_string(), operation(2)).unwrap();
+        assert_eq!(
+            set.observe_removal(&"a".to_string(), operation(1)),
+            Ok(true)
+        );
+        assert_eq!(
+            set.observe_removal(&"a".to_string(), operation(1)),
+            Ok(false)
+        );
+        assert!(set.contains(&"a".to_string()));
+        assert_eq!(set.tombstone_count(), 1);
+        assert_eq!(
+            set.observe_removal(&"a".to_string(), operation(3)),
+            Err(DomainError::InvalidObservedSet)
+        );
+        assert_eq!(
+            set.observe_removal(&"missing".to_string(), operation(1)),
+            Err(DomainError::InvalidObservedSet)
+        );
+    }
+
+    #[test]
+    fn observed_set_merge_rejects_combined_operation_amplification() {
+        let mut left = ObservedSet::new();
+        let mut right = ObservedSet::new();
+        for index in 0..600 {
+            left.add("value".to_string(), indexed_operation(index))
+                .unwrap();
+            right
+                .add("value".to_string(), indexed_operation(index + 600))
+                .unwrap();
+        }
+        assert_eq!(left.merge(&right), Err(DomainError::BoundExceeded));
+    }
+
+    #[test]
+    fn compaction_requires_stability_and_preserves_readds() {
+        let mut set = ObservedSet::new();
+        set.add("a".to_string(), operation(1)).unwrap();
+        set.remove(&"a".to_string());
+        set.add("a".to_string(), operation(2)).unwrap();
+        set.add("b".to_string(), operation(3)).unwrap();
+        set.remove(&"b".to_string());
+
+        assert_eq!(
+            set.compact_stable_removals(|candidate| candidate == operation(1)),
+            1
+        );
+        assert!(set.contains(&"a".to_string()));
+        assert!(!set.contains(&"b".to_string()));
+        assert_eq!(set.add_operation_count(), 2);
+        assert_eq!(set.tombstone_count(), 1);
+        assert_eq!(set.retained_value_count(), 2);
+
+        assert_eq!(set.compact_stable_removals(|_| true), 1);
+        assert_eq!(set.values(), vec![&"a".to_string()]);
+        assert_eq!(set.retained_value_count(), 1);
+        assert_eq!(set.add_operation_count(), 1);
+        assert_eq!(set.tombstone_count(), 0);
     }
 
     #[test]
@@ -1404,7 +1630,7 @@ mod tests {
         assert_eq!(bad_timestamp.unwrap_err(), DomainError::InvalidTimestamp);
 
         let mut tags = ObservedSet::new();
-        tags.add("bad\ntag".to_string(), operation(2));
+        tags.add("bad\ntag".to_string(), operation(2)).unwrap();
         let bad_tag = ItemDocument::new(
             ItemId::new([1; 16]),
             ContentType::new(LOGIN_V1).unwrap(),
@@ -1423,7 +1649,8 @@ mod tests {
     fn document_enforces_membership_bounds() {
         let mut tags = ObservedSet::new();
         for index in 0..=MAX_TAGS {
-            tags.add(format!("tag-{index}"), OperationId::new([index as u8; 32]));
+            tags.add(format!("tag-{index}"), OperationId::new([index as u8; 32]))
+                .unwrap();
         }
         let result = ItemDocument::new(
             ItemId::new([1; 16]),
@@ -1482,7 +1709,7 @@ mod tests {
         let left = document(1, 1, "same");
         let mut right = document(1, 2, "same");
         if let ItemState::Live(value) = &mut right.state {
-            value.tags.add("personal".into(), operation(8));
+            value.tags.add("personal".into(), operation(8)).unwrap();
             value.favorite = LwwRegister::new(true, 21, operation(9));
             value.updated_at_ms = 21;
         }
@@ -1761,7 +1988,8 @@ mod tests {
         let mut set = ObservedSet::new();
         assert!(set.is_empty());
         assert!(!set.remove(&"missing".to_string()));
-        set.add("visible-only-explicitly".to_string(), operation(1));
+        set.add("visible-only-explicitly".to_string(), operation(1))
+            .unwrap();
         assert_eq!(set.values(), vec![&"visible-only-explicitly".to_string()]);
         let set_debug = format!("{set:?}");
         assert!(set_debug.contains("present_count"));
@@ -1856,7 +2084,7 @@ mod tests {
         }
 
         let mut tags = ObservedSet::new();
-        tags.add("retired".into(), operation(20));
+        tags.add("retired".into(), operation(20)).unwrap();
         tags.remove(&"retired".to_string());
         let document = ItemDocument::new(
             ItemId::new([8; 16]),
@@ -2117,6 +2345,7 @@ mod tests {
             DomainError::InvalidTimestamp,
             DomainError::InvalidTag,
             DomainError::BoundExceeded,
+            DomainError::InvalidObservedSet,
             DomainError::SchemaMismatch,
             DomainError::IdentityMismatch,
             DomainError::InvalidConflict,

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1243,6 +1243,11 @@ changelog, focused build, and downstream validation.
 5. Security review of format/key hierarchy before persistent user data exists,
    including fixed wire/GC bounds for accumulated observed-set tombstones and
    operation IDs before domain state is decoded from persistent objects.
+   VLT-PM03 fixes each observed set at 256 retained values, 1,024 add-operation
+   IDs, and 1,024 removal tombstones; mutation, exact reconstruction, and merge
+   reject growth before insertion. Compaction requires repository-supplied
+   proof that every retained head observed the removal and no authorized
+   publisher can reintroduce the old add.
    VLT01's declared 95% line-coverage target is met at 96.99% under Tarpaulin
    LLVM (773/797 lines) after focused malformed-manifest and metadata tests.
    VLT02's record, opaque-payload, and error diagnostics use closed redacted

--- a/code/specs/VLT-PM03-domain.md
+++ b/code/specs/VLT-PM03-domain.md
@@ -76,21 +76,45 @@ VLT02 records remain opaque and retain their validated content type.
 `ObservedSet<T>` records each add as `(value, OperationId)` and each removal as
 the set of add-operation IDs observed at removal time.
 
-- `add(value, operation_id)` is idempotent.
+- `add(value, operation_id)` is fallible and idempotent.
 - `remove(value)` tombstones every currently observed add for that value.
+- `observe_removal(value, operation_id)` reconstructs one exact tombstone and
+  rejects an operation that is not an add for the same value.
 - A later add with a new operation ID makes the value present again.
-- `merge(a, b)` unions adds and removals.
+- `merge(a, b)` fallibly unions adds and removals without crossing a bound.
 - Merge is associative, commutative, and idempotent.
-- Tombstones are retained. Only a future repository GC operation with proof
-  that every retained head observed the removal may discard them.
+- An operation ID may name only one value within an observed set. Repeating
+  the same `(value, operation_id)` pair is idempotent; reusing the ID for a
+  different value is invalid persistent state.
 
-The in-memory V1 document bounds present values. Before a repository decoder
-accepts persistent observed sets, the Phase 0 security review must fix total
-wire bounds for retained values, tombstones, and operation IDs plus the proof
-required for safe compaction.
+Every V1 observed set has the following hard retained-state limits in addition
+to the item-level present-value limits in section 6:
 
-`OperationId` uniqueness is a caller invariant. A future repository can derive
-it from a signed device/counter operation or a domain-separated commit value.
+| Resource | Hard limit per observed set |
+|---|---:|
+| distinct retained values, present or absent | 256 |
+| retained add-operation IDs | 1,024 |
+| retained removal tombstones | 1,024 |
+
+Mutation, exact reconstruction, and merge enforce the limits before inserting
+the next entry. A persistent decoder must rebuild through `add` and
+`observe_removal`; it must not allocate attacker-declared collections and then
+validate them afterward. A bound failure is closed and does not return partial
+state.
+
+Tombstones and their matching adds are retained by default.
+`compact_stable_removals` may discard a removed pair only when the repository
+asserts that every retained head observed the removal and no authorized
+publisher can later introduce a head containing the pre-removal add. That
+usually requires every live device frontier to dominate the removal or an
+authority-signed revocation of devices that do not. Backup age, wall time,
+provider listing age, and observation by only the current head are not GC
+proof. Supplying the causal-stability predicate is a security-critical
+repository obligation; VLT-PM03 performs only the deterministic pair removal.
+
+`OperationId` uniqueness across different observed sets and LWW registers
+remains a caller invariant. A future repository can derive it from a signed
+device/counter operation or a domain-separated commit value.
 
 ### 5.2 Last-writer-wins register
 
@@ -179,9 +203,9 @@ does not expose a "redaction off" flag.
 
 Errors are closed and low-resolution: `InvalidIdentifier`,
 `InvalidContentType`, `InvalidTimestamp`, `InvalidTag`, `BoundExceeded`,
-`SchemaMismatch`, `IdentityMismatch`, and `InvalidConflict`. `Display` uses
-package literals only and never includes input content, IDs, tags, record
-values, or attacker-controlled text.
+`InvalidObservedSet`, `SchemaMismatch`, `IdentityMismatch`, and
+`InvalidConflict`. `Display` uses package literals only and never includes
+input content, IDs, tags, record values, or attacker-controlled text.
 
 ## 10. Required verification
 
@@ -197,7 +221,15 @@ V1 tests must cover:
 8. whole-record and delete/edit conflict preservation;
 9. deterministic tombstone merge;
 10. conflict resolution retaining both candidates; and
-11. redacted views containing no fixture secret or opaque payload bytes.
+11. redacted views containing no fixture secret or opaque payload bytes;
+12. retained value, add-operation, and tombstone hard limits;
+13. operation-ID collision and dangling-tombstone rejection;
+14. bounded merge rejection without partial state; and
+15. compaction retaining unproven tombstones and preserving later adds.
+
+Phase 0 evidence on 2026-08-09 is 29 passing unit tests and 527/532 executable
+lines (99.06%) under Tarpaulin's LLVM engine, including the retained-state,
+collision, dangling-tombstone, merge-amplification, and compaction cases.
 
 ## 11. Security properties and non-goals
 


### PR DESCRIPTION
## Summary

- enforce hard per-set limits of 256 retained values, 1,024 add operations, and 1,024 removal tombstones before insertion
- make observed-set add and merge fallible, reject cross-value operation-ID reuse, and expose exact bounded tombstone reconstruction for future decoders
- compact removed pairs only through repository-supplied causal-stability proof while preserving later adds
- close the remaining VLT-PM03 Phase 0 wire/GC-bound contract in the product spec, README, and changelog

## Security review

- mutation checks limits before allocating the next map/set entry
- merge operates on a clone and returns no partial state on rejection
- exact tombstone reconstruction accepts only an existing add for the same value
- compaction removes only a matching add/tombstone pair selected by the repository proof predicate
- diagnostics remain closed and payload-free; no filesystem, network, entropy, clock, crypto, or unsafe-code capability was added

## Validation

- 29/29 unit tests pass
- strict Clippy passes with warnings denied
- rustdoc passes with warnings denied
- package BUILD passes
- Tarpaulin LLVM: 527/532 lines, 99.06%
- capability taxonomy: 7/7 tests pass
- affected build: 1 package built, 993 skipped