### PR TITLE
Add causal vault item deletion

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this package are documented here.
 
+## [0.15.0] - 2026-08-09
+
+### Added
+
+- Add a session-consuming `delete_item` workflow that locates the caller's
+  expected current live revision and publishes a one-parent tombstone.
+- Accept separate advisory deletion and commit timestamps plus an owned
+  wipe-on-drop entropy block for the three encrypted deletion frames.
+
+### Security
+
+- Reject absent, conflicted, and already-tombstoned targets before the local
+  write-ahead compare-exchange without exposing item identity in errors.
+- Preserve unrelated catalog candidates, make every current repository head a
+  commit parent, and reuse the exact crash-resumable publication journal.
+- Retain tombstones as current causal state while ordinary get/list/search
+  views omit the deleted item and its former secret-bearing document.
+
 ## [0.14.0] - 2026-08-09
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -102,6 +102,17 @@ Replacement uses an owned wipe-on-drop 240-byte entropy block and the same exact
 pending journal, all-head commit parenting, ambiguous-success rules, and
 recovery path as add-item.
 
+Deletion likewise consumes the unlocked session and requires the caller's
+expected revision to be the sole current live candidate. It publishes a new
+tombstone revision whose sole causal parent is that live revision, preserves
+all unrelated catalog candidates, and keeps deletion time separate from the
+commit's advisory wall time. Missing revisions return `NotFound`; conflicts and
+repeat deletion return `ConflictRequired` before any local write. Authenticated
+reopen retains the tombstone for history and restore while ordinary get, list,
+and search views omit the deleted item. The three deletion frames use a
+caller-owned wipe-on-drop 240-byte entropy block and the shared exact pending
+journal/recovery state machine.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
 credential store, or entropy source. Replace, delete, restore, conflict
@@ -127,7 +138,7 @@ paths, and complete error translation.
 Search tests cover Unicode normalization, short queries, oversized safe-field
 fallback, exact collection filters, deterministic product ordering, every
 record schema's allowlist/denylist, secret exclusion, query/result bounds, and
-conflict closure. The exact Tarpaulin LLVM result is 1,953 of 2,043 production
+conflict closure. The exact Tarpaulin LLVM result is 1,996 of 2,088 production
 lines (95.59%). Add-item tests cover exact entropy partitioning and wiping,
 identity validation before local writes, parentless revision and complete
 catalog construction, ambiguous successful compare-exchanges, write-ahead
@@ -135,6 +146,9 @@ publication ordering, ambiguous provider commits, failed final activation,
 and recovery through the exact persisted journal. Replacement tests prove
 one-parent causality, immutable identity fields, complete catalog preservation,
 stale/missing rejection before compare-exchange, and secret/entropy wiping.
+Deletion tests prove one-parent tombstone causality, advisory timestamp
+separation, ordinary-view omission, repeat/missing rejection before
+compare-exchange, and entropy redaction/wiping.
 
 ## Development
 

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -32,7 +32,8 @@ pub use initialize::{
     GENERATION_ZERO_RANDOM_BYTES,
 };
 pub use mutation::{
-    AddItemRandomnessV1, ReplaceItemRandomnessV1, ADD_ITEM_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
+    AddItemRandomnessV1, DeleteItemRandomnessV1, ReplaceItemRandomnessV1, ADD_ITEM_RANDOM_BYTES,
+    DELETE_ITEM_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
 };
 pub use open::{open_active_vault, recover_pending_publication, UnlockedVaultV1};
 pub use repository::{

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use coding_adventures_ed25519::{generate_keypair, sign};
 use coding_adventures_vault_pm_domain::{
-    ItemCandidate, ItemDocument, ItemId, ItemState, RevisionId,
+    ItemCandidate, ItemDocument, ItemId, ItemState, RevisionId, Tombstone,
 };
 use coding_adventures_vault_pm_format::{AnnouncementV1, CommitV1, Signature};
 use coding_adventures_vault_pm_repository::{OpenReport, PinnedHeads};
@@ -21,6 +21,8 @@ const OBJECT_RANDOM_BYTES: usize = 32 + 24 + 24;
 pub const ADD_ITEM_RANDOM_BYTES: usize = ITEM_ID_BYTES + 3 * OBJECT_RANDOM_BYTES;
 /// Exact caller-filled CSPRNG bytes consumed by one replace-item mutation.
 pub const REPLACE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
+/// Exact caller-filled CSPRNG bytes consumed by one delete-item mutation.
+pub const DELETE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
 
 /// Owned wipe-on-drop entropy for one item ID and three encrypted frames.
 pub struct AddItemRandomnessV1 {
@@ -88,6 +90,36 @@ impl Drop for ReplaceItemRandomnessV1 {
 impl Debug for ReplaceItemRandomnessV1 {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         formatter.write_str("ReplaceItemRandomnessV1(<redacted>)")
+    }
+}
+
+/// Owned wipe-on-drop entropy for the three encrypted deletion frames.
+pub struct DeleteItemRandomnessV1 {
+    bytes: [u8; DELETE_ITEM_RANDOM_BYTES],
+}
+
+impl DeleteItemRandomnessV1 {
+    /// Take one exact block filled by the host's cryptographic entropy source.
+    pub const fn new(bytes: [u8; DELETE_ITEM_RANDOM_BYTES]) -> Self {
+        Self { bytes }
+    }
+}
+
+impl Zeroize for DeleteItemRandomnessV1 {
+    fn zeroize(&mut self) {
+        self.bytes.zeroize();
+    }
+}
+
+impl Drop for DeleteItemRandomnessV1 {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl Debug for DeleteItemRandomnessV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("DeleteItemRandomnessV1(<redacted>)")
     }
 }
 
@@ -178,6 +210,57 @@ pub(crate) fn replace_item(
         local_secret,
         document.id(),
         ItemState::Live(Box::new(document)),
+        &BTreeSet::from([expected_revision]),
+        wall_time_ms,
+        &randomness.bytes,
+    )?;
+    publish_mutation(active, repository, publication, local_state_store)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn delete_item(
+    active: &ActiveStateV1,
+    report: &OpenReport,
+    current_items: &BTreeMap<ItemId, Vec<ItemCandidate>>,
+    keys: &V1Keys,
+    local_secret: &LocalSecretV1,
+    repository: &dyn ApplicationRepository,
+    expected_revision: RevisionId,
+    deleted_at_ms: u64,
+    wall_time_ms: u64,
+    randomness: DeleteItemRandomnessV1,
+    local_state_store: &dyn LocalStateStore,
+) -> Result<ActiveStateV1, ApplicationError> {
+    if report.heads() != active.pinned_heads() {
+        return Err(ApplicationError::ConcurrentHost);
+    }
+    let (item_id, candidates) = current_items
+        .iter()
+        .find(|(_, candidates)| {
+            candidates
+                .iter()
+                .any(|candidate| candidate.revision_id() == expected_revision)
+        })
+        .ok_or(ApplicationError::NotFound)?;
+    let [candidate] = candidates.as_slice() else {
+        return Err(ApplicationError::ConflictRequired);
+    };
+    if candidate.revision_id() != expected_revision
+        || !matches!(candidate.state(), ItemState::Live(_))
+    {
+        return Err(ApplicationError::ConflictRequired);
+    }
+
+    let publication = prepare_item_publication(
+        active,
+        current_items,
+        keys,
+        local_secret,
+        *item_id,
+        ItemState::Tombstone(Tombstone {
+            item_id: *item_id,
+            deleted_at_ms,
+        }),
         &BTreeSet::from([expected_revision]),
         wall_time_ms,
         &randomness.bytes,
@@ -424,6 +507,20 @@ mod tests {
             "ReplaceItemRandomnessV1(<redacted>)"
         );
         assert!(randomness.bytes.iter().all(|byte| *byte == 0xa5));
+
+        randomness.zeroize();
+        assert!(randomness.bytes.iter().all(|byte| *byte == 0));
+    }
+
+    #[test]
+    fn delete_item_randomness_redacts_and_zeroizes() {
+        let mut randomness = DeleteItemRandomnessV1::new([0x3c; DELETE_ITEM_RANDOM_BYTES]);
+
+        assert_eq!(
+            format!("{randomness:?}"),
+            "DeleteItemRandomnessV1(<redacted>)"
+        );
+        assert!(randomness.bytes.iter().all(|byte| *byte == 0x3c));
 
         randomness.zeroize();
         assert!(randomness.bytes.iter().all(|byte| *byte == 0));

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1,5 +1,8 @@
 use crate::initialize::{unlock_active_material, UnlockedActiveMaterial};
-use crate::mutation::{add_item, replace_item, AddItemRandomnessV1, ReplaceItemRandomnessV1};
+use crate::mutation::{
+    add_item, delete_item, replace_item, AddItemRandomnessV1, DeleteItemRandomnessV1,
+    ReplaceItemRandomnessV1,
+};
 use crate::search::SearchProjectionV1;
 use crate::{
     open_object, ActiveStateV1, ApplicationError, ApplicationRepository,
@@ -200,6 +203,37 @@ impl UnlockedVaultV1 {
             self._repository.as_ref(),
             expected_revision,
             document,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+        )
+    }
+
+    /// Delete the sole expected current live revision by publishing a causal
+    /// tombstone and return the resulting durable active owner state.
+    ///
+    /// A revision absent from the current catalog returns `NotFound`; a
+    /// conflicted or already-tombstoned target returns `ConflictRequired`.
+    /// Advisory deletion and commit times are supplied separately and do not
+    /// establish causality. The session and randomness are consumed on every
+    /// return path.
+    pub fn delete_item(
+        self,
+        expected_revision: RevisionId,
+        deleted_at_ms: u64,
+        wall_time_ms: u64,
+        randomness: DeleteItemRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        delete_item(
+            &self.active,
+            &self.report,
+            &self.current_catalog.items,
+            &self._keys,
+            &self._local_secret,
+            self._repository.as_ref(),
+            expected_revision,
+            deleted_at_ms,
             wall_time_ms,
             randomness,
             local_state_store,
@@ -474,7 +508,7 @@ mod tests {
         complete_generation_zero, encode_item_revision, encode_signed_commit,
         prepare_generation_zero, seal_object, CatalogV1, GenerationZeroPolicyV1,
         GenerationZeroRandomness, ObjectKind, ObjectRandomness, PublicationJournalV1,
-        V1ApplicationRepositoryFactory, V1Keys, ADD_ITEM_RANDOM_BYTES,
+        V1ApplicationRepositoryFactory, V1Keys, ADD_ITEM_RANDOM_BYTES, DELETE_ITEM_RANDOM_BYTES,
         GENERATION_ZERO_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
     };
     use coding_adventures_ed25519::{generate_keypair, sign};
@@ -621,6 +655,14 @@ mod tests {
             *byte = (index as u8).wrapping_mul(29).wrapping_add(seed);
         }
         ReplaceItemRandomnessV1::new(bytes)
+    }
+
+    fn delete_item_randomness(seed: u8) -> DeleteItemRandomnessV1 {
+        let mut bytes = [0; DELETE_ITEM_RANDOM_BYTES];
+        for (index, byte) in bytes.iter_mut().enumerate() {
+            *byte = (index as u8).wrapping_mul(31).wrapping_add(seed);
+        }
+        DeleteItemRandomnessV1::new(bytes)
     }
 
     fn new_login_document(item_id: ItemId, title: &str, password: &str) -> ItemDocument {
@@ -1954,6 +1996,127 @@ mod tests {
         assert_eq!(
             local.0.lock().unwrap().as_deref(),
             Some(exact_item.as_slice())
+        );
+    }
+
+    #[test]
+    fn delete_item_publishes_one_parent_tombstone_and_rejects_repeat_delete() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let add_randomness = add_item_randomness(0x21);
+        let item_id = add_randomness.item_id();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .add_item(
+            new_login_document(item_id, "Delete me", "secret"),
+            450,
+            add_randomness,
+            &local,
+        )
+        .unwrap();
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let expected_revision = session.current_catalog.items[&item_id][0].revision_id();
+        let prior_heads = session.local_pins().clone();
+        let active = session
+            .delete_item(
+                expected_revision,
+                451,
+                452,
+                delete_item_randomness(0x31),
+                &local,
+            )
+            .unwrap();
+        assert_eq!(active.last_device_counter(), 3);
+
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.item_count(), 1);
+        assert_eq!(reopened.search_item_count(), 0);
+        assert_eq!(reopened.get_item(item_id).unwrap(), None);
+        assert!(reopened.list_items().unwrap().is_empty());
+        let [candidate] = reopened.current_catalog.items[&item_id].as_slice() else {
+            panic!("deletion must become the sole current candidate")
+        };
+        assert_eq!(
+            candidate.causal_parents(),
+            &BTreeSet::from([expected_revision])
+        );
+        let ItemState::Tombstone(tombstone) = candidate.state() else {
+            panic!("deletion must materialize a tombstone")
+        };
+        assert_eq!(tombstone.item_id, item_id);
+        assert_eq!(tombstone.deleted_at_ms, 451);
+        let tombstone_revision = candidate.revision_id();
+        let head = *reopened.open_report().heads().iter().next().unwrap();
+        let commit = reopened._repository.read_commit(head).unwrap();
+        assert_eq!(
+            commit.parents(),
+            prior_heads.iter().copied().collect::<Vec<_>>()
+        );
+        assert_eq!(commit.added_objects().len(), 2);
+        assert_eq!(commit.wall_time_ms(), 452);
+        let exact_deleted = local.0.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            reopened.delete_item(
+                tombstone_revision,
+                453,
+                454,
+                delete_item_randomness(0x41),
+                &local,
+            ),
+            Err(ApplicationError::ConflictRequired)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_deleted.as_slice())
+        );
+    }
+
+    #[test]
+    fn delete_item_rejects_missing_revision_before_cas() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+
+        assert_eq!(
+            open_active_vault(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                locator,
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap()
+            .delete_item(
+                RevisionId::new([0x51; 32]),
+                455,
+                456,
+                delete_item_randomness(0x51),
+                &local,
+            ),
+            Err(ApplicationError::NotFound)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_active.as_slice())
         );
     }
 

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1304,7 +1304,11 @@ changelog, focused build, and downstream validation.
        expected current live revision, preserving immutable identity fields
        and unrelated catalog candidates, creating exact one-parent causality,
        and reusing the crash-resumable publication state machine;
-   7b-1. delete, restore, and explicit conflict-resolution mutation workflows;
+   7b-1. completed delete mutation workflow, locating the sole expected current
+       live revision, producing a one-parent tombstone, retaining it for later
+       history/restore while omitting it from ordinary views, and reusing exact
+       crash-resumable publication;
+   7b-2. restore and explicit conflict-resolution mutation workflows;
    7c. bounded history traversal and explicit zeroizing field reveal;
    7d. authenticated portable export and restore/import preparation; and
    7e. audit, status, and doctor workflows; and


### PR DESCRIPTION
## Summary
- add session-consuming deletion of the sole expected current live revision
- publish a one-parent tombstone while preserving unrelated catalog candidates and all-head commit parenting
- retain deleted state for history/restore while omitting it from ordinary get/list/search projections
- reuse the exact crash-resumable pending-publication state machine

## Verification
- `cargo test -p coding_adventures_vault_pm_application` (78 passed)
- `cargo clippy -p coding_adventures_vault_pm_application --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p coding_adventures_vault_pm_application --no-deps`
- Tarpaulin LLVM: 1,996/2,088 production lines (95.59%)
- `./build-tool -root . -diff-base origin/main -dry-run -validate-build-files`
- `./build-tool -root . -diff-base origin/main -validate-build-files` (1,001 packages discovered; 21 affected; all built)