### PR TITLE
feat(hl-tamil): extend the writing strand over chapter 3's glyphs

### DIFF
--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -124,7 +124,7 @@ enter cross-language review only after focused retrieval.
 | [German](./german/README.md) | Germanic / Latin | 106 | 91 | 31 chapters; through Ch. 31; 15 generated |
 | [Arabic](./arabic/README.md) | Semitic / Arabic | 100 | 98 | 36 chapters; through Ch. 36; 34 generated |
 | [Hindi](./hindi/README.md) | Indo-Aryan / Devanagari | 109 | 103 | 39 chapters; through Ch. 39; 34 generated |
-| [Tamil](./tamil/README.md) | Dravidian / Tamil | 118 | 114 | 38 chapters; through Ch. 38; 33 generated |
+| [Tamil](./tamil/README.md) | Dravidian / Tamil | 122 | 118 | 38 chapters; through Ch. 38; 33 generated |
 | [Kannada](./kannada/README.md) | Dravidian / Kannada | 88 | 84 | 40 chapters; through Ch. 40; 35 generated |
 | [Telugu](./telugu/README.md) | Dravidian / Telugu | 74 | 70 | 34 chapters; through Ch. 34; 29 generated |
 | [Malayalam](./malayalam/README.md) | Dravidian / Malayalam | 78 | 74 | 34 chapters; through Ch. 34; 29 generated |

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -3959,9 +3959,10 @@
     {
       "language": "tamil",
       "chapter": 25,
-      "sourceHash": "fnv1a64:11c2224eeb3cd4b9",
+      "sourceHash": "fnv1a64:98bf0d2bda9177c5",
       "lessonIds": [
         "TA-C25-iniya-iravu",
+        "TA-W10-read-naan",
         "TA-C25-goodnight-alternatives"
       ],
       "tex": "tamil/book/chapters/ch25-good-night.tex"
@@ -3978,9 +3979,10 @@
     {
       "language": "tamil",
       "chapter": 27,
-      "sourceHash": "fnv1a64:6197d3c4b4040882",
+      "sourceHash": "fnv1a64:9f987f9f4c88336d",
       "lessonIds": [
-        "TA-C27-maalai"
+        "TA-C27-maalai",
+        "TA-W11-read-niingal"
       ],
       "tex": "tamil/book/chapters/ch27-evening.tex"
     },
@@ -3997,9 +3999,10 @@
     {
       "language": "tamil",
       "chapter": 29,
-      "sourceHash": "fnv1a64:825f3ac97af78344",
+      "sourceHash": "fnv1a64:02f13e86ba18eac0",
       "lessonIds": [
-        "TA-C29-kaalai-vanakkam"
+        "TA-C29-kaalai-vanakkam",
+        "TA-W12-read-eppadi"
       ],
       "tex": "tamil/book/chapters/ch29-good-morning.tex"
     },
@@ -4015,10 +4018,11 @@
     {
       "language": "tamil",
       "chapter": 31,
-      "sourceHash": "fnv1a64:16928bffcb407199",
+      "sourceHash": "fnv1a64:69fe16e20cd758a3",
       "lessonIds": [
         "TA-C31-matiya-vanakkam",
-        "TA-C31-afternoon-greeting-root"
+        "TA-C31-afternoon-greeting-root",
+        "TA-W13-read-irukkirirgal"
       ],
       "tex": "tamil/book/chapters/ch31-good-afternoon.tex"
     },

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -7047,7 +7047,7 @@
     {
       "language": "tamil",
       "chapter": 2,
-      "sourceHash": "fnv1a64:8d5757d04fc5050e",
+      "sourceHash": "fnv1a64:b828f372c82c3c3a",
       "lessonIds": [
         "TA-C02-peyar",
         "TA-C02-en",
@@ -7058,17 +7058,17 @@
         "TA-C02-magizhcci",
         "TA-C02-practice"
       ],
-      "voiceLessons": 6,
+      "voiceLessons": 7,
       "drivablePrefix": 2,
       "text": "tamil/narration/ch02.txt",
       "json": "tamil/narration/ch02.json",
-      "textHash": "fnv1a64:244586946331121c",
-      "jsonHash": "fnv1a64:7f95b059a49e4b1f"
+      "textHash": "fnv1a64:f8b83f8afdf52b6d",
+      "jsonHash": "fnv1a64:291f8aec772e5a3b"
     },
     {
       "language": "tamil",
       "chapter": 3,
-      "sourceHash": "fnv1a64:1c736a85ee572d92",
+      "sourceHash": "fnv1a64:919bcef05a0e1250",
       "lessonIds": [
         "TA-C03-eppadi",
         "TA-C03-eppadi-irukkirirgal",
@@ -7077,12 +7077,12 @@
         "TA-C03-paravayillai",
         "TA-C03-practice"
       ],
-      "voiceLessons": 1,
-      "drivablePrefix": 0,
+      "voiceLessons": 6,
+      "drivablePrefix": 6,
       "text": "tamil/narration/ch03.txt",
       "json": "tamil/narration/ch03.json",
-      "textHash": "fnv1a64:20361f0a27ab7832",
-      "jsonHash": "fnv1a64:2ec39197c5e28e81"
+      "textHash": "fnv1a64:97e4fd146c1d71e9",
+      "jsonHash": "fnv1a64:126adf0bed4e3b79"
     },
     {
       "language": "tamil",
@@ -7416,17 +7416,18 @@
     {
       "language": "tamil",
       "chapter": 25,
-      "sourceHash": "fnv1a64:a476bb11b5f796c3",
+      "sourceHash": "fnv1a64:2f31b122ac3d89dd",
       "lessonIds": [
         "TA-C25-iniya-iravu",
+        "TA-W10-read-naan",
         "TA-C25-goodnight-alternatives"
       ],
       "voiceLessons": 2,
-      "drivablePrefix": 2,
+      "drivablePrefix": 1,
       "text": "tamil/narration/ch25.txt",
       "json": "tamil/narration/ch25.json",
-      "textHash": "fnv1a64:4b85de6a52f99aa7",
-      "jsonHash": "fnv1a64:526c1b5e091769aa"
+      "textHash": "fnv1a64:dd6cf4b15bfcfa2e",
+      "jsonHash": "fnv1a64:a001cdd75c9bd8e0"
     },
     {
       "language": "tamil",
@@ -7445,16 +7446,17 @@
     {
       "language": "tamil",
       "chapter": 27,
-      "sourceHash": "fnv1a64:8a3ee365c271485b",
+      "sourceHash": "fnv1a64:7cddce6c619c2508",
       "lessonIds": [
-        "TA-C27-maalai"
+        "TA-C27-maalai",
+        "TA-W11-read-niingal"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 1,
       "text": "tamil/narration/ch27.txt",
       "json": "tamil/narration/ch27.json",
-      "textHash": "fnv1a64:eee1bcc33fc7e65c",
-      "jsonHash": "fnv1a64:02e3f70c92b52d45"
+      "textHash": "fnv1a64:4670222b395f378f",
+      "jsonHash": "fnv1a64:93136384361a21aa"
     },
     {
       "language": "tamil",
@@ -7474,16 +7476,17 @@
     {
       "language": "tamil",
       "chapter": 29,
-      "sourceHash": "fnv1a64:c5303420ac3aa1b6",
+      "sourceHash": "fnv1a64:f50670956f8c9ff2",
       "lessonIds": [
-        "TA-C29-kaalai-vanakkam"
+        "TA-C29-kaalai-vanakkam",
+        "TA-W12-read-eppadi"
       ],
       "voiceLessons": 1,
       "drivablePrefix": 1,
       "text": "tamil/narration/ch29.txt",
       "json": "tamil/narration/ch29.json",
-      "textHash": "fnv1a64:411d70e89e1e9e3b",
-      "jsonHash": "fnv1a64:819aefebf24cf2bd"
+      "textHash": "fnv1a64:7f04068190c169a6",
+      "jsonHash": "fnv1a64:ffa5ba963c997062"
     },
     {
       "language": "tamil",
@@ -7502,17 +7505,18 @@
     {
       "language": "tamil",
       "chapter": 31,
-      "sourceHash": "fnv1a64:9da02aa156c2f34f",
+      "sourceHash": "fnv1a64:930027490aca12db",
       "lessonIds": [
         "TA-C31-matiya-vanakkam",
-        "TA-C31-afternoon-greeting-root"
+        "TA-C31-afternoon-greeting-root",
+        "TA-W13-read-irukkirirgal"
       ],
       "voiceLessons": 2,
       "drivablePrefix": 2,
       "text": "tamil/narration/ch31.txt",
       "json": "tamil/narration/ch31.json",
-      "textHash": "fnv1a64:9dd889090730b2ee",
-      "jsonHash": "fnv1a64:e701fc6b90667a99"
+      "textHash": "fnv1a64:dfd13ee08165cd43",
+      "jsonHash": "fnv1a64:50dcc07339596bb8"
     },
     {
       "language": "tamil",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,19 +7,19 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:8b3bca2d35966b86",
+  "sourceHash": "fnv1a64:9256ebdf7b2dd5b8",
   "summary": {
-    "totalLessons": 1680,
-    "voice": 1100,
-    "sight": 522,
-    "pen": 58,
-    "drivableLessons": 1100,
-    "drivablePercent": 65,
+    "totalLessons": 1684,
+    "voice": 1106,
+    "sight": 516,
+    "pen": 62,
+    "drivableLessons": 1106,
+    "drivablePercent": 66,
     "trackCount": 22,
     "chapterCount": 513,
-    "drivablePrefixTotal": 913,
-    "fullyDrivableChapters": 327,
-    "unstartableChapters": 140,
+    "drivablePrefixTotal": 918,
+    "fullyDrivableChapters": 324,
+    "unstartableChapters": 139,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
   },
@@ -7548,12 +7548,12 @@
     },
     {
       "language": "tamil",
-      "lessonCount": 118,
-      "voice": 62,
-      "sight": 43,
-      "pen": 13,
-      "drivablePercent": 53,
-      "drivablePrefixTotal": 49,
+      "lessonCount": 122,
+      "voice": 68,
+      "sight": 37,
+      "pen": 17,
+      "drivablePercent": 56,
+      "drivablePrefixTotal": 54,
       "modalities": [
         "voice",
         "sight",
@@ -7587,8 +7587,8 @@
         {
           "chapter": 2,
           "lessonCount": 8,
-          "voice": 6,
-          "sight": 2,
+          "voice": 7,
+          "sight": 1,
           "pen": 0,
           "modalities": [
             "voice",
@@ -7605,17 +7605,23 @@
         {
           "chapter": 3,
           "lessonCount": 6,
-          "voice": 1,
-          "sight": 5,
+          "voice": 6,
+          "sight": 0,
           "pen": 0,
           "modalities": [
-            "voice",
-            "sight"
+            "voice"
           ],
-          "drivablePrefix": 0,
-          "firstNonVoiceLesson": "TA-C03-eppadi",
-          "drivable": false,
-          "drivableLessonIds": []
+          "drivablePrefix": 6,
+          "firstNonVoiceLesson": null,
+          "drivable": true,
+          "drivableLessonIds": [
+            "TA-C03-eppadi",
+            "TA-C03-eppadi-irukkirirgal",
+            "TA-C03-naan",
+            "TA-C03-nalam",
+            "TA-C03-paravayillai",
+            "TA-C03-practice"
+          ]
         },
         {
           "chapter": 4,
@@ -7977,19 +7983,20 @@
         },
         {
           "chapter": 25,
-          "lessonCount": 2,
+          "lessonCount": 3,
           "voice": 2,
           "sight": 0,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "voice"
+            "voice",
+            "sight",
+            "pen"
           ],
-          "drivablePrefix": 2,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
+          "drivablePrefix": 1,
+          "firstNonVoiceLesson": "TA-W10-read-naan",
+          "drivable": false,
           "drivableLessonIds": [
-            "TA-C25-iniya-iravu",
-            "TA-C25-goodnight-alternatives"
+            "TA-C25-iniya-iravu"
           ]
         },
         {
@@ -8010,16 +8017,18 @@
         },
         {
           "chapter": 27,
-          "lessonCount": 1,
+          "lessonCount": 2,
           "voice": 1,
           "sight": 0,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "voice"
+            "voice",
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 1,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
+          "firstNonVoiceLesson": "TA-W11-read-niingal",
+          "drivable": false,
           "drivableLessonIds": [
             "TA-C27-maalai"
           ]
@@ -8043,16 +8052,18 @@
         },
         {
           "chapter": 29,
-          "lessonCount": 1,
+          "lessonCount": 2,
           "voice": 1,
           "sight": 0,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "voice"
+            "voice",
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 1,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
+          "firstNonVoiceLesson": "TA-W12-read-eppadi",
+          "drivable": false,
           "drivableLessonIds": [
             "TA-C29-kaalai-vanakkam"
           ]
@@ -8075,16 +8086,18 @@
         },
         {
           "chapter": 31,
-          "lessonCount": 2,
+          "lessonCount": 3,
           "voice": 2,
           "sight": 0,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "voice"
+            "voice",
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 2,
-          "firstNonVoiceLesson": null,
-          "drivable": true,
+          "firstNonVoiceLesson": "TA-W13-read-irukkirirgal",
+          "drivable": false,
           "drivableLessonIds": [
             "TA-C31-matiya-vanakkam",
             "TA-C31-afternoon-greeting-root"
@@ -36304,21 +36317,18 @@
       "language": "tamil",
       "chapter": 2,
       "sequence": 140,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:88ed443a4d4d2cbc",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:3b2dc0902dd010a2"
     },
     {
       "id": "TA-C02-enna",
@@ -36397,105 +36407,90 @@
       "language": "tamil",
       "chapter": 3,
       "sequence": 180,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:1d3bf7b5cc442f13",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:64342f32f2e5e919"
     },
     {
       "id": "TA-C03-eppadi-irukkirirgal",
       "language": "tamil",
       "chapter": 3,
       "sequence": 190,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:0a99d5e4478d95d7",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:b0842834ee732703"
     },
     {
       "id": "TA-C03-naan",
       "language": "tamil",
       "chapter": 3,
       "sequence": 200,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:aaef6470e27b2b3d",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:048724de9db451e5"
     },
     {
       "id": "TA-C03-nalam",
       "language": "tamil",
       "chapter": 3,
       "sequence": 210,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:9e274834464afc76",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:45b455e9ad00a5f6"
     },
     {
       "id": "TA-C03-paravayillai",
       "language": "tamil",
       "chapter": 3,
       "sequence": 220,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a7e6694023ebed70",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:8a3e39237641211e"
     },
     {
       "id": "TA-C03-practice",
@@ -37651,7 +37646,31 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:3874dc4fc0a7afb5"
+      "sourceHash": "fnv1a64:93edd99cbcc26b5f"
+    },
+    {
+      "id": "TA-W10-read-naan",
+      "language": "tamil",
+      "chapter": 25,
+      "sequence": 785,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:4cd4df8950c7367a",
+      "detachableSegments": [
+        "Script you'll notice: the ா sign",
+        "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
     },
     {
       "id": "TA-C25-goodnight-alternatives",
@@ -37708,6 +37727,31 @@
       "sourceHash": "fnv1a64:9b58ae9e7d826a6f"
     },
     {
+      "id": "TA-W11-read-niingal",
+      "language": "tamil",
+      "chapter": 27,
+      "sequence": 815,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:32cfc1fb13f08bef",
+      "detachableSegments": [
+        "Script you'll notice: ங and ள",
+        "Script you'll notice: the ீ sign",
+        "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
+    },
+    {
       "id": "TA-C28-pirpakal",
       "language": "tamil",
       "chapter": 28,
@@ -37762,6 +37806,30 @@
       "sourceHash": "fnv1a64:824054e5b5c328eb"
     },
     {
+      "id": "TA-W12-read-eppadi",
+      "language": "tamil",
+      "chapter": 29,
+      "sequence": 845,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:4f8ae089758b39e5",
+      "detachableSegments": [
+        "Script you'll notice: ட",
+        "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
+    },
+    {
       "id": "TA-C30-maalai-vanakkam",
       "language": "tamil",
       "chapter": 30,
@@ -37814,6 +37882,30 @@
       ],
       "coreDrivable": true,
       "sourceHash": "fnv1a64:aebc39e8e3bbc929"
+    },
+    {
+      "id": "TA-W13-read-irukkirirgal",
+      "language": "tamil",
+      "chapter": 31,
+      "sequence": 875,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:23241669861ea8d8",
+      "detachableSegments": [
+        "Script you'll notice: the ு sign",
+        "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
     },
     {
       "id": "TA-C32-iru",

--- a/code/learning/human-languages/tamil/book/chapter-modalities.tex
+++ b/code/learning/human-languages/tamil/book/chapter-modalities.tex
@@ -37,14 +37,14 @@
 
 \expandafter\def\csname hlchaptermodality2\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (6) \quad \hlsightsign{}~\textbf{eyes} (2)\quad
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (7) \quad \hlsightsign{}~\textbf{eyes} (1)\quad
     \hlvoicesign{}~\textbf{Hands-free start:} first 2 of 8 lessons.%
     \par}\medskip
 }
 
 \expandafter\def\csname hlchaptermodality3\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1) \quad \hlsightsign{}~\textbf{eyes} (5)\quad
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (6)\quad
     \hlvoicesign{}~\textbf{Hands-free start:} all 6 lessons.%
     \par}\medskip
 }
@@ -198,8 +198,8 @@
 
 \expandafter\def\csname hlchaptermodality25\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (2)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} all 2 lessons.%
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (2) \quad \hlpensign{}~\textbf{pen} (1)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 1 of 3 lessons.%
     \par}\medskip
 }
 
@@ -212,8 +212,8 @@
 
 \expandafter\def\csname hlchaptermodality27\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} all 1 lesson.%
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1) \quad \hlpensign{}~\textbf{pen} (1)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 1 of 2 lessons.%
     \par}\medskip
 }
 
@@ -226,8 +226,8 @@
 
 \expandafter\def\csname hlchaptermodality29\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} all 1 lesson.%
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1) \quad \hlpensign{}~\textbf{pen} (1)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 1 of 2 lessons.%
     \par}\medskip
 }
 
@@ -240,8 +240,8 @@
 
 \expandafter\def\csname hlchaptermodality31\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (2)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} all 2 lessons.%
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (2) \quad \hlpensign{}~\textbf{pen} (1)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 2 of 3 lessons.%
     \par}\medskip
 }
 

--- a/code/learning/human-languages/tamil/book/chapters/appendix-index.tex
+++ b/code/learning/human-languages/tamil/book/chapters/appendix-index.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons or chapters.json, then run npm run generate:books.
-% canonical-index-candidates: 151
-% canonical-index-entries: 151
+% canonical-index-candidates: 155
+% canonical-index-entries: 155
 
 \chapter*{Index}
 \addcontentsline{toc}{chapter}{Index}
@@ -299,7 +299,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{how}\enspace\emph{\ta{எப்படி}}\par
-\footnotesize explicit focus: script, etymology; \hyperref[ch:responding]{Chapter~3, p.~\pageref*{ch:responding}}
+\footnotesize explicit focus: etymology; \hyperref[ch:responding]{Chapter~3, p.~\pageref*{ch:responding}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -311,7 +311,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{how are you? (respectful)}\enspace\emph{\ta{நீங்கள்} \ta{எப்படி} \ta{இருக்கிறீர்கள்}?}\par
-\footnotesize explicit focus: script, grammar, etymology; \hyperref[ch:responding]{Chapter~3, p.~\pageref*{ch:responding}}
+\footnotesize explicit focus: grammar, etymology; \hyperref[ch:responding]{Chapter~3, p.~\pageref*{ch:responding}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -325,7 +325,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{I}\enspace\emph{\ta{நான்}}\par
-\footnotesize explicit focus: script, grammar, etymology; \hyperref[ch:responding]{Chapter~3, p.~\pageref*{ch:responding}}
+\footnotesize explicit focus: grammar, etymology; \hyperref[ch:responding]{Chapter~3, p.~\pageref*{ch:responding}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -349,7 +349,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{it's okay / no problem / you're welcome}\enspace\emph{\ta{பரவாயில்லை}}\par
-\footnotesize explicit focus: script, grammar, etymology; \hyperref[ch:responding]{Chapter~3, p.~\pageref*{ch:responding}}
+\footnotesize explicit focus: grammar, etymology; \hyperref[ch:responding]{Chapter~3, p.~\pageref*{ch:responding}}
 \end{minipage}\par\smallskip
 
 \section*{J}
@@ -787,7 +787,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{well, wellness, good — and the reply \textquotedblleft{}\ta{நான்} \ta{நலமாக} \ta{இருக்கிறேன்}\textquotedblright{}}\enspace\emph{\ta{நலம்}}\par
-\footnotesize explicit focus: script, etymology; \hyperref[ch:responding]{Chapter~3, p.~\pageref*{ch:responding}}
+\footnotesize explicit focus: etymology; \hyperref[ch:responding]{Chapter~3, p.~\pageref*{ch:responding}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -825,7 +825,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{you (familiar / respectful)}\enspace\emph{\ta{நீ} / \ta{நீங்கள்}}\par
-\footnotesize explicit focus: script, grammar, etymology; \hyperref[ch:introductions]{Chapter~2, p.~\pageref*{ch:introductions}}
+\footnotesize explicit focus: grammar, etymology; \hyperref[ch:introductions]{Chapter~2, p.~\pageref*{ch:introductions}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -850,6 +850,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
+\textbf{\ta{இருக்கிறீர்கள்} — the last sign, and the whole question}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ta-good-afternoon]{Chapter~31, p.~\pageref*{ch:ta-good-afternoon}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
 \textbf{\ta{இல்லை} — a vowel in front, a vowel sign behind}\par
 \footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ta-telling-time]{Chapter~18, p.~\pageref*{ch:ta-telling-time}}
 \end{minipage}\par\smallskip
@@ -864,6 +870,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{\ta{என்} — the third vowel that opens a word}\par
 \footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ta-dog-and-cat]{Chapter~21, p.~\pageref*{ch:ta-dog-and-cat}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{எப்படி} — the retroflex stop}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ta-good-morning]{Chapter~29, p.~\pageref*{ch:ta-good-morning}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -892,8 +904,20 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
+\textbf{\ta{நீங்கள்} — two old promises, paid}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ta-evening]{Chapter~27, p.~\pageref*{ch:ta-evening}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
 \textbf{\ta{நடுப்பகல்} and \ta{நடு} \ta{இரவு} — the transparent twins}\par
 \footnotesize etymology topic; \hyperref[ch:ta-noon-and-midnight]{Chapter~17, p.~\pageref*{ch:ta-noon-and-midnight}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{நான்} — the sign that stands after}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ta-good-night]{Chapter~25, p.~\pageref*{ch:ta-good-night}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}

--- a/code/learning/human-languages/tamil/book/chapters/ch02-introductions.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch02-introductions.tex
@@ -75,11 +75,6 @@ also drops it. Tamil says only ``my name Arun.''
 \section[\ta{நீ} / \ta{நீங்கள்}]{\ta{நீ} / \ta{நீங்கள்} \emph{(n\=\i\ / n\=\i\d{n}gaḷ)} --- ``you,'' familiar and respectful}
 \label{lesson:nii-niingal}
 
-\begin{sounds}
-\ta{நீ}: \ta{ந} (dental \emph{na}) $+$ \ta{ீ} (the long-\=\i\ sign) $\to$
-\emph{n\=\i}. \ta{நீங்கள்} adds \ta{ங்கள்} (\emph{ṅgaḷ}).
-\end{sounds}
-
 \begin{cousinweb}
 \ta{நீ} (\emph{n\=\i}, familiar ``you'') $\leftarrow$ Proto-Dravidian *n\=\i n
 --- native, unrelated to the European ``you'' words (which come from *t\=u).

--- a/code/learning/human-languages/tamil/book/chapters/ch03-responding.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch03-responding.tex
@@ -13,11 +13,6 @@ time, Tamil reaches for a verb ``to be'':
 \section{\ta{எப்படி} \emph{(eppa\d{t}i)} --- ``how,'' another of the e- questions}
 \label{lesson:eppadi}
 
-\begin{sounds}
-\ta{எ} (\emph{e}) $+$ \ta{ப்ப} (\emph{ppa}) $+$ \ta{டி} (\emph{\d{t}i}) $\to$
-\ta{எப்படி} (\emph{eppa\d{t}i}).
-\end{sounds}
-
 \begin{cousinweb}
 \ta{எப்படி} (\emph{eppa\d{t}i}, ``how'') is native Dravidian --- the interrogative
 base \ta{எ} (\emph{e-}) $+$ \emph{pa\d{t}i} (``manner''), ``in what manner.''
@@ -47,11 +42,6 @@ real verb for ``how are you.'' The ending \emph{-\=\i rga\d{l}} already means
 \section{\ta{நான்} \emph{(n\=a\d{n})} --- ``I,'' the Dravidian first person}
 \label{lesson:naan}
 
-\begin{sounds}
-\ta{ந} (dental \emph{na}) $+$ \ta{ா} (long \=a) $+$ \ta{ன்} (\emph{\d{n}}) $\to$
-\ta{நான்} (\emph{n\=a\d{n}}).
-\end{sounds}
-
 \begin{cousinweb}
 \ta{நான்} (\emph{n\=a\d{n}}, ``I'') $\leftarrow$ Proto-Dravidian *y\=a\d{n} /
 *n\=a\d{n} --- native, and (unlike Hindi's \emph{mai\d{m}}, cousin of English
@@ -63,10 +53,6 @@ from the Indo-European world around it.
 
 \section{\ta{நலம்} \emph{(nalam)} --- ``well,'' and how to answer}
 \label{lesson:nalam}
-
-\begin{sounds}
-\ta{ந} (\emph{na}) $+$ \ta{ல} (\emph{la}) $+$ \ta{ம்} (\emph{m}) $\to$ \ta{நலம்}.
-\end{sounds}
 
 \begin{cousinweb}
 \ta{நலம்} (\emph{nalam}, ``wellness, welfare'') is native Dravidian, from

--- a/code/learning/human-languages/tamil/book/chapters/ch25-good-night.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch25-good-night.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:11c2224eeb3cd4b9
-% canonical-lessons: TA-C25-iniya-iravu, TA-C25-goodnight-alternatives
+% canonical-source-hash: fnv1a64:98bf0d2bda9177c5
+% canonical-lessons: TA-C25-iniya-iravu, TA-W10-read-naan, TA-C25-goodnight-alternatives
 
 \chapter{Good Night}
 \label{ch:ta-good-night}
@@ -40,7 +40,71 @@ Say these aloud:
 \end{itemize}
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
-What does \textbf{\ta{இனிய} \ta{இரவு}} literally mean, and what root does \textbf{\ta{இனிய}} come from? (\textquotedblleft{}\textbf{Sweet/pleasant night}\textquotedblright{} — Proto-Dravidian \emph{\textbf{in-}}, \textquotedblleft{}sweet.\textquotedblright{}) Does Tamil's \textquotedblleft{}good night\textquotedblright{} share the same Sanskrit śubha rātri phrase as Hindi, Kannada, Telugu, and Malayalam? (\textbf{No} — no such form turned up in the sources checked for this lesson; Tamil's standard phrase is fully native, breaking the pattern shared by all four other languages.) Next: connect that choice back to Chapter 1 and build two native alternatives.
+What does \textbf{\ta{இனிய} \ta{இரவு}} literally mean, and what root does \textbf{\ta{இனிய}} come from? (\textquotedblleft{}\textbf{Sweet/pleasant night}\textquotedblright{} — Proto-Dravidian \emph{\textbf{in-}}, \textquotedblleft{}sweet.\textquotedblright{}) Does Tamil's \textquotedblleft{}good night\textquotedblright{} share the same Sanskrit śubha rātri phrase as Hindi, Kannada, Telugu, and Malayalam? (\textbf{No} — no such form turned up in the sources checked for this lesson; Tamil's standard phrase is fully native, breaking the pattern shared by all four other languages.) Next: the \ta{ா} sign, and reading \ta{நான்} off the page.
+\end{tcolorbox}
+\section[nāṉ]{\ta{நான்} — the sign that stands after}
+
+\label{lesson:TA-W10-read-naan}
+
+
+
+\begin{quote}
+Two places a vowel sign has sat so far: \textbf{\ta{ி}} goes above and to the right, \textbf{\ta{ை}} and \textbf{\ta{ெ}} go to the left. Here is the third place, and it is the one you would have guessed first.
+\end{quote}
+
+\subsection*{Script you'll notice: the \ta{ா} sign}
+\textbf{\ta{ா}} is the sign for long \emph{ā}, and this book's script data describes it plainly: \textbf{a vertical stroke with a small top hook, written after the consonant.}
+
+\begin{quote}
+\textbf{\ta{ம} + \ta{ா} $\to$ \ta{மா}}, said \emph{mā}.
+\end{quote}
+
+That pairing is the example the data itself gives, on a letter you can already draw.
+
+So the three positions, all seen now:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{sign} & \textbf{sound} & \textbf{where it sits} \\
+\midrule
+\textbf{\ta{ா}} & \emph{ā} & \textbf{after} the consonant \\
+\textbf{\ta{ி}} & \emph{i} & above and to the right \\
+\textbf{\ta{ை}} & \emph{ai} & to the left, spoken after \\
+\textbf{\ta{ெ}} & \emph{e} & to the left, spoken after \\
+\bottomrule
+\end{tabularx}
+
+Notice also that \textbf{\ta{ஆ}}, the independent long \emph{ā} that opens a word, and \textbf{\ta{ா}}, the sign, carry the same lengthening. One is a letter standing on its own; the other hangs off a consonant.
+
+\subsection*{Script you'll notice: build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{நா}} & \emph{nā} — \ta{ந} with the \ta{ா} sign after it & \ta{ந} drawn in \textbf{\ta{நன்றி}} \\
+\textbf{\ta{ன்}} & bare \emph{ṉ} — \textbf{\ta{ன}} under a puḷḷi & \ta{ன} drawn there too, the alveolar \emph{n} \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{நா} · \ta{ன்} $\to$ \ta{நான்}}
+\end{quote}
+
+Two pieces and one new mark. \textbf{\ta{நான்}} is \textquotedblleft{}I,\textquotedblright{} and its possessive is the \textbf{\ta{என்}} (\textquotedblleft{}my\textquotedblright{}) you read in chapter 21 — so \emph{nāṉ} and \emph{eṉ} now both come off the page.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \textbf{\ta{மா}} — then \textbf{\ta{நா}} — then \textbf{\ta{நான்}}
+  \item \emph{Say it:} \textquotedblleft{}nāṉ\textquotedblright{} — \textquotedblleft{}I\textquotedblright{}
+  \item \emph{Contrast:} \textbf{\ta{நா}} · \textbf{\ta{றி}} · \textbf{\ta{பெ}} — a sign after, a sign above-right, a sign before
+  \item \emph{Contrast:} \textbf{\ta{ஆம்}} and \textbf{\ta{நான்}} — the same long \emph{ā}, once as a letter and once as a sign
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read \textbf{\ta{நான்}}. Where does \textbf{\ta{ா}} sit relative to its consonant? (\textbf{After it} — a vertical stroke with a small top hook.) Which of Tamil's three \emph{n}-letters closes the word, and what is the dot doing? (\textbf{\ta{ன}}, the alveolar one; the puḷḷi \textbf{removes its built-in \emph{a}}.) Next: good night, out of roots you already own.
 \end{tcolorbox}
 \section[\ta{நல்ல} \ta{இரவு} / \ta{இரவு} \ta{வணக்கம்}]{\ta{நல்ல} \ta{இரவு} and \ta{இரவு} \ta{வணக்கம்} — old roots recombined}
 

--- a/code/learning/human-languages/tamil/book/chapters/ch27-evening.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch27-evening.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:6197d3c4b4040882
-% canonical-lessons: TA-C27-maalai
+% canonical-source-hash: fnv1a64:9f987f9f4c88336d
+% canonical-lessons: TA-C27-maalai, TA-W11-read-niingal
 
 \chapter{Evening}
 \label{ch:ta-evening}
@@ -42,4 +42,73 @@ Say these aloud:
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Are evening-mālai and garland-mālai the same word with two meanings? (\textbf{No} — Wiktionary treats them as two entirely separate etymologies; a genuine homonym, not one word stretched.) Which direction did the garland sense's Sanskrit connection likely travel? (\textbf{Dravidian into Sanskrit} — a reverse-direction loan, per Wiktionary's own \textquotedblleft{}probably borrowed from Dravidian languages\textquotedblright{} note.) Is it fully certain that \textquotedblleft{}evening\textquotedblright{} derives from māl's \textquotedblleft{}darkness\textquotedblright{} sense specifically? (\textbf{No} — plausible and natural, but Wiktionary only says \textquotedblleft{}compare māl,\textquotedblright{} without spelling out that exact mechanism.)
+\end{tcolorbox}
+\section[nīṅgaḷ]{\ta{நீங்கள்} — two old promises, paid}
+
+\label{lesson:TA-W11-read-niingal}
+
+
+
+\begin{quote}
+This book owes you two letters: the nasal in \textbf{\ta{ங்க}}, printed before you knew what it was, and one of the three \emph{l}-letters it promised. Both come due in one word.
+\end{quote}
+
+\subsection*{Script you'll notice: \ta{ங} and \ta{ள}}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{ங}} & \emph{ṅa} — the nasal made where \textbf{\ta{க}} is made, the \emph{ng} of \textquotedblleft{}sing\textquotedblright{} \\
+\textbf{\ta{ள}} & \emph{ḷa} — the retroflex \emph{l} \\
+\bottomrule
+\end{tabularx}
+
+\textbf{\ta{ங}} is the reason \textbf{\ta{க}} softens: in \textbf{\ta{ங்க}} the nasal comes first — the \textquotedblleft{}after a nasal\textquotedblright{} rule from your first writing lesson, with a face on it.
+
+\textbf{\ta{ள}} is the retroflex one of Tamil's three \emph{l}-letters — \textbf{\ta{ல} \ta{ள} \ta{ழ}}. You met \textbf{\ta{ல}} in \textbf{\ta{இல்லை}}; \textbf{\ta{ழ}} still lies ahead. Retroflex: the tongue curls back, as for \textbf{\ta{ண}}.
+
+\begin{quote}
+Read both; do not draw them yet. Neither has an entry in this book's script data, so neither gets a stroke order. \textbf{\ta{ள}}'s description leans on \textbf{\ta{ண}}'s sourced \textquotedblleft{}tongue curled back\textquotedblright{}; \textbf{\ta{ங}}'s is this lesson's own, since the data says nothing about where \textbf{\ta{க}} is made.
+\end{quote}
+
+\subsection*{Script you'll notice: the \ta{ீ} sign}
+\textbf{\ta{ீ}} is the long partner of the \textbf{\ta{ி}} you hooked onto \textbf{\ta{ற}} in \textbf{\ta{நன்றி}} — the same short/long pairing \textbf{\ta{அ}} and \textbf{\ta{ஆ}} have.
+
+\begin{quote}
+\textbf{\ta{ந} + \ta{ீ} $\to$ \ta{நீ}}, said \emph{nī}, the familiar \textquotedblleft{}you.\textquotedblright{}
+\end{quote}
+
+The data describes \textbf{\ta{ி}} and has no entry for \textbf{\ta{ீ}}, so the pairing is stated from the pattern, not from a source.
+
+\subsection*{Script you'll notice: build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{நீ}} & \emph{nī} — \ta{ந} with the \ta{ீ} sign & \textquotedblleft{}you,\textquotedblright{} familiar \\
+\textbf{\ta{ங்}} & bare \emph{ṅ} — \textbf{\ta{ங}} under a puḷḷi & this lesson \\
+\textbf{\ta{க}} & \emph{ka}, softened to \emph{ga} by the nasal in front of it & from \textbf{\ta{வணக்கம்}} \\
+\textbf{\ta{ள்}} & bare \emph{ḷ} — \textbf{\ta{ள}} under a puḷḷi & this lesson \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{நீ} · \ta{ங்} · \ta{க} · \ta{ள்} $\to$ \ta{நீங்கள்}}
+\end{quote}
+
+The middle two are the \textbf{\ta{ங்க}} you were shown when \textbf{\ta{க}} was new and \textbf{\ta{ங}} unreadable. \textbf{\ta{நீங்கள்}} is the respectful \textquotedblleft{}you\textquotedblright{} — \textbf{\ta{நீ}} plus a plural ending — so the shorter word sits inside the longer one.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \textbf{\ta{நீ}} — then \textbf{\ta{ங்க}} — then \textbf{\ta{நீங்கள்}}
+  \item \emph{Say it:} \textquotedblleft{}nī\textquotedblright{} … \textquotedblleft{}nīṅgaḷ\textquotedblright{} — familiar, then respectful
+  \item \emph{Contrast:} \textbf{\ta{றி}} and \textbf{\ta{நீ}} — the short \emph{i} sign and the long \emph{ī} sign
+  \item \emph{Contrast:} \textbf{\ta{ல}} and \textbf{\ta{ள}} — the first two of the three \emph{l}-letters
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read \textbf{\ta{நீங்கள்}}, then find the shorter \textbf{\ta{நீ}} inside it. Why does the \textbf{\ta{க}} in the middle sound like \emph{g}? (\textbf{\ta{ங்}} stands in front of it — a nasal.) How many \emph{l}-letters does Tamil keep, and which is \textbf{\ta{ள}}? (\textbf{Three} — \ta{ல} \ta{ள} \ta{ழ}; the \textbf{retroflex} one.) What are the two dots doing? (\textbf{Removing the built-in \emph{a}} from \ta{ங} and \ta{ள}.) Next: the afternoon word.
 \end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch29-good-morning.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch29-good-morning.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:825f3ac97af78344
-% canonical-lessons: TA-C29-kaalai-vanakkam
+% canonical-source-hash: fnv1a64:02f13e86ba18eac0
+% canonical-lessons: TA-C29-kaalai-vanakkam, TA-W12-read-eppadi
 
 \chapter{Good Morning}
 \label{ch:ta-good-morning}
@@ -50,4 +50,53 @@ neighbours{]}
   \item Does it follow the śubha-equivalent + time-word pattern used by Hindi, Kannada, Telugu, and Malayalam? (\textbf{No} — \ta{காலை} simply specifies Tamil's own general greeting, \ta{வணக்கம்}.)
   \item Is \textquotedblleft{}suprabhatham\textquotedblright{} confirmed as a casual alternative? (\textbf{No} — neither fetched source supports that claim, so this lesson does not assert it.)
 \end{itemize}
+\end{tcolorbox}
+\section[eppaḍi]{\ta{எப்படி} — the retroflex stop}
+
+\label{lesson:TA-W12-read-eppadi}
+
+
+
+\begin{quote}
+You can read the first word of the question you have been asking since chapter 3. Here is the second, and it needs one new consonant.
+\end{quote}
+
+\subsection*{Script you'll notice: \ta{ட}}
+\textbf{\ta{ட}} is \emph{ṭa}, the retroflex \emph{t} — the tongue curled back to the roof of the mouth. That is the same curl that makes \textbf{\ta{ண}} a retroflex \emph{n}, so hold the pair together: \textbf{\ta{ட}} is that position stopped, \textbf{\ta{ண}} is that position hummed through the nose.
+
+Between vowels it softens toward \emph{ḍ}, which is why \textbf{\ta{டி}} in \textbf{\ta{எப்படி}} is said \emph{ḍi}. That is the position-picks-the-sound economy \textbf{\ta{க}} and \textbf{\ta{ச}} already showed you, now on a third letter.
+
+\begin{quote}
+Read it; do not draw it yet. \textbf{\ta{ட}} has no entry in this book's script data, so it gets no stroke order — and both claims above are stated from sourced neighbours rather than from \textbf{\ta{ட}} itself: the retroflex description leans on \textbf{\ta{ண}}'s, and the softening leans on the position-picks-the-sound note the data carries for \textbf{\ta{க}}.
+\end{quote}
+
+\subsection*{Script you'll notice: build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{எ}} & \emph{e} & the question vowel, from \textbf{\ta{என்}} \\
+\textbf{\ta{ப்}} & bare \emph{p} — \ta{ப} under a puḷḷi & \ta{ப} from \textbf{\ta{பெயர்}} \\
+\textbf{\ta{ப}} & \emph{pa} & the same letter again \\
+\textbf{\ta{டி}} & \emph{ḍi} — \ta{ட} with the \ta{ி} sign & this lesson \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{எ} · \ta{ப்} · \ta{ப} · \ta{டி} $\to$ \ta{எப்படி}}
+\end{quote}
+
+The doubled \textbf{\ta{ப்} + \ta{ப}} is held, like the \textbf{\ta{க்க}} of \emph{vaṇakkam} and the \textbf{\ta{ல்} + \ta{லை}} of \emph{illai}. Tamil marks a long consonant by writing it twice, with the puḷḷi on the first.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \textbf{\ta{டி}} — then \textbf{\ta{எப்படி}}
+  \item \emph{Say it:} \textquotedblleft{}eppaḍi\textquotedblright{} — \textquotedblleft{}how\textquotedblright{}
+  \item \emph{Read it:} \textbf{\ta{நீங்கள்} \ta{எப்படி}} — two words of the question, straight off the page
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read \textbf{\ta{எப்படி}}. Which letter you already knew shares \textbf{\ta{ட}}'s tongue position? (\textbf{\ta{ண}} — the same curl back, stopped rather than nasal.) How does Tamil write the doubled \emph{p}? (\textbf{\ta{ப்} + \ta{ப}} — the letter twice, puḷḷi on the first.) Read \textbf{\ta{நீங்கள்}} again. Next: good evening.
 \end{tcolorbox}

--- a/code/learning/human-languages/tamil/book/chapters/ch31-good-afternoon.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch31-good-afternoon.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:16928bffcb407199
-% canonical-lessons: TA-C31-matiya-vanakkam, TA-C31-afternoon-greeting-root
+% canonical-source-hash: fnv1a64:69fe16e20cd758a3
+% canonical-lessons: TA-C31-matiya-vanakkam, TA-C31-afternoon-greeting-root, TA-W13-read-irukkirirgal
 
 \chapter{Good Afternoon}
 \label{ch:ta-good-afternoon}
@@ -78,4 +78,68 @@ Say these aloud:
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Does \textbf{\ta{மதிய} \ta{வணக்கம்}} begin with \textbf{\ta{பிற்பகல்}}? (\textbf{No.}) What noun is \textbf{\ta{மதிய}} related to? (\textbf{\ta{மதியம்}, \textquotedblleft{}noon.\textquotedblright{}}) What older root lies behind it? (\textbf{Sanskrit madhya, \textquotedblleft{}middle.\textquotedblright{}}) Why should you learn the whole greeting rather than construct it from the time word? (\textbf{Tamil uses a different root in the greeting.})
+\end{tcolorbox}
+\section[irukkiṟīrgaḷ]{\ta{இருக்கிறீர்கள்} — the last sign, and the whole question}
+
+\label{lesson:TA-W13-read-irukkirirgal}
+
+
+
+\begin{quote}
+Two words of the question already come off the page. One vowel sign stands between you and the third.
+\end{quote}
+
+\subsection*{Script you'll notice: the \ta{ு} sign}
+\textbf{\ta{ு}} is the sign for short \emph{u}. It is not left-standing — but it does not stand beside its letter the way \textbf{\ta{ா}} does either: it joins on below and to the right, and the pair is usually drawn as one shape.
+
+Careful with \textquotedblleft{}after\textquotedblright{}: \emph{every} vowel sign is \textbf{spoken} after its consonant, \textbf{\ta{ை}} and \textbf{\ta{ெ}} included. The signs differ in where the mark sits, not when you say it.
+
+\begin{quote}
+\textbf{\ta{ர} + \ta{ு} $\to$ \ta{ரு}}, said \emph{ru}.
+\end{quote}
+
+The script data behind this book carries entries for \textbf{\ta{ா}}, \textbf{\ta{ி}}, \textbf{\ta{ை}} and the puḷḷi, and none for \textbf{\ta{ு}} — so everything here, the joined shape included, is this lesson's own statement of ordinary Tamil, not something it can cite.
+
+\subsection*{Script you'll notice: build the word}
+Every piece is now yours:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{இ}} & \emph{i} & independent — the word opens on a vowel \\
+\textbf{\ta{ரு}} & \emph{ru} — \ta{ர} with the \ta{ு} sign & this lesson \\
+\textbf{\ta{க்}} & bare \emph{k} & \ta{க} under a puḷḷi \\
+\textbf{\ta{கி}} & \emph{ki} — \ta{க} with the \ta{ி} sign &  \\
+\textbf{\ta{றீ}} & \emph{ṟī} — \ta{ற} with the \ta{ீ} sign & \ta{ற} from \textbf{\ta{நன்றி}} \\
+\textbf{\ta{ர்}} & bare \emph{r} & \ta{ர} from \textbf{\ta{சரி}} \\
+\textbf{\ta{க}} & \emph{ka} &  \\
+\textbf{\ta{ள்}} & bare \emph{ḷ} & from \textbf{\ta{நீங்கள்}} \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{இ} · \ta{ரு} · \ta{க்} · \ta{கி} · \ta{றீ} · \ta{ர்} · \ta{க} · \ta{ள்} $\to$ \ta{இருக்கிறீர்கள்}}
+\end{quote}
+
+And the whole question:
+
+\begin{quote}
+\textbf{\ta{நீங்கள்} \ta{எப்படி} \ta{இருக்கிறீர்கள்}?}
+\end{quote}
+
+Nothing in it is new to say. You have asked it since chapter 3; the letters took until now to catch up.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \textbf{\ta{ரு}} — then \textbf{\ta{இருக்கிறீர்கள்}}
+  \item \emph{Read it:} the whole question — \textbf{\ta{நீங்கள்} \ta{எப்படி} \ta{இருக்கிறீர்கள்}?}
+  \item \emph{Say it:} \textquotedblleft{}nīṅgaḷ eppaḍi irukkiṟīrgaḷ?\textquotedblright{} — \textquotedblleft{}how are you?\textquotedblright{}
+  \item \emph{Contrast:} \textbf{\ta{நான்}} and \textbf{\ta{நீங்கள்}} — the \emph{I} of the answer, the \emph{you} of the question
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read \textbf{\ta{நீங்கள்} \ta{எப்படி} \ta{இருக்கிறீர்கள்}?} aloud. Is \textbf{\ta{ு}} written before its consonant or after? (\textbf{After} — \textbf{\ta{ை}} and \textbf{\ta{ெ}} are the ones written before.) When is a vowel sign \emph{spoken}? (\textbf{Always after}, wherever it sits.) Which word did you learn to read first? (\textbf{\ta{நீங்கள்}}.) Next: the verb \ta{இரு} on its own.
 \end{tcolorbox}

--- a/code/learning/human-languages/tamil/chapters.json
+++ b/code/learning/human-languages/tamil/chapters.json
@@ -468,7 +468,8 @@
         "assesses": [
           "TA-ETYMON-INIYA-IRAVU-01",
           "TA-LEX-GOODNIGHT-ALTERNATIVES-01"
-        ]
+        ],
+        "note": "This chapter gained TA-W10-read-naan when the writing strand was extended to cover the glyphs chapters 2-3 had been explaining inline, and the payoff was not widened to match, so representativeness fell from 2/3 to 2/5 and this chapter joins payoffsNotRepresentative. That is the same trade chapter 13 records. Widening it means authoring a payoff that assesses both the good-night vocabulary and the ா sign, which is HL-C25 work."
       }
     },
     {
@@ -507,7 +508,8 @@
           "TA-ETYMON-KAALAI-01",
           "TA-ETYMON-MAALAI-01",
           "TA-ETYMON-MAALAI-02"
-        ]
+        ],
+        "note": "This chapter gained TA-W11-read-niingal when the writing strand was extended, and the payoff was not widened to match, so representativeness fell from 2/2 to 2/5 and this chapter joins payoffsNotRepresentative alongside chapter 25. Widening it means authoring a payoff that assesses both the evening-word homonym and the three glyphs of நீங்கள், which is HL-C25 work."
       }
     },
     {

--- a/code/learning/human-languages/tamil/curriculum.json
+++ b/code/learning/human-languages/tamil/curriculum.json
@@ -42,7 +42,11 @@
         "TA-W06-write-illai",
         "TA-W07-write-sari",
         "TA-W08-read-en",
-        "TA-W09-read-peyar"
+        "TA-W09-read-peyar",
+        "TA-W10-read-naan",
+        "TA-W11-read-niingal",
+        "TA-W12-read-eppadi",
+        "TA-W13-read-irukkirirgal"
       ],
       "before": [],
       "inline": [
@@ -884,7 +888,11 @@
         "TA-W06-write-illai",
         "TA-W07-write-sari",
         "TA-W08-read-en",
-        "TA-W09-read-peyar"
+        "TA-W09-read-peyar",
+        "TA-W10-read-naan",
+        "TA-W11-read-niingal",
+        "TA-W12-read-eppadi",
+        "TA-W13-read-irukkirirgal"
       ]
     },
     {

--- a/code/learning/human-languages/tamil/lessons/TA-C02-nii-niingal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C02-nii-niingal.md
@@ -20,11 +20,6 @@ reviews_of: [TA-C02-en-peyar]
 [PAUSE 2s] To ask a name you need "you" — and Tamil makes respect the same way
 French does.
 
-## The letters in this word
-
-*(Skim if you read Tamil.)* **நீ**: **ந** (dental *na*) + **ீ** (the long-*ī*
-sign) → *nī*. **நீங்கள்** adds **ங்கள்** (*ṅgaḷ*).
-
 ## The word, taken apart
 
 **நீ** (*nī*, familiar "you") ← Proto-Dravidian **\*nīn** — native, unrelated to

--- a/code/learning/human-languages/tamil/lessons/TA-C03-eppadi-irukkirirgal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-eppadi-irukkirirgal.md
@@ -20,12 +20,6 @@ reviews_of: [TA-C02-nii-niingal, TA-C03-eppadi]
 [PAUSE 2s] The everyday "how are you?" — and the first time Tamil actually *needs*
 a verb "to be."
 
-## The letters in this word
-
-The new word is **இருக்கிறீர்கள்** (*irukkiṟīrgaḷ*): the verb stem **இரு** (*iru*)
-+ **க்கிற** (present) + **ீர்கள்** (*-īrgaḷ*, "you," respectful/plural). A long
-verb, but built of clean pieces.
-
 ## The phrase, taken apart
 
 **நீங்கள் எப்படி இருக்கிறீர்கள்?** = **நீங்கள்** (*nīṅgaḷ*, "you," respectful) +
@@ -33,6 +27,9 @@ verb, but built of clean pieces.
 "you how are?" The verb comes **last**, as in every Tamil sentence.
 
 The verb is **இரு** (*iru*), "to be, to exist, to stay" — native Dravidian.
+Inside *irukkiṟīrgaḷ* that stem carries two endings: *iru* + *-kkiṟ-* (present)
++ *-īrgaḷ* ("you," respectful/plural) — the three run together exactly as
+written. A long word, but built of clean pieces, and you can hear all three.
 
 ## Grammar Lens: now the copula returns
 

--- a/code/learning/human-languages/tamil/lessons/TA-C03-eppadi.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-eppadi.md
@@ -20,11 +20,6 @@ reviews_of: [TA-C02-enna]
 [PAUSE 2s] You met **என்ன** (*eṉṉa*, "what") in Chapter 2. Here is its sibling —
 and, like all of Tamil's question-words, it begins with **e-**.
 
-## The letters in this word
-
-*(Skim if you read Tamil.)* **எ** (*e*) + **ப்ப** (*ppa*, a doubled *p*) + **டி**
-(*ḍi*) → **எப்படி** (*eppaḍi*).
-
 ## The word, taken apart
 
 **எப்படி** (*eppaḍi*, "how") is native Dravidian, built on the interrogative base

--- a/code/learning/human-languages/tamil/lessons/TA-C03-naan.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-naan.md
@@ -20,11 +20,6 @@ reviews_of: [TA-C02-en]
 [PAUSE 2s] To answer "how are you?" you first need "I." In Chapter 2 you learned
 *eṉ* ("my"); here is its owner.
 
-## The letters in this word
-
-**ந** (dental *na*) + **ா** (the long-*ā* sign) + **ன்** (the *ṉ*, a special Tamil
-*n*) → **நான்** (*nāṉ*).
-
 ## The word, taken apart
 
 **நான்** (*nāṉ*, "I") ← Proto-Dravidian **\*yāṉ / \*nāṉ** — a native first-person

--- a/code/learning/human-languages/tamil/lessons/TA-C03-nalam.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-nalam.md
@@ -20,10 +20,6 @@ reviews_of: [TA-C03-naan]
 [PAUSE 2s] The word that answers "how are you?" — and a whole family of Tamil
 "good" grows from it.
 
-## The letters in this word
-
-**ந** (*na*) + **ல** (*la*) + **ம்** (*m*) → **நலம்** (*nalam*).
-
 ## The word, taken apart
 
 **நலம்** (*nalam*, "wellness, good, welfare") is native Dravidian, from the root

--- a/code/learning/human-languages/tamil/lessons/TA-C03-paravayillai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C03-paravayillai.md
@@ -20,11 +20,6 @@ reviews_of: [TA-C01-illai, TA-C01-nandri-family-register, TA-C01-nandri]
 [PAUSE 2s] When someone thanks you — or apologises — this is the easy, gracious
 reply, and it hides one of the most Tamil words there is.
 
-## The letters in this word
-
-Two joined words: **பரவாய்** (*paravāy*, "harm, worry") + **இல்லை** (*illai*,
-"is not") → **பரவாயில்லை** (*paravāyillai*).
-
 ## The word, taken apart
 
 **பரவாயில்லை** literally means "**there is no harm**" — *paravāy* ("harm, trouble")

--- a/code/learning/human-languages/tamil/lessons/TA-C25-iniya-iravu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C25-iniya-iravu.md
@@ -78,4 +78,4 @@ Tamil built its own phrase from its own vocabulary.
 phrase as Hindi, Kannada, Telugu, and Malayalam? (**No** — no such form
 turned up in the sources checked for this lesson; Tamil's standard phrase
 is fully native, breaking the pattern shared by all four other languages.)
-Next: connect that choice back to Chapter 1 and build two native alternatives.
+Next: the ா sign, and reading நான் off the page.

--- a/code/learning/human-languages/tamil/lessons/TA-W10-read-naan.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W10-read-naan.md
@@ -1,0 +1,95 @@
+---
+schema_version: 2
+id: TA-W10-read-naan
+spine_node: SPINE-MEET-GREET
+sequence: 785
+delivery: script
+chapter: 25
+type: writing
+headword: "நான்"
+gloss: the long-a sign, the one that stands after its consonant
+romanization: "nāṉ"
+prerequisites: [TA-W09-read-peyar, TA-W02-three-ns]
+sounds: [matra-aa, pulli]
+roots: []
+duration:
+  max_seconds: 225
+requires:
+  knowledge: [TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-E-SIGN-02, TA-SCRIPT-LA-AI-SIGN-02]
+introduces:
+  knowledge: [TA-SCRIPT-AA-SIGN-01, TA-SCRIPT-READ-NAAN-02]
+practises:
+  knowledge: [TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-E-SIGN-02, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-AA-SIGN-01, TA-SCRIPT-READ-NAAN-02]
+skills: [reading]
+modes: [interpretive]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W09-read-peyar, TA-W05-write-aam, TA-C03-naan]
+---
+
+# நான் — the sign that stands after
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-E-SIGN-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-LA-AI-SIGN-02] -->
+
+[PAUSE 2s] Two places a vowel sign has sat so far: **ி** goes above and to
+the right, **ை** and **ெ** go to the left. Here is the third place, and
+it is the one you would have guessed first.
+
+## Script you'll notice: the ா sign
+<!-- hl-knowledge: introduces=[TA-SCRIPT-AA-SIGN-01]; assesses=[TA-SCRIPT-INDEPENDENT-VOWEL-AA-01] -->
+
+**ா** is the sign for long *ā*, and this book's script data describes it
+plainly: **a vertical stroke with a small top hook, written after the
+consonant.**
+
+> **ம + ா → மா**, said *mā*.
+
+That pairing is the example the data itself gives, on a letter you can already
+draw.
+
+So the three positions, all seen now:
+
+| sign | sound | where it sits |
+|---|---|---|
+| **ா** | *ā* | **after** the consonant |
+| **ி** | *i* | above and to the right |
+| **ை** | *ai* | to the left, spoken after |
+| **ெ** | *e* | to the left, spoken after |
+
+Notice also that **ஆ**, the independent long *ā* that opens a word, and
+**ா**, the sign, carry the same lengthening. One is a letter standing on its
+own; the other hangs off a consonant.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-READ-NAAN-02]; assesses=[TA-SCRIPT-AA-SIGN-01, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+| piece | | |
+|---|---|---|
+| **நா** | *nā* — ந with the ா sign after it | ந drawn in **நன்றி** |
+| **ன்** | bare *ṉ* — **ன** under a puḷḷi | ன drawn there too, the alveolar *n* |
+
+> **நா · ன் → நான்**
+
+Two pieces and one new mark. **நான்** is "I," and its
+possessive is the **என்** ("my") you read in chapter 21 — so
+*nāṉ* and *eṉ* now both come off the page.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-AA-SIGN-01, TA-SCRIPT-READ-NAAN-02, TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-E-SIGN-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-LA-AI-SIGN-02] -->
+
+[PAUSE 1s]
+- [YOU READ: **மா** — then **நா** — then **நான்**]
+- [YOU SAY: "nāṉ" — "I"]
+- [YOU CONTRAST: **நா** · **றி** · **பெ** — a sign after, a sign above-right, a sign before]
+- [YOU CONTRAST: **ஆம்** and **நான்** — the same long *ā*, once as a letter and once as a sign]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-AA-SIGN-01, TA-SCRIPT-READ-NAAN-02, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+[PAUSE 3s] Read **நான்**. Where does **ா** sit relative
+to its consonant? (**After it** — a vertical stroke with a small top hook.)
+Which of Tamil's three *n*-letters closes the word, and what is the dot doing?
+(**ன**, the alveolar one; the puḷḷi **removes its built-in *a***.)
+Next: good night, out of roots you already own.

--- a/code/learning/human-languages/tamil/lessons/TA-W11-read-niingal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W11-read-niingal.md
@@ -1,0 +1,104 @@
+---
+schema_version: 2
+id: TA-W11-read-niingal
+spine_node: SPINE-MEET-GREET
+sequence: 815
+delivery: script
+chapter: 27
+type: writing
+headword: "நீங்கள்"
+gloss: the nasal behind the g-sound, the second l-letter, and the long-i sign
+romanization: "nīṅgaḷ"
+prerequisites: [TA-W10-read-naan, TA-W03-write-vanakkam]
+sounds: [matra-ii, pulli]
+roots: []
+duration:
+  max_seconds: 290
+requires:
+  knowledge: [TA-SCRIPT-READ-NAAN-02, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-WRITE-VANAKKAM-01, TA-SCRIPT-LA-AI-SIGN-02, TA-SOUND-ABUGIDA-VA-KA-04]
+introduces:
+  knowledge: [TA-SCRIPT-NGA-LLA-01, TA-SCRIPT-II-SIGN-01, TA-SCRIPT-READ-NIINGAL-03]
+practises:
+  knowledge: [TA-SOUND-ABUGIDA-VA-KA-04, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-WRITE-VANAKKAM-01, TA-SCRIPT-NGA-LLA-01, TA-SCRIPT-II-SIGN-01, TA-SCRIPT-READ-NIINGAL-03]
+skills: [reading]
+modes: [interpretive]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W10-read-naan, TA-W01-abugida-va-ka, TA-W06-write-illai, TA-C02-nii-niingal]
+---
+
+# நீங்கள் — two old promises, paid
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SOUND-ABUGIDA-VA-KA-04, TA-SCRIPT-LA-AI-SIGN-02] -->
+
+[PAUSE 2s] This book owes you two letters: the nasal in **ங்க**, printed before
+you knew what it was, and one of the three *l*-letters it promised. Both come due
+in one word.
+
+## Script you'll notice: ங and ள
+<!-- hl-knowledge: introduces=[TA-SCRIPT-NGA-LLA-01]; assesses=[TA-SOUND-ABUGIDA-VA-KA-04, TA-SCRIPT-LA-AI-SIGN-02] -->
+
+| | |
+|---|---|
+| **ங** | *ṅa* — the nasal made where **க** is made, the *ng* of "sing" |
+| **ள** | *ḷa* — the retroflex *l* |
+
+**ங** is the reason **க** softens: in **ங்க** the nasal comes first — the "after
+a nasal" rule from your first writing lesson, with a face on it.
+
+**ள** is the retroflex one of Tamil's three *l*-letters — **ல ள ழ**. You met
+**ல** in **இல்லை**; **ழ** still lies ahead. Retroflex: the tongue curls back, as
+for **ண**.
+
+> Read both; do not draw them yet. Neither has an entry in this book's script
+> data, so neither gets a stroke order. **ள**'s description leans on **ண**'s
+> sourced "tongue curled back"; **ங**'s is this lesson's own, since the data says
+> nothing about where **க** is made.
+
+## Script you'll notice: the ீ sign
+<!-- hl-knowledge: introduces=[TA-SCRIPT-II-SIGN-01]; assesses=[TA-SCRIPT-I-SIGN-WRITE-NANDRI-01] -->
+
+**ீ** is the long partner of the **ி** you hooked onto **ற** in **நன்றி** — the
+same short/long pairing **அ** and **ஆ** have.
+
+> **ந + ீ → நீ**, said *nī*, the familiar "you."
+
+The data describes **ி** and has no entry for **ீ**, so the pairing is stated
+from the pattern, not from a source.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-READ-NIINGAL-03]; assesses=[TA-SCRIPT-NGA-LLA-01, TA-SCRIPT-II-SIGN-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-WRITE-VANAKKAM-01] -->
+
+| piece | | |
+|---|---|---|
+| **நீ** | *nī* — ந with the ீ sign | "you," familiar |
+| **ங்** | bare *ṅ* — **ங** under a puḷḷi | this lesson |
+| **க** | *ka*, softened to *ga* by the nasal in front of it | from **வணக்கம்** |
+| **ள்** | bare *ḷ* — **ள** under a puḷḷi | this lesson |
+
+> **நீ · ங் · க · ள் → நீங்கள்**
+
+The middle two are the **ங்க** you were shown when **க** was new and **ங**
+unreadable. **நீங்கள்** is the respectful "you" — **நீ** plus a plural ending —
+so the shorter word sits inside the longer one.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-NGA-LLA-01, TA-SCRIPT-II-SIGN-01, TA-SCRIPT-READ-NIINGAL-03, TA-SOUND-ABUGIDA-VA-KA-04] -->
+
+[PAUSE 1s]
+- [YOU READ: **நீ** — then **ங்க** — then **நீங்கள்**]
+- [YOU SAY: "nī" … "nīṅgaḷ" — familiar, then respectful]
+- [YOU CONTRAST: **றி** and **நீ** — the short *i* sign and the long *ī* sign]
+- [YOU CONTRAST: **ல** and **ள** — the first two of the three *l*-letters]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-NGA-LLA-01, TA-SCRIPT-II-SIGN-01, TA-SCRIPT-READ-NIINGAL-03, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-WRITE-VANAKKAM-01] -->
+
+[PAUSE 3s] Read **நீங்கள்**, then find the shorter **நீ** inside it. Why does
+the **க** in the middle sound like *g*? (**ங்** stands in front of it — a
+nasal.) How many *l*-letters does Tamil keep, and which is **ள**? (**Three** —
+ல ள ழ; the **retroflex** one.) What are the two dots doing?
+(**Removing the built-in *a*** from ங and ள.)
+Next: the afternoon word.

--- a/code/learning/human-languages/tamil/lessons/TA-W12-read-eppadi.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W12-read-eppadi.md
@@ -1,0 +1,87 @@
+---
+schema_version: 2
+id: TA-W12-read-eppadi
+spine_node: SPINE-MEET-GREET
+sequence: 845
+delivery: script
+chapter: 29
+type: writing
+headword: "எப்படி"
+gloss: the retroflex t, and the question word it spells
+romanization: "eppaḍi"
+prerequisites: [TA-W11-read-niingal, TA-W02-ma-retroflex-na]
+sounds: [retroflex-ta, pulli]
+roots: []
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-SCRIPT-READ-NIINGAL-03, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SCRIPT-INDEPENDENT-VOWEL-E-01, TA-SCRIPT-PA-YA-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01]
+introduces:
+  knowledge: [TA-SCRIPT-TTA-01, TA-SCRIPT-READ-EPPADI-02]
+practises:
+  knowledge: [TA-SCRIPT-READ-NIINGAL-03, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SCRIPT-INDEPENDENT-VOWEL-E-01, TA-SCRIPT-PA-YA-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-TTA-01, TA-SCRIPT-READ-EPPADI-02]
+skills: [reading]
+modes: [interpretive]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W11-read-niingal, TA-W02-ma-retroflex-na, TA-C03-eppadi]
+---
+
+# எப்படி — the retroflex stop
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-READ-NIINGAL-03] -->
+
+[PAUSE 2s] You can read the first word of the question you have been asking
+since chapter 3. Here is the second, and it needs one new consonant.
+
+## Script you'll notice: ட
+<!-- hl-knowledge: introduces=[TA-SCRIPT-TTA-01]; assesses=[TA-SCRIPT-MA-RETROFLEX-NA-02] -->
+
+**ட** is *ṭa*, the retroflex *t* — the tongue curled back to the roof of the
+mouth. That is the same curl that makes **ண** a retroflex *n*, so hold the pair
+together: **ட** is that position stopped, **ண** is that position hummed through
+the nose.
+
+Between vowels it softens toward *ḍ*, which is why **டி** in **எப்படி** is said
+*ḍi*. That is the position-picks-the-sound economy **க** and **ச** already
+showed you, now on a third letter.
+
+> Read it; do not draw it yet. **ட** has no entry in this book's script data, so
+> it gets no stroke order — and both claims above are stated from sourced
+> neighbours rather than from **ட** itself: the retroflex description leans on
+> **ண**'s, and the softening leans on the position-picks-the-sound note the data
+> carries for **க**.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-READ-EPPADI-02]; assesses=[TA-SCRIPT-TTA-01, TA-SCRIPT-INDEPENDENT-VOWEL-E-01, TA-SCRIPT-PA-YA-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+| piece | | |
+|---|---|---|
+| **எ** | *e* | the question vowel, from **என்** |
+| **ப்** | bare *p* — ப under a puḷḷi | ப from **பெயர்** |
+| **ப** | *pa* | the same letter again |
+| **டி** | *ḍi* — ட with the ி sign | this lesson |
+
+> **எ · ப் · ப · டி → எப்படி**
+
+The doubled **ப் + ப** is held, like the **க்க** of *vaṇakkam* and the
+**ல் + லை** of *illai*. Tamil marks a long consonant by writing it twice, with
+the puḷḷi on the first.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-TTA-01, TA-SCRIPT-READ-EPPADI-02, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+[PAUSE 1s]
+- [YOU READ: **டி** — then **எப்படி**]
+- [YOU SAY: "eppaḍi" — "how"]
+- [YOU READ: **நீங்கள் எப்படி** — two words of the question, straight off the page]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-TTA-01, TA-SCRIPT-READ-EPPADI-02, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SCRIPT-READ-NIINGAL-03] -->
+
+[PAUSE 3s] Read **எப்படி**. Which letter you already knew shares **ட**'s tongue
+position? (**ண** — the same curl back, stopped rather than nasal.) How does
+Tamil write the doubled *p*? (**ப் + ப** — the letter twice, puḷḷi on the
+first.) Read **நீங்கள்** again. Next: good evening.

--- a/code/learning/human-languages/tamil/lessons/TA-W13-read-irukkirirgal.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W13-read-irukkirirgal.md
@@ -1,0 +1,97 @@
+---
+schema_version: 2
+id: TA-W13-read-irukkirirgal
+spine_node: SPINE-MEET-GREET
+sequence: 875
+delivery: script
+chapter: 31
+type: writing
+headword: "இருக்கிறீர்கள்"
+gloss: the u sign, and the whole chapter-3 question off the page
+romanization: "irukkiṟīrgaḷ"
+prerequisites: [TA-W12-read-eppadi, TA-W07-write-sari]
+sounds: [matra-u, pulli]
+roots: []
+duration:
+  max_seconds: 290
+requires:
+  knowledge: [TA-SCRIPT-READ-EPPADI-02, TA-SCRIPT-READ-NIINGAL-03, TA-SCRIPT-II-SIGN-01, TA-SCRIPT-NGA-LLA-01, TA-SCRIPT-AA-SIGN-01, TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-WRITE-VANAKKAM-01]
+introduces:
+  knowledge: [TA-SCRIPT-U-SIGN-01, TA-SCRIPT-READ-QUESTION-02]
+practises:
+  knowledge: [TA-SCRIPT-READ-EPPADI-02, TA-SCRIPT-READ-NIINGAL-03, TA-SCRIPT-II-SIGN-01, TA-SCRIPT-NGA-LLA-01, TA-SCRIPT-READ-NAAN-02, TA-SCRIPT-AA-SIGN-01, TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-WRITE-VANAKKAM-01, TA-SCRIPT-U-SIGN-01, TA-SCRIPT-READ-QUESTION-02]
+skills: [reading]
+modes: [interpretive]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W12-read-eppadi, TA-W11-read-niingal, TA-C03-eppadi-irukkirirgal]
+---
+
+# இருக்கிறீர்கள் — the last sign, and the whole question
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-READ-NIINGAL-03, TA-SCRIPT-READ-EPPADI-02] -->
+
+[PAUSE 2s] Two words of the question already come off the page. One vowel sign
+stands between you and the third.
+
+## Script you'll notice: the ு sign
+<!-- hl-knowledge: introduces=[TA-SCRIPT-U-SIGN-01]; assesses=[TA-SCRIPT-AA-SIGN-01] -->
+
+**ு** is the sign for short *u*. It is not left-standing — but it does not stand
+beside its letter the way **ா** does either: it joins on below and to the right,
+and the pair is usually drawn as one shape.
+
+Careful with "after": *every* vowel sign is **spoken** after its consonant, **ை**
+and **ெ** included. The signs differ in where the mark sits, not when you say
+it.
+
+> **ர + ு → ரு**, said *ru*.
+
+The script data behind this book carries entries for **ா**, **ி**, **ை** and
+the puḷḷi, and none for **ு** — so everything here, the joined shape included,
+is this lesson's own statement of ordinary Tamil, not something it can cite.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-READ-QUESTION-02]; assesses=[TA-SCRIPT-U-SIGN-01, TA-SCRIPT-INDEPENDENT-VOWEL-I-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-SCRIPT-II-SIGN-01, TA-SCRIPT-NGA-LLA-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-WRITE-VANAKKAM-01] -->
+
+Every piece is now yours:
+
+| piece | | |
+|---|---|---|
+| **இ** | *i* | independent — the word opens on a vowel |
+| **ரு** | *ru* — ர with the ு sign | this lesson |
+| **க்** | bare *k* | க under a puḷḷi |
+| **கி** | *ki* — க with the ி sign | |
+| **றீ** | *ṟī* — ற with the ீ sign | ற from **நன்றி** |
+| **ர்** | bare *r* | ர from **சரி** |
+| **க** | *ka* | |
+| **ள்** | bare *ḷ* | from **நீங்கள்** |
+
+> **இ · ரு · க் · கி · றீ · ர் · க · ள் → இருக்கிறீர்கள்**
+
+And the whole question:
+
+> **நீங்கள் எப்படி இருக்கிறீர்கள்?**
+
+Nothing in it is new to say. You have asked it since chapter 3; the letters took
+until now to catch up.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-U-SIGN-01, TA-SCRIPT-READ-QUESTION-02, TA-SCRIPT-READ-EPPADI-02, TA-SCRIPT-READ-NIINGAL-03, TA-SCRIPT-READ-NAAN-02] -->
+
+[PAUSE 1s]
+- [YOU READ: **ரு** — then **இருக்கிறீர்கள்**]
+- [YOU READ: the whole question — **நீங்கள் எப்படி இருக்கிறீர்கள்?**]
+- [YOU SAY: "nīṅgaḷ eppaḍi irukkiṟīrgaḷ?" — "how are you?"]
+- [YOU CONTRAST: **நான்** and **நீங்கள்** — the *I* of the answer, the *you* of the question]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-U-SIGN-01, TA-SCRIPT-READ-QUESTION-02, TA-SCRIPT-AA-SIGN-01, TA-SCRIPT-READ-NIINGAL-03] -->
+
+[PAUSE 3s] Read **நீங்கள் எப்படி இருக்கிறீர்கள்?** aloud. Is **ு** written
+before its consonant or after? (**After** — **ை** and **ெ** are the ones written
+before.) When is a vowel sign *spoken*? (**Always after**, wherever it sits.)
+Which word did you learn to read first?
+(**நீங்கள்**.) Next: the verb இரு on its own.

--- a/code/learning/human-languages/tamil/narration/ch02.json
+++ b/code/learning/human-languages/tamil/narration/ch02.json
@@ -4,7 +4,7 @@
   "chapter": 2,
   "title": "Introducing Yourself",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:8d5757d04fc5050e",
+  "sourceHash": "fnv1a64:b828f372c82c3c3a",
   "lessons": [
     {
       "id": "TA-C02-peyar",
@@ -335,22 +335,13 @@
       "romanization": "",
       "gloss": "you (familiar / respectful)",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:88ed443a4d4d2cbc",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:3b2dc0902dd010a2",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -371,17 +362,6 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Tamil.) நீ: ந (dental na) + ீ (the long-ī sign) becomes nī. நீங்கள் adds ங்கள் (ṅgaḷ)."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The word, taken apart",
           "segments": [
@@ -392,7 +372,7 @@
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "grammar",
           "title": "Grammar Lens: respect by the plural — again",
           "segments": [
@@ -403,7 +383,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -434,7 +414,7 @@
           ]
         },
         {
-          "index": 5,
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [

--- a/code/learning/human-languages/tamil/narration/ch02.txt
+++ b/code/learning/human-languages/tamil/narration/ch02.txt
@@ -81,14 +81,9 @@ Give your name in Tamil. (Eṉ peyar ….) What does Tamil leave out that Englis
 Lesson 4 of 8.
 நீ / நீங்கள் (nī / nīṅgaḷ) — "you," familiar and respectful.
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 To ask a name you need "you" — and Tamil makes respect the same way French does.
-
-The letters in this word.
-(Skim if you read Tamil.) நீ: ந (dental na) + ீ (the long-ī sign) becomes nī. நீங்கள் adds ங்கள் (ṅgaḷ).
 
 The word, taken apart.
 நீ (nī, familiar "you") from Proto-Dravidian nīn — native, unrelated to the European "you" words (from tū). நீங்கள் (nīṅgaḷ) is nī + the plural ending -kaḷ.

--- a/code/learning/human-languages/tamil/narration/ch03.json
+++ b/code/learning/human-languages/tamil/narration/ch03.json
@@ -3,8 +3,8 @@
   "language": "tamil",
   "chapter": 3,
   "title": "How Are You?",
-  "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:1c736a85ee572d92",
+  "drivablePrefix": 6,
+  "sourceHash": "fnv1a64:919bcef05a0e1250",
   "lessons": [
     {
       "id": "TA-C03-eppadi",
@@ -14,22 +14,13 @@
       "romanization": "",
       "gloss": "how",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:1d3bf7b5cc442f13",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:64342f32f2e5e919",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -50,17 +41,6 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "(Skim if you read Tamil.) எ (e) + ப்ப (ppa, a doubled p) + டி (ḍi) becomes எப்படி (eppaḍi)."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The word, taken apart",
           "segments": [
@@ -71,7 +51,7 @@
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -111,7 +91,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -137,22 +117,13 @@
       "romanization": "",
       "gloss": "how are you? (respectful)",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:0a99d5e4478d95d7",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:b0842834ee732703",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -173,21 +144,6 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "The new word is இருக்கிறீர்கள் (irukkiṟīrgaḷ): the verb stem இரு (iru)."
-            },
-            {
-              "kind": "speech",
-              "text": "க்கிற (present) + ீர்கள் (-īrgaḷ, \"you,\" respectful/plural). A long verb, but built of clean pieces."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The phrase, taken apart",
           "segments": [
@@ -197,12 +153,16 @@
             },
             {
               "kind": "speech",
-              "text": "The verb is இரு (iru), \"to be, to exist, to stay\" — native Dravidian."
+              "text": "The verb is இரு (iru), \"to be, to exist, to stay\" — native Dravidian. Inside irukkiṟīrgaḷ that stem carries two endings: iru + -kkiṟ- (present)."
+            },
+            {
+              "kind": "speech",
+              "text": "-īrgaḷ (\"you,\" respectful/plural) — the three run together exactly as written. A long word, but built of clean pieces, and you can hear all three."
             }
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "grammar",
           "title": "Grammar Lens: now the copula returns",
           "segments": [
@@ -213,7 +173,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -253,7 +213,7 @@
           ]
         },
         {
-          "index": 5,
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -279,22 +239,13 @@
       "romanization": "",
       "gloss": "I",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:aaef6470e27b2b3d",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:048724de9db451e5",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -315,17 +266,6 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ந (dental na) + ா (the long-ā sign) + ன் (the ṉ, a special Tamil n) becomes நான் (nāṉ)."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The word, taken apart",
           "segments": [
@@ -336,7 +276,7 @@
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "grammar",
           "title": "Grammar Lens: \"I\" you can drop",
           "segments": [
@@ -347,7 +287,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -387,7 +327,7 @@
           ]
         },
         {
-          "index": 5,
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -413,22 +353,13 @@
       "romanization": "",
       "gloss": "well, wellness, good — and the reply \"நான் நலமாக இருக்கிறேன்\"",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:9e274834464afc76",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:45b455e9ad00a5f6",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -449,17 +380,6 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ந (na) + ல (la) + ம் (m) becomes நலம் (nalam)."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The word, taken apart",
           "segments": [
@@ -470,7 +390,7 @@
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "unknown",
           "title": "The reply",
           "segments": [
@@ -489,7 +409,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -529,7 +449,7 @@
           ]
         },
         {
-          "index": 5,
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -555,22 +475,13 @@
       "romanization": "",
       "gloss": "it's okay / no problem / you're welcome",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a7e6694023ebed70",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:8a3e39237641211e",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -591,17 +502,6 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "Two joined words: பரவாய் (paravāy, \"harm, worry\") + இல்லை (illai, \"is not\") becomes பரவாயில்லை (paravāyillai)."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The word, taken apart",
           "segments": [
@@ -616,7 +516,7 @@
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "grammar",
           "title": "Grammar Lens: இல்லை, the all-purpose \"no\"",
           "segments": [
@@ -627,7 +527,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -667,7 +567,7 @@
           ]
         },
         {
-          "index": 5,
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [

--- a/code/learning/human-languages/tamil/narration/ch03.txt
+++ b/code/learning/human-languages/tamil/narration/ch03.txt
@@ -1,18 +1,13 @@
 Tamil, chapter 3: How Are You?.
-6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+6 lessons. All 6 can be done entirely by ear.
 
 
 Lesson 1 of 6.
 எப்படி (eppaḍi) — "how," another of the e- questions.
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 You met என்ன (eṉṉa, "what") in Chapter 2. Here is its sibling — and, like all of Tamil's question-words, it begins with e-.
-
-The letters in this word.
-(Skim if you read Tamil.) எ (e) + ப்ப (ppa, a doubled p) + டி (ḍi) becomes எப்படி (eppaḍi).
 
 The word, taken apart.
 எப்படி (eppaḍi, "how") is native Dravidian, built on the interrogative base எ- (e-) + paḍi ("manner, way") — literally "in what manner." Notice the pattern: Tamil's questions nearly all start with this e- — eṉṉa (what), eppaḍi (how), eppōdu (when), eṅgē (where), ēṉ (why), and yār (who). Where Hindi and English gather their questions under k- / wh-, Tamil gathers its own under e- — a separate, older family, evolved on its own.
@@ -34,19 +29,14 @@ What base do Tamil's question-words share, and how is it different from Hindi's?
 Lesson 2 of 6.
 நீங்கள் எப்படி இருக்கிறீர்கள்? (nīṅgaḷ eppaḍi irukkiṟīrgaḷ?) — how are you? (respectful).
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 The everyday "how are you?" — and the first time Tamil actually needs a verb "to be."
 
-The letters in this word.
-The new word is இருக்கிறீர்கள் (irukkiṟīrgaḷ): the verb stem இரு (iru).
-க்கிற (present) + ீர்கள் (-īrgaḷ, "you," respectful/plural). A long verb, but built of clean pieces.
-
 The phrase, taken apart.
 நீங்கள் எப்படி இருக்கிறீர்கள்? = நீங்கள் (nīṅgaḷ, "you," respectful) + எப்படி (eppaḍi, "how") + இருக்கிறீர்கள் (irukkiṟīrgaḷ, "are/exist") — "you how are?" The verb comes last, as in every Tamil sentence.
-The verb is இரு (iru), "to be, to exist, to stay" — native Dravidian.
+The verb is இரு (iru), "to be, to exist, to stay" — native Dravidian. Inside irukkiṟīrgaḷ that stem carries two endings: iru + -kkiṟ- (present).
+-īrgaḷ ("you," respectful/plural) — the three run together exactly as written. A long word, but built of clean pieces, and you can hear all three.
 
 Grammar Lens: now the copula returns.
 In Chapter 2 you learned Tamil drops "is" entirely: eṉ peyar Arun ("my name Arun"). That zero copula works for equations (X is Y). But "how are you?" is about a state — how you exist right now — and for that Tamil does use a verb: இரு (iru). So: no verb for "my name is Arun," but a real verb for "how are you." The verb ending -ீர்கள் (-īrgaḷ) already means "you (respectful)," so nīṅgaḷ can even be dropped.
@@ -68,14 +58,9 @@ What verb does "how are you?" use, and why does this sentence need one when "my 
 Lesson 3 of 6.
 நான் (nāṉ) — "I," the Dravidian first person.
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 To answer "how are you?" you first need "I." In Chapter 2 you learned eṉ ("my"); here is its owner.
-
-The letters in this word.
-ந (dental na) + ா (the long-ā sign) + ன் (the ṉ, a special Tamil n) becomes நான் (nāṉ).
 
 The word, taken apart.
 நான் (nāṉ, "I") from Proto-Dravidian yāṉ / nāṉ — a native first-person word, and (unlike Hindi's maiṁ, cousin of English me) not related to the European "I/me" family at all. Its possessive is the என் (eṉ, "my") you already met: nāṉ "I," eṉ "my" — the same root, one standing, one leaning on a noun. Tamil's "I" is one of the clearest markers that Dravidian grew up entirely apart from the Indo-European world around it.
@@ -100,14 +85,9 @@ What is nāṉ's possessive, and is it cousin to English me? (Eṉ, "my"; no —
 Lesson 4 of 6.
 நலம் (nalam) — "well," and how to answer.
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 The word that answers "how are you?" — and a whole family of Tamil "good" grows from it.
-
-The letters in this word.
-ந (na) + ல (la) + ம் (m) becomes நலம் (nalam).
 
 The word, taken apart.
 நலம் (nalam, "wellness, good, welfare") is native Dravidian, from the root நல் (nal-, "good") — the same root behind நல்ல (nalla, "good," an everyday adjective) and நன்றி (naṉṟi, "thanks" — literally "goodness," which you met in Chapter 1). So "thank you" and "I'm well" in Tamil share a root: both are nal-, "good." A purely Dravidian word, with no Sanskrit or European cousin — Tamil answering in its own voice.
@@ -134,14 +114,9 @@ Give the full reply to "how are you?", and name the Chapter-1 word that shares n
 Lesson 5 of 6.
 பரவாயில்லை (paravāyillai) — "no problem".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 When someone thanks you — or apologises — this is the easy, gracious reply, and it hides one of the most Tamil words there is.
-
-The letters in this word.
-Two joined words: பரவாய் (paravāy, "harm, worry") + இல்லை (illai, "is not") becomes பரவாயில்லை (paravāyillai).
 
 The word, taken apart.
 பரவாயில்லை literally means "there is no harm" — paravāy ("harm, trouble").

--- a/code/learning/human-languages/tamil/narration/ch25.json
+++ b/code/learning/human-languages/tamil/narration/ch25.json
@@ -3,8 +3,8 @@
   "language": "tamil",
   "chapter": 25,
   "title": "Good Night",
-  "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:a476bb11b5f796c3",
+  "drivablePrefix": 1,
+  "sourceHash": "fnv1a64:2f31b122ac3d89dd",
   "lessons": [
     {
       "id": "TA-C25-iniya-iravu",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:3874dc4fc0a7afb5",
+      "sourceHash": "fnv1a64:93edd99cbcc26b5f",
       "notice": null,
       "blocks": [
         {
@@ -105,7 +105,192 @@
             },
             {
               "kind": "speech",
-              "text": "What does இனிய இரவு literally mean, and what root does இனிய come from? (\"Sweet/pleasant night\" — Proto-Dravidian in-, \"sweet.\") Does Tamil's \"good night\" share the same Sanskrit śubha rātri phrase as Hindi, Kannada, Telugu, and Malayalam? (No — no such form turned up in the sources checked for this lesson; Tamil's standard phrase is fully native, breaking the pattern shared by all four other languages.) Next: connect that choice back to Chapter 1 and build two native alternatives."
+              "text": "What does இனிய இரவு literally mean, and what root does இனிய come from? (\"Sweet/pleasant night\" — Proto-Dravidian in-, \"sweet.\") Does Tamil's \"good night\" share the same Sanskrit śubha rātri phrase as Hindi, Kannada, Telugu, and Malayalam? (No — no such form turned up in the sources checked for this lesson; Tamil's standard phrase is fully native, breaking the pattern shared by all four other languages.) Next: the ா sign, and reading நான் (nāṉ) off the page."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W10-read-naan",
+      "sequence": 785,
+      "title": "நான் (nāṉ) — the sign that stands after",
+      "headword": "நான்",
+      "romanization": "nāṉ",
+      "gloss": "the long-a sign, the one that stands after its consonant",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:4cd4df8950c7367a",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: the ா sign",
+          "Script you'll notice: build the word"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: the ா sign and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Two places a vowel sign has sat so far: ி goes above and to the right, ை and ெ go to the left. Here is the third place, and it is the one you would have guessed first."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: the ா sign",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ா is the sign for long ā, and this book's script data describes it plainly: a vertical stroke with a small top hook, written after the consonant."
+            },
+            {
+              "kind": "speech",
+              "text": "ம + ா becomes மா, said mā."
+            },
+            {
+              "kind": "speech",
+              "text": "That pairing is the example the data itself gives, on a letter you can already draw."
+            },
+            {
+              "kind": "speech",
+              "text": "So the three positions, all seen now:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "sign",
+                "sound",
+                "where it sits"
+              ],
+              "columns": 3,
+              "rowCount": 4,
+              "utterances": [
+                "sign: ா. sound: ā. where it sits: after the consonant.",
+                "sign: ி. sound: i. where it sits: above and to the right.",
+                "sign: ை. sound: ai. where it sits: to the left, spoken after.",
+                "sign: ெ. sound: e. where it sits: to the left, spoken after."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Notice also that ஆ, the independent long ā that opens a word, and ா, the sign, carry the same lengthening. One is a letter standing on its own; the other hangs off a consonant."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 2,
+              "utterances": [
+                "piece: நா, nā — ந with the ா sign after it, ந drawn in நன்றி.",
+                "piece: ன், bare ṉ — ன under a puḷḷi, ன drawn there too, the alveolar n."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "நா, ன் becomes நான் (nāṉ)."
+            },
+            {
+              "kind": "speech",
+              "text": "Two pieces and one new mark. நான் is \"I,\" and its possessive is the என் (\"my\") you read in chapter 21 — so nāṉ and eṉ now both come off the page."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "மா — then நா — then நான் (nāṉ)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **மா** — then **நா** — then **நான்**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"nāṉ\" — \"I\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"nāṉ\" — \"I\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "நா, றி, பெ — a sign after, a sign above-right, a sign before",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **நா** · **றி** · **பெ** — a sign after, a sign above-right, a sign before]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "ஆம் and நான் (nāṉ) — the same long ā, once as a letter and once as a sign",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **ஆம்** and **நான்** — the same long *ā*, once as a letter and once as a sign]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read நான் (nāṉ). Where does ா sit relative to its consonant? (After it — a vertical stroke with a small top hook.) Which of Tamil's three n-letters closes the word, and what is the dot doing? (ன, the alveolar one; the puḷḷi removes its built-in a.) Next: good night, out of roots you already own."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch25.txt
+++ b/code/learning/human-languages/tamil/narration/ch25.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 25: Good Night.
-2 lessons. All 2 can be done entirely by ear.
+3 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 2.
+Lesson 1 of 3.
 இனிய இரவு (iṉiya iravu) — "good night," and Tamil breaking the pattern one more time.
 
 Warm-up.
@@ -24,10 +24,54 @@ Guided Practice.
 
 Wrap-up Recall.
 [pause 3 seconds]
-What does இனிய இரவு literally mean, and what root does இனிய come from? ("Sweet/pleasant night" — Proto-Dravidian in-, "sweet.") Does Tamil's "good night" share the same Sanskrit śubha rātri phrase as Hindi, Kannada, Telugu, and Malayalam? (No — no such form turned up in the sources checked for this lesson; Tamil's standard phrase is fully native, breaking the pattern shared by all four other languages.) Next: connect that choice back to Chapter 1 and build two native alternatives.
+What does இனிய இரவு literally mean, and what root does இனிய come from? ("Sweet/pleasant night" — Proto-Dravidian in-, "sweet.") Does Tamil's "good night" share the same Sanskrit śubha rātri phrase as Hindi, Kannada, Telugu, and Malayalam? (No — no such form turned up in the sources checked for this lesson; Tamil's standard phrase is fully native, breaking the pattern shared by all four other languages.) Next: the ா sign, and reading நான் (nāṉ) off the page.
 
 
-Lesson 2 of 2.
+Lesson 2 of 3.
+நான் (nāṉ) — the sign that stands after.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: the ா sign and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Two places a vowel sign has sat so far: ி goes above and to the right, ை and ெ go to the left. Here is the third place, and it is the one you would have guessed first.
+
+Script you'll notice: the ா sign.
+ா is the sign for long ā, and this book's script data describes it plainly: a vertical stroke with a small top hook, written after the consonant.
+ம + ா becomes மா, said mā.
+That pairing is the example the data itself gives, on a letter you can already draw.
+So the three positions, all seen now:
+[a table of 4 rows, read aloud]
+sign: ா. sound: ā. where it sits: after the consonant.
+sign: ி. sound: i. where it sits: above and to the right.
+sign: ை. sound: ai. where it sits: to the left, spoken after.
+sign: ெ. sound: e. where it sits: to the left, spoken after.
+Notice also that ஆ, the independent long ā that opens a word, and ா, the sign, carry the same lengthening. One is a letter standing on its own; the other hangs off a consonant.
+
+Script you'll notice: build the word.
+[a table of 2 rows, read aloud]
+piece: நா, nā — ந with the ா sign after it, ந drawn in நன்றி.
+piece: ன், bare ṉ — ன under a puḷḷi, ன drawn there too, the alveolar n.
+நா, ன் becomes நான் (nāṉ).
+Two pieces and one new mark. நான் is "I," and its possessive is the என் ("my") you read in chapter 21 — so nāṉ and eṉ now both come off the page.
+
+Guided Practice.
+[pause 1 second]
+[your turn — read: மா — then நா — then நான் (nāṉ)]
+[pause 8 seconds for the answer]
+[your turn — say: "nāṉ" — "I"]
+[pause 8 seconds for the answer]
+[your turn — contrast: நா, றி, பெ — a sign after, a sign above-right, a sign before]
+[pause 8 seconds for the answer]
+[your turn — contrast: ஆம் and நான் (nāṉ) — the same long ā, once as a letter and once as a sign]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read நான் (nāṉ). Where does ா sit relative to its consonant? (After it — a vertical stroke with a small top hook.) Which of Tamil's three n-letters closes the word, and what is the dot doing? (ன, the alveolar one; the puḷḷi removes its built-in a.) Next: good night, out of roots you already own.
+
+
+Lesson 3 of 3.
 நல்ல இரவு and இரவு வணக்கம் — old roots recombined.
 
 Warm-up.

--- a/code/learning/human-languages/tamil/narration/ch27.json
+++ b/code/learning/human-languages/tamil/narration/ch27.json
@@ -4,7 +4,7 @@
   "chapter": 27,
   "title": "Evening",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:8a3ee365c271485b",
+  "sourceHash": "fnv1a64:7cddce6c619c2508",
   "lessons": [
     {
       "id": "TA-C27-maalai",
@@ -115,6 +115,202 @@
             {
               "kind": "speech",
               "text": "Are evening-mālai and garland-mālai the same word with two meanings? (No — Wiktionary treats them as two entirely separate etymologies; a genuine homonym, not one word stretched.) Which direction did the garland sense's Sanskrit connection likely travel? (Dravidian into Sanskrit — a reverse-direction loan, per Wiktionary's own \"probably borrowed from Dravidian languages\" note.) Is it fully certain that \"evening\" derives from māl's \"darkness\" sense specifically? (No — plausible and natural, but Wiktionary only says \"compare māl,\" without spelling out that exact mechanism.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W11-read-niingal",
+      "sequence": 815,
+      "title": "நீங்கள் (nīṅgaḷ) — two old promises, paid",
+      "headword": "நீங்கள்",
+      "romanization": "nīṅgaḷ",
+      "gloss": "the nasal behind the g-sound, the second l-letter, and the long-i sign",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:32cfc1fb13f08bef",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: ங and ள",
+          "Script you'll notice: the ீ sign",
+          "Script you'll notice: build the word"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ங and ள, Script you'll notice: the ீ sign and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "This book owes you two letters: the nasal in ங்க, printed before you knew what it was, and one of the three l-letters it promised. Both come due in one word."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: ங and ள",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "ங, ṅa — the nasal made where க is made, the ng of \"sing\".",
+                "ள, ḷa — the retroflex l."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "ங is the reason க softens: in ங்க the nasal comes first — the \"after a nasal\" rule from your first writing lesson, with a face on it."
+            },
+            {
+              "kind": "speech",
+              "text": "ள is the retroflex one of Tamil's three l-letters — ல ள ழ. You met ல in இல்லை; ழ still lies ahead. Retroflex: the tongue curls back, as for ண."
+            },
+            {
+              "kind": "speech",
+              "text": "Read both; do not draw them yet. Neither has an entry in this book's script data, so neither gets a stroke order. ள's description leans on ண's sourced \"tongue curled back\"; ங's is this lesson's own, since the data says nothing about where க is made."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: the ீ sign",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ீ is the long partner of the ி you hooked onto ற in நன்றி — the same short/long pairing அ and ஆ have."
+            },
+            {
+              "kind": "speech",
+              "text": "ந + ீ becomes நீ, said nī, the familiar \"you.\""
+            },
+            {
+              "kind": "speech",
+              "text": "The data describes ி and has no entry for ீ, so the pairing is stated from the pattern, not from a source."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 4,
+              "utterances": [
+                "piece: நீ, nī — ந with the ீ sign, \"you,\" familiar.",
+                "piece: ங், bare ṅ — ங under a puḷḷi, this lesson.",
+                "piece: க, ka, softened to ga by the nasal in front of it, from வணக்கம்.",
+                "piece: ள், bare ḷ — ள under a puḷḷi, this lesson."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "நீ, ங், க, ள் becomes நீங்கள் (nīṅgaḷ)."
+            },
+            {
+              "kind": "speech",
+              "text": "The middle two are the ங்க you were shown when க was new and ங unreadable. நீங்கள் (nīṅgaḷ) is the respectful \"you\" — நீ plus a plural ending — so the shorter word sits inside the longer one."
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "நீ — then ங்க — then நீங்கள் (nīṅgaḷ)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **நீ** — then **ங்க** — then **நீங்கள்**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"nī\" … \"nīṅgaḷ\" — familiar, then respectful",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"nī\" … \"nīṅgaḷ\" — familiar, then respectful]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "றி and நீ — the short i sign and the long ī sign",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **றி** and **நீ** — the short *i* sign and the long *ī* sign]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "ல and ள — the first two of the three l-letters",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **ல** and **ள** — the first two of the three *l*-letters]"
+            }
+          ]
+        },
+        {
+          "index": 5,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read நீங்கள் (nīṅgaḷ), then find the shorter நீ inside it. Why does the க in the middle sound like g? (ங் stands in front of it — a nasal.) How many l-letters does Tamil keep, and which is ள? (Three — ல ள ழ; the retroflex one.) What are the two dots doing? (Removing the built-in a from ங and ள.) Next: the afternoon word."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch27.txt
+++ b/code/learning/human-languages/tamil/narration/ch27.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 27: Evening.
-1 lesson. All 1 can be done entirely by ear.
+2 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 1.
+Lesson 1 of 2.
 மாலை (mālai) — "evening," and a garland that only looks like the same word.
 
 Warm-up.
@@ -27,3 +27,50 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Are evening-mālai and garland-mālai the same word with two meanings? (No — Wiktionary treats them as two entirely separate etymologies; a genuine homonym, not one word stretched.) Which direction did the garland sense's Sanskrit connection likely travel? (Dravidian into Sanskrit — a reverse-direction loan, per Wiktionary's own "probably borrowed from Dravidian languages" note.) Is it fully certain that "evening" derives from māl's "darkness" sense specifically? (No — plausible and natural, but Wiktionary only says "compare māl," without spelling out that exact mechanism.)
+
+
+Lesson 2 of 2.
+நீங்கள் (nīṅgaḷ) — two old promises, paid.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ங and ள, Script you'll notice: the ீ sign and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+This book owes you two letters: the nasal in ங்க, printed before you knew what it was, and one of the three l-letters it promised. Both come due in one word.
+
+Script you'll notice: ங and ள.
+[a table of 2 rows, read aloud]
+ங, ṅa — the nasal made where க is made, the ng of "sing".
+ள, ḷa — the retroflex l.
+ங is the reason க softens: in ங்க the nasal comes first — the "after a nasal" rule from your first writing lesson, with a face on it.
+ள is the retroflex one of Tamil's three l-letters — ல ள ழ. You met ல in இல்லை; ழ still lies ahead. Retroflex: the tongue curls back, as for ண.
+Read both; do not draw them yet. Neither has an entry in this book's script data, so neither gets a stroke order. ள's description leans on ண's sourced "tongue curled back"; ங's is this lesson's own, since the data says nothing about where க is made.
+
+Script you'll notice: the ீ sign.
+ீ is the long partner of the ி you hooked onto ற in நன்றி — the same short/long pairing அ and ஆ have.
+ந + ீ becomes நீ, said nī, the familiar "you."
+The data describes ி and has no entry for ீ, so the pairing is stated from the pattern, not from a source.
+
+Script you'll notice: build the word.
+[a table of 4 rows, read aloud]
+piece: நீ, nī — ந with the ீ sign, "you," familiar.
+piece: ங், bare ṅ — ங under a puḷḷi, this lesson.
+piece: க, ka, softened to ga by the nasal in front of it, from வணக்கம்.
+piece: ள், bare ḷ — ள under a puḷḷi, this lesson.
+நீ, ங், க, ள் becomes நீங்கள் (nīṅgaḷ).
+The middle two are the ங்க you were shown when க was new and ங unreadable. நீங்கள் (nīṅgaḷ) is the respectful "you" — நீ plus a plural ending — so the shorter word sits inside the longer one.
+
+Guided Practice.
+[pause 1 second]
+[your turn — read: நீ — then ங்க — then நீங்கள் (nīṅgaḷ)]
+[pause 8 seconds for the answer]
+[your turn — say: "nī" … "nīṅgaḷ" — familiar, then respectful]
+[pause 8 seconds for the answer]
+[your turn — contrast: றி and நீ — the short i sign and the long ī sign]
+[pause 8 seconds for the answer]
+[your turn — contrast: ல and ள — the first two of the three l-letters]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read நீங்கள் (nīṅgaḷ), then find the shorter நீ inside it. Why does the க in the middle sound like g? (ங் stands in front of it — a nasal.) How many l-letters does Tamil keep, and which is ள? (Three — ல ள ழ; the retroflex one.) What are the two dots doing? (Removing the built-in a from ங and ள.) Next: the afternoon word.

--- a/code/learning/human-languages/tamil/narration/ch29.json
+++ b/code/learning/human-languages/tamil/narration/ch29.json
@@ -4,7 +4,7 @@
   "chapter": 29,
   "title": "Good Morning",
   "drivablePrefix": 1,
-  "sourceHash": "fnv1a64:c5303420ac3aa1b6",
+  "sourceHash": "fnv1a64:f50670956f8c9ff2",
   "lessons": [
     {
       "id": "TA-C29-kaalai-vanakkam",
@@ -123,6 +123,160 @@
             {
               "kind": "speech",
               "text": "Is \"suprabhatham\" confirmed as a casual alternative? (No — neither fetched source supports that claim, so this lesson does not assert it.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W12-read-eppadi",
+      "sequence": 845,
+      "title": "எப்படி (eppaḍi) — the retroflex stop",
+      "headword": "எப்படி",
+      "romanization": "eppaḍi",
+      "gloss": "the retroflex t, and the question word it spells",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:4f8ae089758b39e5",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: ட",
+          "Script you'll notice: build the word"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ட and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You can read the first word of the question you have been asking since chapter 3. Here is the second, and it needs one new consonant."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: ட",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ட is ṭa, the retroflex t — the tongue curled back to the roof of the mouth. That is the same curl that makes ண a retroflex n, so hold the pair together: ட is that position stopped, ண is that position hummed through the nose."
+            },
+            {
+              "kind": "speech",
+              "text": "Between vowels it softens toward ḍ, which is why டி in எப்படி (eppaḍi) is said ḍi. That is the position-picks-the-sound economy க and ச already showed you, now on a third letter."
+            },
+            {
+              "kind": "speech",
+              "text": "Read it; do not draw it yet. ட has no entry in this book's script data, so it gets no stroke order — and both claims above are stated from sourced neighbours rather than from ட itself: the retroflex description leans on ண's, and the softening leans on the position-picks-the-sound note the data carries for க."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 4,
+              "utterances": [
+                "piece: எ, e, the question vowel, from என்.",
+                "piece: ப், bare p — ப under a puḷḷi, ப from பெயர்.",
+                "piece: ப, pa, the same letter again.",
+                "piece: டி, ḍi — ட with the ி sign, this lesson."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "எ, ப், ப, டி becomes எப்படி (eppaḍi)."
+            },
+            {
+              "kind": "speech",
+              "text": "The doubled ப் + ப is held, like the க்க of vaṇakkam and the ல் + லை of illai. Tamil marks a long consonant by writing it twice, with the puḷḷi on the first."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "டி — then எப்படி (eppaḍi)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **டி** — then **எப்படி**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"eppaḍi\" — \"how\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"eppaḍi\" — \"how\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "நீங்கள் எப்படி (eppaḍi) — two words of the question, straight off the page",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **நீங்கள் எப்படி** — two words of the question, straight off the page]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read எப்படி (eppaḍi). Which letter you already knew shares ட's tongue position? (ண — the same curl back, stopped rather than nasal.) How does Tamil write the doubled p? (ப் + ப — the letter twice, puḷḷi on the first.) Read நீங்கள் again. Next: good evening."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch29.txt
+++ b/code/learning/human-languages/tamil/narration/ch29.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 29: Good Morning.
-1 lesson. All 1 can be done entirely by ear.
+2 lessons. You can do the first 1 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 1.
+Lesson 1 of 2.
 காலை வணக்கம் — "morning greetings".
 
 Warm-up.
@@ -29,3 +29,40 @@ Wrap-up Recall.
 What two known words build காலை வணக்கம்? (காலை, "morning" + வணக்கம், "reverence/hello.")
 Does it follow the śubha-equivalent + time-word pattern used by Hindi, Kannada, Telugu, and Malayalam? (No — காலை simply specifies Tamil's own general greeting, வணக்கம்.)
 Is "suprabhatham" confirmed as a casual alternative? (No — neither fetched source supports that claim, so this lesson does not assert it.)
+
+
+Lesson 2 of 2.
+எப்படி (eppaḍi) — the retroflex stop.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ட and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You can read the first word of the question you have been asking since chapter 3. Here is the second, and it needs one new consonant.
+
+Script you'll notice: ட.
+ட is ṭa, the retroflex t — the tongue curled back to the roof of the mouth. That is the same curl that makes ண a retroflex n, so hold the pair together: ட is that position stopped, ண is that position hummed through the nose.
+Between vowels it softens toward ḍ, which is why டி in எப்படி (eppaḍi) is said ḍi. That is the position-picks-the-sound economy க and ச already showed you, now on a third letter.
+Read it; do not draw it yet. ட has no entry in this book's script data, so it gets no stroke order — and both claims above are stated from sourced neighbours rather than from ட itself: the retroflex description leans on ண's, and the softening leans on the position-picks-the-sound note the data carries for க.
+
+Script you'll notice: build the word.
+[a table of 4 rows, read aloud]
+piece: எ, e, the question vowel, from என்.
+piece: ப், bare p — ப under a puḷḷi, ப from பெயர்.
+piece: ப, pa, the same letter again.
+piece: டி, ḍi — ட with the ி sign, this lesson.
+எ, ப், ப, டி becomes எப்படி (eppaḍi).
+The doubled ப் + ப is held, like the க்க of vaṇakkam and the ல் + லை of illai. Tamil marks a long consonant by writing it twice, with the puḷḷi on the first.
+
+Guided Practice.
+[pause 1 second]
+[your turn — read: டி — then எப்படி (eppaḍi)]
+[pause 8 seconds for the answer]
+[your turn — say: "eppaḍi" — "how"]
+[pause 8 seconds for the answer]
+[your turn — read: நீங்கள் எப்படி (eppaḍi) — two words of the question, straight off the page]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read எப்படி (eppaḍi). Which letter you already knew shares ட's tongue position? (ண — the same curl back, stopped rather than nasal.) How does Tamil write the doubled p? (ப் + ப — the letter twice, puḷḷi on the first.) Read நீங்கள் again. Next: good evening.

--- a/code/learning/human-languages/tamil/narration/ch31.json
+++ b/code/learning/human-languages/tamil/narration/ch31.json
@@ -4,7 +4,7 @@
   "chapter": 31,
   "title": "Good Afternoon",
   "drivablePrefix": 2,
-  "sourceHash": "fnv1a64:9da02aa156c2f34f",
+  "sourceHash": "fnv1a64:930027490aca12db",
   "lessons": [
     {
       "id": "TA-C31-matiya-vanakkam",
@@ -222,6 +222,189 @@
             {
               "kind": "speech",
               "text": "Does மதிய வணக்கம் begin with பிற்பகல்? (No.) What noun is மதிய related to? (மதியம், \"noon.\") What older root lies behind it? (Sanskrit madhya, \"middle.\") Why should you learn the whole greeting rather than construct it from the time word? (Tamil uses a different root in the greeting.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W13-read-irukkirirgal",
+      "sequence": 875,
+      "title": "இருக்கிறீர்கள் (irukkiṟīrgaḷ) — the last sign, and the whole question",
+      "headword": "இருக்கிறீர்கள்",
+      "romanization": "irukkiṟīrgaḷ",
+      "gloss": "the u sign, and the whole chapter-3 question off the page",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:23241669861ea8d8",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: the ு sign",
+          "Script you'll notice: build the word"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: the ு sign and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Two words of the question already come off the page. One vowel sign stands between you and the third."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: the ு sign",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ு is the sign for short u. It is not left-standing — but it does not stand beside its letter the way ா does either: it joins on below and to the right, and the pair is usually drawn as one shape."
+            },
+            {
+              "kind": "speech",
+              "text": "Careful with \"after\": every vowel sign is spoken after its consonant, ை and ெ included. The signs differ in where the mark sits, not when you say it."
+            },
+            {
+              "kind": "speech",
+              "text": "ர + ு becomes ரு, said ru."
+            },
+            {
+              "kind": "speech",
+              "text": "The script data behind this book carries entries for ா, ி, ை and the puḷḷi, and none for ு — so everything here, the joined shape included, is this lesson's own statement of ordinary Tamil, not something it can cite."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "Every piece is now yours:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 8,
+              "utterances": [
+                "piece: இ, i, independent — the word opens on a vowel.",
+                "piece: ரு, ru — ர with the ு sign, this lesson.",
+                "piece: க், bare k, க under a puḷḷi.",
+                "piece: கி, ki — க with the ி sign, blank.",
+                "piece: றீ, ṟī — ற with the ீ sign, ற from நன்றி.",
+                "piece: ர், bare r, ர from சரி.",
+                "piece: க, ka, blank.",
+                "piece: ள், bare ḷ, from நீங்கள்."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "இ, ரு, க், கி, றீ, ர், க, ள் becomes இருக்கிறீர்கள் (irukkiṟīrgaḷ)."
+            },
+            {
+              "kind": "speech",
+              "text": "And the whole question:"
+            },
+            {
+              "kind": "speech",
+              "text": "நீங்கள் எப்படி இருக்கிறீர்கள் (irukkiṟīrgaḷ)?"
+            },
+            {
+              "kind": "speech",
+              "text": "Nothing in it is new to say. You have asked it since chapter 3; the letters took until now to catch up."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "ரு — then இருக்கிறீர்கள் (irukkiṟīrgaḷ)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **ரு** — then **இருக்கிறீர்கள்**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "the whole question — நீங்கள் எப்படி இருக்கிறீர்கள் (irukkiṟīrgaḷ)?",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: the whole question — **நீங்கள் எப்படி இருக்கிறீர்கள்?**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"nīṅgaḷ eppaḍi irukkiṟīrgaḷ?\" — \"how are you?\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"nīṅgaḷ eppaḍi irukkiṟīrgaḷ?\" — \"how are you?\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "நான் and நீங்கள் — the I of the answer, the you of the question",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **நான்** and **நீங்கள்** — the *I* of the answer, the *you* of the question]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read நீங்கள் எப்படி இருக்கிறீர்கள் (irukkiṟīrgaḷ)? aloud. Is ு written before its consonant or after? (After — ை and ெ are the ones written before.) When is a vowel sign spoken? (Always after, wherever it sits.) Which word did you learn to read first? (நீங்கள்.) Next: the verb இரு on its own."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch31.txt
+++ b/code/learning/human-languages/tamil/narration/ch31.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 31: Good Afternoon.
-2 lessons. All 2 can be done entirely by ear.
+3 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
 
 
-Lesson 1 of 2.
+Lesson 1 of 3.
 மதிய வணக்கம் (matiya vaṇakkam) — a sourced afternoon greeting.
 
 Warm-up.
@@ -25,7 +25,7 @@ Wrap-up Recall.
 What is one sourced Tamil greeting for "good afternoon"? (மதிய வணக்கம், matiya vaṇakkam.) Do all three fetched sources agree on a distinct "afternoon" greeting slot? (No — two confirm மதிய வணக்கம் directly; a third doesn't list a separate afternoon greeting at all, treating morning and evening as bookending the day.) What clock window is a useful guide rather than a universal rule? (Roughly noon to 4 PM.)
 
 
-Lesson 2 of 2.
+Lesson 2 of 3.
 மதிய — the greeting takes a different root.
 
 Warm-up.
@@ -52,3 +52,50 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Does மதிய வணக்கம் begin with பிற்பகல்? (No.) What noun is மதிய related to? (மதியம், "noon.") What older root lies behind it? (Sanskrit madhya, "middle.") Why should you learn the whole greeting rather than construct it from the time word? (Tamil uses a different root in the greeting.)
+
+
+Lesson 3 of 3.
+இருக்கிறீர்கள் (irukkiṟīrgaḷ) — the last sign, and the whole question.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: the ு sign and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Two words of the question already come off the page. One vowel sign stands between you and the third.
+
+Script you'll notice: the ு sign.
+ு is the sign for short u. It is not left-standing — but it does not stand beside its letter the way ா does either: it joins on below and to the right, and the pair is usually drawn as one shape.
+Careful with "after": every vowel sign is spoken after its consonant, ை and ெ included. The signs differ in where the mark sits, not when you say it.
+ர + ு becomes ரு, said ru.
+The script data behind this book carries entries for ா, ி, ை and the puḷḷi, and none for ு — so everything here, the joined shape included, is this lesson's own statement of ordinary Tamil, not something it can cite.
+
+Script you'll notice: build the word.
+Every piece is now yours:
+[a table of 8 rows, read aloud]
+piece: இ, i, independent — the word opens on a vowel.
+piece: ரு, ru — ர with the ு sign, this lesson.
+piece: க், bare k, க under a puḷḷi.
+piece: கி, ki — க with the ி sign, blank.
+piece: றீ, ṟī — ற with the ீ sign, ற from நன்றி.
+piece: ர், bare r, ர from சரி.
+piece: க, ka, blank.
+piece: ள், bare ḷ, from நீங்கள்.
+இ, ரு, க், கி, றீ, ர், க, ள் becomes இருக்கிறீர்கள் (irukkiṟīrgaḷ).
+And the whole question:
+நீங்கள் எப்படி இருக்கிறீர்கள் (irukkiṟīrgaḷ)?
+Nothing in it is new to say. You have asked it since chapter 3; the letters took until now to catch up.
+
+Guided Practice.
+[pause 1 second]
+[your turn — read: ரு — then இருக்கிறீர்கள் (irukkiṟīrgaḷ)]
+[pause 8 seconds for the answer]
+[your turn — read: the whole question — நீங்கள் எப்படி இருக்கிறீர்கள் (irukkiṟīrgaḷ)?]
+[pause 8 seconds for the answer]
+[your turn — say: "nīṅgaḷ eppaḍi irukkiṟīrgaḷ?" — "how are you?"]
+[pause 8 seconds for the answer]
+[your turn — contrast: நான் and நீங்கள் — the I of the answer, the you of the question]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read நீங்கள் எப்படி இருக்கிறீர்கள் (irukkiṟīrgaḷ)? aloud. Is ு written before its consonant or after? (After — ை and ெ are the ones written before.) When is a vowel sign spoken? (Always after, wherever it sits.) Which word did you learn to read first? (நீங்கள்.) Next: the verb இரு on its own.

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -333,6 +333,126 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 - Add `generate:progress` and the byte-for-byte `check:progress` publication gate;
   a new registered language appears even when it has no lessons or book yet.
 
+### Added — the Tamil writing strand reaches chapter 3's words
+
+The chapter 2 pass left six lessons still teaching script inline (`TA-C02-nii-niingal`
+plus all five of chapter 3), and the same rule applied: the glyphs they explained —
+ங, ள, ீ, ா, ட and ு — were taught nowhere in the strand, so deleting the sections
+would have deleted the only explanation those letters had. Four new reading lessons
+close that:
+
+- **`TA-W10-read-naan`** (chapter 25) — the **ா** sign, spelling **நான்**. This is the
+  one sign with a sourced description in `data/scripts/tamil.json` — *"a vertical
+  stroke with a small top hook, written after the consonant"* — and it completes the
+  picture of where a vowel sign can sit: after (ா), above-right (ி), before (ை, ெ).
+- **`TA-W11-read-niingal`** (chapter 27) — **ங**, **ள** and the **ீ** sign, spelling
+  **நீங்கள்**. It pays two debts the corpus had been carrying: `TA-W01` explained that
+  **க** sounds like *g* after a nasal and printed **ங்க** without ever saying what **ங**
+  was, and `TA-W06` promised three *l*-letters while teaching only **ல**.
+- **`TA-W12-read-eppadi`** (chapter 29) — **ட**, spelling **எப்படி**, held against the
+  **ண** the learner already has: the same retroflex curl, stopped rather than nasal.
+- **`TA-W13-read-irukkirirgal`** (chapter 31) — the **ு** sign, spelling
+  **இருக்கிறீர்கள்** and then the whole chapter 3 question off the page.
+
+All four are reading-only. Of the six glyphs, only **ா** appears in
+`data/scripts/tamil.json` at all (under `marks`, not `letters`), so it is the only one
+described from a source. The other five say plainly that the book has no entry for
+them, and the hedge covers the **sound** descriptions as well as the missing stroke
+orders: **ங**, **ள** and **ட** lean on **ண**'s sourced "tongue curled back" and **க**'s
+sourced position-picks-the-sound note, and say so rather than asserting their own
+phonetics flat. `TA-W11` marks the same attestation gap for **ீ** that `TA-W09` marked
+for **ெ**.
+
+This started as three lessons and became four because the corpus caps a lesson under
+300 effective seconds. The first draft put **எப்படி** and **இருக்கிறீர்கள்** in one
+lesson and computed at 380s; splitting them is what the cap is for, and the result is
+gentler than the draft was.
+
+### Removed — six more lessons stop teaching script
+
+`TA-C02-nii-niingal` and all five chapter 3 lessons drop their `## The letters in this
+word` sections, and `ch02-introductions.tex` and `ch03-responding.tex` drop the four
+matching `sounds` boxes. Verified against the **generated** manifest rather than the
+source: all six flip `reasons: ["script-block"]` → `["no-visual-dependency"]` and their
+`detachableSegments` lists empty, so the script teaching genuinely left the lesson.
+
+Two of the six sections were not letter lessons at all. `TA-C03-eppadi-irukkirirgal`
+used the heading to carry **verb morphology**, which is speaking content that happens to
+be printed in Tamil; it moves into the lesson's own prose as *iru* + *-kkiṟ-* +
+*-īrgaḷ* — the segmentation `TA-C32-iru` already pins, and one that concatenates to the
+surface word — rather than being deleted. `TA-C03-paravayillai`'s section was a
+word-joining note the very next section already makes, so it goes.
+
+`sounds:` frontmatter is **kept** on all six, unlike the chapter 2 pass. Those lessons
+list genuine pronunciation ids (`long-aa`, `retroflex-kk`, `final-m`); chapter 2's
+listed script ids (`independent-e`, `pulli`), which is why clearing them was right
+there and would be wrong here.
+
+Chapter 3 is closed; chapters 4-5 are not. The claim carried over from the last pass —
+that their boxes show ப, எ and ய — was wrong, so here is the measured inventory of the
+four `sounds` boxes in `ch04-farewells.tex` and `ch05-first-verbs.tex`, by the chapter
+that first teaches each glyph:
+
+| | glyphs |
+|---|---|
+| never taught by any strand lesson | **ோ**, **ே**, **ழ** |
+| taught long after book chapter 5 | **ா** (25), **ள** (27), **ு** (31), **ப** (23), **ர** (19), **ச** (19), **ல** (18), **ை** (18), **்** (7), **ந** (6), **ம** (6) |
+| taught in time | **வ** (4), **க** (5) |
+
+So the debt there is bigger than "three glyphs," and it is two different debts: three
+glyphs the strand never reaches at all, and eleven it reaches only much later. Neither
+is addressed here.
+
+### Measured, not inferred
+
+Every figure below is a set difference against the pre-change corpus, computed by
+loading both with the same build.
+
+- `totalLessons` 1680 → 1684, `pen` 58 → 62 — the four new lessons. They are `type:
+  writing` and therefore `pen`, even though all four are reading-only.
+- `voice` 1100 → 1106, `sight` 522 → 516, `drivableLessons` 1100 → 1106 — the same six
+  lessons, no others.
+- `drivablePrefixTotal` 913 → 918 and `unstartableChapters` 140 → 139. Chapter 3 gains
+  6 — its first lesson needed eyes, and the whole chapter is now one ear-only run — and
+  chapter 25 loses 1, because holding the 3:1 cadence puts `TA-W10` *between* its two
+  speaking lessons rather than after them. `TA-W06` already sits mid-chapter in chapter
+  18, so this is the established shape, not a new one. `unstartableChapters` is chapter
+  3 alone.
+- `fullyDrivableChapters` 327 → **324**, which moves the wrong way. Chapters 25, 27, 29
+  and 31 each take a writing lesson and stop being fully drivable (−4); chapter 3
+  becomes fully drivable (+1). That is the honest cost of paying the debt where it
+  belongs. Corpus `coreDrivable` does not move, but not because these blocks detach —
+  rule 1 classifies a `type: writing` lesson as `pen` without reading its body, so all
+  four record `coreDrivable: false`. It holds because the six lessons that flipped were
+  already core-drivable and the four new ones were never counted.
+- `payoffsNotRepresentative` 27 → **29**. Tamil 25 (2/3 → 2/5) and 27 (2/2 → 2/5) fall
+  below the 0.5 floor because they gained script atoms their speaking payoffs do not
+  assess — the same trade chapter 13 already records, and both are now noted in
+  `tamil/chapters.json`. Tamil 29 and 31 took the same hit and did **not** join: each
+  landed on exactly 2/4 (0.50). The difference is one atom of arithmetic.
+- `atomsTaught` 2631 → 2640 — 2 + 3 + 2 + 2 new atoms.
+- `atomsNeverRevisited` rises 469 → 470. Three in — `TTA-01`, `U-SIGN-01` and
+  `READ-QUESTION-02`; nothing follows `TA-W13`, so its two are orphans by construction.
+  Two out: extending the strand finally re-uses ெ and ப, so `E-SIGN-02` and `PA-YA-01`
+  leave the set. `READ-PEYAR-03` stays. Three in, two out. `AA-SIGN-01`, `II-SIGN-01`,
+  `NGA-LLA-01` and `READ-NAAN-02` never become orphans, because each lesson declares —
+  and genuinely assesses — the earlier letters its own word is built from: `TA-W11`
+  credits the ந it builds **நீ** from, `TA-W13` credits the ள it re-reads in
+  **ள்** and the **நான்** it holds against **நீங்கள்**.
+- `missedByWindow.R1` 864 → 874. Nine are the new atoms. The cadence puts consecutive
+  strand lessons **four** apart in reading order, and R1 is a 1-3 window — an early draft
+  put `TA-W10` after the fourth speaking lesson instead of the third, which made that gap
+  3 and quietly falsified this rationale; the sequence was moved to 785 so the claim and
+  the corpus agree. The tenth miss is not new and is worth naming: interleaving at
+  chapter 29 pushes `TA-LEX-AFTERNOON-BOUNDARY-01`'s reinforcement past R1.
+- `missedByWindow.R2` 1799 → 1800. Four of the nine new atoms miss R2; the other five —
+  `AA-SIGN-01`, `II-SIGN-01`, `NGA-LLA-01`, `READ-NAAN-02`, `READ-NIINGAL-03` — do not,
+  because a later strand lesson practises them 5-15 lessons on, which is what threading
+  them through `practises` was for. Three pre-existing atoms are pulled back inside R2
+  against that: `PA-YA-01`, `ETYMON-KAALAI-01` and `ETYMON-MAALAI-01`. `E-SIGN-02` leaves
+  the orphan set but not R2 — `TA-W10` re-uses it at a distance R2 does not count.
+  Four in, three out.
+
 ### Added — the Tamil writing strand reaches chapter 2's words
 
 The speaking-first change left nine chapter 2-3 word lessons still teaching script

--- a/code/packages/typescript/human-language-data/tests/chapters.test.ts
+++ b/code/packages/typescript/human-language-data/tests/chapters.test.ts
@@ -328,9 +328,17 @@ describe("corpus snapshot", () => {
     // TA-W04-i-sign-write-nandri when the writing strand was spread out and its payoff
     // was not widened. Both are recorded in tamil/chapters.json's own notes.
     // Empty `assesses` lists on schema-v1 chapters remain unscored rather than pretending
-    // to pass. Chapter 10 now assesses all nine atoms in its terminal checkpoint, so
-    // the current typed-atom corpus still exposes 27 genuinely thin payoffs.
-    expect(report.summary.payoffsNotRepresentative).toBe(27);
+    // to pass. Chapter 10 now assesses all nine atoms in its terminal checkpoint.
+    // 27 -> 29, and both new members are Tamil, both for the chapter-13 reason. Extending
+    // the writing strand to cover chapters 2-3's glyphs dropped a script lesson into four
+    // previously all-speaking chapters, and none of those four payoffs was widened:
+    //   tamil:25 gained TA-W10's two atoms, so its payoff fell from 2/3 to 2/5 (0.40)
+    //   tamil:27 gained TA-W11's three atoms, so its payoff fell from 2/2 to 2/5 (0.40)
+    // tamil:29 and tamil:31 took the same kind of hit and did NOT join: each landed on
+    // exactly 2/4 (0.50), which clears the floor rather than falling below it. So this is
+    // +2 and not +4, and the difference is one atom of arithmetic, not a difference in
+    // kind. Both new members are recorded in tamil/chapters.json's own payoff notes.
+    expect(report.summary.payoffsNotRepresentative).toBe(29);
   });
 
   it("names the tracks whose chapter debt is already zero", () => {

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -385,7 +385,9 @@ describe("the real corpus", () => {
     // Chapter 17 repeats that bounded twelve-atom shape across seven teaching
     // steps and one atom-free terminal checkpoint.
     // Chapter 18 does the same across eight teaching steps before its checkpoint.
-    expect(report.summary.atomsTaught).toBe(2631);
+    // +9: the four lessons that extend the Tamil writing strand to chapters 2-3's
+    // glyphs introduce 2 + 3 + 2 + 2 atoms (TA-W10/11/12/13).
+    expect(report.summary.atomsTaught).toBe(2640);
     // +2, and it goes UP, which is worth stating plainly. Three of the five new atoms
     // are TA-W09's and nothing follows TA-W09, so they are orphans by construction:
     // PA-YA-01, E-SIGN-02, READ-PEYAR-03. TA-W08's two are revisited by TA-W09.
@@ -397,7 +399,16 @@ describe("the real corpus", () => {
     // pulling one pre-existing atom out of the orphan set.
     // The Chapter-14 checkpoint also revives one older item, so the corpus orphan
     // count falls by one while none of the six new atoms becomes an orphan.
-    expect(report.summary.atomsNeverRevisited).toBe(469);
+    // +1, measured as a set difference against the pre-change corpus rather than
+    // inferred from the total. THREE atoms enter the orphan set — TTA-01 (TA-W12),
+    // U-SIGN-01 and READ-QUESTION-02 (TA-W13). Nothing follows TA-W13, so its two are
+    // orphans by construction. TWO leave it, both TA-W09's: extending the strand finally
+    // re-uses ெ and ப, so E-SIGN-02 (TA-W10's sign-position table) and PA-YA-01 (TA-W12,
+    // which spells எப்படி with ப) go from 0 revisits to 1. READ-PEYAR-03 stays an orphan.
+    // Three in, two out. AA-SIGN-01, II-SIGN-01, NGA-LLA-01 and READ-NAAN-02 never become
+    // orphans at all, because each later strand lesson declares — and genuinely assesses
+    // — the earlier letters its own word is built from.
+    expect(report.summary.atomsNeverRevisited).toBe(470);
     expect(report.summary.neverRevisitedPercent).toBe(18);
 
     // 509 -> 517, and the eight split into TWO DIFFERENT PHENOMENA this number conflates.
@@ -525,7 +536,13 @@ describe("the real corpus", () => {
     // retrieved locally, but its eight-lesson footprint pushes two beyond R1.
     // Chapter 18 adds four: its terminal checkpoint retrieves all twelve atoms,
     // but eight small teaching steps push the earliest four beyond R1.
-    expect(report.summary.missedByWindow.R1).toBe(864);
+    // +10, and the composition is measured per atom, not inferred from the total.
+    // NINE of the ten are the new script atoms: every atom TA-W10..TA-W13 introduces
+    // misses R1, because the strand's 3:1 cadence puts consecutive script lessons well
+    // outside a 1-3 window. The TENTH is not new and is worth naming: interleaving a
+    // writing lesson at chapter 29 pushes TA-LEX-AFTERNOON-BOUNDARY-01's reinforcement
+    // past R1 ([R2,R3] -> [R1,R2,R3]). No atom gains R1 reinforcement here.
+    expect(report.summary.missedByWindow.R1).toBe(874);
     // +2 net, and the composition is the interesting part: all FIVE new atoms miss R2
     // as well, offset by THREE pre-existing atoms that TA-W09 pulls back into it.
     // TA-W09 sits 12 lessons after TA-W06 and 8 after TA-W07, both inside R2's 5-15
@@ -548,7 +565,17 @@ describe("the real corpus", () => {
     // Chapter 17 adds seven more: the local checkpoint retrieves every atom,
     // while later chapters still own the five-to-fifteen-lesson revisit window.
     // Chapter 18 adds five more far-window misses for the same reason.
-    expect(report.summary.missedByWindow.R2).toBe(1799);
+    // +1 net, and again the composition matters more than the number. FOUR of the nine
+    // new atoms miss R2 (TTA-01, U-SIGN-01, READ-EPPADI-02, READ-QUESTION-02); the other
+    // five do NOT — AA-SIGN-01, II-SIGN-01, NGA-LLA-01, READ-NAAN-02 and READ-NIINGAL-03
+    // are practised by a later strand lesson 5-15 lessons on, which is exactly what R2
+    // measures and exactly what threading them through `practises` was for. Against those
+    // four, THREE pre-existing atoms are pulled back inside R2: PA-YA-01 (TA-W09's ப, now
+    // re-used by TA-W12) and ETYMON-KAALAI-01 and ETYMON-MAALAI-01, whose distances shift
+    // as the new lessons land between them. Note E-SIGN-02 does NOT leave R2: TA-W10
+    // re-uses it, which is what takes it out of the orphan set above, but at a distance
+    // R2 does not count. Four in, three out.
+    expect(report.summary.missedByWindow.R2).toBe(1800);
   });
 
   it("shows what a declared reading order was worth", () => {

--- a/code/packages/typescript/human-language-data/tests/levels.test.ts
+++ b/code/packages/typescript/human-language-data/tests/levels.test.ts
@@ -219,7 +219,8 @@ describe("corpus snapshot", () => {
 
     // +2: Spanish Chapter 9 maps its identity and ser/estar contrast lessons onto
     // the existing pre-A1 social spine.
-    expect(summary.byLevel["pre-A1"]).toBe(868);
+    // +4: TA-W10..TA-W13, the Tamil writing strand's extension, all sit at pre-A1.
+    expect(summary.byLevel["pre-A1"]).toBe(872);
     // Chapter 10 adds singular ir and possessives at A1. Chapter 11 adds one more
     // definite-reference lesson there; its other work is A2. Chapter 12 adds its
     // newly mapped terminal checkpoints at A2 on SPINE-SAY-WHAT-I-DO.
@@ -290,7 +291,10 @@ describe("corpus snapshot", () => {
     const { lessons, curricula: paths, spine } = loadEverything();
     const ramp = lessonsUpToLevel(lessons, paths, spine, "A1");
     // The whole point: this is a FILTER over the one corpus, not a second corpus.
-    expect(ramp).toHaveLength(1177); // +1: Chapter-11 singular nuestro/nuestra joins the edition
+    // +4, measured as a set difference against the pre-change corpus rather than inferred
+    // from the total: TA-W10-read-naan, TA-W11-read-niingal, TA-W12-read-eppadi and
+    // TA-W13-read-irukkirirgal are the only lessons that join.
+    expect(ramp).toHaveLength(1181);
     expect(ramp.length).toBeLessThan(lessons.length);
   });
 });

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -879,14 +879,17 @@ describe("corpus regression", () => {
       // Chapter 16 replaces three legacy lessons with eight bounded steps.
       // Chapter 17 replaces four legacy lessons with eight bounded steps.
       // Chapter 18 replaces ten legacy lessons with nine bounded steps.
-      totalLessons: 1680,
+      // +4: TA-W10-read-naan, TA-W11-read-niingal, TA-W12-read-eppadi and
+      // TA-W13-read-irukkirirgal extend the writing strand over chapters 2-3's glyphs.
+      totalLessons: 1684,
       // Chapters 10 and 13 replace wide legacy tables with small singular-only
       // comparisons, so three more lessons move from sight to voice.
       // All seven Chapter-16 teaching steps are voice-first. Generating the book
       // exposed the terminal Chapter-15 and Chapter-16 recap tables as too wide,
       // so their same person-by-person comparisons now use speakable bullet rows.
       // All eight Chapter-17 lessons remain voice-first.
-      voice: 1100,
+      // +6, and it is the same six lessons that leave `sight` below.
+      voice: 1106,
       // -3 sight / +3 voice: TA-C02-en, -enna and -peyar dropped their "The letters in
       // this word" sections once TA-W08 and TA-W09 gave those glyphs a home in the
       // strand. Verified against the GENERATED manifest, not the source — all three now
@@ -895,7 +898,14 @@ describe("corpus regression", () => {
       // Chapter 18 removes its one remaining sight-only lesson. Publishing
       // Chapters 7-18 from the AST moves the Chapter-15 and Chapter-16 terminal
       // recaps from sight to voice without changing what either checkpoint asks.
-      sight: 522,
+      // -6 sight / +6 voice, the ch02/ch03 repeat of the TA-C02 move above: once
+      // TA-W10..TA-W13 gave chapters 2-3's glyphs a home, TA-C02-nii-niingal and all
+      // five ch3 lessons (eppadi, eppadi-irukkirirgal, naan, nalam, paravayillai)
+      // dropped their "The letters in this word" sections. Verified against the
+      // GENERATED manifest: every one flips reasons ["script-block"] ->
+      // ["no-visual-dependency"] and its detachableSegments list empties, so the
+      // script teaching genuinely left the lesson rather than a heading being renamed.
+      sight: 516,
       // +3 pen: the Tamil ch1 writing lessons. Rule 1 in src/modality.ts derives
       // this from the lesson TYPE alone — it says outright that it does not look at
       // the body — so all three record reasons ["writing-type","script-block"], and
@@ -903,9 +913,12 @@ describe("corpus regression", () => {
       // voice and drivable are unchanged, which is what a writing lesson should do
       // to this table.
       // +2: both new lessons are writing lessons.
-      pen: 58,
-      drivableLessons: 1100,
-      drivablePercent: 65,
+      // +4: TA-W10..TA-W13 are `type: writing` too, so rule 1 makes them pen even
+      // though all four are reading-only and give no stroke order.
+      pen: 62,
+      // +6: exactly the six lessons that moved sight -> voice; no other lesson changes.
+      drivableLessons: 1106,
+      drivablePercent: 66,
       trackCount: 22,
       chapterCount: 513,
       // Prerequisite order still costs a commuter 132 of the 965 ear-only lessons:
@@ -942,15 +955,31 @@ describe("corpus regression", () => {
       // Chapter 17's reachable voice-first prefix grows by five.
       // All nine redesigned Chapter-18 steps are reachable by ear. The terminal
       // Chapter-15 and Chapter-16 recaps now extend both prefixes by one.
-      drivablePrefixTotal: 913,
+      // +5 net, and TWO chapters move, in opposite directions. Tamil chapter 3 gains 6:
+      // its first lesson was sight, so nothing after it counted; with all six now voice
+      // the whole chapter is one ear-only run. Tamil chapter 25 LOSES 1 (2 -> 1), because
+      // the 3:1 cadence puts TA-W10 between its two speaking lessons rather than after
+      // them — the same mid-chapter placement TA-W06 already has in chapter 18. Chapters
+      // 27/29/31 take their writing lesson after the prefix, so they hold at 1/1/2.
+      drivablePrefixTotal: 918,
       // -2: chapters 21 and 23 each take a writing lesson and stop being ear-only.
       // Spreading the strand cannot happen without landing a pen lesson somewhere.
       // Spanish Chapters 10 and 13 are now fully drivable from their canonical ASTs.
       // Spanish Chapter 18 also becomes fully drivable. Replacing the two wide
       // terminal recap tables makes Spanish Chapters 15 and 16 fully drivable too.
-      fullyDrivableChapters: 327,
+      // -3, and it goes the WRONG way, which is worth stating plainly. Four Tamil
+      // chapters (25, 27, 29, 31) each gain one writing lesson and stop being fully
+      // drivable: -4. Tamil chapter 3 becomes fully drivable for the first time: +1.
+      // Net -3. That is the honest cost of paying the script debt where it belongs.
+      // Corpus `coreDrivable` does not move, but NOT because these blocks detach: rule 1
+      // classifies a `type: writing` lesson as pen without reading its body, so all four
+      // record `coreDrivable: false`. It holds because the six lessons that flipped were
+      // already core-drivable and the four new ones were never counted.
+      fullyDrivableChapters: 324,
       // Tamil chapter 2, Spanish chapter 13, and Spanish chapter 18 can now start by ear.
-      unstartableChapters: 140,
+      // -1: Tamil chapter 3 alone. It was unstartable because its first lesson needed
+      // eyes; it now starts by ear. No other chapter moves.
+      unstartableChapters: 139,
       overriddenLessons: 0,
       lessonsWithoutChapter: 0,
     });


### PR DESCRIPTION
Closes the second of the two limitations recorded by #10088.

## Why

#10088 gave chapter 2's glyphs a home in the writing strand and removed three inline
`## The letters in this word` sections. It left six lessons still teaching script inline —
`TA-C02-nii-niingal` and all five of chapter 3 — and they could **not** simply be deleted:
the glyphs they explained (ங, ள, ீ, ா, ட, ு) were taught nowhere in the strand, so removing
the sections would have removed the only explanation those letters had.

## What

Four new reading-only strand lessons, at the established 3:1 cadence (one script lesson
after every third speaking lesson):

| lesson | ch | teaches | spells |
|---|---|---|---|
| `TA-W10-read-naan` | 25 | the **ா** sign | நான் |
| `TA-W11-read-niingal` | 27 | **ங**, **ள**, the **ீ** sign | நீங்கள் |
| `TA-W12-read-eppadi` | 29 | **ட** | எப்படி |
| `TA-W13-read-irukkirirgal` | 31 | the **ு** sign | இருக்கிறீர்கள், then the whole chapter-3 question |

`TA-W11` pays two debts the corpus was carrying: `TA-W01` printed **ங்க** to explain when
**க** sounds like *g* without ever saying what **ங** was, and `TA-W06` promised three
*l*-letters while teaching only **ல**.

Only **ா** appears in `data/scripts/tamil.json` at all (under `marks`, not `letters`), so
it is the only glyph described from a source. The other five say plainly that the book has
no entry for them, and the hedge covers the **sound** descriptions as well as the missing
stroke orders rather than asserting unsourced phonetics flat.

The six speaking lessons then drop their inline sections, and `ch02-introductions.tex` and
`ch03-responding.tex` drop the four matching `sounds` boxes.

## Verification

Removal was verified against the **generated** manifest, not the source: all six flip
`reasons: ["script-block"] → ["no-visual-dependency"]` with an empty `detachableSegments`,
so this is script teaching genuinely leaving the lesson rather than a heading renamed out
from under the classifier.

Every re-pinned figure was measured as a **set difference against the pre-change corpus**,
loading both with the same build — not inferred from a total. Two move the wrong way and
are stated rather than buried:

- `fullyDrivableChapters` 327 → **324**: chapters 25/27/29/31 each take a writing lesson
  and stop being fully drivable (−4); chapter 3 becomes fully drivable for the first time
  (+1).
- `payoffsNotRepresentative` 27 → **29**: tamil 25 (2/3 → 2/5) and 27 (2/2 → 2/5) fall below
  the 0.5 floor. Chapters 29 and 31 took the same hit and landed on exactly 2/4 (0.50), so
  they do not join. Both new members are recorded in `tamil/chapters.json`, matching the
  precedent chapter 13 already sets.

Also: `totalLessons` 1680 → 1684, `voice` 1100 → 1106, `sight` 522 → 516, `pen` 58 → 62,
`drivablePrefixTotal` 913 → 918, `unstartableChapters` 140 → 139, `atomsTaught` 2631 → 2640,
`atomsNeverRevisited` 469 → 470, `missedByWindow.R1` 864 → 874, `.R2` 1799 → 1800. Full
per-atom compositions are in the CHANGELOG and in the test comments.

460/460 tests pass; `check:books`, `check:modality`, `check:narration`, `check:figures` and
`check:progress` are all clean.

## Not closed here

Chapters 4-5's book `sounds` boxes. The claim carried over from #10088 (that they show
ப, எ and ய) was **wrong** and is corrected in the CHANGELOG with a measured inventory:
three glyphs there (ோ, ே, ழ) are taught by no strand lesson at all, and eleven more are
taught only much later than book chapter 5. Two different debts, both still open.

## Review

Two adversarial review passes were run and everything they found was fixed, including a
defect one of the fixes introduced (moving `TA-W10` to restore the 3:1 cadence broke
`TA-C25-iniya-iravu`'s "Next:" line) and two incomplete fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)