### PR TITLE
Restore reachable vault item revisions

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this package are documented here.
 
+## [0.17.0] - 2026-08-09
+
+### Added
+
+- Add a session-consuming `restore_item` workflow that locates one selected
+  revision through bounded reachable history and republishes its live document
+  as a new current revision.
+- Add owned wipe-on-drop randomness for the three encrypted restoration frames.
+
+### Security
+
+- Require the selected revision to be reachable from a current head, live,
+  different from the sole current candidate, and bound to the same item before
+  the local write-ahead compare-exchange.
+- Make only the selected historical revision the new revision's causal parent,
+  while preserving all current commit heads and historical immutable bytes.
+- Reject unreachable revisions with `NotFound`, tombstones/current selections
+  with `InvalidInput`, and unresolved current candidates with
+  `ConflictRequired`, without asking a host to resupply secret plaintext.
+
 ## [0.16.0] - 2026-08-09
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -124,10 +124,20 @@ accessor and ordinary diagnostics redact them. Historical candidates remain
 inside the unlocked session so restore-by-revision can consume authenticated
 content without adding provider-specific reads or asking a host for plaintext.
 
+Restore-by-revision consumes the unlocked session and proves the requested
+revision appears in a catalog reachable within the 4,096-entry ancestry bound
+from a current head. The selected revision must be live, differ from the sole
+current candidate, and belong to the same current item; unresolved current
+conflicts fail closed. Restoration copies the authenticated historical document
+into a newly randomized revision whose sole direct causal parent is the
+selected revision, then uses the same all-head commit, exact pending journal,
+ambiguous-success handling, and recovery path as other mutations. It never
+rewinds heads, mutates historical bytes, or asks the host to resupply plaintext.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
-credential store, or entropy source. Restore, conflict resolution, explicit
-history reveal, export, audit, and doctor workflows land in the next slices.
+credential store, or entropy source. Conflict resolution, explicit history
+reveal, export, audit, and doctor workflows land in the next slices.
 There is no unchecked
 repository verification path: construction decrypts and
 authority-verifies the exact locally pinned certificate frame and object ID,

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -32,8 +32,9 @@ pub use initialize::{
     GENERATION_ZERO_RANDOM_BYTES,
 };
 pub use mutation::{
-    AddItemRandomnessV1, DeleteItemRandomnessV1, ReplaceItemRandomnessV1, ADD_ITEM_RANDOM_BYTES,
-    DELETE_ITEM_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
+    AddItemRandomnessV1, DeleteItemRandomnessV1, ReplaceItemRandomnessV1, RestoreItemRandomnessV1,
+    ADD_ITEM_RANDOM_BYTES, DELETE_ITEM_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
+    RESTORE_ITEM_RANDOM_BYTES,
 };
 pub use open::{
     open_active_vault, recover_pending_publication, ItemHistoryViewV1, UnlockedVaultV1,
@@ -62,7 +63,7 @@ pub enum ApplicationError {
     AuthenticationFailed,
     /// Caller input violates a V1 precondition.
     InvalidInput,
-    /// The requested item does not exist in the current catalog.
+    /// The requested item or revision does not exist in reachable vault state.
     NotFound,
     /// A fixed parser or collection bound would be exceeded.
     BoundExceeded,

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -23,6 +23,8 @@ pub const ADD_ITEM_RANDOM_BYTES: usize = ITEM_ID_BYTES + 3 * OBJECT_RANDOM_BYTES
 pub const REPLACE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
 /// Exact caller-filled CSPRNG bytes consumed by one delete-item mutation.
 pub const DELETE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
+/// Exact caller-filled CSPRNG bytes consumed by one restore-item mutation.
+pub const RESTORE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
 
 /// Owned wipe-on-drop entropy for one item ID and three encrypted frames.
 pub struct AddItemRandomnessV1 {
@@ -120,6 +122,36 @@ impl Drop for DeleteItemRandomnessV1 {
 impl Debug for DeleteItemRandomnessV1 {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         formatter.write_str("DeleteItemRandomnessV1(<redacted>)")
+    }
+}
+
+/// Owned wipe-on-drop entropy for the three encrypted restoration frames.
+pub struct RestoreItemRandomnessV1 {
+    bytes: [u8; RESTORE_ITEM_RANDOM_BYTES],
+}
+
+impl RestoreItemRandomnessV1 {
+    /// Take one exact block filled by the host's cryptographic entropy source.
+    pub const fn new(bytes: [u8; RESTORE_ITEM_RANDOM_BYTES]) -> Self {
+        Self { bytes }
+    }
+}
+
+impl Zeroize for RestoreItemRandomnessV1 {
+    fn zeroize(&mut self) {
+        self.bytes.zeroize();
+    }
+}
+
+impl Drop for RestoreItemRandomnessV1 {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl Debug for RestoreItemRandomnessV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("RestoreItemRandomnessV1(<redacted>)")
     }
 }
 
@@ -262,6 +294,50 @@ pub(crate) fn delete_item(
             deleted_at_ms,
         }),
         &BTreeSet::from([expected_revision]),
+        wall_time_ms,
+        &randomness.bytes,
+    )?;
+    publish_mutation(active, repository, publication, local_state_store)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn restore_item(
+    active: &ActiveStateV1,
+    report: &OpenReport,
+    current_items: &BTreeMap<ItemId, Vec<ItemCandidate>>,
+    keys: &V1Keys,
+    local_secret: &LocalSecretV1,
+    repository: &dyn ApplicationRepository,
+    selected: ItemCandidate,
+    wall_time_ms: u64,
+    randomness: RestoreItemRandomnessV1,
+    local_state_store: &dyn LocalStateStore,
+) -> Result<ActiveStateV1, ApplicationError> {
+    if report.heads() != active.pinned_heads() {
+        return Err(ApplicationError::ConcurrentHost);
+    }
+    let item_id = selected.item_id();
+    let current = current_items
+        .get(&item_id)
+        .ok_or(ApplicationError::NotFound)?;
+    let [current] = current.as_slice() else {
+        return Err(ApplicationError::ConflictRequired);
+    };
+    if current.revision_id() == selected.revision_id() {
+        return Err(ApplicationError::InvalidInput);
+    }
+    let ItemState::Live(document) = selected.state() else {
+        return Err(ApplicationError::InvalidInput);
+    };
+
+    let publication = prepare_item_publication(
+        active,
+        current_items,
+        keys,
+        local_secret,
+        item_id,
+        ItemState::Live(document.clone()),
+        &BTreeSet::from([selected.revision_id()]),
         wall_time_ms,
         &randomness.bytes,
     )?;
@@ -521,6 +597,20 @@ mod tests {
             "DeleteItemRandomnessV1(<redacted>)"
         );
         assert!(randomness.bytes.iter().all(|byte| *byte == 0x3c));
+
+        randomness.zeroize();
+        assert!(randomness.bytes.iter().all(|byte| *byte == 0));
+    }
+
+    #[test]
+    fn restore_item_randomness_redacts_and_zeroizes() {
+        let mut randomness = RestoreItemRandomnessV1::new([0xc3; RESTORE_ITEM_RANDOM_BYTES]);
+
+        assert_eq!(
+            format!("{randomness:?}"),
+            "RestoreItemRandomnessV1(<redacted>)"
+        );
+        assert!(randomness.bytes.iter().all(|byte| *byte == 0xc3));
 
         randomness.zeroize();
         assert!(randomness.bytes.iter().all(|byte| *byte == 0));

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1,7 +1,7 @@
 use crate::initialize::{unlock_active_material, UnlockedActiveMaterial};
 use crate::mutation::{
-    add_item, delete_item, replace_item, AddItemRandomnessV1, DeleteItemRandomnessV1,
-    ReplaceItemRandomnessV1,
+    add_item, delete_item, replace_item, restore_item, AddItemRandomnessV1, DeleteItemRandomnessV1,
+    ReplaceItemRandomnessV1, RestoreItemRandomnessV1,
 };
 use crate::search::SearchProjectionV1;
 use crate::{
@@ -336,6 +336,42 @@ impl UnlockedVaultV1 {
             local_state_store,
         )
     }
+
+    /// Restore one reachable historical live revision as a new current live
+    /// revision and return the resulting durable active owner state.
+    ///
+    /// The selected revision must be reachable within the hard history bound,
+    /// belong to an item with exactly one current candidate, and differ from
+    /// that current revision. Tombstones cannot be restored. The new revision
+    /// copies the selected live document and names only the selected revision
+    /// as its direct causal parent; repository heads are never rewound.
+    pub fn restore_item(
+        self,
+        selected_revision: RevisionId,
+        wall_time_ms: u64,
+        randomness: RestoreItemRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        let selected = find_reachable_historical_candidate(
+            &self._keys,
+            self._repository.as_ref(),
+            &self.report,
+            self.active.vault_id(),
+            selected_revision,
+        )?;
+        restore_item(
+            &self.active,
+            &self.report,
+            &self.current_catalog.items,
+            &self._keys,
+            &self._local_secret,
+            self._repository.as_ref(),
+            selected,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+        )
+    }
 }
 
 fn project_current_item(
@@ -589,6 +625,76 @@ fn materialize_item_history_candidates(
     Ok(candidates)
 }
 
+fn find_reachable_historical_candidate(
+    keys: &V1Keys,
+    repository: &dyn ApplicationRepository,
+    report: &OpenReport,
+    vault_id: VaultId,
+    selected_revision: RevisionId,
+) -> Result<ItemCandidate, ApplicationError> {
+    let mut histories = Vec::with_capacity(report.heads().len());
+    for head_id in report.heads().iter().copied() {
+        let history = repository
+            .history(head_id, MAX_ITEM_HISTORY_LIMIT)
+            .map_err(map_repository)?;
+        if history.first().map(|commit| commit.id()) != Some(head_id) {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        histories.push(history);
+    }
+
+    let mut seen_commits = BTreeSet::new();
+    let mut seen_catalogs = BTreeSet::new();
+    for depth in 0..MAX_ITEM_HISTORY_LIMIT {
+        let mut commits = histories
+            .iter()
+            .filter_map(|history| history.get(depth))
+            .filter(|commit| !seen_commits.contains(&commit.id()))
+            .collect::<Vec<_>>();
+        commits.sort_unstable_by_key(|commit| commit.id());
+
+        for commit in commits {
+            if !seen_commits.insert(commit.id()) {
+                continue;
+            }
+            if commit.vault_id() != vault_id {
+                return Err(ApplicationError::IntegrityFailure);
+            }
+            let catalog_id = commit.catalog_root();
+            if !seen_catalogs.insert(catalog_id) {
+                continue;
+            }
+            let catalog_object = repository.read_object(catalog_id).map_err(map_repository)?;
+            if catalog_object.id() != catalog_id {
+                return Err(ApplicationError::IntegrityFailure);
+            }
+            let catalog_plaintext = open_object(keys, ObjectKind::Catalog, catalog_object.frame())?;
+            let catalog = CatalogV1::decode(&catalog_plaintext)?;
+            let Some((item_id, _)) = catalog
+                .entries()
+                .iter()
+                .find(|(_, revisions)| revisions.binary_search(&selected_revision).is_ok())
+            else {
+                continue;
+            };
+
+            let candidate = read_candidate(keys, repository, selected_revision)?;
+            if candidate.item_id() != *item_id {
+                return Err(ApplicationError::IntegrityFailure);
+            }
+            for parent_id in candidate.causal_parents() {
+                let parent = read_candidate(keys, repository, *parent_id)?;
+                if parent.item_id() != *item_id {
+                    return Err(ApplicationError::IntegrityFailure);
+                }
+            }
+            return Ok(candidate);
+        }
+    }
+
+    Err(ApplicationError::NotFound)
+}
+
 /// Replay one exact durable `PendingPublication` and atomically advance it to
 /// `Active` only after the repository returns the journal's expected pins.
 ///
@@ -690,7 +796,7 @@ mod tests {
         prepare_generation_zero, seal_object, CatalogV1, GenerationZeroPolicyV1,
         GenerationZeroRandomness, ObjectKind, ObjectRandomness, PublicationJournalV1,
         V1ApplicationRepositoryFactory, V1Keys, ADD_ITEM_RANDOM_BYTES, DELETE_ITEM_RANDOM_BYTES,
-        GENERATION_ZERO_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
+        GENERATION_ZERO_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
     };
     use coding_adventures_ed25519::{generate_keypair, sign};
     use coding_adventures_vault_pm_domain::{
@@ -844,6 +950,14 @@ mod tests {
             *byte = (index as u8).wrapping_mul(31).wrapping_add(seed);
         }
         DeleteItemRandomnessV1::new(bytes)
+    }
+
+    fn restore_item_randomness(seed: u8) -> RestoreItemRandomnessV1 {
+        let mut bytes = [0; RESTORE_ITEM_RANDOM_BYTES];
+        for (index, byte) in bytes.iter_mut().enumerate() {
+            *byte = (index as u8).wrapping_mul(37).wrapping_add(seed);
+        }
+        RestoreItemRandomnessV1::new(bytes)
     }
 
     fn new_login_document(item_id: ItemId, title: &str, password: &str) -> ItemDocument {
@@ -2426,6 +2540,235 @@ mod tests {
         assert_eq!(
             session.item_history(item_id, MAX_ITEM_HISTORY_LIMIT + 1),
             Err(ApplicationError::BoundExceeded)
+        );
+    }
+
+    #[test]
+    fn restore_item_copies_one_reachable_live_revision_without_rewinding_heads() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let add_randomness = add_item_randomness(0xa1);
+        let item_id = add_randomness.item_id();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .add_item(
+            new_login_document(item_id, "Restore me", "original-secret"),
+            600,
+            add_randomness,
+            &local,
+        )
+        .unwrap();
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let original_revision = session.current_catalog.items[&item_id][0].revision_id();
+        session
+            .replace_item(
+                original_revision,
+                new_login_document(item_id, "Changed", "changed-secret"),
+                601,
+                replace_item_randomness(0xb1),
+                &local,
+            )
+            .unwrap();
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let changed_revision = session.current_catalog.items[&item_id][0].revision_id();
+        session
+            .delete_item(
+                changed_revision,
+                602,
+                603,
+                delete_item_randomness(0xc1),
+                &local,
+            )
+            .unwrap();
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let tombstone_revision = session.current_catalog.items[&item_id][0].revision_id();
+        let prior_heads = session.local_pins().clone();
+        let active = session
+            .restore_item(
+                original_revision,
+                604,
+                restore_item_randomness(0xd1),
+                &local,
+            )
+            .unwrap();
+        assert_eq!(active.last_device_counter(), 5);
+
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let [candidate] = reopened.current_catalog.items[&item_id].as_slice() else {
+            panic!("restoration must become the sole current candidate")
+        };
+        let restored_revision = candidate.revision_id();
+        assert_ne!(restored_revision, original_revision);
+        assert_eq!(
+            candidate.causal_parents(),
+            &BTreeSet::from([original_revision])
+        );
+        let ItemState::Live(document) = candidate.state() else {
+            panic!("restoration must create a live revision")
+        };
+        let AnyRecord::Login(login) = document.payload() else {
+            panic!("restoration must preserve the selected schema")
+        };
+        assert_eq!(login.title, "Restore me");
+        assert_eq!(login.password, "original-secret");
+        let history = reopened.item_history(item_id, 100).unwrap();
+        assert_eq!(
+            history
+                .iter()
+                .map(ItemHistoryViewV1::revision_id)
+                .collect::<Vec<_>>(),
+            vec![
+                restored_revision,
+                tombstone_revision,
+                changed_revision,
+                original_revision
+            ]
+        );
+        let head = *reopened.open_report().heads().iter().next().unwrap();
+        let commit = reopened._repository.read_commit(head).unwrap();
+        assert_eq!(
+            commit.parents(),
+            prior_heads.iter().copied().collect::<Vec<_>>()
+        );
+        assert_eq!(commit.added_objects().len(), 2);
+        assert_eq!(commit.wall_time_ms(), 604);
+    }
+
+    #[test]
+    fn restore_item_rejects_missing_current_and_tombstone_selections_before_cas() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let add_randomness = add_item_randomness(0xe1);
+        let item_id = add_randomness.item_id();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .add_item(
+            new_login_document(item_id, "Restore guards", "secret"),
+            610,
+            add_randomness,
+            &local,
+        )
+        .unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let live_revision = session.current_catalog.items[&item_id][0].revision_id();
+        let exact_live = local.0.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            session.restore_item(live_revision, 611, restore_item_randomness(0xf1), &local,),
+            Err(ApplicationError::InvalidInput)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_live.as_slice())
+        );
+
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .delete_item(
+            live_revision,
+            612,
+            613,
+            delete_item_randomness(0x01),
+            &local,
+        )
+        .unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let tombstone_revision = session.current_catalog.items[&item_id][0].revision_id();
+        let exact_deleted = local.0.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            session.restore_item(
+                tombstone_revision,
+                614,
+                restore_item_randomness(0x11),
+                &local,
+            ),
+            Err(ApplicationError::InvalidInput)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_deleted.as_slice())
+        );
+
+        assert_eq!(
+            open_active_vault(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                locator,
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap()
+            .restore_item(
+                RevisionId::new([0x7f; 32]),
+                615,
+                restore_item_randomness(0x21),
+                &local,
+            ),
+            Err(ApplicationError::NotFound)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_deleted.as_slice())
         );
     }
 

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1311,8 +1311,11 @@ changelog, focused build, and downstream validation.
    7b-2. bounded item-history materialization across every current head,
        decrypting distinct historical catalogs and revisions into deterministic
        secret-free views for restore selection without provider-specific reads;
-   7b-3. restore-by-revision and explicit conflict-resolution mutation
-       workflows;
+   7b-3. completed restore-by-revision mutation workflow, proving the selected
+       live revision is reachable through bounded current-head history, copying
+       its authenticated document into a new one-parent revision, and reusing
+       exact crash-resumable publication without rewinding repository heads;
+   7b-4. explicit conflict-resolution mutation workflows;
    7c. bounded history traversal and explicit zeroizing field reveal;
    7d. authenticated portable export and restore/import preparation; and
    7e. audit, status, and doctor workflows; and


### PR DESCRIPTION
## Summary

- restore a selected reachable historical live revision as a new current revision without rewinding repository heads
- prove selection reachability through bounded current-head catalog ancestry and fail closed on current conflicts
- reuse the exact crash-resumable mutation publication state machine and record explicit conflict resolution as the next backlog item

## Security properties

- reject unreachable revisions, tombstones, and the already-current revision before local persistence
- copy authenticated historical plaintext only inside the consumed unlocked session
- make the selected historical revision the sole causal parent while preserving all current commit heads and immutable history

## Verification

- 83 package tests
- strict Clippy and warning-free rustdoc
- Tarpaulin: 2,151/2,261 lines (95.13%)
- monorepo planner: 1 changed package, 21 affected packages, all 21 built with Clippy