### PR TITLE
Add explicit vault conflict resolution

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this package are documented here.
 
+## [0.18.0] - 2026-08-09
+
+### Added
+
+- Add deterministic redacted inspection for every retained current conflict
+  candidate, including typed live metadata and tombstone markers.
+- Add a session-consuming choose-candidate resolution workflow and owned
+  wipe-on-drop randomness for its three encrypted frames.
+
+### Security
+
+- Publish the selected authenticated live document or tombstone as a new
+  revision whose direct parents include the complete current conflict set.
+- Preserve every losing candidate as immutable reachable history, reject
+  missing and unconflicted selections before local persistence, and never ask
+  the host to round-trip secret plaintext.
+
 ## [0.17.0] - 2026-08-09
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -134,10 +134,20 @@ selected revision, then uses the same all-head commit, exact pending journal,
 ambiguous-success handling, and recovery path as other mutations. It never
 rewinds heads, mutates historical bytes, or asks the host to resupply plaintext.
 
+Current conflicts can now be inspected without revealing secret fields. The
+session returns every retained candidate in exact revision-ID order using the
+same typed redacted live view or tombstone marker as history. Choosing one
+authenticated candidate consumes the session and republishes its complete live
+document or tombstone as a new revision whose direct parents are the entire
+current conflict set. The resolution never selects implicitly, drops a losing
+candidate, rewrites history, or asks the host to round-trip plaintext. A later
+slice will add user-authored merged-document resolution after explicit field
+reveal.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
-credential store, or entropy source. Conflict resolution, explicit history
-reveal, export, audit, and doctor workflows land in the next slices.
+credential store, or entropy source. User-authored conflict merging, explicit
+history reveal, export, audit, and doctor workflows land in the next slices.
 There is no unchecked
 repository verification path: construction decrypts and
 authority-verifies the exact locally pinned certificate frame and object ID,
@@ -159,8 +169,8 @@ paths, and complete error translation.
 Search tests cover Unicode normalization, short queries, oversized safe-field
 fallback, exact collection filters, deterministic product ordering, every
 record schema's allowlist/denylist, secret exclusion, query/result bounds, and
-conflict closure. The exact Tarpaulin LLVM result is 1,996 of 2,088 production
-lines (95.59%). Add-item tests cover exact entropy partitioning and wiping,
+conflict closure. The exact Tarpaulin LLVM result is 2,204 of 2,315 production
+lines (95.21%). Add-item tests cover exact entropy partitioning and wiping,
 identity validation before local writes, parentless revision and complete
 catalog construction, ambiguous successful compare-exchanges, write-ahead
 publication ordering, ambiguous provider commits, failed final activation,
@@ -170,6 +180,10 @@ stale/missing rejection before compare-exchange, and secret/entropy wiping.
 Deletion tests prove one-parent tombstone causality, advisory timestamp
 separation, ordinary-view omission, repeat/missing rejection before
 compare-exchange, and entropy redaction/wiping.
+Conflict-resolution tests prove deterministic redacted inspection, live and
+tombstone selection, complete multi-parent causality, immutable losing-candidate
+retention, missing/unconflicted rejection before compare-exchange, and entropy
+redaction/wiping.
 
 ## Development
 

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -32,8 +32,9 @@ pub use initialize::{
     GENERATION_ZERO_RANDOM_BYTES,
 };
 pub use mutation::{
-    AddItemRandomnessV1, DeleteItemRandomnessV1, ReplaceItemRandomnessV1, RestoreItemRandomnessV1,
-    ADD_ITEM_RANDOM_BYTES, DELETE_ITEM_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
+    AddItemRandomnessV1, DeleteItemRandomnessV1, ReplaceItemRandomnessV1,
+    ResolveItemConflictRandomnessV1, RestoreItemRandomnessV1, ADD_ITEM_RANDOM_BYTES,
+    DELETE_ITEM_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES, RESOLVE_ITEM_CONFLICT_RANDOM_BYTES,
     RESTORE_ITEM_RANDOM_BYTES,
 };
 pub use open::{

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -25,6 +25,8 @@ pub const REPLACE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
 pub const DELETE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
 /// Exact caller-filled CSPRNG bytes consumed by one restore-item mutation.
 pub const RESTORE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
+/// Exact caller-filled CSPRNG bytes consumed by one conflict-resolution mutation.
+pub const RESOLVE_ITEM_CONFLICT_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
 
 /// Owned wipe-on-drop entropy for one item ID and three encrypted frames.
 pub struct AddItemRandomnessV1 {
@@ -152,6 +154,36 @@ impl Drop for RestoreItemRandomnessV1 {
 impl Debug for RestoreItemRandomnessV1 {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         formatter.write_str("RestoreItemRandomnessV1(<redacted>)")
+    }
+}
+
+/// Owned wipe-on-drop entropy for the three encrypted conflict-resolution frames.
+pub struct ResolveItemConflictRandomnessV1 {
+    bytes: [u8; RESOLVE_ITEM_CONFLICT_RANDOM_BYTES],
+}
+
+impl ResolveItemConflictRandomnessV1 {
+    /// Take one exact block filled by the host's cryptographic entropy source.
+    pub const fn new(bytes: [u8; RESOLVE_ITEM_CONFLICT_RANDOM_BYTES]) -> Self {
+        Self { bytes }
+    }
+}
+
+impl Zeroize for ResolveItemConflictRandomnessV1 {
+    fn zeroize(&mut self) {
+        self.bytes.zeroize();
+    }
+}
+
+impl Drop for ResolveItemConflictRandomnessV1 {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl Debug for ResolveItemConflictRandomnessV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("ResolveItemConflictRandomnessV1(<redacted>)")
     }
 }
 
@@ -338,6 +370,56 @@ pub(crate) fn restore_item(
         item_id,
         ItemState::Live(document.clone()),
         &BTreeSet::from([selected.revision_id()]),
+        wall_time_ms,
+        &randomness.bytes,
+    )?;
+    publish_mutation(active, repository, publication, local_state_store)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn resolve_item_conflict(
+    active: &ActiveStateV1,
+    report: &OpenReport,
+    current_items: &BTreeMap<ItemId, Vec<ItemCandidate>>,
+    keys: &V1Keys,
+    local_secret: &LocalSecretV1,
+    repository: &dyn ApplicationRepository,
+    selected_revision: RevisionId,
+    wall_time_ms: u64,
+    randomness: ResolveItemConflictRandomnessV1,
+    local_state_store: &dyn LocalStateStore,
+) -> Result<ActiveStateV1, ApplicationError> {
+    if report.heads() != active.pinned_heads() {
+        return Err(ApplicationError::ConcurrentHost);
+    }
+    let (item_id, candidates) = current_items
+        .iter()
+        .find(|(_, candidates)| {
+            candidates
+                .iter()
+                .any(|candidate| candidate.revision_id() == selected_revision)
+        })
+        .ok_or(ApplicationError::NotFound)?;
+    if candidates.len() < 2 {
+        return Err(ApplicationError::ConflictRequired);
+    }
+    let selected = candidates
+        .iter()
+        .find(|candidate| candidate.revision_id() == selected_revision)
+        .ok_or(ApplicationError::InternalInvariant)?;
+    let causal_parents = candidates
+        .iter()
+        .map(ItemCandidate::revision_id)
+        .collect::<BTreeSet<_>>();
+
+    let publication = prepare_item_publication(
+        active,
+        current_items,
+        keys,
+        local_secret,
+        *item_id,
+        selected.state().clone(),
+        &causal_parents,
         wall_time_ms,
         &randomness.bytes,
     )?;
@@ -611,6 +693,21 @@ mod tests {
             "RestoreItemRandomnessV1(<redacted>)"
         );
         assert!(randomness.bytes.iter().all(|byte| *byte == 0xc3));
+
+        randomness.zeroize();
+        assert!(randomness.bytes.iter().all(|byte| *byte == 0));
+    }
+
+    #[test]
+    fn conflict_resolution_randomness_redacts_and_zeroizes() {
+        let mut randomness =
+            ResolveItemConflictRandomnessV1::new([0x6d; RESOLVE_ITEM_CONFLICT_RANDOM_BYTES]);
+
+        assert_eq!(
+            format!("{randomness:?}"),
+            "ResolveItemConflictRandomnessV1(<redacted>)"
+        );
+        assert!(randomness.bytes.iter().all(|byte| *byte == 0x6d));
 
         randomness.zeroize();
         assert!(randomness.bytes.iter().all(|byte| *byte == 0));

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1,7 +1,8 @@
 use crate::initialize::{unlock_active_material, UnlockedActiveMaterial};
 use crate::mutation::{
-    add_item, delete_item, replace_item, restore_item, AddItemRandomnessV1, DeleteItemRandomnessV1,
-    ReplaceItemRandomnessV1, RestoreItemRandomnessV1,
+    add_item, delete_item, replace_item, resolve_item_conflict, restore_item, AddItemRandomnessV1,
+    DeleteItemRandomnessV1, ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1,
+    RestoreItemRandomnessV1,
 };
 use crate::search::SearchProjectionV1;
 use crate::{
@@ -246,6 +247,30 @@ impl UnlockedVaultV1 {
         .collect()
     }
 
+    /// Return every retained current candidate for one conflicted item as a
+    /// deterministic secret-free view.
+    ///
+    /// Candidates are ordered by exact revision ID. A missing item returns
+    /// `NotFound`; an item with fewer than two current candidates returns
+    /// `ConflictRequired`. No candidate is selected or discarded.
+    pub fn conflict_candidates(
+        &self,
+        item_id: ItemId,
+    ) -> Result<Vec<ItemHistoryViewV1>, ApplicationError> {
+        let candidates = self
+            .current_catalog
+            .items
+            .get(&item_id)
+            .ok_or(ApplicationError::NotFound)?;
+        if candidates.len() < 2 {
+            return Err(ApplicationError::ConflictRequired);
+        }
+        candidates
+            .iter()
+            .map(ItemHistoryViewV1::from_candidate)
+            .collect()
+    }
+
     /// Add one new item through the exact crash-resumable publication state
     /// machine and return the resulting durable active owner state.
     ///
@@ -367,6 +392,34 @@ impl UnlockedVaultV1 {
             &self._local_secret,
             self._repository.as_ref(),
             selected,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+        )
+    }
+
+    /// Resolve one current conflict by choosing an existing authenticated
+    /// candidate and publishing it as a new current revision.
+    ///
+    /// The selected revision must be one of at least two current candidates.
+    /// The resolution revision copies its complete live document or tombstone
+    /// and names every retained current candidate as a direct causal parent.
+    /// This consumes the session and never deletes the losing immutable bytes.
+    pub fn resolve_item_conflict(
+        self,
+        selected_revision: RevisionId,
+        wall_time_ms: u64,
+        randomness: ResolveItemConflictRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        resolve_item_conflict(
+            &self.active,
+            &self.report,
+            &self.current_catalog.items,
+            &self._keys,
+            &self._local_secret,
+            self._repository.as_ref(),
+            selected_revision,
             wall_time_ms,
             randomness,
             local_state_store,
@@ -796,7 +849,8 @@ mod tests {
         prepare_generation_zero, seal_object, CatalogV1, GenerationZeroPolicyV1,
         GenerationZeroRandomness, ObjectKind, ObjectRandomness, PublicationJournalV1,
         V1ApplicationRepositoryFactory, V1Keys, ADD_ITEM_RANDOM_BYTES, DELETE_ITEM_RANDOM_BYTES,
-        GENERATION_ZERO_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
+        GENERATION_ZERO_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
+        RESOLVE_ITEM_CONFLICT_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
     };
     use coding_adventures_ed25519::{generate_keypair, sign};
     use coding_adventures_vault_pm_domain::{
@@ -958,6 +1012,14 @@ mod tests {
             *byte = (index as u8).wrapping_mul(37).wrapping_add(seed);
         }
         RestoreItemRandomnessV1::new(bytes)
+    }
+
+    fn resolve_item_conflict_randomness(seed: u8) -> ResolveItemConflictRandomnessV1 {
+        let mut bytes = [0; RESOLVE_ITEM_CONFLICT_RANDOM_BYTES];
+        for (index, byte) in bytes.iter_mut().enumerate() {
+            *byte = (index as u8).wrapping_mul(41).wrapping_add(seed);
+        }
+        ResolveItemConflictRandomnessV1::new(bytes)
     }
 
     fn new_login_document(item_id: ItemId, title: &str, password: &str) -> ItemDocument {
@@ -1123,6 +1185,60 @@ mod tests {
         )
         .unwrap();
         publication_for_catalog(active, vec![revision_frame], catalog_frame)
+    }
+
+    fn pending_live_conflict_publication(
+        active: &ActiveStateV1,
+        item_id: ItemId,
+    ) -> (PublicationJournalV1, Vec<(RevisionId, String)>) {
+        let fixture = generation_zero_bytes();
+        let root_key: [u8; 32] = fixture[48..80].try_into().unwrap();
+        let keys = V1Keys::derive(active.vault_id(), &root_key).unwrap();
+        let mut objects = Vec::new();
+        let mut revisions = Vec::new();
+        for (index, (title, password)) in
+            [("Keep left", "left-secret"), ("Keep right", "right-secret")]
+                .into_iter()
+                .enumerate()
+        {
+            let candidate = ItemCandidate::new(
+                RevisionId::new([0; 32]),
+                [],
+                ItemState::Live(Box::new(new_login_document(item_id, title, password))),
+            )
+            .unwrap();
+            let base = 0xb0u8.wrapping_add(index as u8 * 3);
+            let frame = seal_object(
+                &keys,
+                ObjectKind::ItemRevision,
+                &encode_item_revision(candidate.causal_parents(), candidate.state()).unwrap(),
+                &ObjectRandomness::new([base; 32], [base + 1; 24], [base + 2; 24]),
+            )
+            .unwrap();
+            let revision_id = RevisionId::new(*frame.id().unwrap().as_bytes());
+            revisions.push((revision_id, title.to_owned()));
+            objects.push(frame);
+        }
+        revisions.sort_unstable_by_key(|(revision_id, _)| *revision_id);
+        let catalog = CatalogV1::new(BTreeMap::from([(
+            item_id,
+            revisions
+                .iter()
+                .map(|(revision_id, _)| *revision_id)
+                .collect(),
+        )]))
+        .unwrap();
+        let catalog_frame = seal_object(
+            &keys,
+            ObjectKind::Catalog,
+            &catalog.encode().unwrap(),
+            &ObjectRandomness::new([0xc0; 32], [0xc1; 24], [0xc2; 24]),
+        )
+        .unwrap();
+        (
+            publication_for_catalog(active, objects, catalog_frame),
+            revisions,
+        )
     }
 
     fn pending_dangling_catalog(active: &ActiveStateV1) -> PublicationJournalV1 {
@@ -1534,6 +1650,259 @@ mod tests {
                 Some(exact_state.as_slice())
             );
         }
+    }
+
+    #[test]
+    fn conflict_candidates_are_redacted_and_choose_resolution_retains_every_parent() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x2a; 16]);
+        let (publication, revisions) = pending_live_conflict_publication(&active, item_id);
+        let pending = LocalVaultStateV1::pending_publication(active, publication).unwrap();
+        *local.0.lock().unwrap() = Some(pending.encode().unwrap());
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let views = session.conflict_candidates(item_id).unwrap();
+        assert_eq!(
+            views
+                .iter()
+                .map(ItemHistoryViewV1::revision_id)
+                .collect::<Vec<_>>(),
+            revisions
+                .iter()
+                .map(|(revision_id, _)| *revision_id)
+                .collect::<Vec<_>>()
+        );
+        let titles = views
+            .iter()
+            .map(|view| {
+                let RedactedRecordView::Login { title, .. } = &view.redacted_item().unwrap().record
+                else {
+                    panic!("conflict fixture must contain logins")
+                };
+                title.as_str()
+            })
+            .collect::<Vec<_>>();
+        assert!(titles.contains(&"Keep left"));
+        assert!(titles.contains(&"Keep right"));
+        let debug = format!("{views:?}");
+        for hidden in [
+            "Keep left",
+            "Keep right",
+            "left-secret",
+            "right-secret",
+            &item_id.to_user_string(),
+        ] {
+            assert!(!debug.contains(hidden));
+        }
+
+        let selected_revision = revisions
+            .iter()
+            .find(|(_, title)| title == "Keep right")
+            .map(|(revision_id, _)| *revision_id)
+            .unwrap();
+        let prior_heads = session.local_pins().clone();
+        let resolved = session
+            .resolve_item_conflict(
+                selected_revision,
+                401,
+                resolve_item_conflict_randomness(0x4d),
+                &local,
+            )
+            .unwrap();
+        assert_eq!(resolved.last_device_counter(), 3);
+
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.conflicted_item_count(), 0);
+        let [candidate] = reopened.current_catalog.items[&item_id].as_slice() else {
+            panic!("resolution must become the sole current candidate")
+        };
+        assert_eq!(
+            candidate.causal_parents(),
+            &revisions
+                .iter()
+                .map(|(revision_id, _)| *revision_id)
+                .collect::<BTreeSet<_>>()
+        );
+        let ItemState::Live(document) = candidate.state() else {
+            panic!("selected live conflict candidate must remain live")
+        };
+        let AnyRecord::Login(login) = document.payload() else {
+            panic!("selected conflict candidate must retain its schema")
+        };
+        assert_eq!(login.title, "Keep right");
+        assert_eq!(login.password, "right-secret");
+        assert_eq!(reopened.item_history(item_id, 100).unwrap().len(), 3);
+        let head = *reopened.open_report().heads().iter().next().unwrap();
+        let commit = reopened._repository.read_commit(head).unwrap();
+        assert_eq!(
+            commit.parents(),
+            prior_heads.iter().copied().collect::<Vec<_>>()
+        );
+        assert_eq!(commit.added_objects().len(), 2);
+        assert_eq!(commit.wall_time_ms(), 401);
+    }
+
+    #[test]
+    fn conflict_resolution_rejects_missing_or_unconflicted_revisions_before_cas() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            session.conflict_candidates(ItemId::new([0x2b; 16])),
+            Err(ApplicationError::NotFound)
+        );
+        let exact_empty = local.0.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            session.resolve_item_conflict(
+                RevisionId::new([0x2c; 32]),
+                410,
+                resolve_item_conflict_randomness(0x5d),
+                &local,
+            ),
+            Err(ApplicationError::NotFound)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_empty.as_slice())
+        );
+
+        let add_randomness = add_item_randomness(0x6d);
+        let item_id = add_randomness.item_id();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .add_item(
+            new_login_document(item_id, "Sole candidate", "only-secret"),
+            411,
+            add_randomness,
+            &local,
+        )
+        .unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(
+            session.conflict_candidates(item_id),
+            Err(ApplicationError::ConflictRequired)
+        );
+        let sole_revision = session.current_catalog.items[&item_id][0].revision_id();
+        let exact_sole = local.0.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            session.resolve_item_conflict(
+                sole_revision,
+                412,
+                resolve_item_conflict_randomness(0x7d),
+                &local,
+            ),
+            Err(ApplicationError::ConflictRequired)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_sole.as_slice())
+        );
+    }
+
+    #[test]
+    fn conflict_resolution_can_choose_a_retained_tombstone_without_losing_parents() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x2d; 16]);
+        let (publication, revisions) =
+            pending_tombstone_publication(&active, item_id, item_id, 2, None);
+        let pending = LocalVaultStateV1::pending_publication(active, publication).unwrap();
+        *local.0.lock().unwrap() = Some(pending.encode().unwrap());
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let views = session.conflict_candidates(item_id).unwrap();
+        assert!(views.iter().all(ItemHistoryViewV1::is_deleted));
+        session
+            .resolve_item_conflict(
+                revisions[1],
+                420,
+                resolve_item_conflict_randomness(0x8d),
+                &local,
+            )
+            .unwrap();
+
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.get_item(item_id).unwrap(), None);
+        let [candidate] = reopened.current_catalog.items[&item_id].as_slice() else {
+            panic!("resolution must become the sole current candidate")
+        };
+        assert!(matches!(candidate.state(), ItemState::Tombstone(_)));
+        assert_eq!(
+            candidate.causal_parents(),
+            &revisions.into_iter().collect::<BTreeSet<_>>()
+        );
     }
 
     #[test]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1315,7 +1315,11 @@ changelog, focused build, and downstream validation.
        live revision is reachable through bounded current-head history, copying
        its authenticated document into a new one-parent revision, and reusing
        exact crash-resumable publication without rewinding repository heads;
-   7b-4. explicit conflict-resolution mutation workflows;
+   7b-4a. completed redacted current-conflict inspection and explicit
+       choose-candidate resolution, publishing every retained candidate as a
+       causal parent;
+   7b-4b. user-authored merged-document conflict resolution after explicit
+       field reveal;
    7c. bounded history traversal and explicit zeroizing field reveal;
    7d. authenticated portable export and restore/import preparation; and
    7e. audit, status, and doctor workflows; and


### PR DESCRIPTION
## Summary

- expose every retained current conflict candidate through deterministic typed redacted views
- add a session-consuming choose-candidate resolution mutation for live and tombstone candidates
- publish the resolution as a new revision whose direct parents are the complete current conflict set
- preserve losing candidates as immutable reachable history and record user-authored merge resolution as the next reveal-dependent backlog item

## Security properties

- never select an implicit winner or return a partial conflict
- never ask the host to round-trip secret plaintext for choose-candidate resolution
- reject missing and already-unambiguous selections before the local write-ahead compare-exchange
- consume the unlocked session and owned 240-byte randomness block on every return path
- reuse all-head commit parenting, the exact crash-resumable pending-publication journal, and ambiguous-success checks

## Verification

- `bash BUILD` (87 tests)
- `cargo test --manifest-path code/packages/rust/vault-pm-application/Cargo.toml`
- `cargo clippy --manifest-path code/packages/rust/vault-pm-application/Cargo.toml --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path code/packages/rust/vault-pm-application/Cargo.toml --no-deps`
- Tarpaulin LLVM: 2,204 / 2,315 production lines (95.21%)
- repository build planner: 1,001 packages evaluated, 1 changed, 21 affected, all 21 built with Clippy
