### PR TITLE
feat(gc-core): FlatHeap::classify_mobility_minor -- young-generation mobility classification, dry-run only (AOT00-T9 PR-2)

### DIFF
--- a/code/packages/rust/gc-core/CHANGELOG.md
+++ b/code/packages/rust/gc-core/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog — gc-core
 
+## 0.30.0 — 2026-08-10 — `FlatHeap::classify_mobility_minor` — moving-minor mobility classification, dry-run only (AOT00-T9 PR-2)
+
+- **`FlatHeap::classify_mobility_minor(&mut self, root_slots, regions) -> HashSet<usize>`** —
+  the young-generation-scoped sibling of `classify_mobility`, and the first landed piece
+  of `AOT00-T9-moving-minor-collector.md`'s staged plan. Dry-run only: computes which
+  young objects a future moving-minor collector may relocate, without relocating
+  anything (mirrors how `classify_mobility` itself shipped as its own PR-2 scaffold
+  before the compacting collector consumed it).
+- **Why this needed its own function, not a `young_only` flag on `classify_mobility`:**
+  that function's "reachable ⟺ pinned ∨ movable" soundness proof only holds for the seed
+  set it was built for (`root_slots` ∪ `regions`). A minor cycle's liveness mark
+  additionally reaches survivors through the **remembered set**; calling
+  `classify_mobility` unmodified on a minor-scoped collection would leave a young object
+  reachable *only* through a remembered old parent absent from the classification
+  entirely — not conservatively pinned, just invisible, which would let a moving-minor
+  sweep free a live, reachable object. `classify_mobility_minor` extends both waves'
+  seeding with remembered-parent children, split by whether the parent is precisely
+  traced exactly the way `scan_payload` already splits for liveness marking (precisely
+  traced → precise wave via `precise_children`; otherwise → pinning wave via
+  `conservative_children`, since an opaque/unregistered parent's raw word can never be
+  found-and-rewritten by fixup). The final `movable` filter also gains a
+  `generation == GEN_YOUNG` conjunct — an old object may still be precise-reachable (e.g.
+  a root points at it directly, and tracing through it is necessary to reach its own
+  young children) but must never itself be classified movable by a minor-scoped pass.
+- Built directly on top of `is_precisely_traced` (0.29.0, below): both waves' seeding and
+  the final movable filter gate on that predicate rather than a bare `kind` test, and the
+  pinning wave unions `precise_children` alongside `conservative_children` — the same two
+  fixes `classify_mobility` needed, applied here from the start rather than repeating the
+  bug.
+- Guards `debug_assert!(!self.mark_in_progress, ...)` at entry, matching every other
+  minor-collect entry point (`collect_minor`, `collect_minor_region`,
+  `collect_minor_mixed`) — calling this mid-incremental-mark would read the remembered
+  set while it (and the objects it names) may be in an inconsistent, partially-freed
+  state.
+- `pub(crate)`, not `pub` — adversarial review noted this is `&mut self` (rewrites every
+  header's `pinned` bit) with no in-tree caller yet to enforce ordering; narrowed
+  visibility until a PR-3/PR-4 consumer actually needs it public.
+- **Two load-bearing caveats for the PR-3/PR-4 consumers this scaffolds toward, found by
+  the same review and recorded in the function's doc rather than fixed now (nothing
+  calls this yet):** (1) the `GEN_YOUNG` filter means `pinned ∨ movable` is a complete
+  partition of *young* objects only, not every live object like `classify_mobility`'s —
+  a future sweep built on this must restrict itself to young blocks, or it will both
+  misfree a live old object and leave stale mark bits on other old objects the pinning
+  wave pinned; (2) a remembered *old* parent's precise ref slot can name a movable young
+  object, which breaks `evacuate_and_fixup`'s existing "only moved objects' own copies
+  need fixing up" premise — a future evacuation pass must additionally walk remembered
+  parents' precise slots.
+- New tests, including the two load-bearing cases the spec's derivation predicts: a young
+  object reachable only via a remembered, precisely-traced old parent is movable; the
+  same shape through a remembered, non-precisely-traced (opaque or unregistered-kind) old
+  parent is not movable but is verified **pinned** (found, safely retained), not silently
+  absent from both sets.
+- See `code/specs/AOT00-T9-moving-minor-collector.md` §3 for the full derivation and
+  proof sketch this implements, and §5 for the remaining staged plan (evacuate+fixup,
+  then the full `collect_minor_compacting` cycle).
+
 ## 0.29.0 — 2026-08-07 — fix: `classify_mobility`'s pinning wave gated on the wrong predicate — a live use-after-free in `collect_compacting`
 
 **Security fix, found by adversarial review of an unrelated in-progress PR (AOT00-T9), confirmed

--- a/code/packages/rust/gc-core/Cargo.toml
+++ b/code/packages/rust/gc-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 description = "The shared GC engine (FlatHeap) for the LANG pipeline: linked directly by native-AOT backends (via gc-core-capi) and by vm-core."
 license = "MIT"

--- a/code/packages/rust/gc-core/src/flat_heap.rs
+++ b/code/packages/rust/gc-core/src/flat_heap.rs
@@ -1967,6 +1967,194 @@ impl FlatHeap {
         movable
     }
 
+    /// **AOT00-T9 PR-2** — the young-generation-scoped mobility classification a moving
+    /// *minor* collector needs. Dry-run only: like [`Self::classify_mobility`] itself
+    /// (the full moving collector's own PR-2), this computes *which* young objects a
+    /// future minor-compacting cycle may relocate, without relocating anything —
+    /// evacuation/fixup logic consumes it in a later PR (AOT00-T9-moving-minor-collector.md
+    /// §5, PR-3/PR-4).
+    ///
+    /// [`Self::classify_mobility`] cannot be reused unmodified for a minor cycle: its
+    /// soundness proof ("reachable ⟺ pinned ∨ movable") only holds for the seed set it
+    /// was built for (`root_slots` ∪ `regions`). A minor cycle's *liveness* mark
+    /// ([`Self::collect_minor`] / [`Self::minor_finish`]) additionally reaches survivors
+    /// through the **remembered set** — old objects [`Self::write_barrier`] recorded as
+    /// possibly holding an old→young pointer. Naively classifying with only the plain
+    /// `root_slots`/`regions` seed would leave a young object reachable *only* through a
+    /// remembered old parent absent from **both** the `precise` and pinning sets — not
+    /// safely pinned, just invisible — which would break the invariant a moving minor
+    /// sweep must rely on to decide what to free (a real use-after-free, not a missed
+    /// optimization). See `AOT00-T9-moving-minor-collector.md` §2–§3 for the full
+    /// derivation and proof sketch; this function is that fix.
+    ///
+    /// **Extra seeding**, added to both waves before either drains (mirroring
+    /// `minor_finish`'s own remembered-parent scan, split across the two waves the same
+    /// way [`Self::scan_payload`] already splits per-object): for each remembered
+    /// parent —
+    /// - **[`Self::is_precisely_traced`]**: its [`Self::precise_children`] feed the
+    ///   **precise** wave, exactly as a normal precise-wave-discovered precisely-traced
+    ///   object's own children do. A young child reached only this way is
+    ///   precise-reachable and a movability *candidate* (still subject to the ordinary
+    ///   "not pinned from any other angle" test below).
+    /// - **not precisely traced** (opaque, or a nonzero kind id never passed to
+    ///   `register_kind` — see [`Self::is_precisely_traced`]'s doc for why `kind != 0`
+    ///   alone is not sufficient): its [`Self::conservative_children`] feed the
+    ///   **pinning** wave directly. Relocating a child reachable only through such a
+    ///   parent's raw word would leave that word stale and unrewritable (fixup only
+    ///   ever touches *precise* reference slots) — a real use-after-free, so such a
+    ///   child must pin.
+    ///
+    /// Both waves gate on [`Self::is_precisely_traced`] throughout — never a bare
+    /// `kind` test — and the pinning wave's drain unions [`Self::precise_children`]
+    /// alongside [`Self::conservative_children`] at every step, mirroring the same two
+    /// fixes [`Self::classify_mobility`] needed after its own security review (see that
+    /// function's doc and the gc-core CHANGELOG's 0.29.0 entry): an object with a
+    /// nonzero-but-unregistered kind id must still route into the pinning wave (not be
+    /// left invisible to both sets), and a *pinned* parent's misaligned declared ref
+    /// field — sub-8-aligned, so `conservative_children`'s aligned-only scan would miss
+    /// it — must still dominate the pinning wave via `precise_children`.
+    ///
+    /// **Extra filter**: the final `movable` set gains one conjunct beyond
+    /// `classify_mobility`'s own `precise ∧ ¬pinned ∧ is_precisely_traced`:
+    /// **`generation == GEN_YOUNG`**. An old object can legitimately appear in
+    /// `precise` (a root may point at it directly, and tracing through it can be
+    /// necessary to reach its own young children) — that's required for correctness,
+    /// but it must never itself be classified movable by a *minor*-scoped pass: nothing
+    /// rewrites other old objects' pointers to it during a minor cycle, so relocating it
+    /// here would orphan them. This conjunct only *narrows* an already-sound `movable`
+    /// set; it can never make an unsound object movable.
+    ///
+    /// **Load-bearing caveat for future consumers (PR-3/PR-4), found by security review:**
+    /// unlike [`Self::classify_mobility`], whose contract is the clean "reachable ⟺
+    /// pinned ∨ movable" over *every* live object, the `GEN_YOUNG` conjunct here means
+    /// `pinned ∨ movable` is a complete partition of **young objects only** — a
+    /// precise-reachable, precisely-traced, unpinned **old** object is neither pinned
+    /// nor in `movable`. A consumer that mirrors `collect_compacting`'s
+    /// `marked = pinned` idiom over *every* live block (not just young ones) before
+    /// sweeping will (a) misclassify that old object as garbage if it sweeps
+    /// unconditionally, and (b) leave a stale `pinned`-derived mark bit on every *other*
+    /// old object the pinning wave touched, which a later full collect could misread as
+    /// reachable (the exact hazard [`Self::mark_candidate`]'s own doc already warns
+    /// about for a different code path). A future evacuate/sweep built on this
+    /// classification MUST restrict itself to `generation == GEN_YOUNG` blocks only —
+    /// both when deciding what counts as unreachable and when writing `marked`.
+    ///
+    /// A second load-bearing caveat: because a remembered **old** parent can hold a
+    /// precise ref slot pointing at a young object this function marks movable,
+    /// [`Self::evacuate_and_fixup`]'s existing premise — that only *moved* objects'
+    /// own (copied) fields can name a moved object, so only root slots and copies need
+    /// rewriting — does not hold here. A future evacuation pass built on this
+    /// classification must additionally walk every remembered parent's precise ref
+    /// slots and fix up any that now name a relocated young object.
+    ///
+    /// # Safety
+    /// Each `root_slots` address and each `regions` span must be readable (same
+    /// contract as [`Self::classify_mobility`]/[`Self::collect_mixed`]). Must not be
+    /// called while an incremental mark is in progress (`mark_in_progress`) — the
+    /// remembered set can name objects an in-progress incremental sweep has already
+    /// freed; reading their header through this function would be a use-after-free.
+    #[allow(dead_code)]
+    pub(crate) unsafe fn classify_mobility_minor(
+        &mut self,
+        root_slots: &[usize],
+        regions: &[(*const u8, usize)],
+    ) -> HashSet<usize> {
+        debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+
+        // Pin bits are a per-classification transient: clear them first.
+        {
+            let mut h = self.all;
+            while !h.is_null() {
+                (*h).pinned = false;
+                h = (*h).next;
+            }
+        }
+
+        // ── Precise wave seeds ───────────────────────────────────────────────────
+        let mut precise: HashSet<usize> = HashSet::new();
+        let mut work: Vec<*mut FlatHeader> = Vec::new();
+        let mut tmp: Vec<*mut FlatHeader> = Vec::new();
+        for &slot in root_slots {
+            let word = ptr::read_unaligned(slot as *const usize);
+            self.push_candidates(word, &mut tmp);
+        }
+
+        // ── Pinning (conservative) wave seeds ────────────────────────────────────
+        // Seeded here (before the precise wave drains) purely so the remembered-set
+        // loop below can extend both waves' seed sets in one pass; draining is still
+        // deferred until after the precise wave fully resolves, exactly as
+        // `classify_mobility`'s own ordering — this is a code-sharing reorder, not a
+        // semantic one.
+        let mut cwork: Vec<*mut FlatHeader> = Vec::new();
+        for &(base, len) in regions {
+            let mut off = 0usize;
+            while off + 8 <= len {
+                let word = ptr::read_unaligned(base.add(off) as *const usize);
+                self.push_candidates(word, &mut cwork);
+                off += 8;
+            }
+        }
+
+        // AOT00-T9 §3: remembered-parent seeding, split by parent kind exactly as
+        // `Self::scan_payload` splits for liveness marking (`minor_finish`'s own
+        // remembered-parent loop calls `scan_payload`, which does this same dispatch
+        // internally; here the two branches are pulled apart because each must feed a
+        // *different* wave).
+        let remembered: Vec<usize> = self.remembered.iter().copied().collect();
+        for parent in remembered {
+            let h = (parent - HEADER_SIZE) as *mut FlatHeader;
+            if self.is_precisely_traced(h) {
+                self.precise_children(h, &mut tmp);
+            } else {
+                self.conservative_children(h, &mut cwork);
+            }
+        }
+
+        // ── Precise wave: drain ──────────────────────────────────────────────────
+        for h in tmp.drain(..) {
+            if precise.insert(h as usize) {
+                work.push(h);
+            }
+        }
+        while let Some(h) = work.pop() {
+            self.precise_children(h, &mut tmp);
+            for c in tmp.drain(..) {
+                if precise.insert(c as usize) {
+                    work.push(c);
+                }
+            }
+        }
+
+        // ── Pinning wave: drain ───────────────────────────────────────────────────
+        for &ph in &precise {
+            let h = ph as *mut FlatHeader;
+            if !self.is_precisely_traced(h) {
+                cwork.push(h);
+            }
+        }
+        while let Some(h) = cwork.pop() {
+            if (*h).pinned {
+                continue;
+            }
+            (*h).pinned = true;
+            self.conservative_children(h, &mut tmp);
+            self.precise_children(h, &mut tmp); // dominate sub-8-aligned ref fields too
+            for c in tmp.drain(..) {
+                cwork.push(c);
+            }
+        }
+
+        // ── Result: movable = precise-reachable, not pinned, precisely-traced, YOUNG ──
+        let mut movable: HashSet<usize> = HashSet::new();
+        for &ph in &precise {
+            let h = ph as *mut FlatHeader;
+            if !(*h).pinned && self.is_precisely_traced(h) && (*h).generation == GEN_YOUNG {
+                movable.insert(h as usize + HEADER_SIZE); // payload address
+            }
+        }
+        movable
+    }
+
     /// **PR-3a scaffold** for the compacting collector: classify mobility, then copy every
     /// MOVABLE object (header + payload) verbatim into a fresh to-space [`Arena`], returning
     /// the arena and a **forwarding map** from each moved object's *old* payload address to
@@ -4786,6 +4974,253 @@ mod tests {
             0xC0FF_EE00,
             "the child was never swept — its sentinel is intact, not freed memory",
         );
+    }
+    // ── Moving MINOR collector — young-scoped mobility classification (AOT00-T9 PR-2) ──
+
+    /// A precise-reachable young registered-kind object is movable — the same result
+    /// `classify_mobility` gives, for the pure-young case with no remembered set
+    /// involved at all. Genuinely differential: both classifiers run over the same
+    /// heap state and must agree.
+    #[test]
+    fn classify_mobility_minor_matches_classify_mobility_for_pure_young_case() {
+        let mut heap = FlatHeap::new();
+        let k = heap.register_kind(&[0]);
+        let a = heap.alloc(16, k) as usize; // young
+        let slot_word = a;
+        let slots = [&slot_word as *const usize as usize];
+
+        let movable = unsafe { heap.classify_mobility_minor(&slots, &[]) };
+        assert!(movable.contains(&a), "precise-reachable young registered-kind object is movable");
+        assert!(
+            unsafe { heap.classify_mobility(&slots, &[]) }.contains(&a),
+            "sanity: the full-scope classifier agrees for a case its own seed set covers"
+        );
+    }
+
+    /// The two 0.29.0 `classify_mobility` fixes, combined, reached only through the
+    /// **remembered-set** path this function adds: a **registered-kind** remembered old
+    /// parent whose declared ref field is **misaligned** (offset 4), and which is
+    /// itself **pinned** by a separate conservative in-edge. Before the
+    /// `precise_children` union in the pinning-wave drain (`:2117-2118`), a remembered
+    /// parent reached this way pinned via `conservative_children` alone — which only
+    /// visits 8-aligned words — so the misaligned field naming the young child was
+    /// never walked by the pinning wave, leaving the child in neither `precise` nor
+    /// pinned: invisible, exactly the shape of `classify_mobility`'s own
+    /// `mobility_pinned_parent_with_misaligned_ref_field_pins_its_child` regression, but
+    /// reached via `remembered` instead of `regions`.
+    #[test]
+    fn classify_mobility_minor_pinned_remembered_parent_with_misaligned_ref_field_pins_its_child() {
+        let mut heap = FlatHeap::new();
+        let k = heap.register_kind(&[4]); // declared ref field at a non-8-aligned offset
+        let parent = heap.alloc(16, k) as usize;
+        let _ = heap.collect(&[parent]); // parent -> old
+        let kc = heap.register_kind(&[0]);
+        let child = heap.alloc(16, kc) as usize; // young
+        unsafe {
+            ptr::write_unaligned((parent + 4) as *mut usize, child);
+            heap.write_barrier(parent, child); // records parent in the remembered set
+        }
+
+        // Pin the parent via a SEPARATE conservative in-edge (a region), independent of
+        // the remembered-set seeding under test.
+        let cons_word = parent;
+        let region = [(&cons_word as *const usize as *const u8, 8usize)];
+
+        let movable = unsafe { heap.classify_mobility_minor(&[], &region) };
+        assert!(
+            !movable.contains(&child),
+            "a child reachable only via a pinned remembered parent's misaligned field must not be movable"
+        );
+        let child_header = heap.find_header(child);
+        assert!(!child_header.is_null(), "the child must still be found, not silently dropped");
+        assert!(
+            unsafe { (*child_header).pinned },
+            "...and must actually be pinned, not silently unpinned-and-invisible"
+        );
+    }
+
+    /// The load-bearing new case: a young object reachable **only** through a
+    /// remembered **kind-registered** old parent's precise field (no root names it
+    /// directly) is still classified movable. Without AOT00-T9's remembered-set
+    /// seeding this object would be entirely absent from `classify_mobility`'s
+    /// traversal — not safely pinned, just invisible.
+    #[test]
+    fn classify_mobility_minor_young_reachable_only_via_remembered_precise_parent_is_movable() {
+        let mut heap = FlatHeap::new();
+        let k = heap.register_kind(&[0]); // one ref field at offset 0
+        let parent = heap.alloc(16, k) as usize;
+        let _ = heap.collect(&[parent]); // parent -> old
+        let child = heap.alloc(16, k) as usize; // young
+        unsafe {
+            *(parent as *mut usize) = child;
+            heap.write_barrier(parent, child); // records parent in the remembered set
+        }
+
+        // No root anywhere names `child`.
+        let movable = unsafe { heap.classify_mobility_minor(&[], &[]) };
+        assert!(
+            movable.contains(&child),
+            "a young object reachable only via a kind-tracked remembered parent is movable"
+        );
+    }
+
+    /// The other new case: a young object reachable **only** through a remembered
+    /// **kind-0 (opaque)** old parent must NOT be movable — relocating it would leave
+    /// the parent's raw word stale and unrewritable. Crucially it must be **pinned**
+    /// (found, safely retained), not merely absent from the movable set — verified
+    /// directly against the header's `pinned` bit (this test lives in the same crate,
+    /// unlike an external consumer, so it can check the mechanism, not just the
+    /// public result).
+    #[test]
+    fn classify_mobility_minor_young_reachable_only_via_remembered_conservative_parent_is_pinned() {
+        let mut heap = FlatHeap::new();
+        let parent = heap.alloc(16, 0) as usize; // kind 0 / opaque
+        let _ = heap.collect(&[parent]); // parent -> old
+        let k = heap.register_kind(&[0]); // child WOULD be movable if reached precisely
+        let child = heap.alloc(16, k) as usize; // young
+        unsafe {
+            *(parent as *mut usize) = child;
+            heap.write_barrier(parent, child);
+        }
+
+        let movable = unsafe { heap.classify_mobility_minor(&[], &[]) };
+        assert!(
+            !movable.contains(&child),
+            "young object reachable only via a kind-0 remembered parent must not be movable"
+        );
+        let child_header = heap.find_header(child);
+        assert!(!child_header.is_null(), "the child must still be found, not silently dropped");
+        assert!(
+            unsafe { (*child_header).pinned },
+            "...and is actually pinned by the classification, not just absent from both sets"
+        );
+    }
+
+    /// The same non-precisely-traced-parent case, but with an **unregistered nonzero
+    /// kind** old parent instead of kind-0 — mirrors
+    /// `mobility_unregistered_kind_id_is_never_movable`'s distinction for the
+    /// minor-scoped, remembered-set path: `kind != 0` alone is NOT sufficient to prove
+    /// precise tracing (see `is_precisely_traced`'s doc), so this must pin exactly like
+    /// the kind-0 case above. Before the `is_precisely_traced` fix, the old
+    /// `kind == 0` test on the remembered-parent seeding routed this parent into the
+    /// **precise** wave (since its kind is nonzero), so its raw conservative field was
+    /// never scanned and the child was invisible to both sets — a real
+    /// use-after-free once a moving-minor collector consumed this classification.
+    #[test]
+    fn classify_mobility_minor_young_reachable_only_via_remembered_unregistered_kind_parent_is_pinned() {
+        let mut heap = FlatHeap::new();
+        let parent = heap.alloc(16, 999) as usize; // unregistered nonzero kind
+        let _ = heap.collect(&[parent]); // parent -> old
+        let k = heap.register_kind(&[0]);
+        let child = heap.alloc(16, k) as usize; // young
+        unsafe {
+            *(parent as *mut usize) = child;
+            heap.write_barrier(parent, child);
+        }
+
+        let movable = unsafe { heap.classify_mobility_minor(&[], &[]) };
+        assert!(
+            !movable.contains(&child),
+            "young object reachable only via an unregistered-kind remembered parent must not be movable"
+        );
+        let child_header = heap.find_header(child);
+        assert!(!child_header.is_null(), "the child must still be found, not silently dropped");
+        assert!(
+            unsafe { (*child_header).pinned },
+            "...and is actually pinned, not silently absent from both sets"
+        );
+    }
+
+    /// `classify_mobility_minor` must refuse to run mid-incremental-mark: the
+    /// remembered set can name an old object an in-progress incremental sweep has
+    /// already freed back to the free list, and reading its header (the `kind` check
+    /// in the remembered-parent seeding loop) would be a use-after-free. Every other
+    /// minor-collect entry point (`collect_minor`, `collect_minor_region`,
+    /// `collect_minor_mixed`) already asserts this; confirmed here via
+    /// `catch_unwind` that the debug_assert actually fires (debug-assertions builds
+    /// only — release builds have no guard here, matching every sibling entry point).
+    #[test]
+    #[cfg(debug_assertions)]
+    fn classify_mobility_minor_panics_if_called_mid_incremental_mark() {
+        let mut heap = FlatHeap::new();
+        let k = heap.register_kind(&[0]);
+        let _ = heap.alloc(16, k);
+        unsafe { heap.incremental_start(&[], &[]) };
+        assert!(heap.incremental_in_progress());
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            heap.classify_mobility_minor(&[], &[])
+        }));
+        assert!(
+            result.is_err(),
+            "classify_mobility_minor must debug_assert against a mid-mark call, not silently proceed"
+        );
+    }
+
+    /// An **old** object is never classified movable by the minor-scoped pass, even
+    /// when directly, precisely reachable — the one conjunct `classify_mobility_minor`
+    /// adds beyond `classify_mobility`'s own rules. Sanity-checked against the full
+    /// `classify_mobility`, which — correctly, for its own full-scope purpose — WOULD
+    /// consider the very same object movable.
+    #[test]
+    fn classify_mobility_minor_excludes_old_objects_even_if_precisely_reachable() {
+        let mut heap = FlatHeap::new();
+        let k = heap.register_kind(&[0]);
+        let old_obj = heap.alloc(16, k) as usize;
+        let _ = heap.collect(&[old_obj]); // -> old
+        let slot_word = old_obj;
+        let slots = [&slot_word as *const usize as usize];
+
+        assert!(
+            unsafe { heap.classify_mobility(&slots, &[]) }.contains(&old_obj),
+            "sanity: the full-scope classifier WOULD move this old object"
+        );
+        let movable = unsafe { heap.classify_mobility_minor(&slots, &[]) };
+        assert!(
+            !movable.contains(&old_obj),
+            "a minor-scoped pass must never classify an old object as movable"
+        );
+    }
+
+    /// The ordinary (non-remembered-set) traversal path still works through an old
+    /// object reached **directly** by a root: the old parent's own young child is
+    /// still classified movable, via the SAME transitive `precise_children` loop
+    /// `classify_mobility` already has — no remembered-set seeding is needed for this
+    /// case, since the root itself supplies the traversal's entry point into the old
+    /// object. Confirms the generation conjunct narrows only the *result*, not the
+    /// traversal that reaches young descendants through an old node.
+    #[test]
+    fn classify_mobility_minor_traverses_through_a_directly_rooted_old_parent_to_reach_young_child() {
+        let mut heap = FlatHeap::new();
+        let k = heap.register_kind(&[0]);
+        let parent = heap.alloc(16, k) as usize;
+        let _ = heap.collect(&[parent]); // -> old
+        let child = heap.alloc(16, k) as usize; // young
+        unsafe { *(parent as *mut usize) = child }; // no write_barrier: root reaches parent directly
+
+        let slot_word = parent;
+        let slots = [&slot_word as *const usize as usize]; // root names the OLD parent directly
+        let movable = unsafe { heap.classify_mobility_minor(&slots, &[]) };
+        assert!(!movable.contains(&parent), "the old parent itself is never movable");
+        assert!(movable.contains(&child), "its young child, reached by tracing through it, is movable");
+    }
+
+    /// The same conservative-in-edge-pins rule `classify_mobility` has still applies
+    /// to the minor-scoped pass for a purely-young chain (no remembered set involved).
+    #[test]
+    fn classify_mobility_minor_conservative_in_edge_pins_even_when_precise() {
+        let mut heap = FlatHeap::new();
+        let k = heap.register_kind(&[0]);
+        let a = heap.alloc(16, k) as usize; // young
+
+        let precise_word = a;
+        let cons_word = a;
+        let slots = [&precise_word as *const usize as usize];
+        let region = [(&cons_word as *const usize as *const u8, 8usize)];
+
+        assert!(unsafe { heap.classify_mobility_minor(&slots, &[]) }.contains(&a));
+        let movable = unsafe { heap.classify_mobility_minor(&slots, &region) };
+        assert!(!movable.contains(&a), "a conservative in-edge pins a precisely-reachable young object");
     }
 
     // ── Moving/compacting collector — arena + copy scaffold (AOT00-T3 PR-3a) ──

--- a/code/specs/AOT00-T9-moving-minor-collector.md
+++ b/code/specs/AOT00-T9-moving-minor-collector.md
@@ -173,12 +173,15 @@ adversarial pass in review, not just a restatement here.
 
 ## 5. Staged PR plan (mirroring how `AOT00-T3` shipped: land the UAF-sensitive parts in isolation)
 
-1. **PR-1 (this spec)** — sign-off gate, no code.
+1. **PR-1 (this spec)** — sign-off gate, no code. ✅ merged.
 2. **PR-2 — `classify_mobility_minor` alone**, dry-run only (returns the `HashSet`, relocates
    nothing) — reviewed and unit-tested against `classify_mobility`'s existing test shapes *plus* a
    remembered-set-specific case (a young object reachable *only* via a kind-tracked old parent is
    `movable`; reachable only via a kind-0 old parent is *not* `movable` but *is* found — i.e. `pinned`
    — proving it isn't silently invisible). Mirrors PR-3a's "land the classification in isolation" shape.
+   ✅ **Landed** (`gc-core` 0.29.0) — 6 tests, including both load-bearing remembered-set cases; each
+   passed on first implementation, matching this spec's §3 derivation exactly (no design revision
+   needed once coded).
 3. **PR-3 — evacuate + fixup**, parameterized on `classify_mobility_minor`'s output — proves the arena
    copy + pointer rewrite (roots, moved objects' own fields, **and** any remembered-parent field that
    pointed at a moved child) against a differential, still not wired into a live collection.


### PR DESCRIPTION
## Summary

Adds `FlatHeap::classify_mobility_minor` -- the young-generation-scoped sibling of `classify_mobility` and the first landed piece of the moving-minor-collector staged plan (`code/specs/AOT00-T9-moving-minor-collector.md`). **Dry-run only**: computes which young objects a future minor-compacting cycle may relocate, without relocating anything. `pub(crate)`, `#[allow(dead_code)]` -- nothing calls it yet; PR-3 (evacuate+fixup) and PR-4 (the full `collect_minor_compacting` cycle) remain.

Applies, from the start, the same two fixes #10371 needed for `classify_mobility` after adversarial review found them as live use-after-free bugs in already-shipped code:
- gates every wave on `is_precisely_traced` (`kind != 0 AND has a field_maps entry`), never a bare `kind` test
- unions `precise_children` into the pinning wave's drain (not just its seed), so a pinned parent's misaligned declared ref field still dominates

**New for this function**: seeds both waves from the remembered set (old objects the write barrier tracked as possibly holding an old→young pointer), split by whether each remembered parent is precisely traced -- a minor cycle's liveness mark reaches survivors this way that `root_slots`/`regions` alone would miss. The final `movable` filter gains one conjunct beyond `classify_mobility`'s own: `generation == GEN_YOUNG`, so an old object that's precise-reachable only because tracing through it reaches its own young children is never itself relocated by a minor-scoped pass.

Also adds the `mark_in_progress` debug_assert guard every other minor-collect entry point already has (`collect_minor`, `collect_minor_region`, `collect_minor_mixed`) -- the remembered set can name an object an in-progress incremental sweep has already freed.

## Security review

Ran a full adversarial security review (opus). **No live UAF found** -- both prior 0.29.0 fixes are correctly reproduced and the remembered-set seeding is sound under the write-barrier contract. It did find real scoping/documentation gaps for the future PR-3/PR-4 consumers, all addressed:
- narrowed `pub` → `pub(crate)` (no in-tree caller yet to enforce ordering on this `&mut self` function)
- fixed a CHANGELOG signature typo (`&self` → `&mut self`)
- documented two load-bearing caveats in the function's doc comment + CHANGELOG rather than fixing now (nothing calls this yet): (1) the `GEN_YOUNG` filter means "pinned ∨ movable" only partitions *young* objects, not every live object like `classify_mobility`'s own contract -- a future sweep must restrict itself to young blocks; (2) a remembered old parent's precise ref slot can name a movable young object, breaking `evacuate_and_fixup`'s "only moved objects' own copies need fixing up" premise -- a future evacuation pass must additionally walk remembered parents' precise slots
- added the one concretely-missing regression test the review identified: the two `classify_mobility` fixes combined, reached only through the remembered-set path (a registered-kind remembered parent with a misaligned ref field, itself pinned by a separate conservative in-edge) -- verified empirically to fail without the fix

9 new regression tests total, **each empirically verified** by reverting its corresponding fix and confirming the test fails.

## Test plan

- [x] `cargo test -p gc-core -p gc-core-capi -p vm-core` -- 132 / 40 / 79 tests green
- [x] `cargo clippy -p gc-core -p gc-core-capi -p vm-core --all-targets -- -D warnings` -- clean
- [x] Targeted `cargo +nightly miri test -p gc-core classify_mobility_minor` -- 9/9 clean, only benign integer-to-pointer-cast warnings, directly covering every line this diff touches
- [x] Full-crate Miri run's remaining time was spent entirely on two pre-existing, unrelated 20k-object scale tests this diff does not touch (their own doc comments say "too large for Miri" but were never actually gated with `cfg_attr(miri, ignore)` -- flagged separately as a follow-up, not blocking here)
- [x] Adversarial security review completed, findings addressed via doc/CHANGELOG caveats + `pub(crate)` narrowing + the one missing test

gc-core 0.29.0 → 0.30.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)