### PR TITLE
feat(vault-pm): add application persistence substrate

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1058,4 +1058,5 @@ members = [
   "vault-pm-storage",
   "vault-pm-storage-storage-core",
   "vault-pm-repository",
+  "vault-pm-application",
 ]

--- a/code/packages/rust/vault-pm-application/BUILD
+++ b/code/packages/rust/vault-pm-application/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding_adventures_vault_pm_application -- --nocapture

--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this package are documented here.
+
+## [0.1.0] - 2026-08-09
+
+### Added
+
+- Closed canonical codecs for local device secrets, item revisions, and
+  bounded catalog snapshots.
+- Lossless observed-set persistence, including retained add operations and
+  removal tombstones.
+- V1 HKDF subkey derivation and domain-separated XChaCha20-Poly1305 object
+  framing over caller-provided randomness.
+
+### Security
+
+- Strict kind, vault, suite, bound, and AEAD checks before plaintext parsing.
+- Zeroizing live keys, local secret state, object DEKs, and opened plaintext.
+- Closed payload-free diagnostics and a capability-free package boundary.

--- a/code/packages/rust/vault-pm-application/Cargo.toml
+++ b/code/packages/rust/vault-pm-application/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "coding_adventures_vault_pm_application"
+version = "0.1.0"
+edition = "2021"
+description = "Host-neutral application persistence and cryptographic framing for the local-first password manager"
+
+[dependencies]
+coding_adventures_canonical_cbor = { path = "../canonical-cbor" }
+coding_adventures_chacha20_poly1305 = { path = "../chacha20-poly1305" }
+coding_adventures_hkdf = { path = "../hkdf" }
+coding_adventures_vault_pm_domain = { path = "../vault-pm-domain" }
+coding_adventures_vault_pm_format = { path = "../vault-pm-format" }
+coding_adventures_vault_records = { path = "../vault-records" }
+coding_adventures_zeroize = { path = "../zeroize" }

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -1,0 +1,26 @@
+# `coding_adventures_vault_pm_application`
+
+The host-neutral VLT-PM05 application core for the local-first password
+manager. This first slice defines lossless canonical persistence for local
+device secrets, item revisions, and catalog snapshots, plus domain-separated
+V1 encrypted object framing.
+
+The crate accepts key and randomness material from its caller. It does not own
+a filesystem path, provider SDK, network client, process, environment, clock,
+credential store, or entropy source. Bootstrap, repository sessions,
+crash-recovery journals, and user workflows land in the next slices.
+
+## Verification
+
+The package has 17 tests covering exact canonical and cryptographic vectors,
+lossless removed-value persistence, live and tombstone revisions, catalog
+bounds and ordering, cross-kind and cross-vault rejection, AEAD tampering,
+closed parser failures, diagnostic redaction, and explicit key wiping.
+Tarpaulin's LLVM engine measures 454 of 466 production lines covered (97.42%).
+
+## Development
+
+```bash
+bash BUILD
+cargo clippy -p coding_adventures_vault_pm_application --all-targets -- -D warnings
+```

--- a/code/packages/rust/vault-pm-application/required_capabilities.json
+++ b/code/packages/rust/vault-pm-application/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/vault-pm-application",
+  "capabilities": [],
+  "justification": "Pure canonical persistence and cryptographic framing over caller-provided key and entropy material. It owns no filesystem, network, process, environment, clock, provider, credential-store, or entropy authority."
+}

--- a/code/packages/rust/vault-pm-application/src/codec.rs
+++ b/code/packages/rust/vault-pm-application/src/codec.rs
@@ -1,0 +1,1051 @@
+use crate::{ApplicationError, ObjectKind};
+use coding_adventures_canonical_cbor::{decode, encode, CborValue};
+use coding_adventures_vault_pm_domain::{
+    AttachmentId, CollectionId, ContentType, ItemCandidate, ItemDocument, ItemId, ItemState,
+    LwwRegister, ObservedSet, OperationId, RevisionId, Tombstone,
+};
+use coding_adventures_vault_pm_format::{DeviceId, VaultId};
+use coding_adventures_vault_records::{decode_record, encode_opaque, encode_record, AnyRecord};
+use coding_adventures_zeroize::Zeroize;
+use core::fmt::{self, Debug, Formatter};
+use std::collections::{BTreeMap, BTreeSet};
+
+const VERSION: u64 = 1;
+const LIVE_STATE: u64 = 1;
+const TOMBSTONE_STATE: u64 = 2;
+const MAX_PLAINTEXT_BYTES: usize = 16 * 1024 * 1024;
+const MAX_CATALOG_ENTRIES: usize = 100_000;
+const MAX_CANDIDATES_PER_ITEM: usize = 16;
+
+/// Owner-private authority and device seeds persisted only as encrypted state.
+#[derive(PartialEq, Eq)]
+pub struct LocalSecretV1 {
+    vault_id: VaultId,
+    device_id: DeviceId,
+    authority_seed: [u8; 32],
+    device_signing_seed: [u8; 32],
+    device_x25519_secret: [u8; 32],
+}
+
+impl LocalSecretV1 {
+    /// Construct one complete V1 local secret record.
+    pub const fn new(
+        vault_id: VaultId,
+        device_id: DeviceId,
+        authority_seed: [u8; 32],
+        device_signing_seed: [u8; 32],
+        device_x25519_secret: [u8; 32],
+    ) -> Self {
+        Self {
+            vault_id,
+            device_id,
+            authority_seed,
+            device_signing_seed,
+            device_x25519_secret,
+        }
+    }
+
+    /// Return the vault binding.
+    pub const fn vault_id(&self) -> VaultId {
+        self.vault_id
+    }
+
+    /// Return the local certified device identity.
+    pub const fn device_id(&self) -> DeviceId {
+        self.device_id
+    }
+
+    /// Borrow the Ed25519 authority seed for an explicit unlocked operation.
+    pub const fn authority_seed(&self) -> &[u8; 32] {
+        &self.authority_seed
+    }
+
+    /// Borrow the local device Ed25519 seed for an explicit unlocked operation.
+    pub const fn device_signing_seed(&self) -> &[u8; 32] {
+        &self.device_signing_seed
+    }
+
+    /// Borrow the local device X25519 secret for an explicit unlocked operation.
+    pub const fn device_x25519_secret(&self) -> &[u8; 32] {
+        &self.device_x25519_secret
+    }
+
+    /// Encode the exact closed canonical V1 record.
+    pub fn encode(&self) -> Vec<u8> {
+        encode(&CborValue::Map(vec![
+            field(1, CborValue::Unsigned(VERSION)),
+            field(2, bytes(self.vault_id.as_bytes())),
+            field(3, bytes(self.device_id.as_bytes())),
+            field(4, bytes(&self.authority_seed)),
+            field(5, bytes(&self.device_signing_seed)),
+            field(6, bytes(&self.device_x25519_secret)),
+        ]))
+    }
+
+    /// Strictly decode one exact closed canonical V1 record.
+    pub fn decode(encoded: &[u8]) -> Result<Self, ApplicationError> {
+        let mut fields = closed_fields(encoded, &[1, 2, 3, 4, 5, 6])?;
+        check_version(take_uint(&mut fields, 1)?)?;
+        Ok(Self {
+            vault_id: VaultId::new(take_fixed(&mut fields, 2)?),
+            device_id: DeviceId::new(take_fixed(&mut fields, 3)?),
+            authority_seed: take_fixed(&mut fields, 4)?,
+            device_signing_seed: take_fixed(&mut fields, 5)?,
+            device_x25519_secret: take_fixed(&mut fields, 6)?,
+        })
+    }
+}
+
+impl Zeroize for LocalSecretV1 {
+    fn zeroize(&mut self) {
+        self.authority_seed.zeroize();
+        self.device_signing_seed.zeroize();
+        self.device_x25519_secret.zeroize();
+    }
+}
+
+impl Drop for LocalSecretV1 {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl Debug for LocalSecretV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("LocalSecretV1(<redacted>)")
+    }
+}
+
+/// Bounded immutable map from item IDs to current revision candidates.
+#[derive(Clone, PartialEq, Eq)]
+pub struct CatalogV1 {
+    entries: BTreeMap<ItemId, Vec<RevisionId>>,
+}
+
+impl CatalogV1 {
+    /// Validate and construct a canonical catalog snapshot.
+    pub fn new(entries: BTreeMap<ItemId, Vec<RevisionId>>) -> Result<Self, ApplicationError> {
+        validate_catalog(&entries)?;
+        Ok(Self { entries })
+    }
+
+    /// Construct an empty generation-zero catalog.
+    pub fn empty() -> Self {
+        Self {
+            entries: BTreeMap::new(),
+        }
+    }
+
+    /// Borrow entries in deterministic item-ID order.
+    pub const fn entries(&self) -> &BTreeMap<ItemId, Vec<RevisionId>> {
+        &self.entries
+    }
+
+    /// Encode the exact closed canonical V1 application object.
+    pub fn encode(&self) -> Result<Vec<u8>, ApplicationError> {
+        validate_catalog(&self.entries)?;
+        let entries = self
+            .entries
+            .iter()
+            .map(|(item, candidates)| {
+                CborValue::Map(vec![
+                    field(1, bytes(item.as_bytes())),
+                    field(
+                        2,
+                        CborValue::Array(
+                            candidates
+                                .iter()
+                                .map(|candidate| bytes(candidate.as_bytes()))
+                                .collect(),
+                        ),
+                    ),
+                ])
+            })
+            .collect();
+        Ok(encode(&CborValue::Map(vec![
+            field(1, CborValue::Unsigned(VERSION)),
+            field(2, CborValue::Unsigned(ObjectKind::Catalog.code())),
+            field(3, CborValue::Array(entries)),
+        ])))
+    }
+
+    /// Strictly decode one closed canonical V1 catalog.
+    pub fn decode(encoded: &[u8]) -> Result<Self, ApplicationError> {
+        check_plaintext_bound(encoded)?;
+        let mut fields = closed_fields(encoded, &[1, 2, 3])?;
+        check_version(take_uint(&mut fields, 1)?)?;
+        check_kind(take_uint(&mut fields, 2)?, ObjectKind::Catalog)?;
+        let encoded_entries = take_array(&mut fields, 3)?;
+        if encoded_entries.len() > MAX_CATALOG_ENTRIES {
+            return Err(ApplicationError::BoundExceeded);
+        }
+        let mut entries = BTreeMap::new();
+        let mut previous = None;
+        for value in encoded_entries {
+            let mut entry = value_fields(value, &[1, 2])?;
+            let item = ItemId::new(take_fixed(&mut entry, 1)?);
+            if previous.is_some_and(|prior| prior >= item) {
+                return Err(ApplicationError::IntegrityFailure);
+            }
+            previous = Some(item);
+            let candidate_values = take_array(&mut entry, 2)?;
+            if candidate_values.is_empty() || candidate_values.len() > MAX_CANDIDATES_PER_ITEM {
+                return Err(ApplicationError::IntegrityFailure);
+            }
+            let mut candidates = Vec::with_capacity(candidate_values.len());
+            for candidate in candidate_values {
+                let id = RevisionId::new(fixed_value(candidate)?);
+                if candidates.last().is_some_and(|prior| prior >= &id) {
+                    return Err(ApplicationError::IntegrityFailure);
+                }
+                candidates.push(id);
+            }
+            entries.insert(item, candidates);
+        }
+        Self::new(entries)
+    }
+}
+
+impl Debug for CatalogV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CatalogV1")
+            .field("entry_count", &self.entries.len())
+            .finish()
+    }
+}
+
+/// Encode one lossless item revision application object.
+pub fn encode_item_revision(
+    causal_parents: &BTreeSet<RevisionId>,
+    item_state: &ItemState,
+) -> Result<Vec<u8>, ApplicationError> {
+    let state = match item_state {
+        ItemState::Live(document) => encode_live(document)?,
+        ItemState::Tombstone(tombstone) => CborValue::Map(vec![
+            field(1, bytes(tombstone.item_id.as_bytes())),
+            field(2, CborValue::Unsigned(tombstone.deleted_at_ms)),
+        ]),
+    };
+    let state_code = match item_state {
+        ItemState::Live(_) => LIVE_STATE,
+        ItemState::Tombstone(_) => TOMBSTONE_STATE,
+    };
+    let encoded = encode(&CborValue::Map(vec![
+        field(1, CborValue::Unsigned(VERSION)),
+        field(2, CborValue::Unsigned(ObjectKind::ItemRevision.code())),
+        field(
+            3,
+            CborValue::Array(
+                causal_parents
+                    .iter()
+                    .map(|parent| bytes(parent.as_bytes()))
+                    .collect(),
+            ),
+        ),
+        field(4, CborValue::Unsigned(state_code)),
+        field(5, state),
+    ]));
+    check_plaintext_bound(&encoded)?;
+    Ok(encoded)
+}
+
+/// Strictly decode a lossless item revision using its authenticated frame ID.
+pub fn decode_item_revision(
+    revision_id: RevisionId,
+    encoded: &[u8],
+) -> Result<ItemCandidate, ApplicationError> {
+    check_plaintext_bound(encoded)?;
+    let mut fields = closed_fields(encoded, &[1, 2, 3, 4, 5])?;
+    check_version(take_uint(&mut fields, 1)?)?;
+    check_kind(take_uint(&mut fields, 2)?, ObjectKind::ItemRevision)?;
+    let parents = take_array(&mut fields, 3)?
+        .into_iter()
+        .map(fixed_value)
+        .map(|value| value.map(RevisionId::new))
+        .collect::<Result<Vec<_>, _>>()?;
+    if parents.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+    let state_code = take_uint(&mut fields, 4)?;
+    let state_value = fields
+        .remove(&5)
+        .ok_or(ApplicationError::IntegrityFailure)?;
+    let state = match state_code {
+        LIVE_STATE => ItemState::Live(Box::new(decode_live(state_value)?)),
+        TOMBSTONE_STATE => {
+            let mut tombstone = value_fields(state_value, &[1, 2])?;
+            ItemState::Tombstone(Tombstone {
+                item_id: ItemId::new(take_fixed(&mut tombstone, 1)?),
+                deleted_at_ms: take_uint(&mut tombstone, 2)?,
+            })
+        }
+        _ => return Err(ApplicationError::Unsupported),
+    };
+    ItemCandidate::new(revision_id, parents, state).map_err(map_domain)
+}
+
+fn encode_live(document: &ItemDocument) -> Result<CborValue, ApplicationError> {
+    let record = encode_any_record(document.payload())?;
+    Ok(CborValue::Map(vec![
+        field(1, bytes(document.id().as_bytes())),
+        field(2, CborValue::text(document.schema().as_str())),
+        field(3, CborValue::Unsigned(document.created_at_ms())),
+        field(4, CborValue::Unsigned(document.updated_at_ms())),
+        field(
+            5,
+            CborValue::Map(vec![
+                field(1, CborValue::Bool(*document.favorite().value())),
+                field(2, CborValue::Unsigned(document.favorite().updated_at_ms())),
+                field(3, bytes(document.favorite().operation().as_bytes())),
+            ]),
+        ),
+        field(6, encode_observed(document.collection_ids())),
+        field(7, encode_observed(document.tags())),
+        field(8, CborValue::Bytes(record)),
+        field(9, encode_observed(document.attachments())),
+    ]))
+}
+
+fn decode_live(value: CborValue) -> Result<ItemDocument, ApplicationError> {
+    let mut fields = value_fields(value, &[1, 2, 3, 4, 5, 6, 7, 8, 9])?;
+    let id = ItemId::new(take_fixed(&mut fields, 1)?);
+    let schema = ContentType::new(take_text(&mut fields, 2)?).map_err(map_domain)?;
+    let created_at_ms = take_uint(&mut fields, 3)?;
+    let updated_at_ms = take_uint(&mut fields, 4)?;
+    let mut favorite = value_fields(
+        fields
+            .remove(&5)
+            .ok_or(ApplicationError::IntegrityFailure)?,
+        &[1, 2, 3],
+    )?;
+    let favorite = LwwRegister::new(
+        take_bool(&mut favorite, 1)?,
+        take_uint(&mut favorite, 2)?,
+        OperationId::new(take_fixed(&mut favorite, 3)?),
+    );
+    let collections = decode_observed(
+        fields
+            .remove(&6)
+            .ok_or(ApplicationError::IntegrityFailure)?,
+    )?;
+    let tags = decode_observed(
+        fields
+            .remove(&7)
+            .ok_or(ApplicationError::IntegrityFailure)?,
+    )?;
+    let record_bytes = take_bytes(&mut fields, 8)?;
+    let payload = decode_record(&record_bytes).map_err(|_| ApplicationError::IntegrityFailure)?;
+    let attachments = decode_observed(
+        fields
+            .remove(&9)
+            .ok_or(ApplicationError::IntegrityFailure)?,
+    )?;
+    ItemDocument::new(
+        id,
+        schema,
+        created_at_ms,
+        updated_at_ms,
+        favorite,
+        collections,
+        tags,
+        payload,
+        attachments,
+    )
+    .map_err(map_domain)
+}
+
+trait ObservedValue: Ord + Clone {
+    fn encode_value(&self) -> CborValue;
+    fn decode_value(value: CborValue) -> Result<Self, ApplicationError>;
+}
+
+macro_rules! observed_id {
+    ($name:ty, $size:expr) => {
+        impl ObservedValue for $name {
+            fn encode_value(&self) -> CborValue {
+                bytes(self.as_bytes())
+            }
+
+            fn decode_value(value: CborValue) -> Result<Self, ApplicationError> {
+                Ok(Self::new(fixed_value::<$size>(value)?))
+            }
+        }
+    };
+}
+
+observed_id!(CollectionId, 16);
+observed_id!(AttachmentId, 16);
+
+impl ObservedValue for String {
+    fn encode_value(&self) -> CborValue {
+        CborValue::Text(self.clone())
+    }
+
+    fn decode_value(value: CborValue) -> Result<Self, ApplicationError> {
+        match value {
+            CborValue::Text(value) => Ok(value),
+            _ => Err(ApplicationError::IntegrityFailure),
+        }
+    }
+}
+
+fn encode_observed<T: ObservedValue>(set: &ObservedSet<T>) -> CborValue {
+    CborValue::Array(
+        set.retained_values()
+            .map(|value| {
+                CborValue::Map(vec![
+                    field(1, value.encode_value()),
+                    field(
+                        2,
+                        CborValue::Array(
+                            set.retained_add_operations(value)
+                                .map(|operation| bytes(operation.as_bytes()))
+                                .collect(),
+                        ),
+                    ),
+                    field(
+                        3,
+                        CborValue::Array(
+                            set.retained_removal_operations(value)
+                                .map(|operation| bytes(operation.as_bytes()))
+                                .collect(),
+                        ),
+                    ),
+                ])
+            })
+            .collect(),
+    )
+}
+
+fn decode_observed<T: ObservedValue>(value: CborValue) -> Result<ObservedSet<T>, ApplicationError> {
+    let values = match value {
+        CborValue::Array(values) => values,
+        _ => return Err(ApplicationError::IntegrityFailure),
+    };
+    let mut result = ObservedSet::new();
+    let mut previous: Option<T> = None;
+    for value in values {
+        let mut entry = value_fields(value, &[1, 2, 3])?;
+        let item = T::decode_value(entry.remove(&1).ok_or(ApplicationError::IntegrityFailure)?)?;
+        if previous.as_ref().is_some_and(|prior| prior >= &item) {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        let adds = decode_operations(entry.remove(&2).ok_or(ApplicationError::IntegrityFailure)?)?;
+        if adds.is_empty() {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        let removals =
+            decode_operations(entry.remove(&3).ok_or(ApplicationError::IntegrityFailure)?)?;
+        for operation in adds {
+            result.add(item.clone(), operation).map_err(map_domain)?;
+        }
+        for operation in removals {
+            result
+                .observe_removal(&item, operation)
+                .map_err(map_domain)?;
+        }
+        previous = Some(item);
+    }
+    Ok(result)
+}
+
+fn decode_operations(value: CborValue) -> Result<Vec<OperationId>, ApplicationError> {
+    let values = match value {
+        CborValue::Array(values) => values,
+        _ => return Err(ApplicationError::IntegrityFailure),
+    };
+    let mut operations = Vec::with_capacity(values.len());
+    for value in values {
+        let operation = OperationId::new(fixed_value(value)?);
+        if operations.last().is_some_and(|prior| prior >= &operation) {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        operations.push(operation);
+    }
+    Ok(operations)
+}
+
+fn encode_any_record(record: &AnyRecord) -> Result<Vec<u8>, ApplicationError> {
+    match record {
+        AnyRecord::Login(value) => Ok(encode_record(value)),
+        AnyRecord::SecureNote(value) => Ok(encode_record(value)),
+        AnyRecord::Card(value) => Ok(encode_record(value)),
+        AnyRecord::TotpSeed(value) => Ok(encode_record(value)),
+        AnyRecord::ApiKey(value) => Ok(encode_record(value)),
+        AnyRecord::DatabaseCredential(value) => Ok(encode_record(value)),
+        AnyRecord::Opaque {
+            content_type,
+            payload_bytes,
+        } => encode_opaque(content_type, payload_bytes)
+            .map_err(|_| ApplicationError::IntegrityFailure),
+    }
+}
+
+fn validate_catalog(entries: &BTreeMap<ItemId, Vec<RevisionId>>) -> Result<(), ApplicationError> {
+    if entries.len() > MAX_CATALOG_ENTRIES {
+        return Err(ApplicationError::BoundExceeded);
+    }
+    for candidates in entries.values() {
+        if candidates.is_empty() || candidates.len() > MAX_CANDIDATES_PER_ITEM {
+            return Err(ApplicationError::InvalidInput);
+        }
+        if candidates.windows(2).any(|pair| pair[0] >= pair[1]) {
+            return Err(ApplicationError::InvalidInput);
+        }
+    }
+    Ok(())
+}
+
+fn check_plaintext_bound(encoded: &[u8]) -> Result<(), ApplicationError> {
+    if encoded.len() > MAX_PLAINTEXT_BYTES {
+        Err(ApplicationError::BoundExceeded)
+    } else {
+        Ok(())
+    }
+}
+
+fn closed_fields(
+    encoded: &[u8],
+    expected: &[u64],
+) -> Result<BTreeMap<u64, CborValue>, ApplicationError> {
+    check_plaintext_bound(encoded)?;
+    let value = decode(encoded).map_err(|_| ApplicationError::IntegrityFailure)?;
+    value_fields(value, expected)
+}
+
+fn value_fields(
+    value: CborValue,
+    expected: &[u64],
+) -> Result<BTreeMap<u64, CborValue>, ApplicationError> {
+    let entries = match value {
+        CborValue::Map(entries) => entries,
+        _ => return Err(ApplicationError::IntegrityFailure),
+    };
+    if entries.len() != expected.len() {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+    let mut fields = BTreeMap::new();
+    for (key, value) in entries {
+        let key = match key {
+            CborValue::Unsigned(key) if expected.contains(&key) => key,
+            _ => return Err(ApplicationError::IntegrityFailure),
+        };
+        if fields.insert(key, value).is_some() {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+    }
+    Ok(fields)
+}
+
+fn field(key: u64, value: CborValue) -> (CborValue, CborValue) {
+    (CborValue::Unsigned(key), value)
+}
+
+fn bytes(value: &[u8]) -> CborValue {
+    CborValue::Bytes(value.to_vec())
+}
+
+fn take_uint(fields: &mut BTreeMap<u64, CborValue>, key: u64) -> Result<u64, ApplicationError> {
+    match fields.remove(&key) {
+        Some(CborValue::Unsigned(value)) => Ok(value),
+        _ => Err(ApplicationError::IntegrityFailure),
+    }
+}
+
+fn take_bool(fields: &mut BTreeMap<u64, CborValue>, key: u64) -> Result<bool, ApplicationError> {
+    match fields.remove(&key) {
+        Some(CborValue::Bool(value)) => Ok(value),
+        _ => Err(ApplicationError::IntegrityFailure),
+    }
+}
+
+fn take_text(fields: &mut BTreeMap<u64, CborValue>, key: u64) -> Result<String, ApplicationError> {
+    match fields.remove(&key) {
+        Some(CborValue::Text(value)) => Ok(value),
+        _ => Err(ApplicationError::IntegrityFailure),
+    }
+}
+
+fn take_bytes(
+    fields: &mut BTreeMap<u64, CborValue>,
+    key: u64,
+) -> Result<Vec<u8>, ApplicationError> {
+    match fields.remove(&key) {
+        Some(CborValue::Bytes(value)) => Ok(value),
+        _ => Err(ApplicationError::IntegrityFailure),
+    }
+}
+
+fn take_fixed<const N: usize>(
+    fields: &mut BTreeMap<u64, CborValue>,
+    key: u64,
+) -> Result<[u8; N], ApplicationError> {
+    fixed_value(
+        fields
+            .remove(&key)
+            .ok_or(ApplicationError::IntegrityFailure)?,
+    )
+}
+
+fn fixed_value<const N: usize>(value: CborValue) -> Result<[u8; N], ApplicationError> {
+    match value {
+        CborValue::Bytes(value) => value
+            .try_into()
+            .map_err(|_| ApplicationError::IntegrityFailure),
+        _ => Err(ApplicationError::IntegrityFailure),
+    }
+}
+
+fn take_array(
+    fields: &mut BTreeMap<u64, CborValue>,
+    key: u64,
+) -> Result<Vec<CborValue>, ApplicationError> {
+    match fields.remove(&key) {
+        Some(CborValue::Array(values)) => Ok(values),
+        _ => Err(ApplicationError::IntegrityFailure),
+    }
+}
+
+fn check_version(version: u64) -> Result<(), ApplicationError> {
+    if version == VERSION {
+        Ok(())
+    } else {
+        Err(ApplicationError::Unsupported)
+    }
+}
+
+fn check_kind(value: u64, expected: ObjectKind) -> Result<(), ApplicationError> {
+    if value == expected.code() {
+        Ok(())
+    } else {
+        Err(ApplicationError::IntegrityFailure)
+    }
+}
+
+fn map_domain(error: coding_adventures_vault_pm_domain::DomainError) -> ApplicationError {
+    match error {
+        coding_adventures_vault_pm_domain::DomainError::BoundExceeded => {
+            ApplicationError::BoundExceeded
+        }
+        _ => ApplicationError::IntegrityFailure,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coding_adventures_canonical_cbor::encode;
+    use coding_adventures_vault_records::{Login, LOGIN_V1};
+
+    fn op(value: u8) -> OperationId {
+        OperationId::new([value; 32])
+    }
+
+    fn live_candidate() -> ItemCandidate {
+        let mut collections = ObservedSet::new();
+        let collection = CollectionId::new([0x31; 16]);
+        collections.add(collection, op(1)).unwrap();
+        collections.remove(&collection);
+        collections.add(collection, op(2)).unwrap();
+
+        let mut tags = ObservedSet::new();
+        tags.add("personal".to_string(), op(3)).unwrap();
+        tags.remove(&"personal".to_string());
+
+        let mut attachments = ObservedSet::new();
+        attachments
+            .add(AttachmentId::new([0x41; 16]), op(4))
+            .unwrap();
+
+        let document = ItemDocument::new(
+            ItemId::new([0x21; 16]),
+            ContentType::new(LOGIN_V1).unwrap(),
+            10,
+            20,
+            LwwRegister::new(true, 15, op(5)),
+            collections,
+            tags,
+            AnyRecord::Login(Login {
+                title: "Example".to_string(),
+                username: "alice".to_string(),
+                password: "correct horse".to_string(),
+                urls: vec!["https://example.test".to_string()],
+                notes: Some("private".to_string()),
+            }),
+            attachments,
+        )
+        .unwrap();
+        ItemCandidate::new(
+            RevisionId::new([0x51; 32]),
+            [RevisionId::new([0x50; 32])],
+            ItemState::Live(Box::new(document)),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn local_secret_is_canonical_round_trippable_and_redacted() {
+        let secret = LocalSecretV1::new(
+            VaultId::new([1; 16]),
+            DeviceId::new([2; 16]),
+            [3; 32],
+            [4; 32],
+            [5; 32],
+        );
+        let encoded = secret.encode();
+        assert_eq!(
+            hex(&encoded),
+            "a60101025001010101010101010101010101010101035002020202020202020202020202020202045820030303030303030303030303030303030303030303030303030303030303030305582004040404040404040404040404040404040404040404040404040404040404040658200505050505050505050505050505050505050505050505050505050505050505"
+        );
+        let decoded = LocalSecretV1::decode(&encoded).unwrap();
+        assert_eq!(decoded.vault_id(), VaultId::new([1; 16]));
+        assert_eq!(decoded.device_id(), DeviceId::new([2; 16]));
+        assert_eq!(decoded.authority_seed(), &[3; 32]);
+        assert_eq!(decoded.device_signing_seed(), &[4; 32]);
+        assert_eq!(decoded.device_x25519_secret(), &[5; 32]);
+        assert_eq!(format!("{decoded:?}"), "LocalSecretV1(<redacted>)");
+        assert_eq!(encoded, decoded.encode());
+    }
+
+    #[test]
+    fn local_secret_zeroize_and_strict_decode() {
+        let mut secret = LocalSecretV1::new(
+            VaultId::new([1; 16]),
+            DeviceId::new([2; 16]),
+            [3; 32],
+            [4; 32],
+            [5; 32],
+        );
+        secret.zeroize();
+        assert_eq!(secret.authority_seed(), &[0; 32]);
+        assert_eq!(secret.device_signing_seed(), &[0; 32]);
+        assert_eq!(secret.device_x25519_secret(), &[0; 32]);
+
+        assert_eq!(
+            LocalSecretV1::decode(&[]),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        let extra = encode(&CborValue::Map(vec![field(1, CborValue::Unsigned(1))]));
+        assert_eq!(
+            LocalSecretV1::decode(&extra),
+            Err(ApplicationError::IntegrityFailure)
+        );
+    }
+
+    #[test]
+    fn item_revision_round_trip_retains_removed_observations() {
+        let candidate = live_candidate();
+        let encoded = encode_item_revision(candidate.causal_parents(), candidate.state()).unwrap();
+        let decoded = decode_item_revision(candidate.revision_id(), &encoded).unwrap();
+        assert_eq!(decoded, candidate);
+        let ItemState::Live(document) = decoded.state() else {
+            panic!("expected live state")
+        };
+        assert_eq!(document.collection_ids().retained_value_count(), 1);
+        assert_eq!(document.collection_ids().add_operation_count(), 2);
+        assert_eq!(document.collection_ids().tombstone_count(), 1);
+        assert_eq!(document.tags().len(), 0);
+        assert_eq!(document.tags().retained_value_count(), 1);
+        assert_eq!(document.tags().tombstone_count(), 1);
+    }
+
+    #[test]
+    fn tombstone_revision_round_trips_and_rejects_bad_headers() {
+        let candidate = ItemCandidate::new(
+            RevisionId::new([9; 32]),
+            [],
+            ItemState::Tombstone(Tombstone {
+                item_id: ItemId::new([8; 16]),
+                deleted_at_ms: 44,
+            }),
+        )
+        .unwrap();
+        let encoded = encode_item_revision(candidate.causal_parents(), candidate.state()).unwrap();
+        assert_eq!(
+            hex(&encoded),
+            "a5010102010380040205a201500808080808080808080808080808080802182c"
+        );
+        assert_eq!(
+            decode_item_revision(candidate.revision_id(), &encoded).unwrap(),
+            candidate
+        );
+
+        let wrong_kind = encode(&CborValue::Map(vec![
+            field(1, CborValue::Unsigned(1)),
+            field(2, CborValue::Unsigned(ObjectKind::Catalog.code())),
+            field(3, CborValue::Array(Vec::new())),
+            field(4, CborValue::Unsigned(TOMBSTONE_STATE)),
+            field(
+                5,
+                CborValue::Map(vec![
+                    field(1, bytes(&[8; 16])),
+                    field(2, CborValue::Unsigned(44)),
+                ]),
+            ),
+        ]));
+        assert_eq!(
+            decode_item_revision(RevisionId::new([9; 32]), &wrong_kind),
+            Err(ApplicationError::IntegrityFailure)
+        );
+    }
+
+    #[test]
+    fn catalog_round_trip_is_sorted_bounded_and_redacted() {
+        let mut entries = BTreeMap::new();
+        entries.insert(
+            ItemId::new([1; 16]),
+            vec![RevisionId::new([2; 32]), RevisionId::new([3; 32])],
+        );
+        entries.insert(ItemId::new([4; 16]), vec![RevisionId::new([5; 32])]);
+        let catalog = CatalogV1::new(entries).unwrap();
+        let encoded = catalog.encode().unwrap();
+        assert_eq!(CatalogV1::decode(&encoded).unwrap(), catalog);
+        assert_eq!(format!("{catalog:?}"), "CatalogV1 { entry_count: 2 }");
+        assert!(CatalogV1::empty().entries().is_empty());
+        assert_eq!(hex(&CatalogV1::empty().encode().unwrap()), "a3010102020380");
+    }
+
+    #[test]
+    fn catalog_rejects_empty_unsorted_duplicate_and_wrong_kind_candidates() {
+        let mut empty = BTreeMap::new();
+        empty.insert(ItemId::new([1; 16]), Vec::new());
+        assert_eq!(CatalogV1::new(empty), Err(ApplicationError::InvalidInput));
+
+        let mut unsorted = BTreeMap::new();
+        unsorted.insert(
+            ItemId::new([1; 16]),
+            vec![RevisionId::new([3; 32]), RevisionId::new([2; 32])],
+        );
+        assert_eq!(
+            CatalogV1::new(unsorted),
+            Err(ApplicationError::InvalidInput)
+        );
+
+        let wrong_kind = encode(&CborValue::Map(vec![
+            field(1, CborValue::Unsigned(1)),
+            field(2, CborValue::Unsigned(ObjectKind::ItemRevision.code())),
+            field(3, CborValue::Array(Vec::new())),
+        ]));
+        assert_eq!(
+            CatalogV1::decode(&wrong_kind),
+            Err(ApplicationError::IntegrityFailure)
+        );
+
+        let empty_candidate = encode(&CborValue::Map(vec![
+            field(1, CborValue::Unsigned(1)),
+            field(2, CborValue::Unsigned(ObjectKind::Catalog.code())),
+            field(
+                3,
+                CborValue::Array(vec![CborValue::Map(vec![
+                    field(1, bytes(&[1; 16])),
+                    field(2, CborValue::Array(Vec::new())),
+                ])]),
+            ),
+        ]));
+        assert_eq!(
+            CatalogV1::decode(&empty_candidate),
+            Err(ApplicationError::IntegrityFailure)
+        );
+
+        let unsorted_candidates = encode(&CborValue::Map(vec![
+            field(1, CborValue::Unsigned(1)),
+            field(2, CborValue::Unsigned(ObjectKind::Catalog.code())),
+            field(
+                3,
+                CborValue::Array(vec![CborValue::Map(vec![
+                    field(1, bytes(&[1; 16])),
+                    field(2, CborValue::Array(vec![bytes(&[3; 32]), bytes(&[2; 32])])),
+                ])]),
+            ),
+        ]));
+        assert_eq!(
+            CatalogV1::decode(&unsorted_candidates),
+            Err(ApplicationError::IntegrityFailure)
+        );
+    }
+
+    #[test]
+    fn item_revision_rejects_unsorted_parents_and_unknown_state() {
+        let tombstone = CborValue::Map(vec![
+            field(1, bytes(&[8; 16])),
+            field(2, CborValue::Unsigned(44)),
+        ]);
+        let invalid = |parents: Vec<CborValue>, state| {
+            encode(&CborValue::Map(vec![
+                field(1, CborValue::Unsigned(1)),
+                field(2, CborValue::Unsigned(ObjectKind::ItemRevision.code())),
+                field(3, CborValue::Array(parents)),
+                field(4, CborValue::Unsigned(state)),
+                field(5, tombstone.clone()),
+            ]))
+        };
+        assert_eq!(
+            decode_item_revision(
+                RevisionId::new([9; 32]),
+                &invalid(vec![bytes(&[2; 32]), bytes(&[1; 32])], TOMBSTONE_STATE)
+            ),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        assert_eq!(
+            decode_item_revision(RevisionId::new([9; 32]), &invalid(Vec::new(), 99)),
+            Err(ApplicationError::Unsupported)
+        );
+    }
+
+    #[test]
+    fn observed_set_decoder_rejects_malformed_or_lossy_state() {
+        assert_eq!(
+            decode_observed::<String>(CborValue::Bool(false)),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        let entry = |value: CborValue, adds: CborValue, removals: CborValue| {
+            CborValue::Map(vec![field(1, value), field(2, adds), field(3, removals)])
+        };
+        assert_eq!(
+            decode_observed::<String>(CborValue::Array(vec![entry(
+                CborValue::Unsigned(1),
+                CborValue::Array(vec![bytes(&[1; 32])]),
+                CborValue::Array(Vec::new()),
+            )])),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        assert_eq!(
+            decode_observed::<String>(CborValue::Array(vec![entry(
+                CborValue::text("tag"),
+                CborValue::Array(Vec::new()),
+                CborValue::Array(Vec::new()),
+            )])),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        assert_eq!(
+            decode_operations(CborValue::Bool(false)),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        assert_eq!(
+            decode_operations(CborValue::Array(vec![bytes(&[2; 32]), bytes(&[1; 32])])),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        let duplicate_values = CborValue::Array(vec![
+            entry(
+                CborValue::text("tag"),
+                CborValue::Array(vec![bytes(&[1; 32])]),
+                CborValue::Array(Vec::new()),
+            ),
+            entry(
+                CborValue::text("tag"),
+                CborValue::Array(vec![bytes(&[2; 32])]),
+                CborValue::Array(Vec::new()),
+            ),
+        ]);
+        assert_eq!(
+            decode_observed::<String>(duplicate_values),
+            Err(ApplicationError::IntegrityFailure)
+        );
+    }
+
+    #[test]
+    fn primitive_parser_helpers_fail_closed() {
+        assert_eq!(
+            value_fields(CborValue::Bool(false), &[]),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        assert_eq!(
+            value_fields(
+                CborValue::Map(vec![(CborValue::text("bad"), CborValue::Null)]),
+                &[1],
+            ),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        assert_eq!(
+            value_fields(
+                CborValue::Map(vec![field(1, CborValue::Null), field(1, CborValue::Null),]),
+                &[1, 1],
+            ),
+            Err(ApplicationError::IntegrityFailure)
+        );
+
+        let mut fields = BTreeMap::new();
+        fields.insert(1, CborValue::Bool(false));
+        assert_eq!(
+            take_uint(&mut fields, 1),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        let mut fields = BTreeMap::new();
+        fields.insert(1, CborValue::Unsigned(1));
+        assert_eq!(
+            take_bool(&mut fields, 1),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        let mut fields = BTreeMap::new();
+        fields.insert(1, CborValue::Bytes(Vec::new()));
+        assert_eq!(
+            take_text(&mut fields, 1),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        let mut fields = BTreeMap::new();
+        fields.insert(1, CborValue::Text(String::new()));
+        assert_eq!(
+            take_bytes(&mut fields, 1),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        assert_eq!(
+            fixed_value::<16>(CborValue::Bool(false)),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        let mut fields = BTreeMap::new();
+        fields.insert(1, CborValue::Bool(false));
+        assert_eq!(
+            take_array(&mut fields, 1),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        assert_eq!(check_version(2), Err(ApplicationError::Unsupported));
+        assert_eq!(
+            map_domain(coding_adventures_vault_pm_domain::DomainError::BoundExceeded),
+            ApplicationError::BoundExceeded
+        );
+        assert_eq!(
+            map_domain(coding_adventures_vault_pm_domain::DomainError::InvalidTag),
+            ApplicationError::IntegrityFailure
+        );
+        assert_eq!(
+            CatalogV1::decode(&vec![0; MAX_PLAINTEXT_BYTES + 1]),
+            Err(ApplicationError::BoundExceeded)
+        );
+    }
+
+    #[test]
+    fn opaque_record_encoding_is_exact_and_rejects_bad_payload() {
+        let record = AnyRecord::Opaque {
+            content_type: "example/custom/v1".to_string(),
+            payload_bytes: encode(&CborValue::Map(Vec::new())),
+        };
+        assert!(encode_any_record(&record).is_ok());
+        let invalid = AnyRecord::Opaque {
+            content_type: "example/custom/v1".to_string(),
+            payload_bytes: vec![0xff],
+        };
+        assert_eq!(
+            encode_any_record(&invalid),
+            Err(ApplicationError::IntegrityFailure)
+        );
+    }
+
+    #[test]
+    fn application_errors_are_closed_and_payload_free() {
+        for (error, label) in [
+            (ApplicationError::InvalidInput, "InvalidInput"),
+            (ApplicationError::BoundExceeded, "BoundExceeded"),
+            (ApplicationError::IntegrityFailure, "IntegrityFailure"),
+            (ApplicationError::Unsupported, "Unsupported"),
+            (ApplicationError::InternalInvariant, "InternalInvariant"),
+        ] {
+            assert_eq!(format!("{error:?}"), label);
+            assert_eq!(format!("{error}"), format!("vault-pm-application: {label}"));
+        }
+    }
+
+    fn hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+}

--- a/code/packages/rust/vault-pm-application/src/crypto.rs
+++ b/code/packages/rust/vault-pm-application/src/crypto.rs
@@ -1,0 +1,439 @@
+use crate::ApplicationError;
+use coding_adventures_canonical_cbor::{decode, CborValue};
+use coding_adventures_chacha20_poly1305::{
+    xchacha20_poly1305_aead_decrypt, xchacha20_poly1305_aead_encrypt,
+};
+use coding_adventures_hkdf::{hkdf, HashAlgorithm};
+use coding_adventures_vault_pm_format::{ObjectFrameV1, VaultId, CRYPTO_SUITE_V1};
+use coding_adventures_zeroize::{Zeroize, Zeroizing};
+use core::fmt::{self, Debug, Formatter};
+
+const LOCATOR_KEY_LABEL: &[u8] = b"vpm/locator-key/v1";
+const OBJECT_WRAP_KEY_LABEL: &[u8] = b"vpm/object-wrap-key/v1";
+const LOCAL_STATE_KEY_LABEL: &[u8] = b"vpm/local-state-key/v1";
+const AUDIT_KEY_LABEL: &[u8] = b"vpm/audit-key/v1";
+const WRAP_AAD_PREFIX: &[u8] = b"VPM-OBJECT-DEK-WRAP-v1";
+const PAYLOAD_AAD_PREFIX: &[u8] = b"VPM-OBJECT-PAYLOAD-v1";
+const MAX_PLAINTEXT_BYTES: usize = 16 * 1024 * 1024;
+
+/// Closed registry of authenticated application object kinds.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ObjectKind {
+    /// One live or tombstone item revision.
+    ItemRevision,
+    /// One complete immutable catalog snapshot.
+    Catalog,
+    /// One exact authority-signed VLT-PM01 device certificate.
+    DeviceCertificate,
+    /// One exact device-signed VLT-PM01 repository commit.
+    Commit,
+}
+
+impl ObjectKind {
+    /// Return the stable V1 registry code.
+    pub const fn code(self) -> u64 {
+        match self {
+            Self::ItemRevision => 1,
+            Self::Catalog => 2,
+            Self::DeviceCertificate => 3,
+            Self::Commit => 4,
+        }
+    }
+}
+
+/// Four live V1 subkeys derived from one vault root key.
+pub struct V1Keys {
+    vault_id: VaultId,
+    locator_key: [u8; 32],
+    object_wrap_key: [u8; 32],
+    local_state_key: [u8; 32],
+    audit_key: [u8; 32],
+}
+
+impl V1Keys {
+    /// Derive every V1 32-byte subkey using the vault ID as HKDF-SHA-256 salt.
+    pub fn derive(vault_id: VaultId, vault_root_key: &[u8; 32]) -> Result<Self, ApplicationError> {
+        Ok(Self {
+            vault_id,
+            locator_key: derive_key(vault_id, vault_root_key, LOCATOR_KEY_LABEL)?,
+            object_wrap_key: derive_key(vault_id, vault_root_key, OBJECT_WRAP_KEY_LABEL)?,
+            local_state_key: derive_key(vault_id, vault_root_key, LOCAL_STATE_KEY_LABEL)?,
+            audit_key: derive_key(vault_id, vault_root_key, AUDIT_KEY_LABEL)?,
+        })
+    }
+
+    /// Return the vault identity bound into every derived key and object AAD.
+    pub const fn vault_id(&self) -> VaultId {
+        self.vault_id
+    }
+
+    /// Borrow the opaque repository locator key for VLT-PM04 construction.
+    pub const fn locator_key(&self) -> &[u8; 32] {
+        &self.locator_key
+    }
+
+    /// Borrow the local-state encryption key for the recovery-journal codec.
+    pub const fn local_state_key(&self) -> &[u8; 32] {
+        &self.local_state_key
+    }
+
+    /// Borrow the audit derivation key for the later audit workflow.
+    pub const fn audit_key(&self) -> &[u8; 32] {
+        &self.audit_key
+    }
+}
+
+impl Zeroize for V1Keys {
+    fn zeroize(&mut self) {
+        self.locator_key.zeroize();
+        self.object_wrap_key.zeroize();
+        self.local_state_key.zeroize();
+        self.audit_key.zeroize();
+    }
+}
+
+impl Drop for V1Keys {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl Debug for V1Keys {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("V1Keys(<redacted>)")
+    }
+}
+
+/// Independently generated randomness consumed by one object seal operation.
+pub struct ObjectRandomness {
+    object_dek: [u8; 32],
+    wrap_nonce: [u8; 24],
+    payload_nonce: [u8; 24],
+}
+
+impl ObjectRandomness {
+    /// Construct caller-supplied independent DEK and nonce material.
+    pub const fn new(object_dek: [u8; 32], wrap_nonce: [u8; 24], payload_nonce: [u8; 24]) -> Self {
+        Self {
+            object_dek,
+            wrap_nonce,
+            payload_nonce,
+        }
+    }
+}
+
+impl Zeroize for ObjectRandomness {
+    fn zeroize(&mut self) {
+        self.object_dek.zeroize();
+        self.wrap_nonce.zeroize();
+        self.payload_nonce.zeroize();
+    }
+}
+
+impl Drop for ObjectRandomness {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl Debug for ObjectRandomness {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ObjectRandomness(<redacted>)")
+    }
+}
+
+/// Encrypt one canonical application object into an exact VLT-PM01 frame.
+pub fn seal_object(
+    keys: &V1Keys,
+    kind: ObjectKind,
+    plaintext: &[u8],
+    randomness: &ObjectRandomness,
+) -> Result<ObjectFrameV1, ApplicationError> {
+    if plaintext.len() > MAX_PLAINTEXT_BYTES {
+        return Err(ApplicationError::BoundExceeded);
+    }
+    validate_plaintext_header(plaintext, kind)?;
+    let wrap_aad = object_aad(WRAP_AAD_PREFIX, keys.vault_id, kind);
+    let payload_aad = object_aad(PAYLOAD_AAD_PREFIX, keys.vault_id, kind);
+    let (wrapped_dek, wrap_tag) = xchacha20_poly1305_aead_encrypt(
+        &randomness.object_dek,
+        &keys.object_wrap_key,
+        &randomness.wrap_nonce,
+        &wrap_aad,
+    );
+    let wrapped_dek: [u8; 32] = wrapped_dek
+        .try_into()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    let (ciphertext, payload_tag) = xchacha20_poly1305_aead_encrypt(
+        plaintext,
+        &randomness.object_dek,
+        &randomness.payload_nonce,
+        &payload_aad,
+    );
+    Ok(ObjectFrameV1 {
+        suite: CRYPTO_SUITE_V1,
+        wrap_nonce: randomness.wrap_nonce,
+        wrapped_dek,
+        wrap_tag,
+        payload_nonce: randomness.payload_nonce,
+        ciphertext,
+        payload_tag,
+    })
+}
+
+/// Authenticate and decrypt one exact VLT-PM01 frame for an expected kind.
+pub fn open_object(
+    keys: &V1Keys,
+    expected_kind: ObjectKind,
+    frame: &ObjectFrameV1,
+) -> Result<Zeroizing<Vec<u8>>, ApplicationError> {
+    if frame.suite != CRYPTO_SUITE_V1 {
+        return Err(ApplicationError::Unsupported);
+    }
+    if frame.ciphertext.len() > MAX_PLAINTEXT_BYTES {
+        return Err(ApplicationError::BoundExceeded);
+    }
+    frame
+        .validate()
+        .map_err(|_| ApplicationError::IntegrityFailure)?;
+    let wrap_aad = object_aad(WRAP_AAD_PREFIX, keys.vault_id, expected_kind);
+    let payload_aad = object_aad(PAYLOAD_AAD_PREFIX, keys.vault_id, expected_kind);
+    let dek = xchacha20_poly1305_aead_decrypt(
+        &frame.wrapped_dek,
+        &keys.object_wrap_key,
+        &frame.wrap_nonce,
+        &wrap_aad,
+        &frame.wrap_tag,
+    )
+    .ok_or(ApplicationError::IntegrityFailure)?;
+    let dek: [u8; 32] = dek
+        .try_into()
+        .map_err(|_| ApplicationError::IntegrityFailure)?;
+    let dek = Zeroizing::new(dek);
+    let plaintext = xchacha20_poly1305_aead_decrypt(
+        &frame.ciphertext,
+        &dek,
+        &frame.payload_nonce,
+        &payload_aad,
+        &frame.payload_tag,
+    )
+    .ok_or(ApplicationError::IntegrityFailure)?;
+    let plaintext = Zeroizing::new(plaintext);
+    validate_plaintext_header(&plaintext, expected_kind)?;
+    Ok(plaintext)
+}
+
+fn derive_key(
+    vault_id: VaultId,
+    vault_root_key: &[u8; 32],
+    label: &[u8],
+) -> Result<[u8; 32], ApplicationError> {
+    let mut derived = hkdf(
+        vault_id.as_bytes(),
+        vault_root_key,
+        label,
+        32,
+        HashAlgorithm::Sha256,
+    )
+    .map_err(|_| ApplicationError::InternalInvariant)?;
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&derived);
+    derived.zeroize();
+    Ok(key)
+}
+
+fn object_aad(prefix: &[u8], vault_id: VaultId, kind: ObjectKind) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(prefix.len() + 2 + 16 + 8);
+    aad.extend_from_slice(prefix);
+    aad.extend_from_slice(&CRYPTO_SUITE_V1.to_be_bytes());
+    aad.extend_from_slice(vault_id.as_bytes());
+    aad.extend_from_slice(&kind.code().to_be_bytes());
+    aad
+}
+
+fn validate_plaintext_header(
+    plaintext: &[u8],
+    expected_kind: ObjectKind,
+) -> Result<(), ApplicationError> {
+    let entries = match decode(plaintext).map_err(|_| ApplicationError::IntegrityFailure)? {
+        CborValue::Map(entries) => entries,
+        _ => return Err(ApplicationError::IntegrityFailure),
+    };
+    let mut version = None;
+    let mut kind = None;
+    for (key, value) in entries {
+        match (key, value) {
+            (CborValue::Unsigned(1), CborValue::Unsigned(value)) => version = Some(value),
+            (CborValue::Unsigned(2), CborValue::Unsigned(value)) => kind = Some(value),
+            _ => {}
+        }
+    }
+    if version != Some(1) {
+        return Err(ApplicationError::Unsupported);
+    }
+    if kind != Some(expected_kind.code()) {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ApplicationError, CatalogV1};
+    use coding_adventures_canonical_cbor::{encode, CborValue};
+
+    fn keys() -> V1Keys {
+        V1Keys::derive(VaultId::new([0x11; 16]), &[0x22; 32]).unwrap()
+    }
+
+    fn randomness() -> ObjectRandomness {
+        ObjectRandomness::new([0x33; 32], [0x44; 24], [0x55; 24])
+    }
+
+    fn hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    #[test]
+    fn key_derivation_is_deterministic_domain_separated_and_redacted() {
+        let keys = keys();
+        assert_eq!(
+            hex(keys.locator_key()),
+            "d101b6c82a864a3f089331d6125248c9d0d5481c606895bbba86e5159e18f9fc"
+        );
+        assert_ne!(keys.locator_key(), keys.local_state_key());
+        assert_ne!(keys.local_state_key(), keys.audit_key());
+        assert_eq!(keys.vault_id(), VaultId::new([0x11; 16]));
+        assert_eq!(format!("{keys:?}"), "V1Keys(<redacted>)");
+    }
+
+    #[test]
+    fn catalog_object_seals_and_opens_exactly() {
+        let keys = keys();
+        let randomness = randomness();
+        let plaintext = CatalogV1::empty().encode().unwrap();
+        let frame = seal_object(&keys, ObjectKind::Catalog, &plaintext, &randomness).unwrap();
+        assert_eq!(
+            hex(&frame.encode().unwrap()),
+            "56504f3100014444444444444444444444444444444444444444444444441b67e22415d0bc3f692497398ebb3872d35da3289ae7cb35ddc51e1b82bdc1d39535f3b6fcd552db76ddb9227a3598145555555555555555555555555555555555555555555555550000000000000007d44c77f95a1d570be73353ddd1f6389c1a46960932b52c"
+        );
+        assert_eq!(frame.suite, CRYPTO_SUITE_V1);
+        assert_ne!(frame.ciphertext, plaintext);
+        assert_eq!(
+            &*open_object(&keys, ObjectKind::Catalog, &frame).unwrap(),
+            &plaintext
+        );
+        assert_eq!(format!("{randomness:?}"), "ObjectRandomness(<redacted>)");
+    }
+
+    #[test]
+    fn kind_vault_and_tags_are_authenticated() {
+        let keys = keys();
+        let plaintext = CatalogV1::empty().encode().unwrap();
+        let frame = seal_object(&keys, ObjectKind::Catalog, &plaintext, &randomness()).unwrap();
+        assert_eq!(
+            open_object(&keys, ObjectKind::ItemRevision, &frame).err(),
+            Some(ApplicationError::IntegrityFailure)
+        );
+        let other_keys = V1Keys::derive(VaultId::new([0x12; 16]), &[0x22; 32]).unwrap();
+        assert_eq!(
+            open_object(&other_keys, ObjectKind::Catalog, &frame).err(),
+            Some(ApplicationError::IntegrityFailure)
+        );
+
+        let mut bad_wrap = frame.clone();
+        bad_wrap.wrap_tag[0] ^= 1;
+        assert_eq!(
+            open_object(&keys, ObjectKind::Catalog, &bad_wrap).err(),
+            Some(ApplicationError::IntegrityFailure)
+        );
+        let mut bad_payload = frame;
+        bad_payload.payload_tag[0] ^= 1;
+        assert_eq!(
+            open_object(&keys, ObjectKind::Catalog, &bad_payload).err(),
+            Some(ApplicationError::IntegrityFailure)
+        );
+    }
+
+    #[test]
+    fn seal_and_open_reject_bad_headers_suites_and_bounds() {
+        let keys = keys();
+        let randomness = randomness();
+        let wrong_kind = encode(&CborValue::Map(vec![
+            (CborValue::Unsigned(1), CborValue::Unsigned(1)),
+            (
+                CborValue::Unsigned(2),
+                CborValue::Unsigned(ObjectKind::ItemRevision.code()),
+            ),
+        ]));
+        assert_eq!(
+            seal_object(&keys, ObjectKind::Catalog, &wrong_kind, &randomness),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        let wrong_version = encode(&CborValue::Map(vec![
+            (CborValue::Unsigned(1), CborValue::Unsigned(2)),
+            (
+                CborValue::Unsigned(2),
+                CborValue::Unsigned(ObjectKind::Catalog.code()),
+            ),
+        ]));
+        assert_eq!(
+            seal_object(&keys, ObjectKind::Catalog, &wrong_version, &randomness),
+            Err(ApplicationError::Unsupported)
+        );
+
+        let plaintext = CatalogV1::empty().encode().unwrap();
+        let mut frame = seal_object(&keys, ObjectKind::Catalog, &plaintext, &randomness).unwrap();
+        frame.suite = 2;
+        assert_eq!(
+            open_object(&keys, ObjectKind::Catalog, &frame).err(),
+            Some(ApplicationError::Unsupported)
+        );
+        let oversized = vec![0u8; MAX_PLAINTEXT_BYTES + 1];
+        assert_eq!(
+            seal_object(&keys, ObjectKind::Catalog, &oversized, &randomness),
+            Err(ApplicationError::BoundExceeded)
+        );
+        let mut oversized_frame = frame;
+        oversized_frame.suite = CRYPTO_SUITE_V1;
+        oversized_frame.ciphertext = oversized;
+        assert_eq!(
+            open_object(&keys, ObjectKind::Catalog, &oversized_frame).err(),
+            Some(ApplicationError::BoundExceeded)
+        );
+        assert_eq!(
+            seal_object(
+                &keys,
+                ObjectKind::Catalog,
+                &encode(&CborValue::Bool(false)),
+                &randomness,
+            ),
+            Err(ApplicationError::IntegrityFailure)
+        );
+    }
+
+    #[test]
+    fn live_key_and_randomness_containers_can_be_wiped() {
+        let mut keys = keys();
+        keys.zeroize();
+        assert_eq!(keys.locator_key, [0; 32]);
+        assert_eq!(keys.object_wrap_key, [0; 32]);
+        assert_eq!(keys.local_state_key, [0; 32]);
+        assert_eq!(keys.audit_key, [0; 32]);
+
+        let mut randomness = randomness();
+        randomness.zeroize();
+        assert_eq!(randomness.object_dek, [0; 32]);
+        assert_eq!(randomness.wrap_nonce, [0; 24]);
+        assert_eq!(randomness.payload_nonce, [0; 24]);
+    }
+
+    #[test]
+    fn all_object_kind_codes_are_stable() {
+        assert_eq!(ObjectKind::ItemRevision.code(), 1);
+        assert_eq!(ObjectKind::Catalog.code(), 2);
+        assert_eq!(ObjectKind::DeviceCertificate.code(), 3);
+        assert_eq!(ObjectKind::Commit.code(), 4);
+    }
+}

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -1,0 +1,58 @@
+//! VLT-PM05 host-neutral password-manager application core.
+//!
+//! This first implementation slice owns canonical application persistence and
+//! encrypted object framing. Hosts retain storage, clock, entropy, process,
+//! environment, and credential-custody authority.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+mod codec;
+mod crypto;
+
+pub use codec::{decode_item_revision, encode_item_revision, CatalogV1, LocalSecretV1};
+pub use crypto::{open_object, seal_object, ObjectKind, ObjectRandomness, V1Keys};
+
+use core::fmt::{self, Debug, Display, Formatter};
+
+/// Closed, payload-free application failure taxonomy.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ApplicationError {
+    /// Caller input violates a V1 precondition.
+    InvalidInput,
+    /// A fixed parser or collection bound would be exceeded.
+    BoundExceeded,
+    /// A persisted value is malformed, unauthenticated, or cross-vault.
+    IntegrityFailure,
+    /// A requested version, suite, or object kind is not supported.
+    Unsupported,
+    /// An infallible internal relation was violated.
+    InternalInvariant,
+}
+
+impl ApplicationError {
+    fn label(self) -> &'static str {
+        match self {
+            Self::InvalidInput => "InvalidInput",
+            Self::BoundExceeded => "BoundExceeded",
+            Self::IntegrityFailure => "IntegrityFailure",
+            Self::Unsupported => "Unsupported",
+            Self::InternalInvariant => "InternalInvariant",
+        }
+    }
+}
+
+impl Debug for ApplicationError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.label())
+    }
+}
+
+impl Display for ApplicationError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("vault-pm-application: ")?;
+        formatter.write_str(self.label())
+    }
+}
+
+impl std::error::Error for ApplicationError {}

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1265,9 +1265,14 @@ changelog, focused build, and downstream validation.
 7a. `vault-pm-domain` lossless persistence projection: retained values, add
     operations, and removal tombstones must be enumerable before the
     application codec persists observed sets.
-8. `vault-pm-application`: init/open/item/search/history/export/audit workflows,
-   using the crash-resumable, storage-agnostic contract in
-   `VLT-PM05-application.md`.
+8. `vault-pm-application`, using the crash-resumable, storage-agnostic contract
+   in `VLT-PM05-application.md`:
+   1. canonical local-secret, item-revision, and catalog persistence codecs,
+      plus domain-separated encrypted object framing;
+   2. bootstrap, local-state, repository-verifier, init/open, and publication
+      recovery workflows; and
+   3. item mutation, redacted views, search, history, export, audit, status,
+      and doctor workflows.
 9. `vault-pm-cli` + real executable and pseudo-terminal E2E suite.
 10. Crash/fault matrix and local restore drill.
 

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -170,6 +170,10 @@ VPM-OBJECT-PAYLOAD-v1
 VPM-PORTABLE-EXPORT-v1
 ```
 
+Object wrap and payload AAD are the corresponding prefix bytes followed by the
+big-endian two-byte suite, 16-byte vault ID, and big-endian eight-byte object
+kind. No delimiter or host/provider value is inserted.
+
 The object kind registry is fixed in section 6. A frame cannot be decrypted as
 a different kind. AEAD authentication completes before plaintext parsing.
 
@@ -201,12 +205,12 @@ defined by VLT-PM01. The encrypted local secret record is:
 
 ```text
 LocalSecretV1 {
-    version: 1,
-    vault_id: [u8; 16],
-    device_id: [u8; 16],
-    authority_seed: [u8; 32],
-    device_signing_seed: [u8; 32],
-    device_x25519_secret: [u8; 32],
+    1: version = 1,
+    2: vault_id = [u8; 16],
+    3: device_id = [u8; 16],
+    4: authority_seed = [u8; 32],
+    5: device_signing_seed = [u8; 32],
+    6: device_x25519_secret = [u8; 32],
 }
 ```
 
@@ -221,8 +225,9 @@ later extensions.
 
 ## 6. Encrypted application object kinds
 
-The authenticated plaintext in every VLT-PM01 frame begins with one closed
-canonical CBOR map. Kind codes are:
+The authenticated plaintext in every VLT-PM01 frame is one closed canonical
+CBOR map. Integer key `1` is version `1`, integer key `2` is the object kind,
+and the remaining keys are kind-specific. Kind codes are:
 
 | Code | Name | Purpose |
 |---:|---|---|
@@ -235,14 +240,19 @@ All maps include version `1` and the kind code. Unknown fields or kinds are
 rejected. Plaintext object size is limited to 16 MiB in Phase 1A even though the
 outer frame permits 64 MiB.
 
+Device-certificate and commit objects use integer key `3` for the exact signed
+VLT-PM01 bytes. The wrapper is authenticated as part of the object payload;
+decoders then strictly decode and verify the nested signed value.
+
 ### 6.1 Item revision
 
 ```text
 ItemRevisionV1 {
-    version: 1,
-    kind: 1,
-    causal_parents: sorted unique array<ObjectId>,
-    state: Live(ItemDocumentV1) | Tombstone(ItemId, deleted_at_ms),
+    1: version = 1,
+    2: kind = 1,
+    3: causal_parents = sorted unique array<ObjectId>,
+    4: state = 1 live | 2 tombstone,
+    5: body = ItemDocumentV1 | Tombstone(ItemId, deleted_at_ms),
 }
 ```
 
@@ -261,11 +271,11 @@ validates afterward.
 
 ```text
 CatalogV1 {
-    version: 1,
-    kind: 2,
-    entries: sorted unique array<{
-        item_id: ItemId,
-        candidates: sorted unique array<ObjectId>,
+    1: version = 1,
+    2: kind = 2,
+    3: entries = sorted unique array<{
+        1: item_id = ItemId,
+        2: candidates = sorted unique array<ObjectId>,
     }>,
 }
 ```


### PR DESCRIPTION
## Summary
- add the capability-free `vault-pm-application` crate as the first VLT-PM05 implementation slice
- encode/decode local secret state, lossless item revisions, and bounded catalog snapshots with closed canonical CBOR
- derive V1 HKDF subkeys and seal/open domain-separated XChaCha20-Poly1305 object frames over caller-provided randomness
- split the remaining application backlog into recovery/session and user-workflow slices

## Security properties
- retained observed-set adds and removal tombstones round-trip without resurrection
- object suite, vault ID, kind, and purpose are authenticated
- wrong kind/vault, AEAD tampering, malformed canonical state, and oversized inputs fail closed
- live keys, object DEKs, local seeds, and opened plaintext use zeroizing containers
- diagnostics and required-capability metadata expose no secret/provider authority

## Validation
- `bash BUILD`
- `cargo clippy -p coding_adventures_vault_pm_application --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p coding_adventures_vault_pm_application --no-deps`
- `python3 -m unittest discover -s code/scripts/tests -p "test_capability_taxonomy.py"`
- Tarpaulin LLVM: 454/466 production lines (97.42%)
- affected build: 14/14 packages built