### PR TITLE
Add explicit vault secret disclosure policy

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this package are documented here.
 
+## [0.20.0] - 2026-08-10
+
+### Added
+
+- Add schema-specific selection for every first-party secret field, returning
+  one owned binary-or-UTF-8 `RevealedSecretV1` value.
+- Add explicit clipboard, confirmed interactive reveal, and unsafe
+  non-interactive reveal policy inputs for host adapters.
+
+### Security
+
+- Validate disclosure policy before repository traversal; non-interactive
+  reveal requires both explicit unsafe opt-in and a host-emitted warning.
+- Reject wrong-schema and opaque field selection, and expose secret bytes only
+  through a non-printable, non-cloneable, wipe-on-drop allocation.
+
 ## [0.19.0] - 2026-08-09
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -152,10 +152,24 @@ printable nor cloneable and wipes the secret-bearing payload and tags on drop;
 the application never guesses which current, conflicted, or historical
 candidate a host intended.
 
+Hosts can now narrow that exact revision to one schema-specific first-party
+secret field. The selector covers login passwords, secure-note bodies, card
+numbers and CVVs, raw TOTP seeds, API tokens, and database passwords; a selector
+for the wrong schema or an opaque record fails closed. The resulting
+`RevealedSecretV1` distinguishes UTF-8 from binary bytes but implements no
+printing or cloning and wipes its full allocation on drop.
+
+Every field disclosure also declares one policy path: clipboard with no secret
+stdout, reveal after a confirmed controlling-TTY ceremony, or explicitly
+unsafe non-interactive output after both flag opt-in and a host-emitted stderr
+warning. The application validates those facts before repository traversal.
+Actual TTY inspection, warning rendering, clipboard writes, ownership checks,
+and timed clear remain host responsibilities.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
 credential store, or entropy source. User-authored conflict merging, host field
-selection/copy policy, export, audit, and doctor workflows land in the next
+clipboard implementation, export, audit, and doctor workflows land in the next
 slices.
 There is no unchecked
 repository verification path: construction decrypts and
@@ -178,8 +192,8 @@ paths, and complete error translation.
 Search tests cover Unicode normalization, short queries, oversized safe-field
 fallback, exact collection filters, deterministic product ordering, every
 record schema's allowlist/denylist, secret exclusion, query/result bounds, and
-conflict closure. The exact Tarpaulin LLVM result is 2,213 of 2,324 production
-lines (95.22%). Add-item tests cover exact entropy partitioning and wiping,
+conflict closure. The exact Tarpaulin LLVM result is 2,250 of 2,361 production
+lines (95.30%). Add-item tests cover exact entropy partitioning and wiping,
 identity validation before local writes, parentless revision and complete
 catalog construction, ambiguous successful compare-exchanges, write-ahead
 publication ordering, ambiguous provider commits, failed final activation,

--- a/code/packages/rust/vault-pm-application/src/disclosure.rs
+++ b/code/packages/rust/vault-pm-application/src/disclosure.rs
@@ -1,0 +1,312 @@
+use crate::ApplicationError;
+use coding_adventures_vault_records::AnyRecord;
+use coding_adventures_zeroize::Zeroize;
+
+/// One explicit secret-bearing field understood by the V1 application core.
+///
+/// Selectors are schema-specific so a host cannot accidentally reinterpret a
+/// generic field name across record kinds. Opaque records have no revealable
+/// fields because the application cannot classify their payload safely.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SecretFieldV1 {
+    /// The password in a login record.
+    LoginPassword,
+    /// The body in a secure-note record.
+    SecureNoteBody,
+    /// The primary account number in a card record.
+    CardNumber,
+    /// The verification code in a card record.
+    CardCvv,
+    /// The raw shared-secret bytes in a TOTP record.
+    TotpSecret,
+    /// The token in an API-key record.
+    ApiKeyToken,
+    /// The password in a database-credential record.
+    DatabasePassword,
+}
+
+/// Host-declared destination and authorization ceremony for one secret.
+///
+/// The application owns policy validation, while the host remains responsible
+/// for proving terminal state, emitting the non-interactive warning, and
+/// clearing a clipboard value only while it still owns that value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SecretDisclosureIntentV1 {
+    /// Copy through a host clipboard adapter without writing secret stdout.
+    Clipboard,
+    /// Reveal after a host confirmed an interactive controlling-TTY prompt.
+    InteractiveReveal {
+        /// Whether the user completed the explicit confirmation ceremony.
+        confirmed: bool,
+    },
+    /// Reveal without a TTY only after both opt-in and warning obligations.
+    UnsafeNonInteractiveReveal {
+        /// Whether the explicit unsafe secret-output flag was supplied.
+        unsafe_include_secrets: bool,
+        /// Whether the host emitted its warning to standard error.
+        warning_emitted: bool,
+    },
+}
+
+impl SecretDisclosureIntentV1 {
+    pub(crate) const fn authorize(self) -> Result<(), ApplicationError> {
+        match self {
+            Self::Clipboard => Ok(()),
+            Self::InteractiveReveal { confirmed: true }
+            | Self::UnsafeNonInteractiveReveal {
+                unsafe_include_secrets: true,
+                warning_emitted: true,
+            } => Ok(()),
+            Self::InteractiveReveal { confirmed: false }
+            | Self::UnsafeNonInteractiveReveal { .. } => Err(ApplicationError::InvalidInput),
+        }
+    }
+}
+
+/// Encoding of an explicitly revealed secret value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RevealedSecretEncodingV1 {
+    /// The bytes are valid UTF-8 text.
+    Utf8,
+    /// The bytes are an opaque binary value whose rendering is a host choice.
+    Bytes,
+}
+
+/// One owned secret selected for an already-authorized host disclosure.
+///
+/// This type deliberately implements neither `Debug`, `Display`, nor `Clone`.
+/// Its full-capacity byte allocation is observably wiped before release.
+pub struct RevealedSecretV1 {
+    bytes: Vec<u8>,
+    encoding: RevealedSecretEncodingV1,
+}
+
+impl RevealedSecretV1 {
+    /// Borrow the secret only for the duration of the host disclosure action.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Return whether the value is UTF-8 text or opaque bytes.
+    pub const fn encoding(&self) -> RevealedSecretEncodingV1 {
+        self.encoding
+    }
+
+    fn text(value: &str) -> Self {
+        Self {
+            bytes: value.as_bytes().to_vec(),
+            encoding: RevealedSecretEncodingV1::Utf8,
+        }
+    }
+
+    fn bytes(value: &[u8]) -> Self {
+        Self {
+            bytes: value.to_vec(),
+            encoding: RevealedSecretEncodingV1::Bytes,
+        }
+    }
+}
+
+impl Zeroize for RevealedSecretV1 {
+    fn zeroize(&mut self) {
+        self.bytes.zeroize();
+    }
+}
+
+impl Drop for RevealedSecretV1 {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+pub(crate) fn select_secret(
+    record: &AnyRecord,
+    field: SecretFieldV1,
+) -> Result<RevealedSecretV1, ApplicationError> {
+    match (record, field) {
+        (AnyRecord::Login(value), SecretFieldV1::LoginPassword) => {
+            Ok(RevealedSecretV1::text(&value.password))
+        }
+        (AnyRecord::SecureNote(value), SecretFieldV1::SecureNoteBody) => {
+            Ok(RevealedSecretV1::text(&value.body))
+        }
+        (AnyRecord::Card(value), SecretFieldV1::CardNumber) => {
+            Ok(RevealedSecretV1::text(&value.number))
+        }
+        (AnyRecord::Card(value), SecretFieldV1::CardCvv) => Ok(RevealedSecretV1::text(&value.cvv)),
+        (AnyRecord::TotpSeed(value), SecretFieldV1::TotpSecret) => {
+            Ok(RevealedSecretV1::bytes(&value.secret))
+        }
+        (AnyRecord::ApiKey(value), SecretFieldV1::ApiKeyToken) => {
+            Ok(RevealedSecretV1::text(&value.token))
+        }
+        (AnyRecord::DatabaseCredential(value), SecretFieldV1::DatabasePassword) => {
+            Ok(RevealedSecretV1::text(&value.password))
+        }
+        _ => Err(ApplicationError::InvalidInput),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coding_adventures_vault_records::{
+        ApiKey, Card, DatabaseCredential, Login, SecureNote, TotpSeed,
+    };
+
+    #[test]
+    fn disclosure_policy_requires_complete_reveal_ceremonies() {
+        assert_eq!(SecretDisclosureIntentV1::Clipboard.authorize(), Ok(()));
+        assert_eq!(
+            SecretDisclosureIntentV1::InteractiveReveal { confirmed: true }.authorize(),
+            Ok(())
+        );
+        assert_eq!(
+            SecretDisclosureIntentV1::InteractiveReveal { confirmed: false }.authorize(),
+            Err(ApplicationError::InvalidInput)
+        );
+        for (unsafe_include_secrets, warning_emitted, expected) in [
+            (false, false, Err(ApplicationError::InvalidInput)),
+            (true, false, Err(ApplicationError::InvalidInput)),
+            (false, true, Err(ApplicationError::InvalidInput)),
+            (true, true, Ok(())),
+        ] {
+            assert_eq!(
+                SecretDisclosureIntentV1::UnsafeNonInteractiveReveal {
+                    unsafe_include_secrets,
+                    warning_emitted,
+                }
+                .authorize(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn every_first_party_secret_field_is_selected_exactly() {
+        let cases = [
+            (
+                AnyRecord::Login(Login {
+                    title: "login".into(),
+                    username: "user".into(),
+                    password: "login-secret".into(),
+                    urls: vec![],
+                    notes: None,
+                }),
+                SecretFieldV1::LoginPassword,
+                b"login-secret".as_slice(),
+                RevealedSecretEncodingV1::Utf8,
+            ),
+            (
+                AnyRecord::SecureNote(SecureNote {
+                    title: "note".into(),
+                    body: "note-secret".into(),
+                }),
+                SecretFieldV1::SecureNoteBody,
+                b"note-secret".as_slice(),
+                RevealedSecretEncodingV1::Utf8,
+            ),
+            (
+                AnyRecord::Card(Card {
+                    title: "card".into(),
+                    holder: "holder".into(),
+                    number: "4111111111111111".into(),
+                    expiry_month: 1,
+                    expiry_year: 2030,
+                    cvv: "123".into(),
+                    billing_zip: None,
+                }),
+                SecretFieldV1::CardNumber,
+                b"4111111111111111".as_slice(),
+                RevealedSecretEncodingV1::Utf8,
+            ),
+            (
+                AnyRecord::Card(Card {
+                    title: "card".into(),
+                    holder: "holder".into(),
+                    number: "4111111111111111".into(),
+                    expiry_month: 1,
+                    expiry_year: 2030,
+                    cvv: "123".into(),
+                    billing_zip: None,
+                }),
+                SecretFieldV1::CardCvv,
+                b"123".as_slice(),
+                RevealedSecretEncodingV1::Utf8,
+            ),
+            (
+                AnyRecord::TotpSeed(TotpSeed {
+                    label: "totp".into(),
+                    issuer: None,
+                    secret: vec![0, 1, 2, 255],
+                    algorithm: "SHA1".into(),
+                    digits: 6,
+                    period: 30,
+                }),
+                SecretFieldV1::TotpSecret,
+                &[0, 1, 2, 255],
+                RevealedSecretEncodingV1::Bytes,
+            ),
+            (
+                AnyRecord::ApiKey(ApiKey {
+                    label: "api".into(),
+                    service: "service".into(),
+                    token: "api-secret".into(),
+                    scopes: vec![],
+                    expires_at: None,
+                }),
+                SecretFieldV1::ApiKeyToken,
+                b"api-secret".as_slice(),
+                RevealedSecretEncodingV1::Utf8,
+            ),
+            (
+                AnyRecord::DatabaseCredential(DatabaseCredential {
+                    label: "database".into(),
+                    engine: "postgres".into(),
+                    host: "localhost".into(),
+                    port: 5432,
+                    database: None,
+                    username: "user".into(),
+                    password: "database-secret".into(),
+                    lease_id: None,
+                    expires_at: None,
+                }),
+                SecretFieldV1::DatabasePassword,
+                b"database-secret".as_slice(),
+                RevealedSecretEncodingV1::Utf8,
+            ),
+        ];
+
+        for (record, field, expected, encoding) in cases {
+            let mut revealed = select_secret(&record, field).unwrap();
+            assert_eq!(revealed.as_bytes(), expected);
+            assert_eq!(revealed.encoding(), encoding);
+            revealed.zeroize();
+            assert!(revealed.as_bytes().is_empty());
+        }
+    }
+
+    #[test]
+    fn wrong_schema_and_opaque_fields_fail_closed() {
+        let login = AnyRecord::Login(Login {
+            title: "login".into(),
+            username: "user".into(),
+            password: "secret".into(),
+            urls: vec![],
+            notes: None,
+        });
+        assert!(matches!(
+            select_secret(&login, SecretFieldV1::CardCvv),
+            Err(ApplicationError::InvalidInput)
+        ));
+
+        let opaque = AnyRecord::Opaque {
+            content_type: "future/secret/v1".into(),
+            payload_bytes: vec![1, 2, 3],
+        };
+        assert!(matches!(
+            select_secret(&opaque, SecretFieldV1::ApiKeyToken),
+            Err(ApplicationError::InvalidInput)
+        ));
+    }
+}

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -9,6 +9,7 @@
 
 mod codec;
 mod crypto;
+mod disclosure;
 mod initialize;
 mod mutation;
 mod open;
@@ -25,6 +26,9 @@ pub use codec::{
 pub use crypto::{
     open_local_secret, open_object, seal_local_secret, seal_object, LocalSecretRandomness,
     ObjectKind, ObjectRandomness, V1Keys,
+};
+pub use disclosure::{
+    RevealedSecretEncodingV1, RevealedSecretV1, SecretDisclosureIntentV1, SecretFieldV1,
 };
 pub use initialize::{
     complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -9,7 +9,8 @@ use crate::{
     open_object, ActiveStateV1, ApplicationError, ApplicationRepository,
     ApplicationRepositoryError, ApplicationRepositoryFactory, BootstrapLocator, BootstrapStore,
     BootstrapStoreError, CatalogV1, LocalSecretV1, LocalStateStore, LocalStateStoreError,
-    LocalVaultStateV1, ObjectKind, V1Keys,
+    LocalVaultStateV1, ObjectKind, RevealedSecretV1, SecretDisclosureIntentV1, SecretFieldV1,
+    V1Keys,
 };
 use coding_adventures_vault_pm_domain::{
     CollectionId, ItemCandidate, ItemDocument, ItemId, ItemState, RedactedItemView, RevisionId,
@@ -293,6 +294,24 @@ impl UnlockedVaultV1 {
             return Err(ApplicationError::InvalidInput);
         };
         Ok(Zeroizing::new(document.as_ref().clone()))
+    }
+
+    /// Select and authorize disclosure of one secret-bearing field from one
+    /// exact reachable live revision.
+    ///
+    /// Policy is checked before repository traversal. The returned value is
+    /// owned, non-printable, non-cloneable, and wipe-on-drop. The host remains
+    /// responsible for its controlling-TTY facts, warning output, and secure
+    /// clipboard ownership/clear behavior.
+    pub fn reveal_item_revision_field(
+        &self,
+        selected_revision: RevisionId,
+        field: SecretFieldV1,
+        intent: SecretDisclosureIntentV1,
+    ) -> Result<RevealedSecretV1, ApplicationError> {
+        intent.authorize()?;
+        let document = self.reveal_item_revision(selected_revision)?;
+        crate::disclosure::select_secret(document.payload(), field)
     }
 
     /// Add one new item through the exact crash-resumable publication state
@@ -2991,6 +3010,32 @@ mod tests {
         };
         assert_eq!(login.title, "Reveal original");
         assert_eq!(login.password, "original-secret");
+
+        let revealed = session
+            .reveal_item_revision_field(
+                original_revision,
+                SecretFieldV1::LoginPassword,
+                SecretDisclosureIntentV1::Clipboard,
+            )
+            .unwrap();
+        assert_eq!(revealed.as_bytes(), b"original-secret");
+        assert_eq!(revealed.encoding(), crate::RevealedSecretEncodingV1::Utf8);
+        assert!(matches!(
+            session.reveal_item_revision_field(
+                original_revision,
+                SecretFieldV1::CardCvv,
+                SecretDisclosureIntentV1::Clipboard,
+            ),
+            Err(ApplicationError::InvalidInput)
+        ));
+        assert!(matches!(
+            session.reveal_item_revision_field(
+                RevisionId::new([0x94; 32]),
+                SecretFieldV1::LoginPassword,
+                SecretDisclosureIntentV1::InteractiveReveal { confirmed: false },
+            ),
+            Err(ApplicationError::InvalidInput)
+        ));
 
         let mut current = session.reveal_item_revision(current_revision).unwrap();
         let AnyRecord::Login(login) = current.payload() else {

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1322,7 +1322,10 @@ changelog, focused build, and downstream validation.
        field reveal;
    7c-1. completed bounded reachable live-revision reveal into a non-printable
        owned zeroizing document wrapper;
-   7c-2. host-facing field selection and explicit copy/reveal policy adapters;
+   7c-2. completed schema-specific first-party secret-field selection into a
+       non-printable wipe-on-drop value, with explicit clipboard, confirmed
+       interactive reveal, and warned unsafe non-interactive policy inputs;
+   7c-3. host clipboard adapter with ownership-aware timed clear;
    7d. authenticated portable export and restore/import preparation; and
    7e. audit, status, and doctor workflows; and
    7f. close the remaining VLT-PM05 `Locked` error and explicit lock-state

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -525,8 +525,9 @@ publication. Device enrollment defines the later fresh-device ceremony.
 - `restore_item(revision)` writes a new live revision whose causal parent is the
   selected historical revision;
 - `get_item(id)` and `list_items(filter)` return only `RedactedItemView`;
-- `reveal_field(id, field)` returns one zeroizing `RevealedSecret` through an
-  explicit API; and
+- `reveal_field(id, field, intent)` returns one zeroizing `RevealedSecret`
+  through a schema-specific API after validating clipboard, confirmed
+  interactive reveal, or warned unsafe non-interactive intent; and
 - unresolved concurrent candidates return `ConflictRequired` and remain
   available for a later resolution workflow.
 


### PR DESCRIPTION
## Summary

- select every first-party secret through a schema-specific field enum
- return one binary-or-UTF-8 secret in a non-printable wipe-on-drop value
- require an explicit clipboard, confirmed interactive reveal, or warned unsafe non-interactive policy path
- keep terminal and clipboard authority in host adapters and record the ownership-aware clipboard follow-up

## Security properties

- validates disclosure policy before repository traversal
- requires both explicit unsafe opt-in and a host-emitted warning for non-TTY output
- rejects wrong-schema selectors and opaque records
- exposes no `Debug`, `Display`, or `Clone` implementation for revealed values
- adds no filesystem, provider, terminal, or clipboard dependency to the application core

## Verification

- `bash BUILD` (91 tests)
- focused `cargo test`
- strict Clippy (`-D warnings`)
- strict rustdoc (`-D warnings`)
- Tarpaulin: 2,250/2,361 production lines (95.30%); disclosure module 33/33
- repository planner: 1,001 packages, 1 changed, 21 affected, all affected packages built
