### PR TITLE
Report form starts in table mode

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- `form` start tags processed in table mode now report the required parse
+  error whether the form element pointer is initially null or already set.
+  The first form retains its special detached insertion behavior, while a
+  repeated form is still ignored.
 - A `table` start tag processed in table mode now reports the current-Standard
   parse error before closing the open table and reprocessing the token. Nested
   tables inside cells remain valid and diagnostic-free.

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -102,6 +102,10 @@ Prioritized work items:
    open table and reprocesses the token, matching the minimal WPT
    `tests6.dat` `<table><table>` evidence while leaving tables nested inside
    cells quiet.
+   `form` start tags processed in table mode now report the required parse
+   error both when the form pointer is initially null and when a repeated form
+   is ignored, matching WPT `tests20.dat` `unexpected-form-in-table` evidence
+   while leaving forms inside cells quiet.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5320,19 +5320,14 @@ impl HtmlParser {
             self.close_element("table");
         }
 
-        if !in_foreign_content
-            && name == "form"
-            && self.current_element_is_table_structure()
-            && self.form_element_pointer_set
-        {
-            self.diagnostics.push(ParserDiagnostic::new(
-                "nested-form-start-tag",
-                "form start tag inside a table was ignored while a form was already open",
-            ));
-            return;
-        }
-
         if !in_foreign_content && name == "form" && self.current_element_is_table_structure() {
+            self.diagnostics.push(ParserDiagnostic::new(
+                "unexpected-form-start-tag-in-table",
+                "form start tag in a table context was processed with a parse error",
+            ));
+            if self.form_element_pointer_set {
+                return;
+            }
             self.form_element_pointer_set = true;
             self.append_node(Node::element(name, attributes));
             return;
@@ -31464,6 +31459,41 @@ mod tests {
             .parser_diagnostics
             .iter()
             .all(|diagnostic| { diagnostic.code != "unexpected-table-start-tag-in-table" }));
+    }
+
+    #[test]
+    fn reports_form_start_tags_processed_in_table_mode() {
+        let output =
+            parse_html_with_diagnostics("<!doctype html><table><form><form></table>").unwrap();
+        assert_eq!(
+            output.parser_diagnostics,
+            vec![
+                ParserDiagnostic::new(
+                    "unexpected-form-start-tag-in-table",
+                    "form start tag in a table context was processed with a parse error",
+                ),
+                ParserDiagnostic::new(
+                    "unexpected-form-start-tag-in-table",
+                    "form start tag in a table context was processed with a parse error",
+                ),
+            ]
+        );
+
+        let table = element(&body(&output.document).children[0]);
+        assert_eq!(table.name, "table");
+        assert_eq!(table.children.len(), 1);
+        assert_eq!(element(&table.children[0]).name, "form");
+
+        for source in [
+            "<!doctype html><form></form>",
+            "<!doctype html><table><tr><td><form></form></td></tr></table>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output
+                .parser_diagnostics
+                .iter()
+                .all(|diagnostic| { diagnostic.code != "unexpected-form-start-tag-in-table" }));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- report the required in-table parse error for both first and repeated `form` start tags
- preserve detached first-form insertion and repeated-form ignore behavior
- record the WPT-backed algorithm audit result in the backlog and changelog

## Validation
- `cargo test -p coding-adventures-html-parser`
- `cargo test -p coding-adventures-html-lexer`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- live WPT/html5lib coverage audit at WPT `54f8f933629e7c010ae98a246729af01f8abcda5` and html5lib-tests `224991ec10db04f056a89eed8b0bd8695fd2950e`
- all parser audit guard scripts and Python audit tests
- `git diff --check`

`cargo fmt --package coding-adventures-html-parser -- --check` still reports the repository existing broad rustfmt drift; the new test hunk was aligned to rustfmt output.