### PR TITLE
Add multiline Mermaid sequence accessibility

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -17,7 +17,7 @@ links_stmt = "links" identifier COLON JSON_OBJECT ;
 properties_stmt = "properties" identifier COLON JSON_OBJECT ;
 details_stmt = "details" identifier COLON details_reference ;
 details_reference = identifier { identifier | MINUS } ;
-accessibility_stmt = ( "accTitle" | "accDescr" ) COLON text ;
+accessibility_stmt = ( "accTitle" | "accDescr" ) COLON text | ACC_DESCR_BLOCK ;
 title_stmt = "title" text ;
 autonumber_stmt = "autonumber" [ "off" | NUMBER [ NUMBER ] ] ;
 

--- a/code/grammars/mermaid/sequence.tokens
+++ b/code/grammars/mermaid/sequence.tokens
@@ -8,6 +8,7 @@ skip:
 
 NEWLINE                  = /\r?\n/
 HEADER                   = "sequenceDiagram"
+ACC_DESCR_BLOCK          = /accDescr[ \t]*\{[^\}]*\}/
 BIDIRECTIONAL_SOLID      = "<<->>"
 BIDIRECTIONAL_DOTTED     = "<<-->>"
 DOTTED_FILLED_TOP        = /\-\-\|\\/

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Export sequence accessibility title and description as PaintScene metadata.
+- Preserve multiline accessibility descriptions in that scene metadata.
 - Export sequence actor details references as PaintScene metadata.
 - Export JSON-valued sequence actor properties as PaintScene metadata.
 - Export sequence actor links as PaintScene hit-test metadata.

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -349,7 +349,7 @@ mod apple {
     #[test]
     fn render_mermaid_sequence_to_png() {
         let mut diagram = parse_sequence_diagram(
-            "sequenceDiagram\ntitle Native Mermaid sequence\naccTitle: Native transfer sequence\naccDescr: Banking transfer interaction\nautonumber\nbox aqua Client tier\nactor User\nparticipant API@{ \"type\": \"boundary\" } as Banking API\nend\nbox Services\nparticipant DB@{ \"type\": \"database\", \"alias\": \"Ledger\" }\nend\nalt Transfer accepted\nUser->>+API: Submit transfer\ncreate participant Worker as Audit Worker\nAPI()->>()Worker: Start audit\nWorker--|\\API: Audit complete\ndestroy Worker\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete\nelse Transfer rejected\nAPI-->>User: Validation failed\nend",
+            "sequenceDiagram\ntitle Native Mermaid sequence\naccTitle: Native transfer sequence\naccDescr {\n  Banking transfer\n  interaction\n}\nautonumber\nbox aqua Client tier\nactor User\nparticipant API@{ \"type\": \"boundary\" } as Banking API\nend\nbox Services\nparticipant DB@{ \"type\": \"database\", \"alias\": \"Ledger\" }\nend\nalt Transfer accepted\nUser->>+API: Submit transfer\ncreate participant Worker as Audit Worker\nAPI()->>()Worker: Start audit\nWorker--|\\API: Audit complete\ndestroy Worker\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete\nelse Transfer rejected\nAPI-->>User: Validation failed\nend",
         )
         .expect("Mermaid sequence parse failed");
         diagram.auto_number_start = 10.5;
@@ -445,7 +445,7 @@ mod apple {
                 .as_ref()
                 .and_then(|metadata| metadata.get("accessibility.description"))
                 .map(String::as_str),
-            Some("Banking transfer interaction")
+            Some("Banking transfer\n  interaction")
         );
         assert!(scene.instructions.iter().any(|instruction| matches!(
             instruction,

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.16.0
+
+- Tokenize multiline sequence accessibility-description blocks atomically.
+
 ## 0.15.0
 
 - Tokenize sequence `accTitle` and `accDescr` statements.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.15.0";
+pub const VERSION: &str = "0.16.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.15.0");
+        assert_eq!(VERSION, "0.16.0");
     }
 
     #[test]
@@ -435,5 +435,16 @@ A\\-B: reverse stick bottom
         );
         assert!(tokens.iter().any(|token| token.value == "accTitle"));
         assert!(tokens.iter().any(|token| token.value == "accDescr"));
+    }
+
+    #[test]
+    fn tokenizes_multiline_sequence_accessibility_description() {
+        let tokens = tokenize_mermaid_sequence(
+            "sequenceDiagram\naccDescr {\n  Transfers funds\n  between accounts\n}\n",
+        );
+        assert!(tokens.iter().any(|token| {
+            token.type_name.as_deref() == Some("ACC_DESCR_BLOCK")
+                && token.value.contains("between accounts")
+        }));
     }
 }

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.17.0
+
+- Parse multiline sequence accessibility descriptions.
+
 ## 0.16.0
 
 - Parse single-line sequence accessibility titles and descriptions.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -43,8 +43,8 @@ metadata for interactive backends. Arbitrary JSON-valued actor properties are
 also preserved in scene metadata. DOM-referenced `details` element IDs survive
 the native pipeline; resolving host document contents remains an embedding-layer
 compatibility gap.
-Single-line `accTitle` and `accDescr` statements lower to PaintScene metadata;
-the multiline accessibility-description form remains a compatibility gap.
+Both single-line accessibility statements and multiline `accDescr` blocks
+lower to PaintScene metadata.
 All Mermaid 11.16.1 solid/dotted, normal/reverse filled and stick half-arrow
 forms preserve their line style, half orientation, and endpoint through Paint.
 Central connection markers before and/or after an arrow preserve source,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.16.0";
+pub const VERSION: &str = "0.17.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1056,6 +1056,14 @@ fn parse_sequence_body(
 ) -> Result<(), ParseError> {
     cursor.skip_terminators();
     while !cursor.at_eof() && !terminators.contains(&cursor.current().value.as_str()) {
+        if token_name(cursor.current()) == "ACC_DESCR_BLOCK" {
+            let token = cursor.advance().clone();
+            let open = token.value.find('{').expect("token grammar requires '{'");
+            let close = token.value.rfind('}').expect("token grammar requires '}'");
+            diagram.accessibility_description = Some(token.value[open + 1..close].trim().into());
+            cursor.skip_terminators();
+            continue;
+        }
         match cursor.current().value.as_str() {
             "participant" | "actor" => {
                 parse_sequence_participant(cursor, diagram, participant_indices, false)?;
@@ -3302,6 +3310,18 @@ B//-A: reverse stick top
             Some("Banking interaction")
         );
     }
+
+    #[test]
+    fn sequence_parses_multiline_accessibility_description() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\naccDescr {\n  Transfers funds\n  between accounts\n}\nAlice->>Bob: Hello\n",
+        )
+        .unwrap();
+        assert_eq!(
+            diagram.accessibility_description.as_deref(),
+            Some("Transfers funds\n  between accounts")
+        );
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -3318,7 +3338,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.16.0");
+        assert_eq!(crate::VERSION, "0.17.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -129,9 +129,8 @@ forms. The family remains partial until those forms and the
 pinned upstream corpus pass; unsupported forms must fail grammar validation
 rather than degrade silently.
 
-Single-line sequence `accTitle` and `accDescr` statements preserve accessibility
-semantics in PaintScene metadata. Mermaid's multiline accessibility-description
-form remains compatibility work.
+Sequence `accTitle`, single-line `accDescr`, and multiline `accDescr` blocks
+preserve accessibility semantics in PaintScene metadata.
 
 Inline participant configuration now carries `type` and `alias` into semantic
 IR. Boundary, control, entity, database, collections, and queue kinds lower to


### PR DESCRIPTION
## Summary
- add an atomic portable token and grammar production for multiline `accDescr` blocks
- preserve trimmed multiline accessibility text in sequence semantic IR
- validate PaintScene metadata and Metal-to-PNG rendering end to end

## Verification
- `cargo test -p mermaid-lexer -p mermaid-parser -p diagram-to-paint -- --nocapture`
- `cargo clippy -p mermaid-lexer -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `git diff --check`
- visually inspected `/tmp/mermaid_sequence_e2e.png`