### PR TITLE
Recover caption table boundaries

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,11 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Table-structure start tags and `table` end tags that close a caption now
+  report the current-Standard parse error when implied-end-tag generation
+  leaves a non-caption node current. Caption-scoped `table` end tags also close
+  the caption before reprocessing the token in table mode. The checked legacy
+  corpus does not cover this caption-plus-formatting branch.
 - Repeated `option` and `optgroup` start tags processed with an open `select`
   now report the current-Standard parse error when implied-end-tag recovery
   closes a scoped option or group. The legacy html5lib rows exercise this DOM

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -91,8 +91,11 @@ Prioritized work items:
    Non-whitespace text after a template row now reports when it forces recovery
    from template table mode. Formatting start tags now report when table
    structure foster-parents them, covering the remaining silent fostered-anchor
-   starts. Seeded table and foreign fragment-shell boundaries now report their
-   required parse errors.
+   starts. Caption recovery now reports when a table-structure start tag or
+   `table` end tag closes the caption while a non-implied node remains current;
+   caption-scoped table endings now reprocess after closing the caption.
+   Seeded table and foreign fragment-shell boundaries now report their required
+   parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases
    without changing their now-conforming DOM output.
 3. **Diagnostic positions and error taxonomy.** Carry source positions into

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7028,6 +7028,8 @@ impl HtmlParser {
                 }
             }
             "table" => {
+                self.report_non_current_caption_recovery("end tag `</table>`");
+                self.close_open_table_context_element_if(|name| name == "caption");
                 self.close_element(name);
                 if self
                     .pending_formatting_reconstruction
@@ -7241,6 +7243,13 @@ impl HtmlParser {
     }
 
     fn apply_table_implied_contexts(&mut self, incoming_name: &str) {
+        if matches!(
+            incoming_name,
+            "caption" | "col" | "colgroup" | "tbody" | "td" | "tfoot" | "th" | "thead" | "tr"
+        ) {
+            self.report_non_current_caption_recovery(&format!("start tag `<{incoming_name}>`"));
+        }
+
         match incoming_name {
             "caption" | "colgroup" => {
                 self.pop_table_cell_row_and_section_contexts();
@@ -7287,6 +7296,36 @@ impl HtmlParser {
                 }
             }
             _ => {}
+        }
+    }
+
+    fn report_non_current_caption_recovery(&mut self, token: &str) {
+        let Some(table_index) = self.open_elements.iter().rposition(|path| {
+            element_at_path(&self.document, path).is_some_and(|name| name == "table")
+        }) else {
+            return;
+        };
+        let Some(relative_caption_index) =
+            self.open_elements[table_index + 1..]
+                .iter()
+                .rposition(|path| {
+                    element_at_path(&self.document, path).is_some_and(|name| name == "caption")
+                })
+        else {
+            return;
+        };
+        let caption_index = table_index + 1 + relative_caption_index;
+        let current_after_implied_end_tags_is_caption =
+            self.open_elements[caption_index + 1..].iter().all(|path| {
+                element_at_path(&self.document, path).is_some_and(is_implied_end_tag_element)
+            });
+        if !current_after_implied_end_tags_is_caption {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-token-in-caption",
+                format!(
+                    "{token} closed a caption while a non-caption node remained current after implied-end-tag generation"
+                ),
+            ));
         }
     }
 
@@ -31552,6 +31591,51 @@ mod tests {
         assert_eq!(
             element(&element(&foot.children[0]).children[0]).children,
             vec![Node::text("F")]
+        );
+    }
+
+    #[test]
+    fn reports_caption_recovery_with_a_non_caption_current_node() {
+        for (source, token) in [
+            (
+                "<!doctype html><table><caption><b>Cap<col><tr><td>A</table>",
+                "start tag `<col>`",
+            ),
+            (
+                "<!doctype html><table><caption><i>Cap</table>",
+                "end tag `</table>`",
+            ),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-token-in-caption",
+                    format!(
+                        "{token} closed a caption while a non-caption node remained current after implied-end-tag generation"
+                    ),
+                )],
+                "source {source:?}"
+            );
+        }
+
+        for source in [
+            "<!doctype html><table><caption>Cap<col></table>",
+            "<!doctype html><table><caption><p>Cap<col></table>",
+            "<!doctype html><table><caption><option>Cap</table>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.is_empty(), "source {source:?}");
+        }
+
+        let recovered =
+            parse_html("<!doctype html><table><caption><i>Cap</table><p>After").unwrap();
+        let body = body(&recovered);
+        assert_eq!(element(&body.children[0]).name, "table");
+        assert_eq!(element(&body.children[1]).name, "p");
+        assert_eq!(
+            element(&body.children[1]).children,
+            vec![Node::text("After")]
         );
     }
 


### PR DESCRIPTION
## Summary
- report the current-Standard in-caption parse error when structural table tokens close a caption while a non-implied node remains current
- close caption scope before reprocessing `</table>`, so following content leaves the table correctly
- add positive and quiet-control coverage, and record the audited branch in the conformance backlog

## Evidence
The current WHATWG "in caption" insertion-mode algorithm requires implied-end-tag generation, a parse error when the current node is then not `caption`, caption closure, and token reprocessing for table-structure starts and `</table>`. The checked legacy corpus covers broad caption DOM recovery but has no caption-plus-formatting transition for this branch.

## Validation
- `cargo test` in `code/packages/rust/html-parser`
- `cargo test` in `code/packages/rust/html-lexer`
- live WPT/html5lib coverage audit: 1,934/1,934 tree cases, 6,806/6,806 tokenizer cases, 7,242 normalized cases, 0 skipped
- all four WHATWG fixture/manifest/Rust-test guard scripts
- fixture coverage Python unit tests
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

`cargo fmt -- --check` continues to report broad pre-existing formatting drift in the crate; none of its remaining hunks intersect this patch.