### PR TITLE
Report seeded colgroup text diagnostics

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Non-whitespace character data discarded by a seeded `colgroup` fragment
+  context now reports its table insertion-mode parse error. This covers the
+  final silent table-fragment corpus case without changing DOM recovery or
+  undeclared-diagnostic coverage.
 - An `html` end tag that materializes an implied document shell after leading
   body text now enters the after-html insertion mode, so following character
   data and start tags report their required parse error. This covers 2

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the document-tail diagnostic slice, 2,180 of those cases emit at least
-one lexer or parser diagnostic and 3 remain uncovered.
+After the seeded-colgroup diagnostic slice, 2,181 of those cases emit at least
+one lexer or parser diagnostic and 2 remain uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
 inputs for which the legacy fixtures omit the Standard-required missing-doctype
@@ -65,22 +65,21 @@ open table blocks adoption-agency recovery. Description-list item start tags
 now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
 without flagging adjacent description-list items.
 
-The fresh 3-case residual inventory consists entirely of the final
-fragment-context rows for colgroup text, an after-body token, and an HTML start
-tag in a seeded SVG context. Character data and start tags after an `html` end
-tag now report even when the end tag materializes an implied document shell
-around leading body text. Open framesets report EOF, and non-whitespace
-character data discarded in or after framesets reports the corresponding
-insertion-mode parse error. The current corpus no longer has a silent
-script-tokenizer, document-tail, frameset, table-shell, foreign end-tag,
+The fresh 2-case residual inventory consists entirely of an after-body token in
+an HTML fragment and an HTML start tag in a seeded SVG context. Non-whitespace
+text discarded by a seeded `colgroup` context now reports its table
+insertion-mode parse error. Character data and start tags after an `html` end
+tag report even when the end tag materializes an implied document shell around
+leading body text. The current corpus no longer has a silent script-tokenizer,
+document-tail, frameset, table-shell, table-fragment, foreign end-tag,
 formatting-only, or general in-body group.
 
 Prioritized work items:
 
-1. **Fragment-context parsing.** Cover the final colgroup text, after-body, and
-   foreign HTML start-tag rows. Invalid start and end tags targeting seeded
-   fragment-context elements now report without mutating their synthetic
-   shells.
+1. **Fragment-context parsing.** Cover the final after-body and foreign HTML
+   start-tag rows. Invalid start and end tags targeting seeded fragment-context
+   elements now report without mutating their synthetic shells, and seeded
+   `colgroup` text recovery reports its insertion-mode parse error.
 2. **Table, select, and template insertion modes.** Continue the algorithm
    audit beyond the currently exercised diagnostic corpus.
    Non-whitespace table text now reports when it is foster-parented. The
@@ -95,8 +94,7 @@ Prioritized work items:
    from template table mode. Formatting start tags now report when table
    structure foster-parents them, covering the remaining silent fostered-anchor
    starts. Seeded table and foreign fragment-shell boundaries now report their
-   required parse errors. The only silent table fragment row is non-whitespace
-   text in a seeded `colgroup` context.
+   required parse errors.
 3. **Adoption agency and active formatting.** Cover malformed formatting cases
    without changing their now-conforming DOM output.
 4. **Diagnostic positions and error taxonomy.** Carry source positions into

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5678,6 +5678,10 @@ impl HtmlParser {
         let text = if self.current_element_is_marked_fragment_context("colgroup")
             && !is_html_whitespace_text(&text)
         {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-character-in-colgroup",
+                "non-whitespace character data was ignored by the seeded colgroup fragment context",
+            ));
             text.chars()
                 .filter(|character| is_html_whitespace(*character))
                 .collect::<String>()
@@ -33675,6 +33679,22 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| diagnostic.code != "unexpected-table-start-tag-in-fragment"));
+    }
+
+    #[test]
+    fn reports_text_ignored_by_a_seeded_colgroup_fragment_context() {
+        let output =
+            parse_html_fragment_for_context_with_diagnostics("foo<col>", "colgroup").unwrap();
+
+        assert_eq!(output.nodes.len(), 1);
+        assert_eq!(element(&output.nodes[0]).name, "col");
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-character-in-colgroup",
+                "non-whitespace character data was ignored by the seeded colgroup fragment context"
+            )]
+        );
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 3);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2180);
+    assert_eq!(missing_diagnostic_cases, 2);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2181);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report the required parse error when seeded `colgroup` fragments discard non-whitespace text
- add a focused parser regression without changing recovered DOM output
- advance malformed-tree diagnostic coverage from 2,180 to 2,181 cases and reprioritize the final two fragment rows

## Validation
- `cargo test -p coding-adventures-html-lexer`
- `cargo test -p coding-adventures-html-parser`
- focused seeded-colgroup regression and tree diagnostic ratchet
- live WPT/html5lib coverage audit: 1,934 tree cases, 6,806 tokenizer cases, zero missing/skipped
- all parser audit coverage/manifest/Rust-test guards
- fixture audit Python unit tests
- `cargo clippy -p coding-adventures-html-lexer -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo fmt -p coding-adventures-html-parser -- --check` still reports pre-existing unrelated drift; no formatter diff touches this slice