### PR TITLE
Add explicit vault lock lifecycle

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this package are documented here.
 
+## [0.21.0] - 2026-08-10
+
+### Added
+
+- Add the stable payload-free `Locked` application error class.
+- Add a compact `VaultAccessV1` lifecycle boundary with explicit locked and
+  unlocked states, in-place authenticated unlock, session access, and lock.
+
+### Security
+
+- Failed unlock attempts leave the lifecycle object locked and immediately
+  drop temporary key material.
+- Locking synchronously replaces and drops the live session, wiping its keys,
+  local secrets, decrypted records, and search projection before returning.
+- Lifecycle diagnostics reveal only locked or unlocked state and omit the
+  locator, vault identity, item metadata, and live-session counts.
+
 ## [0.20.0] - 2026-08-10
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -166,6 +166,14 @@ warning. The application validates those facts before repository traversal.
 Actual TTY inspection, warning rendering, clipboard writes, ownership checks,
 and timed clear remain host responsibilities.
 
+Long-lived hosts can retain an explicit `VaultAccessV1` lifecycle boundary.
+It begins with only a redacted `LockedVaultV1` locator handle, authenticates a
+complete verified session in place, returns the stable payload-free `Locked`
+error when a caller asks for session access too early, and synchronously drops
+the live session on `lock()`. A failed unlock leaves the boundary locked;
+repeated lock is idempotent. The unlocked variant is boxed so the host state
+object stays compact without copying key material.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
 credential store, or entropy source. User-authored conflict merging, host field
@@ -192,8 +200,8 @@ paths, and complete error translation.
 Search tests cover Unicode normalization, short queries, oversized safe-field
 fallback, exact collection filters, deterministic product ordering, every
 record schema's allowlist/denylist, secret exclusion, query/result bounds, and
-conflict closure. The exact Tarpaulin LLVM result is 2,250 of 2,361 production
-lines (95.30%). Add-item tests cover exact entropy partitioning and wiping,
+conflict closure. The exact Tarpaulin LLVM result is 2,292 of 2,403 production
+lines (95.38%). Add-item tests cover exact entropy partitioning and wiping,
 identity validation before local writes, parentless revision and complete
 catalog construction, ambiguous successful compare-exchanges, write-ahead
 publication ordering, ambiguous provider commits, failed final activation,

--- a/code/packages/rust/vault-pm-application/src/codec.rs
+++ b/code/packages/rust/vault-pm-application/src/codec.rs
@@ -1148,6 +1148,7 @@ mod tests {
         for (error, label) in [
             (ApplicationError::NotInitialized, "NotInitialized"),
             (ApplicationError::AlreadyInitialized, "AlreadyInitialized"),
+            (ApplicationError::Locked, "Locked"),
             (
                 ApplicationError::AuthenticationFailed,
                 "AuthenticationFailed",

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -11,6 +11,7 @@ mod codec;
 mod crypto;
 mod disclosure;
 mod initialize;
+mod lifecycle;
 mod mutation;
 mod open;
 mod repository;
@@ -35,6 +36,7 @@ pub use initialize::{
     GenerationZeroPolicyV1, GenerationZeroRandomness, PreparedGenerationZero,
     GENERATION_ZERO_RANDOM_BYTES,
 };
+pub use lifecycle::{LockedVaultV1, VaultAccessV1};
 pub use mutation::{
     AddItemRandomnessV1, DeleteItemRandomnessV1, ReplaceItemRandomnessV1,
     ResolveItemConflictRandomnessV1, RestoreItemRandomnessV1, ADD_ITEM_RANDOM_BYTES,
@@ -64,6 +66,8 @@ pub enum ApplicationError {
     NotInitialized,
     /// Owner state already exists and cannot be replaced by initialization.
     AlreadyInitialized,
+    /// An operation requires a live authenticated vault session.
+    Locked,
     /// Passphrase authentication or its indistinguishable root-wrap check failed.
     AuthenticationFailed,
     /// Caller input violates a V1 precondition.
@@ -91,6 +95,7 @@ impl ApplicationError {
         match self {
             Self::NotInitialized => "NotInitialized",
             Self::AlreadyInitialized => "AlreadyInitialized",
+            Self::Locked => "Locked",
             Self::AuthenticationFailed => "AuthenticationFailed",
             Self::InvalidInput => "InvalidInput",
             Self::NotFound => "NotFound",

--- a/code/packages/rust/vault-pm-application/src/lifecycle.rs
+++ b/code/packages/rust/vault-pm-application/src/lifecycle.rs
@@ -1,0 +1,132 @@
+use crate::{
+    open_active_vault, ApplicationError, ApplicationRepositoryFactory, BootstrapLocator,
+    BootstrapStore, LocalStateStore, UnlockedVaultV1,
+};
+use coding_adventures_zeroize::Zeroizing;
+use core::fmt::{self, Debug, Formatter};
+
+/// Key-free handle for one locally configured vault.
+///
+/// The random locator is intentionally available only through an explicit
+/// accessor and remains redacted from ordinary diagnostics.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct LockedVaultV1 {
+    locator: BootstrapLocator,
+}
+
+impl LockedVaultV1 {
+    /// Construct a locked handle from the host's configured opaque locator.
+    pub const fn new(locator: BootstrapLocator) -> Self {
+        Self { locator }
+    }
+
+    /// Return the opaque locator needed by injected owner-state adapters.
+    pub const fn locator(&self) -> BootstrapLocator {
+        self.locator
+    }
+}
+
+impl Debug for LockedVaultV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("LockedVaultV1(<locked>)")
+    }
+}
+
+/// Explicit host lifecycle boundary for a locked or unlocked vault.
+///
+/// This wrapper lets a long-lived CLI or later UI retain one state object
+/// without retaining live keys while locked. It does not own timers, signals,
+/// prompts, stores, or process lifecycle; hosts decide when to invoke
+/// [`Self::unlock`] and [`Self::lock`].
+pub enum VaultAccessV1 {
+    /// No live application keys or decrypted repository view are retained.
+    Locked(LockedVaultV1),
+    /// One authenticated session owns live keys and verified decrypted state.
+    Unlocked(Box<UnlockedVaultV1>),
+}
+
+impl VaultAccessV1 {
+    /// Begin in the key-free locked state.
+    pub const fn locked(locator: BootstrapLocator) -> Self {
+        Self::Locked(LockedVaultV1::new(locator))
+    }
+
+    /// Return whether this boundary currently retains no unlocked session.
+    pub const fn is_locked(&self) -> bool {
+        matches!(self, Self::Locked(_))
+    }
+
+    /// Return whether this boundary currently owns an unlocked session.
+    pub const fn is_unlocked(&self) -> bool {
+        matches!(self, Self::Unlocked(_))
+    }
+
+    /// Borrow the unlocked session or return the stable `Locked` error class.
+    pub fn as_unlocked(&self) -> Result<&UnlockedVaultV1, ApplicationError> {
+        match self {
+            Self::Locked(_) => Err(ApplicationError::Locked),
+            Self::Unlocked(session) => Ok(session.as_ref()),
+        }
+    }
+
+    /// Consume the boundary and return its unlocked session.
+    ///
+    /// A locked boundary fails with the stable `Locked` class and retains no
+    /// secret material that needs recovery.
+    pub fn into_unlocked(self) -> Result<UnlockedVaultV1, ApplicationError> {
+        match self {
+            Self::Locked(_) => Err(ApplicationError::Locked),
+            Self::Unlocked(session) => Ok(*session),
+        }
+    }
+
+    /// Authenticate and install one unlocked session in place.
+    ///
+    /// The state is changed only after the complete verified open succeeds.
+    /// Authentication, storage, integrity, or repository failure therefore
+    /// leaves this boundary locked and immediately drops all temporary key
+    /// material created by the failed attempt.
+    pub fn unlock(
+        &mut self,
+        passphrase: Zeroizing<Vec<u8>>,
+        local_state_store: &dyn LocalStateStore,
+        bootstrap_store: &dyn BootstrapStore,
+        repository_factory: &dyn ApplicationRepositoryFactory,
+    ) -> Result<(), ApplicationError> {
+        let Self::Locked(locked) = self else {
+            return Err(ApplicationError::InvalidInput);
+        };
+        let session = open_active_vault(
+            passphrase,
+            locked.locator(),
+            local_state_store,
+            bootstrap_store,
+            repository_factory,
+        )?;
+        *self = Self::Unlocked(Box::new(session));
+        Ok(())
+    }
+
+    /// Synchronously drop the live session and return to a key-free state.
+    ///
+    /// Repeated locking is idempotent. Replacing the enum before returning
+    /// causes the prior unlocked session, keys, local secret, search index,
+    /// decrypted catalog, and repository verifier to drop in this call.
+    pub fn lock(&mut self) {
+        let locator = match self {
+            Self::Locked(_) => return,
+            Self::Unlocked(session) => session.bootstrap_locator(),
+        };
+        let unlocked = core::mem::replace(self, Self::locked(locator));
+        drop(unlocked);
+    }
+}
+
+impl Debug for VaultAccessV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Locked(_) => formatter.write_str("VaultAccessV1::Locked(<redacted>)"),
+            Self::Unlocked(_) => formatter.write_str("VaultAccessV1::Unlocked(<redacted>)"),
+        }
+    }
+}

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -133,6 +133,10 @@ pub struct UnlockedVaultV1 {
 }
 
 impl UnlockedVaultV1 {
+    pub(crate) const fn bootstrap_locator(&self) -> BootstrapLocator {
+        self.active.bootstrap_locator()
+    }
+
     /// Return the authenticated vault identity.
     pub const fn vault_id(&self) -> VaultId {
         self.active.vault_id()
@@ -1460,6 +1464,75 @@ mod tests {
             format!("{session:?}"),
             "UnlockedVaultV1 { local_pin_count: 1, verified_head_count: 1, item_count: 0, candidate_count: 0, conflicted_item_count: 0, search_item_count: 0, .. }"
         );
+    }
+
+    #[test]
+    fn lifecycle_retains_locked_state_on_failure_and_drops_session_on_lock() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let locked = crate::LockedVaultV1::new(locator);
+        assert_eq!(locked.locator(), locator);
+        assert_eq!(format!("{locked:?}"), "LockedVaultV1(<locked>)");
+
+        let mut access = crate::VaultAccessV1::locked(locator);
+        assert!(access.is_locked());
+        assert!(!access.is_unlocked());
+        assert!(matches!(
+            access.as_unlocked(),
+            Err(ApplicationError::Locked)
+        ));
+        assert_eq!(format!("{access:?}"), "VaultAccessV1::Locked(<redacted>)");
+
+        assert_eq!(
+            access.unlock(
+                Zeroizing::new(b"wrong".to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            ),
+            Err(ApplicationError::AuthenticationFailed)
+        );
+        assert!(access.is_locked());
+
+        access
+            .unlock(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap();
+        assert!(access.is_unlocked());
+        assert_eq!(access.as_unlocked().unwrap().item_count(), 0);
+        assert_eq!(format!("{access:?}"), "VaultAccessV1::Unlocked(<redacted>)");
+        assert_eq!(
+            access.unlock(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            ),
+            Err(ApplicationError::InvalidInput)
+        );
+        assert!(access.is_unlocked());
+
+        access.lock();
+        assert!(access.is_locked());
+        access.lock();
+        assert!(matches!(
+            access.into_unlocked(),
+            Err(ApplicationError::Locked)
+        ));
+
+        let mut access = crate::VaultAccessV1::locked(locator);
+        access
+            .unlock(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap();
+        assert_eq!(access.into_unlocked().unwrap().item_count(), 0);
     }
 
     #[test]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1328,8 +1328,9 @@ changelog, focused build, and downstream validation.
    7c-3. host clipboard adapter with ownership-aware timed clear;
    7d. authenticated portable export and restore/import preparation; and
    7e. audit, status, and doctor workflows; and
-   7f. close the remaining VLT-PM05 `Locked` error and explicit lock-state
-       boundary before CLI composition.
+   7f. completed stable payload-free VLT-PM05 `Locked` error and compact
+       locked/unlocked lifecycle boundary, including failure-stable in-place
+       unlock and synchronous live-session drop on idempotent lock.
 9. `vault-pm-cli` + real executable and pseudo-terminal E2E suite.
 10. Crash/fault matrix and local restore drill.
 

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -509,6 +509,13 @@ root wrap. Bootstrap rollback, pin withholding, signature failure, graph
 equivocation, wrong object kind, malformed domain state, or cross-vault data is
 `IntegrityFailure`.
 
+Long-lived hosts retain an explicit locked/unlocked lifecycle boundary rather
+than a nullable session. Session access while locked returns `Locked`. Unlock
+changes the state only after the complete verified open succeeds, so every
+failure leaves it locked. Lock synchronously replaces and drops the live
+session before returning; repeated lock is idempotent. Timers, terminal-loss
+signals, prompts, and process lifecycle remain host authorities.
+
 Phase 1A does not auto-accept a provider view when pins are absent. The only
 automatic first pin is the receipt from the locally prepared generation-zero
 publication. Device enrollment defines the later fresh-device ceremony.


### PR DESCRIPTION
## Summary

- add the stable payload-free `Locked` application error
- add a compact locked/unlocked lifecycle object for long-lived CLI and UI hosts
- preserve locked state across failed authentication and synchronously drop the live session on lock
- document the completed pre-CLI lifecycle boundary

## Security properties

- failed unlock changes no lifecycle state and drops temporary key material
- locked session access fails with `ApplicationError::Locked`
- lock replaces and drops keys, owner secrets, decrypted catalog, search projection, and verifier before returning
- repeated lock is idempotent; repeated unlock is rejected without discarding the current session
- lifecycle diagnostics expose only low-resolution locked/unlocked state

## Verification

- `bash BUILD` (92 tests)
- focused `cargo test`
- strict Clippy (`-D warnings`)
- strict rustdoc (`-D warnings`)
- Tarpaulin: 2,292/2,403 production lines (95.38%); lifecycle module 39/39
- repository planner: 1,001 packages, 1 changed, 21 affected, all affected packages built
