### PR TITLE
Add Mermaid sequence actor details references

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -3,7 +3,7 @@
 
 document = { NEWLINE } HEADER body EOF ;
 body = { NEWLINE | statement } ;
-statement = participant_stmt | participant_box | destroy_stmt | message_stmt | activation_stmt | note_stmt | link_stmt | links_stmt | properties_stmt | title_stmt | autonumber_stmt | control_block ;
+statement = participant_stmt | participant_box | destroy_stmt | message_stmt | activation_stmt | note_stmt | link_stmt | links_stmt | properties_stmt | details_stmt | title_stmt | autonumber_stmt | control_block ;
 
 participant_stmt = [ "create" ] participant_decl ;
 participant_decl = ( "participant" | "actor" ) identifier [ CONFIG ] [ "as" text ] ;
@@ -15,6 +15,8 @@ note_stmt = "note" ( ( "left" | "right" ) "of" identifier | "over" actor_pair ) 
 link_stmt = "link" identifier COLON text AT URL ;
 links_stmt = "links" identifier COLON JSON_OBJECT ;
 properties_stmt = "properties" identifier COLON JSON_OBJECT ;
+details_stmt = "details" identifier COLON details_reference ;
+details_reference = identifier { identifier | MINUS } ;
 title_stmt = "title" text ;
 autonumber_stmt = "autonumber" [ "off" | NUMBER [ NUMBER ] ] ;
 

--- a/code/grammars/mermaid/sequence.tokens
+++ b/code/grammars/mermaid/sequence.tokens
@@ -56,6 +56,7 @@ keywords:
   link
   links
   properties
+  details
   box
   as
   activate

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.15.0
+
+- Added host document details references to sequence participant and layout IR.
+
 ## 0.14.0
 
 - Added arbitrary JSON-valued properties to sequence participants and layout IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.14.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.15.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.14.0";
+pub const VERSION: &str = "0.15.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -175,6 +175,8 @@ pub struct SequenceParticipant {
     pub group_id: Option<String>,
     pub links: Vec<SequenceLink>,
     pub properties: Vec<SequenceProperty>,
+    /// Host document element whose JSON supplies additional links and properties.
+    pub details_reference: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -315,6 +317,7 @@ pub enum LayoutedSequenceItem {
         kind: SequenceParticipantKind,
         links: Vec<SequenceLink>,
         properties: Vec<SequenceProperty>,
+        details_reference: Option<String>,
         x: f64,
         y: f64,
         width: f64,
@@ -924,8 +927,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_is_0_14_0() {
-        assert_eq!(VERSION, "0.14.0");
+    fn version_is_0_15_0() {
+        assert_eq!(VERSION, "0.15.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.0 - 2026-08-09
+
+- Preserve actor details references on participant layout items.
+
 ## 0.10.0 - 2026-08-09
 
 - Preserve actor properties on participant layout items.

--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-sequence"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
 

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -7,7 +7,7 @@ use diagram_ir::{
     SequenceEvent, SequenceNotePlacement,
 };
 
-pub const VERSION: &str = "0.10.0";
+pub const VERSION: &str = "0.11.0";
 
 const MARGIN: f64 = 28.0;
 const HEADER_Y: f64 = 42.0;
@@ -76,6 +76,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                 kind: participant.kind.clone(),
                 links: participant.links.clone(),
                 properties: participant.properties.clone(),
+                details_reference: participant.details_reference.clone(),
                 x: center - box_width / 2.0,
                 y: header_y,
                 width: box_width,
@@ -174,6 +175,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                         kind: definition.kind.clone(),
                         links: definition.links.clone(),
                         properties: definition.properties.clone(),
+                        details_reference: definition.details_reference.clone(),
                         x: center - box_width / 2.0,
                         y,
                         width: box_width,
@@ -373,6 +375,7 @@ mod tests {
             group_id: None,
             links: vec![],
             properties: vec![],
+            details_reference: None,
         }
     }
 

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Export sequence actor details references as PaintScene metadata.
 - Export JSON-valued sequence actor properties as PaintScene metadata.
 - Export sequence actor links as PaintScene hit-test metadata.
 - Paint sequence rect blocks with their declared functional colors.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.14.0";
+pub const VERSION: &str = "0.15.0";
 
 use std::collections::HashMap;
 
@@ -1430,6 +1430,7 @@ where
                 kind,
                 links,
                 properties,
+                details_reference,
                 x,
                 y,
                 width,
@@ -1446,6 +1447,12 @@ where
                     scene_metadata.insert(
                         format!("sequence.participant.{id}.property.{}", property.name),
                         property.value_json.clone(),
+                    );
+                }
+                if let Some(reference) = details_reference {
+                    scene_metadata.insert(
+                        format!("sequence.participant.{id}.details_reference"),
+                        reference.clone(),
                     );
                 }
                 let specialized = !matches!(
@@ -2662,7 +2669,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.14.0");
+        assert_eq!(crate::VERSION, "0.15.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -373,6 +373,7 @@ mod apple {
             name: "role".into(),
             value_json: "\"administrator\"".into(),
         });
+        diagram.participants[0].details_reference = Some("user-details".into());
         let layout = layout_sequence_diagram(&diagram);
 
         let shaper = CoreTextShaper;
@@ -419,6 +420,16 @@ mod apple {
                 .and_then(|metadata| metadata.get("sequence.participant.User.property.role"))
                 .map(String::as_str),
             Some("\"administrator\"")
+        );
+        assert_eq!(
+            scene
+                .metadata
+                .as_ref()
+                .and_then(|metadata| {
+                    metadata.get("sequence.participant.User.details_reference")
+                })
+                .map(String::as_str),
+            Some("user-details")
         );
         assert!(scene.instructions.iter().any(|instruction| matches!(
             instruction,

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.14.0
+
+- Tokenize sequence actor `details` references.
+
 ## 0.13.0
 
 - Tokenize sequence actor property objects, including nested JSON values.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.13.0";
+pub const VERSION: &str = "0.14.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.13.0");
+        assert_eq!(VERSION, "0.14.0");
     }
 
     #[test]
@@ -417,5 +417,14 @@ A\\-B: reverse stick bottom
         assert!(tokens
             .iter()
             .any(|token| token.type_name.as_deref() == Some("JSON_OBJECT")));
+    }
+
+    #[test]
+    fn tokenizes_sequence_actor_details_reference() {
+        let tokens = tokenize_mermaid_sequence("sequenceDiagram\ndetails Alice: alice-info\n");
+        assert!(tokens.iter().any(|token| token.value == "details"));
+        assert!(tokens.iter().any(|token| token.value == "alice"));
+        assert!(tokens.iter().any(|token| token.value == "-"));
+        assert!(tokens.iter().any(|token| token.value == "info"));
     }
 }

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.15.0
+
+- Parse sequence actor `details` element IDs into semantic IR.
+
 ## 0.14.0
 
 - Parse and merge arbitrary JSON-valued sequence actor properties.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -40,7 +40,8 @@ separators. Participant creation and destruction are lifecycle events consumed
 by layout. Participant `box` declarations preserve group labels, fills, and
 membership. Singular and JSON-map actor-menu links survive as PaintScene
 metadata for interactive backends. Arbitrary JSON-valued actor properties are
-also preserved in scene metadata. DOM-referenced `details` remain an explicit
+also preserved in scene metadata. DOM-referenced `details` element IDs survive
+the native pipeline; resolving host document contents remains an embedding-layer
 compatibility gap.
 All Mermaid 11.16.1 solid/dotted, normal/reverse filled and stick half-arrow
 forms preserve their line style, half orientation, and endpoint through Paint.

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.14.0";
+pub const VERSION: &str = "0.15.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1083,6 +1083,7 @@ fn parse_sequence_body(
             "note" => parse_sequence_note(cursor, diagram, participant_indices)?,
             "link" | "links" => parse_sequence_links(cursor, diagram, participant_indices)?,
             "properties" => parse_sequence_properties(cursor, diagram, participant_indices)?,
+            "details" => parse_sequence_details(cursor, diagram, participant_indices)?,
             "title" => {
                 cursor.advance();
                 diagram.title = Some(take_sequence_line_text(cursor));
@@ -1205,6 +1206,31 @@ fn parse_sequence_properties(
             target.push(property);
         }
     }
+    Ok(())
+}
+
+fn parse_sequence_details(
+    cursor: &mut TokenCursor,
+    diagram: &mut SequenceDiagram,
+    participant_indices: &mut HashMap<String, usize>,
+) -> Result<(), ParseError> {
+    cursor.advance();
+    let participant = take_sequence_identifier(cursor)?;
+    ensure_sequence_participant(diagram, participant_indices, &participant);
+    cursor
+        .consume_if("COLON")
+        .ok_or_else(|| token_error(cursor.current(), "expected ':' before actor details"))?;
+    let mut reference = String::new();
+    while !cursor.at_eof() && token_name(cursor.current()) != "NEWLINE" {
+        reference.push_str(&cursor.advance().value);
+    }
+    if reference.is_empty() {
+        return Err(token_error(
+            cursor.current(),
+            "expected a host document element ID for actor details",
+        ));
+    }
+    diagram.participants[participant_indices[&participant]].details_reference = Some(reference);
     Ok(())
 }
 
@@ -1693,6 +1719,7 @@ fn upsert_sequence_participant(
         group_id: None,
         links: Vec::new(),
         properties: Vec::new(),
+        details_reference: None,
     });
 }
 
@@ -3233,6 +3260,18 @@ B//-A: reverse stick top
             property.name == "limits" && property.value_json == "{\"daily\":5}"
         }));
     }
+
+    #[test]
+    fn sequence_parses_actor_details_reference() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\nparticipant Alice\ndetails Alice: alice-info\n",
+        )
+        .unwrap();
+        assert_eq!(
+            diagram.participants[0].details_reference.as_deref(),
+            Some("alice-info")
+        );
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -3249,7 +3288,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.14.0");
+        assert_eq!(crate::VERSION, "0.15.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -120,8 +120,9 @@ branch dividers before existing PaintInstructions render them. Participant
 to place dynamic participant headers, bound lifelines, and emit destruction
 markers. Singular and JSON-map actor-menu links lower through semantic IR and
 layout into PaintScene metadata. Actor `properties` preserve arbitrary JSON
-values through the same pipeline. DOM-referenced `details` remain compatibility
-work. Participant `box` declarations now lower into
+values through the same pipeline. DOM-referenced `details` element IDs also
+survive the pipeline as scene metadata; host-document resolution remains
+embedding-layer compatibility work. Participant `box` declarations now lower into
 semantic groups, lane-enclosing layout geometry, and backend-neutral Paint
 rectangles and labels, including the supported named and `rgb`/`rgba` color
 forms. The family remains partial until those forms and the


### PR DESCRIPTION
## Summary
- add grammar-backed Mermaid sequence actor `details` statements
- preserve host document element references through semantic IR and sequence layout
- expose details references through PaintScene metadata with Metal PNG coverage

Host-document JSON resolution remains an embedding-layer compatibility gap and is documented honestly.

## Verification
- `cargo test -p diagram-ir -p mermaid-lexer -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint -- --nocapture`
- `cargo clippy -p diagram-ir -p mermaid-lexer -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `git diff --check`
- visually inspected `/tmp/mermaid_sequence_e2e.png`