### PR TITLE
Report seeded HTML fragment tail diagnostics

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- A second `body` end tag in a seeded `html` fragment context now reports that
+  it was reprocessed from the after-body insertion mode. This covers the final
+  silent HTML-fragment corpus case without changing its recovered DOM.
 - Non-whitespace character data discarded by a seeded `colgroup` fragment
   context now reports its table insertion-mode parse error. This covers the
   final silent table-fragment corpus case without changing DOM recovery or

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the seeded-colgroup diagnostic slice, 2,181 of those cases emit at least
-one lexer or parser diagnostic and 2 remain uncovered.
+After the seeded-HTML after-body diagnostic slice, 2,182 of those cases emit at
+least one lexer or parser diagnostic and 1 remains uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
 inputs for which the legacy fixtures omit the Standard-required missing-doctype
@@ -65,21 +65,22 @@ open table blocks adoption-agency recovery. Description-list item start tags
 now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
 without flagging adjacent description-list items.
 
-The fresh 2-case residual inventory consists entirely of an after-body token in
-an HTML fragment and an HTML start tag in a seeded SVG context. Non-whitespace
-text discarded by a seeded `colgroup` context now reports its table
-insertion-mode parse error. Character data and start tags after an `html` end
-tag report even when the end tag materializes an implied document shell around
-leading body text. The current corpus no longer has a silent script-tokenizer,
-document-tail, frameset, table-shell, table-fragment, foreign end-tag,
-formatting-only, or general in-body group.
+The sole residual case is an HTML start tag in a seeded SVG context. A second
+`body` end tag in a seeded `html` fragment now reports its after-body insertion
+mode parse error. Non-whitespace text discarded by a seeded `colgroup` context
+reports its table insertion-mode parse error. Character data and start tags
+after an `html` end tag report even when the end tag materializes an implied
+document shell around leading body text. The current corpus no longer has a
+silent script-tokenizer, document-tail, frameset, table-shell, table-fragment,
+HTML-fragment, foreign end-tag, formatting-only, or general in-body group.
 
 Prioritized work items:
 
-1. **Fragment-context parsing.** Cover the final after-body and foreign HTML
-   start-tag rows. Invalid start and end tags targeting seeded fragment-context
-   elements now report without mutating their synthetic shells, and seeded
-   `colgroup` text recovery reports its insertion-mode parse error.
+1. **Fragment-context parsing.** Cover the final foreign HTML start-tag row.
+   Invalid start and end tags targeting seeded fragment-context elements now
+   report without mutating their synthetic shells, seeded `colgroup` text
+   recovery reports its insertion-mode parse error, and seeded `html` fragments
+   report tokens reprocessed from after-body mode.
 2. **Table, select, and template insertion modes.** Continue the algorithm
    audit beyond the currently exercised diagnostic corpus.
    Non-whitespace table text now reports when it is foster-parented. The

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4691,7 +4691,7 @@ impl HtmlParser {
     }
 
     fn process_document_tail_mode(&mut self, token: &Token) {
-        if self.is_fragment {
+        if self.is_fragment && self.open_fragment_context_name() != Some("html") {
             return;
         }
         if self.document_has_closed_frameset() {
@@ -6847,7 +6847,7 @@ impl HtmlParser {
         if name == "body" && self.has_open_element("body") && self.current_element_is("bdy") {
             return;
         }
-        if !self.is_fragment
+        if (!self.is_fragment || self.open_fragment_context_name() == Some("html"))
             && !self.document_has_closed_frameset()
             && name == "body"
             && self.has_open_element("body")
@@ -34124,6 +34124,25 @@ mod tests {
         assert!(!ignored_html_end.parser_diagnostics.iter().any(|diagnostic| {
             diagnostic.code == "unexpected-token-after-html"
         }));
+    }
+
+    #[test]
+    fn reports_an_after_body_end_tag_in_a_seeded_html_fragment_context() {
+        let output =
+            parse_html_fragment_for_context_with_diagnostics("<body>X</body></body>", "html")
+                .unwrap();
+
+        assert_eq!(output.nodes.len(), 2);
+        assert_eq!(element(&output.nodes[0]).name, "head");
+        assert_eq!(element(&output.nodes[1]).name, "body");
+        assert_eq!(element_text(element(&output.nodes[1])), "X");
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-token-after-body",
+                "unexpected token was reprocessed from the after body insertion mode"
+            )]
+        );
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 2);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2181);
+    assert_eq!(missing_diagnostic_cases, 1);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2182);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- allow seeded `html` fragments to track the after-body insertion mode
- report a second `body` end tag reprocessed from that mode without changing recovered DOM output
- advance malformed-tree diagnostic coverage from 2,181 to 2,182 cases, leaving one seeded SVG fragment row

## Validation
- `cargo test -p coding-adventures-html-lexer`
- `cargo test -p coding-adventures-html-parser`
- focused seeded-HTML regression and tree diagnostic ratchet after rebasing onto current `main`
- live WPT/html5lib coverage audit: 1,934 tree cases, 6,806 tokenizer cases, zero missing/skipped
- all parser audit coverage/manifest/Rust-test guards
- fixture audit Python unit tests
- `cargo clippy -p coding-adventures-html-lexer -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo fmt -p coding-adventures-html-parser -- --check` still reports pre-existing unrelated drift; no formatter diff touches this slice