### PR TITLE
fix(html-parser): diagnose fostered table inputs

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Non-hidden `input` start tags processed in table mode now report the required
+  general parse error before retaining their existing foster-parented DOM
+  placement. Hidden inputs keep their specialized in-table behavior and
+  diagnostic, while inputs inside cells remain quiet.
 - `form` start tags processed in table mode now report the required parse
   error whether the form element pointer is initially null or already set.
   The first form retains its special detached insertion behavior, while a

--- a/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
+++ b/code/packages/rust/html-parser/CONFORMANCE-BACKLOG.md
@@ -106,6 +106,10 @@ Prioritized work items:
    error both when the form pointer is initially null and when a repeated form
    is ignored, matching WPT `tests20.dat` `unexpected-form-in-table` evidence
    while leaving forms inside cells quiet.
+   Non-hidden `input` start tags processed in table mode now report the general
+   parse error before foster parenting, matching WPT `tests7.dat` and
+   `webkit02.dat` evidence while preserving the specialized hidden-input path
+   and leaving inputs inside cells quiet.
    Seeded table and foreign fragment-shell boundaries now report their required
    parse errors.
 2. **Adoption agency and active formatting.** Cover malformed formatting cases

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5378,6 +5378,10 @@ impl HtmlParser {
                 ));
                 self.append_node(Node::element(name, attributes));
             } else {
+                self.diagnostics.push(ParserDiagnostic::new(
+                    "unexpected-input-start-tag-in-table",
+                    "non-hidden input start tag in a table context was foster parented",
+                ));
                 self.insert_node_before_open_table(Node::element(name, attributes));
             }
             return;
@@ -34127,6 +34131,42 @@ mod tests {
             assert!(output.parser_diagnostics.iter().all(|diagnostic| {
                 diagnostic.code != "unexpected-hidden-input-start-tag-in-table"
             }));
+        }
+    }
+
+    #[test]
+    fn reports_non_hidden_input_start_tags_fostered_from_tables() {
+        for source in [
+            "<!doctype html><table><input></table>",
+            "<!doctype html><table><input type=' hidden'></table>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(
+                output.parser_diagnostics.iter().any(|diagnostic| {
+                    diagnostic
+                        == &ParserDiagnostic::new(
+                            "unexpected-input-start-tag-in-table",
+                            "non-hidden input start tag in a table context was foster parented",
+                        )
+                }),
+                "source {source:?}"
+            );
+
+            let children = &body(&output.document).children;
+            assert_eq!(element(&children[0]).name, "input", "source {source:?}");
+            assert_eq!(element(&children[1]).name, "table", "source {source:?}");
+        }
+
+        for source in [
+            "<!doctype html><input type=text>",
+            "<!doctype html><table><tr><td><input></td></tr></table>",
+            "<!doctype html><table><input type=hidden></table>",
+        ] {
+            let output = parse_html_with_diagnostics(source).unwrap();
+            assert!(output
+                .parser_diagnostics
+                .iter()
+                .all(|diagnostic| { diagnostic.code != "unexpected-input-start-tag-in-table" }));
         }
     }
 


### PR DESCRIPTION
## Summary
- report the required in-table parse error for non-hidden `input` start tags
- preserve existing foster-parented DOM placement and the specialized hidden-input path
- record the WPT-backed boundary in the conformance backlog and changelog

## Validation
- `CARGO_BUILD_JOBS=2 cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p coding-adventures-html-lexer`
- full WHATWG audit manifest, coverage, Rust-test, smoke, and Python guards
- live WPT/html5lib coverage audit: 0 missing tree signatures, 0 missing tokenizer signatures, 0 normalized skips
- `CARGO_BUILD_JOBS=2 cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `git diff --check`

`cargo fmt --package coding-adventures-html-parser -- --check` still reports the repository's pre-existing package-wide rustfmt drift; the new hunk itself matches current rustfmt output.