### PR TITLE
Add wipe-on-lock vault search projection

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this package are documented here.
 
+## [0.12.0] - 2026-08-09
+
+### Added
+
+- Build a rebuildable in-memory search projection during authenticated reopen
+  and expose bounded `search_items` reads with optional exact collection
+  filtering.
+- Normalize indexed metadata and owned queries with Unicode lowercase followed
+  by NFC, support valid one- and two-byte queries, and deterministically order
+  results by normalized display title, schema, then item-ID bytes.
+
+### Security
+
+- Admit only display titles/labels, usernames, URLs, services, database hosts,
+  and present tags; passwords, note bodies, seeds, tokens, card data, lease IDs,
+  opaque payloads, and non-allowlisted metadata never enter the projection.
+- Hold normalized searchable text and query terms in wipe-on-drop containers,
+  clear the trigram accelerator with the unlocked session, fail closed on any
+  current conflict, and omit indexed values and identities from diagnostics.
+- Intersect whitespace-delimited token candidates, post-filter every trigram
+  candidate for exact normalized substring matches, and
+  safely scan short queries or entries too large for the accelerator without
+  truncating searchable metadata.
+
 ## [0.11.0] - 2026-08-09
 
 ### Added

--- a/code/packages/rust/vault-pm-application/Cargo.toml
+++ b/code/packages/rust/vault-pm-application/Cargo.toml
@@ -14,7 +14,9 @@ coding_adventures_sha256 = { path = "../sha256" }
 coding_adventures_vault_pm_domain = { path = "../vault-pm-domain" }
 coding_adventures_vault_pm_format = { path = "../vault-pm-format" }
 coding_adventures_vault_pm_repository = { path = "../vault-pm-repository" }
+coding_adventures_vault_search = { path = "../vault-search" }
 coding_adventures_vault_pm_storage = { path = "../vault-pm-storage" }
 coding_adventures_vault_records = { path = "../vault-records" }
 coding_adventures_x25519 = { path = "../x25519" }
 coding_adventures_zeroize = { path = "../zeroize" }
+unicode-normalize = { path = "../unicode-normalize" }

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -66,10 +66,24 @@ returns a partial list, and every candidate remains available for later
 resolution. Returned lists are deterministic by exact item-ID bytes and their
 display metadata is wiped on drop by the domain view types.
 
+Authenticated reopen also builds a session-owned, rebuildable search
+projection. The application admits only the VLT-PM05 allowlist of redacted
+titles/labels, usernames, URLs, services, database hosts, and present tags;
+secret and non-allowlisted fields never enter it. Owned queries are limited to
+1–256 UTF-8 bytes, reject control characters, and are normalized with Unicode
+lowercase plus NFC. The trigram primitive accelerates eligible searches, while
+exact post-filtering and bounded fallbacks preserve correct substring behavior
+for each whitespace-delimited token, including short queries and unusually
+large safe metadata. Results can apply one
+explicit collection filter and are always re-ordered by normalized title,
+schema, and item-ID bytes. Conflicts fail the complete search closed, ordinary
+diagnostics expose only an indexed-item count, and dropping the unlocked
+session clears the accelerator and wipes normalized metadata.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
-credential store, or entropy source. Search projection and mutation workflows
-land in the next slices. There is no unchecked
+credential store, or entropy source. Mutation, history, export, audit, and
+doctor workflows land in the next slices. There is no unchecked
 repository verification path: construction decrypts and
 authority-verifies the exact locally pinned certificate frame and object ID,
 and commits and announcements must match that vault, device, certificate ID,
@@ -87,7 +101,11 @@ catalog materialization plus dangling current-revision, missing-parent, and
 cross-item rejection. Repository tests exercise initialization, publication,
 verified open/read/history, every injected provider operation, constructor
 paths, and complete error translation.
-The exact Tarpaulin LLVM result is 1,580 of 1,647 production lines (95.93%).
+Search tests cover Unicode normalization, short queries, oversized safe-field
+fallback, exact collection filters, deterministic product ordering, every
+record schema's allowlist/denylist, secret exclusion, query/result bounds, and
+conflict closure. The exact Tarpaulin LLVM result is 1,748 of 1,827 production
+lines (95.68%).
 
 ## Development
 

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -12,6 +12,7 @@ mod crypto;
 mod initialize;
 mod open;
 mod repository;
+mod search;
 mod state;
 mod verifier;
 

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1,4 +1,5 @@
 use crate::initialize::{unlock_active_material, UnlockedActiveMaterial};
+use crate::search::SearchProjectionV1;
 use crate::{
     open_object, ActiveStateV1, ApplicationError, ApplicationRepository,
     ApplicationRepositoryError, ApplicationRepositoryFactory, BootstrapLocator, BootstrapStore,
@@ -6,7 +7,7 @@ use crate::{
     LocalVaultStateV1, ObjectKind, V1Keys,
 };
 use coding_adventures_vault_pm_domain::{
-    ItemCandidate, ItemId, ItemState, RedactedItemView, RevisionId,
+    CollectionId, ItemCandidate, ItemId, ItemState, RedactedItemView, RevisionId,
 };
 use coding_adventures_vault_pm_format::{DeviceId, ObjectId, VaultId};
 use coding_adventures_vault_pm_repository::{OpenReport, PinnedHeads};
@@ -47,6 +48,7 @@ pub struct UnlockedVaultV1 {
     active: ActiveStateV1,
     report: OpenReport,
     current_catalog: CurrentCatalogV1,
+    search: SearchProjectionV1,
     _keys: V1Keys,
     _local_secret: LocalSecretV1,
     _repository: Box<dyn ApplicationRepository>,
@@ -116,6 +118,32 @@ impl UnlockedVaultV1 {
         }
         Ok(views)
     }
+
+    /// Search unambiguous live items using only approved redacted metadata.
+    ///
+    /// The owned query is wiped on every return path. It must contain 1–256
+    /// UTF-8 bytes and no control characters. Results optionally require
+    /// membership in one explicit collection and are ordered by normalized
+    /// display title, schema, then exact item-ID bytes. Any current conflict
+    /// aborts the complete search without returning partial results.
+    pub fn search_items(
+        &self,
+        query: Zeroizing<String>,
+        collection: Option<CollectionId>,
+        limit: usize,
+    ) -> Result<Vec<RedactedItemView>, ApplicationError> {
+        if self.current_catalog.conflicted_item_count() != 0 {
+            return Err(ApplicationError::ConflictRequired);
+        }
+        self.search
+            .search(query, collection, limit, &self.current_catalog.items)
+    }
+
+    /// Return how many unambiguous live items are held in the wipe-on-lock
+    /// search projection without exposing item identities or indexed text.
+    pub fn search_item_count(&self) -> usize {
+        self.search.len()
+    }
 }
 
 fn project_current_item(
@@ -144,6 +172,7 @@ impl Debug for UnlockedVaultV1 {
                 "conflicted_item_count",
                 &self.current_catalog.conflicted_item_count(),
             )
+            .field("search_item_count", &self.search.len())
             .finish_non_exhaustive()
     }
 }
@@ -195,11 +224,13 @@ pub fn open_active_vault(
         &report,
         active.vault_id(),
     )?;
+    let search = SearchProjectionV1::build(&current_catalog.items)?;
 
     Ok(UnlockedVaultV1 {
         active,
         report,
         current_catalog,
+        search,
         _keys: material.keys,
         _local_secret: material.local_secret,
         _repository: repository,
@@ -592,14 +623,21 @@ mod tests {
         let fixture = generation_zero_bytes();
         let root_key: [u8; 32] = fixture[48..80].try_into().unwrap();
         let keys = V1Keys::derive(active.vault_id(), &root_key).unwrap();
+        let mut collections = ObservedSet::new();
+        collections
+            .add(CollectionId::new([0x82; 16]), OperationId::new([0x83; 32]))
+            .unwrap();
+        let mut tags = ObservedSet::new();
+        tags.add("Finance".to_owned(), OperationId::new([0x84; 32]))
+            .unwrap();
         let document = ItemDocument::new(
             item_id,
             ContentType::new(LOGIN_V1).unwrap(),
             100,
             200,
             LwwRegister::new(false, 200, OperationId::new([0x81; 32])),
-            ObservedSet::new(),
-            ObservedSet::new(),
+            collections,
+            tags,
             AnyRecord::Login(Login {
                 title: title.into(),
                 username: "ada@example.test".into(),
@@ -805,9 +843,10 @@ mod tests {
         assert_eq!(session.item_count(), 0);
         assert_eq!(session.candidate_count(), 0);
         assert_eq!(session.conflicted_item_count(), 0);
+        assert_eq!(session.search_item_count(), 0);
         assert_eq!(
             format!("{session:?}"),
-            "UnlockedVaultV1 { local_pin_count: 1, verified_head_count: 1, item_count: 0, candidate_count: 0, conflicted_item_count: 0, .. }"
+            "UnlockedVaultV1 { local_pin_count: 1, verified_head_count: 1, item_count: 0, candidate_count: 0, conflicted_item_count: 0, search_item_count: 0, .. }"
         );
     }
 
@@ -865,7 +904,7 @@ mod tests {
             panic!("fixture must be active")
         };
         let item_id = ItemId::new([0x27; 16]);
-        let title = "Personal portal";
+        let title = "ÉCLAIR Personal portal";
         let password = "never-log-this-password";
         let publication = pending_live_publication(&active, item_id, title, password);
         let pending = LocalVaultStateV1::pending_publication(active, publication).unwrap();
@@ -908,6 +947,68 @@ mod tests {
         }
         assert_eq!(session.list_items().unwrap(), vec![view.clone()]);
         assert_eq!(session.get_item(ItemId::new([0x28; 16])).unwrap(), None);
+        assert_eq!(session.search_item_count(), 1);
+        for query in [
+            "E\u{301}CLAIR",
+            "ada@EXAMPLE",
+            "AMPLE.TEST",
+            "finance",
+            "portal ada@example",
+            "a",
+        ] {
+            assert_eq!(
+                session
+                    .search_items(Zeroizing::new(query.to_owned()), None, 10)
+                    .unwrap(),
+                vec![view.clone()]
+            );
+        }
+        assert!(session
+            .search_items(Zeroizing::new("   ".to_owned()), None, 10)
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            session
+                .search_items(
+                    Zeroizing::new("portal".to_owned()),
+                    Some(CollectionId::new([0x82; 16])),
+                    10,
+                )
+                .unwrap(),
+            vec![view.clone()]
+        );
+        assert!(session
+            .search_items(
+                Zeroizing::new("portal".to_owned()),
+                Some(CollectionId::new([0x85; 16])),
+                10,
+            )
+            .unwrap()
+            .is_empty());
+        for secret in [password, "private note"] {
+            assert!(session
+                .search_items(Zeroizing::new(secret.to_owned()), None, 10)
+                .unwrap()
+                .is_empty());
+        }
+        for invalid in ["", "line\nbreak", "\0"] {
+            assert_eq!(
+                session.search_items(Zeroizing::new(invalid.to_owned()), None, 10),
+                Err(ApplicationError::InvalidInput)
+            );
+        }
+        assert_eq!(
+            session.search_items(Zeroizing::new("x".repeat(257)), None, 10),
+            Err(ApplicationError::InvalidInput)
+        );
+        assert_eq!(
+            session.search_items(Zeroizing::new("portal".to_owned()), None, 0),
+            Err(ApplicationError::InvalidInput)
+        );
+        assert_eq!(
+            session.search_items(Zeroizing::new("portal".to_owned()), None, 10_001),
+            Err(ApplicationError::BoundExceeded)
+        );
         let debug = format!("{view:?}");
         assert!(!debug.contains(title));
         assert!(!debug.contains(password));
@@ -959,6 +1060,10 @@ mod tests {
                     Err(ApplicationError::ConflictRequired)
                 );
                 assert_eq!(session.candidate_count(), 2);
+                assert_eq!(
+                    session.search_items(Zeroizing::new("anything".to_owned()), None, 10),
+                    Err(ApplicationError::ConflictRequired)
+                );
             }
         }
     }

--- a/code/packages/rust/vault-pm-application/src/search.rs
+++ b/code/packages/rust/vault-pm-application/src/search.rs
@@ -1,0 +1,554 @@
+use crate::ApplicationError;
+use coding_adventures_vault_pm_domain::{
+    CollectionId, ItemCandidate, ItemDocument, ItemId, ItemState, RedactedItemView,
+    RedactedRecordView,
+};
+use coding_adventures_vault_search::{
+    DocumentId, SearchError, SearchIndex, SearchableFields, MAX_INDEXED_FIELD_LEN,
+};
+use coding_adventures_zeroize::{Zeroize, Zeroizing};
+use std::collections::{BTreeMap, BTreeSet};
+use unicode_normalize::UnicodeNormalize;
+
+pub(crate) const MAX_SEARCH_QUERY_BYTES: usize = 256;
+pub(crate) const MAX_SEARCH_RESULTS: usize = 10_000;
+
+struct SearchEntryV1 {
+    normalized_title: Zeroizing<String>,
+    normalized_text: Zeroizing<String>,
+    accelerated: bool,
+}
+
+pub(crate) struct SearchProjectionV1 {
+    index: SearchIndex,
+    entries: BTreeMap<ItemId, SearchEntryV1>,
+}
+
+impl SearchProjectionV1 {
+    pub(crate) fn build(
+        items: &BTreeMap<ItemId, Vec<ItemCandidate>>,
+    ) -> Result<Self, ApplicationError> {
+        let index = SearchIndex::new();
+        let mut entries = BTreeMap::new();
+        for (item_id, candidates) in items {
+            let [candidate] = candidates.as_slice() else {
+                continue;
+            };
+            let ItemState::Live(document) = candidate.state() else {
+                continue;
+            };
+            let entry = SearchEntryV1::from_document(document)?;
+            if entry.normalized_text.len() <= MAX_INDEXED_FIELD_LEN {
+                index_entry(&index, *item_id, &entry.normalized_text)?;
+            }
+            let accelerated = entry.normalized_text.len() <= MAX_INDEXED_FIELD_LEN;
+            entries.insert(
+                *item_id,
+                SearchEntryV1 {
+                    accelerated,
+                    ..entry
+                },
+            );
+        }
+        Ok(Self { index, entries })
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub(crate) fn search(
+        &self,
+        query: Zeroizing<String>,
+        collection: Option<CollectionId>,
+        limit: usize,
+        items: &BTreeMap<ItemId, Vec<ItemCandidate>>,
+    ) -> Result<Vec<RedactedItemView>, ApplicationError> {
+        validate_query(&query, limit)?;
+        let normalized_query = normalize(&query);
+        let tokens = normalized_query.split_whitespace().collect::<Vec<_>>();
+        if tokens.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut candidate_ids = self.candidates_for_token(tokens[0])?;
+        for token in &tokens[1..] {
+            let token_candidates = self.candidates_for_token(token)?;
+            candidate_ids.retain(|item_id| token_candidates.contains(item_id));
+        }
+
+        let mut matches = Vec::new();
+        for item_id in candidate_ids {
+            let entry = self
+                .entries
+                .get(&item_id)
+                .ok_or(ApplicationError::InternalInvariant)?;
+            if !tokens
+                .iter()
+                .all(|token| entry.normalized_text.contains(token))
+            {
+                continue;
+            }
+            let document = current_live_document(
+                items
+                    .get(&item_id)
+                    .ok_or(ApplicationError::InternalInvariant)?,
+            )?;
+            if collection.is_some_and(|id| !document.collection_ids().contains(&id)) {
+                continue;
+            }
+            matches.push(item_id);
+        }
+
+        matches.sort_by(|left, right| {
+            let left_entry = &self.entries[left];
+            let right_entry = &self.entries[right];
+            let left_document = live_document_invariant(&items[left]);
+            let right_document = live_document_invariant(&items[right]);
+            left_entry
+                .normalized_title
+                .cmp(&right_entry.normalized_title)
+                .then_with(|| {
+                    left_document
+                        .schema()
+                        .as_str()
+                        .cmp(right_document.schema().as_str())
+                })
+                .then_with(|| left.as_bytes().cmp(right.as_bytes()))
+        });
+        matches.truncate(limit);
+
+        matches
+            .into_iter()
+            .map(|item_id| {
+                RedactedItemView::from_document(live_document_invariant(&items[&item_id]))
+                    .map_err(|_| ApplicationError::InternalInvariant)
+            })
+            .collect()
+    }
+
+    fn candidates_for_token(
+        &self,
+        normalized_token: &str,
+    ) -> Result<BTreeSet<ItemId>, ApplicationError> {
+        if normalized_token.len() < 3 {
+            return Ok(self.entries.keys().copied().collect());
+        }
+        let hits = self
+            .index
+            .search(normalized_token, self.index.len())
+            .map_err(map_query_error)?;
+        let mut candidates = BTreeSet::new();
+        for hit in hits {
+            let item_id = ItemId::from_user_string(hit.id.as_str())
+                .map_err(|_| ApplicationError::InternalInvariant)?;
+            if !self.entries.contains_key(&item_id) {
+                return Err(ApplicationError::InternalInvariant);
+            }
+            candidates.insert(item_id);
+        }
+        candidates.extend(
+            self.entries
+                .iter()
+                .filter_map(|(item_id, entry)| (!entry.accelerated).then_some(*item_id)),
+        );
+        Ok(candidates)
+    }
+}
+
+impl Drop for SearchProjectionV1 {
+    fn drop(&mut self) {
+        self.index.clear();
+    }
+}
+
+impl SearchEntryV1 {
+    fn from_document(document: &ItemDocument) -> Result<Self, ApplicationError> {
+        let view = RedactedItemView::from_document(document)
+            .map_err(|_| ApplicationError::InternalInvariant)?;
+        let title = display_title(&view.record).unwrap_or_default();
+        let normalized_title = normalize(title);
+        let mut normalized_text = Zeroizing::new(String::new());
+        push_normalized(&mut normalized_text, title);
+
+        match &view.record {
+            RedactedRecordView::Login { username, urls, .. } => {
+                push_normalized(&mut normalized_text, username);
+                for url in urls {
+                    push_normalized(&mut normalized_text, url);
+                }
+            }
+            RedactedRecordView::ApiKey { service, .. } => {
+                push_normalized(&mut normalized_text, service);
+            }
+            RedactedRecordView::DatabaseCredential { host, username, .. } => {
+                push_normalized(&mut normalized_text, host);
+                push_normalized(&mut normalized_text, username);
+            }
+            RedactedRecordView::SecureNote { .. }
+            | RedactedRecordView::Card { .. }
+            | RedactedRecordView::TotpSeed { .. }
+            | RedactedRecordView::Opaque { .. } => {}
+        }
+        for tag in document.tags().values() {
+            push_normalized(&mut normalized_text, tag);
+        }
+
+        Ok(Self {
+            normalized_title,
+            normalized_text,
+            accelerated: false,
+        })
+    }
+}
+
+fn display_title(record: &RedactedRecordView) -> Option<&str> {
+    match record {
+        RedactedRecordView::Login { title, .. }
+        | RedactedRecordView::SecureNote { title, .. }
+        | RedactedRecordView::Card { title, .. } => Some(title),
+        RedactedRecordView::TotpSeed { label, .. }
+        | RedactedRecordView::ApiKey { label, .. }
+        | RedactedRecordView::DatabaseCredential { label, .. } => Some(label),
+        RedactedRecordView::Opaque { .. } => None,
+    }
+}
+
+fn push_normalized(destination: &mut String, value: &str) {
+    if !destination.is_empty() {
+        destination.push('\n');
+    }
+    let normalized = normalize(value);
+    destination.push_str(&normalized);
+}
+
+fn normalize(value: &str) -> Zeroizing<String> {
+    let mut lowered = Zeroizing::new(
+        value
+            .chars()
+            .flat_map(char::to_lowercase)
+            .collect::<String>(),
+    );
+    let normalized = Zeroizing::new(lowered.as_str().nfc().collect::<String>());
+    lowered.zeroize();
+    normalized
+}
+
+fn index_entry(
+    index: &SearchIndex,
+    item_id: ItemId,
+    normalized_text: &str,
+) -> Result<(), ApplicationError> {
+    let id = DocumentId::new(item_id.to_user_string())
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    let fields = BTreeMap::from([("content".to_owned(), normalized_text.to_owned())]);
+    let searchable = SearchableFields::new().with("content", 1.0);
+    let result = index.index(id, &fields, &searchable);
+    for (mut key, mut value) in fields {
+        key.zeroize();
+        value.zeroize();
+    }
+    result.map_err(map_index_error)
+}
+
+fn validate_query(query: &str, limit: usize) -> Result<(), ApplicationError> {
+    if query.is_empty()
+        || query.len() > MAX_SEARCH_QUERY_BYTES
+        || query.chars().any(char::is_control)
+        || limit == 0
+    {
+        return Err(ApplicationError::InvalidInput);
+    }
+    if limit > MAX_SEARCH_RESULTS {
+        return Err(ApplicationError::BoundExceeded);
+    }
+    Ok(())
+}
+
+fn current_live_document(candidates: &[ItemCandidate]) -> Result<&ItemDocument, ApplicationError> {
+    let [candidate] = candidates else {
+        return Err(ApplicationError::ConflictRequired);
+    };
+    match candidate.state() {
+        ItemState::Live(document) => Ok(document),
+        ItemState::Tombstone(_) => Err(ApplicationError::InternalInvariant),
+    }
+}
+
+fn live_document_invariant(candidates: &[ItemCandidate]) -> &ItemDocument {
+    match candidates {
+        [candidate] => match candidate.state() {
+            ItemState::Live(document) => document,
+            ItemState::Tombstone(_) => unreachable!("search entry cannot reference a tombstone"),
+        },
+        _ => unreachable!("search entry cannot reference a conflict"),
+    }
+}
+
+fn map_index_error(error: SearchError) -> ApplicationError {
+    match error {
+        SearchError::TooLarge(_) => ApplicationError::BoundExceeded,
+        SearchError::InvalidParameter(_) | SearchError::Decode(_) => {
+            ApplicationError::InternalInvariant
+        }
+    }
+}
+
+fn map_query_error(error: SearchError) -> ApplicationError {
+    match error {
+        SearchError::InvalidParameter(_) => ApplicationError::InvalidInput,
+        SearchError::TooLarge(_) => ApplicationError::BoundExceeded,
+        SearchError::Decode(_) => ApplicationError::InternalInvariant,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coding_adventures_vault_pm_domain::{
+        ContentType, LwwRegister, ObservedSet, OperationId, RevisionId,
+    };
+    use coding_adventures_vault_records::{
+        AnyRecord, ApiKey, Card, DatabaseCredential, Login, SecureNote, TotpSeed, API_KEY_V1,
+        CARD_V1, DATABASE_CREDENTIAL_V1, LOGIN_V1, SECURE_NOTE_V1, TOTP_SEED_V1,
+    };
+
+    fn live_candidate(item_id: ItemId, record: AnyRecord) -> ItemCandidate {
+        let schema = match &record {
+            AnyRecord::Login(_) => LOGIN_V1,
+            AnyRecord::SecureNote(_) => SECURE_NOTE_V1,
+            AnyRecord::Card(_) => CARD_V1,
+            AnyRecord::TotpSeed(_) => TOTP_SEED_V1,
+            AnyRecord::ApiKey(_) => API_KEY_V1,
+            AnyRecord::DatabaseCredential(_) => DATABASE_CREDENTIAL_V1,
+            AnyRecord::Opaque { content_type, .. } => content_type,
+        };
+        let document = ItemDocument::new(
+            item_id,
+            ContentType::new(schema).unwrap(),
+            1,
+            2,
+            LwwRegister::new(false, 2, OperationId::new([0x91; 32])),
+            ObservedSet::new(),
+            ObservedSet::new(),
+            record,
+            ObservedSet::new(),
+        )
+        .unwrap();
+        ItemCandidate::new(
+            RevisionId::new([item_id.as_bytes()[0].wrapping_add(1); 32]),
+            [],
+            ItemState::Live(Box::new(document)),
+        )
+        .unwrap()
+    }
+
+    fn login(item_id: ItemId, title: &str) -> (ItemId, Vec<ItemCandidate>) {
+        (
+            item_id,
+            vec![live_candidate(
+                item_id,
+                AnyRecord::Login(Login {
+                    title: title.to_owned(),
+                    username: "user@example.test".to_owned(),
+                    password: "credential-secret".to_owned(),
+                    urls: vec!["https://example.test".to_owned()],
+                    notes: Some("note-secret".to_owned()),
+                }),
+            )],
+        )
+    }
+
+    #[test]
+    fn results_use_title_schema_and_item_id_order_instead_of_rank() {
+        let first_login = ItemId::new([0x10; 16]);
+        let second_login = ItemId::new([0x20; 16]);
+        let note_id = ItemId::new([0x01; 16]);
+        let beta_id = ItemId::new([0x00; 16]);
+        let items = BTreeMap::from([
+            login(second_login, "ALPHA"),
+            login(first_login, "Alpha"),
+            (
+                note_id,
+                vec![live_candidate(
+                    note_id,
+                    AnyRecord::SecureNote(SecureNote {
+                        title: "alpha".to_owned(),
+                        body: "body-secret".to_owned(),
+                    }),
+                )],
+            ),
+            login(beta_id, "beta"),
+        ]);
+        let search = SearchProjectionV1::build(&items).unwrap();
+
+        let results = search
+            .search(Zeroizing::new("a".to_owned()), None, 10, &items)
+            .unwrap();
+        assert_eq!(
+            results.iter().map(|view| view.item_id).collect::<Vec<_>>(),
+            vec![first_login, second_login, note_id, beta_id]
+        );
+    }
+
+    #[test]
+    fn oversized_safe_metadata_uses_exact_fallback_without_indexing_secrets() {
+        let item_id = ItemId::new([0x30; 16]);
+        let mut title = "x".repeat(MAX_INDEXED_FIELD_LEN + 1);
+        title.push_str("needle");
+        let items = BTreeMap::from([login(item_id, &title)]);
+        let search = SearchProjectionV1::build(&items).unwrap();
+        assert_eq!(search.len(), 1);
+        assert_eq!(search.index.len(), 0);
+        assert_eq!(
+            search
+                .search(Zeroizing::new("needle".to_owned()), None, 10, &items)
+                .unwrap()[0]
+                .item_id,
+            item_id
+        );
+        for secret in ["credential-secret", "note-secret"] {
+            assert!(search
+                .search(Zeroizing::new(secret.to_owned()), None, 10, &items)
+                .unwrap()
+                .is_empty());
+        }
+    }
+
+    #[test]
+    fn every_record_schema_obeys_the_search_allowlist() {
+        let login_id = ItemId::new([0x41; 16]);
+        let note_id = ItemId::new([0x42; 16]);
+        let card_id = ItemId::new([0x43; 16]);
+        let totp_id = ItemId::new([0x44; 16]);
+        let api_id = ItemId::new([0x45; 16]);
+        let database_id = ItemId::new([0x46; 16]);
+        let opaque_id = ItemId::new([0x47; 16]);
+        let records = [
+            (
+                login_id,
+                AnyRecord::Login(Login {
+                    title: "Login Alpha".to_owned(),
+                    username: "login-user-visible".to_owned(),
+                    password: "login-password-secret".to_owned(),
+                    urls: vec!["https://login-visible.example".to_owned()],
+                    notes: Some("login-note-secret".to_owned()),
+                }),
+            ),
+            (
+                note_id,
+                AnyRecord::SecureNote(SecureNote {
+                    title: "Note Bravo".to_owned(),
+                    body: "note-body-secret".to_owned(),
+                }),
+            ),
+            (
+                card_id,
+                AnyRecord::Card(Card {
+                    title: "Card Charlie".to_owned(),
+                    holder: "card-holder-hidden".to_owned(),
+                    number: "4111111111111111".to_owned(),
+                    expiry_month: 12,
+                    expiry_year: 2030,
+                    cvv: "card-cvv-secret".to_owned(),
+                    billing_zip: Some("card-zip-hidden".to_owned()),
+                }),
+            ),
+            (
+                totp_id,
+                AnyRecord::TotpSeed(TotpSeed {
+                    label: "Totp Delta".to_owned(),
+                    issuer: Some("totp-issuer-hidden".to_owned()),
+                    secret: b"totp-seed-secret".to_vec(),
+                    algorithm: "totp-algorithm-hidden".to_owned(),
+                    digits: 6,
+                    period: 30,
+                }),
+            ),
+            (
+                api_id,
+                AnyRecord::ApiKey(ApiKey {
+                    label: "Api Echo".to_owned(),
+                    service: "api-service-visible".to_owned(),
+                    token: "api-token-secret".to_owned(),
+                    scopes: vec!["api-scope-hidden".to_owned()],
+                    expires_at: None,
+                }),
+            ),
+            (
+                database_id,
+                AnyRecord::DatabaseCredential(DatabaseCredential {
+                    label: "Database Foxtrot".to_owned(),
+                    engine: "database-engine-hidden".to_owned(),
+                    host: "database-host-visible".to_owned(),
+                    port: 5432,
+                    database: Some("database-name-hidden".to_owned()),
+                    username: "database-user-visible".to_owned(),
+                    password: "database-password-secret".to_owned(),
+                    lease_id: Some("database-lease-secret".to_owned()),
+                    expires_at: None,
+                }),
+            ),
+            (
+                opaque_id,
+                AnyRecord::Opaque {
+                    content_type: "vendor/opaque-hidden/v1".to_owned(),
+                    payload_bytes: b"opaque-payload-secret".to_vec(),
+                },
+            ),
+        ];
+        let items = records
+            .into_iter()
+            .map(|(item_id, record)| (item_id, vec![live_candidate(item_id, record)]))
+            .collect::<BTreeMap<_, _>>();
+        let search = SearchProjectionV1::build(&items).unwrap();
+
+        for (query, expected_id) in [
+            ("login alpha", login_id),
+            ("login-user-visible", login_id),
+            ("login-visible.example", login_id),
+            ("note bravo", note_id),
+            ("card charlie", card_id),
+            ("totp delta", totp_id),
+            ("api echo", api_id),
+            ("api-service-visible", api_id),
+            ("database foxtrot", database_id),
+            ("database-host-visible", database_id),
+            ("database-user-visible", database_id),
+        ] {
+            let results = search
+                .search(Zeroizing::new(query.to_owned()), None, 10, &items)
+                .unwrap();
+            assert_eq!(results.len(), 1, "query {query:?}");
+            assert_eq!(results[0].item_id, expected_id, "query {query:?}");
+        }
+
+        for forbidden in [
+            "login-password-secret",
+            "login-note-secret",
+            "note-body-secret",
+            "card-holder-hidden",
+            "4111111111111111",
+            "card-cvv-secret",
+            "card-zip-hidden",
+            "totp-issuer-hidden",
+            "totp-seed-secret",
+            "totp-algorithm-hidden",
+            "api-token-secret",
+            "api-scope-hidden",
+            "database-engine-hidden",
+            "database-name-hidden",
+            "database-password-secret",
+            "database-lease-secret",
+            "opaque-hidden",
+            "opaque-payload-secret",
+        ] {
+            assert!(
+                search
+                    .search(Zeroizing::new(forbidden.to_owned()), None, 10, &items)
+                    .unwrap()
+                    .is_empty(),
+                "forbidden query {forbidden:?}"
+            );
+        }
+    }
+}

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1292,9 +1292,15 @@ changelog, focused build, and downstream validation.
        rejection, and payload-free session counts;
    6d. redacted current-item views over materialized candidates, failing closed
        on unresolved conflicts without returning partial lists;
-   6e. the wipe-on-lock in-memory search projection, including the
-       password-manager query and Unicode-normalization policy adapter; and
-   7. item mutation, history, export, audit, status, and doctor workflows.
+   6e. the completed wipe-on-lock in-memory search projection, including the
+       password-manager query, exact collection-filter, Unicode-normalization,
+       safe-field allowlist, and deterministic ordering policy adapters;
+   7a. add-item mutation preparation and crash-resumable publication;
+   7b. compare-and-replace, delete, restore, and explicit conflict-resolution
+       mutation workflows;
+   7c. bounded history traversal and explicit zeroizing field reveal;
+   7d. authenticated portable export and restore/import preparation; and
+   7e. audit, status, and doctor workflows.
 9. `vault-pm-cli` + real executable and pseudo-terminal E2E suite.
 10. Crash/fault matrix and local restore drill.
 


### PR DESCRIPTION
## Summary
- build a session-owned in-memory search projection from the authenticated current catalog
- enforce the VLT-PM05 safe-field allowlist, Unicode lowercase plus NFC token matching, exact collection filtering, and deterministic product ordering
- wipe owned queries and normalized metadata on drop, clear the accelerator with the session, and fail complete searches closed on conflicts
- split the next application backlog into add, mutation/conflict, history/reveal, export/import, and audit/status/doctor slices

## Verification
- `cargo test -p coding_adventures_vault_pm_application -- --nocapture` (66 passed)
- `cargo clippy -p coding_adventures_vault_pm_application --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p coding_adventures_vault_pm_application --no-deps`
- Tarpaulin LLVM: 1,748/1,827 production lines (95.68%)
- affected planner: 1 changed package, 21 affected packages, all 21 built