### PR TITLE
Migrate Hue pairing to recoverable transactions

### DIFF
--- a/code/packages/rust/smart-home-hue-pairing-service/CHANGELOG.md
+++ b/code/packages/rust/smart-home-hue-pairing-service/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.2.0
+
+- Require the exact D23 principal and expected durable runtime revision in
+  actor pairing requests.
+- Recover every pending pairing transaction before actor startup and replace
+  live state only from the coordinator's committed durable snapshot.
+- Move Hue credential installation and replacement cleanup onto the
+  recoverable sealed-Vault/runtime-store transaction coordinator.
+- Cover authorization-before-I/O, restart recovery, stale-revision rollback,
+  exact replacement cleanup, and cleanup revision drift.
+
 ## 0.1.0
 
 - Add actor-owned Hue LAN registration execution.

--- a/code/packages/rust/smart-home-hue-pairing-service/Cargo.toml
+++ b/code/packages/rust/smart-home-hue-pairing-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smart-home-hue-pairing-service"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Actor-owned Hue LAN pairing with durable sealed Vault credentials"
 license = "MIT"
@@ -16,10 +16,12 @@ hue-core = { path = "../hue-core" }
 serde_json = "1"
 smart-home-core = { path = "../smart-home-core" }
 smart-home-local-http = { path = "../smart-home-local-http" }
+smart-home-pairing-transaction = { path = "../smart-home-pairing-transaction" }
 smart-home-runtime = { path = "../smart-home-runtime" }
+smart-home-runtime-store = { path = "../smart-home-runtime-store" }
+storage-core = { path = "../storage-core" }
 tls-platform = { path = "../tls-platform" }
 url-parser = { path = "../url-parser" }
 
 [dev-dependencies]
-storage-core = { path = "../storage-core" }
 storage-local-folder = { path = "../storage-local-folder" }

--- a/code/packages/rust/smart-home-hue-pairing-service/README.md
+++ b/code/packages/rust/smart-home-hue-pairing-service/README.md
@@ -1,13 +1,22 @@
 # smart-home-hue-pairing-service
 
-Actor-owned Hue bridge pairing over real LAN HTTP/TLS with credentials written
-to the repository's sealed Vault store.
+Actor-owned Hue bridge pairing over real LAN HTTP/TLS with recoverable durable
+credential installation.
 
-The service consumes a pending D23 pairing session, builds the canonical Hue
-registration request, executes it through an injectable transport, seals the
-returned application key, and completes the runtime session with only an
-opaque `VaultRef`. Runtime state, events, actor snapshots, and reports never
-contain the raw Hue credentials.
+The service restores its actor runtime from `smart-home-runtime-store` and
+resolves every pending `smart-home-pairing-transaction` journal before it can
+accept a request. Each schema-v2 request carries the exact D23 principal and
+expected durable runtime revision. Authorization is checked before LAN or
+secret-storage activity, and the coordinator then seals the returned
+application key, commits the complete runtime snapshot with CAS, cleans any
+captured previous credential at its exact revision, and returns the committed
+snapshot for actor-state replacement.
+
+Raw application and client keys remain in zeroizing process-local values and
+the sealed Vault payload. Runtime state, journals, events, actor snapshots,
+messages, and reports contain only the opaque `VaultRef` and non-secret
+metadata. Startup fails closed when journal recovery or replacement cleanup
+cannot complete safely.
 
 `HueLanRegistrationTransport` supports bounded HTTP/1 over local TCP and TLS.
 Production HTTPS callers provide the Hue trust root through `TlsConfig`; the

--- a/code/packages/rust/smart-home-hue-pairing-service/src/lib.rs
+++ b/code/packages/rust/smart-home-hue-pairing-service/src/lib.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use actor::{ActorError, ActorResult, ActorSystem, Message};
 use coding_adventures_csprng::random_array;
-use coding_adventures_vault_sealed_store::{SealedStore, SealedStoreError};
+use coding_adventures_vault_sealed_store::SealedStore;
 use coding_adventures_zeroize::Zeroizing;
 use http1::{parse_response_head, Http1ParseError};
 use http_core::{BodyKind, Header};
@@ -20,14 +20,22 @@ use hue_core::{
     hue_registration_request, HueBridgePairingPlan, HueError, CLIP_V2_EVENT_STREAM_PATH,
     HUE_APPLICATION_KEY_HEADER,
 };
-use smart_home_core::{Bridge, BridgeId, IntegrationId, VaultRef};
+use smart_home_core::{AgentId, Bridge, BridgeId, IntegrationId, VaultRef};
 use smart_home_local_http::{
     LocalHttpEndpoint, LocalHttpError, LocalHttpRequestPlan, LocalHttpScheme,
 };
+use smart_home_pairing_transaction::{
+    PairingCredentialLocation, PairingTransactionCoordinator, PairingTransactionError,
+    PairingTransactionOutcome, PairingTransactionRequest,
+};
 use smart_home_runtime::{
-    PairingSessionStatus, RuntimeError, RuntimePairingCompletion, RuntimePairingSessionId,
+    PairingSessionStatus, RuntimeCompletePairingToolRequest, RuntimeError, RuntimePairingSessionId,
     SmartHomeRuntime,
 };
+use smart_home_runtime_store::{
+    DurableAutomationDefinition, RestoredSmartHomeRuntime, RuntimeStoreError, SmartHomeRuntimeStore,
+};
+use storage_core::{Revision, StorageBackend};
 use tls_platform::{default_connector, TlsConfig, TlsConnector, TlsError};
 use url_parser::{Url, UrlError};
 
@@ -50,13 +58,13 @@ pub enum HuePairingServiceError {
     LocalHttp(LocalHttpError),
     Hue(HueError),
     Transport(HuePairingTransportError),
-    Vault(SealedStoreError),
     Runtime(RuntimeError),
+    RuntimeStore(RuntimeStoreError),
+    Transaction(PairingTransactionError),
     Entropy(String),
-    RuntimeAfterVaultWrite {
-        runtime_error: String,
-        rollback_error: Option<String>,
-    },
+    MissingDurableRuntime,
+    ExistingCredentialReference(VaultRef),
+    TransactionRolledBack(String),
 }
 
 impl fmt::Display for HuePairingServiceError {
@@ -85,25 +93,26 @@ impl fmt::Display for HuePairingServiceError {
             Self::LocalHttp(error) => write!(formatter, "Hue request planning failed: {error}"),
             Self::Hue(error) => write!(formatter, "Hue registration failed: {error}"),
             Self::Transport(error) => write!(formatter, "Hue LAN transport failed: {error}"),
-            Self::Vault(error) => write!(formatter, "Hue credential Vault write failed: {error}"),
             Self::Runtime(error) => write!(formatter, "Hue runtime completion failed: {error}"),
+            Self::RuntimeStore(error) => write!(formatter, "Hue runtime store failed: {error}"),
+            Self::Transaction(error) => {
+                write!(formatter, "Hue pairing transaction failed: {error}")
+            }
             Self::Entropy(message) => write!(
                 formatter,
-                "Hue Vault reference generation failed: {message}"
+                "Hue pairing transaction generation failed: {message}"
             ),
-            Self::RuntimeAfterVaultWrite {
-                runtime_error,
-                rollback_error,
-            } => {
-                write!(
-                    formatter,
-                    "Hue runtime completion failed after the Vault write: {runtime_error}"
-                )?;
-                if let Some(rollback_error) = rollback_error {
-                    write!(formatter, "; Vault rollback also failed: {rollback_error}")?;
-                }
-                Ok(())
+            Self::MissingDurableRuntime => {
+                formatter.write_str("Hue pairing requires a durable runtime snapshot")
             }
+            Self::ExistingCredentialReference(vault_ref) => write!(
+                formatter,
+                "existing Hue credential reference is outside the Hue Vault namespace: {vault_ref}"
+            ),
+            Self::TransactionRolledBack(transaction_id) => write!(
+                formatter,
+                "Hue pairing transaction {transaction_id} rolled back before runtime commit"
+            ),
         }
     }
 }
@@ -128,21 +137,29 @@ impl From<HuePairingTransportError> for HuePairingServiceError {
     }
 }
 
-impl From<SealedStoreError> for HuePairingServiceError {
-    fn from(error: SealedStoreError) -> Self {
-        Self::Vault(error)
-    }
-}
-
 impl From<RuntimeError> for HuePairingServiceError {
     fn from(error: RuntimeError) -> Self {
         Self::Runtime(error)
     }
 }
 
+impl From<RuntimeStoreError> for HuePairingServiceError {
+    fn from(error: RuntimeStoreError) -> Self {
+        Self::RuntimeStore(error)
+    }
+}
+
+impl From<PairingTransactionError> for HuePairingServiceError {
+    fn from(error: PairingTransactionError) -> Self {
+        Self::Transaction(error)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HuePairingRequest {
     pub session_id: RuntimePairingSessionId,
+    pub principal_id: AgentId,
+    pub expected_runtime_revision: Revision,
     pub app_name: String,
     pub instance_name: String,
     pub completed_at_ms: u64,
@@ -151,6 +168,8 @@ pub struct HuePairingRequest {
 impl HuePairingRequest {
     pub fn new(
         session_id: RuntimePairingSessionId,
+        principal_id: AgentId,
+        expected_runtime_revision: Revision,
         app_name: impl Into<String>,
         instance_name: impl Into<String>,
         completed_at_ms: u64,
@@ -169,6 +188,8 @@ impl HuePairingRequest {
         }
         Ok(Self {
             session_id,
+            principal_id,
+            expected_runtime_revision,
             app_name,
             instance_name,
             completed_at_ms,
@@ -177,8 +198,10 @@ impl HuePairingRequest {
 
     pub fn into_message(self, sender_id: &str) -> Result<Message, HuePairingServiceError> {
         let payload = serde_json::to_vec(&serde_json::json!({
-            "schema_version": 1,
+            "schema_version": 2,
             "session_id": self.session_id.as_str(),
+            "principal_id": self.principal_id.as_str(),
+            "expected_runtime_revision": self.expected_runtime_revision.as_str(),
             "app_name": self.app_name,
             "instance_name": self.instance_name,
             "completed_at_ms": self.completed_at_ms,
@@ -206,7 +229,7 @@ impl HuePairingRequest {
         if object
             .get("schema_version")
             .and_then(serde_json::Value::as_u64)
-            != Some(1)
+            != Some(2)
         {
             return Err(HuePairingServiceError::InvalidRequest(
                 "unsupported schema_version".to_string(),
@@ -214,6 +237,10 @@ impl HuePairingRequest {
         }
         Self::new(
             RuntimePairingSessionId::trusted(required_json_string(object, "session_id")?),
+            AgentId::new(required_json_string(object, "principal_id")?)
+                .map_err(|error| HuePairingServiceError::InvalidRequest(error.to_string()))?,
+            Revision::new(required_json_string(object, "expected_runtime_revision")?)
+                .map_err(|error| HuePairingServiceError::InvalidRequest(error.to_string()))?,
             required_json_string(object, "app_name")?,
             required_json_string(object, "instance_name")?,
             object
@@ -379,6 +406,7 @@ pub struct HuePairingServiceSnapshot {
     pub request_count: u64,
     pub completed_count: u64,
     pub failed_count: u64,
+    pub recovered_transaction_count: u64,
     pub last_completed_at_ms: Option<u64>,
     pub last_bridge_id: Option<BridgeId>,
     pub last_error: Option<String>,
@@ -393,21 +421,90 @@ pub struct HuePairingReport {
     pub client_key_present: bool,
 }
 
-pub struct HuePairingServiceActorState<T> {
+pub struct HuePairingServiceActorState<T, J, R> {
     runtime: SmartHomeRuntime,
+    automation_definitions: Vec<DurableAutomationDefinition>,
+    automation_state: Option<serde_json::Value>,
+    runtime_revision: Revision,
+    journal_backend: J,
+    runtime_store: SmartHomeRuntimeStore<R>,
     vault: Arc<SealedStore>,
     transport: T,
     snapshot: HuePairingServiceSnapshot,
     last_report: Option<HuePairingReport>,
 }
 
-impl<T: HueRegistrationTransport> HuePairingServiceActorState<T> {
-    pub fn new(runtime: SmartHomeRuntime, vault: Arc<SealedStore>, transport: T) -> Self {
+impl<T, J, R> HuePairingServiceActorState<T, J, R>
+where
+    T: HueRegistrationTransport,
+    J: StorageBackend,
+    R: StorageBackend,
+{
+    pub fn restore(
+        journal_backend: J,
+        vault: Arc<SealedStore>,
+        runtime_store: SmartHomeRuntimeStore<R>,
+        transport: T,
+    ) -> Result<Self, HuePairingServiceError> {
+        let mut restored = runtime_store
+            .load()?
+            .ok_or(HuePairingServiceError::MissingDurableRuntime)?;
+        let recovered_transaction_count = {
+            let coordinator =
+                PairingTransactionCoordinator::new(&journal_backend, &vault, &runtime_store);
+            let pending = coordinator.pending_transaction_ids()?;
+            let recovered_count = pending.len() as u64;
+            for transaction_id in pending {
+                match coordinator.recover(&transaction_id)? {
+                    PairingTransactionOutcome::Committed {
+                        restored: committed,
+                        ..
+                    } => restored = *committed,
+                    PairingTransactionOutcome::RolledBack { .. } => {
+                        restored = runtime_store
+                            .load()?
+                            .ok_or(HuePairingServiceError::MissingDurableRuntime)?;
+                    }
+                }
+            }
+            if !coordinator.pending_transaction_ids()?.is_empty() {
+                return Err(HuePairingServiceError::InvalidRequest(
+                    "pairing transaction recovery left unresolved journals".to_string(),
+                ));
+            }
+            recovered_count
+        };
+        Ok(Self::from_restored(
+            restored,
+            journal_backend,
+            vault,
+            runtime_store,
+            transport,
+            recovered_transaction_count,
+        ))
+    }
+
+    fn from_restored(
+        restored: RestoredSmartHomeRuntime,
+        journal_backend: J,
+        vault: Arc<SealedStore>,
+        runtime_store: SmartHomeRuntimeStore<R>,
+        transport: T,
+        recovered_transaction_count: u64,
+    ) -> Self {
         Self {
-            runtime,
+            runtime: restored.runtime,
+            automation_definitions: restored.automation_definitions,
+            automation_state: restored.automation_state,
+            runtime_revision: restored.revision,
+            journal_backend,
+            runtime_store,
             vault,
             transport,
-            snapshot: HuePairingServiceSnapshot::default(),
+            snapshot: HuePairingServiceSnapshot {
+                recovered_transaction_count,
+                ..HuePairingServiceSnapshot::default()
+            },
             last_report: None,
         }
     }
@@ -416,8 +513,8 @@ impl<T: HueRegistrationTransport> HuePairingServiceActorState<T> {
         &self.runtime
     }
 
-    pub fn runtime_mut(&mut self) -> &mut SmartHomeRuntime {
-        &mut self.runtime
+    pub fn runtime_revision(&self) -> &Revision {
+        &self.runtime_revision
     }
 
     pub fn snapshot(&self) -> &HuePairingServiceSnapshot {
@@ -481,6 +578,23 @@ impl<T: HueRegistrationTransport> HuePairingServiceActorState<T> {
             ));
         }
 
+        if request.expected_runtime_revision != self.runtime_revision {
+            return Err(HuePairingServiceError::InvalidRequest(
+                "expected runtime revision is stale".to_string(),
+            ));
+        }
+
+        let authorization_probe = RuntimeCompletePairingToolRequest::new(
+            request.session_id.clone(),
+            VaultRef::trusted("vault://smart-home/hue/authorization-preflight"),
+            request.completed_at_ms,
+        );
+        self.runtime.clone().execute_complete_pairing_tool(
+            request.principal_id.clone(),
+            authorization_probe,
+            request.completed_at_ms,
+        )?;
+
         let endpoint = endpoint_for_bridge(&bridge)?;
         let plan = HueBridgePairingPlan {
             bridge,
@@ -497,30 +611,45 @@ impl<T: HueRegistrationTransport> HuePairingServiceActorState<T> {
 
         let credentials = hue_application_credentials_from_registration_response(&response.body)?;
         let client_key_present = credentials.has_client_key();
-        let vault_key = new_vault_key(plan.bridge_id())?;
+        let transaction_id = new_transaction_id()?;
+        let vault_key = new_vault_key(plan.bridge_id(), &transaction_id);
         let vault_ref = VaultRef::trusted(format!("{HUE_VAULT_REF_PREFIX}{vault_key}"));
         let secret = Zeroizing::new(credentials.vault_secret_json());
-        let revision = self
-            .vault
-            .put(HUE_VAULT_NAMESPACE, &vault_key, &secret, None)?;
         let handoff = credentials.vault_handoff(&plan, vault_ref.clone(), request.completed_at_ms);
-        let completion = RuntimePairingCompletion::new(
+        let new_credential =
+            PairingCredentialLocation::new(vault_ref.clone(), HUE_VAULT_NAMESPACE, vault_key)?;
+        let previous_credential = plan
+            .bridge
+            .auth_ref
+            .as_ref()
+            .map(hue_credential_location)
+            .transpose()?;
+        let transaction = PairingTransactionRequest::new(
+            transaction_id.clone(),
+            request.principal_id,
+            plan.bridge_id().clone(),
             request.session_id.clone(),
-            vault_ref.clone(),
+            new_credential,
             request.completed_at_ms,
-        )
+            request.expected_runtime_revision,
+        )?
         .with_metadata(handoff.metadata);
-        if let Err(error) = self.runtime.complete_pairing_session_with(completion) {
-            let rollback_error = self
-                .vault
-                .delete(HUE_VAULT_NAMESPACE, &vault_key, Some(revision))
-                .err()
-                .map(|rollback| rollback.to_string());
-            return Err(HuePairingServiceError::RuntimeAfterVaultWrite {
-                runtime_error: error.to_string(),
-                rollback_error,
-            });
-        }
+        let transaction = match previous_credential {
+            Some(previous) => transaction.with_previous_credential(previous),
+            None => transaction,
+        };
+        let outcome = PairingTransactionCoordinator::new(
+            &self.journal_backend,
+            &self.vault,
+            &self.runtime_store,
+        )
+        .execute(transaction, &secret)?;
+        let PairingTransactionOutcome::Committed { restored, .. } = outcome else {
+            return Err(HuePairingServiceError::TransactionRolledBack(
+                transaction_id,
+            ));
+        };
+        self.install_restored_runtime(*restored);
 
         Ok(HuePairingReport {
             session_id: request.session_id,
@@ -530,22 +659,31 @@ impl<T: HueRegistrationTransport> HuePairingServiceActorState<T> {
             client_key_present,
         })
     }
+
+    fn install_restored_runtime(&mut self, restored: RestoredSmartHomeRuntime) {
+        self.runtime = restored.runtime;
+        self.automation_definitions = restored.automation_definitions;
+        self.automation_state = restored.automation_state;
+        self.runtime_revision = restored.revision;
+    }
 }
 
-pub fn install_hue_pairing_service_actor<T>(
+pub fn install_hue_pairing_service_actor<T, J, R>(
     system: &mut ActorSystem,
     actor_id: &str,
-    state: HuePairingServiceActorState<T>,
+    state: HuePairingServiceActorState<T, J, R>,
 ) -> Result<String, ActorError>
 where
     T: HueRegistrationTransport + 'static,
+    J: StorageBackend + 'static,
+    R: StorageBackend + 'static,
 {
     system.create_actor(
         actor_id,
         Box::new(state),
         Box::new(|state: Box<dyn Any>, message| {
             let mut state = *state
-                .downcast::<HuePairingServiceActorState<T>>()
+                .downcast::<HuePairingServiceActorState<T, J, R>>()
                 .expect("Hue pairing actor received the wrong state type");
             match HuePairingRequest::from_message(message) {
                 Ok(request) => {
@@ -606,7 +744,7 @@ fn endpoint_for_bridge(bridge: &Bridge) -> Result<LocalHttpEndpoint, HuePairingS
     Ok(endpoint)
 }
 
-fn new_vault_key(bridge_id: &BridgeId) -> Result<String, HuePairingServiceError> {
+fn new_transaction_id() -> Result<String, HuePairingServiceError> {
     let random: [u8; 24] =
         random_array().map_err(|error| HuePairingServiceError::Entropy(error.to_string()))?;
     let mut suffix = String::with_capacity(random.len() * 2);
@@ -614,7 +752,23 @@ fn new_vault_key(bridge_id: &BridgeId) -> Result<String, HuePairingServiceError>
         use std::fmt::Write as _;
         write!(&mut suffix, "{byte:02x}").expect("writing to a String cannot fail");
     }
-    Ok(format!("{}/{suffix}", bridge_id.as_str()))
+    Ok(format!("hue-{suffix}"))
+}
+
+fn new_vault_key(bridge_id: &BridgeId, transaction_id: &str) -> String {
+    format!("{}/{transaction_id}", bridge_id.as_str())
+}
+
+fn hue_credential_location(
+    vault_ref: &VaultRef,
+) -> Result<PairingCredentialLocation, HuePairingServiceError> {
+    let key = vault_record_key(vault_ref)
+        .ok_or_else(|| HuePairingServiceError::ExistingCredentialReference(vault_ref.clone()))?;
+    Ok(PairingCredentialLocation::new(
+        vault_ref.clone(),
+        HUE_VAULT_NAMESPACE,
+        key,
+    )?)
 }
 
 fn encode_http_request(
@@ -831,13 +985,19 @@ mod tests {
     use std::io::{BufRead, BufReader};
     use std::net::TcpListener;
     use std::path::{Path, PathBuf};
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
     use std::thread;
 
     use coding_adventures_vault_sealed_store::InitOptions;
-    use smart_home_core::{AgentId, BridgeTransport, Health, IntegrationId, Metadata, VaultRef};
+    use smart_home_core::{
+        AgentId, BridgeTransport, CapabilityGrant, CapabilityGrantId, CapabilityId, Health,
+        IntegrationId, Metadata, PrivilegeTier, VaultRef,
+    };
     use smart_home_runtime::RuntimePairingSession;
-    use storage_core::StorageBackend;
+    use storage_core::{
+        StorageBackend, StorageError, StorageLease, StorageListOptions, StoragePage,
+        StoragePutInput, StorageRecord, StorageStat,
+    };
     use storage_local_folder::LocalFolderStorageBackend;
 
     use super::*;
@@ -874,7 +1034,11 @@ mod tests {
         vault
     }
 
-    fn runtime_for_bridge(address: String) -> SmartHomeRuntime {
+    fn runtime_for_bridge(
+        address: String,
+        authorized: bool,
+        previous_vault_ref: Option<VaultRef>,
+    ) -> SmartHomeRuntime {
         let mut runtime = SmartHomeRuntime::new();
         let mut bridge = Bridge::new(
             BridgeId::trusted("001788fffeabcdef"),
@@ -883,18 +1047,77 @@ mod tests {
         );
         bridge.address = Some(address);
         bridge.health = Health::Unpaired;
+        bridge.auth_ref = previous_vault_ref;
         runtime.upsert_bridge(bridge.clone()).unwrap();
+        let principal_id = AgentId::trusted("operator");
         runtime
             .start_pairing_session(RuntimePairingSession::pending(
                 RuntimePairingSessionId::trusted("pairing-1"),
                 &bridge,
-                AgentId::trusted("operator"),
+                principal_id.clone(),
                 1_000,
                 30_000,
                 vec![Metadata::new("pairing.mode", "physical_presence")],
             ))
             .unwrap();
+        if authorized {
+            runtime
+                .registry_mut()
+                .upsert_capability_grant(CapabilityGrant::for_capability(
+                    CapabilityGrantId::trusted("grant-hue-pairing"),
+                    principal_id,
+                    CapabilityId::trusted("smart_home.pair"),
+                    PrivilegeTier::HumanApproval,
+                    "test",
+                    1_000,
+                ));
+        }
         runtime
+    }
+
+    fn runtime_root(root: &Path) -> PathBuf {
+        root.join("runtime")
+    }
+
+    fn journal_root(root: &Path) -> PathBuf {
+        root.join("journal")
+    }
+
+    fn persist_runtime(root: &Path, runtime: &SmartHomeRuntime) -> Revision {
+        SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(runtime_root(root)))
+            .save(runtime, &[], 1_500)
+            .unwrap()
+    }
+
+    type LocalService<T> =
+        HuePairingServiceActorState<T, LocalFolderStorageBackend, LocalFolderStorageBackend>;
+
+    fn restore_service<T: HueRegistrationTransport>(
+        root: &Path,
+        vault: Arc<SealedStore>,
+        transport: T,
+    ) -> Result<LocalService<T>, HuePairingServiceError> {
+        HuePairingServiceActorState::restore(
+            LocalFolderStorageBackend::new(journal_root(root)),
+            vault,
+            SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(runtime_root(root))),
+            transport,
+        )
+    }
+
+    fn request<T: HueRegistrationTransport>(
+        service: &LocalService<T>,
+        completed_at_ms: u64,
+    ) -> HuePairingRequest {
+        HuePairingRequest::new(
+            RuntimePairingSessionId::trusted("pairing-1"),
+            AgentId::trusted("operator"),
+            service.runtime_revision().clone(),
+            "coding-adventures",
+            "test-host",
+            completed_at_ms,
+        )
+        .unwrap()
     }
 
     fn spawn_registration_server(
@@ -948,26 +1171,15 @@ mod tests {
         let response =
             br#"[{"success":{"username":"raw-application-key","clientkey":"raw-client-key"}}]"#;
         let (address, server) = spawn_registration_server(response);
-        let vault = open_vault(&root, password);
-        let runtime = runtime_for_bridge(address);
-        let mut service = HuePairingServiceActorState::new(
-            runtime,
-            vault.clone(),
-            HueLanRegistrationTransport::default(),
-        );
+        let vault = open_vault(&root.join("vault"), password);
+        let runtime = runtime_for_bridge(address, true, None);
+        let initial_revision = persist_runtime(&root, &runtime);
+        let mut service =
+            restore_service(&root, vault.clone(), HueLanRegistrationTransport::default()).unwrap();
+        assert_eq!(service.runtime_revision(), &initial_revision);
 
-        let report = service
-            .pair(
-                HuePairingRequest::new(
-                    RuntimePairingSessionId::trusted("pairing-1"),
-                    "coding-adventures",
-                    "test-host",
-                    2_000,
-                )
-                .unwrap(),
-            )
-            .unwrap()
-            .clone();
+        let pairing_request = request(&service, 2_000);
+        let report = service.pair(pairing_request).unwrap().clone();
 
         let request = String::from_utf8(server.join().unwrap()).unwrap();
         assert!(request.starts_with("POST /api HTTP/1.0\r\n"));
@@ -982,6 +1194,7 @@ mod tests {
             .unwrap();
         assert_eq!(bridge.auth_ref.as_ref(), Some(&report.vault_ref));
         assert_eq!(bridge.health, Health::Online);
+        assert_ne!(service.runtime_revision(), &initial_revision);
         let audit_text = service
             .runtime()
             .registry()
@@ -996,7 +1209,7 @@ mod tests {
         vault.seal();
         drop(service);
         drop(vault);
-        let reopened = open_vault(&root, password);
+        let reopened = open_vault(&root.join("vault"), password);
         let key = vault_record_key(&report.vault_ref).unwrap();
         let stored = reopened.get(HUE_VAULT_NAMESPACE, key).unwrap().unwrap();
         let stored_json: serde_json::Value = serde_json::from_slice(&stored.plaintext).unwrap();
@@ -1007,9 +1220,7 @@ mod tests {
     }
 
     #[derive(Default)]
-    struct FailingTransport {
-        calls: usize,
-    }
+    struct FailingTransport;
 
     impl HueRegistrationTransport for FailingTransport {
         fn execute(
@@ -1017,7 +1228,6 @@ mod tests {
             _endpoint: &LocalHttpEndpoint,
             _request: &LocalHttpRequestPlan,
         ) -> Result<HueRegistrationResponse, HuePairingTransportError> {
-            self.calls += 1;
             Err(HuePairingTransportError::Io(io::Error::new(
                 io::ErrorKind::ConnectionRefused,
                 "fixture refused",
@@ -1045,24 +1255,264 @@ mod tests {
     fn transport_failure_keeps_session_pending_and_writes_no_vault_record() {
         let root = test_directory("failure");
         let password = b"test-only-vault-password";
-        let vault = open_vault(&root, password);
-        let runtime = runtime_for_bridge("http://127.0.0.1:1".to_string());
-        let mut service =
-            HuePairingServiceActorState::new(runtime, vault.clone(), FailingTransport::default());
+        let vault = open_vault(&root.join("vault"), password);
+        let runtime = runtime_for_bridge("http://127.0.0.1:1".to_string(), true, None);
+        persist_runtime(&root, &runtime);
+        let mut service = restore_service(&root, vault.clone(), FailingTransport).unwrap();
 
-        let error = service
-            .pair(
-                HuePairingRequest::new(
-                    RuntimePairingSessionId::trusted("pairing-1"),
-                    "coding-adventures",
-                    "test-host",
-                    2_000,
-                )
-                .unwrap(),
-            )
-            .unwrap_err();
+        let pairing_request = request(&service, 2_000);
+        let error = service.pair(pairing_request).unwrap_err();
         assert!(matches!(error, HuePairingServiceError::Transport(_)));
         assert_eq!(service.snapshot().failed_count, 1);
+        assert_eq!(
+            service
+                .runtime()
+                .pairing_session(&RuntimePairingSessionId::trusted("pairing-1"))
+                .unwrap()
+                .status,
+            PairingSessionStatus::PendingUserPresence
+        );
+        assert!(vault
+            .list(HUE_VAULT_NAMESPACE, Default::default())
+            .unwrap()
+            .is_empty());
+        assert!(LocalFolderStorageBackend::new(journal_root(&root))
+            .list("smart-home-pairing-transactions", Default::default())
+            .unwrap()
+            .records
+            .is_empty());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn authorization_denial_precedes_transport_vault_and_journal_activity() {
+        let root = test_directory("denial");
+        let password = b"test-only-vault-password";
+        let vault = open_vault(&root.join("vault"), password);
+        let runtime = runtime_for_bridge("http://127.0.0.1:80".to_string(), false, None);
+        persist_runtime(&root, &runtime);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut service = restore_service(
+            &root,
+            vault.clone(),
+            CountingSuccessfulTransport(calls.clone()),
+        )
+        .unwrap();
+
+        let pairing_request = request(&service, 2_000);
+        assert!(matches!(
+            service.pair(pairing_request).unwrap_err(),
+            HuePairingServiceError::Runtime(_)
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert!(vault
+            .list(HUE_VAULT_NAMESPACE, Default::default())
+            .unwrap()
+            .is_empty());
+        assert!(LocalFolderStorageBackend::new(journal_root(&root))
+            .list("smart-home-pairing-transactions", Default::default())
+            .unwrap()
+            .records
+            .is_empty());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn actor_request_round_trips_without_credential_fields() {
+        let request = HuePairingRequest::new(
+            RuntimePairingSessionId::trusted("pairing-1"),
+            AgentId::trusted("operator"),
+            Revision::new("runtime-r1").unwrap(),
+            "coding-adventures",
+            "living-room-host",
+            2_000,
+        )
+        .unwrap();
+        let message = request.clone().into_message("scheduler").unwrap();
+        assert_eq!(HuePairingRequest::from_message(&message).unwrap(), request);
+        let payload = String::from_utf8(message.payload).unwrap();
+        assert!(!payload.contains("application_key"));
+        assert!(!payload.contains("client_key"));
+        assert!(!payload.contains("vault_ref"));
+        assert!(payload.contains("\"principal_id\":\"operator\""));
+        assert!(payload.contains("\"expected_runtime_revision\":\"runtime-r1\""));
+    }
+
+    struct CountingSuccessfulTransport(Arc<AtomicUsize>);
+
+    impl HueRegistrationTransport for CountingSuccessfulTransport {
+        fn execute(
+            &mut self,
+            _endpoint: &LocalHttpEndpoint,
+            _request: &LocalHttpRequestPlan,
+        ) -> Result<HueRegistrationResponse, HuePairingTransportError> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            SuccessfulTransport.execute(_endpoint, _request)
+        }
+    }
+
+    struct FailOnPutBackend {
+        inner: LocalFolderStorageBackend,
+        fail_on_put: usize,
+        put_count: AtomicUsize,
+    }
+
+    impl FailOnPutBackend {
+        fn new(root: PathBuf, fail_on_put: usize) -> Self {
+            Self {
+                inner: LocalFolderStorageBackend::new(root),
+                fail_on_put,
+                put_count: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl StorageBackend for FailOnPutBackend {
+        fn initialize(&self) -> Result<(), StorageError> {
+            self.inner.initialize()
+        }
+
+        fn get(&self, namespace: &str, key: &str) -> Result<Option<StorageRecord>, StorageError> {
+            self.inner.get(namespace, key)
+        }
+
+        fn put(&self, input: StoragePutInput) -> Result<StorageRecord, StorageError> {
+            let call = self.put_count.fetch_add(1, Ordering::SeqCst) + 1;
+            if call == self.fail_on_put {
+                return Err(StorageError::Unavailable {
+                    message: "injected journal interruption".to_string(),
+                });
+            }
+            self.inner.put(input)
+        }
+
+        fn delete(
+            &self,
+            namespace: &str,
+            key: &str,
+            if_revision: Option<&Revision>,
+        ) -> Result<(), StorageError> {
+            self.inner.delete(namespace, key, if_revision)
+        }
+
+        fn list(
+            &self,
+            namespace: &str,
+            options: StorageListOptions,
+        ) -> Result<StoragePage, StorageError> {
+            self.inner.list(namespace, options)
+        }
+
+        fn stat(&self, namespace: &str, key: &str) -> Result<Option<StorageStat>, StorageError> {
+            self.inner.stat(namespace, key)
+        }
+
+        fn acquire_lease(
+            &self,
+            name: &str,
+            ttl_ms: u64,
+        ) -> Result<Option<StorageLease>, StorageError> {
+            self.inner.acquire_lease(name, ttl_ms)
+        }
+    }
+
+    fn transaction_request(
+        transaction_id: &str,
+        runtime_revision: Revision,
+        previous: Option<VaultRef>,
+    ) -> PairingTransactionRequest {
+        let new_key = format!("001788fffeabcdef/{transaction_id}");
+        let new_ref = VaultRef::trusted(format!("{HUE_VAULT_REF_PREFIX}{new_key}"));
+        let request = PairingTransactionRequest::new(
+            transaction_id,
+            AgentId::trusted("operator"),
+            BridgeId::trusted("001788fffeabcdef"),
+            RuntimePairingSessionId::trusted("pairing-1"),
+            PairingCredentialLocation::new(new_ref, HUE_VAULT_NAMESPACE, new_key).unwrap(),
+            2_000,
+            runtime_revision,
+        )
+        .unwrap()
+        .with_metadata(vec![Metadata::new(
+            "hue.pairing.phase",
+            "credential_stored",
+        )]);
+        match previous {
+            Some(previous_ref) => {
+                request.with_previous_credential(hue_credential_location(&previous_ref).unwrap())
+            }
+            None => request,
+        }
+    }
+
+    #[test]
+    fn startup_recovers_runtime_commit_interrupted_before_journal_ack() {
+        let root = test_directory("restart-recovery");
+        let vault = open_vault(&root.join("vault"), b"test-only-vault-password");
+        let runtime = runtime_for_bridge("http://127.0.0.1:80".to_string(), true, None);
+        let revision = persist_runtime(&root, &runtime);
+        let runtime_store =
+            SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(runtime_root(&root)));
+        let failing_journal = FailOnPutBackend::new(journal_root(&root), 3);
+        let coordinator =
+            PairingTransactionCoordinator::new(&failing_journal, &vault, &runtime_store);
+        assert!(coordinator
+            .execute(
+                transaction_request("hue-restart", revision, None),
+                b"restart-secret",
+            )
+            .is_err());
+
+        let service = restore_service(&root, vault.clone(), SuccessfulTransport).unwrap();
+        assert_eq!(service.snapshot().recovered_transaction_count, 1);
+        assert_eq!(
+            service
+                .runtime()
+                .pairing_session(&RuntimePairingSessionId::trusted("pairing-1"))
+                .unwrap()
+                .status,
+            PairingSessionStatus::Completed
+        );
+        assert!(LocalFolderStorageBackend::new(journal_root(&root))
+            .list("smart-home-pairing-transactions", Default::default())
+            .unwrap()
+            .records
+            .is_empty());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn startup_rolls_back_interrupted_vault_write_after_runtime_revision_changes() {
+        let root = test_directory("stale-revision");
+        let vault = open_vault(&root.join("vault"), b"test-only-vault-password");
+        let runtime = runtime_for_bridge("http://127.0.0.1:80".to_string(), true, None);
+        let revision = persist_runtime(&root, &runtime);
+        let runtime_store =
+            SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(runtime_root(&root)));
+        let failing_journal = FailOnPutBackend::new(journal_root(&root), 2);
+        let coordinator =
+            PairingTransactionCoordinator::new(&failing_journal, &vault, &runtime_store);
+        assert!(coordinator
+            .execute(
+                transaction_request("hue-stale", revision, None),
+                b"stale-secret",
+            )
+            .is_err());
+        let restored = runtime_store.load().unwrap().unwrap();
+        runtime_store
+            .save_with_automation_state(
+                &restored.runtime,
+                &restored.automation_definitions,
+                restored.automation_state,
+                1_900,
+            )
+            .unwrap();
+
+        let service = restore_service(&root, vault.clone(), SuccessfulTransport).unwrap();
+        assert_eq!(service.snapshot().recovered_transaction_count, 1);
         assert_eq!(
             service
                 .runtime()
@@ -1080,69 +1530,110 @@ mod tests {
     }
 
     #[test]
-    fn runtime_rejection_rolls_back_the_revision_bound_vault_write() {
-        let root = test_directory("rollback");
-        let password = b"test-only-vault-password";
-        let vault = open_vault(&root, password);
-        let runtime = runtime_for_bridge("http://127.0.0.1:80".to_string());
-        let mut service =
-            HuePairingServiceActorState::new(runtime, vault.clone(), SuccessfulTransport);
-
-        let error = service
-            .pair(
-                HuePairingRequest::new(
-                    RuntimePairingSessionId::trusted("pairing-1"),
-                    "coding-adventures",
-                    "test-host",
-                    30_000,
-                )
-                .unwrap(),
+    fn replacement_commit_removes_only_the_captured_previous_credential() {
+        let root = test_directory("replacement");
+        let vault = open_vault(&root.join("vault"), b"test-only-vault-password");
+        let old_ref =
+            VaultRef::trusted("vault://smart-home/hue/001788fffeabcdef/previous-credential");
+        vault
+            .put(
+                HUE_VAULT_NAMESPACE,
+                vault_record_key(&old_ref).unwrap(),
+                b"previous-secret",
+                None,
             )
-            .unwrap_err();
-        assert!(matches!(
-            error,
-            HuePairingServiceError::RuntimeAfterVaultWrite {
-                rollback_error: None,
-                ..
-            }
-        ));
+            .unwrap();
+        let runtime = runtime_for_bridge(
+            "http://127.0.0.1:80".to_string(),
+            true,
+            Some(old_ref.clone()),
+        );
+        persist_runtime(&root, &runtime);
+        let mut service = restore_service(&root, vault.clone(), SuccessfulTransport).unwrap();
+        let pairing_request = request(&service, 2_000);
+        let report = service.pair(pairing_request).unwrap().clone();
+
+        assert_ne!(report.vault_ref, old_ref);
         assert!(vault
-            .list(HUE_VAULT_NAMESPACE, Default::default())
+            .get(HUE_VAULT_NAMESPACE, vault_record_key(&old_ref).unwrap(),)
             .unwrap()
-            .is_empty());
+            .is_none());
         assert_eq!(
             service
                 .runtime()
-                .pairing_session(&RuntimePairingSessionId::trusted("pairing-1"))
+                .registry()
+                .bridge(&BridgeId::trusted("001788fffeabcdef"))
                 .unwrap()
-                .status,
-            PairingSessionStatus::Expired
+                .auth_ref,
+            Some(report.vault_ref)
         );
-        assert!(!service
-            .snapshot()
-            .last_error
-            .as_deref()
-            .unwrap()
-            .contains("rollback-application-key"));
 
         fs::remove_dir_all(root).unwrap();
     }
 
     #[test]
-    fn actor_request_round_trips_without_credential_fields() {
-        let request = HuePairingRequest::new(
-            RuntimePairingSessionId::trusted("pairing-1"),
-            "coding-adventures",
-            "living-room-host",
-            2_000,
-        )
-        .unwrap();
-        let message = request.clone().into_message("scheduler").unwrap();
-        assert_eq!(HuePairingRequest::from_message(&message).unwrap(), request);
-        let payload = String::from_utf8(message.payload).unwrap();
-        assert!(!payload.contains("application_key"));
-        assert!(!payload.contains("client_key"));
-        assert!(!payload.contains("vault_ref"));
+    fn startup_refuses_cleanup_when_previous_credential_revision_drifted() {
+        let root = test_directory("cleanup-drift");
+        let vault = open_vault(&root.join("vault"), b"test-only-vault-password");
+        let old_ref =
+            VaultRef::trusted("vault://smart-home/hue/001788fffeabcdef/previous-credential");
+        let old_key = vault_record_key(&old_ref).unwrap().to_string();
+        let old_revision = vault
+            .put(HUE_VAULT_NAMESPACE, &old_key, b"previous-secret", None)
+            .unwrap();
+        let runtime = runtime_for_bridge(
+            "http://127.0.0.1:80".to_string(),
+            true,
+            Some(old_ref.clone()),
+        );
+        let revision = persist_runtime(&root, &runtime);
+        let runtime_store =
+            SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(runtime_root(&root)));
+        let failing_journal = FailOnPutBackend::new(journal_root(&root), 3);
+        let coordinator =
+            PairingTransactionCoordinator::new(&failing_journal, &vault, &runtime_store);
+        assert!(coordinator
+            .execute(
+                transaction_request("hue-cleanup", revision, Some(old_ref)),
+                b"new-secret",
+            )
+            .is_err());
+        vault
+            .put(
+                HUE_VAULT_NAMESPACE,
+                &old_key,
+                b"replacement-owned-secret",
+                Some(old_revision),
+            )
+            .unwrap();
+
+        let recovery_error = match restore_service(&root, vault.clone(), SuccessfulTransport) {
+            Ok(_) => panic!("cleanup drift must block actor startup"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            recovery_error,
+            HuePairingServiceError::Transaction(_)
+        ));
+        assert_eq!(
+            LocalFolderStorageBackend::new(journal_root(&root))
+                .list("smart-home-pairing-transactions", Default::default())
+                .unwrap()
+                .records
+                .len(),
+            1
+        );
+        assert_eq!(
+            vault
+                .get(HUE_VAULT_NAMESPACE, &old_key)
+                .unwrap()
+                .unwrap()
+                .plaintext
+                .as_slice(),
+            b"replacement-owned-secret"
+        );
+
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -253,22 +253,31 @@ network I/O into the Chief bridge:
 ## Current Hue Pairing Service Slice
 
 This slice runs the physical-presence registration exchange through production
-host boundaries and durable secret storage:
+host boundaries, durable secret storage, and the recoverable pairing
+transaction coordinator:
 
-- `smart-home-hue-pairing-service` owns the D23 runtime, an injectable Hue
-  registration transport, and the repository's sealed Vault store inside one
-  actor state.
+- `smart-home-hue-pairing-service` restores its D23 runtime from the durable
+  runtime store and resolves every pending pairing journal before creating an
+  actor that can accept another request.
+- Schema-v2 actor requests carry the exact D23 principal and expected durable
+  runtime revision. D23 Human Approval is checked before LAN I/O, journal
+  creation, or Vault writes and checked again inside the coordinator.
 - The production transport executes bounded HTTP/1 over LAN TCP or the shared
   TLS platform. HTTPS remains certificate-verifying and accepts caller-supplied
   Hue trust roots instead of silently disabling verification.
-- A pending D23 session drives the canonical `/api` registration request,
-  successful application and client keys are encrypted at rest, and D23
-  receives only a random `VaultRef`.
-- If runtime completion fails after the Vault write, the service attempts a
-  revision-bound rollback so an unusable credential is not left behind.
-- Real loopback-network and local-folder restart tests prove the request reaches
-  LAN I/O, credentials survive a Vault restart, and raw secrets never enter
-  runtime state, event metadata, actor snapshots, or pairing reports.
+- A pending authorized D23 session drives the canonical `/api` registration
+  request. Successful application and client keys remain zeroizing and
+  process-local until the coordinator writes a transaction-owned sealed record;
+  the journal, runtime, messages, snapshots, and reports receive only an opaque
+  `VaultRef` and non-secret metadata.
+- Runtime completion is persisted with expected-revision CAS before actor state
+  is replaced from the returned durable snapshot. Replaced credentials are
+  removed only at the exact revision captured by the journal.
+- Real loopback-network and local-folder tests prove delivery, restart recovery
+  around interrupted journal acknowledgements, stale-revision rollback,
+  replacement cleanup, denial before I/O or writes, cleanup-drift refusal, and
+  absence of raw credentials from runtime, journal, event, snapshot, message,
+  and report state.
 
 ## Current Hue LAN Integration Slice
 
@@ -1542,10 +1551,9 @@ claiming that an existing vendor pairing actor has adopted it:
   journal, restart discovery, recovery on both sides of runtime CAS, stale
   runtime rollback, cleanup revision-conflict and partial-reference retention,
   and authorization denial before any journal or Vault write.
-- The existing Hue pairing actor still performs its historical direct
-  Vault-then-in-memory-runtime handoff. Migrating that production composition to
-  this coordinator is the next prerequisite before any vendor host may perform
-  automated credential provisioning.
+- The Hue pairing actor now uses this coordinator as the first production
+  composition. Other vendor credential-provisioning paths must reuse this
+  durable protocol and prove their own exact pairing and secret-input boundary.
 
 ## Smart Home Remaining Work
 
@@ -1559,19 +1567,21 @@ to that image request; the only documented direct URL credentials require
 disabling secure sessions and are rejected. Frigate snapshot delivery remains
 blocked on a cookie-capable media authentication boundary. Revision-guarded
 D23 pairing completion and its recoverable cross-store journal are now
-available. The strongest next prerequisite is migrating the Hue pairing actor
-off its direct Vault-then-in-memory-runtime handoff so one production pairing
-path proves D23 principal propagation, durable runtime revision ownership,
-startup recovery, and actor-state replacement through the coordinator.
+available, and the Hue production actor now proves D23 principal propagation,
+durable runtime revision ownership, startup recovery, and actor-state
+replacement through the coordinator. The strongest next post-merge audit is
+explicit ONVIF credential provisioning: it must identify a host-owned secret
+input boundary that keeps supplied credentials zeroizing and out of actor
+messages, journals, runtime state, reports, and logs before the existing ONVIF
+snapshot host may receive an automatically installed opaque reference.
 
-1. Migrate `smart-home-hue-pairing-service` to the recoverable pairing
-   coordinator. Its actor request must carry the exact D23 principal and
-   expected durable runtime revision; startup must enumerate and resolve
-   pending journals before accepting another pairing; successful resolution
-   must replace actor runtime state from the committed snapshot. Only after
-   that production path is proven may ONVIF, ZoneMinder, Axis, or Reolink gain
-   automated credential provisioning. Snapshot delivery itself is complete and
-   must not become an implicit credential writer.
+1. Audit explicit ONVIF credential provisioning against the completed Hue
+   transaction composition. Require exact D23 pairing authorization, a bounded
+   host-owned zeroizing secret-input boundary, transaction-owned opaque
+   references, expected-revision runtime CAS, startup recovery, replacement
+   cleanup, and exact installed-bridge correspondence. Do not make snapshot
+   delivery an implicit credential writer and do not assume this slice is
+   executable until the secret-input owner is concrete.
 2. Add authenticated AirGradient MQTT only after official firmware removes
    plaintext credential logging and one-shot Vault-leased credential injection
    can be proven without request-plan or normalized-state exposure.


### PR DESCRIPTION
## Summary
- restore the Hue pairing actor from durable runtime state only after all pending pairing journals recover
- propagate the exact D23 principal and expected runtime revision through schema-v2 requests, authorize before LAN or secret writes, and commit through the recoverable coordinator
- replace actor state from the committed snapshot while keeping raw Hue credentials zeroizing and out of messages, journals, runtime, snapshots, and reports
- update the D18-D23 completion inventory and make explicit ONVIF credential provisioning the next prerequisite audit

## Validation
- `cargo fmt -p smart-home-hue-pairing-service -- --check`
- `cargo test -p smart-home-hue-pairing-service` (10 tests)
- `cargo clippy -p smart-home-hue-pairing-service --all-targets --all-features -- -D warnings`
- `bash smart-home-hue-pairing-service/BUILD`
- `bash hue-integration/BUILD` (4 tests)