### PR TITLE
Add safe vault item replacement

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this package are documented here.
 
+## [0.14.0] - 2026-08-09
+
+### Added
+
+- Add a session-consuming `replace_item` workflow that creates a live revision
+  directly descended from the caller's sole expected current revision.
+- Add the specified payload-free `NotFound` application error and owned
+  wipe-on-drop replacement randomness for exactly three encrypted frames.
+
+### Security
+
+- Reject absent, stale, tombstoned, or conflicted replacement targets before
+  local persistence, and preserve item identity, schema, and creation time.
+- Reuse the exact write-ahead `PendingPublication` state machine for
+  replacement, including byte-identical ambiguous winners and crash recovery.
+- Rewrite the complete bounded catalog and make all current repository heads
+  commit parents without using advisory timestamps for causality.
+
 ## [0.13.0] - 2026-08-09
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -91,6 +91,17 @@ and a provider or final-local-write interruption remains recoverable by the
 existing pending-publication workflow. The mutation consumes its unlocked
 session so callers must reopen before observing or mutating the new pins.
 
+Compare-and-replace is available through the same session-consuming boundary.
+It requires the requested item to have exactly one current live candidate equal
+to the caller's expected revision, then writes a new revision whose sole direct
+causal parent is that expected revision. Item identity, content schema, and
+creation time are immutable; every unrelated catalog candidate is preserved.
+Absent items return the payload-free `NotFound` error, while stale, tombstoned,
+or conflicted candidates return `ConflictRequired` before any local write.
+Replacement uses an owned wipe-on-drop 240-byte entropy block and the same exact
+pending journal, all-head commit parenting, ambiguous-success rules, and
+recovery path as add-item.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
 credential store, or entropy source. Replace, delete, restore, conflict
@@ -116,12 +127,14 @@ paths, and complete error translation.
 Search tests cover Unicode normalization, short queries, oversized safe-field
 fallback, exact collection filters, deterministic product ordering, every
 record schema's allowlist/denylist, secret exclusion, query/result bounds, and
-conflict closure. The exact Tarpaulin LLVM result is 1,903 of 1,992 production
-lines (95.53%). Add-item tests cover exact entropy partitioning and wiping,
+conflict closure. The exact Tarpaulin LLVM result is 1,953 of 2,043 production
+lines (95.59%). Add-item tests cover exact entropy partitioning and wiping,
 identity validation before local writes, parentless revision and complete
 catalog construction, ambiguous successful compare-exchanges, write-ahead
 publication ordering, ambiguous provider commits, failed final activation,
-and recovery through the exact persisted journal.
+and recovery through the exact persisted journal. Replacement tests prove
+one-parent causality, immutable identity fields, complete catalog preservation,
+stale/missing rejection before compare-exchange, and secret/entropy wiping.
 
 ## Development
 

--- a/code/packages/rust/vault-pm-application/src/codec.rs
+++ b/code/packages/rust/vault-pm-application/src/codec.rs
@@ -1153,6 +1153,7 @@ mod tests {
                 "AuthenticationFailed",
             ),
             (ApplicationError::InvalidInput, "InvalidInput"),
+            (ApplicationError::NotFound, "NotFound"),
             (ApplicationError::BoundExceeded, "BoundExceeded"),
             (ApplicationError::ConcurrentHost, "ConcurrentHost"),
             (ApplicationError::StorageUnavailable, "StorageUnavailable"),

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -31,7 +31,9 @@ pub use initialize::{
     GenerationZeroPolicyV1, GenerationZeroRandomness, PreparedGenerationZero,
     GENERATION_ZERO_RANDOM_BYTES,
 };
-pub use mutation::{AddItemRandomnessV1, ADD_ITEM_RANDOM_BYTES};
+pub use mutation::{
+    AddItemRandomnessV1, ReplaceItemRandomnessV1, ADD_ITEM_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
+};
 pub use open::{open_active_vault, recover_pending_publication, UnlockedVaultV1};
 pub use repository::{
     ApplicationRepository, ApplicationRepositoryError, ApplicationRepositoryFactory,
@@ -56,6 +58,8 @@ pub enum ApplicationError {
     AuthenticationFailed,
     /// Caller input violates a V1 precondition.
     InvalidInput,
+    /// The requested item does not exist in the current catalog.
+    NotFound,
     /// A fixed parser or collection bound would be exceeded.
     BoundExceeded,
     /// A host compare-exchange lost to another local writer.
@@ -79,6 +83,7 @@ impl ApplicationError {
             Self::AlreadyInitialized => "AlreadyInitialized",
             Self::AuthenticationFailed => "AuthenticationFailed",
             Self::InvalidInput => "InvalidInput",
+            Self::NotFound => "NotFound",
             Self::BoundExceeded => "BoundExceeded",
             Self::ConcurrentHost => "ConcurrentHost",
             Self::StorageUnavailable => "StorageUnavailable",

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -19,6 +19,8 @@ const OBJECT_RANDOM_BYTES: usize = 32 + 24 + 24;
 
 /// Exact caller-filled CSPRNG bytes consumed by one add-item mutation.
 pub const ADD_ITEM_RANDOM_BYTES: usize = ITEM_ID_BYTES + 3 * OBJECT_RANDOM_BYTES;
+/// Exact caller-filled CSPRNG bytes consumed by one replace-item mutation.
+pub const REPLACE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
 
 /// Owned wipe-on-drop entropy for one item ID and three encrypted frames.
 pub struct AddItemRandomnessV1 {
@@ -59,6 +61,36 @@ impl Debug for AddItemRandomnessV1 {
     }
 }
 
+/// Owned wipe-on-drop entropy for the three encrypted replacement frames.
+pub struct ReplaceItemRandomnessV1 {
+    bytes: [u8; REPLACE_ITEM_RANDOM_BYTES],
+}
+
+impl ReplaceItemRandomnessV1 {
+    /// Take one exact block filled by the host's cryptographic entropy source.
+    pub const fn new(bytes: [u8; REPLACE_ITEM_RANDOM_BYTES]) -> Self {
+        Self { bytes }
+    }
+}
+
+impl Zeroize for ReplaceItemRandomnessV1 {
+    fn zeroize(&mut self) {
+        self.bytes.zeroize();
+    }
+}
+
+impl Drop for ReplaceItemRandomnessV1 {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl Debug for ReplaceItemRandomnessV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ReplaceItemRandomnessV1(<redacted>)")
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn add_item(
     active: &ActiveStateV1,
@@ -85,15 +117,80 @@ pub(crate) fn add_item(
         return Err(ApplicationError::InvalidInput);
     }
 
-    let publication = prepare_add_publication(
+    let publication = prepare_item_publication(
         active,
         current_items,
         keys,
         local_secret,
-        document,
+        document.id(),
+        ItemState::Live(Box::new(document)),
+        &BTreeSet::new(),
         wall_time_ms,
-        randomness,
+        randomness.bytes[ITEM_ID_BYTES..]
+            .try_into()
+            .expect("the add-item object-randomness partition length is constant"),
     )?;
+    publish_mutation(active, repository, publication, local_state_store)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn replace_item(
+    active: &ActiveStateV1,
+    report: &OpenReport,
+    current_items: &BTreeMap<ItemId, Vec<ItemCandidate>>,
+    keys: &V1Keys,
+    local_secret: &LocalSecretV1,
+    repository: &dyn ApplicationRepository,
+    expected_revision: RevisionId,
+    document: ItemDocument,
+    wall_time_ms: u64,
+    randomness: ReplaceItemRandomnessV1,
+    local_state_store: &dyn LocalStateStore,
+) -> Result<ActiveStateV1, ApplicationError> {
+    if report.heads() != active.pinned_heads() {
+        return Err(ApplicationError::ConcurrentHost);
+    }
+    document
+        .validate()
+        .map_err(|_| ApplicationError::InvalidInput)?;
+    let candidates = current_items
+        .get(&document.id())
+        .ok_or(ApplicationError::NotFound)?;
+    let [candidate] = candidates.as_slice() else {
+        return Err(ApplicationError::ConflictRequired);
+    };
+    let ItemState::Live(current_document) = candidate.state() else {
+        return Err(ApplicationError::ConflictRequired);
+    };
+    if candidate.revision_id() != expected_revision {
+        return Err(ApplicationError::ConflictRequired);
+    }
+    if current_document.schema() != document.schema()
+        || current_document.created_at_ms() != document.created_at_ms()
+    {
+        return Err(ApplicationError::InvalidInput);
+    }
+
+    let publication = prepare_item_publication(
+        active,
+        current_items,
+        keys,
+        local_secret,
+        document.id(),
+        ItemState::Live(Box::new(document)),
+        &BTreeSet::from([expected_revision]),
+        wall_time_ms,
+        &randomness.bytes,
+    )?;
+    publish_mutation(active, repository, publication, local_state_store)
+}
+
+fn publish_mutation(
+    active: &ActiveStateV1,
+    repository: &dyn ApplicationRepository,
+    publication: PublicationJournalV1,
+    local_state_store: &dyn LocalStateStore,
+) -> Result<ActiveStateV1, ApplicationError> {
     let intended_active = active.after_publication(&publication)?;
     let exact_active = LocalVaultStateV1::Active(active.clone()).encode()?;
     let exact_pending =
@@ -138,28 +235,29 @@ pub(crate) fn add_item(
     }
 }
 
-fn prepare_add_publication(
+#[allow(clippy::too_many_arguments)]
+fn prepare_item_publication(
     active: &ActiveStateV1,
     current_items: &BTreeMap<ItemId, Vec<ItemCandidate>>,
     keys: &V1Keys,
     local_secret: &LocalSecretV1,
-    document: ItemDocument,
+    item_id: ItemId,
+    item_state: ItemState,
+    causal_parents: &BTreeSet<RevisionId>,
     wall_time_ms: u64,
-    randomness: AddItemRandomnessV1,
+    randomness: &[u8; REPLACE_ITEM_RANDOM_BYTES],
 ) -> Result<PublicationJournalV1, ApplicationError> {
     let device_counter = active
         .last_device_counter()
         .checked_add(1)
         .ok_or(ApplicationError::BoundExceeded)?;
-    let mut offset = ITEM_ID_BYTES;
-    let revision_randomness = take_object_randomness(&randomness.bytes, &mut offset);
-    let catalog_randomness = take_object_randomness(&randomness.bytes, &mut offset);
-    let commit_randomness = take_object_randomness(&randomness.bytes, &mut offset);
-    debug_assert_eq!(offset, ADD_ITEM_RANDOM_BYTES);
+    let mut offset = 0;
+    let revision_randomness = take_object_randomness(randomness, &mut offset);
+    let catalog_randomness = take_object_randomness(randomness, &mut offset);
+    let commit_randomness = take_object_randomness(randomness, &mut offset);
+    debug_assert_eq!(offset, REPLACE_ITEM_RANDOM_BYTES);
 
-    let item_id = document.id();
-    let item_state = ItemState::Live(Box::new(document));
-    let revision_plaintext = Zeroizing::new(encode_item_revision(&BTreeSet::new(), &item_state)?);
+    let revision_plaintext = Zeroizing::new(encode_item_revision(causal_parents, &item_state)?);
     let revision_frame = seal_object(
         keys,
         ObjectKind::ItemRevision,
@@ -265,7 +363,7 @@ fn prepare_add_publication(
 }
 
 fn take_object_randomness(
-    bytes: &[u8; ADD_ITEM_RANDOM_BYTES],
+    bytes: &[u8; REPLACE_ITEM_RANDOM_BYTES],
     offset: &mut usize,
 ) -> ObjectRandomness {
     ObjectRandomness::new(
@@ -275,7 +373,7 @@ fn take_object_randomness(
     )
 }
 
-fn take<const N: usize>(bytes: &[u8; ADD_ITEM_RANDOM_BYTES], offset: &mut usize) -> [u8; N] {
+fn take<const N: usize>(bytes: &[u8; REPLACE_ITEM_RANDOM_BYTES], offset: &mut usize) -> [u8; N] {
     let end = *offset + N;
     let value = bytes[*offset..end]
         .try_into()
@@ -315,6 +413,20 @@ mod tests {
 
         randomness.zeroize();
         assert_eq!(randomness.item_id(), ItemId::new([0; ITEM_ID_BYTES]));
+    }
+
+    #[test]
+    fn replace_item_randomness_redacts_and_zeroizes() {
+        let mut randomness = ReplaceItemRandomnessV1::new([0xa5; REPLACE_ITEM_RANDOM_BYTES]);
+
+        assert_eq!(
+            format!("{randomness:?}"),
+            "ReplaceItemRandomnessV1(<redacted>)"
+        );
+        assert!(randomness.bytes.iter().all(|byte| *byte == 0xa5));
+
+        randomness.zeroize();
+        assert!(randomness.bytes.iter().all(|byte| *byte == 0));
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1,5 +1,5 @@
 use crate::initialize::{unlock_active_material, UnlockedActiveMaterial};
-use crate::mutation::{add_item, AddItemRandomnessV1};
+use crate::mutation::{add_item, replace_item, AddItemRandomnessV1, ReplaceItemRandomnessV1};
 use crate::search::SearchProjectionV1;
 use crate::{
     open_object, ActiveStateV1, ApplicationError, ApplicationRepository,
@@ -168,6 +168,37 @@ impl UnlockedVaultV1 {
             &self._keys,
             &self._local_secret,
             self._repository.as_ref(),
+            document,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+        )
+    }
+
+    /// Replace the sole expected current live revision and return the resulting
+    /// durable active owner state.
+    ///
+    /// The replacement preserves item identity, content schema, and creation
+    /// time. Its new revision directly names `expected_revision` as its causal
+    /// parent. A missing item returns `NotFound`; a stale, tombstoned, or
+    /// conflicted current candidate returns `ConflictRequired`. The session and
+    /// all owned mutation inputs are consumed on every return path.
+    pub fn replace_item(
+        self,
+        expected_revision: RevisionId,
+        document: ItemDocument,
+        wall_time_ms: u64,
+        randomness: ReplaceItemRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        replace_item(
+            &self.active,
+            &self.report,
+            &self.current_catalog.items,
+            &self._keys,
+            &self._local_secret,
+            self._repository.as_ref(),
+            expected_revision,
             document,
             wall_time_ms,
             randomness,
@@ -444,7 +475,7 @@ mod tests {
         prepare_generation_zero, seal_object, CatalogV1, GenerationZeroPolicyV1,
         GenerationZeroRandomness, ObjectKind, ObjectRandomness, PublicationJournalV1,
         V1ApplicationRepositoryFactory, V1Keys, ADD_ITEM_RANDOM_BYTES,
-        GENERATION_ZERO_RANDOM_BYTES,
+        GENERATION_ZERO_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
     };
     use coding_adventures_ed25519::{generate_keypair, sign};
     use coding_adventures_vault_pm_domain::{
@@ -582,6 +613,14 @@ mod tests {
             *byte = (index as u8).wrapping_mul(17).wrapping_add(seed);
         }
         AddItemRandomnessV1::new(bytes)
+    }
+
+    fn replace_item_randomness(seed: u8) -> ReplaceItemRandomnessV1 {
+        let mut bytes = [0; REPLACE_ITEM_RANDOM_BYTES];
+        for (index, byte) in bytes.iter_mut().enumerate() {
+            *byte = (index as u8).wrapping_mul(29).wrapping_add(seed);
+        }
+        ReplaceItemRandomnessV1::new(bytes)
     }
 
     fn new_login_document(item_id: ItemId, title: &str, password: &str) -> ItemDocument {
@@ -1141,6 +1180,22 @@ mod tests {
                     Err(ApplicationError::ConflictRequired)
                 );
             }
+            let expected_revision = session.current_catalog.items[&item_id][0].revision_id();
+            let exact_state = local.0.lock().unwrap().clone().unwrap();
+            assert_eq!(
+                session.replace_item(
+                    expected_revision,
+                    new_login_document(item_id, "Cannot replace", "secret"),
+                    299,
+                    replace_item_randomness(0x31),
+                    &local,
+                ),
+                Err(ApplicationError::ConflictRequired)
+            );
+            assert_eq!(
+                local.0.lock().unwrap().as_deref(),
+                Some(exact_state.as_slice())
+            );
         }
     }
 
@@ -1694,6 +1749,212 @@ mod tests {
             item_id
         );
         assert_eq!(reopened.open_report().commit_count(), 2);
+    }
+
+    #[test]
+    fn replace_item_advances_one_expected_live_revision_and_preserves_others() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let first_randomness = add_item_randomness(0xb1);
+        let first_item_id = first_randomness.item_id();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .add_item(
+            new_login_document(first_item_id, "Before", "old-secret"),
+            401,
+            first_randomness,
+            &local,
+        )
+        .unwrap();
+        let second_randomness = add_item_randomness(0xc1);
+        let second_item_id = second_randomness.item_id();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .add_item(
+            new_login_document(second_item_id, "Untouched", "other-secret"),
+            402,
+            second_randomness,
+            &local,
+        )
+        .unwrap();
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let prior_heads = session.local_pins().clone();
+        let expected_revision = session.current_catalog.items[&first_item_id][0].revision_id();
+        let active = session
+            .replace_item(
+                expected_revision,
+                new_login_document(first_item_id, "After", "new-secret"),
+                403,
+                replace_item_randomness(0xd1),
+                &local,
+            )
+            .unwrap();
+
+        assert_eq!(active.last_device_counter(), 4);
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.item_count(), 2);
+        assert!(reopened.get_item(second_item_id).unwrap().is_some());
+        let [candidate] = reopened.current_catalog.items[&first_item_id].as_slice() else {
+            panic!("replacement must become the sole current candidate")
+        };
+        assert_ne!(candidate.revision_id(), expected_revision);
+        assert_eq!(
+            candidate.causal_parents(),
+            &BTreeSet::from([expected_revision])
+        );
+        let ItemState::Live(document) = candidate.state() else {
+            panic!("replacement must remain live")
+        };
+        let AnyRecord::Login(login) = document.payload() else {
+            panic!("replacement schema must remain login")
+        };
+        assert_eq!(login.title, "After");
+        assert_eq!(login.password, "new-secret");
+        let head = *reopened.open_report().heads().iter().next().unwrap();
+        let commit = reopened._repository.read_commit(head).unwrap();
+        assert_eq!(
+            commit.parents(),
+            prior_heads.iter().copied().collect::<Vec<_>>()
+        );
+        assert_eq!(commit.added_objects().len(), 2);
+        assert_eq!(commit.wall_time_ms(), 403);
+    }
+
+    #[test]
+    fn replace_item_rejects_missing_stale_and_immutable_identity_changes_before_cas() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let missing_randomness = add_item_randomness(0xe1);
+        let item_id = missing_randomness.item_id();
+        let exact_empty = local.0.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            open_active_vault(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                locator,
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap()
+            .replace_item(
+                RevisionId::new([0x91; 32]),
+                new_login_document(item_id, "Missing", "secret"),
+                404,
+                replace_item_randomness(0xf1),
+                &local,
+            ),
+            Err(ApplicationError::NotFound)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_empty.as_slice())
+        );
+
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .add_item(
+            new_login_document(item_id, "Original", "secret"),
+            405,
+            missing_randomness,
+            &local,
+        )
+        .unwrap();
+        let exact_item = local.0.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            open_active_vault(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                locator,
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap()
+            .replace_item(
+                RevisionId::new([0x92; 32]),
+                new_login_document(item_id, "Stale", "secret"),
+                406,
+                replace_item_randomness(0x01),
+                &local,
+            ),
+            Err(ApplicationError::ConflictRequired)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_item.as_slice())
+        );
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let expected_revision = session.current_catalog.items[&item_id][0].revision_id();
+        let changed_creation = ItemDocument::new(
+            item_id,
+            ContentType::new(LOGIN_V1).unwrap(),
+            299,
+            300,
+            LwwRegister::new(false, 300, OperationId::new([0x72; 32])),
+            ObservedSet::new(),
+            ObservedSet::new(),
+            AnyRecord::Login(Login {
+                title: "Changed creation".to_owned(),
+                username: "new-user@example.test".to_owned(),
+                password: "secret".to_owned(),
+                urls: vec!["https://new.example.test".to_owned()],
+                notes: None,
+            }),
+            ObservedSet::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            session.replace_item(
+                expected_revision,
+                changed_creation,
+                407,
+                replace_item_randomness(0x11),
+                &local,
+            ),
+            Err(ApplicationError::InvalidInput)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_item.as_slice())
+        );
     }
 
     #[test]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1300,11 +1300,16 @@ changelog, focused build, and downstream validation.
        catalog preservation, all-head commit parenting, exact write-ahead
        owner-state transitions, ambiguous-success handling, and session
        consumption to prevent stale-pin reuse;
-   7b. compare-and-replace, delete, restore, and explicit conflict-resolution
-       mutation workflows;
+   7b. completed compare-and-replace mutation workflow, requiring the sole
+       expected current live revision, preserving immutable identity fields
+       and unrelated catalog candidates, creating exact one-parent causality,
+       and reusing the crash-resumable publication state machine;
+   7b-1. delete, restore, and explicit conflict-resolution mutation workflows;
    7c. bounded history traversal and explicit zeroizing field reveal;
    7d. authenticated portable export and restore/import preparation; and
-   7e. audit, status, and doctor workflows.
+   7e. audit, status, and doctor workflows; and
+   7f. close the remaining VLT-PM05 `Locked` error and explicit lock-state
+       boundary before CLI composition.
 9. `vault-pm-cli` + real executable and pseudo-terminal E2E suite.
 10. Crash/fault matrix and local restore drill.
 


### PR DESCRIPTION
## Summary
- add session-consuming compare-and-replace for the sole expected current live revision
- preserve item identity, schema, creation time, unrelated catalog candidates, and exact one-parent causality
- reuse the crash-resumable pending-publication state machine and add the specified `NotFound` error
- record the remaining `Locked` boundary as a backlog item before CLI composition

## Verification
- `cargo test -p coding_adventures_vault_pm_application` (75 passed)
- `cargo clippy -p coding_adventures_vault_pm_application --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p coding_adventures_vault_pm_application --no-deps`
- Tarpaulin LLVM: 1,953/2,043 production lines (95.59%)
- `./build-tool -root . -diff-base origin/main -dry-run -validate-build-files`
- `./build-tool -root . -diff-base origin/main -validate-build-files` (1,001 packages discovered; 21 affected; all built)