### PR TITLE
Report implied document tail diagnostics

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,11 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- An `html` end tag that materializes an implied document shell after leading
+  body text now enters the after-html insertion mode, so following character
+  data and start tags report their required parse error. This covers 2
+  previously silent malformed corpus cases without changing DOM recovery or
+  undeclared-diagnostic coverage.
 - Open framesets now report EOF, and non-whitespace character data discarded
   in or after a frameset reports its insertion-mode parse error. This covers 7
   previously silent malformed corpus cases without changing DOM recovery or

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the frameset character-data and EOF diagnostic slice, 2,178 of those
-cases emit at least one lexer or parser diagnostic and 5 remain uncovered.
+After the document-tail diagnostic slice, 2,180 of those cases emit at least
+one lexer or parser diagnostic and 3 remain uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
 inputs for which the legacy fixtures omit the Standard-required missing-doctype
@@ -65,26 +65,23 @@ open table blocks adoption-agency recovery. Description-list item start tags
 now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
 without flagging adjacent description-list items.
 
-The fresh 5-case residual inventory keeps the next concrete groups in this
-priority order: two document-tail boundaries; and the final fragment-context
-rows for colgroup text, an after-body token, and an HTML start tag in a seeded
-SVG context. Open framesets now report EOF, and non-whitespace character data
-discarded in or after framesets reports the corresponding insertion-mode parse
-error. Plaintext EOF recovery now reports across the document shell and
-templates, and rejected plaintext start tags no longer incorrectly switch the
-lexer out of data state. The current corpus no longer has a silent
-script-tokenizer, frameset, table-shell, foreign end-tag, formatting-only, or
-general in-body group.
+The fresh 3-case residual inventory consists entirely of the final
+fragment-context rows for colgroup text, an after-body token, and an HTML start
+tag in a seeded SVG context. Character data and start tags after an `html` end
+tag now report even when the end tag materializes an implied document shell
+around leading body text. Open framesets report EOF, and non-whitespace
+character data discarded in or after framesets reports the corresponding
+insertion-mode parse error. The current corpus no longer has a silent
+script-tokenizer, document-tail, frameset, table-shell, foreign end-tag,
+formatting-only, or general in-body group.
 
 Prioritized work items:
 
-1. **Document-tail boundaries.** Cover the two remaining stray-content
-   diagnostics after the document shell closes.
-2. **Fragment-context parsing.** Cover the final colgroup text, after-body, and
+1. **Fragment-context parsing.** Cover the final colgroup text, after-body, and
    foreign HTML start-tag rows. Invalid start and end tags targeting seeded
    fragment-context elements now report without mutating their synthetic
    shells.
-3. **Table, select, and template insertion modes.** Continue the algorithm
+2. **Table, select, and template insertion modes.** Continue the algorithm
    audit beyond the currently exercised diagnostic corpus.
    Non-whitespace table text now reports when it is foster-parented. The
    specialized SVG and MathML start-tag path now reports when table insertion
@@ -100,14 +97,14 @@ Prioritized work items:
    starts. Seeded table and foreign fragment-shell boundaries now report their
    required parse errors. The only silent table fragment row is non-whitespace
    text in a seeded `colgroup` context.
-4. **Adoption agency and active formatting.** Cover malformed formatting cases
+3. **Adoption agency and active formatting.** Cover malformed formatting cases
    without changing their now-conforming DOM output.
-5. **Diagnostic positions and error taxonomy.** Carry source positions into
+4. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.
-6. **Input boundary review.** Document the Unicode-code-point parser boundary
+5. **Input boundary review.** Document the Unicode-code-point parser boundary
    and either add or explicitly separate byte decoding and encoding sniffing.
-7. **Algorithm and differential audit.** Map implemented states/modes to the
+6. **Algorithm and differential audit.** Map implemented states/modes to the
    current HTML Standard and add deterministic differential/fuzz coverage for
    branches not exercised by the upstream corpora.
 

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7012,6 +7012,7 @@ impl HtmlParser {
                     self.append_implied_element("html");
                     self.append_implied_element("body");
                     self.open_elements.clear();
+                    self.document_tail_mode = DocumentTailMode::AfterHtml;
                 } else if !self.open_elements.is_empty() {
                     self.open_elements.clear();
                 } else {
@@ -34052,6 +34053,14 @@ mod tests {
             ),
             (
                 "<!doctype html><body></body></html>text<p>x</p>",
+                "unexpected-token-after-html",
+            ),
+            (
+                "<!doctype html>text</html>text",
+                "unexpected-token-after-html",
+            ),
+            (
+                "<!doctype html>text</html><p>text",
                 "unexpected-token-after-html",
             ),
             (

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 5);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2178);
+    assert_eq!(missing_diagnostic_cases, 3);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2180);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- enter after-html mode when `</html>` materializes an implied shell around leading body text
- report following character data and start tags without changing DOM recovery
- ratchet malformed tree-construction cases without diagnostics from 5 to 3 and prioritize the final fragment rows

## Validation
- `cargo test -p coding-adventures-html-lexer`
- `cargo test -p coding-adventures-html-parser`
- `cargo clippy -p coding-adventures-html-lexer -p coding-adventures-html-parser --all-targets -- -D warnings`
- live WPT/html5lib coverage audit: 1,934 tree cases and 6,806 tokenizer cases, zero missing or skipped
- WHATWG audit coverage, manifest, Rust-test, fixture metadata, and coverage-audit unit guards
- `git diff --check`
- `cargo fmt -p coding-adventures-html-parser -- --check` reports only pre-existing unrelated formatting drift; no changed lines appear in its output