### PR TITLE
Add crash-resumable vault item creation

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this package are documented here.
 
+## [0.13.0] - 2026-08-09
+
+### Added
+
+- Add one new item from an unlocked session using a caller-filled 256-byte
+  CSPRNG block for its item identity and three encrypted object frames.
+- Construct a parentless revision, complete rewritten catalog, signed commit
+  over every current head, signed announcement, and exact expected new pins.
+
+### Security
+
+- Consume the unlocked session and owned document/randomness on every return
+  path so stale pins and mutation inputs cannot remain available to callers.
+- Compare-exchange the exact `Active -> PendingPublication -> Active` owner
+  states around repository publication, accept only byte-identical ambiguous
+  winners, and retain a replayable journal across provider or final-local-write
+  interruption.
+- Reject mismatched generated identities, existing IDs, stale repository
+  heads, invalid documents, and counter overflow before publication.
+
 ## [0.12.0] - 2026-08-09
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -80,10 +80,22 @@ schema, and item-ID bytes. Conflicts fail the complete search closed, ordinary
 diagnostics expose only an indexed-item count, and dropping the unlocked
 session clears the accelerator and wipes normalized metadata.
 
+Unlocked sessions can add one new item through the same durable publication
+state machine. The host supplies one exact 256-byte CSPRNG block for a fresh
+item ID and the three encrypted frames. The application creates a parentless
+item revision, rewrites the complete bounded catalog without discarding any
+candidate, makes every current head a parent of the signed commit, and moves
+the local owner state through an exact compare-exchanged pending journal before
+publishing. Ambiguous writes accept only the byte-identical intended state,
+and a provider or final-local-write interruption remains recoverable by the
+existing pending-publication workflow. The mutation consumes its unlocked
+session so callers must reopen before observing or mutating the new pins.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
-credential store, or entropy source. Mutation, history, export, audit, and
-doctor workflows land in the next slices. There is no unchecked
+credential store, or entropy source. Replace, delete, restore, conflict
+resolution, history, export, audit, and doctor workflows land in the next
+slices. There is no unchecked
 repository verification path: construction decrypts and
 authority-verifies the exact locally pinned certificate frame and object ID,
 and commits and announcements must match that vault, device, certificate ID,
@@ -104,8 +116,12 @@ paths, and complete error translation.
 Search tests cover Unicode normalization, short queries, oversized safe-field
 fallback, exact collection filters, deterministic product ordering, every
 record schema's allowlist/denylist, secret exclusion, query/result bounds, and
-conflict closure. The exact Tarpaulin LLVM result is 1,748 of 1,827 production
-lines (95.68%).
+conflict closure. The exact Tarpaulin LLVM result is 1,903 of 1,992 production
+lines (95.53%). Add-item tests cover exact entropy partitioning and wiping,
+identity validation before local writes, parentless revision and complete
+catalog construction, ambiguous successful compare-exchanges, write-ahead
+publication ordering, ambiguous provider commits, failed final activation,
+and recovery through the exact persisted journal.
 
 ## Development
 

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -10,6 +10,7 @@
 mod codec;
 mod crypto;
 mod initialize;
+mod mutation;
 mod open;
 mod repository;
 mod search;
@@ -30,6 +31,7 @@ pub use initialize::{
     GenerationZeroPolicyV1, GenerationZeroRandomness, PreparedGenerationZero,
     GENERATION_ZERO_RANDOM_BYTES,
 };
+pub use mutation::{AddItemRandomnessV1, ADD_ITEM_RANDOM_BYTES};
 pub use open::{open_active_vault, recover_pending_publication, UnlockedVaultV1};
 pub use repository::{
     ApplicationRepository, ApplicationRepositoryError, ApplicationRepositoryFactory,

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -1,0 +1,355 @@
+use crate::{
+    encode_item_revision, encode_signed_commit, seal_object, ActiveStateV1, ApplicationError,
+    ApplicationRepository, ApplicationRepositoryError, CatalogV1, LocalSecretV1, LocalStateStore,
+    LocalStateStoreError, LocalVaultStateV1, ObjectKind, ObjectRandomness, PublicationJournalV1,
+    V1Keys,
+};
+use coding_adventures_ed25519::{generate_keypair, sign};
+use coding_adventures_vault_pm_domain::{
+    ItemCandidate, ItemDocument, ItemId, ItemState, RevisionId,
+};
+use coding_adventures_vault_pm_format::{AnnouncementV1, CommitV1, Signature};
+use coding_adventures_vault_pm_repository::{OpenReport, PinnedHeads};
+use coding_adventures_zeroize::{Zeroize, Zeroizing};
+use core::fmt::{self, Debug, Formatter};
+use std::collections::{BTreeMap, BTreeSet};
+
+const ITEM_ID_BYTES: usize = 16;
+const OBJECT_RANDOM_BYTES: usize = 32 + 24 + 24;
+
+/// Exact caller-filled CSPRNG bytes consumed by one add-item mutation.
+pub const ADD_ITEM_RANDOM_BYTES: usize = ITEM_ID_BYTES + 3 * OBJECT_RANDOM_BYTES;
+
+/// Owned wipe-on-drop entropy for one item ID and three encrypted frames.
+pub struct AddItemRandomnessV1 {
+    bytes: [u8; ADD_ITEM_RANDOM_BYTES],
+}
+
+impl AddItemRandomnessV1 {
+    /// Take one exact block filled by the host's cryptographic entropy source.
+    pub const fn new(bytes: [u8; ADD_ITEM_RANDOM_BYTES]) -> Self {
+        Self { bytes }
+    }
+
+    /// Return the item ID derived from the dedicated first 16 random bytes.
+    pub fn item_id(&self) -> ItemId {
+        ItemId::new(
+            self.bytes[..ITEM_ID_BYTES]
+                .try_into()
+                .expect("the item-ID partition length is constant"),
+        )
+    }
+}
+
+impl Zeroize for AddItemRandomnessV1 {
+    fn zeroize(&mut self) {
+        self.bytes.zeroize();
+    }
+}
+
+impl Drop for AddItemRandomnessV1 {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl Debug for AddItemRandomnessV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("AddItemRandomnessV1(<redacted>)")
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn add_item(
+    active: &ActiveStateV1,
+    report: &OpenReport,
+    current_items: &BTreeMap<ItemId, Vec<ItemCandidate>>,
+    keys: &V1Keys,
+    local_secret: &LocalSecretV1,
+    repository: &dyn ApplicationRepository,
+    document: ItemDocument,
+    wall_time_ms: u64,
+    randomness: AddItemRandomnessV1,
+    local_state_store: &dyn LocalStateStore,
+) -> Result<ActiveStateV1, ApplicationError> {
+    if report.heads() != active.pinned_heads() {
+        return Err(ApplicationError::ConcurrentHost);
+    }
+    if document.id() != randomness.item_id() {
+        return Err(ApplicationError::InvalidInput);
+    }
+    document
+        .validate()
+        .map_err(|_| ApplicationError::InvalidInput)?;
+    if current_items.contains_key(&document.id()) {
+        return Err(ApplicationError::InvalidInput);
+    }
+
+    let publication = prepare_add_publication(
+        active,
+        current_items,
+        keys,
+        local_secret,
+        document,
+        wall_time_ms,
+        randomness,
+    )?;
+    let intended_active = active.after_publication(&publication)?;
+    let exact_active = LocalVaultStateV1::Active(active.clone()).encode()?;
+    let exact_pending =
+        LocalVaultStateV1::pending_publication(active.clone(), publication.clone())?.encode()?;
+    let exact_intended = LocalVaultStateV1::Active(intended_active.clone()).encode()?;
+    let locator = active.bootstrap_locator();
+
+    match local_state_store.compare_exchange(locator, Some(&exact_active), &exact_pending) {
+        Ok(()) => {}
+        Err(LocalStateStoreError::ConcurrentHost) => {
+            match local_state_store
+                .load(locator)
+                .map_err(map_local_state_store)?
+            {
+                Some(observed) if observed == exact_pending => {}
+                Some(observed) if observed == exact_intended => return Ok(intended_active),
+                _ => return Err(ApplicationError::ConcurrentHost),
+            }
+        }
+        Err(error) => return Err(map_local_state_store(error)),
+    }
+
+    let receipt = repository
+        .publish(publication.publication(), publication.base_heads())
+        .map_err(map_repository)?;
+    if receipt.heads() != publication.expected_heads() {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+
+    match local_state_store.compare_exchange(locator, Some(&exact_pending), &exact_intended) {
+        Ok(()) => Ok(intended_active),
+        Err(LocalStateStoreError::ConcurrentHost) => {
+            match local_state_store
+                .load(locator)
+                .map_err(map_local_state_store)?
+            {
+                Some(observed) if observed == exact_intended => Ok(intended_active),
+                _ => Err(ApplicationError::ConcurrentHost),
+            }
+        }
+        Err(error) => Err(map_local_state_store(error)),
+    }
+}
+
+fn prepare_add_publication(
+    active: &ActiveStateV1,
+    current_items: &BTreeMap<ItemId, Vec<ItemCandidate>>,
+    keys: &V1Keys,
+    local_secret: &LocalSecretV1,
+    document: ItemDocument,
+    wall_time_ms: u64,
+    randomness: AddItemRandomnessV1,
+) -> Result<PublicationJournalV1, ApplicationError> {
+    let device_counter = active
+        .last_device_counter()
+        .checked_add(1)
+        .ok_or(ApplicationError::BoundExceeded)?;
+    let mut offset = ITEM_ID_BYTES;
+    let revision_randomness = take_object_randomness(&randomness.bytes, &mut offset);
+    let catalog_randomness = take_object_randomness(&randomness.bytes, &mut offset);
+    let commit_randomness = take_object_randomness(&randomness.bytes, &mut offset);
+    debug_assert_eq!(offset, ADD_ITEM_RANDOM_BYTES);
+
+    let item_id = document.id();
+    let item_state = ItemState::Live(Box::new(document));
+    let revision_plaintext = Zeroizing::new(encode_item_revision(&BTreeSet::new(), &item_state)?);
+    let revision_frame = seal_object(
+        keys,
+        ObjectKind::ItemRevision,
+        &revision_plaintext,
+        &revision_randomness,
+    )?;
+    let revision_object_id = revision_frame
+        .id()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    let revision_id = RevisionId::new(*revision_object_id.as_bytes());
+
+    let mut catalog_entries = BTreeMap::new();
+    for (existing_item_id, candidates) in current_items {
+        let mut revision_ids = candidates
+            .iter()
+            .map(ItemCandidate::revision_id)
+            .collect::<Vec<_>>();
+        revision_ids.sort_unstable();
+        revision_ids.dedup();
+        catalog_entries.insert(*existing_item_id, revision_ids);
+    }
+    catalog_entries.insert(item_id, vec![revision_id]);
+    let catalog_plaintext = Zeroizing::new(CatalogV1::new(catalog_entries)?.encode()?);
+    let catalog_frame = seal_object(
+        keys,
+        ObjectKind::Catalog,
+        &catalog_plaintext,
+        &catalog_randomness,
+    )?;
+    let catalog_id = catalog_frame
+        .id()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+
+    let mut parents = active.pinned_heads().iter().copied().collect::<Vec<_>>();
+    parents.sort_unstable();
+    let mut added_objects = vec![revision_object_id, catalog_id];
+    added_objects.sort_unstable();
+    added_objects.dedup();
+    if added_objects.len() != 2 {
+        return Err(ApplicationError::InternalInvariant);
+    }
+    let (_, device_signing_secret) = generate_keypair(local_secret.device_signing_seed());
+    let device_signing_secret = Zeroizing::new(device_signing_secret);
+    let unsigned_commit = CommitV1 {
+        vault_id: active.vault_id(),
+        device_id: active.device_id(),
+        device_counter,
+        parents,
+        catalog_root: catalog_id,
+        added_objects,
+        tombstone_root: None,
+        wall_time_ms,
+        device_certificate: active.device_certificate_id(),
+        signature: Signature::new([0; 64]),
+    };
+    let commit_preimage = unsigned_commit
+        .signing_preimage()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    let commit = unsigned_commit.with_signature(Signature::new(sign(
+        &commit_preimage,
+        &device_signing_secret,
+    )));
+    let commit_plaintext = Zeroizing::new(encode_signed_commit(&commit)?);
+    let commit_frame = seal_object(
+        keys,
+        ObjectKind::Commit,
+        &commit_plaintext,
+        &commit_randomness,
+    )?;
+    let commit_id = commit_frame
+        .id()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    let unsigned_announcement = AnnouncementV1 {
+        vault_id: active.vault_id(),
+        device_id: active.device_id(),
+        device_counter,
+        commit_id,
+        device_certificate: active.device_certificate_id(),
+        signature: Signature::new([0; 64]),
+    };
+    let announcement_preimage = unsigned_announcement
+        .signing_preimage()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    let announcement = unsigned_announcement
+        .with_signature(Signature::new(sign(
+            &announcement_preimage,
+            &device_signing_secret,
+        )))
+        .encode()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    let expected_heads =
+        PinnedHeads::new([commit_id]).map_err(|_| ApplicationError::InternalInvariant)?;
+
+    PublicationJournalV1::new(
+        vec![revision_frame, catalog_frame],
+        commit_frame,
+        announcement,
+        active.pinned_heads().clone(),
+        expected_heads,
+        device_counter,
+        catalog_id,
+    )
+}
+
+fn take_object_randomness(
+    bytes: &[u8; ADD_ITEM_RANDOM_BYTES],
+    offset: &mut usize,
+) -> ObjectRandomness {
+    ObjectRandomness::new(
+        take(bytes, offset),
+        take(bytes, offset),
+        take(bytes, offset),
+    )
+}
+
+fn take<const N: usize>(bytes: &[u8; ADD_ITEM_RANDOM_BYTES], offset: &mut usize) -> [u8; N] {
+    let end = *offset + N;
+    let value = bytes[*offset..end]
+        .try_into()
+        .expect("add-item partition lengths are constant");
+    *offset = end;
+    value
+}
+
+fn map_repository(error: ApplicationRepositoryError) -> ApplicationError {
+    match error {
+        ApplicationRepositoryError::NotInitialized => ApplicationError::NotInitialized,
+        ApplicationRepositoryError::InvalidInput => ApplicationError::InvalidInput,
+        ApplicationRepositoryError::BoundExceeded => ApplicationError::BoundExceeded,
+        ApplicationRepositoryError::StorageUnavailable => ApplicationError::StorageUnavailable,
+        ApplicationRepositoryError::IntegrityFailure => ApplicationError::IntegrityFailure,
+    }
+}
+
+fn map_local_state_store(error: LocalStateStoreError) -> ApplicationError {
+    match error {
+        LocalStateStoreError::Unavailable => ApplicationError::StorageUnavailable,
+        LocalStateStoreError::ConcurrentHost => ApplicationError::ConcurrentHost,
+        LocalStateStoreError::Corruption => ApplicationError::IntegrityFailure,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_item_randomness_redacts_and_zeroizes() {
+        let mut randomness = AddItemRandomnessV1::new([0x5a; ADD_ITEM_RANDOM_BYTES]);
+
+        assert_eq!(format!("{randomness:?}"), "AddItemRandomnessV1(<redacted>)");
+        assert_eq!(randomness.item_id(), ItemId::new([0x5a; ITEM_ID_BYTES]));
+
+        randomness.zeroize();
+        assert_eq!(randomness.item_id(), ItemId::new([0; ITEM_ID_BYTES]));
+    }
+
+    #[test]
+    fn mutation_error_translation_is_closed() {
+        assert_eq!(
+            map_repository(ApplicationRepositoryError::NotInitialized),
+            ApplicationError::NotInitialized
+        );
+        assert_eq!(
+            map_repository(ApplicationRepositoryError::InvalidInput),
+            ApplicationError::InvalidInput
+        );
+        assert_eq!(
+            map_repository(ApplicationRepositoryError::BoundExceeded),
+            ApplicationError::BoundExceeded
+        );
+        assert_eq!(
+            map_repository(ApplicationRepositoryError::StorageUnavailable),
+            ApplicationError::StorageUnavailable
+        );
+        assert_eq!(
+            map_repository(ApplicationRepositoryError::IntegrityFailure),
+            ApplicationError::IntegrityFailure
+        );
+        assert_eq!(
+            map_local_state_store(LocalStateStoreError::Unavailable),
+            ApplicationError::StorageUnavailable
+        );
+        assert_eq!(
+            map_local_state_store(LocalStateStoreError::ConcurrentHost),
+            ApplicationError::ConcurrentHost
+        );
+        assert_eq!(
+            map_local_state_store(LocalStateStoreError::Corruption),
+            ApplicationError::IntegrityFailure
+        );
+    }
+}

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1,4 +1,5 @@
 use crate::initialize::{unlock_active_material, UnlockedActiveMaterial};
+use crate::mutation::{add_item, AddItemRandomnessV1};
 use crate::search::SearchProjectionV1;
 use crate::{
     open_object, ActiveStateV1, ApplicationError, ApplicationRepository,
@@ -7,7 +8,7 @@ use crate::{
     LocalVaultStateV1, ObjectKind, V1Keys,
 };
 use coding_adventures_vault_pm_domain::{
-    CollectionId, ItemCandidate, ItemId, ItemState, RedactedItemView, RevisionId,
+    CollectionId, ItemCandidate, ItemDocument, ItemId, ItemState, RedactedItemView, RevisionId,
 };
 use coding_adventures_vault_pm_format::{DeviceId, ObjectId, VaultId};
 use coding_adventures_vault_pm_repository::{OpenReport, PinnedHeads};
@@ -143,6 +144,35 @@ impl UnlockedVaultV1 {
     /// search projection without exposing item identities or indexed text.
     pub fn search_item_count(&self) -> usize {
         self.search.len()
+    }
+
+    /// Add one new item through the exact crash-resumable publication state
+    /// machine and return the resulting durable active owner state.
+    ///
+    /// The session is consumed so a successful caller cannot keep using stale
+    /// pins, catalog contents, or search state. The document and randomness
+    /// are owned and wiped on every return path. Hosts must reopen a new
+    /// session after success or recover the durable pending journal after an
+    /// interrupted provider/local effect.
+    pub fn add_item(
+        self,
+        document: ItemDocument,
+        wall_time_ms: u64,
+        randomness: AddItemRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        add_item(
+            &self.active,
+            &self.report,
+            &self.current_catalog.items,
+            &self._keys,
+            &self._local_secret,
+            self._repository.as_ref(),
+            document,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+        )
     }
 }
 
@@ -413,7 +443,8 @@ mod tests {
         complete_generation_zero, encode_item_revision, encode_signed_commit,
         prepare_generation_zero, seal_object, CatalogV1, GenerationZeroPolicyV1,
         GenerationZeroRandomness, ObjectKind, ObjectRandomness, PublicationJournalV1,
-        V1ApplicationRepositoryFactory, V1Keys, GENERATION_ZERO_RANDOM_BYTES,
+        V1ApplicationRepositoryFactory, V1Keys, ADD_ITEM_RANDOM_BYTES,
+        GENERATION_ZERO_RANDOM_BYTES,
     };
     use coding_adventures_ed25519::{generate_keypair, sign};
     use coding_adventures_vault_pm_domain::{
@@ -426,7 +457,7 @@ mod tests {
     };
     use coding_adventures_vault_records::{AnyRecord, Login, LOGIN_V1};
     use std::sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc, Mutex,
     };
 
@@ -434,7 +465,8 @@ mod tests {
     struct MemoryLocalStateStore(
         Mutex<Option<Vec<u8>>>,
         AtomicBool,
-        Mutex<Option<LocalStateStoreError>>,
+        Mutex<Option<(usize, LocalStateStoreError)>>,
+        AtomicUsize,
     );
 
     impl MemoryLocalStateStore {
@@ -443,6 +475,7 @@ mod tests {
                 Mutex::new(Some(state)),
                 AtomicBool::new(false),
                 Mutex::new(None),
+                AtomicUsize::new(0),
             )
         }
 
@@ -451,7 +484,16 @@ mod tests {
         }
 
         fn fail_next_compare(&self, error: LocalStateStoreError) {
-            *self.2.lock().unwrap() = Some(error);
+            self.fail_compare_after(0, error);
+        }
+
+        fn fail_compare_after(&self, successful_calls: usize, error: LocalStateStoreError) {
+            let target = self
+                .3
+                .load(Ordering::SeqCst)
+                .checked_add(successful_calls + 1)
+                .unwrap();
+            *self.2.lock().unwrap() = Some((target, error));
         }
     }
 
@@ -469,12 +511,17 @@ mod tests {
             expected: Option<&[u8]>,
             replacement: &[u8],
         ) -> Result<(), LocalStateStoreError> {
+            let call = self.3.fetch_add(1, Ordering::SeqCst) + 1;
             let mut state = self.0.lock().unwrap();
             if state.as_deref() != expected {
                 return Err(LocalStateStoreError::ConcurrentHost);
             }
-            if let Some(error) = self.2.lock().unwrap().take() {
-                return Err(error);
+            let scheduled_error = *self.2.lock().unwrap();
+            if let Some((target, error)) = scheduled_error {
+                if target == call {
+                    self.2.lock().unwrap().take();
+                    return Err(error);
+                }
             }
             if self.1.swap(false, Ordering::SeqCst) {
                 *state = Some(replacement.to_vec());
@@ -527,6 +574,35 @@ mod tests {
 
     fn randomness() -> GenerationZeroRandomness {
         GenerationZeroRandomness::new(generation_zero_bytes())
+    }
+
+    fn add_item_randomness(seed: u8) -> AddItemRandomnessV1 {
+        let mut bytes = [0; ADD_ITEM_RANDOM_BYTES];
+        for (index, byte) in bytes.iter_mut().enumerate() {
+            *byte = (index as u8).wrapping_mul(17).wrapping_add(seed);
+        }
+        AddItemRandomnessV1::new(bytes)
+    }
+
+    fn new_login_document(item_id: ItemId, title: &str, password: &str) -> ItemDocument {
+        ItemDocument::new(
+            item_id,
+            ContentType::new(LOGIN_V1).unwrap(),
+            300,
+            300,
+            LwwRegister::new(false, 300, OperationId::new([0x71; 32])),
+            ObservedSet::new(),
+            ObservedSet::new(),
+            AnyRecord::Login(Login {
+                title: title.to_owned(),
+                username: "new-user@example.test".to_owned(),
+                password: password.to_owned(),
+                urls: vec!["https://new.example.test".to_owned()],
+                notes: None,
+            }),
+            ObservedSet::new(),
+        )
+        .unwrap()
     }
 
     fn initialized() -> (
@@ -1307,6 +1383,317 @@ mod tests {
             .err(),
             Some(ApplicationError::InvalidInput)
         );
+    }
+
+    #[test]
+    fn add_item_publishes_parentless_revision_and_requires_reopen() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let prior_heads = session.local_pins().clone();
+        let randomness = add_item_randomness(0x41);
+        let item_id = randomness.item_id();
+        local.concurrent_winner_on_next_compare();
+        let active = session
+            .add_item(
+                new_login_document(item_id, "New portal", "new-password-secret"),
+                301,
+                randomness,
+                &local,
+            )
+            .unwrap();
+
+        assert_eq!(active.last_device_counter(), 2);
+        assert_ne!(active.pinned_heads(), &prior_heads);
+        assert_eq!(
+            LocalVaultStateV1::decode(&local.0.lock().unwrap().clone().unwrap()).unwrap(),
+            LocalVaultStateV1::Active(active.clone())
+        );
+
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.item_count(), 1);
+        assert_eq!(reopened.search_item_count(), 1);
+        assert_eq!(
+            reopened.get_item(item_id).unwrap().unwrap().item_id,
+            item_id
+        );
+        let [candidate] = reopened.current_catalog.items[&item_id].as_slice() else {
+            panic!("new item must have exactly one current revision")
+        };
+        assert!(candidate.causal_parents().is_empty());
+        let head = *reopened.open_report().heads().iter().next().unwrap();
+        let commit = reopened._repository.read_commit(head).unwrap();
+        assert_eq!(commit.device_counter(), 2);
+        assert_eq!(
+            commit.parents(),
+            prior_heads.iter().copied().collect::<Vec<_>>()
+        );
+        assert_eq!(commit.catalog_root(), active.catalog_root());
+        assert_eq!(commit.added_objects().len(), 2);
+        assert_eq!(commit.wall_time_ms(), 301);
+    }
+
+    #[test]
+    fn add_item_rejects_mismatched_or_existing_random_identity_before_cas() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let mismatched = add_item_randomness(0x51);
+        assert_eq!(
+            session.add_item(
+                new_login_document(ItemId::new([0x99; 16]), "Wrong", "secret"),
+                301,
+                mismatched,
+                &local,
+            ),
+            Err(ApplicationError::InvalidInput)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_active.as_slice())
+        );
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let randomness = add_item_randomness(0x61);
+        let item_id = randomness.item_id();
+        session
+            .add_item(
+                new_login_document(item_id, "First", "secret"),
+                302,
+                randomness,
+                &local,
+            )
+            .unwrap();
+        let exact_after_first = local.0.lock().unwrap().clone().unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let mut duplicate_bytes = [0; ADD_ITEM_RANDOM_BYTES];
+        duplicate_bytes[..16].copy_from_slice(item_id.as_bytes());
+        assert_eq!(
+            session.add_item(
+                new_login_document(item_id, "Duplicate", "secret"),
+                303,
+                AddItemRandomnessV1::new(duplicate_bytes),
+                &local,
+            ),
+            Err(ApplicationError::InvalidInput)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_after_first.as_slice())
+        );
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let second_randomness = add_item_randomness(0x71);
+        let second_item_id = second_randomness.item_id();
+        session
+            .add_item(
+                new_login_document(second_item_id, "Second", "secret"),
+                304,
+                second_randomness,
+                &local,
+            )
+            .unwrap();
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.item_count(), 2);
+        assert!(reopened.get_item(item_id).unwrap().is_some());
+        assert!(reopened.get_item(second_item_id).unwrap().is_some());
+    }
+
+    #[test]
+    fn add_item_retains_exact_pending_journal_across_ambiguous_provider_failure() {
+        let passphrase = b"active passphrase";
+        let prepared = prepare_generation_zero(
+            Zeroizing::new(passphrase.to_vec()),
+            GenerationZeroPolicyV1::new(8 * 1024, 1, 1, 10).unwrap(),
+            randomness(),
+        )
+        .unwrap();
+        let locator = prepared.bootstrap_locator();
+        let local = MemoryLocalStateStore::default();
+        let bootstrap = MemoryBootstrapStore::default();
+        let backend = Arc::new(FaultInjectingObjectStore::new(InMemoryObjectStore::new()));
+        let factory = V1ApplicationRepositoryFactory::from_shared(Arc::clone(&backend));
+        complete_generation_zero(prepared, &local, &bootstrap, &factory).unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(passphrase.to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let randomness = add_item_randomness(0x81);
+        let item_id = randomness.item_id();
+        backend
+            .enqueue(FaultAction {
+                operation: StoreOperation::PutImmutable,
+                effect: FaultEffect::CommitPutThenNetwork,
+            })
+            .unwrap();
+
+        assert_eq!(
+            session.add_item(
+                new_login_document(item_id, "Crash safe", "secret"),
+                304,
+                randomness,
+                &local,
+            ),
+            Err(ApplicationError::StorageUnavailable)
+        );
+        let exact_pending = local.0.lock().unwrap().clone().unwrap();
+        assert!(matches!(
+            LocalVaultStateV1::decode(&exact_pending).unwrap(),
+            LocalVaultStateV1::PendingPublication { .. }
+        ));
+
+        let active = recover_pending_publication(
+            Zeroizing::new(passphrase.to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(active.last_device_counter(), 2);
+        let reopened = open_active_vault(
+            Zeroizing::new(passphrase.to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            reopened.get_item(item_id).unwrap().unwrap().item_id,
+            item_id
+        );
+        assert_eq!(backend.pending_faults().unwrap(), 0);
+    }
+
+    #[test]
+    fn add_item_persists_before_publish_and_recovers_after_final_cas_failure() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let randomness = add_item_randomness(0x91);
+        let item_id = randomness.item_id();
+        local.fail_next_compare(LocalStateStoreError::Unavailable);
+        assert_eq!(
+            session.add_item(
+                new_login_document(item_id, "No early publish", "secret"),
+                305,
+                randomness,
+                &local,
+            ),
+            Err(ApplicationError::StorageUnavailable)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_active.as_slice())
+        );
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.open_report().commit_count(), 1);
+
+        let randomness = add_item_randomness(0xa1);
+        let item_id = randomness.item_id();
+        local.fail_compare_after(1, LocalStateStoreError::Unavailable);
+        assert_eq!(
+            reopened.add_item(
+                new_login_document(item_id, "Recover final state", "secret"),
+                306,
+                randomness,
+                &local,
+            ),
+            Err(ApplicationError::StorageUnavailable)
+        );
+        let exact_pending = local.0.lock().unwrap().clone().unwrap();
+        assert!(matches!(
+            LocalVaultStateV1::decode(&exact_pending).unwrap(),
+            LocalVaultStateV1::PendingPublication { .. }
+        ));
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            reopened.get_item(item_id).unwrap().unwrap().item_id,
+            item_id
+        );
+        assert_eq!(reopened.open_report().commit_count(), 2);
     }
 
     #[test]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1295,7 +1295,11 @@ changelog, focused build, and downstream validation.
    6e. the completed wipe-on-lock in-memory search projection, including the
        password-manager query, exact collection-filter, Unicode-normalization,
        safe-field allowlist, and deterministic ordering policy adapters;
-   7a. add-item mutation preparation and crash-resumable publication;
+   7a. completed add-item mutation preparation and crash-resumable publication,
+       including caller-owned entropy, generated identity binding, complete
+       catalog preservation, all-head commit parenting, exact write-ahead
+       owner-state transitions, ambiguous-success handling, and session
+       consumption to prevent stale-pin reuse;
    7b. compare-and-replace, delete, restore, and explicit conflict-resolution
        mutation workflows;
    7c. bounded history traversal and explicit zeroizing field reveal;


### PR DESCRIPTION
## Summary
- add a session-consuming, storage-agnostic add-item workflow to `vault-pm-application`
- persist the exact pending publication journal before repository effects and recover provider/final-CAS interruptions
- bind caller entropy to the item identity, preserve the complete catalog, and parent the commit from every current head
- document completion of VLT-PM00 application slice 7a

## Verification
- `cargo test -p coding_adventures_vault_pm_application` (72 passed)
- `cargo clippy -p coding_adventures_vault_pm_application --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p coding_adventures_vault_pm_application --no-deps`
- Tarpaulin LLVM: 1,903/1,992 production lines (95.53%)
- `./build-tool -root . -diff-base origin/main -dry-run -validate-build-files`
- `./build-tool -root . -diff-base origin/main -validate-build-files` (1,001 packages discovered; 21 affected; all built)