### PR TITLE
Report cells that imply table rows

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Table-body recovery now reports the current-Standard parse error when a `td`
+  or `th` start tag requires an implied row, while preserving the existing DOM
+  recovery and leaving cells already processed in row or template mode quiet.
 - Table-structure start tags and `table` end tags that close a caption now
   report the current-Standard parse error when implied-end-tag generation
   leaves a non-caption node current. Caption-scoped `table` end tags also close

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -94,6 +94,10 @@ Prioritized work items:
    starts. Caption recovery now reports when a table-structure start tag or
    `table` end tag closes the caption while a non-implied node remains current;
    caption-scoped table endings now reprocess after closing the caption.
+   Cell start tags now report when table-body recovery must synthesize a
+   missing row, matching the current Standard and WPT's
+   `unexpected-cell-in-table-body` evidence while leaving normal row and
+   template-mode cells quiet.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -7285,6 +7285,16 @@ impl HtmlParser {
                 self.close_open_table_context_element_if(|name| {
                     name == "caption" || name == "colgroup"
                 });
+                if self.current_element_is("table")
+                    || self.current_element_name().is_some_and(is_table_section)
+                {
+                    self.diagnostics.push(ParserDiagnostic::new(
+                        "unexpected-cell-start-tag-in-table-body",
+                        format!(
+                            "start tag `<{incoming_name}>` in a table body context implied a missing row"
+                        ),
+                    ));
+                }
                 if self.current_element_is("table") {
                     self.append_implied_element("tbody");
                 }
@@ -31387,6 +31397,42 @@ mod tests {
             element(&second_row.children[0]).children,
             vec![Node::text("C")]
         );
+    }
+
+    #[test]
+    fn reports_cells_that_require_an_implied_table_row() {
+        for (source, name) in [
+            ("<!doctype html><table><td>A</td></table>", "td"),
+            (
+                "<!doctype html><table><tbody><th>A</th></tbody></table>",
+                "th",
+            ),
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert_eq!(
+                output.parser_diagnostics,
+                vec![ParserDiagnostic::new(
+                    "unexpected-cell-start-tag-in-table-body",
+                    format!("start tag `<{name}>` in a table body context implied a missing row"),
+                )],
+                "source {source:?}"
+            );
+
+            let table = element(&body(&output.document).children[0]);
+            let tbody = element(&table.children[0]);
+            let row = element(&tbody.children[0]);
+            assert_eq!(element(&row.children[0]).name, name);
+        }
+
+        for source in [
+            "<!doctype html><table><tr><td>A</td></tr></table>",
+            "<!doctype html><template><td>A</td></template>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output.parser_diagnostics.iter().all(|diagnostic| {
+                diagnostic.code != "unexpected-cell-start-tag-in-table-body"
+            }));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report the current-Standard parse error when `td` or `th` starts in table-body mode without a current row
- preserve the existing implied `tbody`/`tr` DOM recovery
- keep normal row cells and template-mode cells diagnostic-free
- record the WPT `unexpected-cell-in-table-body` evidence in the conformance backlog

## Evidence
Current HTML Standard, "in table body" insertion mode: a `td` or `th` start tag is a parse error before synthesizing and reprocessing an implied `tr`. WPT `tables01.dat` covers both `<table><td>` and `<table><th>` with `unexpected-cell-in-table-body`; the parser already matched their DOM but did not emit this branch diagnostic.

## Validation
- live WPT/html5lib coverage audit at WPT `54f8f933629e7c010ae98a246729af01f8abcda5` and html5lib-tests `224991ec10db04f056a89eed8b0bd8695fd2950e`: zero missing, zero normalized skips, checked report matches
- `CARGO_BUILD_JOBS=2 cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p coding-adventures-html-lexer`
- parser fixture smoke, manifest, coverage, Rust-test guards, and Python audit unit tests
- `CARGO_BUILD_JOBS=2 cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `git diff --check`
- `cargo fmt -p coding-adventures-html-parser -- --check` still reports repository-wide pre-existing drift; no changed line remains in its formatter diff
- generated `Cargo.lock`, fixture `__pycache__`, and disposable `target` data removed