### PR TITLE
feat(vault-pm): add authority-anchored repository verifier

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this package are documented here.
 
+## [0.2.0] - 2026-08-09
+
+### Added
+
+- Exact canonical application wrappers for authority-signed device
+  certificates and device-signed commits.
+- An authority-anchored VLT-PM04 verifier for the single authorized Phase 1A
+  device.
+
+### Security
+
+- Commit frames are ID-checked, AEAD-opened as the commit kind, strictly
+  decoded, identity-bound, and Ed25519-verified before repository use.
+- Verifier construction requires the locally pinned certificate frame to
+  reproduce its expected object ID before authority verification.
+- Announcements must match the authorized vault, device, certificate object,
+  and signing key; all verifier failures remain payload-free.
+
 ## [0.1.0] - 2026-08-09
 
 ### Added

--- a/code/packages/rust/vault-pm-application/Cargo.toml
+++ b/code/packages/rust/vault-pm-application/Cargo.toml
@@ -7,8 +7,10 @@ description = "Host-neutral application persistence and cryptographic framing fo
 [dependencies]
 coding_adventures_canonical_cbor = { path = "../canonical-cbor" }
 coding_adventures_chacha20_poly1305 = { path = "../chacha20-poly1305" }
+coding_adventures_ed25519 = { path = "../ed25519" }
 coding_adventures_hkdf = { path = "../hkdf" }
 coding_adventures_vault_pm_domain = { path = "../vault-pm-domain" }
 coding_adventures_vault_pm_format = { path = "../vault-pm-format" }
+coding_adventures_vault_pm_repository = { path = "../vault-pm-repository" }
 coding_adventures_vault_records = { path = "../vault-records" }
 coding_adventures_zeroize = { path = "../zeroize" }

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -1,22 +1,28 @@
 # `coding_adventures_vault_pm_application`
 
 The host-neutral VLT-PM05 application core for the local-first password
-manager. This first slice defines lossless canonical persistence for local
+manager. The current slices define lossless canonical persistence for local
 device secrets, item revisions, and catalog snapshots, plus domain-separated
-V1 encrypted object framing.
+V1 encrypted object framing and an authority-anchored repository verifier for
+the single authorized Phase 1A device.
 
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
-credential store, or entropy source. Bootstrap, repository sessions,
-crash-recovery journals, and user workflows land in the next slices.
+credential store, or entropy source. Bootstrap stores, repository sessions,
+crash-recovery journals, and user workflows land in the next slices. There is
+no unchecked repository verification path: construction decrypts and
+authority-verifies the exact locally pinned certificate frame and object ID,
+and commits and announcements must match that vault, device, certificate ID,
+and Ed25519 key.
 
 ## Verification
 
-The package has 17 tests covering exact canonical and cryptographic vectors,
+The package has 22 tests covering exact canonical and cryptographic vectors,
 lossless removed-value persistence, live and tombstone revisions, catalog
 bounds and ordering, cross-kind and cross-vault rejection, AEAD tampering,
-closed parser failures, diagnostic redaction, and explicit key wiping.
-Tarpaulin's LLVM engine measures 454 of 466 production lines covered (97.42%).
+authority/device/certificate binding, Ed25519 signature rejection, closed
+parser failures, diagnostic redaction, and explicit key wiping.
+Tarpaulin's LLVM engine measures 547 of 559 production lines covered (97.85%).
 
 ## Development
 

--- a/code/packages/rust/vault-pm-application/src/codec.rs
+++ b/code/packages/rust/vault-pm-application/src/codec.rs
@@ -4,7 +4,7 @@ use coding_adventures_vault_pm_domain::{
     AttachmentId, CollectionId, ContentType, ItemCandidate, ItemDocument, ItemId, ItemState,
     LwwRegister, ObservedSet, OperationId, RevisionId, Tombstone,
 };
-use coding_adventures_vault_pm_format::{DeviceId, VaultId};
+use coding_adventures_vault_pm_format::{CommitV1, DeviceCertificateV1, DeviceId, VaultId};
 use coding_adventures_vault_records::{decode_record, encode_opaque, encode_record, AnyRecord};
 use coding_adventures_zeroize::Zeroize;
 use core::fmt::{self, Debug, Formatter};
@@ -283,6 +283,62 @@ pub fn decode_item_revision(
         _ => return Err(ApplicationError::Unsupported),
     };
     ItemCandidate::new(revision_id, parents, state).map_err(map_domain)
+}
+
+/// Wrap one exact authority-signed VLT-PM01 device certificate as a canonical
+/// authenticated application object.
+pub fn encode_device_certificate(
+    certificate: &DeviceCertificateV1,
+) -> Result<Vec<u8>, ApplicationError> {
+    encode_signed_object(
+        ObjectKind::DeviceCertificate,
+        certificate
+            .encode()
+            .map_err(|_| ApplicationError::IntegrityFailure)?,
+    )
+}
+
+/// Strictly unwrap and decode one authority-signed VLT-PM01 device certificate.
+pub fn decode_device_certificate(encoded: &[u8]) -> Result<DeviceCertificateV1, ApplicationError> {
+    let exact = decode_signed_object(encoded, ObjectKind::DeviceCertificate)?;
+    DeviceCertificateV1::decode(&exact).map_err(|_| ApplicationError::IntegrityFailure)
+}
+
+/// Wrap one exact device-signed VLT-PM01 commit as a canonical authenticated
+/// application object.
+pub fn encode_signed_commit(commit: &CommitV1) -> Result<Vec<u8>, ApplicationError> {
+    encode_signed_object(
+        ObjectKind::Commit,
+        commit
+            .encode()
+            .map_err(|_| ApplicationError::IntegrityFailure)?,
+    )
+}
+
+/// Strictly unwrap and decode one device-signed VLT-PM01 commit.
+pub fn decode_signed_commit(encoded: &[u8]) -> Result<CommitV1, ApplicationError> {
+    let exact = decode_signed_object(encoded, ObjectKind::Commit)?;
+    CommitV1::decode(&exact).map_err(|_| ApplicationError::IntegrityFailure)
+}
+
+fn encode_signed_object(kind: ObjectKind, exact: Vec<u8>) -> Result<Vec<u8>, ApplicationError> {
+    let encoded = encode(&CborValue::Map(vec![
+        field(1, CborValue::Unsigned(VERSION)),
+        field(2, CborValue::Unsigned(kind.code())),
+        field(3, CborValue::Bytes(exact)),
+    ]));
+    check_plaintext_bound(&encoded)?;
+    Ok(encoded)
+}
+
+fn decode_signed_object(
+    encoded: &[u8],
+    expected_kind: ObjectKind,
+) -> Result<Vec<u8>, ApplicationError> {
+    let mut fields = closed_fields(encoded, &[1, 2, 3])?;
+    check_version(take_uint(&mut fields, 1)?)?;
+    check_kind(take_uint(&mut fields, 2)?, expected_kind)?;
+    take_bytes(&mut fields, 3)
 }
 
 fn encode_live(document: &ItemDocument) -> Result<CborValue, ApplicationError> {
@@ -636,6 +692,7 @@ fn map_domain(error: coding_adventures_vault_pm_domain::DomainError) -> Applicat
 mod tests {
     use super::*;
     use coding_adventures_canonical_cbor::encode;
+    use coding_adventures_vault_pm_format::{ObjectId, PublicKey, Signature};
     use coding_adventures_vault_records::{Login, LOGIN_V1};
 
     fn op(value: u8) -> OperationId {
@@ -804,6 +861,61 @@ mod tests {
         assert_eq!(format!("{catalog:?}"), "CatalogV1 { entry_count: 2 }");
         assert!(CatalogV1::empty().entries().is_empty());
         assert_eq!(hex(&CatalogV1::empty().encode().unwrap()), "a3010102020380");
+    }
+
+    #[test]
+    fn signed_object_wrappers_are_exact_closed_and_kind_bound() {
+        let certificate = DeviceCertificateV1 {
+            vault_id: VaultId::new([1; 16]),
+            device_id: DeviceId::new([2; 16]),
+            signing_public_key: PublicKey::new([3; 32]),
+            wrapping_public_key: PublicKey::new([4; 32]),
+            created_at_ms: 5,
+            capabilities: Vec::new(),
+            signature: Signature::new([6; 64]),
+        };
+        let encoded_certificate = encode_device_certificate(&certificate).unwrap();
+        assert_eq!(
+            hex(&encoded_certificate),
+            "a3010102030358b4a80101025001010101010101010101010101010101035002020202020202020202020202020202045820030303030303030303030303030303030303030303030303030303030303030305582004040404040404040404040404040404040404040404040404040404040404040605078008584006060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606"
+        );
+        assert_eq!(
+            decode_device_certificate(&encoded_certificate).unwrap(),
+            certificate
+        );
+
+        let commit = CommitV1 {
+            vault_id: VaultId::new([1; 16]),
+            device_id: DeviceId::new([2; 16]),
+            device_counter: 1,
+            parents: Vec::new(),
+            catalog_root: ObjectId::new([3; 32]),
+            added_objects: vec![ObjectId::new([3; 32])],
+            tombstone_root: None,
+            wall_time_ms: 5,
+            device_certificate: ObjectId::new([4; 32]),
+            signature: Signature::new([6; 64]),
+        };
+        let encoded_commit = encode_signed_commit(&commit).unwrap();
+        assert_eq!(
+            hex(&encoded_commit),
+            "a3010102040358dcab010102500101010101010101010101010101010103500202020202020202020202020202020204010580065820030303030303030303030303030303030303030303030303030303030303030307815820030303030303030303030303030303030303030303030303030303030303030308f609050a582004040404040404040404040404040404040404040404040404040404040404040b584006060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606060606"
+        );
+        assert_eq!(decode_signed_commit(&encoded_commit).unwrap(), commit);
+
+        assert_eq!(
+            decode_signed_commit(&encoded_certificate),
+            Err(ApplicationError::IntegrityFailure)
+        );
+        let malformed_nested = encode(&CborValue::Map(vec![
+            field(1, CborValue::Unsigned(VERSION)),
+            field(2, CborValue::Unsigned(ObjectKind::DeviceCertificate.code())),
+            field(3, CborValue::Bytes(vec![0xff])),
+        ]));
+        assert_eq!(
+            decode_device_certificate(&malformed_nested),
+            Err(ApplicationError::IntegrityFailure)
+        );
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -9,9 +9,15 @@
 
 mod codec;
 mod crypto;
+mod verifier;
 
-pub use codec::{decode_item_revision, encode_item_revision, CatalogV1, LocalSecretV1};
+pub use codec::{
+    decode_device_certificate, decode_item_revision, decode_signed_commit,
+    encode_device_certificate, encode_item_revision, encode_signed_commit, CatalogV1,
+    LocalSecretV1,
+};
 pub use crypto::{open_object, seal_object, ObjectKind, ObjectRandomness, V1Keys};
+pub use verifier::V1SingleDeviceVerifier;
 
 use core::fmt::{self, Debug, Display, Formatter};
 

--- a/code/packages/rust/vault-pm-application/src/verifier.rs
+++ b/code/packages/rust/vault-pm-application/src/verifier.rs
@@ -1,0 +1,460 @@
+use crate::{
+    decode_device_certificate, decode_signed_commit, open_object, ApplicationError, ObjectKind,
+    V1Keys,
+};
+use coding_adventures_ed25519::{is_valid_public_key, verify};
+use coding_adventures_vault_pm_format::{
+    AnnouncementV1, CommitV1, DeviceId, ObjectFrameV1, ObjectId, PublicKey, VaultId,
+};
+use coding_adventures_vault_pm_repository::{RepositoryVerifier, VerificationError};
+use core::fmt::{self, Debug, Formatter};
+
+/// Authority-anchored VLT-PM04 verifier for the single authorized Phase 1A
+/// device.
+///
+/// Construction authenticates and decrypts the authority-signed device
+/// certificate. The verifier then accepts only commits and announcements from
+/// that exact vault, device, and certificate object. Multi-device policy and
+/// revocation are deliberately left to the later enrollment slice.
+pub struct V1SingleDeviceVerifier {
+    keys: V1Keys,
+    vault_id: VaultId,
+    device_id: DeviceId,
+    certificate_id: ObjectId,
+    signing_public_key: PublicKey,
+}
+
+impl V1SingleDeviceVerifier {
+    /// Match one pinned encrypted certificate object, authenticate it against
+    /// the pinned vault authority, and construct the mandatory repository
+    /// verification boundary.
+    pub fn authorize(
+        keys: V1Keys,
+        authority_public_key: PublicKey,
+        expected_certificate_id: ObjectId,
+        certificate_frame: &ObjectFrameV1,
+    ) -> Result<Self, ApplicationError> {
+        if !is_valid_public_key(authority_public_key.as_bytes()) {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        let certificate_id = certificate_frame
+            .id()
+            .map_err(|_| ApplicationError::IntegrityFailure)?;
+        if certificate_id != expected_certificate_id {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        let plaintext = open_object(&keys, ObjectKind::DeviceCertificate, certificate_frame)?;
+        let certificate = decode_device_certificate(&plaintext)?;
+        if certificate.vault_id != keys.vault_id()
+            || !is_valid_public_key(certificate.signing_public_key.as_bytes())
+        {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        let preimage = certificate
+            .signing_preimage()
+            .map_err(|_| ApplicationError::IntegrityFailure)?;
+        if !verify(
+            &preimage,
+            certificate.signature.as_bytes(),
+            authority_public_key.as_bytes(),
+        ) {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        Ok(Self {
+            keys,
+            vault_id: certificate.vault_id,
+            device_id: certificate.device_id,
+            certificate_id,
+            signing_public_key: certificate.signing_public_key,
+        })
+    }
+
+    /// Return the authorized vault identity.
+    pub const fn vault_id(&self) -> VaultId {
+        self.vault_id
+    }
+
+    /// Return the authorized writer device identity.
+    pub const fn device_id(&self) -> DeviceId {
+        self.device_id
+    }
+
+    /// Return the exact encrypted certificate object ID authorized at
+    /// construction.
+    pub const fn certificate_id(&self) -> ObjectId {
+        self.certificate_id
+    }
+
+    fn commit_is_authorized(&self, commit: &CommitV1) -> bool {
+        commit.vault_id == self.vault_id
+            && commit.device_id == self.device_id
+            && commit.device_certificate == self.certificate_id
+            && commit.signing_preimage().is_ok_and(|preimage| {
+                verify(
+                    &preimage,
+                    commit.signature.as_bytes(),
+                    self.signing_public_key.as_bytes(),
+                )
+            })
+    }
+
+    fn announcement_is_authorized(&self, announcement: &AnnouncementV1) -> bool {
+        announcement.vault_id == self.vault_id
+            && announcement.device_id == self.device_id
+            && announcement.device_certificate == self.certificate_id
+            && announcement.signing_preimage().is_ok_and(|preimage| {
+                verify(
+                    &preimage,
+                    announcement.signature.as_bytes(),
+                    self.signing_public_key.as_bytes(),
+                )
+            })
+    }
+}
+
+impl RepositoryVerifier for V1SingleDeviceVerifier {
+    fn verify_commit(
+        &self,
+        expected: &ObjectId,
+        frame: &ObjectFrameV1,
+    ) -> Result<CommitV1, VerificationError> {
+        if frame.id().map_err(|_| VerificationError)? != *expected {
+            return Err(VerificationError);
+        }
+        let plaintext =
+            open_object(&self.keys, ObjectKind::Commit, frame).map_err(|_| VerificationError)?;
+        let commit = decode_signed_commit(&plaintext).map_err(|_| VerificationError)?;
+        if !self.commit_is_authorized(&commit) {
+            return Err(VerificationError);
+        }
+        Ok(commit)
+    }
+
+    fn verify_announcement(&self, bytes: &[u8]) -> Result<AnnouncementV1, VerificationError> {
+        let announcement = AnnouncementV1::decode(bytes).map_err(|_| VerificationError)?;
+        if !self.announcement_is_authorized(&announcement) {
+            return Err(VerificationError);
+        }
+        Ok(announcement)
+    }
+}
+
+impl Debug for V1SingleDeviceVerifier {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("V1SingleDeviceVerifier(<redacted>)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{encode_device_certificate, encode_signed_commit, seal_object, ObjectRandomness};
+    use coding_adventures_ed25519::{generate_keypair, sign};
+    use coding_adventures_vault_pm_format::{DeviceCertificateV1, Signature, CRYPTO_SUITE_V1};
+
+    const VAULT_ID: VaultId = VaultId::new([0x11; 16]);
+    const DEVICE_ID: DeviceId = DeviceId::new([0x22; 16]);
+    const ROOT_KEY: [u8; 32] = [0x33; 32];
+
+    struct Fixture {
+        verifier: V1SingleDeviceVerifier,
+        device_secret: [u8; 64],
+        certificate_id: ObjectId,
+    }
+
+    fn randomness(value: u8) -> ObjectRandomness {
+        ObjectRandomness::new(
+            [value; 32],
+            [value.wrapping_add(1); 24],
+            [value.wrapping_add(2); 24],
+        )
+    }
+
+    fn signed_certificate(
+        vault_id: VaultId,
+        authority_secret: &[u8; 64],
+        signing_public_key: PublicKey,
+    ) -> DeviceCertificateV1 {
+        let certificate = DeviceCertificateV1 {
+            vault_id,
+            device_id: DEVICE_ID,
+            signing_public_key,
+            wrapping_public_key: PublicKey::new([0x44; 32]),
+            created_at_ms: 100,
+            capabilities: vec![1],
+            signature: Signature::new([0; 64]),
+        };
+        let signature = sign(&certificate.signing_preimage().unwrap(), authority_secret);
+        certificate.with_signature(Signature::new(signature))
+    }
+
+    fn fixture() -> Fixture {
+        let (authority_public, authority_secret) = generate_keypair(&[0x51; 32]);
+        let (device_public, device_secret) = generate_keypair(&[0x52; 32]);
+        let certificate =
+            signed_certificate(VAULT_ID, &authority_secret, PublicKey::new(device_public));
+        let plaintext = encode_device_certificate(&certificate).unwrap();
+        let certificate_frame = seal_object(
+            &V1Keys::derive(VAULT_ID, &ROOT_KEY).unwrap(),
+            ObjectKind::DeviceCertificate,
+            &plaintext,
+            &randomness(0x61),
+        )
+        .unwrap();
+        let certificate_id = certificate_frame.id().unwrap();
+        let verifier = V1SingleDeviceVerifier::authorize(
+            V1Keys::derive(VAULT_ID, &ROOT_KEY).unwrap(),
+            PublicKey::new(authority_public),
+            certificate_id,
+            &certificate_frame,
+        )
+        .unwrap();
+        Fixture {
+            verifier,
+            device_secret,
+            certificate_id,
+        }
+    }
+
+    fn signed_commit(fixture: &Fixture, vault_id: VaultId) -> CommitV1 {
+        let commit = CommitV1 {
+            vault_id,
+            device_id: DEVICE_ID,
+            device_counter: 1,
+            parents: Vec::new(),
+            catalog_root: ObjectId::new([0x71; 32]),
+            added_objects: vec![ObjectId::new([0x71; 32])],
+            tombstone_root: None,
+            wall_time_ms: 200,
+            device_certificate: fixture.certificate_id,
+            signature: Signature::new([0; 64]),
+        };
+        let signature = sign(&commit.signing_preimage().unwrap(), &fixture.device_secret);
+        commit.with_signature(Signature::new(signature))
+    }
+
+    fn sealed_commit(commit: &CommitV1) -> ObjectFrameV1 {
+        seal_object(
+            &V1Keys::derive(VAULT_ID, &ROOT_KEY).unwrap(),
+            ObjectKind::Commit,
+            &encode_signed_commit(commit).unwrap(),
+            &randomness(0x62),
+        )
+        .unwrap()
+    }
+
+    fn signed_announcement(fixture: &Fixture, commit_id: ObjectId) -> AnnouncementV1 {
+        let announcement = AnnouncementV1 {
+            vault_id: VAULT_ID,
+            device_id: DEVICE_ID,
+            device_counter: 1,
+            commit_id,
+            device_certificate: fixture.certificate_id,
+            signature: Signature::new([0; 64]),
+        };
+        let signature = sign(
+            &announcement.signing_preimage().unwrap(),
+            &fixture.device_secret,
+        );
+        announcement.with_signature(Signature::new(signature))
+    }
+
+    #[test]
+    fn authority_anchors_certificate_commit_and_announcement() {
+        let fixture = fixture();
+        assert_eq!(fixture.verifier.vault_id(), VAULT_ID);
+        assert_eq!(fixture.verifier.device_id(), DEVICE_ID);
+        assert_eq!(fixture.verifier.certificate_id(), fixture.certificate_id);
+        assert_eq!(
+            format!("{:?}", fixture.verifier),
+            "V1SingleDeviceVerifier(<redacted>)"
+        );
+
+        let commit = signed_commit(&fixture, VAULT_ID);
+        let frame = sealed_commit(&commit);
+        let commit_id = frame.id().unwrap();
+        assert_eq!(
+            fixture.verifier.verify_commit(&commit_id, &frame).unwrap(),
+            commit
+        );
+        let announcement = signed_announcement(&fixture, commit_id);
+        assert_eq!(
+            fixture
+                .verifier
+                .verify_announcement(&announcement.encode().unwrap())
+                .unwrap(),
+            announcement
+        );
+    }
+
+    #[test]
+    fn commit_verification_rejects_wrong_id_aead_identity_and_signature() {
+        let fixture = fixture();
+        let commit = signed_commit(&fixture, VAULT_ID);
+        let frame = sealed_commit(&commit);
+        assert!(fixture
+            .verifier
+            .verify_commit(&ObjectId::new([0; 32]), &frame)
+            .is_err());
+
+        let mut tampered = frame.clone();
+        tampered.payload_tag[0] ^= 1;
+        let tampered_id = tampered.id().unwrap();
+        assert!(fixture
+            .verifier
+            .verify_commit(&tampered_id, &tampered)
+            .is_err());
+
+        for invalid in [
+            signed_commit(&fixture, VaultId::new([9; 16])),
+            CommitV1 {
+                device_id: DeviceId::new([9; 16]),
+                ..commit.clone()
+            },
+            CommitV1 {
+                device_certificate: ObjectId::new([9; 32]),
+                ..commit.clone()
+            },
+            CommitV1 {
+                signature: Signature::new([9; 64]),
+                ..commit.clone()
+            },
+        ] {
+            let invalid_frame = sealed_commit(&invalid);
+            assert!(fixture
+                .verifier
+                .verify_commit(&invalid_frame.id().unwrap(), &invalid_frame)
+                .is_err());
+        }
+    }
+
+    #[test]
+    fn announcement_verification_rejects_malformed_identity_and_signature() {
+        let fixture = fixture();
+        let announcement = signed_announcement(&fixture, ObjectId::new([7; 32]));
+        assert!(fixture.verifier.verify_announcement(&[]).is_err());
+        for invalid in [
+            AnnouncementV1 {
+                vault_id: VaultId::new([9; 16]),
+                ..announcement.clone()
+            },
+            AnnouncementV1 {
+                device_id: DeviceId::new([9; 16]),
+                ..announcement.clone()
+            },
+            AnnouncementV1 {
+                device_certificate: ObjectId::new([9; 32]),
+                ..announcement.clone()
+            },
+            AnnouncementV1 {
+                signature: Signature::new([9; 64]),
+                ..announcement.clone()
+            },
+        ] {
+            assert!(fixture
+                .verifier
+                .verify_announcement(&invalid.encode().unwrap())
+                .is_err());
+        }
+    }
+
+    #[test]
+    fn authorization_rejects_bad_authority_certificate_and_vault_binding() {
+        let (authority_public, authority_secret) = generate_keypair(&[0x51; 32]);
+        let (device_public, _) = generate_keypair(&[0x52; 32]);
+        for (certificate, authority) in [
+            (
+                signed_certificate(
+                    VaultId::new([9; 16]),
+                    &authority_secret,
+                    PublicKey::new(device_public),
+                ),
+                PublicKey::new(authority_public),
+            ),
+            (
+                DeviceCertificateV1 {
+                    signature: Signature::new([9; 64]),
+                    ..signed_certificate(VAULT_ID, &authority_secret, PublicKey::new(device_public))
+                },
+                PublicKey::new(authority_public),
+            ),
+        ] {
+            let frame = seal_object(
+                &V1Keys::derive(VAULT_ID, &ROOT_KEY).unwrap(),
+                ObjectKind::DeviceCertificate,
+                &encode_device_certificate(&certificate).unwrap(),
+                &randomness(0x63),
+            )
+            .unwrap();
+            assert!(V1SingleDeviceVerifier::authorize(
+                V1Keys::derive(VAULT_ID, &ROOT_KEY).unwrap(),
+                authority,
+                frame.id().unwrap(),
+                &frame,
+            )
+            .is_err());
+        }
+
+        let invalid_device_certificate =
+            signed_certificate(VAULT_ID, &authority_secret, PublicKey::new([0; 32]));
+        let invalid_device_frame = seal_object(
+            &V1Keys::derive(VAULT_ID, &ROOT_KEY).unwrap(),
+            ObjectKind::DeviceCertificate,
+            &encode_device_certificate(&invalid_device_certificate).unwrap(),
+            &randomness(0x64),
+        )
+        .unwrap();
+        assert!(V1SingleDeviceVerifier::authorize(
+            V1Keys::derive(VAULT_ID, &ROOT_KEY).unwrap(),
+            PublicKey::new(authority_public),
+            invalid_device_frame.id().unwrap(),
+            &invalid_device_frame,
+        )
+        .is_err());
+
+        let valid_certificate =
+            signed_certificate(VAULT_ID, &authority_secret, PublicKey::new(device_public));
+        let valid_certificate_frame = seal_object(
+            &V1Keys::derive(VAULT_ID, &ROOT_KEY).unwrap(),
+            ObjectKind::DeviceCertificate,
+            &encode_device_certificate(&valid_certificate).unwrap(),
+            &randomness(0x65),
+        )
+        .unwrap();
+        assert!(V1SingleDeviceVerifier::authorize(
+            V1Keys::derive(VAULT_ID, &ROOT_KEY).unwrap(),
+            PublicKey::new([0; 32]),
+            valid_certificate_frame.id().unwrap(),
+            &valid_certificate_frame,
+        )
+        .is_err());
+
+        assert!(V1SingleDeviceVerifier::authorize(
+            V1Keys::derive(VAULT_ID, &ROOT_KEY).unwrap(),
+            PublicKey::new(authority_public),
+            ObjectId::new([0; 32]),
+            &valid_certificate_frame,
+        )
+        .is_err());
+
+        let fixture = fixture();
+        let wrong_kind_frame = sealed_commit(&signed_commit(&fixture, VAULT_ID));
+        assert!(V1SingleDeviceVerifier::authorize(
+            V1Keys::derive(VAULT_ID, &ROOT_KEY).unwrap(),
+            PublicKey::new(authority_public),
+            wrong_kind_frame.id().unwrap(),
+            &wrong_kind_frame,
+        )
+        .is_err());
+
+        let mut unsupported = wrong_kind_frame;
+        unsupported.suite = CRYPTO_SUITE_V1 + 1;
+        assert!(V1SingleDeviceVerifier::authorize(
+            V1Keys::derive(VAULT_ID, &ROOT_KEY).unwrap(),
+            PublicKey::new(authority_public),
+            ObjectId::new([0; 32]),
+            &unsupported,
+        )
+        .is_err());
+    }
+}

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1269,9 +1269,13 @@ changelog, focused build, and downstream validation.
    in `VLT-PM05-application.md`:
    1. canonical local-secret, item-revision, and catalog persistence codecs,
       plus domain-separated encrypted object framing;
-   2. bootstrap, local-state, repository-verifier, init/open, and publication
-      recovery workflows; and
-   3. item mutation, redacted views, search, history, export, audit, status,
+   2. exact signed-certificate and commit wrappers plus the authority-anchored
+      single-device repository verifier;
+   3. bootstrap and encrypted local-state codecs, injected stores, and exact
+      initialization/publication journals;
+   4. generation-zero init, open, and crash-resumable publication workflows;
+      and
+   5. item mutation, redacted views, search, history, export, audit, status,
       and doctor workflows.
 9. `vault-pm-cli` + real executable and pseudo-terminal E2E suite.
 10. Crash/fault matrix and local restore drill.

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -124,7 +124,8 @@ The state contains no passphrase or unwrapped root/device key. It may contain:
 
 - pinned bootstrap ID and authority fingerprint;
 - VLT-PM04 head pins;
-- current device ID and encrypted device/authority secret state;
+- current device ID, pinned encrypted certificate object ID and exact frame,
+  and encrypted device/authority secret state;
 - the last consumed device counter;
 - a prepared initialization journal; or
 - one exact pending publication journal.
@@ -186,6 +187,14 @@ The application implements VLT-PM04 `RepositoryVerifier` with the unlocked
 profile. It decrypts commit frames as `Commit`, authority-verifies the encrypted
 device certificate, and verifies commit/announcement signatures. Unknown,
 revoked, cross-vault, or unauthenticated devices fail closed.
+
+Phase 1A constructs the verifier from exactly one locally pinned encrypted
+device certificate frame and its expected object ID, then authority-verifies
+the certificate and accepts only that certificate ID and device ID. Retaining
+the exact frame in owner-private state breaks the pre-repository verification
+cycle without trusting the provider. The multi-device enrollment slice
+replaces the fixed authorized set and adds revocation state without weakening
+this constructor or adding an unchecked verification path.
 
 ## 5. Bootstrap and local secret state
 


### PR DESCRIPTION
## Summary
- add exact canonical wrappers for encrypted device-certificate and commit objects
- add a Phase 1A single-device repository verifier anchored to the pinned certificate frame, object ID, vault authority, and Ed25519 key
- split the remaining application backlog around local-state journals and init/open recovery, including the certificate bootstrap-cycle requirement

## Verification
- cargo test -p coding_adventures_vault_pm_application
- cargo clippy -p coding_adventures_vault_pm_application --all-targets -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc -p coding_adventures_vault_pm_application --no-deps
- cargo tarpaulin -p coding_adventures_vault_pm_application --engine llvm --out Stdout --skip-clean (547/559 production lines, 97.85%)
- capability taxonomy conformance (7 tests)
- monorepo affected-package build (1 changed, 1 affected, 1 built)