### PR TITLE
Add recoverable Synology credential pairing

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -949,6 +949,7 @@ members = [
     "smart-home-zoneminder-snapshot-host",
     "smart-home-axis-pairing-service",
     "smart-home-reolink-pairing-service",
+    "smart-home-synology-pairing-service",
     "smart-home-shelly-integration",
     "smart-home-wled-integration",
     "smart-home-nanoleaf-local-integration",

--- a/code/packages/rust/smart-home-synology-pairing-service/BUILD
+++ b/code/packages/rust/smart-home-synology-pairing-service/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-synology-pairing-service -- --nocapture

--- a/code/packages/rust/smart-home-synology-pairing-service/CHANGELOG.md
+++ b/code/packages/rust/smart-home-synology-pairing-service/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 0.1.0
+
+- Add D23-authorized Synology credential provisioning from one-shot owner-only
+  secret files.
+- Verify the exact installed server through the pending session, canonical
+  hostname, reviewed socket address, strict certificate-verifying HTTPS, API
+  discovery, package permissions, and privilege-filtered cameras.
+- Require exact installed positive camera identifiers, canonical camera
+  entities, and snapshot capabilities before replacement.
+- Persist only the versioned username/password envelope; SID, SynoToken, OTP,
+  and remembered-device material remain process-local.
+- Explicitly log out the isolated Synology session after successful inspection
+  or authenticated failure.
+- Install only transaction-owned opaque references through recoverable runtime
+  CAS and revision-bound replacement cleanup.
+- Resolve all pending journals before actor startup and keep secret material out
+  of messages, runtime state, journals, reports, and logs.

--- a/code/packages/rust/smart-home-synology-pairing-service/Cargo.toml
+++ b/code/packages/rust/smart-home-synology-pairing-service/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "smart-home-synology-pairing-service"
+version = "0.1.0"
+edition = "2021"
+description = "Recoverable credential provisioning for one exact Synology Surveillance Station server"
+license = "MIT"
+
+[dependencies]
+actor = { path = "../actor" }
+chief-of-staff-daemon-secret-file = { path = "../chief-of-staff-daemon-secret-file" }
+coding_adventures_csprng = { path = "../csprng" }
+coding_adventures_vault_sealed_store = { path = "../vault-sealed-store" }
+coding_adventures_zeroize = { path = "../zeroize" }
+serde_json = "1"
+smart-home-core = { path = "../smart-home-core" }
+smart-home-pairing-transaction = { path = "../smart-home-pairing-transaction" }
+smart-home-runtime = { path = "../smart-home-runtime" }
+smart-home-runtime-store = { path = "../smart-home-runtime-store" }
+smart-home-synology-snapshot-host = { path = "../smart-home-synology-snapshot-host" }
+smart-home-synology-surveillance-integration = { path = "../smart-home-synology-surveillance-integration" }
+storage-core = { path = "../storage-core" }
+url-parser = { path = "../url-parser" }
+
+[dev-dependencies]
+coding_adventures_vault_leases = { path = "../vault-leases" }
+storage-local-folder = { path = "../storage-local-folder" }

--- a/code/packages/rust/smart-home-synology-pairing-service/README.md
+++ b/code/packages/rust/smart-home-synology-pairing-service/README.md
@@ -1,0 +1,36 @@
+# smart-home-synology-pairing-service
+
+Explicit, recoverable credential provisioning for one exact installed Synology
+Surveillance Station server.
+
+The actor request carries only the D23 principal, pending pairing session,
+expected durable runtime revision, and completion time. A host-owned input reads
+the username and password once from configured exact-length owner-only files
+after authorization succeeds. Neither file paths nor credential bytes enter
+actor messages, runtime state, journals, reports, or logs.
+
+Before writing a secret, the service binds the pending session bridge to a
+host-owned canonical hostname and reviewed socket address. Any installed
+Synology `https_endpoint` must equal that credential-free bridge address. The
+native verifier retains the hostname for strict certificate verification and
+SNI while bypassing fresh DNS, discovers the advertised Synology APIs, opens an
+isolated SID-format session, and inspects package permissions plus the
+privilege-filtered camera list. A non-empty returned camera set must exactly
+match every already installed positive `camera_id`, canonical camera entity,
+and `camera.snapshot` capability.
+
+The verifier explicitly logs out after success or authenticated failure. SID,
+SynoToken, OTP, and remembered-device material remain process-local and are
+never persisted. The service encodes the same versioned username/password
+envelope consumed by `smart-home-synology-snapshot-host`; its opaque reference
+is committed through `smart-home-pairing-transaction`. Startup resolves all
+pending journals before accepting work, and replacement cleanup remains bound
+to the captured Vault revision.
+
+Snapshot delivery remains read-only and never provisions credentials.
+
+## Development
+
+```bash
+bash BUILD
+```

--- a/code/packages/rust/smart-home-synology-pairing-service/src/lib.rs
+++ b/code/packages/rust/smart-home-synology-pairing-service/src/lib.rs
@@ -1,0 +1,1754 @@
+//! Actor-owned Synology credential verification and recoverable durable handoff.
+
+#![forbid(unsafe_code)]
+
+use std::any::Any;
+use std::collections::BTreeSet;
+use std::fmt;
+use std::net::{IpAddr, SocketAddr};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use actor::{ActorError, ActorResult, ActorSystem, Message};
+use chief_of_staff_daemon_secret_file::{read_owner_only_secret, SecretFileError};
+use coding_adventures_csprng::random_array;
+use coding_adventures_vault_sealed_store::SealedStore;
+use coding_adventures_zeroize::Zeroizing;
+use smart_home_core::{
+    AgentId, Bridge, BridgeId, CapabilityId, EntityId, EntityKind, IntegrationId, Metadata,
+    ProtocolFamily, VaultRef,
+};
+use smart_home_pairing_transaction::{
+    PairingCredentialLocation, PairingTransactionCoordinator, PairingTransactionError,
+    PairingTransactionOutcome, PairingTransactionRequest,
+};
+use smart_home_runtime::{
+    PairingSessionStatus, RuntimeCompletePairingToolRequest, RuntimeError, RuntimePairingSessionId,
+    SmartHomeRuntime,
+};
+use smart_home_runtime_store::{
+    DurableAutomationDefinition, RestoredSmartHomeRuntime, RuntimeStoreError, SmartHomeRuntimeStore,
+};
+use smart_home_synology_snapshot_host::{
+    encode_synology_credentials, SynologySnapshotHostError, SYNOLOGY_VAULT_NAMESPACE,
+    SYNOLOGY_VAULT_REF_PREFIX,
+};
+use smart_home_synology_surveillance_integration::{
+    SynologyClient, SynologyConfig, SynologyCredentials, SynologyError, SynologyLanTransport,
+    INTEGRATION_ID, PROTOCOL_ID,
+};
+use storage_core::{Revision, StorageBackend};
+use url_parser::Url;
+
+pub const PAIR_REQUEST_CONTENT_TYPE: &str =
+    "application/vnd.smart-home.synology-pairing-request+json";
+const HTTPS_ENDPOINT_KIND: &str = "https_endpoint";
+const CAMERA_ID_KIND: &str = "camera_id";
+
+#[derive(Debug)]
+pub enum SynologyPairingServiceError {
+    UnknownSession(RuntimePairingSessionId),
+    SessionNotPending {
+        session_id: RuntimePairingSessionId,
+        status: PairingSessionStatus,
+    },
+    UnknownBridge(BridgeId),
+    WrongIntegration(IntegrationId),
+    MissingBridgeAddress(BridgeId),
+    InvalidHttpsEndpoint(BridgeId),
+    InvalidInstalledCameras(BridgeId),
+    CameraCorrespondence,
+    InvalidRequest(String),
+    SecretInput(&'static str),
+    Synology(SynologyError),
+    CredentialEncoding(SynologySnapshotHostError),
+    Runtime(RuntimeError),
+    RuntimeStore(RuntimeStoreError),
+    Transaction(PairingTransactionError),
+    Entropy(String),
+    MissingDurableRuntime,
+    ExistingCredentialReference(VaultRef),
+    TransactionRolledBack(String),
+}
+
+impl fmt::Display for SynologyPairingServiceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownSession(session_id) => {
+                write!(formatter, "unknown Synology pairing session {session_id}")
+            }
+            Self::SessionNotPending { session_id, status } => write!(
+                formatter,
+                "Synology pairing session {session_id} is not pending user presence ({status:?})"
+            ),
+            Self::UnknownBridge(bridge_id) => write!(formatter, "unknown Synology bridge {bridge_id}"),
+            Self::WrongIntegration(integration_id) => write!(
+                formatter,
+                "pairing service only accepts Synology bridges, got integration {integration_id}"
+            ),
+            Self::MissingBridgeAddress(bridge_id) => {
+                write!(formatter, "Synology bridge {bridge_id} has no HTTPS address")
+            }
+            Self::InvalidHttpsEndpoint(bridge_id) => write!(
+                formatter,
+                "Synology bridge {bridge_id} does not match the reviewed HTTPS connection target"
+            ),
+            Self::InvalidInstalledCameras(bridge_id) => write!(
+                formatter,
+                "Synology bridge {bridge_id} has ambiguous installed camera identifiers"
+            ),
+            Self::CameraCorrespondence => formatter.write_str(
+                "Synology credential verification did not match the installed camera set",
+            ),
+            Self::InvalidRequest(message) => {
+                write!(formatter, "invalid Synology pairing request: {message}")
+            }
+            Self::SecretInput(message) => write!(formatter, "Synology secret input failed: {message}"),
+            Self::Synology(error) => write!(formatter, "Synology credential verification failed: {error}"),
+            Self::CredentialEncoding(_) => {
+                formatter.write_str("Synology credential envelope encoding failed")
+            }
+            Self::Runtime(error) => write!(formatter, "Synology runtime completion failed: {error}"),
+            Self::RuntimeStore(error) => write!(formatter, "Synology runtime store failed: {error}"),
+            Self::Transaction(error) => write!(formatter, "Synology pairing transaction failed: {error}"),
+            Self::Entropy(message) => write!(
+                formatter,
+                "Synology pairing transaction generation failed: {message}"
+            ),
+            Self::MissingDurableRuntime => {
+                formatter.write_str("Synology pairing requires a durable runtime snapshot")
+            }
+            Self::ExistingCredentialReference(vault_ref) => write!(
+                formatter,
+                "existing Synology credential reference is outside the Synology Vault namespace: {vault_ref}"
+            ),
+            Self::TransactionRolledBack(transaction_id) => write!(
+                formatter,
+                "Synology pairing transaction {transaction_id} rolled back before runtime commit"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SynologyPairingServiceError {}
+
+impl From<SynologyError> for SynologyPairingServiceError {
+    fn from(error: SynologyError) -> Self {
+        Self::Synology(error)
+    }
+}
+
+impl From<SynologySnapshotHostError> for SynologyPairingServiceError {
+    fn from(error: SynologySnapshotHostError) -> Self {
+        Self::CredentialEncoding(error)
+    }
+}
+
+impl From<RuntimeError> for SynologyPairingServiceError {
+    fn from(error: RuntimeError) -> Self {
+        Self::Runtime(error)
+    }
+}
+
+impl From<RuntimeStoreError> for SynologyPairingServiceError {
+    fn from(error: RuntimeStoreError) -> Self {
+        Self::RuntimeStore(error)
+    }
+}
+
+impl From<PairingTransactionError> for SynologyPairingServiceError {
+    fn from(error: PairingTransactionError) -> Self {
+        Self::Transaction(error)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SynologyPairingRequest {
+    pub session_id: RuntimePairingSessionId,
+    pub principal_id: AgentId,
+    pub expected_runtime_revision: Revision,
+    pub completed_at_ms: u64,
+}
+
+impl SynologyPairingRequest {
+    pub fn new(
+        session_id: RuntimePairingSessionId,
+        principal_id: AgentId,
+        expected_runtime_revision: Revision,
+        completed_at_ms: u64,
+    ) -> Self {
+        Self {
+            session_id,
+            principal_id,
+            expected_runtime_revision,
+            completed_at_ms,
+        }
+    }
+
+    pub fn into_message(self, sender_id: &str) -> Result<Message, SynologyPairingServiceError> {
+        let payload = serde_json::to_vec(&serde_json::json!({
+            "schema_version": 1,
+            "session_id": self.session_id.as_str(),
+            "principal_id": self.principal_id.as_str(),
+            "expected_runtime_revision": self.expected_runtime_revision.as_str(),
+            "completed_at_ms": self.completed_at_ms,
+        }))
+        .map_err(|error| SynologyPairingServiceError::InvalidRequest(error.to_string()))?;
+        Ok(Message::new(
+            sender_id,
+            PAIR_REQUEST_CONTENT_TYPE,
+            payload,
+            None,
+        ))
+    }
+
+    fn from_message(message: &Message) -> Result<Self, SynologyPairingServiceError> {
+        if message.content_type != PAIR_REQUEST_CONTENT_TYPE {
+            return Err(SynologyPairingServiceError::InvalidRequest(format!(
+                "message content type must be `{PAIR_REQUEST_CONTENT_TYPE}`"
+            )));
+        }
+        let value: serde_json::Value = serde_json::from_slice(&message.payload)
+            .map_err(|error| SynologyPairingServiceError::InvalidRequest(error.to_string()))?;
+        let object = value.as_object().ok_or_else(|| {
+            SynologyPairingServiceError::InvalidRequest(
+                "message body must be an object".to_string(),
+            )
+        })?;
+        if object
+            .get("schema_version")
+            .and_then(serde_json::Value::as_u64)
+            != Some(1)
+        {
+            return Err(SynologyPairingServiceError::InvalidRequest(
+                "unsupported schema_version".to_string(),
+            ));
+        }
+        Ok(Self::new(
+            RuntimePairingSessionId::trusted(required_json_string(object, "session_id")?),
+            AgentId::new(required_json_string(object, "principal_id")?)
+                .map_err(|error| SynologyPairingServiceError::InvalidRequest(error.to_string()))?,
+            Revision::new(required_json_string(object, "expected_runtime_revision")?)
+                .map_err(|error| SynologyPairingServiceError::InvalidRequest(error.to_string()))?,
+            object
+                .get("completed_at_ms")
+                .and_then(serde_json::Value::as_u64)
+                .ok_or_else(|| {
+                    SynologyPairingServiceError::InvalidRequest(
+                        "completed_at_ms must be a non-negative integer".to_string(),
+                    )
+                })?,
+        ))
+    }
+}
+
+pub struct SynologyCredentialSecret {
+    username: Zeroizing<String>,
+    password: Zeroizing<String>,
+}
+
+impl SynologyCredentialSecret {
+    pub fn new(
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> Result<Self, SynologyPairingServiceError> {
+        let username = Zeroizing::new(username.into());
+        let password = Zeroizing::new(password.into());
+        SynologyCredentials::new(username.as_str(), password.as_str())?;
+        Ok(Self { username, password })
+    }
+
+    fn username(&self) -> &str {
+        self.username.as_str()
+    }
+
+    fn password(&self) -> &str {
+        self.password.as_str()
+    }
+}
+
+impl fmt::Debug for SynologyCredentialSecret {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SynologyCredentialSecret([REDACTED])")
+    }
+}
+
+pub trait SynologyCredentialInput {
+    fn take_for_bridge(
+        &mut self,
+        bridge: &Bridge,
+    ) -> Result<SynologyCredentialSecret, SynologyPairingServiceError>;
+}
+
+pub struct OwnerOnlySynologyCredentialInput {
+    bridge_id: BridgeId,
+    username_path: PathBuf,
+    username_length: usize,
+    password_path: PathBuf,
+    password_length: usize,
+    consumed: bool,
+}
+
+impl OwnerOnlySynologyCredentialInput {
+    pub fn new(
+        bridge_id: BridgeId,
+        username_path: impl Into<PathBuf>,
+        username_length: usize,
+        password_path: impl Into<PathBuf>,
+        password_length: usize,
+    ) -> Self {
+        Self {
+            bridge_id,
+            username_path: username_path.into(),
+            username_length,
+            password_path: password_path.into(),
+            password_length,
+            consumed: false,
+        }
+    }
+
+    fn read_utf8(
+        path: &Path,
+        length: usize,
+    ) -> Result<Zeroizing<String>, SynologyPairingServiceError> {
+        let bytes = read_owner_only_secret(path, length).map_err(map_secret_file_error)?;
+        let value = std::str::from_utf8(bytes.as_slice())
+            .map_err(|_| SynologyPairingServiceError::SecretInput("secret is not UTF-8"))?;
+        Ok(Zeroizing::new(value.to_string()))
+    }
+}
+
+impl fmt::Debug for OwnerOnlySynologyCredentialInput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OwnerOnlySynologyCredentialInput")
+            .field("bridge_id", &self.bridge_id)
+            .field("paths", &"[REDACTED]")
+            .field("consumed", &self.consumed)
+            .finish()
+    }
+}
+
+impl SynologyCredentialInput for OwnerOnlySynologyCredentialInput {
+    fn take_for_bridge(
+        &mut self,
+        bridge: &Bridge,
+    ) -> Result<SynologyCredentialSecret, SynologyPairingServiceError> {
+        if bridge.bridge_id != self.bridge_id {
+            return Err(SynologyPairingServiceError::SecretInput(
+                "credential input is bound to another bridge",
+            ));
+        }
+        if self.consumed {
+            return Err(SynologyPairingServiceError::SecretInput(
+                "credential input was already consumed",
+            ));
+        }
+        let username = Self::read_utf8(&self.username_path, self.username_length)?;
+        let password = Self::read_utf8(&self.password_path, self.password_length)?;
+        let secret = SynologyCredentialSecret::new(username.as_str(), password.as_str())?;
+        self.consumed = true;
+        Ok(secret)
+    }
+}
+
+fn map_secret_file_error(error: SecretFileError) -> SynologyPairingServiceError {
+    let message = match error {
+        SecretFileError::InvalidPath => "secret path is invalid",
+        SecretFileError::ParentUnavailable => "secret parent is unavailable",
+        SecretFileError::AccessFailed => "secret file is unavailable",
+        SecretFileError::UnsafeFileType => "secret file type is unsafe",
+        SecretFileError::InsecureOwner => "secret file owner is unsafe",
+        SecretFileError::InsecurePermissions => "secret file permissions are unsafe",
+        SecretFileError::InvalidLength => "secret length is invalid",
+    };
+    SynologyPairingServiceError::SecretInput(message)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedSynologyNvr {
+    pub camera_count: usize,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SynologyPairingConnectionTarget {
+    pub bridge_id: BridgeId,
+    pub canonical_host: String,
+    pub pinned_address: SocketAddr,
+}
+
+impl SynologyPairingConnectionTarget {
+    pub fn new(
+        bridge_id: BridgeId,
+        canonical_host: impl Into<String>,
+        pinned_address: SocketAddr,
+    ) -> Result<Self, SynologyPairingServiceError> {
+        let canonical_host = canonical_host.into();
+        if canonical_host.trim().is_empty()
+            || canonical_host.chars().any(char::is_control)
+            || canonical_host.contains(['/', '@', '?', '#'])
+        {
+            return Err(SynologyPairingServiceError::InvalidHttpsEndpoint(bridge_id));
+        }
+        Ok(Self {
+            bridge_id,
+            canonical_host,
+            pinned_address,
+        })
+    }
+
+    fn validate(&self, bridge: &Bridge) -> Result<String, SynologyPairingServiceError> {
+        if bridge.bridge_id != self.bridge_id {
+            return Err(SynologyPairingServiceError::InvalidHttpsEndpoint(
+                bridge.bridge_id.clone(),
+            ));
+        }
+        let address = bridge.address.as_deref().ok_or_else(|| {
+            SynologyPairingServiceError::MissingBridgeAddress(bridge.bridge_id.clone())
+        })?;
+        let parsed = Url::parse(address).map_err(|_| {
+            SynologyPairingServiceError::InvalidHttpsEndpoint(bridge.bridge_id.clone())
+        })?;
+        let host = parsed.host.as_deref().ok_or_else(|| {
+            SynologyPairingServiceError::InvalidHttpsEndpoint(bridge.bridge_id.clone())
+        })?;
+        let loopback_test = parsed.scheme == "http"
+            && is_loopback_host(host)
+            && self.pinned_address.ip().is_loopback();
+        if (parsed.scheme != "https" && !loopback_test)
+            || !host.eq_ignore_ascii_case(&self.canonical_host)
+            || parsed.effective_port() != Some(self.pinned_address.port())
+            || !matches!(parsed.path.as_str(), "" | "/")
+            || parsed.userinfo.is_some()
+            || parsed.query.is_some()
+            || parsed.fragment.is_some()
+        {
+            return Err(SynologyPairingServiceError::InvalidHttpsEndpoint(
+                bridge.bridge_id.clone(),
+            ));
+        }
+        let endpoints = bridge
+            .identifiers
+            .iter()
+            .filter(|identifier| {
+                identifier.family == ProtocolFamily::Vendor(PROTOCOL_ID.to_string())
+                    && identifier.kind == HTTPS_ENDPOINT_KIND
+            })
+            .collect::<Vec<_>>();
+        if endpoints.len() > 1
+            || endpoints
+                .first()
+                .is_some_and(|identifier| identifier.value != address)
+        {
+            return Err(SynologyPairingServiceError::InvalidHttpsEndpoint(
+                bridge.bridge_id.clone(),
+            ));
+        }
+        Ok(address.trim_end_matches('/').to_string())
+    }
+}
+
+pub trait SynologyPairingVerifier {
+    fn preflight(&self, bridge: &Bridge) -> Result<String, SynologyPairingServiceError>;
+
+    fn verify(
+        &mut self,
+        bridge: &Bridge,
+        credentials: &SynologyCredentialSecret,
+        expected_camera_ids: &BTreeSet<u64>,
+    ) -> Result<VerifiedSynologyNvr, SynologyPairingServiceError>;
+}
+
+pub struct NativeSynologyPairingVerifier {
+    target: SynologyPairingConnectionTarget,
+}
+
+impl NativeSynologyPairingVerifier {
+    pub fn new(target: SynologyPairingConnectionTarget) -> Self {
+        Self { target }
+    }
+}
+
+impl SynologyPairingVerifier for NativeSynologyPairingVerifier {
+    fn preflight(&self, bridge: &Bridge) -> Result<String, SynologyPairingServiceError> {
+        self.target.validate(bridge)
+    }
+
+    fn verify(
+        &mut self,
+        bridge: &Bridge,
+        credentials: &SynologyCredentialSecret,
+        expected_camera_ids: &BTreeSet<u64>,
+    ) -> Result<VerifiedSynologyNvr, SynologyPairingServiceError> {
+        let address = self.target.validate(bridge)?;
+        let config = SynologyConfig::new(
+            bridge.bridge_id.clone(),
+            address,
+            VaultRef::trusted("vault://smart-home/synology/verification-only"),
+        )?;
+        let credentials = SynologyCredentials::new(credentials.username(), credentials.password())?;
+        let mut client = SynologyClient::new(
+            config,
+            credentials,
+            SynologyLanTransport::default().with_pinned_address(self.target.pinned_address),
+        )?;
+        let snapshot = client.inspect()?;
+        if snapshot.info.allow_snapshot != Some(true) {
+            return Err(SynologyPairingServiceError::CameraCorrespondence);
+        }
+        let observed_camera_ids = snapshot
+            .cameras
+            .iter()
+            .map(|camera| camera.id)
+            .collect::<BTreeSet<_>>();
+        validate_camera_correspondence(expected_camera_ids, &observed_camera_ids)?;
+        Ok(VerifiedSynologyNvr {
+            camera_count: observed_camera_ids.len(),
+            version: snapshot.info.version,
+        })
+    }
+}
+
+fn validate_camera_correspondence(
+    expected_camera_ids: &BTreeSet<u64>,
+    observed_camera_ids: &BTreeSet<u64>,
+) -> Result<(), SynologyPairingServiceError> {
+    if observed_camera_ids.is_empty()
+        || (!expected_camera_ids.is_empty() && observed_camera_ids != expected_camera_ids)
+    {
+        Err(SynologyPairingServiceError::CameraCorrespondence)
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SynologyPairingServiceSnapshot {
+    pub request_count: u64,
+    pub completed_count: u64,
+    pub failed_count: u64,
+    pub recovered_transaction_count: u64,
+    pub last_completed_at_ms: Option<u64>,
+    pub last_bridge_id: Option<BridgeId>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SynologyPairingReport {
+    pub session_id: RuntimePairingSessionId,
+    pub bridge_id: BridgeId,
+    pub vault_ref: VaultRef,
+    pub completed_at_ms: u64,
+    pub camera_count: usize,
+    pub version: String,
+}
+
+pub struct SynologyPairingServiceActorState<I, V, J, R> {
+    runtime: SmartHomeRuntime,
+    automation_definitions: Vec<DurableAutomationDefinition>,
+    automation_state: Option<serde_json::Value>,
+    runtime_revision: Revision,
+    journal_backend: J,
+    runtime_store: SmartHomeRuntimeStore<R>,
+    vault: Arc<SealedStore>,
+    credential_input: I,
+    verifier: V,
+    snapshot: SynologyPairingServiceSnapshot,
+    last_report: Option<SynologyPairingReport>,
+}
+
+impl<I, V, J, R> SynologyPairingServiceActorState<I, V, J, R>
+where
+    I: SynologyCredentialInput,
+    V: SynologyPairingVerifier,
+    J: StorageBackend,
+    R: StorageBackend,
+{
+    pub fn restore(
+        journal_backend: J,
+        vault: Arc<SealedStore>,
+        runtime_store: SmartHomeRuntimeStore<R>,
+        credential_input: I,
+        verifier: V,
+    ) -> Result<Self, SynologyPairingServiceError> {
+        let mut restored = runtime_store
+            .load()?
+            .ok_or(SynologyPairingServiceError::MissingDurableRuntime)?;
+        let recovered_transaction_count = {
+            let coordinator =
+                PairingTransactionCoordinator::new(&journal_backend, &vault, &runtime_store);
+            let pending = coordinator.pending_transaction_ids()?;
+            let recovered_count = pending.len() as u64;
+            for transaction_id in pending {
+                match coordinator.recover(&transaction_id)? {
+                    PairingTransactionOutcome::Committed {
+                        restored: committed,
+                        ..
+                    } => restored = *committed,
+                    PairingTransactionOutcome::RolledBack { .. } => {
+                        restored = runtime_store
+                            .load()?
+                            .ok_or(SynologyPairingServiceError::MissingDurableRuntime)?;
+                    }
+                }
+            }
+            if !coordinator.pending_transaction_ids()?.is_empty() {
+                return Err(SynologyPairingServiceError::InvalidRequest(
+                    "pairing transaction recovery left unresolved journals".to_string(),
+                ));
+            }
+            recovered_count
+        };
+        Ok(Self {
+            runtime: restored.runtime,
+            automation_definitions: restored.automation_definitions,
+            automation_state: restored.automation_state,
+            runtime_revision: restored.revision,
+            journal_backend,
+            runtime_store,
+            vault,
+            credential_input,
+            verifier,
+            snapshot: SynologyPairingServiceSnapshot {
+                recovered_transaction_count,
+                ..SynologyPairingServiceSnapshot::default()
+            },
+            last_report: None,
+        })
+    }
+
+    pub fn runtime(&self) -> &SmartHomeRuntime {
+        &self.runtime
+    }
+
+    pub fn runtime_revision(&self) -> &Revision {
+        &self.runtime_revision
+    }
+
+    pub fn snapshot(&self) -> &SynologyPairingServiceSnapshot {
+        &self.snapshot
+    }
+
+    pub fn last_report(&self) -> Option<&SynologyPairingReport> {
+        self.last_report.as_ref()
+    }
+
+    pub fn pair(
+        &mut self,
+        request: SynologyPairingRequest,
+    ) -> Result<&SynologyPairingReport, SynologyPairingServiceError> {
+        self.snapshot.request_count = self.snapshot.request_count.saturating_add(1);
+        match self.execute_pairing(request) {
+            Ok(report) => {
+                self.snapshot.completed_count = self.snapshot.completed_count.saturating_add(1);
+                self.snapshot.last_completed_at_ms = Some(report.completed_at_ms);
+                self.snapshot.last_bridge_id = Some(report.bridge_id.clone());
+                self.snapshot.last_error = None;
+                self.last_report = Some(report);
+                Ok(self
+                    .last_report
+                    .as_ref()
+                    .expect("pairing report was assigned"))
+            }
+            Err(error) => {
+                self.snapshot.failed_count = self.snapshot.failed_count.saturating_add(1);
+                self.snapshot.last_error = Some(error.to_string());
+                Err(error)
+            }
+        }
+    }
+
+    fn execute_pairing(
+        &mut self,
+        request: SynologyPairingRequest,
+    ) -> Result<SynologyPairingReport, SynologyPairingServiceError> {
+        let session = self
+            .runtime
+            .pairing_session(&request.session_id)
+            .cloned()
+            .ok_or_else(|| {
+                SynologyPairingServiceError::UnknownSession(request.session_id.clone())
+            })?;
+        if session.status != PairingSessionStatus::PendingUserPresence {
+            return Err(SynologyPairingServiceError::SessionNotPending {
+                session_id: session.session_id,
+                status: session.status,
+            });
+        }
+        let bridge = self
+            .runtime
+            .registry()
+            .bridge(&session.bridge_id)
+            .cloned()
+            .ok_or_else(|| SynologyPairingServiceError::UnknownBridge(session.bridge_id.clone()))?;
+        if bridge.integration_id.as_str() != INTEGRATION_ID {
+            return Err(SynologyPairingServiceError::WrongIntegration(
+                bridge.integration_id,
+            ));
+        }
+        let https_endpoint = self.verifier.preflight(&bridge)?;
+        let expected_camera_ids = installed_camera_ids(&self.runtime, &bridge)?;
+        SynologyConfig::new(
+            bridge.bridge_id.clone(),
+            https_endpoint.as_str(),
+            VaultRef::trusted("vault://smart-home/synology/validation-only"),
+        )?;
+        if request.expected_runtime_revision != self.runtime_revision {
+            return Err(SynologyPairingServiceError::InvalidRequest(
+                "expected runtime revision is stale".to_string(),
+            ));
+        }
+
+        let authorization_probe = RuntimeCompletePairingToolRequest::new(
+            request.session_id.clone(),
+            VaultRef::trusted("vault://smart-home/synology/authorization-preflight"),
+            request.completed_at_ms,
+        );
+        self.runtime.clone().execute_complete_pairing_tool(
+            request.principal_id.clone(),
+            authorization_probe,
+            request.completed_at_ms,
+        )?;
+
+        let credentials = self.credential_input.take_for_bridge(&bridge)?;
+        let verified = self
+            .verifier
+            .verify(&bridge, &credentials, &expected_camera_ids)?;
+        let payload = encode_synology_credentials(credentials.username(), credentials.password())?;
+        let transaction_id = new_transaction_id()?;
+        let vault_key = format!("{}/{}", bridge.bridge_id.as_str(), transaction_id);
+        let vault_ref = VaultRef::trusted(format!("{SYNOLOGY_VAULT_REF_PREFIX}{vault_key}"));
+        let new_credential =
+            PairingCredentialLocation::new(vault_ref.clone(), SYNOLOGY_VAULT_NAMESPACE, vault_key)?;
+        let previous_credential = bridge
+            .auth_ref
+            .as_ref()
+            .map(synology_credential_location)
+            .transpose()?;
+        let transaction = PairingTransactionRequest::new(
+            transaction_id.clone(),
+            request.principal_id,
+            bridge.bridge_id.clone(),
+            request.session_id.clone(),
+            new_credential,
+            request.completed_at_ms,
+            request.expected_runtime_revision,
+        )?
+        .with_metadata(vec![
+            Metadata::new("synology.pairing.verified", "true"),
+            Metadata::new("synology.pairing.https_endpoint", https_endpoint),
+            Metadata::new(
+                "synology.pairing.camera_count",
+                verified.camera_count.to_string(),
+            ),
+            Metadata::new("synology.pairing.version", verified.version.clone()),
+        ]);
+        let transaction = match previous_credential {
+            Some(previous) => transaction.with_previous_credential(previous),
+            None => transaction,
+        };
+        let outcome = PairingTransactionCoordinator::new(
+            &self.journal_backend,
+            &self.vault,
+            &self.runtime_store,
+        )
+        .execute(transaction, payload.as_bytes())?;
+        let PairingTransactionOutcome::Committed { restored, .. } = outcome else {
+            return Err(SynologyPairingServiceError::TransactionRolledBack(
+                transaction_id,
+            ));
+        };
+        self.install_restored_runtime(*restored);
+        Ok(SynologyPairingReport {
+            session_id: request.session_id,
+            bridge_id: bridge.bridge_id,
+            vault_ref,
+            completed_at_ms: request.completed_at_ms,
+            camera_count: verified.camera_count,
+            version: verified.version,
+        })
+    }
+
+    fn install_restored_runtime(&mut self, restored: RestoredSmartHomeRuntime) {
+        self.runtime = restored.runtime;
+        self.automation_definitions = restored.automation_definitions;
+        self.automation_state = restored.automation_state;
+        self.runtime_revision = restored.revision;
+    }
+}
+
+pub fn install_synology_pairing_service_actor<I, V, J, R>(
+    system: &mut ActorSystem,
+    actor_id: &str,
+    state: SynologyPairingServiceActorState<I, V, J, R>,
+) -> Result<String, ActorError>
+where
+    I: SynologyCredentialInput + 'static,
+    V: SynologyPairingVerifier + 'static,
+    J: StorageBackend + 'static,
+    R: StorageBackend + 'static,
+{
+    system.create_actor(
+        actor_id,
+        Box::new(state),
+        Box::new(|state: Box<dyn Any>, message| {
+            let mut state = *state
+                .downcast::<SynologyPairingServiceActorState<I, V, J, R>>()
+                .expect("Synology pairing actor received the wrong state type");
+            match SynologyPairingRequest::from_message(message) {
+                Ok(request) => {
+                    let _ = state.pair(request);
+                }
+                Err(error) => {
+                    state.snapshot.request_count = state.snapshot.request_count.saturating_add(1);
+                    state.snapshot.failed_count = state.snapshot.failed_count.saturating_add(1);
+                    state.snapshot.last_error = Some(error.to_string());
+                }
+            }
+            ActorResult {
+                new_state: Box::new(state),
+                messages_to_send: Vec::new(),
+                actors_to_create: Vec::new(),
+                stop: false,
+            }
+        }),
+    )
+}
+
+pub fn vault_record_key(vault_ref: &VaultRef) -> Option<&str> {
+    vault_ref.as_str().strip_prefix(SYNOLOGY_VAULT_REF_PREFIX)
+}
+
+fn installed_camera_ids(
+    runtime: &SmartHomeRuntime,
+    bridge: &Bridge,
+) -> Result<BTreeSet<u64>, SynologyPairingServiceError> {
+    let expected_family = ProtocolFamily::Vendor(PROTOCOL_ID.to_string());
+    let mut camera_ids = BTreeSet::new();
+    for device in runtime.registry().devices_for_bridge(&bridge.bridge_id) {
+        let matches = device
+            .identifiers
+            .iter()
+            .filter(|identifier| {
+                identifier.family == expected_family && identifier.kind == CAMERA_ID_KIND
+            })
+            .collect::<Vec<_>>();
+        if matches.len() != 1 {
+            return Err(SynologyPairingServiceError::InvalidInstalledCameras(
+                bridge.bridge_id.clone(),
+            ));
+        }
+        let camera_id = matches[0]
+            .value
+            .parse::<u64>()
+            .ok()
+            .filter(|value| *value > 0)
+            .ok_or_else(|| {
+                SynologyPairingServiceError::InvalidInstalledCameras(bridge.bridge_id.clone())
+            })?;
+        if !camera_ids.insert(camera_id) {
+            return Err(SynologyPairingServiceError::InvalidInstalledCameras(
+                bridge.bridge_id.clone(),
+            ));
+        }
+        let expected_entity_id =
+            EntityId::trusted(format!("synology-surveillance:{camera_id}:camera"));
+        if device.entity_ids.len() != 1 || device.entity_ids[0] != expected_entity_id {
+            return Err(SynologyPairingServiceError::InvalidInstalledCameras(
+                bridge.bridge_id.clone(),
+            ));
+        }
+        let entity = runtime
+            .registry()
+            .entity(&expected_entity_id)
+            .ok_or_else(|| {
+                SynologyPairingServiceError::InvalidInstalledCameras(bridge.bridge_id.clone())
+            })?;
+        if entity.device_id != device.device_id
+            || entity.kind != EntityKind::Camera
+            || !entity.capabilities.iter().any(|capability| {
+                capability.capability_id == CapabilityId::trusted("camera.snapshot")
+            })
+        {
+            return Err(SynologyPairingServiceError::InvalidInstalledCameras(
+                bridge.bridge_id.clone(),
+            ));
+        }
+    }
+    Ok(camera_ids)
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<IpAddr>()
+            .is_ok_and(|address| address.is_loopback())
+}
+
+fn synology_credential_location(
+    vault_ref: &VaultRef,
+) -> Result<PairingCredentialLocation, SynologyPairingServiceError> {
+    let key = vault_record_key(vault_ref).ok_or_else(|| {
+        SynologyPairingServiceError::ExistingCredentialReference(vault_ref.clone())
+    })?;
+    Ok(PairingCredentialLocation::new(
+        vault_ref.clone(),
+        SYNOLOGY_VAULT_NAMESPACE,
+        key,
+    )?)
+}
+
+fn new_transaction_id() -> Result<String, SynologyPairingServiceError> {
+    let random: [u8; 24] =
+        random_array().map_err(|error| SynologyPairingServiceError::Entropy(error.to_string()))?;
+    let mut suffix = String::with_capacity(random.len() * 2);
+    for byte in random {
+        use std::fmt::Write as _;
+        write!(&mut suffix, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    Ok(format!("synology-{suffix}"))
+}
+
+fn required_json_string(
+    object: &serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Result<String, SynologyPairingServiceError> {
+    object
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| {
+            SynologyPairingServiceError::InvalidRequest(format!("`{field}` must be a string"))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::TcpListener;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::sync::Mutex;
+    use std::thread;
+
+    use coding_adventures_vault_sealed_store::InitOptions;
+    use smart_home_core::{
+        BridgeTransport, Capability, CapabilityGrant, CapabilityGrantId, CapabilityMode, Device,
+        DeviceId, Entity, Health, PrivilegeTier, ProtocolIdentifier, ValueKind,
+    };
+    use smart_home_runtime::RuntimePairingSession;
+    use storage_core::{
+        StorageError, StorageLease, StorageListOptions, StoragePage, StoragePutInput,
+        StorageRecord, StorageStat,
+    };
+    use storage_local_folder::LocalFolderStorageBackend;
+
+    use super::*;
+
+    static TEST_DIRECTORY_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn test_directory(label: &str) -> PathBuf {
+        let suffix = TEST_DIRECTORY_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let path = std::env::temp_dir().join(format!(
+            "smart-home-synology-pairing-service-{}-{label}-{suffix}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        fs::canonicalize(path).unwrap()
+    }
+
+    fn open_vault(root: &Path) -> Arc<SealedStore> {
+        let backend: Arc<dyn StorageBackend> = Arc::new(LocalFolderStorageBackend::new(root));
+        backend.initialize().unwrap();
+        let vault = Arc::new(SealedStore::new(backend));
+        vault
+            .init(
+                b"test-only-vault-password",
+                &InitOptions {
+                    argon2id_time_cost: 1,
+                    argon2id_memory_kib: 32,
+                    argon2id_parallelism: 1,
+                    salt_override: Some(vec![0x31; 16]),
+                },
+            )
+            .unwrap();
+        vault
+    }
+
+    fn runtime_for_bridge(authorized: bool, previous: Option<VaultRef>) -> SmartHomeRuntime {
+        let mut runtime = SmartHomeRuntime::new();
+        let mut bridge = Bridge::new(
+            BridgeId::trusted("synology-camera-front"),
+            IntegrationId::trusted(INTEGRATION_ID),
+            BridgeTransport::LanHttp,
+        );
+        bridge.address = Some("https://synology.local".to_string());
+        bridge.health = Health::Unpaired;
+        bridge.auth_ref = previous;
+        bridge.identifiers.push(
+            ProtocolIdentifier::new(
+                ProtocolFamily::Vendor(PROTOCOL_ID.to_string()),
+                HTTPS_ENDPOINT_KIND,
+                "https://synology.local",
+            )
+            .unwrap(),
+        );
+        runtime.upsert_bridge(bridge.clone()).unwrap();
+        let principal = AgentId::trusted("operator");
+        runtime
+            .start_pairing_session(RuntimePairingSession::pending(
+                RuntimePairingSessionId::trusted("synology-pairing-1"),
+                &bridge,
+                principal.clone(),
+                1_000,
+                30_000,
+                vec![Metadata::new("pairing.mode", "explicit_credentials")],
+            ))
+            .unwrap();
+        if authorized {
+            runtime
+                .registry_mut()
+                .upsert_capability_grant(CapabilityGrant::for_capability(
+                    CapabilityGrantId::trusted("grant-synology-pairing"),
+                    principal,
+                    CapabilityId::trusted("smart_home.pair"),
+                    PrivilegeTier::HumanApproval,
+                    "test",
+                    1_000,
+                ));
+        }
+        runtime
+    }
+
+    fn runtime_root(root: &Path) -> PathBuf {
+        root.join("runtime")
+    }
+
+    fn journal_root(root: &Path) -> PathBuf {
+        root.join("journal")
+    }
+
+    fn persist_runtime(root: &Path, runtime: &SmartHomeRuntime) -> Revision {
+        SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(runtime_root(root)))
+            .save(runtime, &[], 1_500)
+            .unwrap()
+    }
+
+    struct FixedInput {
+        calls: Arc<AtomicUsize>,
+        username: &'static str,
+        password: &'static str,
+    }
+
+    impl SynologyCredentialInput for FixedInput {
+        fn take_for_bridge(
+            &mut self,
+            bridge: &Bridge,
+        ) -> Result<SynologyCredentialSecret, SynologyPairingServiceError> {
+            assert_eq!(bridge.bridge_id.as_str(), "synology-camera-front");
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            SynologyCredentialSecret::new(self.username, self.password)
+        }
+    }
+
+    struct ExactVerifier {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl SynologyPairingVerifier for ExactVerifier {
+        fn preflight(&self, bridge: &Bridge) -> Result<String, SynologyPairingServiceError> {
+            SynologyPairingConnectionTarget::new(
+                BridgeId::trusted("synology-camera-front"),
+                "synology.local",
+                "192.0.2.44:443".parse().unwrap(),
+            )?
+            .validate(bridge)
+        }
+
+        fn verify(
+            &mut self,
+            bridge: &Bridge,
+            credentials: &SynologyCredentialSecret,
+            expected_camera_ids: &BTreeSet<u64>,
+        ) -> Result<VerifiedSynologyNvr, SynologyPairingServiceError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            assert_eq!(bridge.address.as_deref(), Some("https://synology.local"));
+            assert!(expected_camera_ids.is_empty());
+            assert_eq!(credentials.username(), "camera-user");
+            assert_eq!(credentials.password(), "camera-password");
+            assert_eq!(
+                format!("{credentials:?}"),
+                "SynologyCredentialSecret([REDACTED])"
+            );
+            Ok(VerifiedSynologyNvr {
+                camera_count: 2,
+                version: "9.2-11289".to_string(),
+            })
+        }
+    }
+
+    type LocalService = SynologyPairingServiceActorState<
+        FixedInput,
+        ExactVerifier,
+        LocalFolderStorageBackend,
+        LocalFolderStorageBackend,
+    >;
+
+    fn restore_service(
+        root: &Path,
+        vault: Arc<SealedStore>,
+        input_calls: Arc<AtomicUsize>,
+        verifier_calls: Arc<AtomicUsize>,
+    ) -> Result<LocalService, SynologyPairingServiceError> {
+        SynologyPairingServiceActorState::restore(
+            LocalFolderStorageBackend::new(journal_root(root)),
+            vault,
+            SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(runtime_root(root))),
+            FixedInput {
+                calls: input_calls,
+                username: "camera-user",
+                password: "camera-password",
+            },
+            ExactVerifier {
+                calls: verifier_calls,
+            },
+        )
+    }
+
+    fn request(service: &LocalService) -> SynologyPairingRequest {
+        SynologyPairingRequest::new(
+            RuntimePairingSessionId::trusted("synology-pairing-1"),
+            AgentId::trusted("operator"),
+            service.runtime_revision().clone(),
+            2_000,
+        )
+    }
+
+    #[test]
+    fn authorized_pairing_verifies_exact_bridge_and_seals_snapshot_envelope() {
+        let root = test_directory("success");
+        let vault = open_vault(&root.join("vault"));
+        let initial_revision = persist_runtime(&root, &runtime_for_bridge(true, None));
+        let input_calls = Arc::new(AtomicUsize::new(0));
+        let verifier_calls = Arc::new(AtomicUsize::new(0));
+        let mut service = restore_service(
+            &root,
+            vault.clone(),
+            input_calls.clone(),
+            verifier_calls.clone(),
+        )
+        .unwrap();
+
+        let pairing_request = request(&service);
+        let report = service.pair(pairing_request).unwrap().clone();
+
+        assert_eq!(input_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(verifier_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(report.camera_count, 2);
+        assert_ne!(service.runtime_revision(), &initial_revision);
+        assert_eq!(
+            service
+                .runtime()
+                .registry()
+                .bridge(&BridgeId::trusted("synology-camera-front"))
+                .unwrap()
+                .auth_ref,
+            Some(report.vault_ref.clone())
+        );
+        let record = vault
+            .get(
+                SYNOLOGY_VAULT_NAMESPACE,
+                vault_record_key(&report.vault_ref).unwrap(),
+            )
+            .unwrap()
+            .unwrap();
+        let envelope: serde_json::Value = serde_json::from_slice(&record.plaintext).unwrap();
+        assert_eq!(envelope["schema_version"], 1);
+        assert_eq!(envelope["username"], "camera-user");
+        assert_eq!(envelope["password"], "camera-password");
+        let durable_text = service
+            .runtime()
+            .registry()
+            .events()
+            .flat_map(|event| event.metadata.iter())
+            .map(|metadata| format!("{}={}", metadata.key, metadata.value))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(!durable_text.contains("camera-user"));
+        assert!(!durable_text.contains("camera-password"));
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn denial_precedes_secret_input_verification_vault_and_journal_writes() {
+        let root = test_directory("denial");
+        let vault = open_vault(&root.join("vault"));
+        persist_runtime(&root, &runtime_for_bridge(false, None));
+        let input_calls = Arc::new(AtomicUsize::new(0));
+        let verifier_calls = Arc::new(AtomicUsize::new(0));
+        let mut service = restore_service(
+            &root,
+            vault.clone(),
+            input_calls.clone(),
+            verifier_calls.clone(),
+        )
+        .unwrap();
+
+        let pairing_request = request(&service);
+        assert!(matches!(
+            service.pair(pairing_request).unwrap_err(),
+            SynologyPairingServiceError::Runtime(_)
+        ));
+        assert_eq!(input_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(verifier_calls.load(Ordering::SeqCst), 0);
+
+        let mut ambiguous = service
+            .runtime()
+            .registry()
+            .bridge(&BridgeId::trusted("synology-camera-front"))
+            .unwrap()
+            .clone();
+        ambiguous.identifiers.push(
+            ProtocolIdentifier::new(
+                ProtocolFamily::Vendor(PROTOCOL_ID.to_string()),
+                HTTPS_ENDPOINT_KIND,
+                "https://other-synology.local",
+            )
+            .unwrap(),
+        );
+        service.runtime.upsert_bridge(ambiguous).unwrap();
+        let current = request(&service);
+        assert!(matches!(
+            service.pair(current).unwrap_err(),
+            SynologyPairingServiceError::InvalidHttpsEndpoint(_)
+        ));
+        assert_eq!(input_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(verifier_calls.load(Ordering::SeqCst), 0);
+        assert!(vault
+            .list(SYNOLOGY_VAULT_NAMESPACE, Default::default())
+            .unwrap()
+            .is_empty());
+        assert!(LocalFolderStorageBackend::new(journal_root(&root))
+            .list("smart-home-pairing-transactions", Default::default())
+            .unwrap()
+            .records
+            .is_empty());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn stale_revision_and_ambiguous_identity_fail_before_secret_input() {
+        let root = test_directory("preflight");
+        let vault = open_vault(&root.join("vault"));
+        persist_runtime(&root, &runtime_for_bridge(true, None));
+        let input_calls = Arc::new(AtomicUsize::new(0));
+        let verifier_calls = Arc::new(AtomicUsize::new(0));
+        let mut service =
+            restore_service(&root, vault, input_calls.clone(), verifier_calls.clone()).unwrap();
+        let stale = SynologyPairingRequest::new(
+            RuntimePairingSessionId::trusted("synology-pairing-1"),
+            AgentId::trusted("operator"),
+            Revision::new("stale-runtime").unwrap(),
+            2_000,
+        );
+        assert!(matches!(
+            service.pair(stale).unwrap_err(),
+            SynologyPairingServiceError::InvalidRequest(_)
+        ));
+        assert_eq!(input_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(verifier_calls.load(Ordering::SeqCst), 0);
+
+        let mut embedded_credentials = service
+            .runtime()
+            .registry()
+            .bridge(&BridgeId::trusted("synology-camera-front"))
+            .unwrap()
+            .clone();
+        embedded_credentials.address = Some("https://operator:password@synology.local".to_string());
+        embedded_credentials.identifiers[0].value =
+            "https://operator:password@synology.local".to_string();
+        service.runtime.upsert_bridge(embedded_credentials).unwrap();
+        let current = request(&service);
+        assert!(matches!(
+            service.pair(current).unwrap_err(),
+            SynologyPairingServiceError::InvalidHttpsEndpoint(_)
+        ));
+        assert_eq!(input_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(verifier_calls.load(Ordering::SeqCst), 0);
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn installed_camera_identity_is_exact_positive_and_unique() {
+        let mut runtime = runtime_for_bridge(true, None);
+        let bridge = runtime
+            .registry()
+            .bridge(&BridgeId::trusted("synology-camera-front"))
+            .unwrap()
+            .clone();
+        let device_id = DeviceId::trusted("synology-surveillance:7");
+        let entity_id = EntityId::trusted("synology-surveillance:7:camera");
+        runtime
+            .upsert_device(Device {
+                device_id: device_id.clone(),
+                bridge_id: bridge.bridge_id.clone(),
+                manufacturer: "Synology".to_string(),
+                model: "Managed camera".to_string(),
+                name: "Front".to_string(),
+                serial: None,
+                firmware_version: None,
+                room_id: None,
+                entity_ids: vec![entity_id.clone()],
+                identifiers: vec![ProtocolIdentifier::new(
+                    ProtocolFamily::Vendor(PROTOCOL_ID.to_string()),
+                    CAMERA_ID_KIND,
+                    "7",
+                )
+                .unwrap()],
+                health: Health::Online,
+                metadata: Vec::new(),
+            })
+            .unwrap();
+        runtime
+            .upsert_entity(Entity {
+                entity_id: entity_id.clone(),
+                device_id: device_id.clone(),
+                kind: EntityKind::Camera,
+                name: "Front".to_string(),
+                capabilities: vec![Capability::new(
+                    CapabilityId::trusted("camera.snapshot"),
+                    CapabilityMode::Command,
+                    ValueKind::Text,
+                )],
+                state: None,
+                metadata: Vec::new(),
+            })
+            .unwrap();
+        assert_eq!(
+            installed_camera_ids(&runtime, &bridge).unwrap(),
+            BTreeSet::from([7])
+        );
+
+        let mut invalid_entity = runtime.registry().entity(&entity_id).unwrap().clone();
+        invalid_entity.capabilities.clear();
+        runtime.upsert_entity(invalid_entity).unwrap();
+        assert!(matches!(
+            installed_camera_ids(&runtime, &bridge).unwrap_err(),
+            SynologyPairingServiceError::InvalidInstalledCameras(_)
+        ));
+
+        let mut invalid = runtime.registry().device(&device_id).unwrap().clone();
+        invalid.identifiers[0].value = "0".to_string();
+        runtime.upsert_device(invalid).unwrap();
+        assert!(matches!(
+            installed_camera_ids(&runtime, &bridge).unwrap_err(),
+            SynologyPairingServiceError::InvalidInstalledCameras(_)
+        ));
+    }
+
+    #[test]
+    fn camera_correspondence_requires_a_nonempty_exact_installed_set() {
+        assert!(validate_camera_correspondence(&BTreeSet::new(), &BTreeSet::new()).is_err());
+        assert!(validate_camera_correspondence(&BTreeSet::new(), &BTreeSet::from([2])).is_ok());
+        assert!(validate_camera_correspondence(&BTreeSet::from([2]), &BTreeSet::from([2])).is_ok());
+        assert!(
+            validate_camera_correspondence(&BTreeSet::from([2]), &BTreeSet::from([2, 3])).is_err()
+        );
+    }
+
+    #[test]
+    fn native_verifier_uses_isolated_synology_session_and_exact_camera_inspection() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let server_requests = Arc::clone(&requests);
+        let responses = vec![
+            r#"{"success":true,"data":{"SYNO.API.Auth":{"path":"auth.cgi","minVersion":1,"maxVersion":6},"SYNO.SurveillanceStation.Info":{"path":"entry.cgi","minVersion":1,"maxVersion":5},"SYNO.SurveillanceStation.Camera":{"path":"entry.cgi","minVersion":1,"maxVersion":9}}}"#,
+            r#"{"success":true,"data":{"sid":"secret.sid.value","synotoken":"secret-token"}}"#,
+            r#"{"success":true,"data":{"version":{"major":9,"minor":2,"build":11289},"cameraNumber":1,"maxCameraSupport":40,"userPriv":4,"allowSnapshot":true,"allowManualRec":false}}"#,
+            r#"{"success":true,"data":{"total":1,"cameras":[{"id":2,"name":"Front","vendor":"Synology","model":"BC500","channel":"1","status":1}]}}"#,
+            r#"{"success":true}"#,
+        ];
+        let handle = thread::spawn(move || {
+            for body in responses {
+                let (stream, _) = listener.accept().unwrap();
+                let mut reader = BufReader::new(stream);
+                let mut head = String::new();
+                loop {
+                    let mut line = String::new();
+                    reader.read_line(&mut line).unwrap();
+                    if line == "\r\n" {
+                        break;
+                    }
+                    head.push_str(&line);
+                }
+                let length = head
+                    .lines()
+                    .find_map(|line| line.strip_prefix("Content-Length: "))
+                    .unwrap_or("0")
+                    .parse::<usize>()
+                    .unwrap();
+                let mut request_body = vec![0u8; length];
+                reader.read_exact(&mut request_body).unwrap();
+                server_requests
+                    .lock()
+                    .unwrap()
+                    .push((head, String::from_utf8(request_body).unwrap()));
+                let reply = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                reader.get_mut().write_all(reply.as_bytes()).unwrap();
+            }
+        });
+
+        let mut bridge = Bridge::new(
+            BridgeId::trusted("synology-camera-front"),
+            IntegrationId::trusted(INTEGRATION_ID),
+            BridgeTransport::LanHttp,
+        );
+        bridge.address = Some(format!("http://localhost:{}", address.port()));
+        let credentials =
+            SynologyCredentialSecret::new("operator name", "secret&password").unwrap();
+        let target =
+            SynologyPairingConnectionTarget::new(bridge.bridge_id.clone(), "localhost", address)
+                .unwrap();
+        let verified = NativeSynologyPairingVerifier::new(target)
+            .verify(&bridge, &credentials, &BTreeSet::from([2]))
+            .unwrap();
+        handle.join().unwrap();
+
+        assert_eq!(verified.camera_count, 1);
+        assert_eq!(verified.version, "9.2-11289");
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 5);
+        assert!(requests[0].0.starts_with("GET /webapi/query.cgi?"));
+        assert!(requests[1].0.starts_with("POST /webapi/auth.cgi HTTP/1.1"));
+        assert_eq!(
+            requests[1].1,
+            "api=SYNO.API.Auth&method=login&version=6&account=operator%20name&passwd=secret%26password&session=SurveillanceStation&format=sid&enable_syno_token=yes"
+        );
+        assert!(requests[2].0.contains("method=GetInfo"));
+        assert!(requests[3].0.contains("method=List"));
+        assert!(requests[3].0.contains("blPrivilege=true"));
+        assert!(requests[4].0.contains("method=logout"));
+        assert!(requests[2..]
+            .iter()
+            .all(|(head, _)| head.contains("_sid=secret.sid.value")
+                && head.contains("SynoToken=secret-token")));
+        assert!(!format!("{verified:?}").contains("secret.sid.value"));
+    }
+
+    #[test]
+    fn actor_message_contains_authority_and_revision_but_no_secret_input() {
+        let request = SynologyPairingRequest::new(
+            RuntimePairingSessionId::trusted("synology-pairing-1"),
+            AgentId::trusted("operator"),
+            Revision::new("runtime-r1").unwrap(),
+            2_000,
+        );
+        let message = request.clone().into_message("scheduler").unwrap();
+        assert_eq!(
+            SynologyPairingRequest::from_message(&message).unwrap(),
+            request
+        );
+        let payload = String::from_utf8(message.payload).unwrap();
+        assert!(payload.contains("\"principal_id\":\"operator\""));
+        assert!(payload.contains("\"expected_runtime_revision\":\"runtime-r1\""));
+        assert!(!payload.contains("username"));
+        assert!(!payload.contains("password"));
+        assert!(!payload.contains("path"));
+        assert!(!payload.contains("vault_ref"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owner_only_input_is_exact_length_bridge_bound_and_one_shot() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = test_directory("owner-input");
+        let username_path = root.join("username");
+        let password_path = root.join("password");
+        fs::write(&username_path, b"camera-user").unwrap();
+        fs::write(&password_path, b"camera-password").unwrap();
+        fs::set_permissions(&username_path, fs::Permissions::from_mode(0o600)).unwrap();
+        fs::set_permissions(&password_path, fs::Permissions::from_mode(0o600)).unwrap();
+        let bridge = runtime_for_bridge(true, None)
+            .registry()
+            .bridge(&BridgeId::trusted("synology-camera-front"))
+            .unwrap()
+            .clone();
+        let mut input = OwnerOnlySynologyCredentialInput::new(
+            bridge.bridge_id.clone(),
+            &username_path,
+            11,
+            &password_path,
+            15,
+        );
+        let mut other_bridge = bridge.clone();
+        other_bridge.bridge_id = BridgeId::trusted("synology-camera-other");
+        assert!(matches!(
+            input.take_for_bridge(&other_bridge).unwrap_err(),
+            SynologyPairingServiceError::SecretInput("credential input is bound to another bridge")
+        ));
+        let secret = input.take_for_bridge(&bridge).unwrap();
+        assert_eq!(secret.username(), "camera-user");
+        assert_eq!(secret.password(), "camera-password");
+        assert!(matches!(
+            input.take_for_bridge(&bridge).unwrap_err(),
+            SynologyPairingServiceError::SecretInput("credential input was already consumed")
+        ));
+        assert!(!format!("{input:?}").contains(username_path.to_str().unwrap()));
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    struct FailOnPutBackend {
+        inner: LocalFolderStorageBackend,
+        fail_on_put: usize,
+        put_count: AtomicUsize,
+    }
+
+    impl FailOnPutBackend {
+        fn new(root: PathBuf, fail_on_put: usize) -> Self {
+            Self {
+                inner: LocalFolderStorageBackend::new(root),
+                fail_on_put,
+                put_count: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl StorageBackend for FailOnPutBackend {
+        fn initialize(&self) -> Result<(), StorageError> {
+            self.inner.initialize()
+        }
+
+        fn get(&self, namespace: &str, key: &str) -> Result<Option<StorageRecord>, StorageError> {
+            self.inner.get(namespace, key)
+        }
+
+        fn put(&self, input: StoragePutInput) -> Result<StorageRecord, StorageError> {
+            let call = self.put_count.fetch_add(1, Ordering::SeqCst) + 1;
+            if call == self.fail_on_put {
+                return Err(StorageError::Unavailable {
+                    message: "injected journal interruption".to_string(),
+                });
+            }
+            self.inner.put(input)
+        }
+
+        fn delete(
+            &self,
+            namespace: &str,
+            key: &str,
+            if_revision: Option<&Revision>,
+        ) -> Result<(), StorageError> {
+            self.inner.delete(namespace, key, if_revision)
+        }
+
+        fn list(
+            &self,
+            namespace: &str,
+            options: StorageListOptions,
+        ) -> Result<StoragePage, StorageError> {
+            self.inner.list(namespace, options)
+        }
+
+        fn stat(&self, namespace: &str, key: &str) -> Result<Option<StorageStat>, StorageError> {
+            self.inner.stat(namespace, key)
+        }
+
+        fn acquire_lease(
+            &self,
+            name: &str,
+            ttl_ms: u64,
+        ) -> Result<Option<StorageLease>, StorageError> {
+            self.inner.acquire_lease(name, ttl_ms)
+        }
+    }
+
+    fn transaction_request(
+        transaction_id: &str,
+        runtime_revision: Revision,
+        previous: Option<VaultRef>,
+    ) -> PairingTransactionRequest {
+        let new_key = format!("synology-camera-front/{transaction_id}");
+        let new_ref = VaultRef::trusted(format!("{SYNOLOGY_VAULT_REF_PREFIX}{new_key}"));
+        let request = PairingTransactionRequest::new(
+            transaction_id,
+            AgentId::trusted("operator"),
+            BridgeId::trusted("synology-camera-front"),
+            RuntimePairingSessionId::trusted("synology-pairing-1"),
+            PairingCredentialLocation::new(new_ref, SYNOLOGY_VAULT_NAMESPACE, new_key).unwrap(),
+            2_000,
+            runtime_revision,
+        )
+        .unwrap()
+        .with_metadata(vec![Metadata::new("synology.pairing.verified", "true")]);
+        match previous {
+            Some(previous) => {
+                request.with_previous_credential(synology_credential_location(&previous).unwrap())
+            }
+            None => request,
+        }
+    }
+
+    #[test]
+    fn startup_recovers_runtime_commit_interrupted_before_journal_ack() {
+        let root = test_directory("restart-recovery");
+        let vault = open_vault(&root.join("vault"));
+        let revision = persist_runtime(&root, &runtime_for_bridge(true, None));
+        let runtime_store =
+            SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(runtime_root(&root)));
+        let failing_journal = FailOnPutBackend::new(journal_root(&root), 3);
+        assert!(
+            PairingTransactionCoordinator::new(&failing_journal, &vault, &runtime_store)
+                .execute(
+                    transaction_request("synology-restart", revision, None),
+                    br#"{"schema_version":1,"username":"u","password":"p"}"#,
+                )
+                .is_err()
+        );
+
+        let service = restore_service(
+            &root,
+            vault,
+            Arc::new(AtomicUsize::new(0)),
+            Arc::new(AtomicUsize::new(0)),
+        )
+        .unwrap();
+        assert_eq!(service.snapshot().recovered_transaction_count, 1);
+        assert_eq!(
+            service
+                .runtime()
+                .pairing_session(&RuntimePairingSessionId::trusted("synology-pairing-1"))
+                .unwrap()
+                .status,
+            PairingSessionStatus::Completed
+        );
+        assert!(LocalFolderStorageBackend::new(journal_root(&root))
+            .list("smart-home-pairing-transactions", Default::default())
+            .unwrap()
+            .records
+            .is_empty());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn replacement_commit_removes_the_captured_previous_credential() {
+        let root = test_directory("replacement");
+        let vault = open_vault(&root.join("vault"));
+        let old_ref = VaultRef::trusted(format!(
+            "{SYNOLOGY_VAULT_REF_PREFIX}synology-camera-front/previous"
+        ));
+        let old_key = vault_record_key(&old_ref).unwrap().to_string();
+        vault
+            .put(SYNOLOGY_VAULT_NAMESPACE, &old_key, b"previous-secret", None)
+            .unwrap();
+        persist_runtime(&root, &runtime_for_bridge(true, Some(old_ref.clone())));
+        let mut service = restore_service(
+            &root,
+            vault.clone(),
+            Arc::new(AtomicUsize::new(0)),
+            Arc::new(AtomicUsize::new(0)),
+        )
+        .unwrap();
+
+        let pairing_request = request(&service);
+        let report = service.pair(pairing_request).unwrap().clone();
+
+        assert_ne!(report.vault_ref, old_ref);
+        assert!(vault
+            .get(SYNOLOGY_VAULT_NAMESPACE, &old_key)
+            .unwrap()
+            .is_none());
+        assert!(vault
+            .get(
+                SYNOLOGY_VAULT_NAMESPACE,
+                vault_record_key(&report.vault_ref).unwrap(),
+            )
+            .unwrap()
+            .is_some());
+        assert_eq!(
+            service
+                .runtime()
+                .registry()
+                .bridge(&BridgeId::trusted("synology-camera-front"))
+                .unwrap()
+                .auth_ref,
+            Some(report.vault_ref)
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn replacement_cleanup_is_exact_and_cleanup_drift_blocks_restart() {
+        let root = test_directory("cleanup-drift");
+        let vault = open_vault(&root.join("vault"));
+        let old_ref = VaultRef::trusted(format!(
+            "{SYNOLOGY_VAULT_REF_PREFIX}synology-camera-front/previous"
+        ));
+        let old_key = vault_record_key(&old_ref).unwrap().to_string();
+        let old_revision = vault
+            .put(SYNOLOGY_VAULT_NAMESPACE, &old_key, b"previous-secret", None)
+            .unwrap();
+        let revision = persist_runtime(&root, &runtime_for_bridge(true, Some(old_ref.clone())));
+        let runtime_store =
+            SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(runtime_root(&root)));
+        let failing_journal = FailOnPutBackend::new(journal_root(&root), 3);
+        assert!(
+            PairingTransactionCoordinator::new(&failing_journal, &vault, &runtime_store)
+                .execute(
+                    transaction_request("synology-cleanup", revision, Some(old_ref)),
+                    br#"{"schema_version":1,"username":"u","password":"p"}"#,
+                )
+                .is_err()
+        );
+        vault
+            .put(
+                SYNOLOGY_VAULT_NAMESPACE,
+                &old_key,
+                b"replacement-owned-secret",
+                Some(old_revision),
+            )
+            .unwrap();
+
+        let result = restore_service(
+            &root,
+            vault.clone(),
+            Arc::new(AtomicUsize::new(0)),
+            Arc::new(AtomicUsize::new(0)),
+        );
+        assert!(matches!(
+            result,
+            Err(SynologyPairingServiceError::Transaction(_))
+        ));
+        assert_eq!(
+            vault
+                .get(SYNOLOGY_VAULT_NAMESPACE, &old_key)
+                .unwrap()
+                .unwrap()
+                .plaintext
+                .as_slice(),
+            b"replacement-owned-secret"
+        );
+        assert_eq!(
+            LocalFolderStorageBackend::new(journal_root(&root))
+                .list("smart-home-pairing-transactions", Default::default())
+                .unwrap()
+                .records
+                .len(),
+            1
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/code/packages/rust/smart-home-synology-surveillance-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-synology-surveillance-integration/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.1
+
+- Add reviewed-socket pinning for loopback tests and certificate-verifying
+  HTTPS while retaining the canonical hostname for SNI.
+- Move credentials into zeroizing storage before validation so rejected input
+  is cleared on drop.
+
 ## 0.1.0
 
 - Add manual local-HTTPS endpoint intake and Vault-backed Synology credentials.

--- a/code/packages/rust/smart-home-synology-surveillance-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-synology-surveillance-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smart-home-synology-surveillance-integration"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Authenticated local Synology Surveillance Station camera health inspection"
 license = "MIT"

--- a/code/packages/rust/smart-home-synology-surveillance-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-synology-surveillance-integration/src/lib.rs
@@ -23,12 +23,12 @@ use smart_home_runtime::{RuntimeError, SmartHomeRuntime};
 use std::collections::BTreeSet;
 use std::fmt;
 use std::io::{self, Read, Write};
-use std::net::{TcpStream, ToSocketAddrs};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::time::Duration;
 use tls_platform::{default_connector, TlsConfig, TlsConnector};
 use url_parser::{Url, UrlError};
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.1.1";
 pub const INTEGRATION_ID: &str = "synology-surveillance";
 pub const PROTOCOL_ID: &str = "synology_surveillance_webapi";
 pub const API_INFO_PATH: &str = "/webapi/query.cgi?api=SYNO.API.Info&method=Query&version=1&query=SYNO.API.Auth%2CSYNO.SurveillanceStation.Info%2CSYNO.SurveillanceStation.Camera";
@@ -156,8 +156,8 @@ impl SynologyCredentials {
         username: impl Into<String>,
         password: impl Into<String>,
     ) -> Result<Self, SynologyError> {
-        let username = username.into();
-        let password = password.into();
+        let username = Zeroizing::new(username.into());
+        let password = Zeroizing::new(password.into());
         if username.trim().is_empty() || password.is_empty() {
             return Err(SynologyError::Validation(
                 "username and password must not be empty".to_string(),
@@ -172,10 +172,7 @@ impl SynologyCredentials {
                 "credentials exceed bounds or contain a NUL byte".to_string(),
             ));
         }
-        Ok(Self {
-            username: Zeroizing::new(username),
-            password: Zeroizing::new(password),
-        })
+        Ok(Self { username, password })
     }
 }
 
@@ -322,6 +319,7 @@ pub struct SynologyLanTransport {
     connector: Box<dyn TlsConnector>,
     tls_config: TlsConfig,
     maximum_response_bytes: usize,
+    pinned_address: Option<SocketAddr>,
 }
 
 /// One operation-scoped Surveillance Station session and its bearer endpoint.
@@ -360,11 +358,17 @@ impl SynologyLanTransport {
             connector,
             tls_config,
             maximum_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
+            pinned_address: None,
         }
     }
 
     pub fn with_maximum_response_bytes(mut self, maximum: usize) -> Self {
         self.maximum_response_bytes = maximum.max(1);
+        self
+    }
+
+    pub fn with_pinned_address(mut self, address: SocketAddr) -> Self {
+        self.pinned_address = Some(address);
         self
     }
 
@@ -384,9 +388,20 @@ impl SynologyLanTransport {
             .effective_port()
             .ok_or(SynologyError::MissingField("request URL port"))?;
         let timeout = Duration::from_millis(plan.timeout_ms.max(1));
+        if self
+            .pinned_address
+            .is_some_and(|address| address.port() != port)
+        {
+            return Err(SynologyError::Validation(
+                "reviewed socket port does not match the Synology endpoint".to_string(),
+            ));
+        }
         let response = match url.scheme.as_str() {
             "http" if is_loopback_host(host) => {
-                let mut stream = connect_tcp(host, port, timeout)?;
+                let mut stream = match self.pinned_address {
+                    Some(address) => connect_tcp_addr(address, timeout)?,
+                    None => connect_tcp(host, port, timeout)?,
+                };
                 write_request(&mut stream, request.as_slice())?;
                 Zeroizing::new(read_bounded(&mut stream, self.maximum_response_bytes)?)
             }
@@ -395,10 +410,11 @@ impl SynologyLanTransport {
                 config.connect_timeout = timeout;
                 config.read_timeout = Some(timeout);
                 config.write_timeout = Some(timeout);
-                let mut stream = self
-                    .connector
-                    .connect(host, port, &config)
-                    .map_err(|error| SynologyError::Tls(error.to_string()))?;
+                let mut stream = match self.pinned_address {
+                    Some(address) => self.connector.connect_addr(host, address, &config),
+                    None => self.connector.connect(host, port, &config),
+                }
+                .map_err(|error| SynologyError::Tls(error.to_string()))?;
                 write_request(&mut stream, request.as_slice())?;
                 let bytes = Zeroizing::new(read_bounded(&mut stream, self.maximum_response_bytes)?);
                 stream
@@ -1486,6 +1502,16 @@ fn connect_tcp(host: &str, port: u16, timeout: Duration) -> Result<TcpStream, Sy
     ))
 }
 
+fn connect_tcp_addr(address: SocketAddr, timeout: Duration) -> Result<TcpStream, SynologyError> {
+    let stream = TcpStream::connect_timeout(&address, timeout)
+        .map_err(|error| SynologyError::Io(error.to_string()))?;
+    stream
+        .set_read_timeout(Some(timeout))
+        .and_then(|_| stream.set_write_timeout(Some(timeout)))
+        .map_err(|error| SynologyError::Io(error.to_string()))?;
+    Ok(stream)
+}
+
 fn write_request(writer: &mut dyn Write, request: &[u8]) -> Result<(), SynologyError> {
     writer
         .write_all(request)
@@ -1604,11 +1630,99 @@ fn decode_chunked(input: &[u8], maximum: usize) -> Result<Vec<u8>, SynologyError
 mod tests {
     use super::*;
     use smart_home_core::{CapabilityGrant, CapabilityGrantId, PrivilegeTier};
-    use std::io::{BufRead, BufReader};
+    use std::io::{BufRead, BufReader, Cursor};
     use std::net::TcpListener;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::thread;
+    use tls_platform::{TlsConnectionSummary, TlsError, TlsStream, TlsVersion, VerifyMode};
+
+    #[derive(Default)]
+    struct TlsCapture {
+        connects: Vec<(String, SocketAddr, bool)>,
+        request: Vec<u8>,
+    }
+
+    struct RecordingConnector {
+        response: Vec<u8>,
+        capture: Arc<Mutex<TlsCapture>>,
+    }
+
+    impl TlsConnector for RecordingConnector {
+        fn connect(
+            &self,
+            _host: &str,
+            _port: u16,
+            _config: &TlsConfig,
+        ) -> Result<Box<dyn TlsStream>, TlsError> {
+            panic!("pinned Synology transport must not resolve the endpoint hostname")
+        }
+
+        fn connect_addr(
+            &self,
+            server_name: &str,
+            address: SocketAddr,
+            config: &TlsConfig,
+        ) -> Result<Box<dyn TlsStream>, TlsError> {
+            self.capture.lock().unwrap().connects.push((
+                server_name.to_string(),
+                address,
+                config.verify_mode == VerifyMode::Strict,
+            ));
+            Ok(Box::new(RecordingTlsStream {
+                response: Cursor::new(self.response.clone()),
+                capture: Arc::clone(&self.capture),
+            }))
+        }
+    }
+
+    struct RecordingTlsStream {
+        response: Cursor<Vec<u8>>,
+        capture: Arc<Mutex<TlsCapture>>,
+    }
+
+    impl Read for RecordingTlsStream {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            self.response.read(buffer)
+        }
+    }
+
+    impl Write for RecordingTlsStream {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            self.capture
+                .lock()
+                .unwrap()
+                .request
+                .extend_from_slice(buffer);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl TlsStream for RecordingTlsStream {
+        fn peer_certificates(&self) -> Result<Vec<Vec<u8>>, TlsError> {
+            Ok(Vec::new())
+        }
+
+        fn negotiated_alpn(&self) -> Option<String> {
+            Some("http/1.1".to_string())
+        }
+
+        fn negotiated_version(&self) -> TlsVersion {
+            TlsVersion::Tls13
+        }
+
+        fn close_notify(&mut self) -> Result<(), TlsError> {
+            Ok(())
+        }
+
+        fn summary(&self) -> TlsConnectionSummary {
+            panic!("summary is not used by the Synology transport")
+        }
+    }
 
     fn credentials() -> SynologyCredentials {
         SynologyCredentials::new("operator", "secret-password").unwrap()
@@ -1621,6 +1735,37 @@ mod tests {
             VaultRef::trusted("vault://synology/test"),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn reviewed_socket_pinning_keeps_canonical_tls_identity_and_strict_verification() {
+        let response = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 26\r\nConnection: close\r\n\r\n{\"success\":true,\"data\":{}}".to_vec();
+        let capture = Arc::new(Mutex::new(TlsCapture::default()));
+        let address: SocketAddr = "192.0.2.44:443".parse().unwrap();
+        let connector = RecordingConnector {
+            response,
+            capture: Arc::clone(&capture),
+        };
+        let config = SynologyConfig::new(
+            BridgeId::trusted("synology.test"),
+            "https://diskstation.example",
+            VaultRef::trusted("vault://synology/test"),
+        )
+        .unwrap();
+        let plans = SynologyRequestPlans::new(&config).unwrap();
+        let mut transport =
+            SynologyLanTransport::new(Box::new(connector), TlsConfig::https_default())
+                .with_pinned_address(address);
+
+        transport.request(&plans.api_info, None, &[]).unwrap();
+        let capture = capture.lock().unwrap();
+        assert_eq!(
+            capture.connects,
+            vec![("diskstation.example".to_string(), address, true)]
+        );
+        let request = String::from_utf8_lossy(&capture.request);
+        assert!(request.starts_with("GET /webapi/query.cgi?"));
+        assert!(request.contains("Host: diskstation.example"));
     }
 
     fn snapshot() -> SynologySnapshot {

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1686,6 +1686,41 @@ direct Reolink RLC camera without turning snapshot delivery into a writer:
   `GetChannelstatus` inspection does not prove the RLC model identity behind
   each physical NVR channel.
 
+## Current Synology Credential Pairing Slice
+
+This slice completes recoverable credential provisioning for one exact
+Synology Surveillance Station server without persisting session material:
+
+- `smart-home-synology-pairing-service` accepts only the exact pending pairing
+  session, D23 principal, expected durable runtime revision, and completion
+  time. Actor messages cannot carry credential paths, bytes, session material,
+  or Vault references.
+- One host-owned username/password input is bridge-bound, exact-length,
+  owner-only, one-shot, and zeroizing. Human Approval succeeds before either
+  file is opened, LAN I/O begins, or a transaction journal or Vault record is
+  created.
+- The pending bridge's credential-free address must match a host-owned
+  canonical hostname and reviewed socket address. Production inspection keeps
+  the hostname for SNI and strict certificate verification while connecting
+  only to the reviewed address.
+- Authenticated API discovery, isolated SID-format login, package-permission
+  inspection, and privilege-filtered camera listing must prove a non-empty set
+  equal to every installed positive `camera_id`, canonical camera entity, and
+  snapshot capability. Explicit logout runs after success or authenticated
+  failure.
+- Only the snapshot host's bounded versioned username/password envelope enters
+  the transaction-owned Vault record. SID, SynoToken, OTP, and
+  remembered-device material remain process-local and are never persisted.
+- Expected-revision runtime CAS, startup recovery, durable actor-state
+  replacement, and revision-bound prior-record cleanup reuse
+  `smart-home-pairing-transaction` unchanged. Snapshot delivery remains a
+  read-only consumer.
+- Tests cover denial and stale revision before input, exact installed server
+  and camera identity, one-shot owner-only files, reviewed-address-pinned
+  strict TLS, a real discovery-to-logout loopback, secret-free durable state,
+  interrupted-commit recovery, exact replacement cleanup, and cleanup-drift
+  refusal.
+
 ## Smart Home Remaining Work
 
 The remaining backlog is ordered by the strongest executable production path
@@ -1698,130 +1733,126 @@ to that image request; the only documented direct URL credentials require
 disabling secure sessions and are rejected. Frigate snapshot delivery remains
 blocked on a cookie-capable media authentication boundary. Revision-guarded
 D23 pairing completion, its recoverable cross-store journal, and production
-Hue, ONVIF, ZoneMinder, Axis, and direct Reolink RLC compositions are now
-available. The camera pairing services prove bounded host-owned secret input,
+Hue, ONVIF, ZoneMinder, Axis, direct Reolink RLC, and Synology compositions are
+now available. The camera pairing services prove bounded host-owned secret input,
 D23 principal propagation, authenticated exact-bridge inspection, durable
 runtime revision ownership, startup recovery, actor-state replacement, and
 revision-bound cleanup without turning snapshot delivery into a writer. The
-strongest next post-merge audit is explicit Synology credential provisioning
-because its isolated authenticated session, installed server and camera
-correspondence, snapshot envelope, and sealed-Vault namespace are concrete.
+strongest next post-merge audit is Reolink NVR credential pairing. It must prove
+the exact model identity and snapshot capability behind every installed
+physical channel through authenticated inspection before an implementation
+slice can be selected.
 
-1. Audit automated Synology credential provisioning only through an explicit
-   pairing flow that proves exact installed-server and camera correspondence,
-   bounded host-owned secret input, isolated session logout, the versioned
-   envelope, and transaction-owned opaque references. Snapshot delivery must
-   not become an implicit credential writer.
-2. Add Reolink NVR credential pairing only after authenticated inspection proves
+1. Add Reolink NVR credential pairing only after authenticated inspection proves
    the exact model identity and snapshot capability behind every installed
    physical channel. Keep query credentials operation-scoped and preserve
    explicit logout on every outcome.
-3. Add authenticated AirGradient MQTT only after official firmware removes
+2. Add authenticated AirGradient MQTT only after official firmware removes
    plaintext credential logging and one-shot Vault-leased credential injection
    can be proven without request-plan or normalized-state exposure.
-4. Add independent AirGradient telemetry, remote-configuration, and OTA
+3. Add independent AirGradient telemetry, remote-configuration, and OTA
    destinations only if firmware exposes separate settings; the current
    `httpDomain` contract intentionally governs all three as one HTTPS origin.
-5. Add authenticated HEOS source browsing and queue insertion only after the
+4. Add authenticated HEOS source browsing and queue insertion only after the
    account/session and Vault-leasing prerequisites are concrete.
-6. Automate Enphase access-token acquisition or renewal only after Enphase
+5. Automate Enphase access-token acquisition or renewal only after Enphase
    account authentication, cloud-session handling, operator consent, and
    Vault-leased credential policy are concrete; the current host accepts a
    pre-generated token.
-7. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
+6. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
    stable LAN advertisement; the current production path uses explicit local
    HTTPS endpoint and gateway-serial configuration.
-8. Add Enphase live battery, relay, generator, grid, and system-topology state
+7. Add Enphase live battery, relay, generator, grid, and system-topology state
    only after the normalized energy topology and retention semantics are
    concrete.
-9. Add Enphase relay, grid-services, or configuration controls only with
+8. Add Enphase relay, grid-services, or configuration controls only with
    operation-specific D23 contracts, explicit safety approval, bounded native
    semantics, and readable postcondition verification.
-10. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
+9. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
    supervised session lifecycle and Vault policy for refresh-token residency are
    concrete; the current isolated inspection drops both tokens after each read.
-11. Add ZoneMinder event push only after a concrete authenticated event host and
+10. Add ZoneMinder event push only after a concrete authenticated event host and
     supervised subscription lifecycle exist.
-12. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
+11. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
     mutations only with operation-specific D23 contracts, least-privilege user
     checks, bounded semantics, and readable postcondition verification.
-13. Add UniFi connected-client key rotation across multiple sites or more than
+12. Add UniFi connected-client key rotation across multiple sites or more than
     one 100-client page only after a resumable protocol can prove exact global
     correspondence and all-or-none persistence without extending native-ID or
     one-shot key residency across partial responses.
-14. Add UniFi connected-client native details only after field-specific
+13. Add UniFi connected-client native details only after field-specific
    minimization and retention are approved; current presence intentionally
    excludes names, native IDs, MACs, IPs, and connection timestamps.
-15. Add UniFi historical device statistics, heartbeat-time correlation, or
+14. Add UniFi historical device statistics, heartbeat-time correlation, or
    broader fleet polling only after durable time-series schema, query access,
    clock semantics, and retention/deletion policy are concrete; current live
    statistics are explicit-target, 64-device bounded, one-minute rate-limited,
    and expire after two minutes.
-16. Add remote UniFi Site Manager inspection only after telemetry-egress,
+15. Add remote UniFi Site Manager inspection only after telemetry-egress,
    destination, and operator-consent policy are concrete; keep the current host
    local-only.
-17. Add UniFi Network push or change events only after a concrete authenticated
+16. Add UniFi Network push or change events only after a concrete authenticated
    event host and supervised subscription lifecycle exist.
-18. Add UniFi adoption, guest authorization, port actions, or configuration
+17. Add UniFi adoption, guest authorization, port actions, or configuration
    mutations only with operation-specific D23 contracts, least-privilege API
    keys, bounded semantics, and readable postcondition verification.
-19. Add Synology Surveillance Station OTP and remembered-device authentication
+18. Add Synology Surveillance Station OTP and remembered-device authentication
    only after an interactive challenge lifecycle and Vault-leased device-token
    policy are concrete.
-20. Add Synology Surveillance Station events only after a concrete authenticated
+19. Add Synology Surveillance Station events only after a concrete authenticated
    event host and supervised subscription lifecycle exist.
-21. Add Synology Surveillance Station PTZ, external recording, or configuration
+20. Add Synology Surveillance Station PTZ, external recording, or configuration
    mutations only with operation-specific D23 contracts, least-privilege API
    checks, bounded semantics, and readable postcondition verification.
-22. Add Frigate event and review push only after a concrete authenticated event
+21. Add Frigate event and review push only after a concrete authenticated event
    or WebSocket host and supervised subscription lifecycle exist.
-23. Add bounded Frigate snapshots through the completed camera-media HTTPS
+22. Add bounded Frigate snapshots through the completed camera-media HTTPS
     executor after process-local endpoint registration and credential lifetime
     are wired; recordings, export, and playback still require a concrete
     supervised resource executor.
-24. Add Frigate commands or configuration mutations only with operation-specific
+23. Add Frigate commands or configuration mutations only with operation-specific
    D23 contracts, least-privilege role checks, and readable postcondition
    verification.
-25. Add bounded Blue Iris snapshots only after an official interface documents
+24. Add bounded Blue Iris snapshots only after an official interface documents
     how an isolated secure JSON session authenticates `/image/{camera}`, or a
     concrete cookie/session-bound media executor exists. Never disable secure
     sessions or place reusable Blue Iris credentials in a URL. Alert/clip
     search, export, and playback still require a supervised resource executor.
-26. Add broader Blue Iris `camconfig` or administrative mutations only with
+25. Add broader Blue Iris `camconfig` or administrative mutations only with
    operation-specific D23 contracts, least-privilege permissions, and readable
    postcondition verification; do not persist the license value returned at
    login.
-27. Add automatic Blue Iris discovery only if the server exposes a documented,
+26. Add automatic Blue Iris discovery only if the server exposes a documented,
    stable LAN advertisement; the current production path is explicit local
    HTTPS endpoint configuration.
-28. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
+27. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
    controls only when each operation has a specific native capability probe,
    bounded semantics, and readable verification where the device exposes it.
-29. Add Axis event streaming only after the existing WebSocket protocol core has
+28. Add Axis event streaming only after the existing WebSocket protocol core has
    a concrete authenticated host using the completed Digest primitive or a
    short-lived session token, plus subscription supervision.
-30. Enumerate Axis video sources/channels before extending PTZ beyond the current
+29. Enumerate Axis video sources/channels before extending PTZ beyond the current
     capability-probed VAPIX camera 1 boundary.
-31. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
+30. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
     only when each operation has a specific capability probe and readable state.
-32. Add Reolink current-position, zoom, guard-point, or patrol controls only when
+31. Add Reolink current-position, zoom, guard-point, or patrol controls only when
     each operation has a capability-specific probe and the firmware exposes the
     native state needed to avoid invented orientation claims.
-33. Add Reolink push events only after a concrete webhook or event-stream host
+32. Add Reolink push events only after a concrete webhook or event-stream host
     and subscription lifecycle exist.
-34. Add authenticated KLAP/Tapo devices and other broader-device families only
+33. Add authenticated KLAP/Tapo devices and other broader-device families only
     after their authentication and session prerequisites are concrete.
-35. Add ONVIF PullPoint events once a concrete event host and subscription
+34. Add ONVIF PullPoint events once a concrete event host and subscription
     lifecycle exist.
-36. Add RTSP media transfer and recording once concrete media transfer and
+35. Add RTSP media transfer and recording once concrete media transfer and
     recorder host primitives exist.
-37. Add a production Matter commissioning, secure-session, and network host only
+36. Add a production Matter commissioning, secure-session, and network host only
     after certificate, fabric, Interaction Model encoding, subscription, and
     transport prerequisites exist.
-38. Add a Thread border-router host only after an actual host transport exists.
-39. Add a production Zigbee coordinator, join, and security host only after
+37. Add a Thread border-router host only after an actual host transport exists.
+38. Add a production Zigbee coordinator, join, and security host only after
     concrete coordinator transport and security primitives exist.
-40. Add production Z-Wave inclusion and S2 only after concrete host transport
+39. Add production Z-Wave inclusion and S2 only after concrete host transport
     and security primitives exist.
 
 ## End-To-End Definition
@@ -1829,19 +1860,19 @@ correspondence, snapshot envelope, and sealed-Vault namespace are concrete.
 The first meaningful "working end to end" target should be:
 
 1. A D18 Chief job starts from a host/orchestrator profile.
-2. The job calls D18D `smart_home.*` tools.
-3. The tools reach the D23 runtime.
-4. D23 authorizes reads, subscribe, pair, and low-risk light commands.
-5. A Hue fixture or local Hue bridge returns normalized state and health.
-6. The job writes a D18D execution journal.
-7. The user receives a compact home status or action report.
+1. The job calls D18D `smart_home.*` tools.
+2. The tools reach the D23 runtime.
+3. D23 authorizes reads, subscribe, pair, and low-risk light commands.
+4. A Hue fixture or local Hue bridge returns normalized state and health.
+5. The job writes a D18D execution journal.
+6. The user receives a compact home status or action report.
 
 The first real-home target after that should be:
 
 1. Discover one Hue bridge on LAN.
-2. Pair it through a vault-backed credential path.
-3. List lights and health.
-4. Subscribe to normalized events.
-5. Turn one light on and off.
-6. Persist state and command audit.
-7. Show the result through a local API or dashboard.
+1. Pair it through a vault-backed credential path.
+2. List lights and health.
+3. Subscribe to normalized events.
+4. Turn one light on and off.
+5. Persist state and command audit.
+6. Show the result through a local API or dashboard.


### PR DESCRIPTION
## Summary

- add explicit D23-authorized Synology credential provisioning through the recoverable pairing transaction coordinator
- bind strict HTTPS to a canonical hostname and reviewed socket address, then verify API discovery, package permission, and exact privilege-filtered camera correspondence before writing credentials
- keep username/password input one-shot and zeroizing, keep SID/SynoToken process-local with explicit logout, and install only the snapshot host's versioned envelope through a transaction-owned opaque Vault reference
- record the completed slice and advance the remaining Smart Home backlog

## Validation

- `cargo test -p smart-home-synology-surveillance-integration -p smart-home-synology-snapshot-host -p smart-home-synology-pairing-service`
- `cargo clippy -p smart-home-synology-surveillance-integration -p smart-home-synology-snapshot-host -p smart-home-synology-pairing-service --all-targets -- -D warnings`
- `cargo fmt -p smart-home-synology-surveillance-integration -p smart-home-synology-pairing-service -- --check`
- `bash BUILD` in each of the three impacted packages