### PR TITLE
Unify Mosaic package composition across compile entry points

### DIFF
--- a/code/packages/rust/mosaic-compile/CHANGELOG.md
+++ b/code/packages/rust/mosaic-compile/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed - dependency styles in standalone pipeline mode
+
+Standalone `--interface` / `--layout` / `--style` builds now use the same
+package-composition API as `mosaic-compile pkg`. Qualified dependency layouts
+and their MSL styles therefore reach every backend together; reusable package
+components no longer render structurally correct but unstyled outside package
+mode.
+
 ### Added - `--theme` selector for the `pkg` subcommand
 
 `mosaic-compile pkg <ROOT> --backend <b> --output <dir> --theme <name>` selects

--- a/code/packages/rust/mosaic-compile/Cargo.toml
+++ b/code/packages/rust/mosaic-compile/Cargo.toml
@@ -26,9 +26,7 @@ mosaic-emit-qt = { path = "../mosaic-emit-qt" }
 mosaic-emit-flutter = { path = "../mosaic-emit-flutter" }
 mosaic-emit-compose = { path = "../mosaic-emit-compose" }
 mosaic-package-manifest = { path = "../mosaic-package-manifest" }
-mosaic-package-resolver = { path = "../mosaic-package-resolver" }
 mosmodel-compiler = { path = "../mosmodel-compiler" }
-moslayout-compiler = { path = "../moslayout-compiler" }
 mosstyle-compiler = { path = "../mosstyle-compiler" }
 mosaic-package-artifact-builder = { path = "../mosaic-package-artifact-builder" }
 serde_json = "1"

--- a/code/packages/rust/mosaic-compile/README.md
+++ b/code/packages/rust/mosaic-compile/README.md
@@ -80,6 +80,11 @@ Pipeline mode supports the text/native emitter family (`react`, `html`,
 `webcomponent`, `swiftui`, `qt`, `xaml`, `compose`, and `flutter`). The `paint` backend
 remains legacy single-file only.
 
+When a layout contains `pkg::package::Component`, pipeline mode resolves that
+component and merges its MSL defaults before the consumer's own styles. This is
+the same composition path used by package mode, so reusable controls keep their
+authored appearance in every backend.
+
 Package mode compiles a Mosaic package directory that contains
 `mosaic-package.toml` plus `src/*.mil`, `src/*.mll`, and optional `src/*.msl`
 files:

--- a/code/packages/rust/mosaic-compile/src/main.rs
+++ b/code/packages/rust/mosaic-compile/src/main.rs
@@ -26,17 +26,18 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process;
 
-// UI34 PR-3 — package-reference resolver.  Wired into the
-// `run_pipeline` path between `moslayout_compiler::compile()` and the
-// backend emitter so every `pkg::P::C` reference in the consumer's
-// layout is substituted before any emitter sees it.
+// Package composition is delegated to mosaic-package-artifact-builder so the
+// standalone and package CLI entry points share layout resolution and style
+// merging before any backend sees the component.
 use cli_builder::types::ParserOutput;
 use cli_builder::{load_spec_from_file, Parser};
 use mosaic_analyzer::analyze;
 use mosaic_emit_html::HtmlRenderer;
 use mosaic_emit_react::ReactRenderer;
 use mosaic_emit_webcomponent::WebComponentRenderer;
-use mosaic_package_artifact_builder::{build_package, Backend, BuildOptions};
+use mosaic_package_artifact_builder::{
+    build_package, compose_component_with_model, Backend, BuildOptions,
+};
 use mosaic_vm::MosaicVM;
 
 // ===========================================================================
@@ -661,15 +662,6 @@ fn run_pipeline(
     // every `@slot` and `emit onX` reference resolves correctly.
     let layout_path = resolved_layout_path.as_str();
     let layout_src = read_file_or_die(layout_path);
-    let mut layout_out =
-        moslayout_compiler::compile(&layout_src, Some(&mosmodel_out.descriptor_json))
-            .unwrap_or_else(|errs| {
-                eprintln!("mosaic-compile: moslayout error(s) in {layout_path}:");
-                for e in errs {
-                    eprintln!("  {e:?}");
-                }
-                process::exit(1);
-            });
 
     // -- 2b. UI34 — resolve `pkg::P::C` qualified references -------------
     //
@@ -702,58 +694,29 @@ fn run_pipeline(
             paths
         }
     };
-    let resolver = mosaic_package_resolver::LayoutPackageResolver::new(search_paths);
-    if let Err(e) = resolver.resolve(&mut layout_out.def) {
-        eprintln!("mosaic-compile: package-resolver error in {layout_path}:");
-        eprintln!("  {e:?}");
-        process::exit(1);
-    }
-    if let Some(t) = mosaic_package_resolver::first_qualified_tag(&layout_out.def.root) {
-        // Defensive — the resolver should leave no qualified tags
-        // behind.  If one slips through we exit cleanly rather than
-        // letting it confuse the backend emitter.
-        eprintln!(
-            "mosaic-compile: internal error: package-resolver left \
-             qualified tag `{t}` in the layout"
-        );
-        process::exit(1);
-    }
-    // Re-run `validate()` on the resolved tree so the part-map JSON
-    // reflects the package's inlined parts.  Without this, the
-    // consumer's `.msl` would reject the package's part names as
-    // unknown — they came from the package's `.mll`, not the
-    // consumer's.  Resolution is also a chance for the validator to
-    // catch any slot/emit mismatches that survived the package call,
-    // surfacing them with the same UnknownSlot / UnknownEmit
-    // diagnostics that pre-UI34 builds get.
-    let resolved_parts =
-        moslayout_compiler::validate(&layout_out.def, Some(&mosmodel_out.descriptor_json))
-            .unwrap_or_else(|errs| {
-                eprintln!(
-                    "mosaic-compile: moslayout post-resolver validation error(s) in {layout_path}:"
-                );
-                for e in errs {
-                    eprintln!("  {e:?}");
-                }
-                process::exit(1);
-            });
-    layout_out.parts = resolved_parts;
-    layout_out.part_map_json =
-        moslayout_compiler::emit_part_map_json(&layout_out.def.component_name, &layout_out.parts);
-
-    // -- 3. Compile the mosstyle file ---------------------------------------
+    // -- 3. Compose package layout + style ----------------------------------
     //
-    // The part map JSON from moslayout tells mosstyle which part names are
-    // legal targets for style blocks.
+    // The shared package-composition path resolves qualified dependency
+    // layouts, rebuilds the resolved part map, and merges dependency styles
+    // before any backend sees the component. Package and standalone builds
+    // therefore consume identical composed IR.
     let style_src = read_file_or_die(style_path);
-    let style_out = mosstyle_compiler::compile(&style_src, Some(&layout_out.part_map_json))
-        .unwrap_or_else(|errs| {
-            eprintln!("mosaic-compile: mosstyle error(s) in {style_path}:");
-            for e in errs {
-                eprintln!("  {e:?}");
-            }
-            process::exit(1);
-        });
+    let component_name = mosmodel_out.component.component.clone();
+    let composed = compose_component_with_model(
+        &component_name,
+        mosmodel_out,
+        &layout_src,
+        &style_src,
+        &search_paths,
+        None,
+    )
+    .unwrap_or_else(|error| {
+        eprintln!("mosaic-compile: package composition failed for {component_name}: {error}");
+        process::exit(1);
+    });
+    let mosmodel_out = composed.model;
+    let layout_out = composed.layout;
+    let style_def = composed.style;
 
     // -- 3b. Warn on style parts that match no layout part ------------------
     //
@@ -766,8 +729,7 @@ fn run_pipeline(
     // (Grid.light.msl used the legacy `sheet/cell` naming). Surface it here so
     // the typo can't hide: a warning by default, a hard error under
     // --strict-style for CI that wants to fail on stale stylesheets.
-    let unmatched =
-        mosstyle_compiler::unmatched_parts(&style_out.def, Some(&layout_out.part_map_json));
+    let unmatched = mosstyle_compiler::unmatched_parts(&style_def, Some(&layout_out.part_map_json));
     if !unmatched.is_empty() {
         let component = &layout_out.def.component_name;
         for u in &unmatched {
@@ -809,7 +771,7 @@ fn run_pipeline(
             let result = mosaic_emit_react::pipeline::from_pipeline_with_options(
                 &mosmodel_out.component,
                 &layout_out.def,
-                &style_out.def,
+                &style_def,
                 &react_opts,
             )
             .unwrap_or_else(|e| {
@@ -879,7 +841,7 @@ fn run_pipeline(
             let result = mosaic_emit_xaml::from_pipeline(
                 &mosmodel_out.component,
                 &layout_out.def,
-                &style_out.def,
+                &style_def,
                 registry.as_ref(),
                 &opts,
             )
@@ -968,7 +930,7 @@ fn run_pipeline(
             let result = mosaic_emit_html::pipeline::from_pipeline_with_options(
                 &mosmodel_out.component,
                 &layout_out.def,
-                &style_out.def,
+                &style_def,
                 &html_opts,
             )
             .unwrap_or_else(|e| {
@@ -1013,7 +975,7 @@ fn run_pipeline(
             let result = mosaic_emit_webcomponent::pipeline::from_pipeline_with_options(
                 &mosmodel_out.component,
                 &layout_out.def,
-                &style_out.def,
+                &style_def,
                 &wc_opts,
             )
             .unwrap_or_else(|e| {
@@ -1059,7 +1021,7 @@ fn run_pipeline(
             let result = mosaic_emit_swiftui::pipeline::from_pipeline_with_options(
                 &mosmodel_out.component,
                 &layout_out.def,
-                &style_out.def,
+                &style_def,
                 &sw_opts,
             )
             .unwrap_or_else(|e| {
@@ -1115,7 +1077,7 @@ fn run_pipeline(
             let result = mosaic_emit_qt::pipeline::from_pipeline_with_options(
                 &mosmodel_out.component,
                 &layout_out.def,
-                &style_out.def,
+                &style_def,
                 &qt_opts,
             )
             .unwrap_or_else(|e| {
@@ -1162,7 +1124,7 @@ fn run_pipeline(
             let result = mosaic_emit_flutter::pipeline::from_pipeline_with_options(
                 &mosmodel_out.component,
                 &layout_out.def,
-                &style_out.def,
+                &style_def,
                 &fl_opts,
             )
             .unwrap_or_else(|e| {
@@ -1216,7 +1178,7 @@ fn run_pipeline(
             let result = mosaic_emit_compose::from_pipeline(
                 &mosmodel_out.component,
                 &layout_out.def,
-                &style_out.def,
+                &style_def,
             )
             .unwrap_or_else(|e| {
                 eprintln!("mosaic-compile: compose pipeline emit error: {e}");

--- a/code/packages/rust/mosaic-compile/tests/shared_composition.rs
+++ b/code/packages/rust/mosaic-compile/tests/shared_composition.rs
@@ -1,0 +1,121 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temporary_workspace() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "mosaic-compile-shared-composition-{}-{nonce}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&path).expect("temporary workspace");
+    path
+}
+
+fn write_dependency(root: &Path) {
+    let package = root.join("mosaic-pkg-accent");
+    let source = package.join("src");
+    fs::create_dir_all(&source).unwrap();
+    fs::write(
+        package.join("mosaic-package.toml"),
+        r#"[package]
+name = "mosaic-pkg-accent"
+version = "0.1.0"
+description = "standalone composition fixture"
+license = "MIT"
+
+[components]
+exports = ["Accent"]
+
+[dependencies]
+
+[kernel]
+version = "1"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        source.join("Accent.mil"),
+        "component Accent { slot label : text ; }",
+    )
+    .unwrap();
+    fs::write(
+        source.join("Accent.mll"),
+        r#"layout Accent {
+  Box [ accent-panel ] {
+    Text [ accent-label ] ( content : slot: label )
+  }
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        source.join("Accent.msl"),
+        r##"style Accent {
+  part accent-panel { background : "#123456" ; }
+  part accent-label { color : "#abcdef" ; }
+}"##,
+    )
+    .unwrap();
+}
+
+#[test]
+fn standalone_pipeline_preserves_dependency_styles() {
+    let workspace = temporary_workspace();
+    write_dependency(&workspace);
+    let consumer = workspace.join("consumer");
+    fs::create_dir_all(&consumer).unwrap();
+    let interface = consumer.join("Shell.mil");
+    let layout = consumer.join("Shell.mll");
+    let style = consumer.join("Shell.msl");
+    let output = consumer.join("Shell.html");
+    fs::write(&interface, "component Shell { slot label : text ; }").unwrap();
+    fs::write(
+        &layout,
+        r#"layout Shell {
+  Column [ shell-root ] {
+    pkg::mosaic-pkg-accent::Accent ( label : slot: label )
+  }
+}"#,
+    )
+    .unwrap();
+    fs::write(&style, "style Shell { part shell-root { padding : 8 ; } }").unwrap();
+
+    let result = Command::new(env!("CARGO_BIN_EXE_mosaic-compile"))
+        .args([
+            "--backend",
+            "html",
+            "--interface",
+            interface.to_str().unwrap(),
+            "--layout",
+            layout.to_str().unwrap(),
+            "--style",
+            style.to_str().unwrap(),
+            "--package-search-path",
+            workspace.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run mosaic-compile");
+
+    assert!(
+        result.status.success(),
+        "mosaic-compile failed:\n{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let html = fs::read_to_string(&output).expect("standalone HTML artifact");
+    assert!(
+        html.contains("#123456"),
+        "missing dependency panel style:\n{html}"
+    );
+    assert!(
+        html.contains("#abcdef"),
+        "missing dependency label style:\n{html}"
+    );
+
+    fs::remove_dir_all(workspace).ok();
+}

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased] - shared package composition
+
+- Added `compose_component` and `compose_component_with_model` as the canonical
+  MIL/MLL/MSL composition API: qualified layouts are resolved and dependency
+  styles are merged before backend emission.
+- Package component artifacts and generated project shells now consume that
+  shared result instead of maintaining duplicate compilation pipelines.
+
 ## [Unreleased] - reproducible XAML SDK selection
 
 - XAML package shells now preserve the emitter's `global.json`, keeping WinUI

--- a/code/packages/rust/mosaic-package-artifact-builder/README.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/README.md
@@ -23,6 +23,10 @@ the requested backend and writes a backend-shaped artifact tree:
 It is the library underneath the `mosaic-compile pkg <root> --backend <name>
 --output <dir>` CLI subcommand.
 
+`compose_component` is the canonical in-memory entry point shared by package
+builds and standalone three-file compilation. It returns the compiled model,
+resolved layout, and merged style definition without selecting a backend.
+
 Package references such as `pkg::mosaic-pkg-card::Card` are inlined before
 backend emission. Styles from referenced packages are compiled and merged first,
 then the consuming package's style is applied, so apps get reusable component
@@ -81,7 +85,8 @@ so a fresh emitted project is runnable without a separate build step.
 ## Boundaries
 
 - Cross-package layout inlining lives in `mosaic-package-resolver`; this crate
-  coordinates that resolver during artifact builds.
+  coordinates layout resolution and dependency-style composition for every
+  compile entry point.
 - Emitters stay backend-owned. This crate consumes their public
   `from_pipeline(interface, layout, style)` entry points.
 

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -375,6 +375,83 @@ impl From<ManifestError> for BuildError {
     }
 }
 
+/// Canonical three-language result after package composition.
+///
+/// Both package artifact builds and standalone `mosaic-compile` pipeline
+/// builds consume this type so qualified dependency layouts and their styles
+/// cannot drift between entry points.
+#[derive(Debug, Clone)]
+pub struct ComposedComponent {
+    pub model: mosmodel_compiler::CompileOutput,
+    pub layout: moslayout_compiler::CompileOutput,
+    pub style: mosstyle_compiler::StyleDef,
+}
+
+/// Compile MIL, MLL, and MSL sources into one package-composed component.
+///
+/// Qualified `pkg::P::C` layout nodes are resolved recursively before
+/// emission. Styles from those dependencies are collected in the same order
+/// and placed before the component's own styles, preserving the existing
+/// parent-overrides-dependency cascade.
+pub fn compose_component(
+    component: &str,
+    mil_src: &str,
+    mll_src: &str,
+    msl_src: &str,
+    package_search_paths: &[PathBuf],
+    theme: Option<&str>,
+) -> Result<ComposedComponent, BuildError> {
+    let model =
+        mosmodel_compiler::compile(mil_src).map_err(|errs| pipeline_err(component, &errs[0]))?;
+    compose_component_with_model(
+        component,
+        model,
+        mll_src,
+        msl_src,
+        package_search_paths,
+        theme,
+    )
+}
+
+/// Complete package composition from an interface model compiled by a caller.
+///
+/// This variant lets CLI entry points inspect the component name before layout
+/// path resolution without compiling the MIL source a second time.
+pub fn compose_component_with_model(
+    component: &str,
+    model: mosmodel_compiler::CompileOutput,
+    mll_src: &str,
+    msl_src: &str,
+    package_search_paths: &[PathBuf],
+    theme: Option<&str>,
+) -> Result<ComposedComponent, BuildError> {
+    let mut layout = moslayout_compiler::compile(mll_src, Some(&model.descriptor_json))
+        .map_err(|errs| pipeline_err(component, &errs[0]))?;
+    let dependency_style_parts = collect_dependency_style_parts(
+        component,
+        &layout.def,
+        package_search_paths,
+        theme,
+        &mut Vec::new(),
+        &mut HashSet::new(),
+    )?;
+    resolve_layout_package_references(
+        component,
+        &mut layout,
+        &model.descriptor_json,
+        package_search_paths,
+    )?;
+    let own_style = mosstyle_compiler::compile(msl_src, Some(&layout.part_map_json))
+        .map_err(|errs| pipeline_err(component, &errs[0]))?;
+    let style = merge_dependency_styles(own_style.def, dependency_style_parts);
+
+    Ok(ComposedComponent {
+        model,
+        layout,
+        style,
+    })
+}
+
 // ===========================================================================
 // Public entry point
 // ===========================================================================
@@ -773,27 +850,17 @@ fn emit_project_shell(
         format!("style {component} {{ }}")
     };
 
-    let mosmodel_out =
-        mosmodel_compiler::compile(&mil_src).map_err(|errs| pipeline_err(component, &errs[0]))?;
-    let mut layout_out = moslayout_compiler::compile(&mll_src, Some(&mosmodel_out.descriptor_json))
-        .map_err(|errs| pipeline_err(component, &errs[0]))?;
-    let dependency_style_parts = collect_dependency_style_parts(
+    let composed = compose_component(
         component,
-        &layout_out.def,
+        &mil_src,
+        &mll_src,
+        &msl_src,
         package_search_paths,
         theme,
-        &mut Vec::new(),
-        &mut HashSet::new(),
     )?;
-    resolve_layout_package_references(
-        component,
-        &mut layout_out,
-        &mosmodel_out.descriptor_json,
-        package_search_paths,
-    )?;
-    let style_out = mosstyle_compiler::compile(&msl_src, Some(&layout_out.part_map_json))
-        .map_err(|errs| pipeline_err(component, &errs[0]))?;
-    let style_def = merge_dependency_styles(style_out.def, dependency_style_parts);
+    let mosmodel_out = composed.model;
+    let layout_out = composed.layout;
+    let style_def = composed.style;
 
     // Per-backend dispatch. Each branch builds an EmitOptions with
     // emit_project: true, calls the appropriate from_pipeline_with_options,
@@ -1649,29 +1716,17 @@ fn compile_one_component(
     // Each compile call may return a `Vec<CompileError>`. We render the
     // first one and wrap it as `PipelineError` so the caller gets one
     // line per component rather than a flood.
-    let mosmodel_out =
-        mosmodel_compiler::compile(&mil_src).map_err(|errs| pipeline_err(component, &errs[0]))?;
-
-    let mut layout_out = moslayout_compiler::compile(&mll_src, Some(&mosmodel_out.descriptor_json))
-        .map_err(|errs| pipeline_err(component, &errs[0]))?;
-    let dependency_style_parts = collect_dependency_style_parts(
+    let composed = compose_component(
         component,
-        &layout_out.def,
+        &mil_src,
+        &mll_src,
+        &msl_src,
         package_search_paths,
         theme,
-        &mut Vec::new(),
-        &mut HashSet::new(),
     )?;
-    resolve_layout_package_references(
-        component,
-        &mut layout_out,
-        &mosmodel_out.descriptor_json,
-        package_search_paths,
-    )?;
-
-    let style_out = mosstyle_compiler::compile(&msl_src, Some(&layout_out.part_map_json))
-        .map_err(|errs| pipeline_err(component, &errs[0]))?;
-    let style_def = merge_dependency_styles(style_out.def, dependency_style_parts);
+    let mosmodel_out = composed.model;
+    let layout_out = composed.layout;
+    let style_def = composed.style;
     let lattice = mosstyle_compiler::emit_lattice(&style_def);
 
     // ----- 3. Hand the three IRs to the chosen backend ---------------------

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -315,9 +315,9 @@ unblocks multiple downstream targets; never count source generation as completio
   its lint configuration, and omit unused authored `For` bindings.
 - [x] Complete Compose TaskApp Kotlin typing: normalize Mosaic value truthiness
   in boolean positions and supply required native input commit payloads.
-- [ ] Route every compile entry point through one package-composition pipeline;
-  standalone `mosaic-compile` currently inlines dependency layouts without merging
-  their MSL, while the artifact builder merges both layout and style.
+- [x] Route every compile entry point through one package-composition pipeline;
+  standalone and package builds now consume the same resolved layout and merged
+  dependency-style IR before selecting a backend.
 - [ ] Type-check the complete generated Trestle application on every target, not
   only focused fixtures; the complete package-expanded TaskApp now passes the
   Swift compiler and SwiftPM linker with type-correct truthiness, collision-safe


### PR DESCRIPTION
## Summary

- expose one canonical composed component IR from the package artifact builder
- route package artifacts, project shells, and standalone pipeline compilation through it
- preserve dependency MSL defaults in standalone builds before consumer overrides
- remove redundant direct resolver/layout dependencies from mosaic-compile
- close the UI38 shared-composition backlog item

## Validation

- cargo fmt --package mosaic-package-artifact-builder --package mosaic-compile -- --check
- cargo clippy -p mosaic-package-artifact-builder -p mosaic-compile --all-targets -- -D warnings
- cargo test -p mosaic-package-artifact-builder -p mosaic-compile
- 56 artifact-builder tests, 9 mosaic-compile unit tests, standalone dependency-style integration test, and doc test pass
- Venture package builds across Backend::ALL in the artifact-builder suite

This PR is ready for review and intentionally not a draft.