### PR TITLE
Report seeded SVG fragment breakouts

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- HTML `p` and `br` start tags recovered from seeded foreign fragment contexts
+  now report the foreign-content breakout parse error. This closes the final
+  malformed tree-construction case that previously emitted no diagnostic.
 - A second `body` end tag in a seeded `html` fragment context now reports that
   it was reprocessed from the after-body insertion mode. This covers the final
   silent HTML-fragment corpus case without changing its recovered DOM.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -28,8 +28,8 @@ tree-construction cases and all 6,806 html5lib tokenizer cases with zero missing
 signatures and zero normalized skips. DOM output is complete, but diagnostic
 coverage is not:
 the checked 2,637-case tree corpus declares 6,243 errors across 2,183 cases.
-After the seeded-HTML after-body diagnostic slice, 2,182 of those cases emit at
-least one lexer or parser diagnostic and 1 remains uncovered.
+After the seeded-SVG foreign-breakout diagnostic slice, all 2,183 malformed
+cases emit at least one lexer or parser diagnostic and none remain uncovered.
 Another 139 cases emit diagnostics despite having no legacy `#errors` rows.
 These are reviewed rather than automatically removed: 89 are full-document
 inputs for which the legacy fixtures omit the Standard-required missing-doctype
@@ -65,23 +65,16 @@ open table blocks adoption-agency recovery. Description-list item start tags
 now report when implied-end-tag recovery closes a non-current `dt` or `dd`,
 without flagging adjacent description-list items.
 
-The sole residual case is an HTML start tag in a seeded SVG context. A second
-`body` end tag in a seeded `html` fragment now reports its after-body insertion
-mode parse error. Non-whitespace text discarded by a seeded `colgroup` context
-reports its table insertion-mode parse error. Character data and start tags
-after an `html` end tag report even when the end tag materializes an implied
-document shell around leading body text. The current corpus no longer has a
-silent script-tokenizer, document-tail, frameset, table-shell, table-fragment,
-HTML-fragment, foreign end-tag, formatting-only, or general in-body group.
+There are no residual malformed tree-construction cases without a lexer or
+parser diagnostic. HTML `p` and `br` start tags recovered from seeded foreign
+fragment contexts now report their foreign-content breakout parse error. A
+second `body` end tag in a seeded `html` fragment reports its after-body
+insertion-mode parse error, and non-whitespace text discarded by a seeded
+`colgroup` context reports its table insertion-mode parse error.
 
 Prioritized work items:
 
-1. **Fragment-context parsing.** Cover the final foreign HTML start-tag row.
-   Invalid start and end tags targeting seeded fragment-context elements now
-   report without mutating their synthetic shells, seeded `colgroup` text
-   recovery reports its insertion-mode parse error, and seeded `html` fragments
-   report tokens reprocessed from after-body mode.
-2. **Table, select, and template insertion modes.** Continue the algorithm
+1. **Table, select, and template insertion modes.** Continue the algorithm
    audit beyond the currently exercised diagnostic corpus.
    Non-whitespace table text now reports when it is foster-parented. The
    specialized SVG and MathML start-tag path now reports when table insertion
@@ -96,14 +89,14 @@ Prioritized work items:
    structure foster-parents them, covering the remaining silent fostered-anchor
    starts. Seeded table and foreign fragment-shell boundaries now report their
    required parse errors.
-3. **Adoption agency and active formatting.** Cover malformed formatting cases
+2. **Adoption agency and active formatting.** Cover malformed formatting cases
    without changing their now-conforming DOM output.
-4. **Diagnostic positions and error taxonomy.** Carry source positions into
+3. **Diagnostic positions and error taxonomy.** Carry source positions into
    tree construction and map diagnostics to current WHATWG concepts. Legacy
    WPT/html5lib error labels are evidence hints, not a normative public API.
-5. **Input boundary review.** Document the Unicode-code-point parser boundary
+4. **Input boundary review.** Document the Unicode-code-point parser boundary
    and either add or explicitly separate byte decoding and encoding sniffing.
-6. **Algorithm and differential audit.** Map implemented states/modes to the
+5. **Algorithm and differential audit.** Map implemented states/modes to the
    current HTML Standard and add deterministic differential/fuzz coverage for
    branches not exercised by the upstream corpora.
 

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4917,6 +4917,10 @@ impl HtmlParser {
             && self.current_element_is_marked_foreign_fragment_context()
             && matches!(name.as_str(), "br" | "p")
         {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-html-start-tag-in-foreign-content",
+                format!("HTML start tag `<{name}>` forced recovery from foreign content"),
+            ));
             let child_index = self.append_node(Node::element(name.clone(), Vec::new()));
             if name == "p" {
                 let mut path = self.current_parent_path().to_vec();
@@ -33956,6 +33960,17 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| diagnostic.code != "unexpected-html-start-tag-in-foreign-content"));
+
+        let fragment = parse_html_fragment_for_context_with_diagnostics("<p>", "svg svg").unwrap();
+        assert_eq!(fragment.nodes.len(), 1);
+        assert_eq!(element(&fragment.nodes[0]).name, "p");
+        assert_eq!(
+            fragment.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-html-start-tag-in-foreign-content",
+                "HTML start tag `<p>` forced recovery from foreign content"
+            )]
+        );
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/tree_construction_test.rs
+++ b/code/packages/rust/html-parser/tests/tree_construction_test.rs
@@ -54,7 +54,7 @@ fn tree_construction_diagnostic_coverage_is_ratcheted() {
 
     assert_eq!(expected_error_rows, 6243);
     assert_eq!(expected_error_cases, 2183);
-    assert_eq!(missing_diagnostic_cases, 1);
-    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2182);
+    assert_eq!(missing_diagnostic_cases, 0);
+    assert_eq!(expected_error_cases - missing_diagnostic_cases, 2183);
     assert_eq!(undeclared_diagnostic_cases, 139);
 }


### PR DESCRIPTION
## Summary
- report foreign-content breakout diagnostics for HTML `p` and `br` recovery in seeded foreign fragments
- preserve the existing conforming recovered DOM and add focused seeded-SVG coverage
- close malformed-tree diagnostic coverage from 2,182 of 2,183 cases to all 2,183, then reprioritize the backlog

## Validation
- `cargo test -p coding-adventures-html-lexer`
- `cargo test -p coding-adventures-html-parser`
- focused foreign-breakout regression and zero-residual diagnostic ratchet
- live WPT/html5lib coverage audit: 1,934 tree cases, 6,806 tokenizer cases, zero missing/skipped
- all parser audit coverage/manifest/Rust-test guards
- fixture audit Python unit tests
- `cargo clippy -p coding-adventures-html-lexer -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo fmt -p coding-adventures-html-parser -- --check` still reports pre-existing unrelated drift; no formatter diff touches this slice