### PR TITLE
Add Mermaid sequence semicolon terminators

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -1,13 +1,13 @@
 # @version 1
 # Mermaid 11.16.1 sequence diagram parser grammar: initial native subset.
 
-document = { NEWLINE } HEADER body EOF ;
-body = { NEWLINE | statement } ;
+document = { terminator } HEADER body EOF ;
+body = { terminator | statement } ;
 statement = participant_stmt | participant_box | destroy_stmt | message_stmt | activation_stmt | note_stmt | link_stmt | links_stmt | properties_stmt | details_stmt | accessibility_stmt | title_stmt | autonumber_stmt | control_block ;
 
 participant_stmt = [ "create" ] participant_decl ;
 participant_decl = ( "participant" | "actor" ) identifier [ CONFIG ] [ "as" text ] ;
-participant_box = "box" [ text ] NEWLINE { NEWLINE | participant_decl } "end" ;
+participant_box = "box" [ text ] terminator { terminator | participant_decl } "end" ;
 destroy_stmt = "destroy" identifier ;
 message_stmt = identifier [ CENTRAL ] message_arrow [ CENTRAL ] [ PLUS | MINUS ] identifier COLON [ text ] ;
 activation_stmt = ( "activate" | "deactivate" ) identifier ;
@@ -22,13 +22,14 @@ title_stmt = "title" text ;
 autonumber_stmt = "autonumber" [ "off" | NUMBER [ NUMBER ] ] ;
 
 control_block = simple_block | rect_block | alt_block | par_block | critical_block ;
-simple_block = ( "loop" | "opt" | "break" ) [ text ] NEWLINE body "end" ;
-rect_block = "rect" COLOR NEWLINE body "end" ;
-alt_block = "alt" [ text ] NEWLINE body { "else" [ text ] NEWLINE body } "end" ;
-par_block = ( "par" | "par_over" ) [ text ] NEWLINE body { "and" [ text ] NEWLINE body } "end" ;
-critical_block = "critical" [ text ] NEWLINE body { "option" [ text ] NEWLINE body } "end" ;
+simple_block = ( "loop" | "opt" | "break" ) [ text ] terminator body "end" ;
+rect_block = "rect" COLOR terminator body "end" ;
+alt_block = "alt" [ text ] terminator body { "else" [ text ] terminator body } "end" ;
+par_block = ( "par" | "par_over" ) [ text ] terminator body { "and" [ text ] terminator body } "end" ;
+critical_block = "critical" [ text ] terminator body { "option" [ text ] terminator body } "end" ;
 
 actor_pair = identifier [ COMMA identifier ] ;
 message_arrow = SOLID_OPEN_ARROW | DOTTED_OPEN_ARROW | SOLID_FILLED_ARROW | DOTTED_FILLED_ARROW | BIDIRECTIONAL_SOLID | BIDIRECTIONAL_DOTTED | SOLID_CROSS_ARROW | DOTTED_CROSS_ARROW | SOLID_POINT_ARROW | DOTTED_POINT_ARROW | SOLID_FILLED_TOP | SOLID_FILLED_BOTTOM | SOLID_STICK_TOP | SOLID_STICK_BOTTOM | DOTTED_FILLED_TOP | DOTTED_FILLED_BOTTOM | DOTTED_STICK_TOP | DOTTED_STICK_BOTTOM | SOLID_REVERSE_FILLED_TOP | SOLID_REVERSE_FILLED_BOTTOM | SOLID_REVERSE_STICK_TOP | SOLID_REVERSE_STICK_BOTTOM | DOTTED_REVERSE_FILLED_TOP | DOTTED_REVERSE_FILLED_BOTTOM | DOTTED_REVERSE_STICK_TOP | DOTTED_REVERSE_STICK_BOTTOM ;
 identifier = IDENTIFIER | WORD | COLOR | NUMBER ;
 text = identifier { identifier } ;
+terminator = NEWLINE | SEMICOLON ;

--- a/code/grammars/mermaid/sequence.tokens
+++ b/code/grammars/mermaid/sequence.tokens
@@ -7,6 +7,7 @@ skip:
   COMMENT               = /%%[^\r\n]*/
 
 NEWLINE                  = /\r?\n/
+SEMICOLON                = ";"
 HEADER                   = "sequenceDiagram"
 ACC_DESCR_BLOCK          = /accDescr[ \t]*\{[^\}]*\}/
 BIDIRECTIONAL_SOLID      = "<<->>"
@@ -47,7 +48,7 @@ PLUS                     = "+"
 MINUS                    = "-"
 NUMBER                   = /(?:[0-9]+(?:\.[0-9]{1,2})?|\.[0-9]{1,2})/
 IDENTIFIER               = /[A-Za-z0-9_.$]+/
-WORD                     = /[^ \t\r\n:,+-@]+/
+WORD                     = /[^ \t\r\n:,+-@;]+/
 
 keywords:
   participant

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Export sequence accessibility title and description as PaintScene metadata.
 - Preserve multiline accessibility descriptions in that scene metadata.
+- Validate semicolon-separated sequence input through Metal PNG rendering.
 - Export sequence actor details references as PaintScene metadata.
 - Export JSON-valued sequence actor properties as PaintScene metadata.
 - Export sequence actor links as PaintScene hit-test metadata.

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -349,7 +349,7 @@ mod apple {
     #[test]
     fn render_mermaid_sequence_to_png() {
         let mut diagram = parse_sequence_diagram(
-            "sequenceDiagram\ntitle Native Mermaid sequence\naccTitle: Native transfer sequence\naccDescr {\n  Banking transfer\n  interaction\n}\nautonumber\nbox aqua Client tier\nactor User\nparticipant API@{ \"type\": \"boundary\" } as Banking API\nend\nbox Services\nparticipant DB@{ \"type\": \"database\", \"alias\": \"Ledger\" }\nend\nalt Transfer accepted\nUser->>+API: Submit transfer\ncreate participant Worker as Audit Worker\nAPI()->>()Worker: Start audit\nWorker--|\\API: Audit complete\ndestroy Worker\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete\nelse Transfer rejected\nAPI-->>User: Validation failed\nend",
+            "sequenceDiagram;title Native Mermaid sequence;accTitle: Native transfer sequence;accDescr {\n  Banking transfer\n  interaction\n}\nautonumber\nbox aqua Client tier\nactor User\nparticipant API@{ \"type\": \"boundary\" } as Banking API\nend\nbox Services\nparticipant DB@{ \"type\": \"database\", \"alias\": \"Ledger\" }\nend\nalt Transfer accepted\nUser->>+API: Submit transfer\ncreate participant Worker as Audit Worker\nAPI()->>()Worker: Start audit\nWorker--|\\API: Audit complete\ndestroy Worker\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete\nelse Transfer rejected\nAPI-->>User: Validation failed\nend",
         )
         .expect("Mermaid sequence parse failed");
         diagram.auto_number_start = 10.5;

--- a/code/packages/rust/mermaid-lexer/CHANGELOG.md
+++ b/code/packages/rust/mermaid-lexer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.17.0
+
+- Tokenize semicolons as sequence statement terminators.
+
 ## 0.16.0
 
 - Tokenize multiline sequence accessibility-description blocks atomically.

--- a/code/packages/rust/mermaid-lexer/Cargo.toml
+++ b/code/packages/rust/mermaid-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-lexer"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Grammar-driven lexers for Mermaid diagram families"
 

--- a/code/packages/rust/mermaid-lexer/src/lib.rs
+++ b/code/packages/rust/mermaid-lexer/src/lib.rs
@@ -1,6 +1,6 @@
 //! Grammar-driven lexers for Mermaid diagram families.
 
-pub const VERSION: &str = "0.16.0";
+pub const VERSION: &str = "0.17.0";
 
 use grammar_tools::token_grammar::parse_token_grammar;
 use lexer::grammar_lexer::GrammarLexer;
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(VERSION, "0.16.0");
+        assert_eq!(VERSION, "0.17.0");
     }
 
     #[test]
@@ -446,5 +446,12 @@ A\\-B: reverse stick bottom
             token.type_name.as_deref() == Some("ACC_DESCR_BLOCK")
                 && token.value.contains("between accounts")
         }));
+    }
+
+    #[test]
+    fn tokenizes_sequence_semicolon_terminators() {
+        let tokens =
+            tokenize_mermaid_sequence("sequenceDiagram;participant Alice;Alice->>Bob: Hello;");
+        assert_eq!(tokens.iter().filter(|token| token.value == ";").count(), 3);
     }
 }

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.18.0
+
+- Accept semicolon terminators between sequence statements and block contents.
+
 ## 0.17.0
 
 - Parse multiline sequence accessibility descriptions.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -45,6 +45,8 @@ the native pipeline; resolving host document contents remains an embedding-layer
 compatibility gap.
 Both single-line accessibility statements and multiline `accDescr` blocks
 lower to PaintScene metadata.
+Newlines and semicolons are interchangeable sequence statement terminators,
+including inside control blocks.
 All Mermaid 11.16.1 solid/dotted, normal/reverse filled and stick half-arrow
 forms preserve their line style, half orientation, and endpoint through Paint.
 Central connection markers before and/or after an arrow preserve source,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.17.0";
+pub const VERSION: &str = "0.18.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1132,7 +1132,7 @@ fn parse_sequence_body(
 }
 
 fn take_sequence_number(cursor: &mut TokenCursor) -> Result<Option<f64>, ParseError> {
-    if cursor.at_eof() || token_name(cursor.current()) == "NEWLINE" {
+    if cursor.at_eof() || matches!(token_name(cursor.current()), "NEWLINE" | "SEMICOLON") {
         return Ok(None);
     }
     let token = cursor.advance().clone();
@@ -1243,7 +1243,7 @@ fn parse_sequence_details(
         .consume_if("COLON")
         .ok_or_else(|| token_error(cursor.current(), "expected ':' before actor details"))?;
     let mut reference = String::new();
-    while !cursor.at_eof() && token_name(cursor.current()) != "NEWLINE" {
+    while !cursor.at_eof() && !matches!(token_name(cursor.current()), "NEWLINE" | "SEMICOLON") {
         reference.push_str(&cursor.advance().value);
     }
     if reference.is_empty() {
@@ -1698,7 +1698,7 @@ fn take_sequence_identifier(cursor: &mut TokenCursor) -> Result<String, ParseErr
 
 fn take_sequence_line_text(cursor: &mut TokenCursor) -> String {
     let mut words = Vec::new();
-    while !cursor.at_eof() && token_name(cursor.current()) != "NEWLINE" {
+    while !cursor.at_eof() && !matches!(token_name(cursor.current()), "NEWLINE" | "SEMICOLON") {
         words.push(cursor.advance().value.clone());
     }
     words.join(" ")
@@ -3322,6 +3322,23 @@ B//-A: reverse stick top
             Some("Transfers funds\n  between accounts")
         );
     }
+
+    #[test]
+    fn sequence_parses_semicolon_terminated_statements_and_blocks() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram;participant Alice;participant Bob;loop Retry;Alice->>Bob: Ping;end;",
+        )
+        .unwrap();
+        assert_eq!(diagram.participants.len(), 2);
+        assert!(matches!(
+            diagram.events.as_slice(),
+            [
+                SequenceEvent::BlockStart { .. },
+                SequenceEvent::Message { label, .. },
+                SequenceEvent::BlockEnd { .. }
+            ] if label == "Ping"
+        ));
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -3338,7 +3355,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.17.0");
+        assert_eq!(crate::VERSION, "0.18.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -131,6 +131,8 @@ rather than degrade silently.
 
 Sequence `accTitle`, single-line `accDescr`, and multiline `accDescr` blocks
 preserve accessibility semantics in PaintScene metadata.
+Sequence newlines and semicolons are interchangeable statement terminators at
+the document level and inside control blocks.
 
 Inline participant configuration now carries `type` and `alias` into semantic
 IR. Boundary, control, entity, database, collections, and queue kinds lower to


### PR DESCRIPTION
## Summary
- add portable semicolon tokens and shared terminator grammar productions
- accept semicolon-separated sequence statements and nested control-block contents
- validate unchanged semantic IR, layout, PaintScene lowering, and Metal PNG output

## Verification
- `cargo test -p mermaid-lexer -p mermaid-parser -p diagram-to-paint -- --nocapture`
- `cargo clippy -p mermaid-lexer -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `git diff --check`
- visually inspected `/tmp/mermaid_sequence_e2e.png`