### PR TITLE
Report nested table start recovery

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- A `table` start tag processed in table mode now reports the current-Standard
+  parse error before closing the open table and reprocessing the token. Nested
+  tables inside cells remain valid and diagnostic-free.
 - Table-body recovery now reports the current-Standard parse error when a `td`
   or `th` start tag requires an implied row, while preserving the existing DOM
   recovery and leaving cells already processed in row or template mode quiet.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -98,6 +98,10 @@ Prioritized work items:
    missing row, matching the current Standard and WPT's
    `unexpected-cell-in-table-body` evidence while leaving normal row and
    template-mode cells quiet.
+   Nested `table` start tags now report before table-mode recovery closes the
+   open table and reprocesses the token, matching the minimal WPT
+   `tests6.dat` `<table><table>` evidence while leaving tables nested inside
+   cells quiet.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5313,6 +5313,10 @@ impl HtmlParser {
         }
 
         if !in_foreign_content && name == "table" && self.current_element_is_table_structure() {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-table-start-tag-in-table",
+                "table start tag closed and replaced the open table",
+            ));
             self.close_element("table");
         }
 
@@ -31433,6 +31437,33 @@ mod tests {
                 diagnostic.code != "unexpected-cell-start-tag-in-table-body"
             }));
         }
+    }
+
+    #[test]
+    fn reports_table_start_tags_that_replace_an_open_table() {
+        let output = parse_html_with_diagnostics("<!doctype html><table><table></table>").unwrap();
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![ParserDiagnostic::new(
+                "unexpected-table-start-tag-in-table",
+                "table start tag closed and replaced the open table",
+            )]
+        );
+
+        let children = &body(&output.document).children;
+        assert_eq!(children.len(), 2);
+        assert_eq!(element(&children[0]).name, "table");
+        assert_eq!(element(&children[1]).name, "table");
+        assert!(element(&children[1]).children.is_empty());
+
+        let nested_cell = parse_html_with_diagnostics(
+            "<!doctype html><table><tr><td><table>A</table></td></tr></table>",
+        )
+        .unwrap();
+        assert!(nested_cell
+            .parser_diagnostics
+            .iter()
+            .all(|diagnostic| { diagnostic.code != "unexpected-table-start-tag-in-table" }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report the current-Standard parse error when a nested `table` start tag closes and replaces the open table
- retain the existing conforming DOM recovery and keep tables nested inside cells quiet
- record the WPT `tests6.dat` evidence and reprioritized table/template audit boundary

## Validation
- live WPT/html5lib coverage audit: 1,934 tree cases, 6,806 tokenizer cases, zero missing, 7,242 normalized cases, zero skipped
- `cargo test` in `code/packages/rust/html-parser`
- `cargo test` in `code/packages/rust/html-lexer`
- all four checked parser audit guard scripts
- `python3 code/packages/rust/html-parser/tests/fixtures/test_html_conformance_coverage_audit.py`
- `cargo clippy --all-targets -- -D warnings` in the parser crate
- `git diff --check`

## Formatting note
`cargo fmt -- --check` still reports pre-existing repository-wide drift in parser and audit-test files. The new and changed lines were manually aligned with rustfmt; no remaining rustfmt hunk touches this patch.