### PR TITLE
Reopen active vaults securely

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this package are documented here.
 
+## [0.8.0] - 2026-08-09
+
+### Added
+
+- Add authenticated active-vault reopen from injected local/bootstrap stores,
+  including exact signed-bootstrap pin checks, passphrase root unwrap, private
+  identity re-derivation, opaque repository connection, and verified open from
+  non-empty local head pins.
+- Add a wipe-on-drop `UnlockedVaultV1` session boundary with redacted ordinary
+  diagnostics and payload-free verified-open metadata.
+
+### Security
+
+- Refuse missing, malformed, unsigned, rolled-back, cross-vault, or locally
+  unpinned bootstrap state before repository access.
+- Anchor complete repository discovery to durable non-empty head pins and keep
+  provider-specific failures outside the closed application error surface.
+
 ## [0.7.0] - 2026-08-09
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -34,10 +34,18 @@ the first external write, performs idempotent bootstrap and repository work,
 verifies the exact resulting pins, and compare-exchanges to `Active`. A retry
 after any failure rehydrates and reuses the same signed and randomized journal.
 
+Stable active vaults can also be reopened from only their durable locator and
+injected stores. Reopen strictly decodes local state, requires the exact latest
+authority-signed bootstrap pinned locally, authenticates the passphrase root
+wrap, reproduces every persisted public identity from encrypted local seeds,
+derives the opaque repository address, and performs a complete repository open
+relative to non-empty local head pins. The returned session owns wipe-on-drop
+keys and exposes only identities, pins, and the payload-free verified report.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
-credential store, or entropy source. Active open/unlock, pending-publication
-recovery, and session workflows land in the next slices. There is no unchecked
+credential store, or entropy source. Pending-publication recovery and catalog
+session workflows land in the next slices. There is no unchecked
 repository verification path: construction decrypts and
 authority-verifies the exact locally pinned certificate frame and object ID,
 and commits and announcements must match that vault, device, certificate ID,
@@ -45,7 +53,7 @@ and Ed25519 key.
 
 ## Verification
 
-The package has 47 tests covering exact canonical and cryptographic vectors,
+The package has 51 tests covering exact canonical and cryptographic vectors,
 lossless removed-value persistence, live and tombstone revisions, catalog
 bounds and ordering, cross-kind and cross-vault rejection, AEAD tampering,
 authority/device/certificate binding, Ed25519 signature rejection, closed
@@ -53,9 +61,7 @@ parser failures, crash-state relationship checks, diagnostic redaction, and
 explicit key wiping. Repository tests additionally exercise initialization,
 publication, verified open/read/history, every injected provider operation,
 constructor paths, and complete error translation. The exact Tarpaulin result
-under its LLVM engine is 1,386 of 1,431 production lines (96.86%); the
-generation-zero preparation, rehydration, and completion module covers 365 of
-378 lines.
+under its LLVM engine is 1,443 of 1,510 production lines (95.56%).
 
 ## Development
 

--- a/code/packages/rust/vault-pm-application/required_capabilities.json
+++ b/code/packages/rust/vault-pm-application/required_capabilities.json
@@ -3,5 +3,5 @@
   "version": 1,
   "package": "rust/vault-pm-application",
   "capabilities": [],
-  "justification": "Pure canonical persistence, crash-state contracts, deterministic generation-zero construction, injected crash-resumable effect sequencing, cryptographic framing, and verified repository composition over caller-provided stores, keys, time, and CSPRNG material. Store traits inject byte operations but the package owns no filesystem, network, process, environment, clock, provider, credential-store, or entropy authority."
+  "justification": "Pure canonical persistence, crash-state contracts, deterministic generation-zero construction, injected crash-resumable effect sequencing, authenticated active reopen, cryptographic framing, and verified repository composition over caller-provided stores, keys, time, and CSPRNG material. Store traits inject byte operations but the package owns no filesystem, network, process, environment, clock, provider, credential-store, or entropy authority."
 }

--- a/code/packages/rust/vault-pm-application/src/initialize.rs
+++ b/code/packages/rust/vault-pm-application/src/initialize.rs
@@ -10,7 +10,7 @@ use coding_adventures_argon2id::{argon2id, Options as Argon2idOptions};
 use coding_adventures_chacha20_poly1305::{
     xchacha20_poly1305_aead_decrypt, xchacha20_poly1305_aead_encrypt,
 };
-use coding_adventures_ed25519::{generate_keypair, sign};
+use coding_adventures_ed25519::{generate_keypair, is_valid_public_key, sign, verify};
 use coding_adventures_vault_pm_format::{
     AeadEnvelopeV1, AnnouncementV1, Argon2idParametersV1, BootstrapV1, CommitV1,
     DeviceCertificateV1, DeviceId, PublicKey, Signature, VaultId, CRYPTO_SUITE_V1,
@@ -147,6 +147,13 @@ pub struct PreparedGenerationZero {
     owner_state: LocalVaultStateV1,
     repository_address: RepositoryAddress,
     verifier: V1SingleDeviceVerifier,
+}
+
+pub(crate) struct UnlockedActiveMaterial {
+    pub repository_address: RepositoryAddress,
+    pub keys: V1Keys,
+    pub local_secret: LocalSecretV1,
+    pub verifier: V1SingleDeviceVerifier,
 }
 
 impl PreparedGenerationZero {
@@ -395,10 +402,46 @@ pub fn rehydrate_prepared_init(
         return Err(ApplicationError::InvalidInput);
     };
     let active = prepared.intended_active();
-    let bootstrap = BootstrapV1::decode(prepared.bootstrap())
+    let material = unlock_active_material(passphrase, active, prepared.bootstrap())?;
+
+    Ok(PreparedGenerationZero {
+        bootstrap_locator: active.bootstrap_locator(),
+        owner_state,
+        repository_address: material.repository_address,
+        verifier: material.verifier,
+    })
+}
+
+pub(crate) fn unlock_active_material(
+    passphrase: Zeroizing<Vec<u8>>,
+    active: &ActiveStateV1,
+    exact_bootstrap: &[u8],
+) -> Result<UnlockedActiveMaterial, ApplicationError> {
+    let bootstrap =
+        BootstrapV1::decode(exact_bootstrap).map_err(|_| ApplicationError::IntegrityFailure)?;
+    let bootstrap_id = bootstrap
+        .id()
         .map_err(|_| ApplicationError::IntegrityFailure)?;
+    let bootstrap_preimage = bootstrap
+        .signing_preimage()
+        .map_err(|_| ApplicationError::IntegrityFailure)?;
+    if !is_valid_public_key(bootstrap.authority_public_key.as_bytes())
+        || !verify(
+            &bootstrap_preimage,
+            bootstrap.signature.as_bytes(),
+            bootstrap.authority_public_key.as_bytes(),
+        )
+        || bootstrap_id != active.bootstrap_id()
+        || bootstrap.vault_id != active.vault_id()
+        || AuthorityFingerprint::for_public_key(bootstrap.authority_public_key)
+            != active.authority_fingerprint()
+    {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+
     let vault_root_key = unwrap_root_key(&passphrase, &bootstrap)?;
     let keys = V1Keys::derive(bootstrap.vault_id, &vault_root_key)?;
+    let verifier_keys = V1Keys::derive(bootstrap.vault_id, &vault_root_key)?;
     let repository_address = RepositoryAddress::derive(keys.locator_key());
     let local_secret = open_local_secret(&keys, active.local_secret())?;
 
@@ -437,16 +480,16 @@ pub fn rehydrate_prepared_init(
     }
 
     let verifier = V1SingleDeviceVerifier::authorize(
-        keys,
+        verifier_keys,
         authority_public,
         active.device_certificate_id(),
         active.device_certificate_frame(),
     )?;
 
-    Ok(PreparedGenerationZero {
-        bootstrap_locator: active.bootstrap_locator(),
-        owner_state,
+    Ok(UnlockedActiveMaterial {
         repository_address,
+        keys,
+        local_secret,
         verifier,
     })
 }

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -10,6 +10,7 @@
 mod codec;
 mod crypto;
 mod initialize;
+mod open;
 mod repository;
 mod state;
 mod verifier;
@@ -28,6 +29,7 @@ pub use initialize::{
     GenerationZeroPolicyV1, GenerationZeroRandomness, PreparedGenerationZero,
     GENERATION_ZERO_RANDOM_BYTES,
 };
+pub use open::{open_active_vault, UnlockedVaultV1};
 pub use repository::{
     ApplicationRepository, ApplicationRepositoryError, ApplicationRepositoryFactory,
     V1ApplicationRepositoryFactory,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1,0 +1,340 @@
+use crate::initialize::unlock_active_material;
+use crate::{
+    ActiveStateV1, ApplicationError, ApplicationRepository, ApplicationRepositoryError,
+    ApplicationRepositoryFactory, BootstrapLocator, BootstrapStore, BootstrapStoreError,
+    LocalSecretV1, LocalStateStore, LocalStateStoreError, LocalVaultStateV1, V1Keys,
+};
+use coding_adventures_vault_pm_format::{DeviceId, VaultId};
+use coding_adventures_vault_pm_repository::{OpenReport, PinnedHeads};
+use coding_adventures_zeroize::Zeroizing;
+use core::fmt::{self, Debug, Formatter};
+
+/// One authenticated active-vault session with live keys and a verified
+/// repository view.
+///
+/// Dropping the session wipes its application keys and owner/device secrets.
+/// The repository owns a separate wipe-on-drop verifier key set.
+pub struct UnlockedVaultV1 {
+    active: ActiveStateV1,
+    report: OpenReport,
+    _keys: V1Keys,
+    _local_secret: LocalSecretV1,
+    _repository: Box<dyn ApplicationRepository>,
+}
+
+impl UnlockedVaultV1 {
+    /// Return the authenticated vault identity.
+    pub const fn vault_id(&self) -> VaultId {
+        self.active.vault_id()
+    }
+
+    /// Return the authenticated local device identity.
+    pub const fn device_id(&self) -> DeviceId {
+        self.active.device_id()
+    }
+
+    /// Borrow the durable local head pins used to anchor this open.
+    pub const fn local_pins(&self) -> &PinnedHeads {
+        self.active.pinned_heads()
+    }
+
+    /// Borrow the complete payload-free verified repository report.
+    pub const fn open_report(&self) -> &OpenReport {
+        &self.report
+    }
+}
+
+impl Debug for UnlockedVaultV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("UnlockedVaultV1")
+            .field("local_pin_count", &self.active.pinned_heads().len())
+            .field("verified_head_count", &self.report.heads().len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Authenticated-reopen one stable `Active` vault from injected byte stores.
+///
+/// This slice deliberately accepts only `Active`; callers must complete a
+/// `PreparedInit` or recover a `PendingPublication` before invoking it. The
+/// latest bootstrap must exactly match the locally pinned signed generation,
+/// the passphrase must authenticate its root wrap, all private seeds must
+/// reproduce pinned public identities, and the repository must open relative
+/// to non-empty local pins.
+pub fn open_active_vault(
+    passphrase: Zeroizing<Vec<u8>>,
+    locator: BootstrapLocator,
+    local_state_store: &dyn LocalStateStore,
+    bootstrap_store: &dyn BootstrapStore,
+    repository_factory: &dyn ApplicationRepositoryFactory,
+) -> Result<UnlockedVaultV1, ApplicationError> {
+    let exact_state = local_state_store
+        .load(locator)
+        .map_err(map_local_state_store)?
+        .ok_or(ApplicationError::NotInitialized)?;
+    let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_state)? else {
+        return Err(ApplicationError::InvalidInput);
+    };
+    if active.bootstrap_locator() != locator {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+
+    let exact_bootstrap = bootstrap_store
+        .load_latest(locator)
+        .map_err(map_bootstrap_store)?
+        .ok_or(ApplicationError::IntegrityFailure)?;
+    let material = unlock_active_material(passphrase, &active, &exact_bootstrap)?;
+    let repository = repository_factory
+        .connect(material.repository_address, Box::new(material.verifier))
+        .map_err(map_repository)?;
+    repository.initialize().map_err(map_repository)?;
+    let report = repository
+        .open(active.pinned_heads())
+        .map_err(map_repository)?;
+    if report.fresh_device_unanchored() || report.heads().is_empty() {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+
+    Ok(UnlockedVaultV1 {
+        active,
+        report,
+        _keys: material.keys,
+        _local_secret: material.local_secret,
+        _repository: repository,
+    })
+}
+
+fn map_bootstrap_store(error: BootstrapStoreError) -> ApplicationError {
+    match error {
+        BootstrapStoreError::Unavailable => ApplicationError::StorageUnavailable,
+        BootstrapStoreError::Conflict | BootstrapStoreError::Corruption => {
+            ApplicationError::IntegrityFailure
+        }
+    }
+}
+
+fn map_local_state_store(error: LocalStateStoreError) -> ApplicationError {
+    match error {
+        LocalStateStoreError::Unavailable => ApplicationError::StorageUnavailable,
+        LocalStateStoreError::ConcurrentHost => ApplicationError::ConcurrentHost,
+        LocalStateStoreError::Corruption => ApplicationError::IntegrityFailure,
+    }
+}
+
+fn map_repository(error: ApplicationRepositoryError) -> ApplicationError {
+    match error {
+        ApplicationRepositoryError::NotInitialized => ApplicationError::NotInitialized,
+        ApplicationRepositoryError::InvalidInput => ApplicationError::InvalidInput,
+        ApplicationRepositoryError::BoundExceeded => ApplicationError::BoundExceeded,
+        ApplicationRepositoryError::StorageUnavailable => ApplicationError::StorageUnavailable,
+        ApplicationRepositoryError::IntegrityFailure => ApplicationError::IntegrityFailure,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        complete_generation_zero, prepare_generation_zero, GenerationZeroPolicyV1,
+        GenerationZeroRandomness, V1ApplicationRepositoryFactory, GENERATION_ZERO_RANDOM_BYTES,
+    };
+    use coding_adventures_vault_pm_format::BootstrapId;
+    use coding_adventures_vault_pm_storage::InMemoryObjectStore;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct MemoryLocalStateStore(Mutex<Option<Vec<u8>>>);
+
+    impl LocalStateStore for MemoryLocalStateStore {
+        fn load(
+            &self,
+            _locator: BootstrapLocator,
+        ) -> Result<Option<Vec<u8>>, LocalStateStoreError> {
+            Ok(self.0.lock().unwrap().clone())
+        }
+
+        fn compare_exchange(
+            &self,
+            _locator: BootstrapLocator,
+            expected: Option<&[u8]>,
+            replacement: &[u8],
+        ) -> Result<(), LocalStateStoreError> {
+            let mut state = self.0.lock().unwrap();
+            if state.as_deref() != expected {
+                return Err(LocalStateStoreError::ConcurrentHost);
+            }
+            *state = Some(replacement.to_vec());
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct MemoryBootstrapStore(Mutex<Option<Vec<u8>>>);
+
+    impl BootstrapStore for MemoryBootstrapStore {
+        fn load_latest(
+            &self,
+            _locator: BootstrapLocator,
+        ) -> Result<Option<Vec<u8>>, BootstrapStoreError> {
+            Ok(self.0.lock().unwrap().clone())
+        }
+
+        fn put_generation(
+            &self,
+            _locator: BootstrapLocator,
+            expected_previous: Option<BootstrapId>,
+            exact_bootstrap: &[u8],
+        ) -> Result<(), BootstrapStoreError> {
+            if expected_previous.is_some() {
+                return Err(BootstrapStoreError::Conflict);
+            }
+            let mut stored = self.0.lock().unwrap();
+            match &*stored {
+                Some(existing) if existing == exact_bootstrap => Ok(()),
+                Some(_) => Err(BootstrapStoreError::Conflict),
+                None => {
+                    *stored = Some(exact_bootstrap.to_vec());
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn randomness() -> GenerationZeroRandomness {
+        let mut bytes = [0; GENERATION_ZERO_RANDOM_BYTES];
+        for (index, byte) in bytes.iter_mut().enumerate() {
+            *byte = (index as u8).wrapping_mul(29).wrapping_add(7);
+        }
+        GenerationZeroRandomness::new(bytes)
+    }
+
+    fn initialized() -> (
+        BootstrapLocator,
+        MemoryLocalStateStore,
+        MemoryBootstrapStore,
+        V1ApplicationRepositoryFactory<InMemoryObjectStore>,
+    ) {
+        let passphrase = Zeroizing::new(b"active passphrase".to_vec());
+        let prepared = prepare_generation_zero(
+            passphrase,
+            GenerationZeroPolicyV1::new(8 * 1024, 1, 1, 10).unwrap(),
+            randomness(),
+        )
+        .unwrap();
+        let locator = prepared.bootstrap_locator();
+        let local = MemoryLocalStateStore::default();
+        let bootstrap = MemoryBootstrapStore::default();
+        let backend = Arc::new(InMemoryObjectStore::new());
+        let factory = V1ApplicationRepositoryFactory::from_shared(backend);
+        complete_generation_zero(prepared, &local, &bootstrap, &factory).unwrap();
+        (locator, local, bootstrap, factory)
+    }
+
+    #[test]
+    fn active_vault_reopens_from_only_durable_state() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+
+        assert_eq!(session.local_pins(), session.open_report().heads());
+        assert_eq!(session.open_report().announcement_count(), 1);
+        assert_eq!(session.open_report().commit_count(), 1);
+        assert!(!session.open_report().fresh_device_unanchored());
+        assert_eq!(
+            format!("{session:?}"),
+            "UnlockedVaultV1 { local_pin_count: 1, verified_head_count: 1, .. }"
+        );
+    }
+
+    #[test]
+    fn active_open_closes_wrong_passphrase_and_bootstrap_rollback() {
+        let (locator, local, bootstrap, factory) = initialized();
+        assert_eq!(
+            open_active_vault(
+                Zeroizing::new(b"wrong".to_vec()),
+                locator,
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .err(),
+            Some(ApplicationError::AuthenticationFailed)
+        );
+
+        bootstrap.0.lock().unwrap().as_mut().unwrap()[0] ^= 1;
+        assert_eq!(
+            open_active_vault(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                locator,
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .err(),
+            Some(ApplicationError::IntegrityFailure)
+        );
+    }
+
+    #[test]
+    fn active_open_requires_matching_locator_and_stable_state() {
+        let (locator, local, bootstrap, factory) = initialized();
+        assert_eq!(
+            open_active_vault(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                BootstrapLocator::new([0x99; 32]),
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .err(),
+            Some(ApplicationError::IntegrityFailure)
+        );
+
+        *local.0.lock().unwrap() = None;
+        assert_eq!(
+            open_active_vault(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                locator,
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .err(),
+            Some(ApplicationError::NotInitialized)
+        );
+    }
+
+    #[test]
+    fn active_open_rejects_unfinished_initialization() {
+        let prepared = prepare_generation_zero(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            GenerationZeroPolicyV1::new(8 * 1024, 1, 1, 10).unwrap(),
+            randomness(),
+        )
+        .unwrap();
+        let locator = prepared.bootstrap_locator();
+        let local =
+            MemoryLocalStateStore(Mutex::new(Some(prepared.owner_state().encode().unwrap())));
+        let bootstrap = MemoryBootstrapStore::default();
+        let factory = V1ApplicationRepositoryFactory::new(InMemoryObjectStore::new());
+
+        assert_eq!(
+            open_active_vault(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                locator,
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .err(),
+            Some(ApplicationError::InvalidInput)
+        );
+    }
+}

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1284,7 +1284,9 @@ changelog, focused build, and downstream validation.
        reproduce every pinned bootstrap/certificate public identity;
    6. crash-resumable generation-zero bootstrap, repository-publication, and
       local activation side effects;
-   6a. active open/unlock and pending-publication recovery; and
+   6a. authenticated active-state unlock and verified repository open;
+   6b. exact pending-publication recovery and durable active-state advancement;
+   6c. current catalog/revision materialization into an unlocked session; and
    7. item mutation, redacted views, search, history, export, audit, status,
       and doctor workflows.
 9. `vault-pm-cli` + real executable and pseudo-terminal E2E suite.


### PR DESCRIPTION
## Summary
- add authenticated active-state reopen from durable local and bootstrap stores
- verify signed bootstrap pins, passphrase root unwrap, and re-derived owner/device identities before repository access
- return a wipe-on-drop session after a complete repository open anchored to non-empty local heads
- split pending-publication replay and catalog materialization into the next prioritized backlog slices

## Verification
- 51 vault-pm-application tests pass
- strict Clippy and rustdoc pass
- Tarpaulin LLVM coverage: 1,443 / 1,510 production lines (95.56%)
- affected planner: 1 changed, 19 affected, all 19 built
- manual security review: closed error mapping, redacted diagnostics, authenticated bootstrap-before-KDF, pinned repository open