### PR TITLE
Expose lossless vault domain persistence state

### DIFF
--- a/code/packages/rust/vault-pm-domain/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-domain/CHANGELOG.md
@@ -22,3 +22,5 @@ All notable changes to this package are documented here.
 - Operation-ID collisions and dangling removal tombstones are rejected.
 - Tombstone compaction requires an explicit repository causal-stability
   predicate and preserves concurrent or later adds.
+- Lossless persistence iterators expose retained add and removal observations;
+  present-only projections no longer tempt codecs to discard tombstones.

--- a/code/packages/rust/vault-pm-domain/README.md
+++ b/code/packages/rust/vault-pm-domain/README.md
@@ -24,6 +24,11 @@ pairs remain until a repository supplies causal-stability proof to
 `compact_stable_removals`; elapsed time or observation by one head is not
 sufficient proof.
 
+Persistent codecs must enumerate `retained_values` and each value's retained
+add and removal operations. The present-only `values` projection deliberately
+cannot be used for lossless persistence because it would discard tombstones
+and could resurrect removed membership after a merge.
+
 ## Development
 
 ```bash
@@ -31,5 +36,5 @@ bash BUILD
 cargo clippy -p coding_adventures_vault_pm_domain --all-targets -- -D warnings
 ```
 
-The Phase 0 suite contains 29 unit tests and covers 527/532 executable crate
-lines (99.06%) under Tarpaulin's LLVM engine.
+The Phase 0 suite contains 30 unit tests and covers 537/542 executable crate
+lines (99.08%) under Tarpaulin's LLVM engine.

--- a/code/packages/rust/vault-pm-domain/src/lib.rs
+++ b/code/packages/rust/vault-pm-domain/src/lib.rs
@@ -342,6 +342,45 @@ impl<T: Ord + Clone> ObservedSet<T> {
             .collect()
     }
 
+    /// Iterate every retained value, including values hidden by removals.
+    ///
+    /// Persistent codecs must use this together with
+    /// [`Self::retained_add_operations`] and
+    /// [`Self::retained_removal_operations`] instead of serializing only
+    /// [`Self::values`]. Dropping removed observations can resurrect a value
+    /// after a later merge.
+    pub fn retained_values(&self) -> impl ExactSizeIterator<Item = &T> {
+        self.adds.keys()
+    }
+
+    /// Iterate the retained add operations for one exact retained value.
+    ///
+    /// The iterator is deterministically ordered. An unknown value produces
+    /// an empty iterator.
+    pub fn retained_add_operations<'a>(
+        &'a self,
+        value: &T,
+    ) -> impl Iterator<Item = OperationId> + 'a {
+        self.adds
+            .get(value)
+            .into_iter()
+            .flat_map(|operations| operations.iter().copied())
+    }
+
+    /// Iterate the retained removal tombstones for one exact retained value.
+    ///
+    /// The iterator is deterministically ordered. An unknown or never-removed
+    /// value produces an empty iterator.
+    pub fn retained_removal_operations<'a>(
+        &'a self,
+        value: &T,
+    ) -> impl Iterator<Item = OperationId> + 'a {
+        self.removals
+            .get(value)
+            .into_iter()
+            .flat_map(|operations| operations.iter().copied())
+    }
+
     /// Return the number of distinct values retained on wire, including absent values.
     pub fn retained_value_count(&self) -> usize {
         self.adds.len()
@@ -1551,6 +1590,39 @@ mod tests {
             set.observe_removal(&"missing".to_string(), operation(1)),
             Err(DomainError::InvalidObservedSet)
         );
+    }
+
+    #[test]
+    fn retained_observations_round_trip_without_resurrection() {
+        let mut source = ObservedSet::new();
+        source.add("a".to_string(), operation(1)).unwrap();
+        source.add("a".to_string(), operation(2)).unwrap();
+        source.add("b".to_string(), operation(3)).unwrap();
+        source.remove(&"a".to_string());
+        source.add("a".to_string(), operation(4)).unwrap();
+        source.remove(&"b".to_string());
+
+        let mut reconstructed = ObservedSet::new();
+        for value in source.retained_values() {
+            for operation in source.retained_add_operations(value) {
+                reconstructed.add(value.clone(), operation).unwrap();
+            }
+            for operation in source.retained_removal_operations(value) {
+                reconstructed.observe_removal(value, operation).unwrap();
+            }
+        }
+
+        assert_eq!(reconstructed, source);
+        assert!(reconstructed.contains(&"a".to_string()));
+        assert!(!reconstructed.contains(&"b".to_string()));
+        assert!(source
+            .retained_add_operations(&"missing".to_string())
+            .next()
+            .is_none());
+        assert!(source
+            .retained_removal_operations(&"missing".to_string())
+            .next()
+            .is_none());
     }
 
     #[test]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1262,6 +1262,9 @@ changelog, focused build, and downstream validation.
 7. `vault-pm-repository`: publication, verification, local heads, history, GC
    plan, using the bounded fail-closed contract in
    `VLT-PM04-repository.md`.
+7a. `vault-pm-domain` lossless persistence projection: retained values, add
+    operations, and removal tombstones must be enumerable before the
+    application codec persists observed sets.
 8. `vault-pm-application`: init/open/item/search/history/export/audit workflows.
 9. `vault-pm-cli` + real executable and pseudo-terminal E2E suite.
 10. Crash/fault matrix and local restore drill.

--- a/code/specs/VLT-PM03-domain.md
+++ b/code/specs/VLT-PM03-domain.md
@@ -102,6 +102,13 @@ the next entry. A persistent decoder must rebuild through `add` and
 validate them afterward. A bound failure is closed and does not return partial
 state.
 
+A persistent encoder must iterate `retained_values` and, for each value, the
+deterministically ordered `retained_add_operations` and
+`retained_removal_operations`. The present-only `values` projection is for UI
+and filtering, not persistence. Omitting a retained add or tombstone is data
+loss and can resurrect a removed value after a later merge. These persistence
+iterators are explicit accessors and do not alter redacted diagnostics.
+
 Tombstones and their matching adds are retained by default.
 `compact_stable_removals` may discard a removed pair only when the repository
 asserts that every retained head observed the removal and no authorized
@@ -227,9 +234,10 @@ V1 tests must cover:
 14. bounded merge rejection without partial state; and
 15. compaction retaining unproven tombstones and preserving later adds.
 
-Phase 0 evidence on 2026-08-09 is 29 passing unit tests and 527/532 executable
-lines (99.06%) under Tarpaulin's LLVM engine, including the retained-state,
-collision, dangling-tombstone, merge-amplification, and compaction cases.
+Phase 0 evidence on 2026-08-09 is 30 passing unit tests and 537/542 executable
+lines (99.08%) under Tarpaulin's LLVM engine, including the retained-state,
+collision, dangling-tombstone, merge-amplification, persistence-round-trip, and
+compaction cases.
 
 ## 11. Security properties and non-goals
 


### PR DESCRIPTION
## Summary

- add explicit deterministic iterators for every retained observed-set value
- expose retained add operations and removal tombstones for exact application codecs
- document why the present-only values projection must never be persisted
- add backlog item 7a ahead of the application layer

## Security rationale

Serializing only currently present tags, collections, or attachments discards CRDT tombstones. A later merge can then resurrect a value the user removed. The new API lets a bounded decoder rebuild exact state through the existing checked `add` and `observe_removal` operations without exposing raw internal maps or changing redacted diagnostics.

## Verification

- `cargo test -p coding_adventures_vault_pm_domain` — 30 passed
- scoped rustfmt, strict clippy, and rustdoc warnings — passed
- `bash BUILD` — 30 passed
- capability taxonomy suite — 7 passed
- Tarpaulin LLVM coverage — 537/542 executable lines, 99.08%
- affected build — 1 package built, 996 skipped