### PR TITLE
Report select implied-end diagnostics

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Repeated `option` and `optgroup` start tags processed with an open `select`
+  now report the current-Standard parse error when implied-end-tag recovery
+  closes a scoped option or group. The legacy html5lib rows exercise this DOM
+  recovery without declaring the branch error.
 - HTML `p` and `br` start tags recovered from seeded foreign fragment contexts
   now report the foreign-content breakout parse error. This closes the final
   malformed tree-construction case that previously emitted no diagnostic.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -84,6 +84,10 @@ Prioritized work items:
    special in-table insertion behavior. Foster-parented `title` and `meta`
    start tags now report the general in-table parse error. Nested `select` and
    `input` start tags now report when they force recovery from select mode.
+   Repeated `option` and `optgroup` start tags now report the current-Standard
+   parse error when implied-end-tag recovery finds an option or optgroup in
+   select scope; the legacy html5lib error rows exercise the DOM recovery
+   without declaring that branch error.
    Non-whitespace text after a template row now reports when it forces recovery
    from template table mode. Formatting start tags now report when table
    structure foster-parents them, covering the remaining silent fostered-anchor

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7355,11 +7355,23 @@ impl HtmlParser {
             && (self.current_element_is("option") || self.has_open_element("select"))
         {
             if !self.current_empty_select_is_nested_in_option() {
-                self.close_open_element_if(|name| name == "option");
+                let closed_option = self.close_open_element_if(|name| name == "option");
+                if closed_option && self.has_open_element("select") {
+                    self.diagnostics.push(ParserDiagnostic::new(
+                        "unexpected-option-start-tag-in-select",
+                        "start tag `<option>` implied the end of an option in select scope",
+                    ));
+                }
             }
         } else if incoming_name == "optgroup" {
-            self.close_open_element_if(|name| name == "option");
-            self.close_open_element_if(|name| name == "optgroup");
+            let closed_option = self.close_open_element_if(|name| name == "option");
+            let closed_optgroup = self.close_open_element_if(|name| name == "optgroup");
+            if (closed_option || closed_optgroup) && self.has_open_element("select") {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-optgroup-start-tag-in-select",
+                    "start tag `<optgroup>` implied the end of an option or optgroup in select scope",
+                ));
+            }
         } else if incoming_name == "rb" {
             self.close_open_ruby_element_if(is_ruby_annotation_element);
             self.close_open_ruby_element_if(|name| name == "rtc");
@@ -33796,6 +33808,53 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| diagnostic.code != "unexpected-start-tag-in-select"));
+    }
+
+    #[test]
+    fn reports_select_option_and_optgroup_implied_end_starts() {
+        for (source, diagnostic) in [
+            (
+                "<!doctype html><select><option><option>",
+                ParserDiagnostic::new(
+                    "unexpected-option-start-tag-in-select",
+                    "start tag `<option>` implied the end of an option in select scope",
+                ),
+            ),
+            (
+                "<!doctype html><select><optgroup><option><optgroup>",
+                ParserDiagnostic::new(
+                    "unexpected-optgroup-start-tag-in-select",
+                    "start tag `<optgroup>` implied the end of an option or optgroup in select scope",
+                ),
+            ),
+            (
+                "<!doctype html><select><optgroup><optgroup>",
+                ParserDiagnostic::new(
+                    "unexpected-optgroup-start-tag-in-select",
+                    "start tag `<optgroup>` implied the end of an option or optgroup in select scope",
+                ),
+            ),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.contains(&diagnostic),
+                "source {source:?}"
+            );
+        }
+
+        for source in [
+            "<!doctype html><select><option></select><option>",
+            "<!doctype html><select><optgroup></select><optgroup>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                !matches!(
+                    diagnostic.code.as_str(),
+                    "unexpected-option-start-tag-in-select"
+                        | "unexpected-optgroup-start-tag-in-select"
+                )
+            }));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report current-Standard parse errors when repeated `option` starts imply an option end in select scope
- report the sibling `optgroup` branch when an option or optgroup is implicitly closed
- record the evidence-backed algorithm audit result in the changelog and conformance backlog

## Validation
- `cargo test -p coding-adventures-html-lexer`
- `cargo test -p coding-adventures-html-parser`
- live WPT/html5lib coverage audit: 1,934 tree cases, 6,806 tokenizer cases, zero missing, zero skipped
- all four audit guard scripts plus fixture audit unittests
- `cargo clippy -p coding-adventures-html-lexer -p coding-adventures-html-parser --all-targets -- -D warnings`
- `cargo fmt -p coding-adventures-html-parser -- --check` still reports broad pre-existing `lib.rs` drift; none of its hunks intersects this patch

## Standard evidence
The current WHATWG in-body rules require a parse error when repeated `option` or `optgroup` starts find the corresponding element in select scope. Legacy html5lib rows exercise the recovered DOM but do not declare these branch errors.