### PR TITLE
Report plaintext insertion diagnostics

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,11 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Plaintext elements left open at EOF across the document shell and templates
+  now report their required parse error. Text-mode lexer handoff now occurs
+  only after tree construction accepts the start tag, so plaintext rejected in
+  or after a frameset remains tokenized as markup and reports the rejected
+  start and end tags. This covers 12 previously silent malformed corpus cases.
 - Malformed script end tags that reach EOF while the lexer is assembling the
   tag now report `eof-in-tag`, covering 14 previously silent malformed corpus
   cases without changing DOM recovery or undeclared-diagnostic coverage.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -66,18 +66,19 @@ open table blocks adoption-agency recovery. Description-list item start tags
 now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
 without flagging adjacent description-list items.
 
-The fresh 24-case residual inventory keeps the next concrete groups in this
-priority order: plaintext handling across document-shell, template, and
-frameset contexts; frameset and document-tail boundaries; and the final
+The fresh 12-case residual inventory keeps the next concrete groups in this
+priority order: frameset and document-tail boundaries; and the final
 fragment-context rows for colgroup text, an after-body token, and an HTML start
-tag in a seeded SVG context. The current corpus no longer has a silent
-script-tokenizer, table-shell, foreign end-tag, formatting-only, or general
-in-body group.
+tag in a seeded SVG context. Plaintext EOF recovery now reports across the
+document shell and templates, and rejected plaintext start tags no longer
+incorrectly switch the lexer out of data state. The current corpus no longer
+has a silent script-tokenizer, table-shell, foreign end-tag, formatting-only,
+or general in-body group.
 
 Prioritized work items:
 
-1. **Plaintext, frameset, and document-tail boundaries.** Cover EOF and stray
-   content diagnostics after plaintext and frameset transitions.
+1. **Frameset and document-tail boundaries.** Cover stray content diagnostics
+   around frameset transitions and after the document shell closes.
 2. **Fragment-context parsing.** Cover the final colgroup text, after-body, and
    foreign HTML start-tag rows. Invalid start and end tags targeting seeded
    fragment-context elements now report without mutating their synthetic

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4663,7 +4663,9 @@ impl HtmlParser {
                             ));
                             self.open_elements.pop();
                         }
-                        if (self.is_fragment || self.has_open_element("body"))
+                        if (self.is_fragment
+                            || self.has_open_element("body")
+                            || self.current_element_is("plaintext"))
                             && self.has_disallowed_authored_open_element_for_eof()
                         {
                             self.diagnostics.push(ParserDiagnostic::new(
@@ -4968,6 +4970,10 @@ impl HtmlParser {
             && self.current_element_is("frameset")
             && !matches!(name.as_str(), "frame" | "frameset" | "noframes")
         {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-start-tag-in-frameset",
+                format!("start tag `<{name}>` in a frameset was ignored"),
+            ));
             return;
         }
         if !in_foreign_content
@@ -4977,6 +4983,10 @@ impl HtmlParser {
             && name != "html"
             && name != "frameset"
         {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-start-tag-after-frameset",
+                format!("start tag `<{name}>` after a frameset was ignored"),
+            ));
             return;
         }
         if !in_foreign_content
@@ -4986,6 +4996,10 @@ impl HtmlParser {
             && name != "html"
             && name != "frameset"
         {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-start-tag-after-frameset",
+                format!("start tag `<{name}>` after a frameset was ignored"),
+            ));
             return;
         }
         if !in_foreign_content
@@ -8957,7 +8971,7 @@ fn drain_parser_tokens(
         parser.process_lexer_token(token, final_drain);
 
         let next_context = if let Some(name) = start_tag_name {
-            (parser.current_namespace().is_none())
+            (parser.current_namespace().is_none() && parser.current_element_is(&name))
                 .then(|| {
                     HtmlLexContext::for_element_text_with_scripting(&name, parser.options.scripting)
                 })
@@ -31857,6 +31871,67 @@ mod tests {
                 )
             ]
         );
+    }
+
+    #[test]
+    fn reports_plaintext_eof_across_document_shell_and_template_contexts() {
+        for source in [
+            "<!doctype html><html><plaintext></plaintext>",
+            "<!doctype html><head><plaintext></plaintext>",
+            "<!doctype html><template><plaintext>a</template>b",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output
+                    .parser_diagnostics
+                    .iter()
+                    .any(|diagnostic| { diagnostic.code == "eof-with-unclosed-elements" }),
+                "source {source:?}"
+            );
+        }
+
+        let noscript = parse_html_with_diagnostics_and_options(
+            "<!doctype html><html><noscript><plaintext></plaintext>",
+            HtmlParseOptions {
+                scripting: HtmlScriptingMode::Disabled,
+                ..HtmlParseOptions::default()
+            },
+        )
+        .unwrap();
+        assert!(noscript
+            .parser_diagnostics
+            .iter()
+            .any(|diagnostic| { diagnostic.code == "eof-with-unclosed-elements" }));
+    }
+
+    #[test]
+    fn rejected_plaintext_does_not_switch_lexer_state_after_frameset() {
+        for (source, code) in [
+            (
+                "<!doctype html><frameset><plaintext></plaintext>",
+                "unexpected-start-tag-in-frameset",
+            ),
+            (
+                "<!doctype html><frameset></frameset><plaintext></plaintext>",
+                "unexpected-start-tag-after-frameset",
+            ),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output
+                    .parser_diagnostics
+                    .iter()
+                    .any(|diagnostic| diagnostic.code == code),
+                "source {source:?}"
+            );
+            assert!(
+                output
+                    .parser_diagnostics
+                    .iter()
+                    .any(|diagnostic| diagnostic.code == "unexpected-end-tag"),
+                "source {source:?}"
+            );
+        }
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 24);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2159);
+    assert_eq!(missing_diagnostic_cases, 12);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2171);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report unclosed plaintext EOF recovery across document-shell and template contexts
- only switch lexer text modes after tree construction accepts the corresponding start tag
- report plaintext start and end tags rejected in or after framesets
- ratchet malformed tree cases without diagnostics from 24 to 12 and reprioritize the backlog

## Validation
- `cargo test -p coding-adventures-html-lexer`
- `cargo test -p coding-adventures-html-parser`
- `cargo clippy -p coding-adventures-html-lexer -p coding-adventures-html-parser --all-targets -- -D warnings`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py --html5lib-tests /private/tmp/html-parser-live-html5lib-tests-20260809-1845 --wpt-tests /private/tmp/html-parser-live-wpt-20260809-1845`
- `git diff --check`

Live audit remained complete at 1,934 WPT tree cases and 6,806 html5lib tokenizer cases, with zero missing or skipped cases. `cargo fmt -p coding-adventures-html-parser -- --check` continues to report pre-existing formatting drift outside the lines changed here; the new lines match rustfmt output.