### PR TITLE
Add Mermaid sequence accessibility metadata

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -3,7 +3,7 @@
 
 document = { NEWLINE } HEADER body EOF ;
 body = { NEWLINE | statement } ;
-statement = participant_stmt | participant_box | destroy_stmt | message_stmt | activation_stmt | note_stmt | link_stmt | links_stmt | properties_stmt | details_stmt | title_stmt | autonumber_stmt | control_block ;
+statement = participant_stmt | participant_box | destroy_stmt | message_stmt | activation_stmt | note_stmt | link_stmt | links_stmt | properties_stmt | details_stmt | accessibility_stmt | title_stmt | autonumber_stmt | control_block ;
 
 participant_stmt = [ "create" ] participant_decl ;
 participant_decl = ( "participant" | "actor" ) identifier [ CONFIG ] [ "as" text ] ;
@@ -17,6 +17,7 @@ links_stmt = "links" identifier COLON JSON_OBJECT ;
 properties_stmt = "properties" identifier COLON JSON_OBJECT ;
 details_stmt = "details" identifier COLON details_reference ;
 details_reference = identifier { identifier | MINUS } ;
+accessibility_stmt = ( "accTitle" | "accDescr" ) COLON text ;
 title_stmt = "title" text ;
 autonumber_stmt = "autonumber" [ "off" | NUMBER [ NUMBER ] ] ;
 

--- a/code/grammars/mermaid/sequence.tokens
+++ b/code/grammars/mermaid/sequence.tokens
@@ -57,6 +57,8 @@ keywords:
   links
   properties
   details
+  accTitle
+  accDescr
   box
   as
   activate

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.16.0
+
+- Added sequence accessibility title and description semantics.
+
 ## 0.15.0
 
 - Added host document details references to sequence participant and layout IR.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.15.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.16.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.15.0";
+pub const VERSION: &str = "0.16.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -292,6 +292,8 @@ pub enum SequenceEvent {
 #[derive(Clone, Debug, PartialEq)]
 pub struct SequenceDiagram {
     pub title: Option<String>,
+    pub accessibility_title: Option<String>,
+    pub accessibility_description: Option<String>,
     pub auto_number: bool,
     pub auto_number_start: f64,
     pub auto_number_step: f64,
@@ -381,6 +383,8 @@ pub struct LayoutedSequenceDiagram {
     pub width: f64,
     pub height: f64,
     pub title: Option<String>,
+    pub accessibility_title: Option<String>,
+    pub accessibility_description: Option<String>,
     pub items: Vec<LayoutedSequenceItem>,
 }
 
@@ -927,8 +931,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_is_0_15_0() {
-        assert_eq!(VERSION, "0.15.0");
+    fn version_is_0_16_0() {
+        assert_eq!(VERSION, "0.16.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.0 - 2026-08-09
+
+- Preserve sequence accessibility text through layout.
+
 ## 0.11.0 - 2026-08-09
 
 - Preserve actor details references on participant layout items.

--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-sequence"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
 

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -7,7 +7,7 @@ use diagram_ir::{
     SequenceEvent, SequenceNotePlacement,
 };
 
-pub const VERSION: &str = "0.11.0";
+pub const VERSION: &str = "0.12.0";
 
 const MARGIN: f64 = 28.0;
 const HEADER_Y: f64 = 42.0;
@@ -337,6 +337,8 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
         width,
         height,
         title: diagram.title.clone(),
+        accessibility_title: diagram.accessibility_title.clone(),
+        accessibility_description: diagram.accessibility_description.clone(),
         items,
     }
 }
@@ -383,6 +385,8 @@ mod tests {
     fn lays_out_messages_and_lifelines() {
         let diagram = SequenceDiagram {
             title: None,
+            accessibility_title: None,
+            accessibility_description: None,
             auto_number: true,
             auto_number_start: 10.5,
             auto_number_step: 2.25,
@@ -430,6 +434,8 @@ mod tests {
     fn preserves_half_arrow_semantics() {
         let diagram = SequenceDiagram {
             title: None,
+            accessibility_title: None,
+            accessibility_description: None,
             auto_number: false,
             auto_number_start: 1.0,
             auto_number_step: 1.0,
@@ -463,6 +469,8 @@ mod tests {
     fn closes_activation_on_deactivation_event() {
         let diagram = SequenceDiagram {
             title: None,
+            accessibility_title: None,
+            accessibility_description: None,
             auto_number: false,
             auto_number_start: 1.0,
             auto_number_step: 1.0,
@@ -489,6 +497,8 @@ mod tests {
     fn lays_out_nested_block_frames_and_branch_dividers() {
         let diagram = SequenceDiagram {
             title: None,
+            accessibility_title: None,
+            accessibility_description: None,
             auto_number: false,
             auto_number_start: 1.0,
             auto_number_step: 1.0,
@@ -548,6 +558,8 @@ mod tests {
     fn created_participant_has_bounded_lifeline() {
         let diagram = SequenceDiagram {
             title: None,
+            accessibility_title: None,
+            accessibility_description: None,
             auto_number: false,
             auto_number_start: 1.0,
             auto_number_step: 1.0,
@@ -631,6 +643,8 @@ mod tests {
         bob.group_id = Some("client".into());
         let diagram = SequenceDiagram {
             title: None,
+            accessibility_title: None,
+            accessibility_description: None,
             auto_number: false,
             auto_number_start: 1.0,
             auto_number_step: 1.0,

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Export sequence accessibility title and description as PaintScene metadata.
 - Export sequence actor details references as PaintScene metadata.
 - Export JSON-valued sequence actor properties as PaintScene metadata.
 - Export sequence actor links as PaintScene hit-test metadata.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.15.0";
+pub const VERSION: &str = "0.16.0";
 
 use std::collections::HashMap;
 
@@ -1081,6 +1081,12 @@ where
     let mut text_children = Vec::new();
     let mut central_markers = Vec::new();
     let mut scene_metadata = HashMap::new();
+    if let Some(title) = &diagram.accessibility_title {
+        scene_metadata.insert("accessibility.title".into(), title.clone());
+    }
+    if let Some(description) = &diagram.accessibility_description {
+        scene_metadata.insert("accessibility.description".into(), description.clone());
+    }
     let label_font = options.label_font.clone();
     let text_color = Color {
         r: 30,
@@ -2669,7 +2675,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.15.0");
+        assert_eq!(crate::VERSION, "0.16.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -349,7 +349,7 @@ mod apple {
     #[test]
     fn render_mermaid_sequence_to_png() {
         let mut diagram = parse_sequence_diagram(
-            "sequenceDiagram\ntitle Native Mermaid sequence\nautonumber\nbox aqua Client tier\nactor User\nparticipant API@{ \"type\": \"boundary\" } as Banking API\nend\nbox Services\nparticipant DB@{ \"type\": \"database\", \"alias\": \"Ledger\" }\nend\nalt Transfer accepted\nUser->>+API: Submit transfer\ncreate participant Worker as Audit Worker\nAPI()->>()Worker: Start audit\nWorker--|\\API: Audit complete\ndestroy Worker\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete\nelse Transfer rejected\nAPI-->>User: Validation failed\nend",
+            "sequenceDiagram\ntitle Native Mermaid sequence\naccTitle: Native transfer sequence\naccDescr: Banking transfer interaction\nautonumber\nbox aqua Client tier\nactor User\nparticipant API@{ \"type\": \"boundary\" } as Banking API\nend\nbox Services\nparticipant DB@{ \"type\": \"database\", \"alias\": \"Ledger\" }\nend\nalt Transfer accepted\nUser->>+API: Submit transfer\ncreate participant Worker as Audit Worker\nAPI()->>()Worker: Start audit\nWorker--|\\API: Audit complete\ndestroy Worker\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete\nelse Transfer rejected\nAPI-->>User: Validation failed\nend",
         )
         .expect("Mermaid sequence parse failed");
         diagram.auto_number_start = 10.5;
@@ -430,6 +430,22 @@ mod apple {
                 })
                 .map(String::as_str),
             Some("user-details")
+        );
+        assert_eq!(
+            scene
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("accessibility.title"))
+                .map(String::as_str),
+            Some("Native transfer sequence")
+        );
+        assert_eq!(
+            scene
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("accessibility.description"))
+                .map(String::as_str),
+            Some("Banking transfer interaction")
         );
         assert!(scene.instructions.iter().any(|instruction| matches!(
             instruction,

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.15.0
+
+- Tokenize sequence `accTitle` and `accDescr` statements.
+
 ## 0.14.0
 
 - Tokenize sequence actor `details` references.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.14.0";
+pub const VERSION: &str = "0.15.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.14.0");
+        assert_eq!(VERSION, "0.15.0");
     }
 
     #[test]
@@ -426,5 +426,14 @@ A\\-B: reverse stick bottom
         assert!(tokens.iter().any(|token| token.value == "alice"));
         assert!(tokens.iter().any(|token| token.value == "-"));
         assert!(tokens.iter().any(|token| token.value == "info"));
+    }
+
+    #[test]
+    fn tokenizes_sequence_accessibility_statements() {
+        let tokens = tokenize_mermaid_sequence(
+            "sequenceDiagram\naccTitle: Transfer flow\naccDescr: Banking interaction\n",
+        );
+        assert!(tokens.iter().any(|token| token.value == "accTitle"));
+        assert!(tokens.iter().any(|token| token.value == "accDescr"));
     }
 }

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.16.0
+
+- Parse single-line sequence accessibility titles and descriptions.
+
 ## 0.15.0
 
 - Parse sequence actor `details` element IDs into semantic IR.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -43,6 +43,8 @@ metadata for interactive backends. Arbitrary JSON-valued actor properties are
 also preserved in scene metadata. DOM-referenced `details` element IDs survive
 the native pipeline; resolving host document contents remains an embedding-layer
 compatibility gap.
+Single-line `accTitle` and `accDescr` statements lower to PaintScene metadata;
+the multiline accessibility-description form remains a compatibility gap.
 All Mermaid 11.16.1 solid/dotted, normal/reverse filled and stick half-arrow
 forms preserve their line style, half orientation, and endpoint through Paint.
 Central connection markers before and/or after an arrow preserve source,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.15.0";
+pub const VERSION: &str = "0.16.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1032,6 +1032,8 @@ pub fn parse_sequence_diagram(source: &str) -> Result<SequenceDiagram, ParseErro
 
     let mut diagram = SequenceDiagram {
         title: None,
+        accessibility_title: None,
+        accessibility_description: None,
         auto_number: false,
         auto_number_start: 1.0,
         auto_number_step: 1.0,
@@ -1084,6 +1086,18 @@ fn parse_sequence_body(
             "link" | "links" => parse_sequence_links(cursor, diagram, participant_indices)?,
             "properties" => parse_sequence_properties(cursor, diagram, participant_indices)?,
             "details" => parse_sequence_details(cursor, diagram, participant_indices)?,
+            "accTitle" | "accDescr" => {
+                let kind = cursor.advance().value.clone();
+                cursor.consume_if("COLON").ok_or_else(|| {
+                    token_error(cursor.current(), "expected ':' before accessibility text")
+                })?;
+                let text = take_sequence_line_text(cursor);
+                if kind == "accTitle" {
+                    diagram.accessibility_title = Some(text);
+                } else {
+                    diagram.accessibility_description = Some(text);
+                }
+            }
             "title" => {
                 cursor.advance();
                 diagram.title = Some(take_sequence_line_text(cursor));
@@ -3272,6 +3286,22 @@ B//-A: reverse stick top
             Some("alice-info")
         );
     }
+
+    #[test]
+    fn sequence_parses_accessibility_title_and_description() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\naccTitle: Transfer flow\naccDescr: Banking interaction\nAlice->>Bob: Hello\n",
+        )
+        .unwrap();
+        assert_eq!(
+            diagram.accessibility_title.as_deref(),
+            Some("Transfer flow")
+        );
+        assert_eq!(
+            diagram.accessibility_description.as_deref(),
+            Some("Banking interaction")
+        );
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -3288,7 +3318,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.15.0");
+        assert_eq!(crate::VERSION, "0.16.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -129,6 +129,10 @@ forms. The family remains partial until those forms and the
 pinned upstream corpus pass; unsupported forms must fail grammar validation
 rather than degrade silently.
 
+Single-line sequence `accTitle` and `accDescr` statements preserve accessibility
+semantics in PaintScene metadata. Mermaid's multiline accessibility-description
+form remains compatibility work.
+
 Inline participant configuration now carries `type` and `alias` into semantic
 IR. Boundary, control, entity, database, collections, and queue kinds lower to
 backend-neutral path, ellipse, and rectangle symbols and have Metal PNG coverage.


### PR DESCRIPTION
## Summary
- add grammar-backed single-line `accTitle` and `accDescr` statements
- preserve accessibility semantics through sequence IR and layout
- expose accessibility text through PaintScene metadata with Metal PNG coverage

The upstream multiline `accDescr` form remains explicitly documented compatibility work.

## Verification
- `cargo test -p diagram-ir -p mermaid-lexer -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint -- --nocapture`
- `cargo clippy -p diagram-ir -p mermaid-lexer -p mermaid-parser -p diagram-layout-sequence -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `git diff --check`
- visually inspected `/tmp/mermaid_sequence_e2e.png`