### PR TITLE
Report frameset text and EOF diagnostics

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Open framesets now report EOF, and non-whitespace character data discarded
+  in or after a frameset reports its insertion-mode parse error. This covers 7
+  previously silent malformed corpus cases without changing DOM recovery or
+  undeclared-diagnostic coverage.
 - Plaintext elements left open at EOF across the document shell and templates
   now report their required parse error. Text-mode lexer handoff now occurs
   only after tree construction accepts the start tag, so plaintext rejected in

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,9 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the script end-tag EOF diagnostic slice, 2,159 of those cases emit at
-least one lexer or parser diagnostic and 24 remain
-uncovered.
+After the frameset character-data and EOF diagnostic slice, 2,178 of those
+cases emit at least one lexer or parser diagnostic and 5 remain uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
 inputs for which the legacy fixtures omit the Standard-required missing-doctype
@@ -66,19 +65,21 @@ open table blocks adoption-agency recovery. Description-list item start tags
 now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
 without flagging adjacent description-list items.
 
-The fresh 12-case residual inventory keeps the next concrete groups in this
-priority order: frameset and document-tail boundaries; and the final
-fragment-context rows for colgroup text, an after-body token, and an HTML start
-tag in a seeded SVG context. Plaintext EOF recovery now reports across the
-document shell and templates, and rejected plaintext start tags no longer
-incorrectly switch the lexer out of data state. The current corpus no longer
-has a silent script-tokenizer, table-shell, foreign end-tag, formatting-only,
-or general in-body group.
+The fresh 5-case residual inventory keeps the next concrete groups in this
+priority order: two document-tail boundaries; and the final fragment-context
+rows for colgroup text, an after-body token, and an HTML start tag in a seeded
+SVG context. Open framesets now report EOF, and non-whitespace character data
+discarded in or after framesets reports the corresponding insertion-mode parse
+error. Plaintext EOF recovery now reports across the document shell and
+templates, and rejected plaintext start tags no longer incorrectly switch the
+lexer out of data state. The current corpus no longer has a silent
+script-tokenizer, frameset, table-shell, foreign end-tag, formatting-only, or
+general in-body group.
 
 Prioritized work items:
 
-1. **Frameset and document-tail boundaries.** Cover stray content diagnostics
-   around frameset transitions and after the document shell closes.
+1. **Document-tail boundaries.** Cover the two remaining stray-content
+   diagnostics after the document shell closes.
 2. **Fragment-context parsing.** Cover the final colgroup text, after-body, and
    foreign HTML start-tag rows. Invalid start and end tags targeting seeded
    fragment-context elements now report without mutating their synthetic

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4656,6 +4656,12 @@ impl HtmlParser {
                         }));
                     }
                     Token::Eof => {
+                        if !self.is_fragment && self.has_open_element("frameset") {
+                            self.diagnostics.push(ParserDiagnostic::new(
+                                "eof-in-frameset",
+                                "end of file was reached while parsing a frameset",
+                            ));
+                        }
                         if self.current_element_is_authored_text_mode_element() {
                             self.diagnostics.push(ParserDiagnostic::new(
                                 "eof-in-text-mode",
@@ -5630,6 +5636,12 @@ impl HtmlParser {
         }
 
         if self.document_has_closed_frameset() && !self.current_element_is("noframes") {
+            if text.chars().any(|character| !is_html_whitespace(character)) {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-char-after-frameset",
+                    "non-whitespace character data was ignored after the frameset",
+                ));
+            }
             let whitespace = text
                 .chars()
                 .filter(|character| character.is_whitespace())
@@ -5751,6 +5763,12 @@ impl HtmlParser {
         }
 
         let text = if self.in_frameset_text_context() {
+            if text.chars().any(|character| !is_html_whitespace(character)) {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-char-in-frameset",
+                    "non-whitespace character data was ignored in the frameset",
+                ));
+            }
             let whitespace = text
                 .chars()
                 .filter(|character| character.is_whitespace())
@@ -32080,30 +32098,82 @@ mod tests {
 
     #[test]
     fn ignores_non_whitespace_text_directly_inside_framesets() {
-        let document = parse_html("<!DOCTYPE html><frameset>test").unwrap();
+        let output = parse_html_with_diagnostics("<!DOCTYPE html><frameset>test").unwrap();
 
-        let html = html(&document);
+        let html = html(&output.document);
         let frameset = element(&html.children[1]);
         assert_eq!(frameset.name, "frameset");
         assert!(frameset.children.is_empty());
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![
+                ParserDiagnostic::new(
+                    "unexpected-char-in-frameset",
+                    "non-whitespace character data was ignored in the frameset"
+                ),
+                ParserDiagnostic::new(
+                    "eof-in-frameset",
+                    "end of file was reached while parsing a frameset"
+                ),
+            ]
+        );
     }
 
     #[test]
     fn preserves_only_whitespace_from_mixed_frameset_text() {
-        let document = parse_html("<!DOCTYPE html><frameset> te st").unwrap();
+        let output = parse_html_with_diagnostics("<!DOCTYPE html><frameset> te st").unwrap();
 
-        let html = html(&document);
+        let html = html(&output.document);
         let frameset = element(&html.children[1]);
         assert_eq!(frameset.children, vec![Node::text("  ")]);
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![
+                ParserDiagnostic::new(
+                    "unexpected-char-in-frameset",
+                    "non-whitespace character data was ignored in the frameset"
+                ),
+                ParserDiagnostic::new(
+                    "eof-in-frameset",
+                    "end of file was reached while parsing a frameset"
+                ),
+            ]
+        );
     }
 
     #[test]
     fn top_level_frameset_keeps_filtered_trailing_html_text() {
-        let document = parse_html("<!DOCTYPE html><frameset></frameset> te st").unwrap();
+        let output =
+            parse_html_with_diagnostics("<!DOCTYPE html><frameset></frameset> te st").unwrap();
 
-        let html = html(&document);
+        let html = html(&output.document);
         assert_eq!(element(&html.children[1]).name, "frameset");
         assert_eq!(html.children[2], Node::text("  "));
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-char-after-frameset",
+                "non-whitespace character data was ignored after the frameset"
+            )]
+        );
+    }
+
+    #[test]
+    fn reports_eof_with_an_open_frameset_after_head_void_elements() {
+        for source in [
+            "<!doctype html><basefont><frameset>",
+            "<!doctype html><bgsound><frameset>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "eof-in-frameset",
+                    "end of file was reached while parsing a frameset"
+                )],
+                "source {source:?}"
+            );
+        }
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 12);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2171);
+    assert_eq!(missing_diagnostic_cases, 5);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2178);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report EOF while a document frameset remains open
- report non-whitespace character data discarded in and after framesets
- ratchet malformed tree-construction cases without diagnostics from 12 to 5 and reprioritize the residual backlog

## Validation
- `cargo test -p coding-adventures-html-lexer`
- `cargo test -p coding-adventures-html-parser`
- `cargo clippy -p coding-adventures-html-lexer -p coding-adventures-html-parser --all-targets -- -D warnings`
- live WPT/html5lib coverage audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing or skipped
- WHATWG audit coverage, manifest, Rust-test, fixture metadata, and coverage-audit unit guards
- `git diff --check`
- `cargo fmt -p coding-adventures-html-parser -- --check` reports only pre-existing unrelated formatting drift; no changed lines appear in its output