### PR TITLE
Add exact Reolink NVR credential pairing

### DIFF
--- a/code/packages/rust/smart-home-reolink-integration/CHANGELOG.md
+++ b/code/packages/rust/smart-home-reolink-integration/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.0
+
+- Retain documented `GetDevInfo.exactType` and per-channel
+  `GetChannelstatus.typeInfo`, excluding empty NVR slots from installed camera
+  state.
+- Add pairing-only `GetAbility` inspection and bind each NVR physical channel's
+  JPEG snapshot support to its documented `abilityChn.snap` version and execute
+  permission.
+
 ## 0.4.1
 
 - Add reviewed-socket pinning for HTTP loopback tests and certificate-verifying

--- a/code/packages/rust/smart-home-reolink-integration/Cargo.toml
+++ b/code/packages/rust/smart-home-reolink-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smart-home-reolink-integration"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "Authenticated Reolink camera and NVR CGI inspection and recording control for the smart-home runtime"
 license = "MIT"

--- a/code/packages/rust/smart-home-reolink-integration/README.md
+++ b/code/packages/rust/smart-home-reolink-integration/README.md
@@ -4,11 +4,12 @@ This package connects Reolink cameras and NVRs to D23 through the authenticated
 local HTTP/HTTPS CGI API:
 
 - manual fixed-endpoint discovery after authenticated inspection;
-- bounded login-token, device-information, channel-status, motion-state, and
-  logout exchanges;
+- bounded login-token, device-information, channel-status, pairing-only channel
+  ability, motion-state, and logout exchanges;
 - normalized camera-channel and motion-sensor entities;
 - documented JPEG snapshot capability for awake, online `RLC-*` physical
-  channels, composed by `smart-home-reolink-snapshot-host`;
+  channels, including NVR channels whose `typeInfo` and `abilityChn.snap` are
+  authenticated during pairing, composed by `smart-home-reolink-snapshot-host`;
 - capability-probed `GetRecV20` state plus authorized `SetRecV20` recording
   enable/disable with exact readback verification; and
 - capability-probed `GetPtzPreset` support plus authorized preset recall and
@@ -18,9 +19,9 @@ local HTTP/HTTPS CGI API:
 Credentials are zeroized after use and are represented in D23 only by a
 `VaultRef`. Session tokens are redacted and never enter normalized state.
 
-This package does not infer snapshot support for NVRs, battery cameras, or
-logical channels, and it does not infer a current PTZ position where firmware
-offers no portable readback. Recording search/download, RTSP media transfer,
+This package excludes empty NVR slots and does not infer snapshot support for
+battery cameras or logical channels. It does not infer a current PTZ position
+where firmware offers no portable readback. Recording search/download, RTSP media transfer,
 autonomous guard/patrol behavior, webhook events, and ONVIF PullPoint events
 remain separate transport/runtime work.
 

--- a/code/packages/rust/smart-home-reolink-integration/src/lib.rs
+++ b/code/packages/rust/smart-home-reolink-integration/src/lib.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 use tls_platform::{default_connector, TlsConfig, TlsConnector};
 use url_parser::{Url, UrlError};
 
-pub const VERSION: &str = "0.4.1";
+pub const VERSION: &str = "0.5.0";
 pub const INTEGRATION_ID: &str = "reolink";
 pub const PROTOCOL_ID: &str = "reolink_cgi";
 pub const SNAPSHOT_PATH: &str = "/cgi-bin/api.cgi";
@@ -222,6 +222,7 @@ pub struct ReolinkDeviceInformation {
     pub name: String,
     pub model: String,
     pub serial: String,
+    pub exact_type: Option<String>,
     pub firmware_version: Option<String>,
     pub hardware_version: Option<String>,
 }
@@ -230,8 +231,10 @@ pub struct ReolinkDeviceInformation {
 pub struct ReolinkChannelStatus {
     pub channel: u32,
     pub name: String,
+    pub model: Option<String>,
     pub online: bool,
     pub sleeping: bool,
+    pub snapshot_supported: Option<bool>,
     pub motion: Option<bool>,
     pub recording_enabled: Option<bool>,
     pub ptz_presets: Option<Vec<ReolinkPtzPreset>>,
@@ -279,7 +282,16 @@ pub struct ReolinkSnapshot {
 }
 
 pub fn supports_documented_jpeg_snapshot(model: &str, channel: &ReolinkChannelStatus) -> bool {
-    model.trim().to_ascii_uppercase().starts_with("RLC-") && channel.online && !channel.sleeping
+    channel
+        .model
+        .as_deref()
+        .unwrap_or(model)
+        .trim()
+        .to_ascii_uppercase()
+        .starts_with("RLC-")
+        && channel.online
+        && !channel.sleeping
+        && channel.snapshot_supported.unwrap_or(true)
 }
 
 pub trait ReolinkTransport {
@@ -431,6 +443,41 @@ impl<T: ReolinkTransport> ReolinkClient<T> {
         }
     }
 
+    pub fn inspect_for_pairing(&mut self) -> Result<ReolinkSnapshot, ReolinkError> {
+        let session = self.login()?;
+        let result = self.inspect_pairing_session(&session);
+        let logout = self.logout(&session);
+        match (result, logout) {
+            (Ok(snapshot), Ok(())) => Ok(snapshot),
+            (Err(error), _) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+        }
+    }
+
+    fn inspect_pairing_session(
+        &mut self,
+        session: &ReolinkSession,
+    ) -> Result<ReolinkSnapshot, ReolinkError> {
+        let mut snapshot = self.inspect_session(session)?;
+        if snapshot
+            .device
+            .exact_type
+            .as_deref()
+            .is_some_and(|exact_type| exact_type.eq_ignore_ascii_case("NVR"))
+        {
+            let abilities = parse_channel_snapshot_abilities(&self.command(
+                "GetAbility",
+                Some(session),
+                json!({"User": {"userName": self.credentials.username.as_str()}}),
+            )?)?;
+            for channel in &mut snapshot.channels {
+                channel.snapshot_supported =
+                    abilities.get(channel.channel as usize).copied().flatten();
+            }
+        }
+        Ok(snapshot)
+    }
+
     fn inspect_session(
         &mut self,
         session: &ReolinkSession,
@@ -439,6 +486,13 @@ impl<T: ReolinkTransport> ReolinkClient<T> {
             parse_device_information(&self.command("GetDevInfo", Some(session), json!({}))?)?;
         let mut channels =
             parse_channels(&self.command("GetChannelstatus", Some(session), json!({}))?)?;
+        if device
+            .exact_type
+            .as_deref()
+            .is_some_and(|exact_type| exact_type.eq_ignore_ascii_case("NVR"))
+        {
+            channels.retain(|channel| channel.model.is_some());
+        }
         if channels.is_empty() {
             return Err(ReolinkError::NoChannels);
         }
@@ -889,7 +943,10 @@ pub fn install_snapshot(
             device_id: device_id.clone(),
             bridge_id: config.bridge_id.clone(),
             manufacturer: "Reolink".to_string(),
-            model: snapshot.device.model.clone(),
+            model: channel
+                .model
+                .clone()
+                .unwrap_or_else(|| snapshot.device.model.clone()),
             name: channel.name.clone(),
             serial: Some(format!("{}:ch{}", snapshot.device.serial, channel.channel)),
             firmware_version: snapshot.device.firmware_version.clone(),
@@ -1024,6 +1081,7 @@ fn parse_device_information(value: &JsonValue) -> Result<ReolinkDeviceInformatio
         name: text(info, "name").unwrap_or_else(|| model.clone()),
         model,
         serial,
+        exact_type: text(info, "exactType"),
         firmware_version: text(info, "firmVer"),
         hardware_version: text(info, "hardVer"),
     })
@@ -1052,14 +1110,36 @@ fn parse_channels(value: &JsonValue) -> Result<Vec<ReolinkChannelStatus>, Reolin
             Ok(ReolinkChannelStatus {
                 channel,
                 name: text(status, "name").unwrap_or_else(|| format!("Camera {}", channel + 1)),
+                model: text(status, "typeInfo").filter(|model| !model.trim().is_empty()),
                 online: boolean(status.get("online")).unwrap_or(false),
                 sleeping: boolean(status.get("sleep")).unwrap_or(false),
+                snapshot_supported: None,
                 motion: None,
                 recording_enabled: None,
                 ptz_presets: None,
             })
         })
         .collect()
+}
+
+fn parse_channel_snapshot_abilities(value: &JsonValue) -> Result<Vec<Option<bool>>, ReolinkError> {
+    let abilities = value
+        .pointer("/Ability/abilityChn")
+        .and_then(JsonValue::as_array)
+        .ok_or(ReolinkError::MissingField {
+            command: "GetAbility",
+            field: "value.Ability.abilityChn",
+        })?;
+    Ok(abilities
+        .iter()
+        .map(|ability| {
+            let version = ability.pointer("/snap/ver").and_then(JsonValue::as_u64)?;
+            let permit = ability
+                .pointer("/snap/permit")
+                .and_then(JsonValue::as_u64)?;
+            Some(version > 0 && permit & 4 != 0)
+        })
+        .collect())
 }
 
 fn parse_motion(value: &JsonValue) -> Option<bool> {
@@ -1935,14 +2015,17 @@ mod tests {
                 name: "NVR".to_string(),
                 model: "RLN8-410".to_string(),
                 serial: "ABC123".to_string(),
+                exact_type: Some("NVR".to_string()),
                 firmware_version: Some("v3".to_string()),
                 hardware_version: None,
             },
             channels: vec![ReolinkChannelStatus {
                 channel: 0,
                 name: "Porch".to_string(),
+                model: Some("RLC-520A".to_string()),
                 online: true,
                 sleeping: false,
+                snapshot_supported: Some(true),
                 motion: Some(false),
                 recording_enabled: Some(true),
                 ptz_presets: None,
@@ -1960,8 +2043,10 @@ mod tests {
         let channel = ReolinkChannelStatus {
             channel: 0,
             name: "Porch".to_string(),
+            model: None,
             online: true,
             sleeping: false,
+            snapshot_supported: None,
             motion: None,
             recording_enabled: None,
             ptz_presets: None,
@@ -1977,5 +2062,27 @@ mod tests {
         assert!(!supports_documented_jpeg_snapshot("RLC-520A", &sleeping));
         assert!(!supports_documented_jpeg_snapshot("RLN8-410", &channel));
         assert!(!supports_documented_jpeg_snapshot("E1 Pro", &channel));
+
+        let mut nvr_channel = channel.clone();
+        nvr_channel.model = Some("RLC-810A".to_string());
+        nvr_channel.snapshot_supported = Some(true);
+        assert!(supports_documented_jpeg_snapshot("RLN8-410", &nvr_channel));
+        nvr_channel.snapshot_supported = Some(false);
+        assert!(!supports_documented_jpeg_snapshot("RLN8-410", &nvr_channel));
+    }
+
+    #[test]
+    fn documented_channel_abilities_are_indexed_and_version_gated() {
+        let abilities = parse_channel_snapshot_abilities(&json!({
+            "Ability": {
+                "abilityChn": [
+                    {"snap": {"permit": 6, "ver": 1}},
+                    {"snap": {"permit": 0, "ver": 1}},
+                    {}
+                ]
+            }
+        }))
+        .unwrap();
+        assert_eq!(abilities, vec![Some(true), Some(false), None]);
     }
 }

--- a/code/packages/rust/smart-home-reolink-pairing-service/CHANGELOG.md
+++ b/code/packages/rust/smart-home-reolink-pairing-service/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.2.0
+
+- Extend exact recoverable credential provisioning to installed Reolink NVRs.
+- Require authenticated NVR product type, exact NVR model and serial, exact
+  per-channel `typeInfo`, and supported executable `abilityChn.snap`
+  correspondence before any pairing transaction write.
+- Continue using operation-scoped query tokens with explicit logout after every
+  authenticated success or failure.
+
 ## 0.1.0
 
 - Add D23-authorized Reolink credential provisioning from one-shot owner-only

--- a/code/packages/rust/smart-home-reolink-pairing-service/Cargo.toml
+++ b/code/packages/rust/smart-home-reolink-pairing-service/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "smart-home-reolink-pairing-service"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "Recoverable credential provisioning for one exact Reolink RLC camera"
+description = "Recoverable credential provisioning for exact Reolink cameras and NVR channels"
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/smart-home-reolink-pairing-service/README.md
+++ b/code/packages/rust/smart-home-reolink-pairing-service/README.md
@@ -1,7 +1,7 @@
 # smart-home-reolink-pairing-service
 
 Explicit, recoverable credential provisioning for one exact direct Reolink RLC
-camera bridge.
+camera or one exact installed Reolink NVR bridge.
 
 The actor request carries only the D23 principal, pending pairing session,
 expected durable runtime revision, and completion time. A host-owned input reads
@@ -15,15 +15,18 @@ reviewed socket address. Production traffic uses strict certificate-verifying
 HTTPS, keeps the canonical hostname for SNI, and bypasses fresh name
 resolution. An authenticated CGI session must prove a non-empty stable serial,
 the exact installed physical-channel set when one exists, and at least one
-awake online snapshot-capable channel on a direct `RLC-*` camera. Query tokens
-stay process-local and the verifier logs out on success or failure.
+awake online snapshot-capable channel on a direct `RLC-*` camera. For an NVR,
+authenticated `exactType`, NVR model and serial, every installed physical
+channel's `typeInfo`, and every channel's supported executable
+`abilityChn.snap` value must exactly match durable state. Empty channel slots
+are excluded. Query tokens stay process-local and the verifier logs out on
+success or failure.
 
 The service encodes the same versioned username/password envelope consumed by
 `smart-home-reolink-snapshot-host`. The opaque reference is committed through
 `smart-home-pairing-transaction`. Startup resolves all pending journals before
 accepting work, and replacement cleanup remains bound to the captured Vault
-revision. Reolink NVR pairing remains out of scope until authenticated
-inspection proves the model identity behind every physical channel.
+revision.
 
 Snapshot delivery remains read-only and never provisions credentials.
 

--- a/code/packages/rust/smart-home-reolink-pairing-service/src/lib.rs
+++ b/code/packages/rust/smart-home-reolink-pairing-service/src/lib.rs
@@ -3,7 +3,7 @@
 #![forbid(unsafe_code)]
 
 use std::any::Any;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
@@ -377,7 +377,9 @@ pub struct VerifiedReolinkCamera {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct InstalledReolinkIdentity {
     pub serial_number: Option<String>,
+    pub bridge_model: Option<String>,
     pub channels: BTreeSet<u32>,
+    pub channel_models: BTreeMap<u32, String>,
     pub snapshot_channels: BTreeSet<u32>,
 }
 
@@ -486,7 +488,7 @@ impl ReolinkPairingVerifier for NativeReolinkPairingVerifier {
             credentials,
             ReolinkLanTransport::default().with_pinned_address(self.target.pinned_address),
         );
-        let snapshot = client.inspect()?;
+        let snapshot = client.inspect_for_pairing()?;
         let serial_number = snapshot.device.serial.trim();
         validate_camera_correspondence(expected.serial_number.as_deref(), serial_number)?;
         let channels = snapshot
@@ -496,6 +498,35 @@ impl ReolinkPairingVerifier for NativeReolinkPairingVerifier {
             .collect::<BTreeSet<_>>();
         if channels.len() != snapshot.channels.len()
             || (!expected.channels.is_empty() && channels != expected.channels)
+        {
+            return Err(ReolinkPairingServiceError::CameraCorrespondence);
+        }
+        let channel_models = snapshot
+            .channels
+            .iter()
+            .filter_map(|channel| {
+                channel
+                    .model
+                    .as_ref()
+                    .map(|model| (channel.channel, model.clone()))
+            })
+            .collect::<BTreeMap<_, _>>();
+        let observed_nvr = snapshot
+            .device
+            .exact_type
+            .as_deref()
+            .is_some_and(|exact_type| exact_type.eq_ignore_ascii_case("NVR"));
+        let is_nvr = observed_nvr
+            || expected
+                .bridge_model
+                .as_deref()
+                .is_some_and(|model| model.trim().to_ascii_uppercase().starts_with("RLN"));
+        if is_nvr
+            && (!observed_nvr
+                || expected.bridge_model.as_deref() != Some(snapshot.device.model.as_str())
+                || channel_models.len() != channels.len()
+                || expected.channel_models.is_empty()
+                || channel_models != expected.channel_models)
         {
             return Err(ReolinkPairingServiceError::CameraCorrespondence);
         }
@@ -511,6 +542,16 @@ impl ReolinkPairingVerifier for NativeReolinkPairingVerifier {
         if !expected.snapshot_channels.is_empty() && snapshot_channels != expected.snapshot_channels
         {
             return Err(ReolinkPairingServiceError::CameraCorrespondence);
+        }
+        if is_nvr
+            && (snapshot
+                .channels
+                .iter()
+                .any(|channel| channel.snapshot_supported != Some(true))
+                || snapshot_channels != channels
+                || expected.snapshot_channels != channels)
+        {
+            return Err(ReolinkPairingServiceError::MissingSnapshotCapability);
         }
         Ok(VerifiedReolinkCamera {
             serial_number: serial_number.to_string(),
@@ -868,10 +909,12 @@ fn installed_camera_identity(
     if devices.is_empty() {
         return Ok(InstalledReolinkIdentity {
             serial_number,
+            bridge_model: bridge.hardware_model.clone(),
             ..InstalledReolinkIdentity::default()
         });
     }
     let mut channels = BTreeSet::new();
+    let mut channel_models = BTreeMap::new();
     let mut snapshot_channels = BTreeSet::new();
     for device in devices {
         let channel_ids = device
@@ -889,6 +932,15 @@ fn installed_camera_identity(
             .ok_or_else(|| {
                 ReolinkPairingServiceError::InvalidInstalledCamera(bridge.bridge_id.clone())
             })?;
+        if device.model.trim().is_empty()
+            || channel_models
+                .insert(channel, device.model.clone())
+                .is_some()
+        {
+            return Err(ReolinkPairingServiceError::InvalidInstalledCamera(
+                bridge.bridge_id.clone(),
+            ));
+        }
         let cameras = device
             .entity_ids
             .iter()
@@ -919,7 +971,9 @@ fn installed_camera_identity(
     }
     Ok(InstalledReolinkIdentity {
         serial_number,
+        bridge_model: bridge.hardware_model.clone(),
         channels,
+        channel_models,
         snapshot_channels,
     })
 }
@@ -1372,6 +1426,10 @@ mod tests {
         let expected = installed_camera_identity(&runtime, &bridge).unwrap();
         assert_eq!(expected.serial_number.as_deref(), Some("ACCC8EAF8C30"));
         assert_eq!(expected.channels, BTreeSet::from([0]));
+        assert_eq!(
+            expected.channel_models,
+            BTreeMap::from([(0, "RLC-520A".to_string())])
+        );
         assert_eq!(expected.snapshot_channels, BTreeSet::from([0]));
 
         let mut invalid = runtime
@@ -1480,6 +1538,96 @@ mod tests {
             .0
             .starts_with("POST /api.cgi?cmd=Logout&token=token123 HTTP/1.1"));
         assert!(!format!("{verified:?}").contains("secret&password"));
+    }
+
+    #[test]
+    fn native_verifier_requires_exact_nvr_models_and_snapshot_abilities() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let server_requests = Arc::clone(&requests);
+        let response_bodies = [
+            r#"[{"cmd":"Login","code":0,"value":{"Token":{"name":"token123","leaseTime":3600}}}]"#,
+            r#"[{"cmd":"GetDevInfo","code":0,"value":{"DevInfo":{"name":"Garage NVR","model":"RLN8-410","serial":"NVR123","exactType":"NVR"}}}]"#,
+            r#"[{"cmd":"GetChannelstatus","code":0,"value":{"status":[{"channel":0,"name":"Porch","online":1,"sleep":0,"typeInfo":"RLC-520A"},{"channel":1,"name":"Driveway","online":1,"sleep":0,"typeInfo":"RLC-810A"},{"channel":2,"name":"","online":0,"sleep":0,"typeInfo":""}]}}]"#,
+            r#"[{"cmd":"GetMdState","code":1,"error":{"rspCode":-1,"detail":"unsupported"}}]"#,
+            r#"[{"cmd":"GetRecV20","code":1,"error":{"rspCode":-1,"detail":"unsupported"}}]"#,
+            r#"[{"cmd":"GetPtzPreset","code":1,"error":{"rspCode":-1,"detail":"unsupported"}}]"#,
+            r#"[{"cmd":"GetMdState","code":1,"error":{"rspCode":-1,"detail":"unsupported"}}]"#,
+            r#"[{"cmd":"GetRecV20","code":1,"error":{"rspCode":-1,"detail":"unsupported"}}]"#,
+            r#"[{"cmd":"GetPtzPreset","code":1,"error":{"rspCode":-1,"detail":"unsupported"}}]"#,
+            r#"[{"cmd":"GetAbility","code":0,"value":{"Ability":{"abilityChn":[{"snap":{"permit":6,"ver":1}},{"snap":{"permit":6,"ver":1}},{"snap":{"permit":0,"ver":0}}]}}}]"#,
+            r#"[{"cmd":"Logout","code":0,"value":{}}]"#,
+        ];
+        let handle = thread::spawn(move || {
+            for body in response_bodies {
+                let (stream, _) = listener.accept().unwrap();
+                let mut reader = BufReader::new(stream);
+                let mut head = String::new();
+                loop {
+                    let mut line = String::new();
+                    reader.read_line(&mut line).unwrap();
+                    if line == "\r\n" {
+                        break;
+                    }
+                    head.push_str(&line);
+                }
+                let length = head
+                    .lines()
+                    .find_map(|line| line.strip_prefix("Content-Length: "))
+                    .unwrap_or("0")
+                    .parse::<usize>()
+                    .unwrap();
+                let mut request_body = vec![0u8; length];
+                reader.read_exact(&mut request_body).unwrap();
+                server_requests
+                    .lock()
+                    .unwrap()
+                    .push((head, String::from_utf8(request_body).unwrap()));
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                reader.get_mut().write_all(response.as_bytes()).unwrap();
+            }
+        });
+
+        let mut bridge = Bridge::new(
+            BridgeId::trusted("reolink-nvr-garage"),
+            IntegrationId::trusted(INTEGRATION_ID),
+            BridgeTransport::LanHttp,
+        );
+        bridge.address = Some(format!("http://{address}"));
+        let target =
+            ReolinkPairingConnectionTarget::new(bridge.bridge_id.clone(), "127.0.0.1", address)
+                .unwrap();
+        let mut verifier = NativeReolinkPairingVerifier::new(target);
+        let credentials = ReolinkCredentialSecret::new("operator", "password").unwrap();
+        let expected = InstalledReolinkIdentity {
+            serial_number: Some("NVR123".to_string()),
+            bridge_model: Some("RLN8-410".to_string()),
+            channels: BTreeSet::from([0, 1]),
+            channel_models: BTreeMap::from([
+                (0, "RLC-520A".to_string()),
+                (1, "RLC-810A".to_string()),
+            ]),
+            snapshot_channels: BTreeSet::from([0, 1]),
+        };
+        let verified = verifier.verify(&bridge, &credentials, &expected).unwrap();
+        handle.join().unwrap();
+
+        assert_eq!(verified.serial_number, "NVR123");
+        assert_eq!(verified.channel_count, 2);
+        assert_eq!(verified.snapshot_channel_count, 2);
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 11);
+        assert!(requests[9]
+            .0
+            .starts_with("POST /api.cgi?cmd=GetAbility&token=token123 HTTP/1.1"));
+        assert!(requests[9].1.contains("\"userName\":\"operator\""));
+        assert!(requests[10]
+            .0
+            .starts_with("POST /api.cgi?cmd=Logout&token=token123 HTTP/1.1"));
     }
 
     #[test]

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -1682,9 +1682,34 @@ direct Reolink RLC camera without turning snapshot delivery into a writer:
   one-shot owner-only files, reviewed-address-pinned strict TLS, a real
   login-to-logout CGI loopback, secret-free durable state, interrupted-commit
   recovery, exact replacement cleanup, and cleanup-drift refusal.
-- NVR credential pairing remains blocked because current authenticated
-  `GetChannelstatus` inspection does not prove the RLC model identity behind
-  each physical NVR channel.
+- The NVR extension below adds the separately documented per-channel identity
+  and snapshot-ability proof without weakening this direct-camera boundary.
+
+## Current Reolink NVR Credential Pairing Slice
+
+This slice extends the completed recoverable transaction composition to one
+exact installed Reolink NVR without inferring capabilities from the NVR model:
+
+- Authenticated `GetDevInfo` must report exact product type `NVR` plus the exact
+  durable NVR model and serial. `GetChannelstatus.typeInfo` must be non-empty
+  and exactly equal to the durable device model for every installed physical
+  channel; empty NVR slots are excluded from normalized devices.
+- Pairing-only authenticated `GetAbility` inspection requires a positive
+  documented `abilityChn[channel].snap.ver` and execute permission for every
+  installed channel. A
+  missing channel entry, missing field, zero version, offline channel, sleeping
+  channel, non-`RLC-*` model, or any durable-set mismatch fails before the
+  transaction writes a journal or credential.
+- The existing exact D23 principal, one-shot owner-only zeroizing input,
+  reviewed-address-pinned strict HTTPS, transaction-owned opaque reference,
+  expected-revision runtime CAS, startup recovery, and revision-bound
+  replacement cleanup remain unchanged.
+- CGI query tokens remain operation-scoped and process-local. Explicit logout
+  runs after every authenticated success or failure, and snapshot delivery
+  remains a read-only consumer of the bounded versioned credential envelope.
+- Tests cover exact NVR serial/model/channel correspondence, empty-slot
+  exclusion, documented per-channel snapshot ability, and explicit logout in
+  addition to the existing denial, rollback, recovery, and cleanup suite.
 
 ## Current Synology Credential Pairing Slice
 
@@ -1733,126 +1758,120 @@ to that image request; the only documented direct URL credentials require
 disabling secure sessions and are rejected. Frigate snapshot delivery remains
 blocked on a cookie-capable media authentication boundary. Revision-guarded
 D23 pairing completion, its recoverable cross-store journal, and production
-Hue, ONVIF, ZoneMinder, Axis, direct Reolink RLC, and Synology compositions are
-now available. The camera pairing services prove bounded host-owned secret input,
-D23 principal propagation, authenticated exact-bridge inspection, durable
-runtime revision ownership, startup recovery, actor-state replacement, and
-revision-bound cleanup without turning snapshot delivery into a writer. The
-strongest next post-merge audit is Reolink NVR credential pairing. It must prove
-the exact model identity and snapshot capability behind every installed
-physical channel through authenticated inspection before an implementation
-slice can be selected.
+Hue, ONVIF, ZoneMinder, Axis, direct Reolink RLC, Reolink NVR, and Synology
+compositions are now available. The camera pairing services prove bounded
+host-owned secret input, D23 principal propagation, authenticated exact-bridge
+inspection, durable runtime revision ownership, startup recovery, actor-state
+replacement, and revision-bound cleanup without turning snapshot delivery into
+a writer. The strongest remaining prerequisite is authenticated AirGradient
+MQTT after firmware no longer logs plaintext credentials.
 
-1. Add Reolink NVR credential pairing only after authenticated inspection proves
-   the exact model identity and snapshot capability behind every installed
-   physical channel. Keep query credentials operation-scoped and preserve
-   explicit logout on every outcome.
-2. Add authenticated AirGradient MQTT only after official firmware removes
+1. Add authenticated AirGradient MQTT only after official firmware removes
    plaintext credential logging and one-shot Vault-leased credential injection
    can be proven without request-plan or normalized-state exposure.
-3. Add independent AirGradient telemetry, remote-configuration, and OTA
+2. Add independent AirGradient telemetry, remote-configuration, and OTA
    destinations only if firmware exposes separate settings; the current
    `httpDomain` contract intentionally governs all three as one HTTPS origin.
-4. Add authenticated HEOS source browsing and queue insertion only after the
+3. Add authenticated HEOS source browsing and queue insertion only after the
    account/session and Vault-leasing prerequisites are concrete.
-5. Automate Enphase access-token acquisition or renewal only after Enphase
+4. Automate Enphase access-token acquisition or renewal only after Enphase
    account authentication, cloud-session handling, operator consent, and
    Vault-leased credential policy are concrete; the current host accepts a
    pre-generated token.
-6. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
+5. Add automatic Enphase IQ Gateway discovery only if Enphase documents a
    stable LAN advertisement; the current production path uses explicit local
    HTTPS endpoint and gateway-serial configuration.
-7. Add Enphase live battery, relay, generator, grid, and system-topology state
+6. Add Enphase live battery, relay, generator, grid, and system-topology state
    only after the normalized energy topology and retention semantics are
    concrete.
-8. Add Enphase relay, grid-services, or configuration controls only with
+7. Add Enphase relay, grid-services, or configuration controls only with
    operation-specific D23 contracts, explicit safety approval, bounded native
    semantics, and readable postcondition verification.
-9. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
+8. Add expiration-aware ZoneMinder access-token reuse and refresh only after a
    supervised session lifecycle and Vault policy for refresh-token residency are
    concrete; the current isolated inspection drops both tokens after each read.
-10. Add ZoneMinder event push only after a concrete authenticated event host and
+9. Add ZoneMinder event push only after a concrete authenticated event host and
     supervised subscription lifecycle exist.
-11. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
+10. Add ZoneMinder PTZ, monitor configuration, recording-mode, or administrative
     mutations only with operation-specific D23 contracts, least-privilege user
     checks, bounded semantics, and readable postcondition verification.
-12. Add UniFi connected-client key rotation across multiple sites or more than
+11. Add UniFi connected-client key rotation across multiple sites or more than
     one 100-client page only after a resumable protocol can prove exact global
     correspondence and all-or-none persistence without extending native-ID or
     one-shot key residency across partial responses.
-13. Add UniFi connected-client native details only after field-specific
+12. Add UniFi connected-client native details only after field-specific
    minimization and retention are approved; current presence intentionally
    excludes names, native IDs, MACs, IPs, and connection timestamps.
-14. Add UniFi historical device statistics, heartbeat-time correlation, or
+13. Add UniFi historical device statistics, heartbeat-time correlation, or
    broader fleet polling only after durable time-series schema, query access,
    clock semantics, and retention/deletion policy are concrete; current live
    statistics are explicit-target, 64-device bounded, one-minute rate-limited,
    and expire after two minutes.
-15. Add remote UniFi Site Manager inspection only after telemetry-egress,
+14. Add remote UniFi Site Manager inspection only after telemetry-egress,
    destination, and operator-consent policy are concrete; keep the current host
    local-only.
-16. Add UniFi Network push or change events only after a concrete authenticated
+15. Add UniFi Network push or change events only after a concrete authenticated
    event host and supervised subscription lifecycle exist.
-17. Add UniFi adoption, guest authorization, port actions, or configuration
+16. Add UniFi adoption, guest authorization, port actions, or configuration
    mutations only with operation-specific D23 contracts, least-privilege API
    keys, bounded semantics, and readable postcondition verification.
-18. Add Synology Surveillance Station OTP and remembered-device authentication
+17. Add Synology Surveillance Station OTP and remembered-device authentication
    only after an interactive challenge lifecycle and Vault-leased device-token
    policy are concrete.
-19. Add Synology Surveillance Station events only after a concrete authenticated
+18. Add Synology Surveillance Station events only after a concrete authenticated
    event host and supervised subscription lifecycle exist.
-20. Add Synology Surveillance Station PTZ, external recording, or configuration
+19. Add Synology Surveillance Station PTZ, external recording, or configuration
    mutations only with operation-specific D23 contracts, least-privilege API
    checks, bounded semantics, and readable postcondition verification.
-21. Add Frigate event and review push only after a concrete authenticated event
+20. Add Frigate event and review push only after a concrete authenticated event
    or WebSocket host and supervised subscription lifecycle exist.
-22. Add bounded Frigate snapshots through the completed camera-media HTTPS
+21. Add bounded Frigate snapshots through the completed camera-media HTTPS
     executor after process-local endpoint registration and credential lifetime
     are wired; recordings, export, and playback still require a concrete
     supervised resource executor.
-23. Add Frigate commands or configuration mutations only with operation-specific
+22. Add Frigate commands or configuration mutations only with operation-specific
    D23 contracts, least-privilege role checks, and readable postcondition
    verification.
-24. Add bounded Blue Iris snapshots only after an official interface documents
+23. Add bounded Blue Iris snapshots only after an official interface documents
     how an isolated secure JSON session authenticates `/image/{camera}`, or a
     concrete cookie/session-bound media executor exists. Never disable secure
     sessions or place reusable Blue Iris credentials in a URL. Alert/clip
     search, export, and playback still require a supervised resource executor.
-25. Add broader Blue Iris `camconfig` or administrative mutations only with
+24. Add broader Blue Iris `camconfig` or administrative mutations only with
    operation-specific D23 contracts, least-privilege permissions, and readable
    postcondition verification; do not persist the license value returned at
    login.
-26. Add automatic Blue Iris discovery only if the server exposes a documented,
+25. Add automatic Blue Iris discovery only if the server exposes a documented,
    stable LAN advertisement; the current production path is explicit local
    HTTPS endpoint configuration.
-27. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
+26. Add Blue Iris focus, iris, digital-I/O, preset-setting, or broader PTZ
    controls only when each operation has a specific native capability probe,
    bounded semantics, and readable verification where the device exposes it.
-28. Add Axis event streaming only after the existing WebSocket protocol core has
+27. Add Axis event streaming only after the existing WebSocket protocol core has
    a concrete authenticated host using the completed Digest primitive or a
    short-lived session token, plus subscription supervision.
-29. Enumerate Axis video sources/channels before extending PTZ beyond the current
+28. Enumerate Axis video sources/channels before extending PTZ beyond the current
     capability-probed VAPIX camera 1 boundary.
-30. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
+29. Add Axis absolute/relative zoom, guard-tour, or advanced preset management
     only when each operation has a specific capability probe and readable state.
-31. Add Reolink current-position, zoom, guard-point, or patrol controls only when
+30. Add Reolink current-position, zoom, guard-point, or patrol controls only when
     each operation has a capability-specific probe and the firmware exposes the
     native state needed to avoid invented orientation claims.
-32. Add Reolink push events only after a concrete webhook or event-stream host
+31. Add Reolink push events only after a concrete webhook or event-stream host
     and subscription lifecycle exist.
-33. Add authenticated KLAP/Tapo devices and other broader-device families only
+32. Add authenticated KLAP/Tapo devices and other broader-device families only
     after their authentication and session prerequisites are concrete.
-34. Add ONVIF PullPoint events once a concrete event host and subscription
+33. Add ONVIF PullPoint events once a concrete event host and subscription
     lifecycle exist.
-35. Add RTSP media transfer and recording once concrete media transfer and
+34. Add RTSP media transfer and recording once concrete media transfer and
     recorder host primitives exist.
-36. Add a production Matter commissioning, secure-session, and network host only
+35. Add a production Matter commissioning, secure-session, and network host only
     after certificate, fabric, Interaction Model encoding, subscription, and
     transport prerequisites exist.
-37. Add a Thread border-router host only after an actual host transport exists.
-38. Add a production Zigbee coordinator, join, and security host only after
+36. Add a Thread border-router host only after an actual host transport exists.
+37. Add a production Zigbee coordinator, join, and security host only after
     concrete coordinator transport and security primitives exist.
-39. Add production Z-Wave inclusion and S2 only after concrete host transport
+38. Add production Z-Wave inclusion and S2 only after concrete host transport
     and security primitives exist.
 
 ## End-To-End Definition


### PR DESCRIPTION
## Summary
- retain authenticated Reolink `exactType` and per-channel `typeInfo`, exclude empty NVR slots, and install each physical camera with its exact model
- extend recoverable pairing to exact installed NVRs by matching durable NVR serial/model and every physical channel model before any transaction write
- require supported executable `GetAbility.abilityChn[channel].snap` for every installed channel while preserving operation-scoped tokens, explicit logout, strict reviewed-address-pinned HTTPS, runtime CAS, startup recovery, and revision-bound cleanup
- record the completed slice and reprioritize the remaining Smart Home backlog

## Validation
- `bash BUILD` in `smart-home-reolink-integration`
- `bash BUILD` in `smart-home-reolink-pairing-service`
- `bash BUILD` in `smart-home-reolink-snapshot-host`
- `cargo clippy -p smart-home-reolink-integration -p smart-home-reolink-pairing-service -p smart-home-reolink-snapshot-host --all-targets -- -D warnings`
- targeted Rust formatting check

Generated `code/packages/rust/Cargo.lock` and disposable Cargo build artifacts were removed before publication.