### PR TITLE
Report script end tag EOF diagnostics

### DIFF
--- a/code/packages/rust/html-lexer/CHANGELOG.md
+++ b/code/packages/rust/html-lexer/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Script end tags that reach EOF after whitespace, attributes, quoted attribute
+  data, or a trailing solidus now report `eof-in-tag` while preserving their
+  literal-text recovery in normal and escaped script data.
 - Added current HTML processing-instruction tokenizer states, including target
   validation, data accumulation, EOF recovery, and legacy XML-target comment
   recovery.

--- a/code/packages/rust/html-lexer/html1.lexer.states.toml
+++ b/code/packages/rust/html-lexer/html1.lexer.states.toml
@@ -1904,6 +1904,7 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = [
+  "parse_error_if_appropriate_end_tag(eof-in-tag)",
   "discard_current_token",
   "append_text(</)",
   "append_temporary_buffer_to_text",
@@ -1964,6 +1965,7 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = [
+  "parse_error_if_appropriate_end_tag(eof-in-tag)",
   "discard_current_token",
   "append_text(</)",
   "append_temporary_buffer_to_text",
@@ -2051,6 +2053,7 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = [
+  "parse_error_if_appropriate_end_tag(eof-in-tag)",
   "discard_current_token",
   "append_text(</)",
   "append_temporary_buffer_to_text",
@@ -2076,6 +2079,7 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = [
+  "parse_error_if_appropriate_end_tag(eof-in-tag)",
   "discard_current_token",
   "append_text(</)",
   "append_temporary_buffer_to_text",
@@ -2101,6 +2105,7 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = [
+  "parse_error_if_appropriate_end_tag(eof-in-tag)",
   "discard_current_token",
   "append_text(</)",
   "append_temporary_buffer_to_text",
@@ -2138,6 +2143,7 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = [
+  "parse_error_if_appropriate_end_tag(eof-in-tag)",
   "discard_current_token",
   "append_text(</)",
   "append_temporary_buffer_to_text",
@@ -2163,6 +2169,7 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = [
+  "parse_error_if_appropriate_end_tag(eof-in-tag)",
   "discard_current_token",
   "append_text(</)",
   "append_temporary_buffer_to_text",
@@ -2188,6 +2195,7 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = [
+  "parse_error_if_appropriate_end_tag(eof-in-tag)",
   "discard_current_token",
   "append_text(</)",
   "append_temporary_buffer_to_text",
@@ -2277,6 +2285,7 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = [
+  "parse_error_if_appropriate_end_tag(eof-in-tag)",
   "discard_current_token",
   "append_text(</)",
   "append_temporary_buffer_to_text",
@@ -2309,6 +2318,7 @@ matcher = { eof = true }
 to = "done"
 consume = false
 actions = [
+  "parse_error_if_appropriate_end_tag(eof-in-tag)",
   "discard_current_token",
   "append_text(</)",
   "append_temporary_buffer_to_text",

--- a/code/packages/rust/html-lexer/src/generated_html1.rs
+++ b/code/packages/rust/html-lexer/src/generated_html1.rs
@@ -4252,6 +4252,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error_if_appropriate_end_tag(eof-in-tag)".to_string(),
                 "discard_current_token".to_string(),
                 "append_text(</)".to_string(),
                 "append_temporary_buffer_to_text".to_string(),
@@ -4389,6 +4390,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error_if_appropriate_end_tag(eof-in-tag)".to_string(),
                 "discard_current_token".to_string(),
                 "append_text(</)".to_string(),
                 "append_temporary_buffer_to_text".to_string(),
@@ -4566,6 +4568,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error_if_appropriate_end_tag(eof-in-tag)".to_string(),
                 "discard_current_token".to_string(),
                 "append_text(</)".to_string(),
                 "append_temporary_buffer_to_text".to_string(),
@@ -4615,6 +4618,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error_if_appropriate_end_tag(eof-in-tag)".to_string(),
                 "discard_current_token".to_string(),
                 "append_text(</)".to_string(),
                 "append_temporary_buffer_to_text".to_string(),
@@ -4664,6 +4668,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error_if_appropriate_end_tag(eof-in-tag)".to_string(),
                 "discard_current_token".to_string(),
                 "append_text(</)".to_string(),
                 "append_temporary_buffer_to_text".to_string(),
@@ -4743,6 +4748,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error_if_appropriate_end_tag(eof-in-tag)".to_string(),
                 "discard_current_token".to_string(),
                 "append_text(</)".to_string(),
                 "append_temporary_buffer_to_text".to_string(),
@@ -4792,6 +4798,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error_if_appropriate_end_tag(eof-in-tag)".to_string(),
                 "discard_current_token".to_string(),
                 "append_text(</)".to_string(),
                 "append_temporary_buffer_to_text".to_string(),
@@ -4841,6 +4848,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error_if_appropriate_end_tag(eof-in-tag)".to_string(),
                 "discard_current_token".to_string(),
                 "append_text(</)".to_string(),
                 "append_temporary_buffer_to_text".to_string(),
@@ -4998,6 +5006,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error_if_appropriate_end_tag(eof-in-tag)".to_string(),
                 "discard_current_token".to_string(),
                 "append_text(</)".to_string(),
                 "append_temporary_buffer_to_text".to_string(),
@@ -5052,6 +5061,7 @@ pub fn html1_lexer_definition() -> StateMachineDefinition {
             stack_pop: None,
             stack_push: Vec::new(),
             actions: vec![
+                "parse_error_if_appropriate_end_tag(eof-in-tag)".to_string(),
                 "discard_current_token".to_string(),
                 "append_text(</)".to_string(),
                 "append_temporary_buffer_to_text".to_string(),

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -6294,6 +6294,112 @@ fn parser_facing_end_tag_continuation_contexts_recover_seeded_text_and_diagnosti
 }
 
 #[test]
+fn script_end_tag_continuations_report_eof_in_tag() {
+    for (state, temporary_buffer, input, expected_text) in [
+        (
+            HtmlTokenizerState::ScriptDataEndTagWhitespace,
+            "script ",
+            "",
+            "</script ",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEndTagAttributes,
+            "script class=x",
+            "",
+            "</script class=x",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEndTagAttributes,
+            "script class=",
+            "\"x",
+            "</script class=\"x",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEndTagAttributes,
+            "script class=",
+            "'x",
+            "</script class='x",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataSelfClosingEndTag,
+            "script",
+            "",
+            "</script/",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedEndTagWhitespace,
+            "script ",
+            "",
+            "</script ",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedEndTagAttributes,
+            "script class=x",
+            "",
+            "</script class=x",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedEndTagAttributes,
+            "script class=",
+            "\"x",
+            "</script class=\"x",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedEndTagAttributes,
+            "script class=",
+            "'x",
+            "</script class='x",
+        ),
+        (
+            HtmlTokenizerState::ScriptDataEscapedSelfClosingEndTag,
+            "script",
+            "",
+            "</script/",
+        ),
+    ] {
+        let context =
+            HtmlLexContext::end_tag_continuation(state, "script", "script", temporary_buffer)
+                .unwrap();
+        let mut lexer = create_html_lexer_with_context(&context).unwrap();
+
+        lexer.push(input).unwrap();
+        lexer.finish().unwrap();
+
+        assert_eq!(
+            lexer.drain_tokens(),
+            vec![Token::Text(expected_text.to_string()), Token::Eof],
+            "context {state:?}"
+        );
+        assert_eq!(
+            lexer
+                .diagnostics()
+                .iter()
+                .map(|diagnostic| diagnostic.code.as_str())
+                .collect::<Vec<_>>(),
+            vec!["eof-in-tag"],
+            "context {state:?}"
+        );
+    }
+
+    let context = HtmlLexContext::end_tag_continuation(
+        HtmlTokenizerState::ScriptDataEndTagWhitespace,
+        "script",
+        "style",
+        "style ",
+    )
+    .unwrap();
+    let mut lexer = create_html_lexer_with_context(&context).unwrap();
+
+    lexer.finish().unwrap();
+
+    assert_eq!(
+        lexer.drain_tokens(),
+        vec![Token::Text("</style ".to_string()), Token::Eof]
+    );
+    assert!(lexer.diagnostics().is_empty());
+}
+
+#[test]
 fn parser_facing_end_tag_continuation_contexts_keep_mismatches_literal() {
     for (state, last_start_tag, current_end_tag, temporary_buffer, input, expected_text) in [
         (

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Malformed script end tags that reach EOF while the lexer is assembling the
+  tag now report `eof-in-tag`, covering 14 previously silent malformed corpus
+  cases without changing DOM recovery or undeclared-diagnostic coverage.
 - Start and end tags rejected against seeded fragment-context elements now
   report their required parse errors, covering 37 previously silent table,
   select, frameset, document-shell, and foreign fragment cases without changing

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the seeded fragment-context boundary diagnostic slice, 2,145 of those
-cases emit at least one lexer or parser diagnostic and 38 remain
+After the script end-tag EOF diagnostic slice, 2,159 of those cases emit at
+least one lexer or parser diagnostic and 24 remain
 uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
@@ -66,24 +66,23 @@ open table blocks adoption-agency recovery. Description-list item start tags
 now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
 without flagging adjacent description-list items.
 
-The fresh 38-case residual inventory keeps the next concrete groups in this
-priority order: script-tokenizer EOF recovery; plaintext/frameset and
-document-tail boundaries; and the final fragment-context rows for colgroup
-text, an after-body token, and an HTML start tag in a seeded SVG context. The
-current corpus no longer has a silent table-shell, foreign end-tag,
-formatting-only, or general in-body group.
+The fresh 24-case residual inventory keeps the next concrete groups in this
+priority order: plaintext handling across document-shell, template, and
+frameset contexts; frameset and document-tail boundaries; and the final
+fragment-context rows for colgroup text, an after-body token, and an HTML start
+tag in a seeded SVG context. The current corpus no longer has a silent
+script-tokenizer, table-shell, foreign end-tag, formatting-only, or general
+in-body group.
 
 Prioritized work items:
 
-1. **Script-tokenizer EOF recovery.** Cover malformed script end tags that
-   reach EOF while the lexer is still assembling the tag.
-2. **Plaintext, frameset, and document-tail boundaries.** Cover EOF and stray
+1. **Plaintext, frameset, and document-tail boundaries.** Cover EOF and stray
    content diagnostics after plaintext and frameset transitions.
-3. **Fragment-context parsing.** Cover the final colgroup text, after-body, and
+2. **Fragment-context parsing.** Cover the final colgroup text, after-body, and
    foreign HTML start-tag rows. Invalid start and end tags targeting seeded
    fragment-context elements now report without mutating their synthetic
    shells.
-4. **Table, select, and template insertion modes.** Continue the algorithm
+3. **Table, select, and template insertion modes.** Continue the algorithm
    audit beyond the currently exercised diagnostic corpus.
    Non-whitespace table text now reports when it is foster-parented. The
    specialized SVG and MathML start-tag path now reports when table insertion
@@ -99,14 +98,14 @@ Prioritized work items:
    starts. Seeded table and foreign fragment-shell boundaries now report their
    required parse errors. The only silent table fragment row is non-whitespace
    text in a seeded `colgroup` context.
-5. **Adoption agency and active formatting.** Cover malformed formatting cases
+4. **Adoption agency and active formatting.** Cover malformed formatting cases
    without changing their now-conforming DOM output.
-6. **Diagnostic positions and error taxonomy.** Carry source positions into
+5. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.
-7. **Input boundary review.** Document the Unicode-code-point parser boundary
+6. **Input boundary review.** Document the Unicode-code-point parser boundary
    and either add or explicitly separate byte decoding and encoding sniffing.
-8. **Algorithm and differential audit.** Map implemented states/modes to the
+7. **Algorithm and differential audit.** Map implemented states/modes to the
    current HTML Standard and add deterministic differential/fuzz coverage for
    branches not exercised by the upstream corpora.
 

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 38);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2145);
+    assert_eq!(missing_diagnostic_cases, 24);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2159);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }

--- a/code/packages/rust/state-machine-markup-deserializer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-markup-deserializer/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this package will be documented in this file.
   references.
 - Recognized the temporary-buffer conditional state-switch action in
   lexer-profile validation.
+- Recognized the conditional appropriate-end-tag parse-error action in
+  lexer-profile validation.
 
 ## [0.1.0] - 2026-04-20
 

--- a/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/src/lib.rs
@@ -770,6 +770,9 @@ fn validate_action(action: &str, token_names: &HashSet<String>) -> Result<()> {
     if action.starts_with("parse_error(") && action.ends_with(')') {
         return Ok(());
     }
+    if action.starts_with("parse_error_if_appropriate_end_tag(") && action.ends_with(')') {
+        return Ok(());
+    }
     if action.starts_with("set_return_state(") && action.ends_with(')') {
         return Ok(());
     }

--- a/code/packages/rust/state-machine-markup-deserializer/tests/toml_test.rs
+++ b/code/packages/rust/state-machine-markup-deserializer/tests/toml_test.rs
@@ -157,6 +157,10 @@ fn lexer_profile_html1_toml_parses_into_typed_definition() {
         .actions
         .iter()
         .any(|action| action.starts_with("switch_to_if_temporary_buffer_equals("))));
+    assert!(definition.transitions.iter().any(|transition| transition
+        .actions
+        .iter()
+        .any(|action| action.starts_with("parse_error_if_appropriate_end_tag("))));
     assert_eq!(definition.fixtures.len(), 11);
 }
 

--- a/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to the `state-machine-tokenizer` crate will be documented in
 
 ### Added
 
+- Added a conditional parse-error action for appropriate HTML end tags, so
+  declarative text-mode EOF recovery can distinguish matching tags from
+  mismatched markup that remains literal text.
 - Added processing-instruction token construction, data accumulation, target
   finalization, comment recovery, and continuation-state seeding actions for
   declarative HTML tokenizer definitions.

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -1093,6 +1093,21 @@ impl Tokenizer {
                         .trim_end_matches(')');
                     self.temporary_buffer.push_str(literal);
                 }
+                _ if action.starts_with("parse_error_if_appropriate_end_tag(")
+                    && action.ends_with(')') =>
+                {
+                    let code = action
+                        .trim_start_matches("parse_error_if_appropriate_end_tag(")
+                        .trim_end_matches(')')
+                        .to_string();
+                    if self.current_end_tag_matches_last_start_tag() {
+                        self.diagnostics.push(Diagnostic {
+                            code,
+                            position,
+                            state: state.to_string(),
+                        });
+                    }
+                }
                 _ if action.starts_with("parse_error(") && action.ends_with(')') => {
                     let code = action
                         .trim_start_matches("parse_error(")
@@ -1115,6 +1130,14 @@ impl Tokenizer {
             self.tokens
                 .push_back(Token::Text(std::mem::take(&mut self.text_buffer)));
         }
+    }
+
+    fn current_end_tag_matches_last_start_tag(&self) -> bool {
+        matches!(
+            self.current_token.as_ref(),
+            Some(CurrentToken::EndTag { name })
+                if self.last_start_tag.as_deref() == Some(name.as_str())
+        )
     }
 
     fn append_tag_name(&mut self, action: &str, ch: char, lowercase: bool) -> Result<()> {


### PR DESCRIPTION
## Summary
- add a conditional tokenizer action for reporting parse errors only when the current end tag is appropriate
- report `eof-in-tag` from normal and escaped script end-tag continuation states while preserving mismatched tags as literal text
- reduce malformed tree-construction cases without diagnostics from 38 to 24 and reprioritize the conformance backlog

## Validation
- `cargo test -p coding-adventures-html-lexer`
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p state-machine-tokenizer`
- `cargo test -p state-machine-markup-deserializer`
- `cargo clippy -p state-machine-tokenizer -p state-machine-markup-deserializer -p coding-adventures-html-lexer -p coding-adventures-html-parser --all-targets -- -D warnings`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /private/tmp/html-parser-live-html5lib-tests-20260809-1845 --wpt-tests /private/tmp/html-parser-live-wpt-20260809-1845`

Formatting note: the scoped `cargo fmt --check` still reports existing drift in generated and parser files; the touched Rust regions pass `git diff --check`, and no unrelated formatting churn is included.