### PR TITLE
feat(mosaic): emit multiline Input with Compose

### DIFF
--- a/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
@@ -16,6 +16,10 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- The legacy `Input ( multiline: true )` spelling now lowers to a native
+  multiline `BasicTextField` with a useful editor-sized minimum line count.
+  This preserves the multiline capability used by the shared Notes package
+  without requiring app-owned Compose code.
 - Generated optional boolean slot predicates now compile as nullable-safe Kotlin
   conditions, and large root containers split their direct children into private
   composables so generated Compose Desktop projects avoid JVM method-size

--- a/code/packages/rust/mosaic-emit-compose/README.md
+++ b/code/packages/rust/mosaic-emit-compose/README.md
@@ -58,6 +58,7 @@ wants the strict-Flux store/dispatcher contract.
 | Text         | `Text(text = ...)`                        |
 | Spacer       | `Spacer(modifier = Modifier.weight(1f))`  |
 | HostInput    | `BasicTextField(value, onValueChange...)` |
+| Input        | multiline-capable `BasicTextField`        |
 | HostButton   | `Button(onClick) { Text(label) }`         |
 
 `For`, `If`/`Else`, `Grid`, `HostTable`, `HostDialog`,

--- a/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
@@ -848,12 +848,11 @@ fn compose_box_style(
                 }
             }
             "border-color" => set(&mut border_color, compose_color_value(&p.value)),
-            "text-align"
-                if layer_idx.is_none() => {
-                    if let Some(a) = content_alignment(&p.value) {
-                        text_align = Some(a);
-                    }
+            "text-align" if layer_idx.is_none() => {
+                if let Some(a) = content_alignment(&p.value) {
+                    text_align = Some(a);
                 }
+            }
             // border-style, border-collapse, outline, width:100% — skipped.
             _ => {}
         }
@@ -1211,7 +1210,12 @@ fn emit_compose_tree(
         }
         "Text" => emit_text(node, depth, text_ctx),
         "Spacer" => Ok(format!("{pad}Spacer(modifier = Modifier.weight(1f))\n")),
-        "HostInput" => emit_host_input(node, depth, component_name, emits, part_styles, text_ctx),
+        // `Input` is the pre-UI29 spelling retained for capabilities such as
+        // multiline editing that were not present on the first HostInput
+        // contract. Both spellings are native text fields on Compose.
+        "HostInput" | "Input" => {
+            emit_host_input(node, depth, component_name, emits, part_styles, text_ctx)
+        }
         "HostButton" => emit_host_button(
             node,
             depth,
@@ -1926,6 +1930,18 @@ fn emit_host_input(
     writeln!(out, "{pad}BasicTextField(").unwrap();
     writeln!(out, "{inner}value = {value_expr},").unwrap();
 
+    let multiline = matches!(
+        find_prop_value(node, "multiline"),
+        Some(LayoutPropValue::Keyword(value)) if value == "true"
+    );
+    if multiline {
+        // BasicTextField is multiline by default, but emitting the contract
+        // explicitly prevents a future default change and gives editor-shaped
+        // inputs a useful native minimum without app-specific Compose code.
+        writeln!(out, "{inner}singleLine = false,").unwrap();
+        writeln!(out, "{inner}minLines = 8,").unwrap();
+    }
+
     // onChange — wraps the new value in a dispatched event whose
     // case mirrors the .mil declaration.  The strict-Flux contract
     // matches mosaic-emit-flutter's `dispatch(<Component>Event<Case>(value:
@@ -1966,7 +1982,9 @@ fn emit_host_input(
     if let Some(emit_name) = find_emit_ref_prop(node, "onCommit") {
         let case = pascalize(&strip_on_prefix(emit_name));
         validate_safe_identifier(&case).map_err(PipelineEmitError::UnsafeEmitName)?;
-        writeln!(out, "{inner}singleLine = true,").unwrap();
+        if !multiline {
+            writeln!(out, "{inner}singleLine = true,").unwrap();
+        }
         writeln!(
             out,
             "{inner}keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),"
@@ -3136,6 +3154,46 @@ mod tests {
             "expected real dispatch call, got:\n{out}"
         );
         assert!(out.contains("enabled = readOnly != true,"));
+    }
+
+    #[test]
+    fn legacy_multiline_input_emits_native_compose_editor() {
+        let m = component(
+            "Notes",
+            vec![slot("body-value", SlotType::Text, true)],
+            vec![emit_decl(
+                "onBodyChange",
+                vec![param("value", EmitPayloadType::Text)],
+            )],
+        );
+        let l = layout(
+            "Notes",
+            styled_node(
+                "Input",
+                "notes-body-input",
+                vec![
+                    slot_prop("value", "body-value"),
+                    LayoutProp {
+                        name: "multiline".into(),
+                        value: LayoutPropValue::Keyword("true".into()),
+                    },
+                    LayoutProp {
+                        name: "onChange".into(),
+                        value: LayoutPropValue::EmitRef("onBodyChange".into()),
+                    },
+                ],
+                vec![],
+            ),
+        );
+        let output = from_pipeline(&m, &l, &empty_style("Notes"))
+            .expect("emit legacy multiline Input")
+            .output;
+
+        assert!(output.contains("BasicTextField("));
+        assert!(output.contains("value = bodyValue,"));
+        assert!(output.contains("singleLine = false,"));
+        assert!(output.contains("minLines = 8,"));
+        assert!(output.contains("NotesEvent.BodyChange(v)"));
     }
 
     #[test]

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -305,6 +305,8 @@ unblocks multiple downstream targets; never count source generation as completio
 - [ ] Make the generated Flutter project analyzer-clean after its documented
   `flutter create` bootstrap: replace the stock `MyApp` widget test, provision
   its lint configuration, and omit unused authored `For` bindings.
+- [ ] Complete Compose TaskApp Kotlin typing: normalize Mosaic value truthiness
+  in boolean positions and supply required native input commit payloads.
 - [ ] Route every compile entry point through one package-composition pipeline;
   standalone `mosaic-compile` currently inlines dependency layouts without merging
   their MSL, while the artifact builder merges both layout and style.
@@ -329,6 +331,10 @@ unblocks multiple downstream targets; never count source generation as completio
   lowers to `mosaicEmitDelete()` while its engine envelope remains `onDelete`.
   The real standalone Notes project passes Qt's QML compiler, resource/AOT
   generation, AUTOMOC, C++ compiler, linker, and a headless launch.
+  Compose now emits the Notes package's legacy multiline `Input` as a native
+  editor, clearing the first package-expansion blocker; the complete TaskApp
+  reaches Kotlin compilation and reports the separately tracked truthiness and
+  required commit-payload typing gaps.
 
 ### P1 — reusable application vocabulary
 


### PR DESCRIPTION
## Summary

- lower the legacy `Input` spelling through Compose's native `BasicTextField`
- preserve `multiline: true` with explicit multiline behavior and an editor-sized minimum line count
- unblock complete TaskApp package expansion through Compose and record the next Kotlin type-check blockers

## Validation

- `cargo test -p mosaic-emit-compose` (36 passed)
- `cargo clippy -p mosaic-emit-compose --all-targets -- -D warnings`
- regenerated the package-expanded TaskApp with `mosaic-compile pkg ... --backend compose --emit-project`
- confirmed the generated Compose Desktop project now reaches Kotlin compilation; remaining truthiness and required commit-payload failures are separately tracked in UI38