### PR TITLE
Complete vault generation zero safely

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this package are documented here.
 
+## [0.7.0] - 2026-08-09
+
+### Added
+
+- One injected, provider-neutral generation-zero completion workflow for both
+  first execution and restart recovery.
+- Exact idempotent bootstrap installation/readback, repository initialization
+  and publication, receipt verification, and final local activation.
+- An explicit bootstrap-store contract requiring exact generation replay to
+  succeed idempotently while different bytes conflict.
+
+### Security
+
+- The exact `PreparedInit` journal is atomically durable before the first
+  bootstrap or repository effect.
+- Every failure retains the same randomized and signed bytes for retry; only an
+  exact expected receipt can advance local state to `Active`.
+- Exact already-active replay succeeds idempotently, while conflicting local,
+  bootstrap, repository, and compare-exchange state fails closed.
+
 ## [0.6.0] - 2026-08-09
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -28,18 +28,24 @@ re-derives the repository address, decrypts local custody, and proves that all
 three private seeds reproduce the authority and device public identities
 pinned in the bootstrap and certificate before rebuilding the verifier.
 
+Generation-zero side effects are crash-resumable over injected stores. The
+completion workflow atomically installs the exact `PreparedInit` bytes before
+the first external write, performs idempotent bootstrap and repository work,
+verifies the exact resulting pins, and compare-exchanges to `Active`. A retry
+after any failure rehydrates and reuses the same signed and randomized journal.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
-credential store, or entropy source. Crash-resumable side effects and session
-workflows land in the next slices. There is no unchecked repository
-verification path: construction decrypts and
+credential store, or entropy source. Active open/unlock, pending-publication
+recovery, and session workflows land in the next slices. There is no unchecked
+repository verification path: construction decrypts and
 authority-verifies the exact locally pinned certificate frame and object ID,
 and commits and announcements must match that vault, device, certificate ID,
 and Ed25519 key.
 
 ## Verification
 
-The package has 40 tests covering exact canonical and cryptographic vectors,
+The package has 47 tests covering exact canonical and cryptographic vectors,
 lossless removed-value persistence, live and tombstone revisions, catalog
 bounds and ordering, cross-kind and cross-vault rejection, AEAD tampering,
 authority/device/certificate binding, Ed25519 signature rejection, closed
@@ -47,8 +53,9 @@ parser failures, crash-state relationship checks, diagnostic redaction, and
 explicit key wiping. Repository tests additionally exercise initialization,
 publication, verified open/read/history, every injected provider operation,
 constructor paths, and complete error translation. The exact Tarpaulin result
-under its LLVM engine is 1,315 of 1,350 production lines (97.41%); the
-generation-zero and restart-rehydration module covers 294 of 297 lines.
+under its LLVM engine is 1,386 of 1,431 production lines (96.86%); the
+generation-zero preparation, rehydration, and completion module covers 365 of
+378 lines.
 
 ## Development
 

--- a/code/packages/rust/vault-pm-application/required_capabilities.json
+++ b/code/packages/rust/vault-pm-application/required_capabilities.json
@@ -3,5 +3,5 @@
   "version": 1,
   "package": "rust/vault-pm-application",
   "capabilities": [],
-  "justification": "Pure canonical persistence, crash-state contracts, deterministic generation-zero construction, cryptographic framing, and verified repository composition over caller-provided stores, keys, time, and CSPRNG material. Store traits inject byte operations but the package owns no filesystem, network, process, environment, clock, provider, credential-store, or entropy authority."
+  "justification": "Pure canonical persistence, crash-state contracts, deterministic generation-zero construction, injected crash-resumable effect sequencing, cryptographic framing, and verified repository composition over caller-provided stores, keys, time, and CSPRNG material. Store traits inject byte operations but the package owns no filesystem, network, process, environment, clock, provider, credential-store, or entropy authority."
 }

--- a/code/packages/rust/vault-pm-application/src/initialize.rs
+++ b/code/packages/rust/vault-pm-application/src/initialize.rs
@@ -1,9 +1,10 @@
 use crate::{
     decode_device_certificate, encode_device_certificate, encode_signed_commit, open_local_secret,
     open_object, seal_local_secret, seal_object, ActiveStateV1, ApplicationError,
-    AuthorityFingerprint, BootstrapLocator, CatalogV1, LocalSecretRandomness, LocalSecretV1,
-    LocalVaultStateV1, ObjectKind, ObjectRandomness, PreparedInitV1, PublicationJournalV1, V1Keys,
-    V1SingleDeviceVerifier,
+    ApplicationRepositoryError, ApplicationRepositoryFactory, AuthorityFingerprint,
+    BootstrapLocator, BootstrapStore, BootstrapStoreError, CatalogV1, LocalSecretRandomness,
+    LocalSecretV1, LocalStateStore, LocalStateStoreError, LocalVaultStateV1, ObjectKind,
+    ObjectRandomness, PreparedInitV1, PublicationJournalV1, V1Keys, V1SingleDeviceVerifier,
 };
 use coding_adventures_argon2id::{argon2id, Options as Argon2idOptions};
 use coding_adventures_chacha20_poly1305::{
@@ -450,6 +451,156 @@ pub fn rehydrate_prepared_init(
     })
 }
 
+/// Durably install and idempotently complete one exact generation-zero
+/// journal through injected local, bootstrap, and repository authorities.
+///
+/// The exact `PreparedInit` bytes are atomically installed before the first
+/// external effect. Every retry reuses the same signed and randomized bytes,
+/// and the intended `Active` bytes replace the journal only after exact
+/// bootstrap read-back and repository receipt verification.
+pub fn complete_generation_zero(
+    prepared: PreparedGenerationZero,
+    local_state_store: &dyn LocalStateStore,
+    bootstrap_store: &dyn BootstrapStore,
+    repository_factory: &dyn ApplicationRepositoryFactory,
+) -> Result<ActiveStateV1, ApplicationError> {
+    let (locator, owner_state, address, verifier) = prepared.into_parts();
+    let LocalVaultStateV1::PreparedInit(journal) = owner_state else {
+        return Err(ApplicationError::InternalInvariant);
+    };
+    let prepared_state = LocalVaultStateV1::PreparedInit(journal.clone());
+    let exact_prepared = prepared_state.encode()?;
+    let intended_active = journal.intended_active().clone();
+    let exact_active = LocalVaultStateV1::Active(intended_active.clone()).encode()?;
+
+    if ensure_prepared_state(
+        local_state_store,
+        locator,
+        &exact_prepared,
+        &exact_active,
+        &intended_active,
+    )? {
+        return Ok(intended_active);
+    }
+
+    bootstrap_store
+        .put_generation(locator, None, journal.bootstrap())
+        .map_err(map_bootstrap_store)?;
+    let observed_bootstrap = bootstrap_store
+        .load_latest(locator)
+        .map_err(map_bootstrap_store)?
+        .ok_or(ApplicationError::IntegrityFailure)?;
+    if observed_bootstrap != journal.bootstrap() {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+
+    let repository = repository_factory
+        .connect(address, Box::new(verifier))
+        .map_err(map_application_repository)?;
+    repository
+        .initialize()
+        .map_err(map_application_repository)?;
+    let receipt = repository
+        .publish(
+            journal.publication().publication(),
+            journal.publication().base_heads(),
+        )
+        .map_err(map_application_repository)?;
+    if receipt.heads() != journal.publication().expected_heads() {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+
+    install_active_state(
+        local_state_store,
+        locator,
+        &exact_prepared,
+        &exact_active,
+        intended_active,
+    )
+}
+
+fn ensure_prepared_state(
+    store: &dyn LocalStateStore,
+    locator: BootstrapLocator,
+    exact_prepared: &[u8],
+    exact_active: &[u8],
+    intended_active: &ActiveStateV1,
+) -> Result<bool, ApplicationError> {
+    match store.load(locator).map_err(map_local_state_store)? {
+        Some(observed) if observed == exact_prepared => return Ok(false),
+        Some(observed) if observed == exact_active => {
+            let state = LocalVaultStateV1::decode(&observed)?;
+            if state == LocalVaultStateV1::Active(intended_active.clone()) {
+                return Ok(true);
+            }
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        Some(observed) => {
+            LocalVaultStateV1::decode(&observed)?;
+            return Err(ApplicationError::AlreadyInitialized);
+        }
+        None => {}
+    }
+
+    match store.compare_exchange(locator, None, exact_prepared) {
+        Ok(()) => Ok(false),
+        Err(LocalStateStoreError::ConcurrentHost) => {
+            match store.load(locator).map_err(map_local_state_store)? {
+                Some(observed) if observed == exact_prepared => Ok(false),
+                Some(observed) if observed == exact_active => Ok(true),
+                _ => Err(ApplicationError::ConcurrentHost),
+            }
+        }
+        Err(error) => Err(map_local_state_store(error)),
+    }
+}
+
+fn install_active_state(
+    store: &dyn LocalStateStore,
+    locator: BootstrapLocator,
+    exact_prepared: &[u8],
+    exact_active: &[u8],
+    intended_active: ActiveStateV1,
+) -> Result<ActiveStateV1, ApplicationError> {
+    match store.compare_exchange(locator, Some(exact_prepared), exact_active) {
+        Ok(()) => Ok(intended_active),
+        Err(LocalStateStoreError::ConcurrentHost) => {
+            match store.load(locator).map_err(map_local_state_store)? {
+                Some(observed) if observed == exact_active => Ok(intended_active),
+                _ => Err(ApplicationError::ConcurrentHost),
+            }
+        }
+        Err(error) => Err(map_local_state_store(error)),
+    }
+}
+
+fn map_bootstrap_store(error: BootstrapStoreError) -> ApplicationError {
+    match error {
+        BootstrapStoreError::Unavailable => ApplicationError::StorageUnavailable,
+        BootstrapStoreError::Conflict | BootstrapStoreError::Corruption => {
+            ApplicationError::IntegrityFailure
+        }
+    }
+}
+
+fn map_local_state_store(error: LocalStateStoreError) -> ApplicationError {
+    match error {
+        LocalStateStoreError::Unavailable => ApplicationError::StorageUnavailable,
+        LocalStateStoreError::ConcurrentHost => ApplicationError::ConcurrentHost,
+        LocalStateStoreError::Corruption => ApplicationError::IntegrityFailure,
+    }
+}
+
+fn map_application_repository(error: ApplicationRepositoryError) -> ApplicationError {
+    match error {
+        ApplicationRepositoryError::NotInitialized => ApplicationError::NotInitialized,
+        ApplicationRepositoryError::InvalidInput => ApplicationError::InvalidInput,
+        ApplicationRepositoryError::BoundExceeded => ApplicationError::BoundExceeded,
+        ApplicationRepositoryError::StorageUnavailable => ApplicationError::StorageUnavailable,
+        ApplicationRepositoryError::IntegrityFailure => ApplicationError::IntegrityFailure,
+    }
+}
+
 fn wrap_root_key(
     passphrase: &[u8],
     kdf: &Argon2idParametersV1,
@@ -594,8 +745,130 @@ mod tests {
     use coding_adventures_argon2id::argon2id;
     use coding_adventures_chacha20_poly1305::xchacha20_poly1305_aead_decrypt;
     use coding_adventures_ed25519::verify;
-    use coding_adventures_vault_pm_format::BootstrapV1;
-    use coding_adventures_vault_pm_storage::InMemoryObjectStore;
+    use coding_adventures_vault_pm_format::{BootstrapId, BootstrapV1};
+    use coding_adventures_vault_pm_storage::{
+        FaultAction, FaultEffect, FaultInjectingObjectStore, InMemoryObjectStore, StoreError,
+        StoreOperation,
+    };
+    use std::sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc, Mutex,
+    };
+
+    #[derive(Default)]
+    struct MemoryLocalStateStore {
+        state: Mutex<Option<Vec<u8>>>,
+        compare_calls: AtomicUsize,
+        fail_compare_call: AtomicUsize,
+    }
+
+    impl MemoryLocalStateStore {
+        fn fail_compare_call(&self, call: usize) {
+            self.fail_compare_call.store(call, Ordering::SeqCst);
+        }
+
+        fn stored(&self) -> Option<Vec<u8>> {
+            self.state.lock().unwrap().clone()
+        }
+    }
+
+    impl LocalStateStore for MemoryLocalStateStore {
+        fn load(
+            &self,
+            _locator: BootstrapLocator,
+        ) -> Result<Option<Vec<u8>>, LocalStateStoreError> {
+            Ok(self.stored())
+        }
+
+        fn compare_exchange(
+            &self,
+            _locator: BootstrapLocator,
+            expected: Option<&[u8]>,
+            replacement: &[u8],
+        ) -> Result<(), LocalStateStoreError> {
+            let call = self.compare_calls.fetch_add(1, Ordering::SeqCst) + 1;
+            if self.fail_compare_call.load(Ordering::SeqCst) == call {
+                return Err(LocalStateStoreError::Unavailable);
+            }
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| LocalStateStoreError::Unavailable)?;
+            if state.as_deref() != expected {
+                return Err(LocalStateStoreError::ConcurrentHost);
+            }
+            *state = Some(replacement.to_vec());
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct MemoryBootstrapStore {
+        bootstrap: Mutex<Option<Vec<u8>>>,
+        put_calls: AtomicUsize,
+        fail_next_put: AtomicBool,
+        corrupt_next_read: AtomicBool,
+    }
+
+    impl MemoryBootstrapStore {
+        fn fail_next_put(&self) {
+            self.fail_next_put.store(true, Ordering::SeqCst);
+        }
+
+        fn corrupt_next_read(&self) {
+            self.corrupt_next_read.store(true, Ordering::SeqCst);
+        }
+
+        fn put_calls(&self) -> usize {
+            self.put_calls.load(Ordering::SeqCst)
+        }
+
+        fn stored(&self) -> Option<Vec<u8>> {
+            self.bootstrap.lock().unwrap().clone()
+        }
+    }
+
+    impl BootstrapStore for MemoryBootstrapStore {
+        fn load_latest(
+            &self,
+            _locator: BootstrapLocator,
+        ) -> Result<Option<Vec<u8>>, BootstrapStoreError> {
+            let mut value = self.stored();
+            if self.corrupt_next_read.swap(false, Ordering::SeqCst) {
+                if let Some(bytes) = &mut value {
+                    bytes[0] ^= 1;
+                }
+            }
+            Ok(value)
+        }
+
+        fn put_generation(
+            &self,
+            _locator: BootstrapLocator,
+            expected_previous: Option<BootstrapId>,
+            exact_bootstrap: &[u8],
+        ) -> Result<(), BootstrapStoreError> {
+            self.put_calls.fetch_add(1, Ordering::SeqCst);
+            if expected_previous.is_some() {
+                return Err(BootstrapStoreError::Conflict);
+            }
+            if self.fail_next_put.swap(false, Ordering::SeqCst) {
+                return Err(BootstrapStoreError::Unavailable);
+            }
+            let mut bootstrap = self
+                .bootstrap
+                .lock()
+                .map_err(|_| BootstrapStoreError::Unavailable)?;
+            match &*bootstrap {
+                Some(existing) if existing == exact_bootstrap => Ok(()),
+                Some(_) => Err(BootstrapStoreError::Conflict),
+                None => {
+                    *bootstrap = Some(exact_bootstrap.to_vec());
+                    Ok(())
+                }
+            }
+        }
+    }
 
     fn fixture_randomness() -> GenerationZeroRandomness {
         let mut bytes = [0; GENERATION_ZERO_RANDOM_BYTES];
@@ -607,6 +880,23 @@ mod tests {
 
     fn policy() -> GenerationZeroPolicyV1 {
         GenerationZeroPolicyV1::new(8 * 1024, 1, 1, 1_700_000_000_000).unwrap()
+    }
+
+    fn prepared(passphrase: &[u8]) -> PreparedGenerationZero {
+        prepare_generation_zero(
+            Zeroizing::new(passphrase.to_vec()),
+            policy(),
+            fixture_randomness(),
+        )
+        .unwrap()
+    }
+
+    fn rehydrated(passphrase: &[u8], store: &MemoryLocalStateStore) -> PreparedGenerationZero {
+        rehydrate_prepared_init(
+            Zeroizing::new(passphrase.to_vec()),
+            LocalVaultStateV1::decode(&store.stored().unwrap()).unwrap(),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -834,6 +1124,232 @@ mod tests {
         assert_eq!(
             rehydrate_prepared_init(Zeroizing::new(passphrase.to_vec()), mismatched_state).err(),
             Some(ApplicationError::IntegrityFailure)
+        );
+    }
+
+    #[test]
+    fn completion_persists_first_finishes_exactly_and_is_idempotent() {
+        let passphrase = b"completion passphrase";
+        let initial = prepared(passphrase);
+        let expected_active = match initial.owner_state() {
+            LocalVaultStateV1::PreparedInit(journal) => journal.intended_active().clone(),
+            _ => panic!("generation zero must be prepared"),
+        };
+        let expected_bootstrap = match initial.owner_state() {
+            LocalVaultStateV1::PreparedInit(journal) => journal.bootstrap().to_vec(),
+            _ => unreachable!(),
+        };
+        let local = MemoryLocalStateStore::default();
+        let bootstrap = MemoryBootstrapStore::default();
+        let factory = V1ApplicationRepositoryFactory::new(InMemoryObjectStore::new());
+
+        let active = complete_generation_zero(initial, &local, &bootstrap, &factory).unwrap();
+        assert_eq!(active, expected_active);
+        assert_eq!(bootstrap.stored(), Some(expected_bootstrap));
+        assert_eq!(
+            LocalVaultStateV1::decode(&local.stored().unwrap()).unwrap(),
+            LocalVaultStateV1::Active(expected_active.clone())
+        );
+
+        let put_calls = bootstrap.put_calls();
+        assert_eq!(
+            complete_generation_zero(prepared(passphrase), &local, &bootstrap, &factory).unwrap(),
+            expected_active
+        );
+        assert_eq!(bootstrap.put_calls(), put_calls);
+    }
+
+    #[test]
+    fn completion_performs_no_external_effect_when_prepared_state_is_not_durable() {
+        let local = MemoryLocalStateStore::default();
+        local.fail_compare_call(1);
+        let bootstrap = MemoryBootstrapStore::default();
+        let factory = V1ApplicationRepositoryFactory::new(InMemoryObjectStore::new());
+
+        assert_eq!(
+            complete_generation_zero(prepared(b"persist-first"), &local, &bootstrap, &factory,)
+                .err(),
+            Some(ApplicationError::StorageUnavailable)
+        );
+        assert_eq!(local.stored(), None);
+        assert_eq!(bootstrap.put_calls(), 0);
+    }
+
+    #[test]
+    fn completion_resumes_exactly_after_bootstrap_and_readback_failures() {
+        let passphrase = b"bootstrap recovery";
+        for corrupt_readback in [false, true] {
+            let local = MemoryLocalStateStore::default();
+            let bootstrap = MemoryBootstrapStore::default();
+            if corrupt_readback {
+                bootstrap.corrupt_next_read();
+            } else {
+                bootstrap.fail_next_put();
+            }
+            let factory = V1ApplicationRepositoryFactory::new(InMemoryObjectStore::new());
+
+            let error =
+                complete_generation_zero(prepared(passphrase), &local, &bootstrap, &factory).err();
+            assert_eq!(
+                error,
+                Some(if corrupt_readback {
+                    ApplicationError::IntegrityFailure
+                } else {
+                    ApplicationError::StorageUnavailable
+                })
+            );
+            assert!(matches!(
+                LocalVaultStateV1::decode(&local.stored().unwrap()).unwrap(),
+                LocalVaultStateV1::PreparedInit(_)
+            ));
+
+            complete_generation_zero(rehydrated(passphrase, &local), &local, &bootstrap, &factory)
+                .unwrap();
+            assert!(matches!(
+                LocalVaultStateV1::decode(&local.stored().unwrap()).unwrap(),
+                LocalVaultStateV1::Active(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn completion_recovers_exact_publication_after_provider_failures() {
+        let passphrase = b"repository recovery";
+        for fault in [
+            FaultAction {
+                operation: StoreOperation::Initialize,
+                effect: FaultEffect::Return(StoreError::Network),
+            },
+            FaultAction {
+                operation: StoreOperation::PutImmutable,
+                effect: FaultEffect::CommitPutThenNetwork,
+            },
+        ] {
+            let local = MemoryLocalStateStore::default();
+            let bootstrap = MemoryBootstrapStore::default();
+            let backend = Arc::new(FaultInjectingObjectStore::new(InMemoryObjectStore::new()));
+            backend.enqueue(fault).unwrap();
+            let factory = V1ApplicationRepositoryFactory::from_shared(Arc::clone(&backend));
+
+            assert_eq!(
+                complete_generation_zero(prepared(passphrase), &local, &bootstrap, &factory,).err(),
+                Some(ApplicationError::StorageUnavailable)
+            );
+            assert!(matches!(
+                LocalVaultStateV1::decode(&local.stored().unwrap()).unwrap(),
+                LocalVaultStateV1::PreparedInit(_)
+            ));
+
+            complete_generation_zero(rehydrated(passphrase, &local), &local, &bootstrap, &factory)
+                .unwrap();
+            assert_eq!(backend.pending_faults().unwrap(), 0);
+            assert!(matches!(
+                LocalVaultStateV1::decode(&local.stored().unwrap()).unwrap(),
+                LocalVaultStateV1::Active(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn completion_recovers_after_active_compare_exchange_failure() {
+        let passphrase = b"local commit recovery";
+        let local = MemoryLocalStateStore::default();
+        local.fail_compare_call(2);
+        let bootstrap = MemoryBootstrapStore::default();
+        let factory = V1ApplicationRepositoryFactory::new(InMemoryObjectStore::new());
+
+        assert_eq!(
+            complete_generation_zero(prepared(passphrase), &local, &bootstrap, &factory,).err(),
+            Some(ApplicationError::StorageUnavailable)
+        );
+        assert!(matches!(
+            LocalVaultStateV1::decode(&local.stored().unwrap()).unwrap(),
+            LocalVaultStateV1::PreparedInit(_)
+        ));
+
+        complete_generation_zero(rehydrated(passphrase, &local), &local, &bootstrap, &factory)
+            .unwrap();
+        assert!(matches!(
+            LocalVaultStateV1::decode(&local.stored().unwrap()).unwrap(),
+            LocalVaultStateV1::Active(_)
+        ));
+    }
+
+    #[test]
+    fn completion_rejects_occupied_or_corrupt_local_state_before_external_effects() {
+        for (occupied, expected) in [
+            (
+                prepared(b"different initialization")
+                    .owner_state()
+                    .encode()
+                    .unwrap(),
+                ApplicationError::AlreadyInitialized,
+            ),
+            (vec![0xff], ApplicationError::IntegrityFailure),
+        ] {
+            let local = MemoryLocalStateStore::default();
+            *local.state.lock().unwrap() = Some(occupied);
+            let bootstrap = MemoryBootstrapStore::default();
+            let factory = V1ApplicationRepositoryFactory::new(InMemoryObjectStore::new());
+
+            assert_eq!(
+                complete_generation_zero(
+                    prepared(b"requested initialization"),
+                    &local,
+                    &bootstrap,
+                    &factory,
+                )
+                .err(),
+                Some(expected)
+            );
+            assert_eq!(bootstrap.put_calls(), 0);
+        }
+    }
+
+    #[test]
+    fn completion_error_translation_is_closed() {
+        assert_eq!(
+            [
+                BootstrapStoreError::Unavailable,
+                BootstrapStoreError::Conflict,
+                BootstrapStoreError::Corruption,
+            ]
+            .map(map_bootstrap_store),
+            [
+                ApplicationError::StorageUnavailable,
+                ApplicationError::IntegrityFailure,
+                ApplicationError::IntegrityFailure,
+            ]
+        );
+        assert_eq!(
+            [
+                LocalStateStoreError::Unavailable,
+                LocalStateStoreError::ConcurrentHost,
+                LocalStateStoreError::Corruption,
+            ]
+            .map(map_local_state_store),
+            [
+                ApplicationError::StorageUnavailable,
+                ApplicationError::ConcurrentHost,
+                ApplicationError::IntegrityFailure,
+            ]
+        );
+        assert_eq!(
+            [
+                ApplicationRepositoryError::NotInitialized,
+                ApplicationRepositoryError::InvalidInput,
+                ApplicationRepositoryError::BoundExceeded,
+                ApplicationRepositoryError::StorageUnavailable,
+                ApplicationRepositoryError::IntegrityFailure,
+            ]
+            .map(map_application_repository),
+            [
+                ApplicationError::NotInitialized,
+                ApplicationError::InvalidInput,
+                ApplicationError::BoundExceeded,
+                ApplicationError::StorageUnavailable,
+                ApplicationError::IntegrityFailure,
+            ]
         );
     }
 

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -24,8 +24,9 @@ pub use crypto::{
     ObjectKind, ObjectRandomness, V1Keys,
 };
 pub use initialize::{
-    prepare_generation_zero, rehydrate_prepared_init, GenerationZeroPolicyV1,
-    GenerationZeroRandomness, PreparedGenerationZero, GENERATION_ZERO_RANDOM_BYTES,
+    complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init,
+    GenerationZeroPolicyV1, GenerationZeroRandomness, PreparedGenerationZero,
+    GENERATION_ZERO_RANDOM_BYTES,
 };
 pub use repository::{
     ApplicationRepository, ApplicationRepositoryError, ApplicationRepositoryFactory,

--- a/code/packages/rust/vault-pm-application/src/state.rs
+++ b/code/packages/rust/vault-pm-application/src/state.rs
@@ -564,6 +564,8 @@ pub trait BootstrapStore: Send + Sync {
     ) -> Result<Option<Vec<u8>>, BootstrapStoreError>;
 
     /// Immutably install one generation after the expected predecessor.
+    /// Repeating the exact already-installed generation is idempotent success;
+    /// the same generation with different bytes is a conflict.
     fn put_generation(
         &self,
         locator: BootstrapLocator,

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1282,8 +1282,9 @@ changelog, focused build, and downstream validation.
    5a. passphrase-authenticated `PreparedInit` rehydration after process loss,
        re-deriving the same repository address and proving local private seeds
        reproduce every pinned bootstrap/certificate public identity;
-   6. crash-resumable initialization side effects, open/unlock, and pending
-      publication recovery; and
+   6. crash-resumable generation-zero bootstrap, repository-publication, and
+      local activation side effects;
+   6a. active open/unlock and pending-publication recovery; and
    7. item mutation, redacted views, search, history, export, audit, status,
       and doctor workflows.
 9. `vault-pm-cli` + real executable and pseudo-terminal E2E suite.


### PR DESCRIPTION
## Summary

- add one provider-neutral generation-zero completion workflow for first execution and restart recovery
- persist exact `PreparedInit` locally before bootstrap or repository effects
- idempotently install/read back the bootstrap, initialize and publish the exact repository journal, verify returned pins, then compare-exchange to `Active`
- recover from bootstrap, ambiguous provider, repository initialization/publication, and final local activation failures without regenerating bytes
- split the remaining Phase 1A backlog so active open/unlock and pending recovery are the next bounded slice

## Validation

- `cargo test` (47 tests)
- `cargo clippy --all-targets -- -D warnings`
- `cargo doc --no-deps`
- `bash BUILD`
- `python3 code/scripts/tests/test_capability_taxonomy.py`
- Tarpaulin LLVM: 1,386/1,431 production lines (96.86%); initialize module 365/378
- affected build: 1,000 discovered, 1 changed, 19 affected, all 19 built
