### PR TITLE
Add Mermaid sequence block wrapping

### DIFF
--- a/code/grammars/mermaid/sequence.grammar
+++ b/code/grammars/mermaid/sequence.grammar
@@ -22,11 +22,11 @@ title_stmt = "title" [ COLON ] text ;
 autonumber_stmt = "autonumber" [ "off" | NUMBER [ NUMBER ] ] ;
 
 control_block = simple_block | rect_block | alt_block | par_block | critical_block ;
-simple_block = ( "loop" | "opt" | "break" ) [ text ] terminator body "end" ;
+simple_block = ( "loop" | "opt" | "break" ) wrapped_text terminator body "end" ;
 rect_block = "rect" COLOR terminator body "end" ;
-alt_block = "alt" [ text ] terminator body { "else" [ text ] terminator body } "end" ;
-par_block = ( "par" | "par_over" ) [ text ] terminator body { "and" [ text ] terminator body } "end" ;
-critical_block = "critical" [ text ] terminator body { "option" [ text ] terminator body } "end" ;
+alt_block = "alt" wrapped_text terminator body { "else" wrapped_text terminator body } "end" ;
+par_block = ( "par" | "par_over" ) wrapped_text terminator body { "and" wrapped_text terminator body } "end" ;
+critical_block = "critical" wrapped_text terminator body { "option" wrapped_text terminator body } "end" ;
 
 actor_pair = actor_ref [ COMMA actor_ref ] ;
 message_arrow = SOLID_OPEN_ARROW | DOTTED_OPEN_ARROW | SOLID_FILLED_ARROW | DOTTED_FILLED_ARROW | BIDIRECTIONAL_SOLID | BIDIRECTIONAL_DOTTED | SOLID_CROSS_ARROW | DOTTED_CROSS_ARROW | SOLID_POINT_ARROW | DOTTED_POINT_ARROW | SOLID_FILLED_TOP | SOLID_FILLED_BOTTOM | SOLID_STICK_TOP | SOLID_STICK_BOTTOM | DOTTED_FILLED_TOP | DOTTED_FILLED_BOTTOM | DOTTED_STICK_TOP | DOTTED_STICK_BOTTOM | SOLID_REVERSE_FILLED_TOP | SOLID_REVERSE_FILLED_BOTTOM | SOLID_REVERSE_STICK_TOP | SOLID_REVERSE_STICK_BOTTOM | DOTTED_REVERSE_FILLED_TOP | DOTTED_REVERSE_FILLED_BOTTOM | DOTTED_REVERSE_STICK_TOP | DOTTED_REVERSE_STICK_BOTTOM ;

--- a/code/packages/rust/diagram-ir/CHANGELOG.md
+++ b/code/packages/rust/diagram-ir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog — diagram-ir
 
+## 0.19.0
+
+- Preserve explicit wrap intent and line-aware layout geometry for sequence control-block labels.
+
 ## 0.18.0
 
 - Preserve default, forced-wrap, and forced-no-wrap sequence text intent.

--- a/code/packages/rust/diagram-ir/Cargo.toml
+++ b/code/packages/rust/diagram-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-ir"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Semantic diagram intermediate representation (DG00+DG04): types shared across all diagram pipeline families"
 

--- a/code/packages/rust/diagram-ir/src/lib.rs
+++ b/code/packages/rust/diagram-ir/src/lib.rs
@@ -1,6 +1,6 @@
-//! diagram-ir v0.18.0 - DG00/DG04 semantic IR
+//! diagram-ir v0.19.0 - DG00/DG04 semantic IR
 
-pub const VERSION: &str = "0.18.0";
+pub const VERSION: &str = "0.19.0";
 
 #[derive(Clone, Debug, PartialEq, Default)]
 pub enum DiagramDirection {
@@ -289,10 +289,12 @@ pub enum SequenceEvent {
     BlockStart {
         kind: SequenceBlockKind,
         label: String,
+        wrap: SequenceTextWrap,
         fill: Option<String>,
     },
     BlockBranch {
         label: String,
+        wrap: SequenceTextWrap,
     },
     BlockEnd {
         kind: SequenceBlockKind,
@@ -374,6 +376,7 @@ pub enum LayoutedSequenceItem {
     BlockFrame {
         kind: SequenceBlockKind,
         label: String,
+        label_height: f64,
         fill: Option<String>,
         depth: usize,
         x: f64,
@@ -383,6 +386,7 @@ pub enum LayoutedSequenceItem {
     },
     BlockDivider {
         label: String,
+        label_height: f64,
         x: f64,
         y: f64,
         width: f64,
@@ -942,8 +946,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_is_0_18_0() {
-        assert_eq!(VERSION, "0.18.0");
+    fn version_is_0_19_0() {
+        assert_eq!(VERSION, "0.19.0");
     }
     #[test]
     fn default_direction_is_tb() {

--- a/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
+++ b/code/packages/rust/diagram-layout-sequence/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.15.0 - 2026-08-10
+
+- Resolve wrapped sequence control and branch labels into deterministic frame geometry.
+
 ## 0.14.0 - 2026-08-10
 
 - Apply explicit sequence wrap directives with deterministic backend-neutral line breaks.

--- a/code/packages/rust/diagram-layout-sequence/Cargo.toml
+++ b/code/packages/rust/diagram-layout-sequence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-layout-sequence"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Participant, lifeline, message, note, and activation layout for sequence diagrams"
 

--- a/code/packages/rust/diagram-layout-sequence/src/lib.rs
+++ b/code/packages/rust/diagram-layout-sequence/src/lib.rs
@@ -7,7 +7,7 @@ use diagram_ir::{
     SequenceEvent, SequenceNotePlacement, SequenceTextWrap,
 };
 
-pub const VERSION: &str = "0.14.0";
+pub const VERSION: &str = "0.15.0";
 
 const MARGIN: f64 = 28.0;
 const HEADER_Y: f64 = 42.0;
@@ -26,6 +26,7 @@ const WRAPPED_TEXT_MAX_WIDTH: f64 = 240.0;
 struct BlockFrameState {
     kind: SequenceBlockKind,
     label: String,
+    label_height: f64,
     fill: Option<String>,
     depth: usize,
     x: f64,
@@ -119,12 +120,14 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                     wrap,
                     (to_x - from_x).abs().clamp(80.0, WRAPPED_TEXT_MAX_WIDTH),
                 );
+                let label_height = 16.0 * label.lines().count().max(1) as f64;
+                let message_y = y + label_height + 6.0;
                 items.push(LayoutedSequenceItem::Message {
                     from_x,
                     to_x,
-                    y,
+                    y: message_y,
                     label: label.clone(),
-                    label_height: 16.0 * label.lines().count().max(1) as f64,
+                    label_height,
                     line_style: line_style.clone(),
                     arrowhead: arrowhead.clone(),
                     bidirectional: *bidirectional,
@@ -133,12 +136,15 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                 });
                 message_number += diagram.auto_number_step;
                 if *activate {
-                    activation_starts.entry(to.clone()).or_default().push(y);
+                    activation_starts
+                        .entry(to.clone())
+                        .or_default()
+                        .push(message_y);
                 }
                 if *deactivate {
-                    close_activation(&mut items, &mut activation_starts, from, from_x, y);
+                    close_activation(&mut items, &mut activation_starts, from, from_x, message_y);
                 }
-                y += EVENT_H + 16.0 * label.lines().count().saturating_sub(1) as f64;
+                y = message_y + EVENT_H;
             }
             SequenceEvent::Activation {
                 participant,
@@ -250,32 +256,44 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                 });
                 y += NOTE_H + 16.0 * line_count.saturating_sub(1) as f64 + 20.0;
             }
-            SequenceEvent::BlockStart { kind, label, fill } => {
+            SequenceEvent::BlockStart {
+                kind,
+                label,
+                wrap,
+                fill,
+            } => {
                 let depth = block_stack.len();
                 let x = MARGIN + depth as f64 * BLOCK_INSET;
+                let frame_width = (width - x * 2.0).max(120.0);
+                let label = wrap_sequence_text(label, wrap, frame_width - 16.0);
+                let label_height = 16.0 * label.lines().count().max(1) as f64;
                 block_stack.push(BlockFrameState {
                     kind: kind.clone(),
-                    label: label.clone(),
+                    label,
+                    label_height,
                     fill: fill.clone(),
                     depth,
                     x,
                     y,
-                    width: (width - x * 2.0).max(120.0),
+                    width: frame_width,
                 });
                 if kind != &SequenceBlockKind::Rect {
-                    y += BLOCK_HEADER_H;
+                    y += BLOCK_HEADER_H + label_height - 16.0;
                 }
             }
-            SequenceEvent::BlockBranch { label } => {
+            SequenceEvent::BlockBranch { label, wrap } => {
                 if let Some(frame) = block_stack.last() {
+                    let label = wrap_sequence_text(label, wrap, frame.width - 16.0);
+                    let label_height = 16.0 * label.lines().count().max(1) as f64;
                     items.push(LayoutedSequenceItem::BlockDivider {
-                        label: label.clone(),
+                        label,
+                        label_height,
                         x: frame.x,
                         y,
                         width: frame.width,
                     });
+                    y += BLOCK_BRANCH_H + label_height - 16.0;
                 }
-                y += BLOCK_BRANCH_H;
             }
             SequenceEvent::BlockEnd { kind } => {
                 if let Some(frame) = block_stack.pop() {
@@ -285,6 +303,7 @@ pub fn layout_sequence_diagram(diagram: &SequenceDiagram) -> LayoutedSequenceDia
                     items.push(LayoutedSequenceItem::BlockFrame {
                         kind: frame.kind,
                         label: frame.label,
+                        label_height: frame.label_height,
                         fill: frame.fill,
                         depth: frame.depth,
                         x: frame.x,
@@ -569,12 +588,14 @@ mod tests {
             events: vec![
                 SequenceEvent::BlockStart {
                     kind: SequenceBlockKind::Alt,
-                    label: "Ready".into(),
+                    label: "Ready for a deliberately detailed transfer acceptance path".into(),
+                    wrap: SequenceTextWrap::Wrap,
                     fill: None,
                 },
                 SequenceEvent::BlockStart {
                     kind: SequenceBlockKind::Loop,
                     label: "Retry".into(),
+                    wrap: SequenceTextWrap::Default,
                     fill: None,
                 },
                 SequenceEvent::Message {
@@ -593,7 +614,8 @@ mod tests {
                     kind: SequenceBlockKind::Loop,
                 },
                 SequenceEvent::BlockBranch {
-                    label: "Fallback".into(),
+                    label: "Fallback after a deliberately detailed rejection path".into(),
+                    wrap: SequenceTextWrap::Wrap,
                 },
                 SequenceEvent::BlockEnd {
                     kind: SequenceBlockKind::Alt,
@@ -614,7 +636,16 @@ mod tests {
         assert_eq!(frames.len(), 2);
         assert!(frames.iter().any(|(depth, _, _)| *depth == 1));
         assert!(frames.iter().all(|(_, _, height)| *height > BLOCK_HEADER_H));
-        assert!(layout.items.iter().any(|item| matches!(item, LayoutedSequenceItem::BlockDivider { label, .. } if label == "Fallback")));
+        assert!(layout.items.iter().any(|item| matches!(
+            item,
+            LayoutedSequenceItem::BlockFrame { label, label_height, .. }
+                if label.contains('\n') && *label_height > 16.0
+        )));
+        assert!(layout.items.iter().any(|item| matches!(
+            item,
+            LayoutedSequenceItem::BlockDivider { label, label_height, .. }
+                if label.contains('\n') && *label_height > 16.0
+        )));
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/CHANGELOG.md
+++ b/code/packages/rust/diagram-to-paint/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Shape resolved multiline sequence control labels without backend soft rewrapping.
 - Validate hyphenated sequence actor IDs through the native Metal PNG pipeline.
 - Validate multiword sequence actor IDs through the native Metal PNG pipeline.
 - Validate forced sequence text wrapping through PaintScene and Metal PNG rendering.

--- a/code/packages/rust/diagram-to-paint/Cargo.toml
+++ b/code/packages/rust/diagram-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diagram-to-paint"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Lowers a LayoutedGraphDiagram (DG00) into a PaintScene (P2D00) for rendering by paint-metal and other backends"
 

--- a/code/packages/rust/diagram-to-paint/src/lib.rs
+++ b/code/packages/rust/diagram-to-paint/src/lib.rs
@@ -26,7 +26,7 @@
 //! 2. All node shapes (filled over edges so endpoints are hidden).
 //! 3. All text (node labels + edge labels + title) via `layout-to-paint`.
 
-pub const VERSION: &str = "0.18.0";
+pub const VERSION: &str = "0.19.0";
 
 use std::collections::HashMap;
 
@@ -1166,6 +1166,7 @@ where
         if let LayoutedSequenceItem::BlockFrame {
             kind,
             label,
+            label_height,
             fill: frame_fill,
             x,
             y,
@@ -1194,12 +1195,12 @@ where
                 } else {
                     format!("{}  {label}", sequence_block_name(kind))
                 };
-                text_children.push(text_node(
+                text_children.push(text_node_no_wrap(
                     &frame_label,
                     *x + 8.0,
                     *y + 6.0,
                     *width - 16.0,
-                    20.0,
+                    *label_height,
                     label_font.clone(),
                     text_color,
                 ));
@@ -1208,7 +1209,14 @@ where
     }
 
     for item in &diagram.items {
-        if let LayoutedSequenceItem::BlockDivider { label, x, y, width } = item {
+        if let LayoutedSequenceItem::BlockDivider {
+            label,
+            label_height,
+            x,
+            y,
+            width,
+        } = item
+        {
             instructions.push(PaintInstruction::Path(PaintPath {
                 base: PaintBase::default(),
                 commands: vec![
@@ -1227,12 +1235,12 @@ where
                 stroke_dash: Some(vec![4.0, 3.0]),
                 stroke_dash_offset: None,
             }));
-            text_children.push(text_node(
+            text_children.push(text_node_no_wrap(
                 label,
                 *x + 8.0,
                 *y + 5.0,
                 *width - 16.0,
-                20.0,
+                *label_height,
                 label_font.clone(),
                 text_color,
             ));
@@ -2694,7 +2702,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.18.0");
+        assert_eq!(crate::VERSION, "0.19.0");
     }
 
     #[test]

--- a/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
+++ b/code/packages/rust/diagram-to-paint/tests/e2e_render.rs
@@ -349,7 +349,7 @@ mod apple {
     #[test]
     fn render_mermaid_sequence_to_png() {
         let mut diagram = parse_sequence_diagram(
-            "sequenceDiagram;title: Native Mermaid sequence;accTitle: Native transfer sequence;accDescr {\n  Banking transfer\n  interaction\n}\nautonumber\nbox hsl(180, 100%, 50%) Client tier\nactor Banking User-Primary as User\nparticipant API@{ \"type\": \"boundary\" } as Banking API\nend\nbox Services\nparticipant DB@{ \"type\": \"database\", \"alias\": \"Ledger\" }\nend\nalt Transfer accepted\nBanking User-Primary->>+API: wrap: Submit a deliberately detailed native transfer request\ncreate participant Worker as Audit Worker\nAPI()->>()Worker: Start audit\nWorker--|\\API: Audit complete\ndestroy Worker\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal #9829;<br/>native scene\nAPI-->>-Banking User-Primary: Transfer complete\nelse Transfer rejected\nAPI-->>Banking User-Primary: Validation failed\nend",
+            "sequenceDiagram;title: Native Mermaid sequence;accTitle: Native transfer sequence;accDescr {\n  Banking transfer\n  interaction\n}\nautonumber\nbox hsl(180, 100%, 50%) Client tier\nactor Banking User-Primary as User\nparticipant API@{ \"type\": \"boundary\" } as Banking API\nend\nbox Services\nparticipant DB@{ \"type\": \"database\", \"alias\": \"Ledger\" }\nend\nalt wrap: Transfer accepted after a deliberately detailed native policy and compliance evaluation\nBanking User-Primary->>+API: wrap: Submit a deliberately detailed native transfer request\ncreate participant Worker as Audit Worker\nAPI()->>()Worker: Start audit\nWorker--|\\API: Audit complete\ndestroy Worker\nloop Persist until committed\nAPI->>DB: Record transaction\nDB-->>API: Committed\nend\nnote right of API: Metal #9829;<br/>native scene\nAPI-->>-Banking User-Primary: Transfer complete\nelse wrap: Transfer rejected after a deliberately detailed native policy and compliance evaluation\nAPI-->>Banking User-Primary: Validation failed\nend",
         )
         .expect("Mermaid sequence parse failed");
         diagram.auto_number_start = 10.5;
@@ -359,6 +359,7 @@ mod apple {
             SequenceEvent::BlockStart {
                 kind: SequenceBlockKind::Rect,
                 label: String::new(),
+                wrap: diagram_ir::SequenceTextWrap::Default,
                 fill: Some("rgba(255, 200, 100, 0.12)".into()),
             },
         );

--- a/code/packages/rust/mermaid-parser/CHANGELOG.md
+++ b/code/packages/rust/mermaid-parser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.26.0
+
+- Preserve `wrap:` and `nowrap:` directives on sequence control-block and branch labels.
+
 ## 0.25.0
 
 - Preserve hyphens inside sequence actor identifiers without confusing them with message deactivation markers.

--- a/code/packages/rust/mermaid-parser/Cargo.toml
+++ b/code/packages/rust/mermaid-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermaid-parser"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "Versioned Mermaid compatibility dispatcher and grammar-driven diagram parsers"
 

--- a/code/packages/rust/mermaid-parser/README.md
+++ b/code/packages/rust/mermaid-parser/README.md
@@ -61,6 +61,8 @@ Sequence message and note `<br>` variants become semantic newlines with
 deterministic multiline layout and native glyph shaping.
 Message and note `wrap:` and `nowrap:` directives survive semantic lowering;
 forced wrapping becomes deterministic hard lines before backend-neutral Paint shaping.
+The same wrap controls apply to control-block and branch labels, with sequence
+layout reserving line-aware frame and divider geometry.
 All Mermaid 11.16.1 solid/dotted, normal/reverse filled and stick half-arrow
 forms preserve their line style, half orientation, and endpoint through Paint.
 Central connection markers before and/or after an arrow preserve source,

--- a/code/packages/rust/mermaid-parser/src/lib.rs
+++ b/code/packages/rust/mermaid-parser/src/lib.rs
@@ -6,7 +6,7 @@
 // of the lint file-wide.
 #![allow(clippy::manual_strip)]
 
-pub const VERSION: &str = "0.25.0";
+pub const VERSION: &str = "0.26.0";
 pub const MERMAID_COMPATIBILITY_BASELINE: &str = "11.16.1";
 
 use std::collections::HashMap;
@@ -1524,15 +1524,21 @@ fn parse_sequence_control_block(
             ))
         }
     };
-    let block_text = take_sequence_line_text(cursor);
-    let (label, fill) = if kind == SequenceBlockKind::Rect {
-        (String::new(), Some(normalize_sequence_color(&block_text)))
+    let (label, wrap, fill) = if kind == SequenceBlockKind::Rect {
+        let color = take_sequence_line_text(cursor);
+        (
+            String::new(),
+            SequenceTextWrap::Default,
+            Some(normalize_sequence_color(&color)),
+        )
     } else {
-        (block_text, None)
+        let (label, wrap) = take_sequence_wrapped_text(cursor);
+        (label, wrap, None)
     };
     diagram.events.push(SequenceEvent::BlockStart {
         kind: kind.clone(),
         label,
+        wrap,
         fill,
     });
     cursor.skip_terminators();
@@ -1562,9 +1568,10 @@ fn parse_sequence_control_block(
                 format!("unexpected sequence block branch {:?}", branch.value),
             ));
         }
-        diagram.events.push(SequenceEvent::BlockBranch {
-            label: take_sequence_line_text(cursor),
-        });
+        let (label, wrap) = take_sequence_wrapped_text(cursor);
+        diagram
+            .events
+            .push(SequenceEvent::BlockBranch { label, wrap });
         cursor.skip_terminators();
     }
 }
@@ -3189,7 +3196,7 @@ Rel(customer, web, \"Uses\", \"HTTPS\")";
         ));
         assert!(matches!(
             &diagram.events[5],
-            SequenceEvent::BlockBranch { label } if label == "Rejected"
+            SequenceEvent::BlockBranch { label, .. } if label == "Rejected"
         ));
         assert!(matches!(
             diagram.events.last(),
@@ -3504,6 +3511,29 @@ B//-A: reverse stick top
     }
 
     #[test]
+    fn sequence_preserves_control_block_wrap_directives() {
+        let diagram = parse_sequence_diagram(
+            "sequenceDiagram\nalt wrap: A deliberately detailed acceptance path\nA->>B: Yes\nelse nowrap: A deliberately detailed rejection path\nB-->>A: No\nend\n",
+        )
+        .unwrap();
+        assert!(matches!(
+            &diagram.events[0],
+            SequenceEvent::BlockStart {
+                label,
+                wrap: SequenceTextWrap::Wrap,
+                ..
+            } if label == "A deliberately detailed acceptance path"
+        ));
+        assert!(matches!(
+            &diagram.events[2],
+            SequenceEvent::BlockBranch {
+                label,
+                wrap: SequenceTextWrap::NoWrap,
+            } if label == "A deliberately detailed rejection path"
+        ));
+    }
+
+    #[test]
     fn sequence_preserves_multiword_actor_identifiers() {
         let diagram = parse_sequence_diagram(
             "sequenceDiagram\nparticipant Customer Portal as Customer\nparticipant Order Service\nCustomer Portal->>Order Service: Submit\nnote over Customer Portal,Order Service: Accepted\nactivate Order Service\ndeactivate Order Service\n",
@@ -3593,7 +3623,7 @@ mod tests {
 
     #[test]
     fn version_exists() {
-        assert_eq!(crate::VERSION, "0.25.0");
+        assert_eq!(crate::VERSION, "0.26.0");
     }
 
     #[test]

--- a/code/specs/DG04-mermaid-compatibility.md
+++ b/code/specs/DG04-mermaid-compatibility.md
@@ -143,6 +143,8 @@ sequence layout reserves line-aware geometry before Paint glyph shaping.
 Message and note `wrap:` and `nowrap:` directives lower to explicit semantic
 wrap intent. Forced wrapping is resolved into deterministic lines during
 sequence layout, before Paint glyph shaping and native backend rendering.
+Control-block and branch labels carry the same explicit wrap intent; layout
+reserves line-aware frame headers and branch bands before Paint lowering.
 Whitespace-separated multiword actor IDs are grammar-backed and retain one
 semantic identity across declarations, messages, notes, lifecycle events, and
 participant metadata before layout and Paint lowering.


### PR DESCRIPTION
## Summary
- add grammar-backed `wrap:` and `nowrap:` directives for sequence control and branch labels
- preserve wrap intent in semantic IR and resolve it into line-aware frame/divider geometry
- prevent backend soft rewrapping of resolved labels and reserve multiline message labels below block headers
- validate wrapped blocks through PaintScene/PaintInstructions and Metal-to-PNG rendering

## Verification
- `cargo test -p diagram-ir -p diagram-layout-sequence -p mermaid-lexer -p mermaid-parser -p diagram-to-paint`
- `cargo clippy -p diagram-ir -p diagram-layout-sequence -p mermaid-lexer -p mermaid-parser -p diagram-to-paint --all-targets --no-deps -- -D warnings`
- Metal PNG: `/tmp/mermaid_sequence_e2e.png`