### PR TITLE
Add zeroizing vault revision reveal

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this package are documented here.
 
+## [0.19.0] - 2026-08-09
+
+### Added
+
+- Add explicit reveal for one exact reachable live revision, returning its
+  authenticated document in a non-printable owned zeroizing wrapper.
+
+### Security
+
+- Reuse bounded verified current-head history traversal, reject tombstones and
+  unreachable revisions, and never select a current or conflict candidate
+  implicitly.
+
 ## [0.18.0] - 2026-08-09
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -144,10 +144,19 @@ candidate, rewrites history, or asks the host to round-trip plaintext. A later
 slice will add user-authored merged-document resolution after explicit field
 reveal.
 
+An unlocked session can explicitly reveal one exact reachable live revision.
+The application proves reachability through the same bounded verified history
+walk, rejects tombstones and missing revisions, and moves the authenticated
+document into an owned `Zeroizing<ItemDocument>`. That wrapper is neither
+printable nor cloneable and wipes the secret-bearing payload and tags on drop;
+the application never guesses which current, conflicted, or historical
+candidate a host intended.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
-credential store, or entropy source. User-authored conflict merging, explicit
-history reveal, export, audit, and doctor workflows land in the next slices.
+credential store, or entropy source. User-authored conflict merging, host field
+selection/copy policy, export, audit, and doctor workflows land in the next
+slices.
 There is no unchecked
 repository verification path: construction decrypts and
 authority-verifies the exact locally pinned certificate frame and object ID,
@@ -169,8 +178,8 @@ paths, and complete error translation.
 Search tests cover Unicode normalization, short queries, oversized safe-field
 fallback, exact collection filters, deterministic product ordering, every
 record schema's allowlist/denylist, secret exclusion, query/result bounds, and
-conflict closure. The exact Tarpaulin LLVM result is 2,204 of 2,315 production
-lines (95.21%). Add-item tests cover exact entropy partitioning and wiping,
+conflict closure. The exact Tarpaulin LLVM result is 2,213 of 2,324 production
+lines (95.22%). Add-item tests cover exact entropy partitioning and wiping,
 identity validation before local writes, parentless revision and complete
 catalog construction, ambiguous successful compare-exchanges, write-ahead
 publication ordering, ambiguous provider commits, failed final activation,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -271,6 +271,30 @@ impl UnlockedVaultV1 {
             .collect()
     }
 
+    /// Explicitly reveal one reachable live revision inside an owned
+    /// wipe-on-drop wrapper.
+    ///
+    /// The exact revision must appear in a catalog reachable within the hard
+    /// history bound from a current head. Tombstones return `InvalidInput` and
+    /// unreachable revisions return `NotFound`. The wrapper deliberately has
+    /// no `Debug`, `Display`, or `Clone` implementation.
+    pub fn reveal_item_revision(
+        &self,
+        selected_revision: RevisionId,
+    ) -> Result<Zeroizing<ItemDocument>, ApplicationError> {
+        let selected = find_reachable_historical_candidate(
+            &self._keys,
+            self._repository.as_ref(),
+            &self.report,
+            self.active.vault_id(),
+            selected_revision,
+        )?;
+        let ItemState::Live(document) = selected.state() else {
+            return Err(ApplicationError::InvalidInput);
+        };
+        Ok(Zeroizing::new(document.as_ref().clone()))
+    }
+
     /// Add one new item through the exact crash-resumable publication state
     /// machine and return the resulting durable active owner state.
     ///
@@ -862,6 +886,7 @@ mod tests {
         FaultAction, FaultEffect, FaultInjectingObjectStore, InMemoryObjectStore, StoreOperation,
     };
     use coding_adventures_vault_records::{AnyRecord, Login, LOGIN_V1};
+    use coding_adventures_zeroize::Zeroize;
     use std::sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc, Mutex,
@@ -2910,6 +2935,101 @@ mod tests {
             session.item_history(item_id, MAX_ITEM_HISTORY_LIMIT + 1),
             Err(ApplicationError::BoundExceeded)
         );
+    }
+
+    #[test]
+    fn reveal_item_revision_is_exact_reachable_live_and_zeroizing() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let add_randomness = add_item_randomness(0x92);
+        let item_id = add_randomness.item_id();
+        open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap()
+        .add_item(
+            new_login_document(item_id, "Reveal original", "original-secret"),
+            500,
+            add_randomness,
+            &local,
+        )
+        .unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let original_revision = session.current_catalog.items[&item_id][0].revision_id();
+        session
+            .replace_item(
+                original_revision,
+                new_login_document(item_id, "Reveal current", "current-secret"),
+                501,
+                replace_item_randomness(0x93),
+                &local,
+            )
+            .unwrap();
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let current_revision = session.current_catalog.items[&item_id][0].revision_id();
+        let original = session.reveal_item_revision(original_revision).unwrap();
+        let AnyRecord::Login(login) = original.payload() else {
+            panic!("fixture must reveal a login")
+        };
+        assert_eq!(login.title, "Reveal original");
+        assert_eq!(login.password, "original-secret");
+
+        let mut current = session.reveal_item_revision(current_revision).unwrap();
+        let AnyRecord::Login(login) = current.payload() else {
+            panic!("fixture must reveal a login")
+        };
+        assert_eq!(login.password, "current-secret");
+        current.zeroize();
+        let AnyRecord::Login(login) = current.payload() else {
+            panic!("zeroized fixture must retain its record variant")
+        };
+        assert!(login.password.is_empty());
+        assert!(login.title.is_empty());
+        assert!(matches!(
+            session.reveal_item_revision(RevisionId::new([0x94; 32])),
+            Err(ApplicationError::NotFound)
+        ));
+
+        session
+            .delete_item(
+                current_revision,
+                502,
+                503,
+                delete_item_randomness(0x95),
+                &local,
+            )
+            .unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let tombstone_revision = session.current_catalog.items[&item_id][0].revision_id();
+        assert!(matches!(
+            session.reveal_item_revision(tombstone_revision),
+            Err(ApplicationError::InvalidInput)
+        ));
     }
 
     #[test]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1320,7 +1320,9 @@ changelog, focused build, and downstream validation.
        causal parent;
    7b-4b. user-authored merged-document conflict resolution after explicit
        field reveal;
-   7c. bounded history traversal and explicit zeroizing field reveal;
+   7c-1. completed bounded reachable live-revision reveal into a non-printable
+       owned zeroizing document wrapper;
+   7c-2. host-facing field selection and explicit copy/reveal policy adapters;
    7d. authenticated portable export and restore/import preparation; and
    7e. audit, status, and doctor workflows; and
    7f. close the remaining VLT-PM05 `Locked` error and explicit lock-state


### PR DESCRIPTION
## Summary

- reveal one exact reachable live revision in an owned `Zeroizing<ItemDocument>`
- reuse bounded, verified current-head history traversal without choosing an implicit winner
- document the follow-up host field policy and user-authored conflict merge slices

## Security properties

- requires an exact revision and rejects missing or tombstone revisions
- returns a non-printable, non-cloneable wrapper whose document payload and tags are zeroized
- performs no provider-specific reads and does not expose plaintext through repository or storage interfaces

## Verification

- `bash BUILD` (88 tests)
- focused `cargo test`
- strict Clippy (`-D warnings`)
- strict rustdoc (`-D warnings`)
- Tarpaulin: 2,213/2,324 production lines (95.22%)
- repository planner: 1,001 packages, 1 changed, 21 affected, all affected packages built
