### PR TITLE
Add Mermaid sequence colon titles

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -18,7 +18,7 @@ properties_stmt = "properties" identifier COLON JSON_OBJECT ;
 details_stmt = "details" identifier COLON details_reference ;
 details_reference = identifier { identifier | MINUS } ;
 accessibility_stmt = ( "accTitle" | "accDescr" ) COLON text | ACC_DESCR_BLOCK ;
-title_stmt = "title" text ;
+title_stmt = "title" [ COLON ] text ;
 autonumber_stmt = "autonumber" [ "off" | NUMBER [ NUMBER ] ] ;
 
 control_block = simple_block | rect_block | alt_block | par_block | critical_block ;

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Preserve multiline accessibility descriptions in that scene metadata.
 - Validate semicolon-separated sequence input through Metal PNG rendering.
 - Validate normalized HSL sequence group colors through Metal PNG rendering.
+- Validate legacy colon-prefixed sequence titles through Metal PNG rendering.
 - Export sequence actor details references as PaintScene metadata.
 - Export JSON-valued sequence actor properties as PaintScene metadata.
 - Export sequence actor links as PaintScene hit-test metadata.

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -349,7 +349,7 @@ mod apple {
     #[test]
     fn render_mermaid_sequence_to_png() {
         let mut diagram = parse_sequence_diagram(
-            "sequenceDiagram;title Native Mermaid sequence;accTitle: Native transfer sequence;accDescr {\n  Banking transfer\n  interaction\n}\nautonumber\nbox hsl(180, 100%, 50%) Client tier\nactor User\nparticipant API@{ \"type\": \"boundary\" } as Banking API\nend\nbox Services\nparticipant DB@{ \"type\": \"database\", \"alias\": \"Ledger\" }\nend\nalt Transfer accepted\nUser->>+API: Submit transfer\ncreate participant Worker as Audit Worker\nAPI()->>()Worker: Start audit\nWorker--|\\API: Audit complete\ndestroy Worker\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete\nelse Transfer rejected\nAPI-->>User: Validation failed\nend",
+            "sequenceDiagram;title: Native Mermaid sequence;accTitle: Native transfer sequence;accDescr {\n  Banking transfer\n  interaction\n}\nautonumber\nbox hsl(180, 100%, 50%) Client tier\nactor User\nparticipant API@{ \"type\": \"boundary\" } as Banking API\nend\nbox Services\nparticipant DB@{ \"type\": \"database\", \"alias\": \"Ledger\" }\nend\nalt Transfer accepted\nUser->>+API: Submit transfer\ncreate participant Worker as Audit Worker\nAPI()->>()Worker: Start audit\nWorker--|\\API: Audit complete\ndestroy Worker\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal paints this scene\nAPI-->>-User: Transfer complete\nelse Transfer rejected\nAPI-->>User: Validation failed\nend",
         )
         .expect("Mermaid sequence parse failed");
         diagram.auto_number_start = 10.5;

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.20.0
+
+- Parse legacy colon-prefixed sequence titles.
+
 ## 0.19.0
 
 - Parse HSL sequence box and rect colors and normalize them to backend-safe RGB.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -49,6 +49,7 @@ Newlines and semicolons are interchangeable sequence statement terminators,
 including inside control blocks.
 Sequence boxes and rect highlights accept `rgb`, `rgba`, `hsl`, and `hsla`;
 HSL colors normalize to RGB so native backends receive portable paint values.
+Sequence titles accept both `title Text` and legacy `title: Text` syntax.
 All Mermaid 11.16.1 solid/dotted, normal/reverse filled and stick half-arrow
 forms preserve their line style, half orientation, and endpoint through Paint.
 Central connection markers before and/or after an arrow preserve source,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.19.0";
+pub const VERSION: &str = "0.20.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1108,6 +1108,7 @@ fn parse_sequence_body(
             }
             "title" => {
                 cursor.advance();
+                cursor.consume_if("COLON");
                 diagram.title = Some(take_sequence_line_text(cursor));
             }
             "autonumber" => {
@@ -3392,6 +3393,15 @@ B//-A: reverse stick top
     }
 
     #[test]
+    fn sequence_parses_legacy_colon_title() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\ntitle: Native transfer sequence\nAlice->>Bob: Hello\n",
+        )
+        .unwrap();
+        assert_eq!(diagram.title.as_deref(), Some("Native transfer sequence"));
+    }
+
+    #[test]
     fn sequence_parses_multiline_accessibility_description() {
         let diagram = parse_sequence_diagram(
             "sequenceDiagram\naccDescr {\n  Transfers funds\n  between accounts\n}\nAlice->>Bob: Hello\n",
@@ -3435,7 +3445,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.19.0");
+        assert_eq!(crate::VERSION, "0.20.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -134,6 +134,8 @@ Sequence `accTitle`, single-line `accDescr`, and multiline `accDescr` blocks
 preserve accessibility semantics in PaintScene metadata.
 Sequence newlines and semicolons are interchangeable statement terminators at
 the document level and inside control blocks.
+Both modern `title Text` and legacy `title: Text` sequence title forms lower
+through the same title semantics and native text pipeline.
 
 Inline participant configuration now carries `type` and `alias` into semantic
 IR. Boundary, control, entity, database, collections, and queue kinds lower to


### PR DESCRIPTION
## Summary
- extend the shared sequence grammar with optional title colons
- lower legacy `title: Text` through the existing semantic title and layout path
- validate shaped PaintScene text and Metal PNG rendering end to end

## Verification
- `cargo test -p mermaid-parser -p diagram-to-paint -- --nocapture`
- `cargo clippy -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- `git diff --check`
- visually inspected `/tmp/mermaid_sequence_e2e.png`