### PR TITLE
feat(hl-tamil): close chapters 4-5's script debt

### DIFF
--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -124,7 +124,7 @@ enter cross-language review only after focused retrieval.
 | [German](./german/README.md) | Germanic / Latin | 106 | 91 | 31 chapters; through Ch. 31; 15 generated |
 | [Arabic](./arabic/README.md) | Semitic / Arabic | 100 | 98 | 36 chapters; through Ch. 36; 34 generated |
 | [Hindi](./hindi/README.md) | Indo-Aryan / Devanagari | 109 | 103 | 39 chapters; through Ch. 39; 34 generated |
-| [Tamil](./tamil/README.md) | Dravidian / Tamil | 122 | 118 | 38 chapters; through Ch. 38; 33 generated |
+| [Tamil](./tamil/README.md) | Dravidian / Tamil | 125 | 121 | 38 chapters; through Ch. 38; 33 generated |
 | [Kannada](./kannada/README.md) | Dravidian / Kannada | 88 | 84 | 40 chapters; through Ch. 40; 35 generated |
 | [Telugu](./telugu/README.md) | Dravidian / Telugu | 74 | 70 | 34 chapters; through Ch. 34; 29 generated |
 | [Malayalam](./malayalam/README.md) | Dravidian / Malayalam | 78 | 74 | 34 chapters; through Ch. 34; 29 generated |

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -4043,11 +4043,12 @@
     {
       "language": "tamil",
       "chapter": 33,
-      "sourceHash": "fnv1a64:3bc295a90be3325d",
+      "sourceHash": "fnv1a64:c9ee25acee4c3a7f",
       "lessonIds": [
         "TA-C33-ninai",
         "TA-C33-puri",
         "TA-C33-padi",
+        "TA-W16-read-tamizh",
         "TA-C33-ezhutu"
       ],
       "tex": "tamil/book/chapters/ch33-verbs-of-the-mind.tex"
@@ -4055,10 +4056,11 @@
     {
       "language": "tamil",
       "chapter": 34,
-      "sourceHash": "fnv1a64:913881ac8f00f9b0",
+      "sourceHash": "fnv1a64:a11a552c200636de",
       "lessonIds": [
         "TA-C34-edu",
         "TA-C34-kel",
+        "TA-W14-read-pesu",
         "TA-C34-utavu",
         "TA-C34-pidi"
       ],
@@ -4067,9 +4069,10 @@
     {
       "language": "tamil",
       "chapter": 35,
-      "sourceHash": "fnv1a64:cc781feef9dd0947",
+      "sourceHash": "fnv1a64:65a207deb9f6b6df",
       "lessonIds": [
         "TA-C35-veedu",
+        "TA-W15-read-po",
         "TA-C35-kadavu",
         "TA-C35-arai",
         "TA-C35-naarkaali"

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -7087,7 +7087,7 @@
     {
       "language": "tamil",
       "chapter": 4,
-      "sourceHash": "fnv1a64:ac8d1a3a89c18c13",
+      "sourceHash": "fnv1a64:a5a6cf8447b604ca",
       "lessonIds": [
         "TA-C04-po",
         "TA-C04-poy-varugiren",
@@ -7096,17 +7096,17 @@
         "TA-W01-curves-va-ka",
         "TA-C04-practice"
       ],
-      "voiceLessons": 1,
-      "drivablePrefix": 0,
+      "voiceLessons": 5,
+      "drivablePrefix": 4,
       "text": "tamil/narration/ch04.txt",
       "json": "tamil/narration/ch04.json",
-      "textHash": "fnv1a64:e5095270ae59ea43",
-      "jsonHash": "fnv1a64:4fdf4e9833823a52"
+      "textHash": "fnv1a64:82b53ce6bf0c7508",
+      "jsonHash": "fnv1a64:e64a303e793a3fef"
     },
     {
       "language": "tamil",
       "chapter": 5,
-      "sourceHash": "fnv1a64:0718a395630b7532",
+      "sourceHash": "fnv1a64:e673ee026212e7ec",
       "lessonIds": [
         "TA-C05-pesu",
         "TA-C05-naan-tamizh-pesugiren",
@@ -7115,12 +7115,12 @@
         "TA-C05-velai-sey",
         "TA-C05-practice"
       ],
-      "voiceLessons": 1,
-      "drivablePrefix": 0,
+      "voiceLessons": 5,
+      "drivablePrefix": 2,
       "text": "tamil/narration/ch05.txt",
       "json": "tamil/narration/ch05.json",
-      "textHash": "fnv1a64:75cb0e6472b4e312",
-      "jsonHash": "fnv1a64:d069e67cf6116dd0"
+      "textHash": "fnv1a64:4942146a0615affe",
+      "jsonHash": "fnv1a64:9c706cca35666885"
     },
     {
       "language": "tamil",
@@ -7540,27 +7540,29 @@
     {
       "language": "tamil",
       "chapter": 33,
-      "sourceHash": "fnv1a64:87330318c12938c6",
+      "sourceHash": "fnv1a64:1692ee153a91024f",
       "lessonIds": [
         "TA-C33-ninai",
         "TA-C33-puri",
         "TA-C33-padi",
+        "TA-W16-read-tamizh",
         "TA-C33-ezhutu"
       ],
       "voiceLessons": 0,
       "drivablePrefix": 0,
       "text": "tamil/narration/ch33.txt",
       "json": "tamil/narration/ch33.json",
-      "textHash": "fnv1a64:d5d28e2aea496fd2",
-      "jsonHash": "fnv1a64:a7856dd949e95471"
+      "textHash": "fnv1a64:70dee08f58a6d6a0",
+      "jsonHash": "fnv1a64:dc9c376c15fc5184"
     },
     {
       "language": "tamil",
       "chapter": 34,
-      "sourceHash": "fnv1a64:0afe185a93c0169e",
+      "sourceHash": "fnv1a64:7389731691de483a",
       "lessonIds": [
         "TA-C34-edu",
         "TA-C34-kel",
+        "TA-W14-read-pesu",
         "TA-C34-utavu",
         "TA-C34-pidi"
       ],
@@ -7568,15 +7570,16 @@
       "drivablePrefix": 0,
       "text": "tamil/narration/ch34.txt",
       "json": "tamil/narration/ch34.json",
-      "textHash": "fnv1a64:3b698d59bb660735",
-      "jsonHash": "fnv1a64:157d4fcd23ee1fbb"
+      "textHash": "fnv1a64:df1589ac7e6aa906",
+      "jsonHash": "fnv1a64:f2f3abc0dc06540e"
     },
     {
       "language": "tamil",
       "chapter": 35,
-      "sourceHash": "fnv1a64:c26956daee7bf61d",
+      "sourceHash": "fnv1a64:ef59f7e86d3ed65d",
       "lessonIds": [
         "TA-C35-veedu",
+        "TA-W15-read-po",
         "TA-C35-kadavu",
         "TA-C35-arai",
         "TA-C35-naarkaali"
@@ -7585,8 +7588,8 @@
       "drivablePrefix": 0,
       "text": "tamil/narration/ch35.txt",
       "json": "tamil/narration/ch35.json",
-      "textHash": "fnv1a64:73c0cbf33267d147",
-      "jsonHash": "fnv1a64:c720257d941123fc"
+      "textHash": "fnv1a64:eb692dab7ce74c09",
+      "jsonHash": "fnv1a64:8701f8e9b5e65685"
     },
     {
       "language": "tamil",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,19 +7,19 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:9256ebdf7b2dd5b8",
+  "sourceHash": "fnv1a64:d6e3ba9e6a7c8cf2",
   "summary": {
-    "totalLessons": 1684,
-    "voice": 1106,
-    "sight": 516,
-    "pen": 62,
-    "drivableLessons": 1106,
+    "totalLessons": 1687,
+    "voice": 1114,
+    "sight": 508,
+    "pen": 65,
+    "drivableLessons": 1114,
     "drivablePercent": 66,
     "trackCount": 22,
     "chapterCount": 513,
-    "drivablePrefixTotal": 918,
+    "drivablePrefixTotal": 924,
     "fullyDrivableChapters": 324,
-    "unstartableChapters": 139,
+    "unstartableChapters": 137,
     "overriddenLessons": 0,
     "lessonsWithoutChapter": 0
   },
@@ -7548,12 +7548,12 @@
     },
     {
       "language": "tamil",
-      "lessonCount": 122,
-      "voice": 68,
-      "sight": 37,
-      "pen": 17,
-      "drivablePercent": 56,
-      "drivablePrefixTotal": 54,
+      "lessonCount": 125,
+      "voice": 76,
+      "sight": 29,
+      "pen": 20,
+      "drivablePercent": 61,
+      "drivablePrefixTotal": 60,
       "modalities": [
         "voice",
         "sight",
@@ -7626,34 +7626,42 @@
         {
           "chapter": 4,
           "lessonCount": 6,
-          "voice": 1,
-          "sight": 4,
+          "voice": 5,
+          "sight": 0,
           "pen": 1,
           "modalities": [
             "voice",
             "sight",
             "pen"
           ],
-          "drivablePrefix": 0,
-          "firstNonVoiceLesson": "TA-C04-po",
+          "drivablePrefix": 4,
+          "firstNonVoiceLesson": "TA-W01-curves-va-ka",
           "drivable": false,
-          "drivableLessonIds": []
+          "drivableLessonIds": [
+            "TA-C04-po",
+            "TA-C04-poy-varugiren",
+            "TA-C04-naalai",
+            "TA-C04-mindum-sandippom"
+          ]
         },
         {
           "chapter": 5,
           "lessonCount": 6,
-          "voice": 1,
-          "sight": 4,
+          "voice": 5,
+          "sight": 0,
           "pen": 1,
           "modalities": [
             "voice",
             "sight",
             "pen"
           ],
-          "drivablePrefix": 0,
-          "firstNonVoiceLesson": "TA-C05-pesu",
+          "drivablePrefix": 2,
+          "firstNonVoiceLesson": "TA-W01-abugida-va-ka",
           "drivable": false,
-          "drivableLessonIds": []
+          "drivableLessonIds": [
+            "TA-C05-pesu",
+            "TA-C05-naan-tamizh-pesugiren"
+          ]
         },
         {
           "chapter": 6,
@@ -8126,12 +8134,13 @@
         },
         {
           "chapter": 33,
-          "lessonCount": 4,
+          "lessonCount": 5,
           "voice": 0,
           "sight": 4,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "sight"
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 0,
           "firstNonVoiceLesson": "TA-C33-ninai",
@@ -8140,13 +8149,14 @@
         },
         {
           "chapter": 34,
-          "lessonCount": 4,
+          "lessonCount": 5,
           "voice": 1,
           "sight": 3,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
             "voice",
-            "sight"
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 0,
           "firstNonVoiceLesson": "TA-C34-edu",
@@ -8155,12 +8165,13 @@
         },
         {
           "chapter": 35,
-          "lessonCount": 4,
+          "lessonCount": 5,
           "voice": 0,
           "sight": 4,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "sight"
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 0,
           "firstNonVoiceLesson": "TA-C35-veedu",
@@ -36515,84 +36526,72 @@
       "language": "tamil",
       "chapter": 4,
       "sequence": 240,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:a137cdf96f4af1dd",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:4032f776949c58bb"
     },
     {
       "id": "TA-C04-poy-varugiren",
       "language": "tamil",
       "chapter": 4,
       "sequence": 250,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:b827e77978feac54",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:4db27cf81bd3a648"
     },
     {
       "id": "TA-C04-naalai",
       "language": "tamil",
       "chapter": 4,
       "sequence": 255,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:93385c7a8e7ee524",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:34d2538c5a595200"
     },
     {
       "id": "TA-C04-mindum-sandippom",
       "language": "tamil",
       "chapter": 4,
       "sequence": 260,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:8dd1d2b81b09c384",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:5d3e6bac3fb15ffa"
     },
     {
       "id": "TA-W01-curves-va-ka",
@@ -36642,42 +36641,36 @@
       "language": "tamil",
       "chapter": 5,
       "sequence": 300,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:d3ef5e5538b5a60d",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:fb566b65a21c956b"
     },
     {
       "id": "TA-C05-naan-tamizh-pesugiren",
       "language": "tamil",
       "chapter": 5,
       "sequence": 310,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:ea295f6dbc121380",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:c8fbce5b84c6ca12"
     },
     {
       "id": "TA-W01-abugida-va-ka",
@@ -36709,42 +36702,36 @@
       "language": "tamil",
       "chapter": 5,
       "sequence": 330,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:c25a4a6426c60568",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:897c0df3eca3c5a6"
     },
     {
       "id": "TA-C05-velai-sey",
       "language": "tamil",
       "chapter": 5,
       "sequence": 340,
-      "modality": "sight",
-      "derived": "sight",
-      "drivable": false,
+      "modality": "voice",
+      "derived": "voice",
+      "drivable": true,
       "reasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
       "coreModality": "voice",
       "coreReasons": [
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:64528b6911be0db6",
-      "detachableSegments": [
-        "The letters in this word"
-      ]
+      "sourceHash": "fnv1a64:41f470fad02f3716"
     },
     {
       "id": "TA-C05-practice",
@@ -38079,6 +38066,30 @@
       ]
     },
     {
+      "id": "TA-W16-read-tamizh",
+      "language": "tamil",
+      "chapter": 33,
+      "sequence": 965,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:cd982d731316d61c",
+      "detachableSegments": [
+        "Script you'll notice: த and ழ",
+        "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
+    },
+    {
       "id": "TA-C33-ezhutu",
       "language": "tamil",
       "chapter": 33,
@@ -38142,6 +38153,30 @@
       ]
     },
     {
+      "id": "TA-W14-read-pesu",
+      "language": "tamil",
+      "chapter": 34,
+      "sequence": 995,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:20e9fcd487bbd15c",
+      "detachableSegments": [
+        "Script you'll notice: the ே sign",
+        "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
+    },
+    {
       "id": "TA-C34-utavu",
       "language": "tamil",
       "chapter": 34,
@@ -38200,6 +38235,30 @@
       "detachableSegments": [
         "The letters in this word"
       ]
+    },
+    {
+      "id": "TA-W15-read-po",
+      "language": "tamil",
+      "chapter": 35,
+      "sequence": 1025,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:7b8a45f2c391781b",
+      "detachableSegments": [
+        "Script you'll notice: the ோ sign",
+        "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
     },
     {
       "id": "TA-C35-kadavu",

--- a/code/learning/human-languages/tamil/book/chapter-modalities.tex
+++ b/code/learning/human-languages/tamil/book/chapter-modalities.tex
@@ -51,14 +51,14 @@
 
 \expandafter\def\csname hlchaptermodality4\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1) \quad \hlsightsign{}~\textbf{eyes} (4) \quad \hlpensign{}~\textbf{pen} (1)\quad
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (5) \quad \hlpensign{}~\textbf{pen} (1)\quad
     \hlvoicesign{}~\textbf{Hands-free start:} first 4 of 6 lessons.%
     \par}\medskip
 }
 
 \expandafter\def\csname hlchaptermodality5\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1) \quad \hlsightsign{}~\textbf{eyes} (4) \quad \hlpensign{}~\textbf{pen} (1)\quad
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (5) \quad \hlpensign{}~\textbf{pen} (1)\quad
     \hlvoicesign{}~\textbf{Hands-free start:} first 2 of 6 lessons.%
     \par}\medskip
 }
@@ -254,22 +254,22 @@
 
 \expandafter\def\csname hlchaptermodality33\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (4)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} all 4 lessons.%
+    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (4) \quad \hlpensign{}~\textbf{pen} (1)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 3 of 5 lessons.%
     \par}\medskip
 }
 
 \expandafter\def\csname hlchaptermodality34\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1) \quad \hlsightsign{}~\textbf{eyes} (3)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} all 4 lessons.%
+    \textbf{Modes:} \hlvoicesign{}~\textbf{voice} (1) \quad \hlsightsign{}~\textbf{eyes} (3) \quad \hlpensign{}~\textbf{pen} (1)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 2 of 5 lessons.%
     \par}\medskip
 }
 
 \expandafter\def\csname hlchaptermodality35\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (4)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} all 4 lessons.%
+    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (4) \quad \hlpensign{}~\textbf{pen} (1)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 1 of 5 lessons.%
     \par}\medskip
 }
 

--- a/code/learning/human-languages/tamil/book/chapters/appendix-index.tex
+++ b/code/learning/human-languages/tamil/book/chapters/appendix-index.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons or chapters.json, then run npm run generate:books.
-% canonical-index-candidates: 155
-% canonical-index-entries: 155
+% canonical-index-candidates: 158
+% canonical-index-entries: 158
 
 \chapter*{Index}
 \addcontentsline{toc}{chapter}{Index}
@@ -249,7 +249,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{goodbye (lit. \textquotedblleft{}I'll go and come back\textquotedblright{})}\enspace\emph{\ta{போய்} \ta{வருகிறேன்}}\par
-\footnotesize explicit focus: script, grammar, etymology; \hyperref[ch:farewells]{Chapter~4, p.~\pageref*{ch:farewells}}
+\footnotesize explicit focus: grammar, etymology; \hyperref[ch:farewells]{Chapter~4, p.~\pageref*{ch:farewells}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -337,7 +337,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{I speak Tamil}\enspace\emph{\ta{நான்} \ta{தமிழ்} \ta{பேசுகிறேன்}}\par
-\footnotesize explicit focus: script, grammar, etymology; \hyperref[ch:first-verbs]{Chapter~5, p.~\pageref*{ch:first-verbs}}
+\footnotesize explicit focus: grammar, etymology; \hyperref[ch:first-verbs]{Chapter~5, p.~\pageref*{ch:first-verbs}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -523,7 +523,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{see you tomorrow}\enspace\emph{\ta{நாளை} \ta{பார்க்கலாம்}}\par
-\footnotesize explicit focus: script, etymology; \hyperref[ch:farewells]{Chapter~4, p.~\pageref*{ch:farewells}}
+\footnotesize explicit focus: etymology; \hyperref[ch:farewells]{Chapter~4, p.~\pageref*{ch:farewells}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -669,7 +669,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{to go (and \ta{வா}, to come)}\enspace\emph{\ta{போ}}\par
-\footnotesize explicit focus: script, etymology; \hyperref[ch:farewells]{Chapter~4, p.~\pageref*{ch:farewells}}
+\footnotesize explicit focus: etymology; \hyperref[ch:farewells]{Chapter~4, p.~\pageref*{ch:farewells}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -693,7 +693,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{to live, to flourish}\enspace\emph{\ta{வாழ்}}\par
-\footnotesize explicit focus: script, grammar, etymology; \hyperref[ch:first-verbs]{Chapter~5, p.~\pageref*{ch:first-verbs}}
+\footnotesize explicit focus: grammar, etymology; \hyperref[ch:first-verbs]{Chapter~5, p.~\pageref*{ch:first-verbs}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -711,7 +711,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{to speak}\enspace\emph{\ta{பேசு}}\par
-\footnotesize explicit focus: script, grammar, etymology; \hyperref[ch:first-verbs]{Chapter~5, p.~\pageref*{ch:first-verbs}}
+\footnotesize explicit focus: grammar, etymology; \hyperref[ch:first-verbs]{Chapter~5, p.~\pageref*{ch:first-verbs}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -729,7 +729,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{to work (lit. \textquotedblleft{}work-do\textquotedblright{})}\enspace\emph{\ta{வேலை} \ta{செய்}}\par
-\footnotesize explicit focus: script, grammar, etymology; \hyperref[ch:first-verbs]{Chapter~5, p.~\pageref*{ch:first-verbs}}
+\footnotesize explicit focus: grammar, etymology; \hyperref[ch:first-verbs]{Chapter~5, p.~\pageref*{ch:first-verbs}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -775,7 +775,7 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
 \textbf{we'll meet again}\enspace\emph{\ta{மீண்டும்} \ta{சந்திப்போம்}}\par
-\footnotesize explicit focus: script, etymology; \hyperref[ch:farewells]{Chapter~4, p.~\pageref*{ch:farewells}}
+\footnotesize explicit focus: etymology; \hyperref[ch:farewells]{Chapter~4, p.~\pageref*{ch:farewells}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}
@@ -886,6 +886,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 
 \noindent\begin{minipage}[t]{\linewidth}
 \raggedright
+\textbf{\ta{தமிழ்} — the letter the language is named for}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ta-verbs-of-the-mind]{Chapter~33, p.~\pageref*{ch:ta-verbs-of-the-mind}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
 \textbf{\ta{தயவுசெய்து} or -\ta{உங்கள்}? — politeness in phrase or verb}\par
 \footnotesize grammar topic; explicit focus: script, usage and culture; \hyperref[ch:ta-please]{Chapter~8, p.~\pageref*{ch:ta-please}}
 \end{minipage}\par\smallskip
@@ -936,6 +942,18 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{\ta{நாள்} and \ta{தினம்} — everyday native, formal borrowed}\par
 \footnotesize etymology topic; \hyperref[ch:ta-day]{Chapter~23, p.~\pageref*{ch:ta-day}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{போ} — one sign, two marks}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ta-arriving-at-a-house]{Chapter~35, p.~\pageref*{ch:ta-arriving-at-a-house}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{பேசு} — the long partner of \ta{ெ}}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ta-verbs-between-people]{Chapter~34, p.~\pageref*{ch:ta-verbs-between-people}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}

--- a/code/learning/human-languages/tamil/book/chapters/ch04-farewells.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch04-farewells.tex
@@ -12,11 +12,6 @@ English ears --- ``I'll go and \emph{come back}'':
 \section{\ta{போ} \emph{(p\=o)} --- ``go,'' and \ta{வா} (come)}
 \label{lesson:po}
 
-\begin{sounds}
-\ta{ப} (\emph{pa}) $+$ \ta{ோ} (long \=o) $\to$ \ta{போ} (\emph{p\=o}). Its partner
-\ta{வா} (\emph{v\=a}, ``come'').
-\end{sounds}
-
 \begin{cousinweb}
 \ta{போ} (\emph{p\=o}, ``go'') and \ta{வா} (\emph{v\=a}, ``come'') are native
 Dravidian verbs of the deepest layer --- single syllables, whole words on their
@@ -61,12 +56,6 @@ last in a participle form, the last fully conjugated.
 
 \section{\ta{நாளை பார்க்கலாம்} \emph{(n\=a\d{l}ai p\=arkkal\=am)} --- ``see you tomorrow''}
 \label{lesson:naalai}
-
-\begin{sounds}
-\ta{நாளை} (\emph{n\=a\d{l}ai}): \ta{நா} (\emph{n\=a}) $+$ \ta{ளை} (\emph{\d{l}ai},
-retroflex \ta{ள} \emph{\d{l}}). \ta{பார்க்கலாம்} (\emph{p\=arkkal\=am}) $=$
-\emph{p\=ar} (``see'') $+$ \emph{-kkal\=am} (``let's / we may'').
-\end{sounds}
 
 \begin{cousinweb}
 \ta{நாளை} (\emph{n\=a\d{l}ai}, ``tomorrow'') is native, from \ta{நாள்} (\emph{n\=a\d{l}},

--- a/code/learning/human-languages/tamil/book/chapters/ch05-first-verbs.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch05-first-verbs.tex
@@ -12,11 +12,6 @@ sentences begin to move:
 \section{\ta{பேசு} \emph{(p\=esu)} --- ``to speak,'' your first full verb}
 \label{lesson:pesu}
 
-\begin{sounds}
-\ta{ப} (\emph{pa}) $+$ \ta{ே} (long \=e) $+$ \ta{சு} (\emph{su}) $\to$ \ta{பேசு}
-(\emph{p\=esu}).
-\end{sounds}
-
 \begin{cousinweb}
 \ta{பேசு} (\emph{p\=esu}, ``to speak'') is native Dravidian; the bare stem is also
 the command ``speak!'' To say ``I speak,'' Tamil stacks two endings on the stem
@@ -87,11 +82,6 @@ do not depend on those written distinctions.
 
 \section{\ta{வாழ்} \emph{(v\=a\d{l})} --- ``to live, to flourish''}
 \label{lesson:vaazh}
-
-\begin{sounds}
-\ta{வா} (\emph{v\=a}) $+$ \ta{ழ்} (\emph{\d{l}}, the retroflex from \emph{tami\d{l}})
-$\to$ \ta{வாழ்} (\emph{v\=a\d{l}}).
-\end{sounds}
 
 \begin{cousinweb}
 \ta{வாழ்} (\emph{v\=a\d{l}}, ``to live, flourish, thrive'') is native, warmer than

--- a/code/learning/human-languages/tamil/book/chapters/ch33-verbs-of-the-mind.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch33-verbs-of-the-mind.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:3bc295a90be3325d
-% canonical-lessons: TA-C33-ninai, TA-C33-puri, TA-C33-padi, TA-C33-ezhutu
+% canonical-source-hash: fnv1a64:c9ee25acee4c3a7f
+% canonical-lessons: TA-C33-ninai, TA-C33-puri, TA-C33-padi, TA-W16-read-tamizh, TA-C33-ezhutu
 
 \chapter{Four Verbs of the Mind}
 \label{ch:ta-verbs-of-the-mind}
@@ -185,6 +185,65 @@ Say these aloud:
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Why is \textbf{\ta{ட}} written one way and heard two ways, and where is it made? (\textbf{Tamil marks no voicing} — position decides, as with \textbf{\ta{க}}; and it is \textbf{retroflex}, made where \textbf{\ta{ண}} is.) Is \emph{paḍi} borrowed from Sanskrit \emph{paṭh}, and what can Tamil never keep from a Sanskrit word? (\textbf{Unsettled}; \textbf{the aspiration}.) Say \textquotedblleft{}I study Tamil.\textquotedblright{} (\emph{Nāṉ tamiḻ paḍikkiṟēṉ}.)
+\end{tcolorbox}
+\section[tamiḻ]{\ta{தமிழ்} — the letter the language is named for}
+
+\label{lesson:TA-W16-read-tamizh}
+
+
+
+\begin{quote}
+This book has said more than once that Tamil keeps three \emph{l}-letters, and the strand has shown you two: \textbf{\ta{ல}} in \textbf{\ta{இல்லை}}, \textbf{\ta{ள}} in \textbf{\ta{நீங்கள்}}. The third has been outstanding since chapter 18. Here it is, in the word it matters most in.
+\end{quote}
+
+\subsection*{Script you'll notice: \ta{த} and \ta{ழ}}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{த}} & \emph{ta} — the dental \emph{t}, tongue on the teeth \\
+\textbf{\ta{ழ}} & \emph{ḻ} — the third \emph{l}-letter, curled far back \\
+\bottomrule
+\end{tabularx}
+
+\textbf{\ta{த}} is the dental partner of the retroflex \textbf{\ta{ட}} you read in \textbf{\ta{எப்படி}}: same kind of stop, different place in the mouth. Tamil keeps the pair apart in writing, so \textbf{\ta{த}} and \textbf{\ta{ட}} are never interchangeable.
+
+\textbf{\ta{ழ}} is the one Tamil is known for. It is made further back than \textbf{\ta{ள}}, and its sound sits somewhere between an \emph{r}, an \emph{l} and a \emph{zh} — rare enough in the world's languages that Tamil is sometimes called the \textbf{ḻ} language. That is why the word for the language itself ends in it.
+
+\begin{quote}
+Read both; do not draw them yet. Neither \textbf{\ta{த}} nor \textbf{\ta{ழ}} has an entry in this book's script data, so neither gets a stroke order, and the mouth positions above are this lesson's own — the data is sourced for \textbf{\ta{ண}}'s retroflex curl and nothing else here.
+\end{quote}
+
+\subsection*{Script you'll notice: build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{த}} & \emph{ta} & this lesson \\
+\textbf{\ta{மி}} & \emph{mi} — \ta{ம} with the \ta{ி} sign & \ta{ம} from \textbf{\ta{வணக்கம்}}, \ta{ி} from \textbf{\ta{நன்றி}} \\
+\textbf{\ta{ழ்}} & bare \emph{ḻ} — \textbf{\ta{ழ}} under a puḷḷi & this lesson \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{த} · \ta{மி} · \ta{ழ்} $\to$ \ta{தமிழ்}}
+\end{quote}
+
+Three pieces, and you can now read the name of the language you have been speaking since page one. That was the plan: the word first, the letters when they can be earned.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \textbf{\ta{த}} · \textbf{\ta{ழ}} — then \textbf{\ta{தமிழ்}}
+  \item \emph{Say it:} \textquotedblleft{}tamiḻ\textquotedblright{} — and hold that last sound
+  \item \emph{Contrast:} \textbf{\ta{த}} and \textbf{\ta{ட}} — dental and retroflex, teeth and roof
+  \item \emph{Contrast:} \textbf{\ta{ல}} · \textbf{\ta{ள}} · \textbf{\ta{ழ}} — all three \emph{l}-letters, at last
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read \textbf{\ta{தமிழ்}}. Which letter is \textbf{\ta{த}}'s retroflex partner? (\textbf{\ta{ட}}, from \textbf{\ta{எப்படி}}.) Which of the three \emph{l}-letters ends the word, and what is the dot doing? (\textbf{\ta{ழ}}; the puḷḷi \textbf{removes its built-in \emph{a}}.) Next: the verb for writing — spelled with the \ta{ழ} you just met.
 \end{tcolorbox}
 \section[eḻudu]{\ta{எழுது} (eḻudu) — \textquotedblleft{}to write,\textquotedblright{} and the sound Tamil is named for}
 

--- a/code/learning/human-languages/tamil/book/chapters/ch34-verbs-between-people.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch34-verbs-between-people.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:913881ac8f00f9b0
-% canonical-lessons: TA-C34-edu, TA-C34-kel, TA-C34-utavu, TA-C34-pidi
+% canonical-source-hash: fnv1a64:a11a552c200636de
+% canonical-lessons: TA-C34-edu, TA-C34-kel, TA-W14-read-pesu, TA-C34-utavu, TA-C34-pidi
 
 \chapter{Four Verbs Between People}
 \label{ch:ta-verbs-between-people}
@@ -138,6 +138,66 @@ Say these aloud:
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 What two English verbs is \emph{kēḷ}, and what happens to its \textbf{\ta{ள்}} before an ending? (\textbf{Ask} and \textbf{hear}; it hardens to \textbf{\ta{ட்}}.) Which verb taught you to expect a second stem, and what is \emph{kēḷvi}? (\emph{\textbf{\ta{வா}}}, built on \emph{varu-}; \textbf{a question}.) Which register do these lessons teach, and how do you ask politely? (\textbf{Standard spoken} \emph{kēṭkiṟēṉ}; \emph{\textbf{kēḷungaḷ}}.)
+\end{tcolorbox}
+\section[pēsu]{\ta{பேசு} — the long partner of \ta{ெ}}
+
+\label{lesson:TA-W14-read-pesu}
+
+
+
+\begin{quote}
+Twice now a Tamil vowel has come in a short and a long version: \textbf{\ta{அ}} and \textbf{\ta{ஆ}}, \textbf{\ta{ி}} and \textbf{\ta{ீ}}. For \textbf{\ta{அ}}/\textbf{\ta{ஆ}} the script data even says the long one is the short one plus a tail; for \textbf{\ta{ி}}/\textbf{\ta{ீ}} it says nothing, and the pairing is the lesson's. Here is a third pair.
+\end{quote}
+
+\subsection*{Script you'll notice: the \ta{ே} sign}
+\textbf{\ta{ே}} is the sign for long \emph{ē}, and it is the long partner of the \textbf{\ta{ெ}} you met in \textbf{\ta{பெயர்}}. Like \textbf{\ta{ெ}}, it is written to the \textbf{left} of its consonant and spoken after it.
+
+\begin{quote}
+\textbf{\ta{ப} + \ta{ே} $\to$ \ta{பே}}, said \emph{pē}.
+\end{quote}
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{sign} & \textbf{sound} & \textbf{where it is written} \\
+\midrule
+\textbf{\ta{ெ}} & short \emph{e} & to the left \\
+\textbf{\ta{ே}} & long \emph{ē} & to the left \\
+\textbf{\ta{ை}} & \emph{ai} & to the left \\
+\bottomrule
+\end{tabularx}
+
+Three left-standing signs now. The evidence is the same as it was for \textbf{\ta{ெ}}: the script data describes \textbf{\ta{ை}} and has no entry for \textbf{\ta{ெ}} or \textbf{\ta{ே}} at all, so both the shared position \textbf{and} the short/long pairing are stated from the pattern these signs share, not from a source for either one.
+
+\subsection*{Script you'll notice: build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{பே}} & \emph{pē} — \ta{ப} with the \ta{ே} sign on its left & \ta{ப} from \textbf{\ta{பெயர்}} \\
+\textbf{\ta{சு}} & \emph{su} — \ta{ச} with the \ta{ு} sign & \ta{ச} from \textbf{\ta{சரி}}, \ta{ு} from \textbf{\ta{இருக்கிறீர்கள்}} \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{பே} · \ta{சு} $\to$ \ta{பேசு}}
+\end{quote}
+
+Two pieces, one new sign, and its two signs pull in opposite directions on the page: \textbf{\ta{ே}} stands before its letter, \textbf{\ta{ு}} joins after it. \textbf{\ta{பேசு}} is \textquotedblleft{}speak\textquotedblright{} — the verb every lesson so far has been in service of.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \textbf{\ta{பே}} — then \textbf{\ta{பேசு}}
+  \item \emph{Say it:} \textquotedblleft{}pēsu\textquotedblright{} — \textquotedblleft{}speak\textquotedblright{}
+  \item \emph{Contrast:} \textbf{\ta{பெ}} and \textbf{\ta{பே}} — the short sign and the long one, both on the left
+  \item \emph{Contrast:} \textbf{\ta{பே}} and \textbf{\ta{சு}} — a sign before, a sign after, inside one word
+  \item \emph{Read it:} \textbf{\ta{தமிழ்} \ta{பேசு}} — \textquotedblleft{}speak Tamil,\textquotedblright{} both words off the page
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read \textbf{\ta{பேசு}}. Which side of its consonant is \textbf{\ta{ே}} written on? (\textbf{The left} — like \textbf{\ta{ெ}} and \textbf{\ta{ை}}.) Which sign is its short partner? (\textbf{\ta{ெ}}, as in \textbf{\ta{பெயர்}}.) What is the \textbf{\ta{ச}} doing here — is it \emph{s} or \emph{ch}? (\textbf{Either}; one letter covers both, and position picks.) Next: the verb for helping.
 \end{tcolorbox}
 \section[udavu]{\ta{உதவு} (udavu) — \textquotedblleft{}to help,\textquotedblright{} and a word Tamil did not borrow}
 

--- a/code/learning/human-languages/tamil/book/chapters/ch35-arriving-at-a-house.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch35-arriving-at-a-house.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:cc781feef9dd0947
-% canonical-lessons: TA-C35-veedu, TA-C35-kadavu, TA-C35-arai, TA-C35-naarkaali
+% canonical-source-hash: fnv1a64:65a207deb9f6b6df
+% canonical-lessons: TA-C35-veedu, TA-W15-read-po, TA-C35-kadavu, TA-C35-arai, TA-C35-naarkaali
 
 \chapter{Arriving at a House}
 \label{ch:ta-arriving-at-a-house}
@@ -76,6 +76,60 @@ Say these aloud:
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Why does one Tamil word do two English jobs here, and which letter opens both \emph{vīḍu} and \emph{vaṇakkam}? (\textbf{House} and \textbf{home} are not split; and \textbf{\ta{வ}}.) What does Kannada put at the front instead of \emph{v}, and is it a one-off? (\textbf{b} — \emph{bīḍu}; \textbf{regular}, from the seventh century on.) Is the Tamil word for \textquotedblleft{}release\textquotedblright{} the same root as the house? (\textbf{Yes} — both under \textbf{\ta{விடு}}, \textquotedblleft{}to let go.\textquotedblright{})
+\end{tcolorbox}
+\section[pō]{\ta{போ} — one sign, two marks}
+
+\label{lesson:TA-W15-read-po}
+
+
+
+\begin{quote}
+Every vowel sign so far has been one mark in one place: before the consonant, above it, or after it. This one is in two places at once, and you already own both halves.
+\end{quote}
+
+\subsection*{Script you'll notice: the \ta{ோ} sign}
+\textbf{\ta{ோ}} is the sign for long \emph{ō}, and it \textbf{wraps} its consonant: a hook on the left, a stroke on the right, one vowel.
+
+Those two halves are not a guess. The Unicode Character Database gives \textbf{\ta{ோ}} a canonical decomposition, and it is exactly the two signs you have:
+
+\begin{quote}
+\textbf{\ta{ோ}} = \textbf{\ta{ே}} (the long-\emph{ē} hook, written left) + \textbf{\ta{ா}} (the long-\emph{ā} stroke, written right)
+\end{quote}
+
+So this is not one more mark to memorise. It is the sign you learned last lesson and the sign you learned in \textbf{\ta{நான்}}, put around the same letter — read the letter in the middle, and say the vowel once.
+
+\begin{quote}
+Be exact about what that citation settles. A canonical decomposition says the character is \textbf{composed of} those two, for text processing; it says nothing about how either half is drawn or where it lands. \texttt{tamil.json} has no entry for \textbf{\ta{ோ}} at all. So take the composition from Unicode and the placement — hook left, stroke right — from the page in front of you.
+\end{quote}
+
+\subsection*{Script you'll notice: build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{ப}} & \emph{pa} & from \textbf{\ta{பெயர்}} \\
+\textbf{\ta{ோ}} & long \emph{ō}, wrapped around it & this lesson \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{ப} + \ta{ோ} $\to$ \ta{போ}}
+\end{quote}
+
+One letter and one wrapped sign, and the whole word is two marks on the page. \textbf{\ta{போ}} is \textquotedblleft{}go\textquotedblright{} — the \textbf{\ta{போ}} inside \emph{pōy varugiṟēṉ}, \textquotedblleft{}I'll go and come back,\textquotedblright{} the farewell chapter 1 closes on and chapter 4 takes apart.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \textbf{\ta{பே}} — then \textbf{\ta{போ}} — the hook alone, then the hook with the stroke
+  \item \emph{Say it:} \textquotedblleft{}pō\textquotedblright{} — \textquotedblleft{}go\textquotedblright{}
+  \item \emph{Contrast:} \textbf{\ta{பே}} · \textbf{\ta{பா}} · \textbf{\ta{போ}} — left only, right only, both at once
+  \item \emph{Read it:} \textbf{\ta{பேசு}} again, and notice its \ta{ே} is the same hook
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read \textbf{\ta{போ}}. Which two signs is \textbf{\ta{ோ}} made of, and where does each one sit? (\textbf{\ta{ே}} on the \textbf{left}, \textbf{\ta{ா}} on the \textbf{right}.) How many vowels do you say when you read it? (\textbf{One} — the two marks are one sign.) Which of its halves did you meet in \textbf{\ta{நான்}}? (\textbf{\ta{ா}}.) Next: the word for a door.
 \end{tcolorbox}
 \section[kadavu]{\ta{கதவு} (kadavu) — \textquotedblleft{}door,\textquotedblright{} and a word Tamil never gave up}
 

--- a/code/learning/human-languages/tamil/curriculum.json
+++ b/code/learning/human-languages/tamil/curriculum.json
@@ -46,7 +46,10 @@
         "TA-W10-read-naan",
         "TA-W11-read-niingal",
         "TA-W12-read-eppadi",
-        "TA-W13-read-irukkirirgal"
+        "TA-W13-read-irukkirirgal",
+        "TA-W16-read-tamizh",
+        "TA-W14-read-pesu",
+        "TA-W15-read-po"
       ],
       "before": [],
       "inline": [
@@ -892,7 +895,10 @@
         "TA-W10-read-naan",
         "TA-W11-read-niingal",
         "TA-W12-read-eppadi",
-        "TA-W13-read-irukkirirgal"
+        "TA-W13-read-irukkirirgal",
+        "TA-W16-read-tamizh",
+        "TA-W14-read-pesu",
+        "TA-W15-read-po"
       ]
     },
     {

--- a/code/learning/human-languages/tamil/lessons/TA-C04-mindum-sandippom.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C04-mindum-sandippom.md
@@ -20,11 +20,6 @@ reviews_of: [TA-C04-naalai]
 [PAUSE 2s] A warmer, open-ended goodbye — and a chance to see Tamil's two
 vocabularies side by side.
 
-## The letters in this word
-
-**மீண்டும்** (*mīṇḍum*): note the retroflex cluster **ண்ட** (*ṇḍ*). **சந்திப்போம்**
-(*sandippōm*): **சந்தி** (*sandi*) + **-ப்போம்** (*-ppōm*, "we will").
-
 ## The word, taken apart
 
 **மீண்டும் சந்திப்போம்** = **மீண்டும்** (*mīṇḍum*, "again") + **சந்திப்போம்**
@@ -32,10 +27,12 @@ vocabularies side by side.
 these two words:
 
 - **மீண்டும்** (*mīṇḍum*, "again") is **native Dravidian**, from *mīḷ* ("to
-  return").
+  return"). Say it *mīṇ-ḍum*: the *ṇḍ* in the middle is a retroflex pair, both
+  halves made with the tongue curled back, and it is one gesture rather than two.
 - **சந்தி** (*sandi*, "to meet, a junction") is a **Sanskrit** loan — from
   *sandhi* ("a joining, union"), the very word Sanskrit grammar uses for how
-  sounds join at a word-boundary.
+  sounds join at a word-boundary. The ending on it is *-ppōm*, "we will," so
+  *sandippōm* is "we will meet."
 
 So even a goodbye shows Tamil's balance: an ancient Dravidian core (*mīṇḍum*)
 beside a Sanskrit borrowing (*sandi*) — the recurring thread of this whole track.

--- a/code/learning/human-languages/tamil/lessons/TA-C04-naalai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C04-naalai.md
@@ -19,21 +19,15 @@ reviews_of: [TA-C04-poy-varugiren]
 
 [PAUSE 2s] A goodbye with a date on it — built on the Tamil word for "day."
 
-## The letters in this word
-
-**நாளை** (*nāḷai*): **நா** (*nā*) + **ளை** (*ḷai*, with the retroflex **ள** *ḷ*,
-tongue curled back). **பார்க்கலாம்** (*pārkkalām*) = *pār* ("see") + *-kkalām*
-("let's / we may").
-
 ## The word, taken apart
 
 **நாளை** (*nāḷai*, "tomorrow") is native Dravidian, from **நாள்** (*nāḷ*, "day")
 — the same *nāḷ* in *iṉṟu* / *nāḷ* counting and in *nal-vāḻttukkaḷ* ("good
-[day]-wishes"). **பார்க்கலாம்** (*pārkkalām*) is "let's see / we may see," from
-**பார்** (*pār*, "to see, to look") — so the whole phrase is "**tomorrow, let's
-see [each other]**," the Tamil "see you tomorrow." Note the retroflex **ள்**
-(*ḷ*) — a sound English lacks entirely, made with the tongue-tip curled up and
-back.
+[day]-wishes"). **பார்க்கலாம்** (*pārkkalām*) is "let's see / we may see" —
+*pār* ("to see, to look") plus the ending *-kkalām*, "let's / we may" — so the
+whole phrase is "**tomorrow, let's see [each other]**," the Tamil "see you
+tomorrow." Note the retroflex **ள்** (*ḷ*) — a sound English lacks entirely,
+made with the tongue-tip curled up and back.
 
 ## Guided Practice
 

--- a/code/learning/human-languages/tamil/lessons/TA-C04-po.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C04-po.md
@@ -20,11 +20,6 @@ reviews_of: []
 [PAUSE 2s] Two of the shortest, oldest verbs in Tamil — and together they make
 the Tamil goodbye.
 
-## The letters in this word
-
-**ப** (*pa*) + **ோ** (the long-*ō* sign) → **போ** (*pō*). Its partner: **வா**
-(*vā*, "come") — **வ** (*va*) + long *ā*.
-
 ## The word, taken apart
 
 **போ** (*pō*, "to go") and **வா** (*vā*, "to come") are native Dravidian verbs of

--- a/code/learning/human-languages/tamil/lessons/TA-C04-poy-varugiren.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C04-poy-varugiren.md
@@ -20,12 +20,6 @@ reviews_of: [TA-C04-po]
 [PAUSE 2s] The everyday Tamil goodbye — and it is, quite literally, a promise to
 return.
 
-## The letters in this word
-
-**போய்** (*pōy*, "having gone") is *pō* + the ending **-ய்** that means "having
-…d." **வருகிறேன்** (*varugiṟēṉ*, "I come") is *varu* (come) + present + **-ஏன்**
-("I").
-
 ## The phrase, taken apart
 
 **போய் வருகிறேன்** = **போய்** (*pōy*, "having gone") + **வருகிறேன்** (*varugiṟēṉ*,
@@ -36,6 +30,10 @@ return" farewell you meet, in its own words, across the Dravidian south (Kannada
 *hōgi baruttēne*, Telugu *veḷḷi vastānu*, Malayalam *pōyi varāṁ*) — and it echoes
 the Indo-Aryan tracks too (Bengali *āshi*, Marathi *yeto*, Hindi *phir milenge*).
 The reply is warm: **போய் வா** (*pōy vā*, "go and come [back]").
+
+*Varugiṟēṉ* itself is built in three parts: *varu* ("come") + a present-tense
+marker + *-ēṉ* ("I"). Chapter 5 makes that stem-tense-person pattern explicit;
+here it is enough to hear the three pieces.
 
 ## Grammar Lens: the "having …d" participle
 

--- a/code/learning/human-languages/tamil/lessons/TA-C05-naan-tamizh-pesugiren.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-naan-tamizh-pesugiren.md
@@ -20,13 +20,6 @@ reviews_of: [TA-C05-pesu, TA-C03-naan]
 [PAUSE 2s] Your first full, moving sentence — and it names the language itself,
 with a sound almost no other language has.
 
-## The letters in this word
-
-**தமிழ்** (*tamiḻ*): **த** (*ta*) + **மி** (*mi*) + **ழ்** (*ḻ*) — that last
-letter, **ழ**, is the famous Tamil **ḻ**, a curled retroflex sound between "r,"
-"l," and "zh," found in almost no other language on earth. It is so identified
-with the language that Tamil is sometimes called "the *ḻ* language."
-
 ## The sentence, taken apart
 
 **நான் தமிழ் பேசுகிறேன்** = **நான்** (*nāṉ*, "I") + **தமிழ்** (*tamiḻ*, "Tamil,"
@@ -35,6 +28,12 @@ verb last as always. The name **தமிழ்** (*tamiḻ*) is native, of deba
 clearly Dravidian origin (often linked to a sense of "sweetness / one's own
 speech"); it names one of the oldest living literary languages in the world, with
 poetry two thousand years old still read today.
+
+That final sound is worth dwelling on. The *ḻ* of *tamiḻ* is a curled retroflex
+sitting somewhere between an *r*, an *l* and a *zh* — rare enough among the
+world's languages that Tamil is sometimes called "the *ḻ* language." Getting it
+approximately right matters more than getting it perfect; nobody will mistake
+what you mean.
 
 ## Grammar Lens: no gender on "I speak"
 

--- a/code/learning/human-languages/tamil/lessons/TA-C05-pesu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-pesu.md
@@ -20,10 +20,6 @@ reviews_of: []
 [PAUSE 2s] So far, "to be." Here is a verb that *does* something — and it shows
 how Tamil builds "I do X."
 
-## The letters in this word
-
-**ப** (*pa*) + **ே** (the long-*ē* sign) + **சு** (*su*) → **பேசு** (*pēsu*).
-
 ## The word, taken apart
 
 **பேசு** (*pēsu*, "to speak") is native Dravidian. The bare stem *pēsu* is also

--- a/code/learning/human-languages/tamil/lessons/TA-C05-vaazh.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-vaazh.md
@@ -20,11 +20,6 @@ reviews_of: [TA-C05-pesu, TA-C05-naan-tamizh-pesugiren]
 [PAUSE 2s] A second verb — and one of the most beloved words in the language, the
 one Tamils use to bless.
 
-## The letters in this word
-
-**வா** (*vā*) + **ழ்** (*ḻ*, the retroflex you just met in *tamiḻ*) → **வாழ்**
-(*vāḻ*).
-
 ## The word, taken apart
 
 **வாழ்** (*vāḻ*, "to live, to flourish, to thrive") is native Dravidian, and

--- a/code/learning/human-languages/tamil/lessons/TA-C05-velai-sey.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C05-velai-sey.md
@@ -7,7 +7,7 @@ headword: வேலை செய்
 gloss: to work (lit. "work-do")
 concept_tag: TA-VERB-SEY
 prerequisites: [TA-C05-pesu]
-sounds: [long-e, ai-sign]
+sounds: [long-e]
 roots: [sey-do-dravidian, velai-work-dravidian]
 est_minutes: 4
 reviews_of: [TA-C05-pesu, TA-C05-vaazh]
@@ -19,11 +19,6 @@ reviews_of: [TA-C05-pesu, TA-C05-vaazh]
 
 [PAUSE 2s] The last verb of the chapter — and, like Hindi's *karnā*, it is a
 "do" verb that builds a hundred others.
-
-## The letters in this word
-
-**வேலை** (*vēlai*, "work"): **வே** (*vē*) + **லை** (*lai*). **செய்** (*sey*,
-"do"): **செ** (*se*) + **ய்** (*y*).
 
 ## The word, taken apart
 

--- a/code/learning/human-languages/tamil/lessons/TA-W14-read-pesu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W14-read-pesu.md
@@ -1,0 +1,92 @@
+---
+schema_version: 2
+id: TA-W14-read-pesu
+spine_node: SPINE-MEET-GREET
+sequence: 995
+delivery: script
+chapter: 34
+type: writing
+headword: "பேசு"
+gloss: the long-e sign, and the third short-and-long pair
+romanization: "pēsu"
+prerequisites: [TA-W16-read-tamizh, TA-W09-read-peyar]
+sounds: [matra-ee, matra-u]
+roots: []
+duration:
+  max_seconds: 250
+requires:
+  knowledge: [TA-SCRIPT-READ-TAMIZH-02, TA-SCRIPT-TA-ZHA-01, TA-SCRIPT-E-SIGN-02, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PA-YA-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-U-SIGN-01, TA-SCRIPT-II-SIGN-01, TA-SCRIPT-INDEPENDENT-VOWEL-AA-01]
+introduces:
+  knowledge: [TA-SCRIPT-EE-SIGN-01, TA-SCRIPT-READ-PESU-02]
+practises:
+  knowledge: [TA-SCRIPT-READ-TAMIZH-02, TA-SCRIPT-TA-ZHA-01, TA-SCRIPT-E-SIGN-02, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PA-YA-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-U-SIGN-01, TA-SCRIPT-II-SIGN-01, TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-EE-SIGN-01, TA-SCRIPT-READ-PESU-02]
+skills: [reading]
+modes: [interpretive]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W16-read-tamizh, TA-W09-read-peyar, TA-C05-pesu]
+---
+
+# பேசு — the long partner of ெ
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-E-SIGN-02, TA-SCRIPT-II-SIGN-01, TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01] -->
+
+[PAUSE 2s] Twice now a Tamil vowel has come in a short and a long version:
+**அ** and **ஆ**, **ி** and **ீ**. For **அ**/**ஆ** the script data even says the
+long one is the short one plus a tail; for **ி**/**ீ** it says nothing, and the
+pairing is the lesson's. Here is a third pair.
+
+## Script you'll notice: the ே sign
+<!-- hl-knowledge: introduces=[TA-SCRIPT-EE-SIGN-01]; assesses=[TA-SCRIPT-E-SIGN-02, TA-SCRIPT-LA-AI-SIGN-02] -->
+
+**ே** is the sign for long *ē*, and it is the long partner of the **ெ** you met
+in **பெயர்**. Like **ெ**, it is written to the **left** of its consonant and
+spoken after it.
+
+> **ப + ே → பே**, said *pē*.
+
+| sign | sound | where it is written |
+|---|---|---|
+| **ெ** | short *e* | to the left |
+| **ே** | long *ē* | to the left |
+| **ை** | *ai* | to the left |
+
+Three left-standing signs now. The evidence is the same as it was for **ெ**: the
+script data describes **ை** and has no entry for **ெ** or **ே** at all, so both
+the shared position **and** the short/long pairing are stated from the pattern
+these signs share, not from a source for either one.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-READ-PESU-02]; assesses=[TA-SCRIPT-EE-SIGN-01, TA-SCRIPT-PA-YA-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-U-SIGN-01] -->
+
+| piece | | |
+|---|---|---|
+| **பே** | *pē* — ப with the ே sign on its left | ப from **பெயர்** |
+| **சு** | *su* — ச with the ு sign | ச from **சரி**, ு from **இருக்கிறீர்கள்** |
+
+> **பே · சு → பேசு**
+
+Two pieces, one new sign, and its two signs pull in opposite directions on the
+page: **ே** stands before its letter, **ு** joins after it. **பேசு** is "speak" —
+the verb every lesson so far has been in service of.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-EE-SIGN-01, TA-SCRIPT-READ-PESU-02, TA-SCRIPT-E-SIGN-02, TA-SCRIPT-U-SIGN-01, TA-SCRIPT-READ-TAMIZH-02, TA-SCRIPT-TA-ZHA-01] -->
+
+[PAUSE 1s]
+- [YOU READ: **பே** — then **பேசு**]
+- [YOU SAY: "pēsu" — "speak"]
+- [YOU CONTRAST: **பெ** and **பே** — the short sign and the long one, both on the left]
+- [YOU CONTRAST: **பே** and **சு** — a sign before, a sign after, inside one word]
+- [YOU READ: **தமிழ் பேசு** — "speak Tamil," both words off the page]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-EE-SIGN-01, TA-SCRIPT-READ-PESU-02, TA-SCRIPT-E-SIGN-02, TA-SCRIPT-CA-ONE-LETTER-01] -->
+
+[PAUSE 3s] Read **பேசு**. Which side of its consonant is **ே** written on?
+(**The left** — like **ெ** and **ை**.) Which sign is its short partner?
+(**ெ**, as in **பெயர்**.) What is the **ச** doing here — is it *s* or *ch*?
+(**Either**; one letter covers both, and position picks.) Next: the verb for
+helping.

--- a/code/learning/human-languages/tamil/lessons/TA-W15-read-po.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W15-read-po.md
@@ -1,0 +1,91 @@
+---
+schema_version: 2
+id: TA-W15-read-po
+spine_node: SPINE-MEET-GREET
+sequence: 1025
+delivery: script
+chapter: 35
+type: writing
+headword: "போ"
+gloss: a sign made of two signs, one before the consonant and one after
+romanization: "pō"
+prerequisites: [TA-W14-read-pesu, TA-W10-read-naan]
+sounds: [matra-oo]
+roots: []
+duration:
+  max_seconds: 260
+requires:
+  knowledge: [TA-SCRIPT-EE-SIGN-01, TA-SCRIPT-AA-SIGN-01, TA-SCRIPT-PA-YA-01, TA-SCRIPT-READ-PESU-02, TA-SCRIPT-READ-NAAN-02]
+introduces:
+  knowledge: [TA-SCRIPT-OO-SIGN-01, TA-SCRIPT-READ-PO-02]
+practises:
+  knowledge: [TA-SCRIPT-EE-SIGN-01, TA-SCRIPT-AA-SIGN-01, TA-SCRIPT-PA-YA-01, TA-SCRIPT-READ-PESU-02, TA-SCRIPT-READ-NAAN-02, TA-SCRIPT-OO-SIGN-01, TA-SCRIPT-READ-PO-02]
+skills: [reading]
+modes: [interpretive]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W14-read-pesu, TA-W10-read-naan, TA-C04-po]
+---
+
+# போ — one sign, two marks
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-EE-SIGN-01, TA-SCRIPT-AA-SIGN-01] -->
+
+[PAUSE 2s] Every vowel sign so far has been one mark in one place: before the
+consonant, above it, or after it. This one is in two places at once, and you
+already own both halves.
+
+## Script you'll notice: the ோ sign
+<!-- hl-knowledge: introduces=[TA-SCRIPT-OO-SIGN-01]; assesses=[TA-SCRIPT-EE-SIGN-01, TA-SCRIPT-AA-SIGN-01] -->
+
+**ோ** is the sign for long *ō*, and it **wraps** its consonant: a hook on the
+left, a stroke on the right, one vowel.
+
+Those two halves are not a guess. The Unicode Character Database gives **ோ** a
+canonical decomposition, and it is exactly the two signs you have:
+
+> **ோ** = **ே** (the long-*ē* hook, written left) + **ா** (the long-*ā* stroke,
+> written right)
+
+So this is not one more mark to memorise. It is the sign you learned last lesson
+and the sign you learned in **நான்**, put around the same letter — read the
+letter in the middle, and say the vowel once.
+
+> Be exact about what that citation settles. A canonical decomposition says the
+> character is **composed of** those two, for text processing; it says nothing
+> about how either half is drawn or where it lands. `tamil.json` has no entry for
+> **ோ** at all. So take the composition from Unicode and the placement — hook
+> left, stroke right — from the page in front of you.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-READ-PO-02]; assesses=[TA-SCRIPT-OO-SIGN-01, TA-SCRIPT-PA-YA-01] -->
+
+| piece | | |
+|---|---|---|
+| **ப** | *pa* | from **பெயர்** |
+| **ோ** | long *ō*, wrapped around it | this lesson |
+
+> **ப + ோ → போ**
+
+One letter and one wrapped sign, and the whole word is two marks on the page.
+**போ** is "go" — the **போ** inside *pōy varugiṟēṉ*, "I'll go and come back," the
+farewell chapter 1 closes on and chapter 4 takes apart.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-OO-SIGN-01, TA-SCRIPT-READ-PO-02, TA-SCRIPT-EE-SIGN-01, TA-SCRIPT-READ-PESU-02] -->
+
+[PAUSE 1s]
+- [YOU READ: **பே** — then **போ** — the hook alone, then the hook with the stroke]
+- [YOU SAY: "pō" — "go"]
+- [YOU CONTRAST: **பே** · **பா** · **போ** — left only, right only, both at once]
+- [YOU READ: **பேசு** again, and notice its ே is the same hook]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-OO-SIGN-01, TA-SCRIPT-READ-PO-02, TA-SCRIPT-EE-SIGN-01, TA-SCRIPT-AA-SIGN-01, TA-SCRIPT-READ-NAAN-02] -->
+
+[PAUSE 3s] Read **போ**. Which two signs is **ோ** made of, and where does each
+one sit? (**ே** on the **left**, **ா** on the **right**.) How many vowels do you
+say when you read it? (**One** — the two marks are one sign.) Which of its halves
+did you meet in **நான்**? (**ா**.) Next: the word for a door.

--- a/code/learning/human-languages/tamil/lessons/TA-W16-read-tamizh.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W16-read-tamizh.md
@@ -1,0 +1,93 @@
+---
+schema_version: 2
+id: TA-W16-read-tamizh
+spine_node: SPINE-MEET-GREET
+sequence: 965
+delivery: script
+chapter: 33
+type: writing
+headword: "தமிழ்"
+gloss: த and ழ — the third l-letter, and the name of the language
+romanization: "tamiḻ"
+prerequisites: [TA-W13-read-irukkirirgal, TA-W02-ma-retroflex-na]
+sounds: [retroflex-zh]
+roots: []
+duration:
+  max_seconds: 260
+requires:
+  knowledge: [TA-SCRIPT-READ-QUESTION-02, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-NGA-LLA-01, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-TTA-01]
+introduces:
+  knowledge: [TA-SCRIPT-TA-ZHA-01, TA-SCRIPT-READ-TAMIZH-02]
+practises:
+  knowledge: [TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-NGA-LLA-01, TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-TTA-01, TA-SCRIPT-TA-ZHA-01, TA-SCRIPT-READ-TAMIZH-02]
+skills: [reading]
+modes: [interpretive]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W13-read-irukkirirgal, TA-W11-read-niingal, TA-W06-write-illai, TA-C05-naan-tamizh-pesugiren]
+---
+
+# தமிழ் — the letter the language is named for
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-LA-AI-SIGN-02, TA-SCRIPT-NGA-LLA-01] -->
+
+[PAUSE 2s] This book has said more than once that Tamil keeps three *l*-letters,
+and the strand has shown you two: **ல** in **இல்லை**, **ள** in **நீங்கள்**. The
+third has been outstanding since chapter 18. Here it is, in the word it matters
+most in.
+
+## Script you'll notice: த and ழ
+<!-- hl-knowledge: introduces=[TA-SCRIPT-TA-ZHA-01]; assesses=[TA-SCRIPT-TTA-01] -->
+
+| | |
+|---|---|
+| **த** | *ta* — the dental *t*, tongue on the teeth |
+| **ழ** | *ḻ* — the third *l*-letter, curled far back |
+
+**த** is the dental partner of the retroflex **ட** you read in **எப்படி**: same
+kind of stop, different place in the mouth. Tamil keeps the pair apart in
+writing, so **த** and **ட** are never interchangeable.
+
+**ழ** is the one Tamil is known for. It is made further back than **ள**, and its
+sound sits somewhere between an *r*, an *l* and a *zh* — rare enough in the
+world's languages that Tamil is sometimes called the **ḻ** language. That is why
+the word for the language itself ends in it.
+
+> Read both; do not draw them yet. Neither **த** nor **ழ** has an entry in this
+> book's script data, so neither gets a stroke order, and the mouth positions
+> above are this lesson's own — the data is sourced for **ண**'s retroflex curl
+> and nothing else here.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-READ-TAMIZH-02]; assesses=[TA-SCRIPT-TA-ZHA-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-I-SIGN-WRITE-NANDRI-01, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+| piece | | |
+|---|---|---|
+| **த** | *ta* | this lesson |
+| **மி** | *mi* — ம with the ி sign | ம from **வணக்கம்**, ி from **நன்றி** |
+| **ழ்** | bare *ḻ* — **ழ** under a puḷḷi | this lesson |
+
+> **த · மி · ழ் → தமிழ்**
+
+Three pieces, and you can now read the name of the language you have been
+speaking since page one. That was the plan: the word first, the letters when
+they can be earned.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-TA-ZHA-01, TA-SCRIPT-READ-TAMIZH-02, TA-SCRIPT-TTA-01, TA-SCRIPT-NGA-LLA-01] -->
+
+[PAUSE 1s]
+- [YOU READ: **த** · **ழ** — then **தமிழ்**]
+- [YOU SAY: "tamiḻ" — and hold that last sound]
+- [YOU CONTRAST: **த** and **ட** — dental and retroflex, teeth and roof]
+- [YOU CONTRAST: **ல** · **ள** · **ழ** — all three *l*-letters, at last]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-TA-ZHA-01, TA-SCRIPT-READ-TAMIZH-02, TA-SCRIPT-TTA-01, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+[PAUSE 3s] Read **தமிழ்**. Which letter is **த**'s retroflex partner? (**ட**,
+from **எப்படி**.) Which of the three *l*-letters ends the word, and what is the
+dot doing? (**ழ**; the puḷḷi **removes its built-in *a***.) Next: the verb for
+writing — spelled with the ழ you just met.

--- a/code/learning/human-languages/tamil/narration/ch04.json
+++ b/code/learning/human-languages/tamil/narration/ch04.json
@@ -3,8 +3,8 @@
   "language": "tamil",
   "chapter": 4,
   "title": "Farewells",
-  "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:ac8d1a3a89c18c13",
+  "drivablePrefix": 4,
+  "sourceHash": "fnv1a64:a5a6cf8447b604ca",
   "lessons": [
     {
       "id": "TA-C04-po",
@@ -14,22 +14,13 @@
       "romanization": "",
       "gloss": "to go (and வா, to come)",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:a137cdf96f4af1dd",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:4032f776949c58bb",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -50,17 +41,6 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ப (pa) + ோ (the long-ō sign) becomes போ (pō). Its partner: வா (vā, \"come\") — வ (va) + long ā."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The word, taken apart",
           "segments": [
@@ -71,7 +51,7 @@
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -102,7 +82,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -128,22 +108,13 @@
       "romanization": "",
       "gloss": "goodbye (lit. \"I'll go and come back\")",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:b827e77978feac54",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:4db27cf81bd3a648",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -164,28 +135,21 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "போய் (pōy, \"having gone\") is pō + the ending -ய் that means \"having …d.\" வருகிறேன் (varugiṟēṉ, \"I come\") is varu (come) + present + -ஏன் (\"I\")."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The phrase, taken apart",
           "segments": [
             {
               "kind": "speech",
               "text": "போய் வருகிறேன் = போய் (pōy, \"having gone\") + வருகிறேன் (varugiṟēṉ, \"I come\") — literally \"having gone, I come,\" i.e. \"I'll go and come back.\" A Tamil speaker never signs off with a bare \"I'm leaving\" — that sounds final, even ill-omened. Instead they promise return. It is the exact \"promise of return\" farewell you meet, in its own words, across the Dravidian south (Kannada hōgi baruttēne, Telugu veḷḷi vastānu, Malayalam pōyi varāṁ) — and it echoes the Indo-Aryan tracks too (Bengali āshi, Marathi yeto, Hindi phir milenge). The reply is warm: போய் வா (pōy vā, \"go and come [back]\")."
+            },
+            {
+              "kind": "speech",
+              "text": "Varugiṟēṉ itself is built in three parts: varu (\"come\") + a present-tense marker + -ēṉ (\"I\"). Chapter 5 makes that stem-tense-person pattern explicit; here it is enough to hear the three pieces."
             }
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "grammar",
           "title": "Grammar Lens: the \"having …d\" participle",
           "segments": [
@@ -196,7 +160,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -236,7 +200,7 @@
           ]
         },
         {
-          "index": 5,
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -262,22 +226,13 @@
       "romanization": "",
       "gloss": "see you tomorrow",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:93385c7a8e7ee524",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:34d2538c5a595200",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -298,28 +253,17 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "நாளை (nāḷai): நா (nā) + ளை (ḷai, with the retroflex ள ḷ, tongue curled back). பார்க்கலாம் (pārkkalām) = pār (\"see\") + -kkalām (\"let's / we may\")."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The word, taken apart",
           "segments": [
             {
               "kind": "speech",
-              "text": "நாளை (nāḷai, \"tomorrow\") is native Dravidian, from நாள் (nāḷ, \"day\") — the same nāḷ in iṉṟu / nāḷ counting and in nal-vāḻttukkaḷ (\"good [day]-wishes\"). பார்க்கலாம் (pārkkalām) is \"let's see / we may see,\" from பார் (pār, \"to see, to look\") — so the whole phrase is \"tomorrow, let's see [each other],\" the Tamil \"see you tomorrow.\" Note the retroflex ள் (ḷ) — a sound English lacks entirely, made with the tongue-tip curled up and back."
+              "text": "நாளை (nāḷai, \"tomorrow\") is native Dravidian, from நாள் (nāḷ, \"day\") — the same nāḷ in iṉṟu / nāḷ counting and in nal-vāḻttukkaḷ (\"good [day]-wishes\"). பார்க்கலாம் (pārkkalām) is \"let's see / we may see\" — pār (\"to see, to look\") plus the ending -kkalām, \"let's / we may\" — so the whole phrase is \"tomorrow, let's see [each other],\" the Tamil \"see you tomorrow.\" Note the retroflex ள் (ḷ) — a sound English lacks entirely, made with the tongue-tip curled up and back."
             }
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -359,7 +303,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -385,22 +329,13 @@
       "romanization": "",
       "gloss": "we'll meet again",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:8dd1d2b81b09c384",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:5d3e6bac3fb15ffa",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -421,17 +356,6 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "மீண்டும் (mīṇḍum): note the retroflex cluster ண்ட (ṇḍ). சந்திப்போம் (sandippōm): சந்தி (sandi) + -ப்போம் (-ppōm, \"we will\")."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The word, taken apart",
           "segments": [
@@ -441,11 +365,11 @@
             },
             {
               "kind": "speech",
-              "text": "மீண்டும் (mīṇḍum, \"again\") is native Dravidian, from mīḷ (\"to return\")."
+              "text": "மீண்டும் (mīṇḍum, \"again\") is native Dravidian, from mīḷ (\"to return\"). Say it mīṇ-ḍum: the ṇḍ in the middle is a retroflex pair, both halves made with the tongue curled back, and it is one gesture rather than two."
             },
             {
               "kind": "speech",
-              "text": "சந்தி (sandi, \"to meet, a junction\") is a Sanskrit loan — from sandhi (\"a joining, union\"), the very word Sanskrit grammar uses for how sounds join at a word-boundary."
+              "text": "சந்தி (sandi, \"to meet, a junction\") is a Sanskrit loan — from sandhi (\"a joining, union\"), the very word Sanskrit grammar uses for how sounds join at a word-boundary. The ending on it is -ppōm, \"we will,\" so sandippōm is \"we will meet.\""
             },
             {
               "kind": "speech",
@@ -454,7 +378,7 @@
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -485,7 +409,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [

--- a/code/learning/human-languages/tamil/narration/ch04.txt
+++ b/code/learning/human-languages/tamil/narration/ch04.txt
@@ -1,18 +1,13 @@
 Tamil, chapter 4: Farewells.
-6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+6 lessons. You can do the first 4 of them in the car; after that you will want to have stopped.
 
 
 Lesson 1 of 6.
 போ (pō) — "go," and வா (come).
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 Two of the shortest, oldest verbs in Tamil — and together they make the Tamil goodbye.
-
-The letters in this word.
-ப (pa) + ோ (the long-ō sign) becomes போ (pō). Its partner: வா (vā, "come") — வ (va) + long ā.
 
 The word, taken apart.
 போ (pō, "to go") and வா (vā, "to come") are native Dravidian verbs of the deepest layer — single syllables, unchanged for millennia. As bare commands they are already whole words: pō! ("go!"), vā! ("come!"). You need both for the next lesson, because Tamil does not say a plain "goodbye" — it says "I go, and I come back."
@@ -32,17 +27,13 @@ What do pō and vā mean, and why will you need them both to say goodbye? ("Go" 
 Lesson 2 of 6.
 போய் வருகிறேன் (pōy varugiṟēṉ) — "I'll go and come back".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 The everyday Tamil goodbye — and it is, quite literally, a promise to return.
 
-The letters in this word.
-போய் (pōy, "having gone") is pō + the ending -ய் that means "having …d." வருகிறேன் (varugiṟēṉ, "I come") is varu (come) + present + -ஏன் ("I").
-
 The phrase, taken apart.
 போய் வருகிறேன் = போய் (pōy, "having gone") + வருகிறேன் (varugiṟēṉ, "I come") — literally "having gone, I come," i.e. "I'll go and come back." A Tamil speaker never signs off with a bare "I'm leaving" — that sounds final, even ill-omened. Instead they promise return. It is the exact "promise of return" farewell you meet, in its own words, across the Dravidian south (Kannada hōgi baruttēne, Telugu veḷḷi vastānu, Malayalam pōyi varāṁ) — and it echoes the Indo-Aryan tracks too (Bengali āshi, Marathi yeto, Hindi phir milenge). The reply is warm: போய் வா (pōy vā, "go and come [back]").
+Varugiṟēṉ itself is built in three parts: varu ("come") + a present-tense marker + -ēṉ ("I"). Chapter 5 makes that stem-tense-person pattern explicit; here it is enough to hear the three pieces.
 
 Grammar Lens: the "having …d" participle.
 Pōy is Tamil's way of chaining actions: "having gone, (then) I come." Tamil strings verbs like beads — one in the participle "-y" form, the last one fully conjugated. You will see this chaining everywhere.
@@ -64,17 +55,12 @@ What does the Tamil goodbye literally promise, and how do you answer it? ("I'll 
 Lesson 3 of 6.
 நாளை பார்க்கலாம் (nāḷai pārkkalām) — "see you tomorrow".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 A goodbye with a date on it — built on the Tamil word for "day."
 
-The letters in this word.
-நாளை (nāḷai): நா (nā) + ளை (ḷai, with the retroflex ள ḷ, tongue curled back). பார்க்கலாம் (pārkkalām) = pār ("see") + -kkalām ("let's / we may").
-
 The word, taken apart.
-நாளை (nāḷai, "tomorrow") is native Dravidian, from நாள் (nāḷ, "day") — the same nāḷ in iṉṟu / nāḷ counting and in nal-vāḻttukkaḷ ("good [day]-wishes"). பார்க்கலாம் (pārkkalām) is "let's see / we may see," from பார் (pār, "to see, to look") — so the whole phrase is "tomorrow, let's see [each other]," the Tamil "see you tomorrow." Note the retroflex ள் (ḷ) — a sound English lacks entirely, made with the tongue-tip curled up and back.
+நாளை (nāḷai, "tomorrow") is native Dravidian, from நாள் (nāḷ, "day") — the same nāḷ in iṉṟu / nāḷ counting and in nal-vāḻttukkaḷ ("good [day]-wishes"). பார்க்கலாம் (pārkkalām) is "let's see / we may see" — pār ("to see, to look") plus the ending -kkalām, "let's / we may" — so the whole phrase is "tomorrow, let's see [each other]," the Tamil "see you tomorrow." Note the retroflex ள் (ḷ) — a sound English lacks entirely, made with the tongue-tip curled up and back.
 
 Guided Practice.
 [pause 1 second]
@@ -93,19 +79,14 @@ What does nāḷai come from, and what does pārkkalām add? (Nāḷ, "day"; "le
 Lesson 4 of 6.
 மீண்டும் சந்திப்போம் (mīṇḍum sandippōm) — "we'll meet again".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 A warmer, open-ended goodbye — and a chance to see Tamil's two vocabularies side by side.
 
-The letters in this word.
-மீண்டும் (mīṇḍum): note the retroflex cluster ண்ட (ṇḍ). சந்திப்போம் (sandippōm): சந்தி (sandi) + -ப்போம் (-ppōm, "we will").
-
 The word, taken apart.
 மீண்டும் சந்திப்போம் = மீண்டும் (mīṇḍum, "again") + சந்திப்போம் (sandippōm, "we will meet") — "we'll meet again." Two vocabularies meet in these two words:
-மீண்டும் (mīṇḍum, "again") is native Dravidian, from mīḷ ("to return").
-சந்தி (sandi, "to meet, a junction") is a Sanskrit loan — from sandhi ("a joining, union"), the very word Sanskrit grammar uses for how sounds join at a word-boundary.
+மீண்டும் (mīṇḍum, "again") is native Dravidian, from mīḷ ("to return"). Say it mīṇ-ḍum: the ṇḍ in the middle is a retroflex pair, both halves made with the tongue curled back, and it is one gesture rather than two.
+சந்தி (sandi, "to meet, a junction") is a Sanskrit loan — from sandhi ("a joining, union"), the very word Sanskrit grammar uses for how sounds join at a word-boundary. The ending on it is -ppōm, "we will," so sandippōm is "we will meet."
 So even a goodbye shows Tamil's balance: an ancient Dravidian core (mīṇḍum) beside a Sanskrit borrowing (sandi) — the recurring thread of this whole track.
 
 Guided Practice.

--- a/code/learning/human-languages/tamil/narration/ch05.json
+++ b/code/learning/human-languages/tamil/narration/ch05.json
@@ -3,8 +3,8 @@
   "language": "tamil",
   "chapter": 5,
   "title": "The First Verbs",
-  "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:0718a395630b7532",
+  "drivablePrefix": 2,
+  "sourceHash": "fnv1a64:e673ee026212e7ec",
   "lessons": [
     {
       "id": "TA-C05-pesu",
@@ -14,22 +14,13 @@
       "romanization": "",
       "gloss": "to speak",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:d3ef5e5538b5a60d",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:fb566b65a21c956b",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -50,17 +41,6 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "ப (pa) + ே (the long-ē sign) + சு (su) becomes பேசு (pēsu)."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The word, taken apart",
           "segments": [
@@ -79,7 +59,7 @@
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "grammar",
           "title": "Grammar Lens: stem + tense + person",
           "segments": [
@@ -90,7 +70,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -130,7 +110,7 @@
           ]
         },
         {
-          "index": 5,
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -156,22 +136,13 @@
       "romanization": "",
       "gloss": "I speak Tamil",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:ea295f6dbc121380",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:c8fbce5b84c6ca12",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -192,28 +163,21 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "தமிழ் (tamiḻ): த (ta) + மி (mi) + ழ் (ḻ) — that last letter, ழ, is the famous Tamil ḻ, a curled retroflex sound between \"r,\" \"l,\" and \"zh,\" found in almost no other language on earth. It is so identified with the language that Tamil is sometimes called \"the ḻ language.\""
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The sentence, taken apart",
           "segments": [
             {
               "kind": "speech",
               "text": "நான் தமிழ் பேசுகிறேன் = நான் (nāṉ, \"I\") + தமிழ் (tamiḻ, \"Tamil,\" the object) + பேசுகிறேன் (pēsugiṟēṉ, \"speak\") — \"I Tamil speak,\" the verb last as always. The name தமிழ் (tamiḻ) is native, of debated but clearly Dravidian origin (often linked to a sense of \"sweetness / one's own speech\"); it names one of the oldest living literary languages in the world, with poetry two thousand years old still read today."
+            },
+            {
+              "kind": "speech",
+              "text": "That final sound is worth dwelling on. The ḻ of tamiḻ is a curled retroflex sitting somewhere between an r, an l and a zh — rare enough among the world's languages that Tamil is sometimes called \"the ḻ language.\" Getting it approximately right matters more than getting it perfect; nobody will mistake what you mean."
             }
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "grammar",
           "title": "Grammar Lens: no gender on \"I speak\"",
           "segments": [
@@ -224,7 +188,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -264,7 +228,7 @@
           ]
         },
         {
-          "index": 5,
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -473,22 +437,13 @@
       "romanization": "",
       "gloss": "to live, to flourish",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:c25a4a6426c60568",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:897c0df3eca3c5a6",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -509,17 +464,6 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "வா (vā) + ழ் (ḻ, the retroflex you just met in tamiḻ) becomes வாழ் (vāḻ)."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The word, taken apart",
           "segments": [
@@ -534,7 +478,7 @@
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "grammar",
           "title": "Grammar Lens: same engine, new verb",
           "segments": [
@@ -545,7 +489,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -585,7 +529,7 @@
           ]
         },
         {
-          "index": 5,
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [
@@ -611,22 +555,13 @@
       "romanization": "",
       "gloss": "to work (lit. \"work-do\")",
       "script": "tamil",
-      "modality": "sight",
-      "derivedModality": "sight",
+      "modality": "voice",
+      "derivedModality": "voice",
       "modalityReasons": [
-        "script-block"
+        "no-visual-dependency"
       ],
-      "sourceHash": "fnv1a64:64528b6911be0db6",
-      "notice": {
-        "modality": "sight",
-        "needs": [
-          "your eyes, for letter shapes on the page"
-        ],
-        "waitUntilStopped": [
-          "The letters in this word"
-        ],
-        "text": "Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it."
-      },
+      "sourceHash": "fnv1a64:41f470fad02f3716",
+      "notice": null,
       "blocks": [
         {
           "index": 0,
@@ -647,17 +582,6 @@
         },
         {
           "index": 1,
-          "type": "script",
-          "title": "The letters in this word",
-          "segments": [
-            {
-              "kind": "speech",
-              "text": "வேலை (vēlai, \"work\"): வே (vē) + லை (lai). செய் (sey, \"do\"): செ (se) + ய் (y)."
-            }
-          ]
-        },
-        {
-          "index": 2,
           "type": "etymology",
           "title": "The word, taken apart",
           "segments": [
@@ -688,7 +612,7 @@
           ]
         },
         {
-          "index": 3,
+          "index": 2,
           "type": "grammar",
           "title": "Grammar Lens: noun + செய் = a new verb",
           "segments": [
@@ -699,7 +623,7 @@
           ]
         },
         {
-          "index": 4,
+          "index": 3,
           "type": "guided-production",
           "title": "Guided Practice",
           "segments": [
@@ -739,7 +663,7 @@
           ]
         },
         {
-          "index": 5,
+          "index": 4,
           "type": "recall",
           "title": "Wrap-up Recall",
           "segments": [

--- a/code/learning/human-languages/tamil/narration/ch05.txt
+++ b/code/learning/human-languages/tamil/narration/ch05.txt
@@ -1,18 +1,13 @@
 Tamil, chapter 5: The First Verbs.
-6 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+6 lessons. You can do the first 2 of them in the car; after that you will want to have stopped.
 
 
 Lesson 1 of 6.
 பேசு (pēsu) — "to speak," your first full verb.
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 So far, "to be." Here is a verb that does something — and it shows how Tamil builds "I do X."
-
-The letters in this word.
-ப (pa) + ே (the long-ē sign) + சு (su) becomes பேசு (pēsu).
 
 The word, taken apart.
 பேசு (pēsu, "to speak") is native Dravidian. The bare stem pēsu is also the command "speak!" To say "I speak," Tamil adds a two-part ending to the stem: tense + person:
@@ -39,17 +34,13 @@ Build "I speak" from pēsu, and name the three pieces of a Tamil verb. (Pēsugi�
 Lesson 2 of 6.
 நான் தமிழ் பேசுகிறேன் (nāṉ tamiḻ pēsugiṟēṉ) — "I speak Tamil".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 Your first full, moving sentence — and it names the language itself, with a sound almost no other language has.
 
-The letters in this word.
-தமிழ் (tamiḻ): த (ta) + மி (mi) + ழ் (ḻ) — that last letter, ழ, is the famous Tamil ḻ, a curled retroflex sound between "r," "l," and "zh," found in almost no other language on earth. It is so identified with the language that Tamil is sometimes called "the ḻ language."
-
 The sentence, taken apart.
 நான் தமிழ் பேசுகிறேன் = நான் (nāṉ, "I") + தமிழ் (tamiḻ, "Tamil," the object) + பேசுகிறேன் (pēsugiṟēṉ, "speak") — "I Tamil speak," the verb last as always. The name தமிழ் (tamiḻ) is native, of debated but clearly Dravidian origin (often linked to a sense of "sweetness / one's own speech"); it names one of the oldest living literary languages in the world, with poetry two thousand years old still read today.
+That final sound is worth dwelling on. The ḻ of tamiḻ is a curled retroflex sitting somewhere between an r, an l and a zh — rare enough among the world's languages that Tamil is sometimes called "the ḻ language." Getting it approximately right matters more than getting it perfect; nobody will mistake what you mean.
 
 Grammar Lens: no gender on "I speak".
 Notice pēsugiṟēṉ is the same whether a man or a woman says it — Tamil marks no gender in the first or second person (only the third: pēsugiṟāṉ he / pēsugiṟāḷ she). This is unlike Hindi, where even "I speak" changes for a male or female speaker (boltā/boltī). Tamil saves gender for "he/she/it."
@@ -112,14 +103,9 @@ What does க say alone? (Ka — the vowel is inherent.) What kind of script is 
 Lesson 4 of 6.
 வாழ் (vāḻ) — "to live, to flourish".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 A second verb — and one of the most beloved words in the language, the one Tamils use to bless.
-
-The letters in this word.
-வா (vā) + ழ் (ḻ, the retroflex you just met in tamiḻ) becomes வாழ் (vāḻ).
 
 The word, taken apart.
 வாழ் (vāḻ, "to live, to flourish, to thrive") is native Dravidian, and carries more warmth than a plain "to reside." From it grow வாழ்க்கை (vāḻkkai, "life") and the blessing வாழ்க (vāḻga, "may you live / long live"), heard in vāḻga tamiḻ ("long live Tamil"). To say "I live," add the familiar ending: நான் … வாழ்கிறேன் (nāṉ … vāḻgiṟēṉ), stem + present -giṟ-.
@@ -145,14 +131,9 @@ Build "I live" from vāḻ, and give the blessing made from it. (Vāḻgiṟē�
 Lesson 5 of 6.
 வேலை செய் (vēlai sey) — "to work".
 
-Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
-
 Warm-up.
 [pause 2 seconds]
 The last verb of the chapter — and, like Hindi's karnā, it is a "do" verb that builds a hundred others.
-
-The letters in this word.
-வேலை (vēlai, "work"): வே (vē) + லை (lai). செய் (sey, "do"): செ (se) + ய் (y).
 
 The word, taken apart.
 செய் (sey, "to do, to make") is a core native Dravidian verb, and Tamil — like Hindi with karnā — builds compound verbs by putting a noun in front of it:

--- a/code/learning/human-languages/tamil/narration/ch33.json
+++ b/code/learning/human-languages/tamil/narration/ch33.json
@@ -4,7 +4,7 @@
   "chapter": 33,
   "title": "Four Verbs of the Mind",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:87330318c12938c6",
+  "sourceHash": "fnv1a64:1692ee153a91024f",
   "lessons": [
     {
       "id": "TA-C33-ninai",
@@ -552,6 +552,181 @@
             {
               "kind": "speech",
               "text": "Why is ட written one way and heard two ways, and where is it made? (Tamil marks no voicing — position decides, as with க; and it is retroflex, made where ண is.) Is paḍi borrowed from Sanskrit paṭh, and what can Tamil never keep from a Sanskrit word? (Unsettled; the aspiration.) Say \"I study Tamil.\" (Nāṉ tamiḻ paḍikkiṟēṉ.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W16-read-tamizh",
+      "sequence": 965,
+      "title": "தமிழ் (tamiḻ) — the letter the language is named for",
+      "headword": "தமிழ்",
+      "romanization": "tamiḻ",
+      "gloss": "த and ழ — the third l-letter, and the name of the language",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:cd982d731316d61c",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: த and ழ",
+          "Script you'll notice: build the word"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: த and ழ and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "This book has said more than once that Tamil keeps three l-letters, and the strand has shown you two: ல in இல்லை, ள in நீங்கள். The third has been outstanding since chapter 18. Here it is, in the word it matters most in."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: த and ழ",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "த, ta — the dental t, tongue on the teeth.",
+                "ழ, ḻ — the third l-letter, curled far back."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "த is the dental partner of the retroflex ட you read in எப்படி: same kind of stop, different place in the mouth. Tamil keeps the pair apart in writing, so த and ட are never interchangeable."
+            },
+            {
+              "kind": "speech",
+              "text": "ழ is the one Tamil is known for. It is made further back than ள, and its sound sits somewhere between an r, an l and a zh — rare enough in the world's languages that Tamil is sometimes called the ḻ language. That is why the word for the language itself ends in it."
+            },
+            {
+              "kind": "speech",
+              "text": "Read both; do not draw them yet. Neither த nor ழ has an entry in this book's script data, so neither gets a stroke order, and the mouth positions above are this lesson's own — the data is sourced for ண's retroflex curl and nothing else here."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "piece: த, ta, this lesson.",
+                "piece: மி, mi — ம with the ி sign, ம from வணக்கம், ி from நன்றி.",
+                "piece: ழ், bare ḻ — ழ under a puḷḷi, this lesson."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "த, மி, ழ் becomes தமிழ் (tamiḻ)."
+            },
+            {
+              "kind": "speech",
+              "text": "Three pieces, and you can now read the name of the language you have been speaking since page one. That was the plan: the word first, the letters when they can be earned."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "த, ழ — then தமிழ் (tamiḻ)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **த** · **ழ** — then **தமிழ்**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"tamiḻ\" — and hold that last sound",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"tamiḻ\" — and hold that last sound]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "த and ட — dental and retroflex, teeth and roof",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **த** and **ட** — dental and retroflex, teeth and roof]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "ல, ள, ழ — all three l-letters, at last",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **ல** · **ள** · **ழ** — all three *l*-letters, at last]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read தமிழ் (tamiḻ). Which letter is த's retroflex partner? (ட, from எப்படி.) Which of the three l-letters ends the word, and what is the dot doing? (ழ; the puḷḷi removes its built-in a.) Next: the verb for writing — spelled with the ழ you just met."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch33.txt
+++ b/code/learning/human-languages/tamil/narration/ch33.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 33: Four Verbs of the Mind.
-4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
-Lesson 1 of 4.
+Lesson 1 of 5.
 நினை (ninai) — "to think," which is also "to remember".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -42,7 +42,7 @@ Wrap-up Recall.
 What two English verbs does ninai cover, and which camp is it in? (Think and remember; strong, from the held kk.) What is ninaivu, and which sister keeps the root? (Memory; Kannada, nene / nenapu.) Which two n's does ninai use, in order? (Dental ந, then alveolar ன.) And why does teriyum carry no -ēṉ? (Knowing happens to you — its person sits in the dative instead.)
 
 
-Lesson 2 of 4.
+Lesson 2 of 5.
 புரி (puri) — "to become clear," and who it becomes clear to.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -93,7 +93,7 @@ Wrap-up Recall.
 What does puri mean underneath "understand," and what fills its person slot? (To become clear; -அது, "it".) So where does the understander go? (Into the dative — enakku.) Name the other verb that puts you there. (Teri — enakku teriyum.) And which verb from this chapter keeps the person on the ending? (Ninai — nāṉ ninaikkiṟēṉ.)
 
 
-Lesson 3 of 4.
+Lesson 3 of 5.
 படி (paḍi) — "to read," and the letter that is two sounds.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -135,7 +135,48 @@ Wrap-up Recall.
 Why is ட written one way and heard two ways, and where is it made? (Tamil marks no voicing — position decides, as with க; and it is retroflex, made where ண is.) Is paḍi borrowed from Sanskrit paṭh, and what can Tamil never keep from a Sanskrit word? (Unsettled; the aspiration.) Say "I study Tamil." (Nāṉ tamiḻ paḍikkiṟēṉ.)
 
 
-Lesson 4 of 4.
+Lesson 4 of 5.
+தமிழ் (tamiḻ) — the letter the language is named for.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: த and ழ and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+This book has said more than once that Tamil keeps three l-letters, and the strand has shown you two: ல in இல்லை, ள in நீங்கள். The third has been outstanding since chapter 18. Here it is, in the word it matters most in.
+
+Script you'll notice: த and ழ.
+[a table of 2 rows, read aloud]
+த, ta — the dental t, tongue on the teeth.
+ழ, ḻ — the third l-letter, curled far back.
+த is the dental partner of the retroflex ட you read in எப்படி: same kind of stop, different place in the mouth. Tamil keeps the pair apart in writing, so த and ட are never interchangeable.
+ழ is the one Tamil is known for. It is made further back than ள, and its sound sits somewhere between an r, an l and a zh — rare enough in the world's languages that Tamil is sometimes called the ḻ language. That is why the word for the language itself ends in it.
+Read both; do not draw them yet. Neither த nor ழ has an entry in this book's script data, so neither gets a stroke order, and the mouth positions above are this lesson's own — the data is sourced for ண's retroflex curl and nothing else here.
+
+Script you'll notice: build the word.
+[a table of 3 rows, read aloud]
+piece: த, ta, this lesson.
+piece: மி, mi — ம with the ி sign, ம from வணக்கம், ி from நன்றி.
+piece: ழ், bare ḻ — ழ under a puḷḷi, this lesson.
+த, மி, ழ் becomes தமிழ் (tamiḻ).
+Three pieces, and you can now read the name of the language you have been speaking since page one. That was the plan: the word first, the letters when they can be earned.
+
+Guided Practice.
+[pause 1 second]
+[your turn — read: த, ழ — then தமிழ் (tamiḻ)]
+[pause 8 seconds for the answer]
+[your turn — say: "tamiḻ" — and hold that last sound]
+[pause 8 seconds for the answer]
+[your turn — contrast: த and ட — dental and retroflex, teeth and roof]
+[pause 8 seconds for the answer]
+[your turn — contrast: ல, ள, ழ — all three l-letters, at last]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read தமிழ் (tamiḻ). Which letter is த's retroflex partner? (ட, from எப்படி.) Which of the three l-letters ends the word, and what is the dot doing? (ழ; the puḷḷi removes its built-in a.) Next: the verb for writing — spelled with the ழ you just met.
+
+
+Lesson 5 of 5.
 எழுது (eḻudu) — "to write," and the sound Tamil is named for.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.

--- a/code/learning/human-languages/tamil/narration/ch34.json
+++ b/code/learning/human-languages/tamil/narration/ch34.json
@@ -4,7 +4,7 @@
   "chapter": 34,
   "title": "Four Verbs Between People",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:0afe185a93c0169e",
+  "sourceHash": "fnv1a64:7389731691de483a",
   "lessons": [
     {
       "id": "TA-C34-edu",
@@ -362,6 +362,191 @@
             {
               "kind": "speech",
               "text": "What two English verbs is kēḷ, and what happens to its ள் before an ending? (Ask and hear; it hardens to ட்.) Which verb taught you to expect a second stem, and what is kēḷvi? (வா, built on varu-; a question.) Which register do these lessons teach, and how do you ask politely? (Standard spoken kēṭkiṟēṉ; kēḷungaḷ.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W14-read-pesu",
+      "sequence": 995,
+      "title": "பேசு (pēsu) — the long partner of ெ",
+      "headword": "பேசு",
+      "romanization": "pēsu",
+      "gloss": "the long-e sign, and the third short-and-long pair",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:20e9fcd487bbd15c",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: the ே sign",
+          "Script you'll notice: build the word"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: the ே sign and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Twice now a Tamil vowel has come in a short and a long version: அ and ஆ, ி and ீ. For அ/ஆ the script data even says the long one is the short one plus a tail; for ி/ீ it says nothing, and the pairing is the lesson's. Here is a third pair."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: the ே sign",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ே is the sign for long ē, and it is the long partner of the ெ you met in பெயர். Like ெ, it is written to the left of its consonant and spoken after it."
+            },
+            {
+              "kind": "speech",
+              "text": "ப + ே becomes பே, said pē."
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "sign",
+                "sound",
+                "where it is written"
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "sign: ெ. sound: short e. where it is written: to the left.",
+                "sign: ே. sound: long ē. where it is written: to the left.",
+                "sign: ை. sound: ai. where it is written: to the left."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Three left-standing signs now. The evidence is the same as it was for ெ: the script data describes ை and has no entry for ெ or ே at all, so both the shared position and the short/long pairing are stated from the pattern these signs share, not from a source for either one."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 2,
+              "utterances": [
+                "piece: பே, pē — ப with the ே sign on its left, ப from பெயர்.",
+                "piece: சு, su — ச with the ு sign, ச from சரி, ு from இருக்கிறீர்கள்."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "பே, சு becomes பேசு (pēsu)."
+            },
+            {
+              "kind": "speech",
+              "text": "Two pieces, one new sign, and its two signs pull in opposite directions on the page: ே stands before its letter, ு joins after it. பேசு (pēsu) is \"speak\" — the verb every lesson so far has been in service of."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "பே — then பேசு (pēsu)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **பே** — then **பேசு**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"pēsu\" — \"speak\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"pēsu\" — \"speak\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "பெ and பே — the short sign and the long one, both on the left",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **பெ** and **பே** — the short sign and the long one, both on the left]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "பே and சு — a sign before, a sign after, inside one word",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **பே** and **சு** — a sign before, a sign after, inside one word]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "தமிழ் பேசு (pēsu) — \"speak Tamil,\" both words off the page",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **தமிழ் பேசு** — \"speak Tamil,\" both words off the page]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read பேசு (pēsu). Which side of its consonant is ே written on? (The left — like ெ and ை.) Which sign is its short partner? (ெ, as in பெயர்.) What is the ச doing here — is it s or ch? (Either; one letter covers both, and position picks.) Next: the verb for helping."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch34.txt
+++ b/code/learning/human-languages/tamil/narration/ch34.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 34: Four Verbs Between People.
-4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
-Lesson 1 of 4.
+Lesson 1 of 5.
 எடு (eḍu) — "to take," beside the "put" you already own.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -43,7 +43,7 @@ Wrap-up Recall.
 What does eḍu mean, and which camp is it in? (To take; strong — eḍukkiṟēṉ holds the kk.) Which verb is one vowel away, and where did you meet it? (இடு, "to put" — inside சாப்பிடு.) Is that pair related? (No — the dictionaries keep them apart; it is a memory hook, not evidence.) Say "I take water," then "I take rice." (Nāṉ taṇṇīr eḍukkiṟēṉ; nāṉ arisi eḍukkiṟēṉ.)
 
 
-Lesson 2 of 4.
+Lesson 2 of 5.
 கேள் (kēḷ) — one verb for asking and for hearing.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -89,7 +89,50 @@ Wrap-up Recall.
 What two English verbs is kēḷ, and what happens to its ள் before an ending? (Ask and hear; it hardens to ட்.) Which verb taught you to expect a second stem, and what is kēḷvi? (வா, built on varu-; a question.) Which register do these lessons teach, and how do you ask politely? (Standard spoken kēṭkiṟēṉ; kēḷungaḷ.)
 
 
-Lesson 3 of 4.
+Lesson 3 of 5.
+பேசு (pēsu) — the long partner of ெ.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: the ே sign and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Twice now a Tamil vowel has come in a short and a long version: அ and ஆ, ி and ீ. For அ/ஆ the script data even says the long one is the short one plus a tail; for ி/ீ it says nothing, and the pairing is the lesson's. Here is a third pair.
+
+Script you'll notice: the ே sign.
+ே is the sign for long ē, and it is the long partner of the ெ you met in பெயர். Like ெ, it is written to the left of its consonant and spoken after it.
+ப + ே becomes பே, said pē.
+[a table of 3 rows, read aloud]
+sign: ெ. sound: short e. where it is written: to the left.
+sign: ே. sound: long ē. where it is written: to the left.
+sign: ை. sound: ai. where it is written: to the left.
+Three left-standing signs now. The evidence is the same as it was for ெ: the script data describes ை and has no entry for ெ or ே at all, so both the shared position and the short/long pairing are stated from the pattern these signs share, not from a source for either one.
+
+Script you'll notice: build the word.
+[a table of 2 rows, read aloud]
+piece: பே, pē — ப with the ே sign on its left, ப from பெயர்.
+piece: சு, su — ச with the ு sign, ச from சரி, ு from இருக்கிறீர்கள்.
+பே, சு becomes பேசு (pēsu).
+Two pieces, one new sign, and its two signs pull in opposite directions on the page: ே stands before its letter, ு joins after it. பேசு (pēsu) is "speak" — the verb every lesson so far has been in service of.
+
+Guided Practice.
+[pause 1 second]
+[your turn — read: பே — then பேசு (pēsu)]
+[pause 8 seconds for the answer]
+[your turn — say: "pēsu" — "speak"]
+[pause 8 seconds for the answer]
+[your turn — contrast: பெ and பே — the short sign and the long one, both on the left]
+[pause 8 seconds for the answer]
+[your turn — contrast: பே and சு — a sign before, a sign after, inside one word]
+[pause 8 seconds for the answer]
+[your turn — read: தமிழ் பேசு (pēsu) — "speak Tamil," both words off the page]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read பேசு (pēsu). Which side of its consonant is ே written on? (The left — like ெ and ை.) Which sign is its short partner? (ெ, as in பெயர்.) What is the ச doing here — is it s or ch? (Either; one letter covers both, and position picks.) Next: the verb for helping.
+
+
+Lesson 4 of 5.
 உதவு (udavu) — "to help," and a word Tamil did not borrow.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -128,7 +171,7 @@ Wrap-up Recall.
 Which camp is udavu in, and what is udavi? (Weak, by the single softened bead; help, the noun.) Say "I help you," then "please help." (Nāṉ ungaḷukku udavugiṟēṉ; udavungaḷ.) Which word do the neighbours borrow from Sanskrit where Tamil keeps its own? (Help — sahāya against udavi.) And which word did all four sisters borrow together? (Please — daya plus a light verb.)
 
 
-Lesson 4 of 4.
+Lesson 5 of 5.
 பிடி (piḍi) — "to catch," and therefore "to like".
 
 Warm-up.

--- a/code/learning/human-languages/tamil/narration/ch35.json
+++ b/code/learning/human-languages/tamil/narration/ch35.json
@@ -4,7 +4,7 @@
   "chapter": 35,
   "title": "Arriving at a House",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:c26956daee7bf61d",
+  "sourceHash": "fnv1a64:ef59f7e86d3ed65d",
   "lessons": [
     {
       "id": "TA-C35-veedu",
@@ -190,6 +190,175 @@
             {
               "kind": "speech",
               "text": "Why does one Tamil word do two English jobs here, and which letter opens both vīḍu and vaṇakkam? (House and home are not split; and வ.) What does Kannada put at the front instead of v, and is it a one-off? (b — bīḍu; regular, from the seventh century on.) Is the Tamil word for \"release\" the same root as the house? (Yes — both under விடு, \"to let go.\")"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W15-read-po",
+      "sequence": 1025,
+      "title": "போ (pō) — one sign, two marks",
+      "headword": "போ",
+      "romanization": "pō",
+      "gloss": "a sign made of two signs, one before the consonant and one after",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:7b8a45f2c391781b",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: the ோ sign",
+          "Script you'll notice: build the word"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: the ோ sign and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Every vowel sign so far has been one mark in one place: before the consonant, above it, or after it. This one is in two places at once, and you already own both halves."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: the ோ sign",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ோ is the sign for long ō, and it wraps its consonant: a hook on the left, a stroke on the right, one vowel."
+            },
+            {
+              "kind": "speech",
+              "text": "Those two halves are not a guess. The Unicode Character Database gives ோ a canonical decomposition, and it is exactly the two signs you have:"
+            },
+            {
+              "kind": "speech",
+              "text": "ோ = ே (the long-ē hook, written left) + ா (the long-ā stroke, written right)."
+            },
+            {
+              "kind": "speech",
+              "text": "So this is not one more mark to memorise. It is the sign you learned last lesson and the sign you learned in நான், put around the same letter — read the letter in the middle, and say the vowel once."
+            },
+            {
+              "kind": "speech",
+              "text": "Be exact about what that citation settles. A canonical decomposition says the character is composed of those two, for text processing; it says nothing about how either half is drawn or where it lands. tamil.json has no entry for ோ at all. So take the composition from Unicode and the placement — hook left, stroke right — from the page in front of you."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 2,
+              "utterances": [
+                "piece: ப, pa, from பெயர்.",
+                "piece: ோ, long ō, wrapped around it, this lesson."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "ப + ோ becomes போ (pō)."
+            },
+            {
+              "kind": "speech",
+              "text": "One letter and one wrapped sign, and the whole word is two marks on the page. போ is \"go\" — the போ inside pōy varugiṟēṉ, \"I'll go and come back,\" the farewell chapter 1 closes on and chapter 4 takes apart."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "பே — then போ (pō) — the hook alone, then the hook with the stroke",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **பே** — then **போ** — the hook alone, then the hook with the stroke]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"pō\" — \"go\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"pō\" — \"go\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "பே, பா, போ (pō) — left only, right only, both at once",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **பே** · **பா** · **போ** — left only, right only, both at once]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "பேசு again, and notice its ே is the same hook",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **பேசு** again, and notice its ே is the same hook]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read போ (pō). Which two signs is ோ made of, and where does each one sit? (ே on the left, ா on the right.) How many vowels do you say when you read it? (One — the two marks are one sign.) Which of its halves did you meet in நான்? (ா.) Next: the word for a door."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch35.txt
+++ b/code/learning/human-languages/tamil/narration/ch35.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 35: Arriving at a House.
-4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
-Lesson 1 of 4.
+Lesson 1 of 5.
 வீடு (vīḍu) — "house," and the place the greeting happens.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -48,7 +48,46 @@ Wrap-up Recall.
 Why does one Tamil word do two English jobs here, and which letter opens both vīḍu and vaṇakkam? (House and home are not split; and வ.) What does Kannada put at the front instead of v, and is it a one-off? (b — bīḍu; regular, from the seventh century on.) Is the Tamil word for "release" the same root as the house? (Yes — both under விடு, "to let go.")
 
 
-Lesson 2 of 4.
+Lesson 2 of 5.
+போ (pō) — one sign, two marks.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: the ோ sign and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Every vowel sign so far has been one mark in one place: before the consonant, above it, or after it. This one is in two places at once, and you already own both halves.
+
+Script you'll notice: the ோ sign.
+ோ is the sign for long ō, and it wraps its consonant: a hook on the left, a stroke on the right, one vowel.
+Those two halves are not a guess. The Unicode Character Database gives ோ a canonical decomposition, and it is exactly the two signs you have:
+ோ = ே (the long-ē hook, written left) + ா (the long-ā stroke, written right).
+So this is not one more mark to memorise. It is the sign you learned last lesson and the sign you learned in நான், put around the same letter — read the letter in the middle, and say the vowel once.
+Be exact about what that citation settles. A canonical decomposition says the character is composed of those two, for text processing; it says nothing about how either half is drawn or where it lands. tamil.json has no entry for ோ at all. So take the composition from Unicode and the placement — hook left, stroke right — from the page in front of you.
+
+Script you'll notice: build the word.
+[a table of 2 rows, read aloud]
+piece: ப, pa, from பெயர்.
+piece: ோ, long ō, wrapped around it, this lesson.
+ப + ோ becomes போ (pō).
+One letter and one wrapped sign, and the whole word is two marks on the page. போ is "go" — the போ inside pōy varugiṟēṉ, "I'll go and come back," the farewell chapter 1 closes on and chapter 4 takes apart.
+
+Guided Practice.
+[pause 1 second]
+[your turn — read: பே — then போ (pō) — the hook alone, then the hook with the stroke]
+[pause 8 seconds for the answer]
+[your turn — say: "pō" — "go"]
+[pause 8 seconds for the answer]
+[your turn — contrast: பே, பா, போ (pō) — left only, right only, both at once]
+[pause 8 seconds for the answer]
+[your turn — read: பேசு again, and notice its ே is the same hook]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read போ (pō). Which two signs is ோ made of, and where does each one sit? (ே on the left, ா on the right.) How many vowels do you say when you read it? (One — the two marks are one sign.) Which of its halves did you meet in நான்? (ா.) Next: the word for a door.
+
+
+Lesson 3 of 5.
 கதவு (kadavu) — "door," and a word Tamil never gave up.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -88,7 +127,7 @@ Wrap-up Recall.
 Say "the house door," then explain why the க is hard and the த soft when neither changed shape. (Vīṭṭuk kadavu; Tamil marks no voicing — position decides.) Which of kadavu and kabāḍam would you hear at somebody's house, and where did the other come from? (Kadavu; kabāḍam is Sanskrit, and stays literary.) Does keeping both mean Tamil refuses to borrow? (No — it borrows without evicting.)
 
 
-Lesson 3 of 4.
+Lesson 4 of 5.
 அறை (aṟai) — "room," and Tamil's second r.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -132,7 +171,7 @@ Wrap-up Recall.
 Say "a room of the house," and name which of Tamil's two r-letters is in aṟai and where else you have read it. (Vīṭṭu aṟai; ற, the hard one, in நன்றி.) Where is ற made, and what must your tongue not do? (At the ridge behind the teeth — do not curl it back.) If many speakers merge the two r's, why bother? (Because the spelling does not merge.)
 
 
-Lesson 4 of 4.
+Lesson 5 of 5.
 நாற்காலி (nāṟkāli) — "chair," counted out in legs.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -333,6 +333,118 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 - Add `generate:progress` and the byte-for-byte `check:progress` publication gate;
   a new registered language appears even when it has no lessons or book yet.
 
+### Added — the Tamil writing strand reaches chapters 4-5, and stops at chapter 32
+
+Chapters 4 and 5 were the last hand-authored Tamil chapters still teaching script
+inline: eight lessons carrying a `## The letters in this word` section, and four
+`sounds` boxes in the book. The glyphs they explained — **ே**, **ோ**, **த**, **ழ** —
+were taught nowhere in the strand, so the sections could not simply go.
+
+- **`TA-W16-read-tamizh`** (chapter 33) — **த** and **ழ**, spelling **தமிழ்**. **ழ** is
+  the third *l*-letter, outstanding since chapter 18, and the letter the language is
+  named for. It goes **first** of the three, and deliberately: `TA-C33-ezhutu` at
+  sequence 970 already takes **ழு** and **து** apart inline, so the strand has to reach
+  those letters before that lesson, not after it.
+- **`TA-W14-read-pesu`** (chapter 34) — the **ே** sign, spelling **பேசு**. It is the
+  long partner of the **ெ** from **பெயர்**, which makes it the third short/long pair
+  after **அ**/**ஆ** and **ி**/**ீ**.
+- **`TA-W15-read-po`** (chapter 35) — the **ோ** sign, spelling **போ**. This is the
+  first sign that is two marks at once, and it carries the strand's first citation from
+  outside `tamil.json`: the **Unicode Character Database** gives **ோ** (U+0BCB) a
+  canonical decomposition of **ே** (U+0BC7) + **ா** (U+0BBE), both already taught. That
+  is an encoding fact and the lesson says so — it settles what the sign is *composed
+  of*, not how either half is drawn; the placement comes from the page.
+
+Neither **த**, **ழ**, **ே** nor **ோ** has an entry in `tamil.json`, so none gets a
+stroke order and the mouth-position descriptions are marked as the lesson's own rather
+than sourced — except the **ோ** decomposition, which is cited to Unicode.
+
+### Removed — chapters 4-5's inline script sections and book boxes
+
+`TA-C04-po`, `-poy-varugiren`, `-naalai`, `-mindum-sandippom` and `TA-C05-pesu`,
+`-velai-sey`, `-vaazh`, `-naan-tamizh-pesugiren` drop their sections. That closes the
+five hand-authored chapters; **22** lessons in the generated chapters 33-38 still carry
+one, which is the next chunk of this work rather than part of it. Meanwhile
+`ch04-farewells.tex` and `ch05-first-verbs.tex` drop their four `sounds` boxes. All
+eight flip `reasons: ["script-block"] → ["no-visual-dependency"]` in the generated
+manifest with an empty `detachableSegments`.
+
+Four of the eight sections held content that was not letter teaching — five items
+between them — and all of it stays. The
+*varu* + present + *-ēṉ* build, the *-ppōm* ending and the *-kkalām* ending move into
+their lessons' prose in romanization; the retroflex *ṇḍ* of *mīṇḍum* becomes a spoken
+note, which is what its `sounds: [retroflex-nd]` id was always pointing at; and the
+**ḻ** note — which is about a *sound*, and about why Tamil is sometimes called "the *ḻ*
+language" — moves into `TA-C05-naan-tamizh-pesugiren`'s discussion of the name rather
+than being deleted with the block it happened to sit in.
+
+### Two constraints that moved the lessons
+
+Two constraints bit here, and both are recorded because both changed the plan.
+
+**Ordering.** `TA-C33-ezhutu` (sequence 970) already makes **ழ** and **த** its own
+subjects inline — "**ழு** is **ழ** with the *u* sign" — so a strand lesson introducing
+them afterwards would be claiming first contact it does not have. `TA-W16` has no
+dependency on the other two, so it goes first, at sequence 965, immediately ahead of
+that lesson. The cost is visible in R2 above and is worth naming rather than smoothing.
+
+**The chapter-32 budget.** The strand's 3:1 cadence put two of these lessons inside
+chapter 32. Chapter 32 was
+already **at** the ramp policy's ceiling — six verb lessons, two atoms each, exactly the
+`maxNewAtomsPerChapter: 12` budget — so interleaving there took it to **16** and broke
+`chapterViolations`, the number `ramp.test.ts` calls the one that most directly measures
+"do not throw many things at the reader at once."
+
+That is the opposite of the point, so the cadence yields and chapter 32 is skipped
+entirely. The three lessons sit at chapters 33, 34 and 35, which leaves one nine-lesson
+gap after `TA-W13` and then resumes 3:1. Reading distance between consecutive strand
+lessons stays at 4 or more everywhere, so the R1 rationale in `continuity.test.ts` still
+holds.
+
+Skipping chapter 32 was not only the gentler choice, it was the cheaper one. Measured
+both ways: interleaving there would have cost a ramp violation (24 → 25), a payoff
+representativeness failure (29 → 30, chapter 32 at 7/16), a fully-drivable chapter
+(324 → 323) and three lessons of chapter-32 drivable prefix. Skipping it costs none of
+those.
+
+### Measured, not inferred
+
+Set differences against the pre-change corpus, both loaded with the same build.
+
+- `totalLessons` 1684 → 1687, `pen` 62 → 65 — the three new lessons.
+- `voice` 1106 → 1114, `sight` 516 → 508, `drivableLessons` 1106 → 1114 — the eight
+  chapter 4-5 lessons, no others.
+- `drivablePrefixTotal` 918 → 924 and `unstartableChapters` 139 → 137 — chapters 4 and 5
+  gain 4 and 2 and both start by ear for the first time. Nothing is lost anywhere.
+- `fullyDrivableChapters` **324, unchanged**; `payoffsNotRepresentative` **29,
+  unchanged**; `chapterViolations` **24, unchanged**. All three because of the skip.
+- `atomsTaught` 2640 → 2646 — 2 + 2 + 2.
+- `atomsNeverRevisited` **470, unchanged** — the first time extending the strand has been
+  free. Two in (`READ-TAMIZH-02`, `TA-ZHA-01`; nothing follows `TA-W16`), two out
+  (`TTA-01` and `U-SIGN-01`, genuinely re-used by `TA-W16`'s ட/த contrast and `TA-W14`'s
+  சு).
+- `missedByWindow.R1` 874 → 880 — the six new atoms, nothing out.
+- `missedByWindow.R2` 1800 → 1804 — all six miss it, and that is an ordering
+  consequence rather than an authoring one. Putting `TA-W16` ahead of the other two, so
+  it lands before `TA-C33-ezhutu`, spaces consecutive strand lessons 4 apart: outside
+  R1's 1-3, but short of R2's 5-15, so nothing one introduces can be reinforced at R2
+  distance by the next. Two leave: `TTA-01` and `U-SIGN-01`.
+- `forwardReferences` 425 → **423**, and it improves for Tamil reasons rather than
+  Spanish ones. Two chapter 4-5 lessons were quoting a verb in *script* that chapter 32
+  teaches some twenty-seven chapters later: `TA-C05-vaazh` spelled **வாழ்** out of
+  **வா**, and `TA-C04-naalai` glossed **பார்க்கலாம்** from **பார்**. Neither word moved;
+  both are now named in romanization, which is what a speaking-first lesson should have
+  been doing with them anyway.
+
+### Still open
+
+Chapter 1 keeps five `sounds` boxes, and they are a different problem again: their
+content is pure pronunciation prose in romanization, with no Tamil letters in it at all.
+The box is what is wrong there — `preamble.tex` hard-codes its title as "The letters in
+this word", and `book.ts` routes every generated `Sounds you'll need` block into the same
+box, so the mis-titling is corpus-wide across all 22 tracks rather than Tamil-specific.
+That wants its own change.
+
 ### Added — the Tamil writing strand reaches chapter 3's words
 
 The chapter 2 pass left six lessons still teaching script inline (`TA-C02-nii-niingal`

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -387,7 +387,8 @@ describe("the real corpus", () => {
     // Chapter 18 does the same across eight teaching steps before its checkpoint.
     // +9: the four lessons that extend the Tamil writing strand to chapters 2-3's
     // glyphs introduce 2 + 3 + 2 + 2 atoms (TA-W10/11/12/13).
-    expect(report.summary.atomsTaught).toBe(2640);
+    // +6 more: TA-W14/15/16 close chapters 4-5's glyphs at 2 atoms each.
+    expect(report.summary.atomsTaught).toBe(2646);
     // +2, and it goes UP, which is worth stating plainly. Three of the five new atoms
     // are TA-W09's and nothing follows TA-W09, so they are orphans by construction:
     // PA-YA-01, E-SIGN-02, READ-PEYAR-03. TA-W08's two are revisited by TA-W09.
@@ -408,6 +409,11 @@ describe("the real corpus", () => {
     // Three in, two out. AA-SIGN-01, II-SIGN-01, NGA-LLA-01 and READ-NAAN-02 never become
     // orphans at all, because each later strand lesson declares — and genuinely assesses
     // — the earlier letters its own word is built from.
+    // The chapters 4-5 tranche then moves this number NOT AT ALL, the first time
+    // extending the strand has been free. Two in — READ-TAMIZH-02 and TA-ZHA-01,
+    // TA-W16's, orphans by construction because nothing follows it. Two out — TTA-01
+    // and U-SIGN-01, which TA-W16 and TA-W14 genuinely re-use (the ட/த contrast, and
+    // the ு of சு).
     expect(report.summary.atomsNeverRevisited).toBe(470);
     expect(report.summary.neverRevisitedPercent).toBe(18);
 
@@ -480,7 +486,12 @@ describe("the real corpus", () => {
     // Chapter 15 removes one more net leak by deferring every plural form and using
     // only already-declared café, en, bien, and Madrid in its singular examples.
     // Chapter 18 removes one more by deferring its untaught clause-frame examples.
-    expect(report.summary.forwardReferences).toBe(425);
+    // -2, and both are Tamil leaks this change closes rather than Spanish ones. Both
+    // were chapter 4-5 lessons quoting a verb in SCRIPT that chapter 32 teaches, ~27
+    // chapters later: TA-C05-vaazh spelled வாழ் out of வா, and TA-C04-naalai glossed
+    // பார்க்கலாம் from பார். Neither word moved; both are now named in romanization,
+    // which is what a speaking-first lesson should have been doing anyway.
+    expect(report.summary.forwardReferences).toBe(423);
 
     // HL09 step 3 closed 17 R1 windows in chapters 3-6, measured on the corpus of the
     // day as 766 -> 749. The absolute figures drift as main lands lessons; what the
@@ -542,7 +553,9 @@ describe("the real corpus", () => {
     // outside a 1-3 window. The TENTH is not new and is worth naming: interleaving a
     // writing lesson at chapter 29 pushes TA-LEX-AFTERNOON-BOUNDARY-01's reinforcement
     // past R1 ([R2,R3] -> [R1,R2,R3]). No atom gains R1 reinforcement here.
-    expect(report.summary.missedByWindow.R1).toBe(874);
+    // +6 for chapters 4-5: all six of TA-W14/15/16's atoms miss R1 and nothing leaves,
+    // the same cadence arithmetic as above.
+    expect(report.summary.missedByWindow.R1).toBe(880);
     // +2 net, and the composition is the interesting part: all FIVE new atoms miss R2
     // as well, offset by THREE pre-existing atoms that TA-W09 pulls back into it.
     // TA-W09 sits 12 lessons after TA-W06 and 8 after TA-W07, both inside R2's 5-15
@@ -575,7 +588,14 @@ describe("the real corpus", () => {
     // as the new lessons land between them. Note E-SIGN-02 does NOT leave R2: TA-W10
     // re-uses it, which is what takes it out of the orphan set above, but at a distance
     // R2 does not count. Four in, three out.
-    expect(report.summary.missedByWindow.R2).toBe(1800);
+    // Chapters 4-5 add +4. All SIX new atoms miss R2 this time, and the reason is worth
+    // recording because it is a consequence of ordering, not of authoring: TA-W16 was
+    // moved ahead of TA-W14/W15 so it lands before TA-C33-ezhutu, which already takes
+    // ழ and த apart. That puts consecutive strand lessons 4 apart — outside R1's 1-3,
+    // but also short of R2's 5-15 — so nothing any of the three introduces can be
+    // reinforced at R2 distance by the next one. TWO leave: TTA-01 and U-SIGN-01, both
+    // genuinely re-used far enough back to land inside the window. Six in, two out.
+    expect(report.summary.missedByWindow.R2).toBe(1804);
   });
 
   it("shows what a declared reading order was worth", () => {

--- a/code/packages/typescript/human-language-data/tests/levels.test.ts
+++ b/code/packages/typescript/human-language-data/tests/levels.test.ts
@@ -220,7 +220,8 @@ describe("corpus snapshot", () => {
     // +2: Spanish Chapter 9 maps its identity and ser/estar contrast lessons onto
     // the existing pre-A1 social spine.
     // +4: TA-W10..TA-W13, the Tamil writing strand's extension, all sit at pre-A1.
-    expect(summary.byLevel["pre-A1"]).toBe(872);
+    // +3 more: TA-W14/15/16, closing chapters 4-5, sit there too.
+    expect(summary.byLevel["pre-A1"]).toBe(875);
     // Chapter 10 adds singular ir and possessives at A1. Chapter 11 adds one more
     // definite-reference lesson there; its other work is A2. Chapter 12 adds its
     // newly mapped terminal checkpoints at A2 on SPINE-SAY-WHAT-I-DO.
@@ -294,7 +295,9 @@ describe("corpus snapshot", () => {
     // +4, measured as a set difference against the pre-change corpus rather than inferred
     // from the total: TA-W10-read-naan, TA-W11-read-niingal, TA-W12-read-eppadi and
     // TA-W13-read-irukkirirgal are the only lessons that join.
-    expect(ramp).toHaveLength(1181);
+    // +3: TA-W14-read-pesu, TA-W15-read-po and TA-W16-read-tamizh, likewise the only
+    // lessons that join.
+    expect(ramp).toHaveLength(1184);
     expect(ramp.length).toBeLessThan(lessons.length);
   });
 });

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -881,7 +881,8 @@ describe("corpus regression", () => {
       // Chapter 18 replaces ten legacy lessons with nine bounded steps.
       // +4: TA-W10-read-naan, TA-W11-read-niingal, TA-W12-read-eppadi and
       // TA-W13-read-irukkirirgal extend the writing strand over chapters 2-3's glyphs.
-      totalLessons: 1684,
+      // +3: TA-W14-read-pesu, TA-W15-read-po and TA-W16-read-tamizh close chapters 4-5.
+      totalLessons: 1687,
       // Chapters 10 and 13 replace wide legacy tables with small singular-only
       // comparisons, so three more lessons move from sight to voice.
       // All seven Chapter-16 teaching steps are voice-first. Generating the book
@@ -889,7 +890,8 @@ describe("corpus regression", () => {
       // so their same person-by-person comparisons now use speakable bullet rows.
       // All eight Chapter-17 lessons remain voice-first.
       // +6, and it is the same six lessons that leave `sight` below.
-      voice: 1106,
+      // +8, the eight chapter 4-5 lessons that drop their inline script sections.
+      voice: 1114,
       // -3 sight / +3 voice: TA-C02-en, -enna and -peyar dropped their "The letters in
       // this word" sections once TA-W08 and TA-W09 gave those glyphs a home in the
       // strand. Verified against the GENERATED manifest, not the source — all three now
@@ -905,7 +907,11 @@ describe("corpus regression", () => {
       // GENERATED manifest: every one flips reasons ["script-block"] ->
       // ["no-visual-dependency"] and its detachableSegments list empties, so the
       // script teaching genuinely left the lesson rather than a heading being renamed.
-      sight: 516,
+      // -8 sight / +8 voice, the ch04/ch05 repeat of the same move: TA-C04-po,
+      // -poy-varugiren, -naalai, -mindum-sandippom and TA-C05-pesu, -velai-sey, -vaazh,
+      // -naan-tamizh-pesugiren all flip ["script-block"] -> ["no-visual-dependency"]
+      // with an empty detachableSegments, verified against the GENERATED manifest.
+      sight: 508,
       // +3 pen: the Tamil ch1 writing lessons. Rule 1 in src/modality.ts derives
       // this from the lesson TYPE alone — it says outright that it does not look at
       // the body — so all three record reasons ["writing-type","script-block"], and
@@ -915,9 +921,11 @@ describe("corpus regression", () => {
       // +2: both new lessons are writing lessons.
       // +4: TA-W10..TA-W13 are `type: writing` too, so rule 1 makes them pen even
       // though all four are reading-only and give no stroke order.
-      pen: 62,
+      // +3: TA-W14/15/16 are `type: writing` too.
+      pen: 65,
       // +6: exactly the six lessons that moved sight -> voice; no other lesson changes.
-      drivableLessons: 1106,
+      // +8: exactly the eight lessons that moved sight -> voice.
+      drivableLessons: 1114,
       drivablePercent: 66,
       trackCount: 22,
       chapterCount: 513,
@@ -961,7 +969,10 @@ describe("corpus regression", () => {
       // the 3:1 cadence puts TA-W10 between its two speaking lessons rather than after
       // them — the same mid-chapter placement TA-W06 already has in chapter 18. Chapters
       // 27/29/31 take their writing lesson after the prefix, so they hold at 1/1/2.
-      drivablePrefixTotal: 918,
+      // +6, and only two chapters move, both upward this time: Tamil chapter 4 gains 4
+      // and chapter 5 gains 2. Nothing is lost, because TA-W14/15/16 are placed to skip
+      // chapter 32 — see the ramp test for why — so no chapter's prefix is cut short.
+      drivablePrefixTotal: 924,
       // -2: chapters 21 and 23 each take a writing lesson and stop being ear-only.
       // Spreading the strand cannot happen without landing a pen lesson somewhere.
       // Spanish Chapters 10 and 13 are now fully drivable from their canonical ASTs.
@@ -979,7 +990,8 @@ describe("corpus regression", () => {
       // Tamil chapter 2, Spanish chapter 13, and Spanish chapter 18 can now start by ear.
       // -1: Tamil chapter 3 alone. It was unstartable because its first lesson needed
       // eyes; it now starts by ear. No other chapter moves.
-      unstartableChapters: 139,
+      // -2 more: Tamil chapters 4 and 5 now start by ear as well.
+      unstartableChapters: 137,
       overriddenLessons: 0,
       lessonsWithoutChapter: 0,
     });


### PR DESCRIPTION
Closes item (b) from #10373. Chapters 4 and 5 were the last **hand-authored** Tamil
chapters still teaching script inline.

## Why the old note was wrong

#10088 recorded that chapters 4-5's book boxes "still show ப, எ and ய". Measured, that
is false — ய is in neither box. The real inventory of the four boxes, by the chapter
that first teaches each glyph:

| | glyphs |
|---|---|
| never taught by any strand lesson | **ோ**, **ே**, **ழ** |
| taught long after book chapter 5 | ா(25) ள(27) ு(31) ப(23) ர(19) ச(19) ல(18) ை(18) ்(7) ந(6) ம(6) |
| taught in time | வ(4) க(5) |

## What

Three new reading-only strand lessons teach **த**, **ழ**, **ே**, **ோ**; then eight
ch4/ch5 lessons drop their `## The letters in this word` sections and
`ch04-farewells.tex` / `ch05-first-verbs.tex` drop their four `sounds` boxes.

| lesson | ch | teaches | spells |
|---|---|---|---|
| `TA-W16-read-tamizh` | 33 | **த**, **ழ** | தமிழ் |
| `TA-W14-read-pesu` | 34 | the **ே** sign | பேசு |
| `TA-W15-read-po` | 35 | the **ோ** sign | போ |

`TA-W15` carries the strand's first citation from **outside** `tamil.json`: the Unicode
Character Database gives **ோ** (U+0BCB) a canonical decomposition of **ே** (U+0BC7) +
**ா** (U+0BBE), both already taught. The lesson is explicit that this settles what the
sign is *composed of*, not how either half is drawn.

## Two constraints that moved the lessons

Both are recorded rather than smoothed, because both changed the plan.

**Ordering.** `TA-C33-ezhutu` (sequence 970) already makes **ழ** and **து** its own
subjects inline, so a strand lesson introducing them afterwards would be claiming first
contact it does not have. `TA-W16` has no dependency on the other two, so it goes first
at sequence 965, immediately ahead of that lesson. The cost: consecutive strand lessons
sit 4 apart — outside R1's 1-3 but short of R2's 5-15 — so all six new atoms miss R2.

**The chapter-32 budget.** The 3:1 cadence put two of these inside chapter 32, which was
already **at** the ramp policy's `maxNewAtomsPerChapter: 12` (six verb lessons, two atoms
each). Interleaving there took it to **16** and broke `chapterViolations` — the number
`ramp.test.ts` calls the one that most directly measures "do not throw many things at the
reader at once." So chapter 32 is skipped: one nine-lesson gap, then 3:1 resumes.
Measured both ways, skipping it also avoided a payoff-representativeness failure
(29 → 30, chapter 32 at 7/16), a fully-drivable chapter (324 → 323) and three lessons of
chapter-32 drivable prefix.

## Verification

Set differences against the pre-change corpus, both loaded with the same build.

- `totalLessons` 1684 → 1687, `pen` 62 → 65 — the three new lessons.
- `voice` 1106 → 1114, `sight` 516 → 508 — the eight ch4/ch5 lessons, no others, verified
  against the **generated** manifest (`["script-block"] → ["no-visual-dependency"]`,
  `detachableSegments` emptied).
- `drivablePrefixTotal` 918 → 924 and `unstartableChapters` 139 → 137 — chapters 4 and 5
  gain 4 and 2 and both start by ear for the first time. Nothing lost anywhere.
- `fullyDrivableChapters` **324**, `payoffsNotRepresentative` **29**, `chapterViolations`
  **24** — all three unchanged, because of the skip.
- `atomsTaught` 2640 → 2646; `atomsNeverRevisited` **470, unchanged** (two in, two out).
- `missedByWindow.R1` 874 → 880, `.R2` 1800 → 1804.
- `forwardReferences` 425 → **423** — two ch4/ch5 lessons were quoting a verb in *script*
  that chapter 32 teaches ~27 chapters later (`வா`, `பார்`). Both now romanized.

460/460 tests pass; all five generator `check:*` gates clean.

## Not closed here

- **22 lessons in the generated chapters 33-38** still carry an inline section. Those are
  the next chunk, not part of this one.
- **Chapter 1's five `sounds` boxes** are a different problem again: their content is pure
  pronunciation prose with no Tamil letters in it. The *box* is what is wrong —
  `preamble.tex` hard-codes its title as "The letters in this word", and `book.ts` routes
  every generated `Sounds you'll need` block into it, so the mis-titling is corpus-wide
  across all 22 tracks. That wants its own change.

## Review

Two adversarial passes. The second caught the `TA-C33-ezhutu` ordering conflict above,
which the reorder fixes rather than papers over, plus a half-applied duration fix and
three CHANGELOG claims that were wrong ("the last eight sections" — 22 remain; "five
sections" — four sections, five items; a positional claim attributed to Unicode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)