### PR TITLE
Add safe vault status workflow

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this package are documented here.
 
+## [0.22.0] - 2026-08-10
+
+### Added
+
+- Add a closed five-state `VaultStatusV1` projection for absent, prepared,
+  locked, unlocked, and recovery-required lifecycle states.
+- Add authenticated item, candidate, and conflicted-item counts while unlocked.
+
+### Security
+
+- Locked status strictly decodes only bounded owner-private state and never
+  opens the bootstrap or repository.
+- Omit all counts outside an authenticated live session, keep diagnostics free
+  of identities and provider details, and translate store failures through the
+  closed application error taxonomy.
+
 ## [0.21.0] - 2026-08-10
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -174,11 +174,19 @@ the live session on `lock()`. A failed unlock leaves the boundary locked;
 repeated lock is idempotent. The unlocked variant is boxed so the host state
 object stays compact without copying key material.
 
+That boundary now exposes a safe status workflow for CLI and later UI hosts.
+While locked it strictly decodes the bounded owner-private record to report
+only `Absent`, `Prepared`, `Locked`, or `RecoveryRequired`; it does not access
+bootstrap or repository providers. While unlocked it reports `Unlocked` plus
+authenticated aggregate item, candidate, and conflicted-item counts. Counts
+are omitted in every other state, and status diagnostics contain no vault,
+device, item, revision, object, locator, or provider identity.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
 credential store, or entropy source. User-authored conflict merging, host field
-clipboard implementation, export, audit, and doctor workflows land in the next
-slices.
+clipboard implementation, export, audit verification, and doctor workflows
+land in the next slices.
 There is no unchecked
 repository verification path: construction decrypts and
 authority-verifies the exact locally pinned certificate frame and object ID,
@@ -192,7 +200,10 @@ lossless removed-value persistence, live and tombstone revisions, catalog
 bounds and ordering, cross-kind and cross-vault rejection, AEAD tampering,
 authority/device/certificate binding, Ed25519 signature rejection, closed
 parser failures, crash-state relationship checks, diagnostic redaction, and
-explicit key wiping. Open tests additionally prove empty and conflicted current
+explicit key wiping. Status tests prove every coarse lifecycle state,
+unlocked-only counts, diagnostic redaction, strict corrupt-state rejection,
+and closed local-store error translation. Open tests additionally prove empty
+and conflicted current
 catalog materialization plus dangling current-revision, missing-parent, and
 cross-item rejection. Repository tests exercise initialization, publication,
 verified open/read/history, every injected provider operation, constructor
@@ -200,8 +211,9 @@ paths, and complete error translation.
 Search tests cover Unicode normalization, short queries, oversized safe-field
 fallback, exact collection filters, deterministic product ordering, every
 record schema's allowlist/denylist, secret exclusion, query/result bounds, and
-conflict closure. The exact Tarpaulin LLVM result is 2,292 of 2,403 production
-lines (95.38%). Add-item tests cover exact entropy partitioning and wiping,
+conflict closure. The exact Tarpaulin LLVM result is 2,340 of 2,451 production
+lines (95.47%); the status module is 46 of 46. Add-item tests cover exact
+entropy partitioning and wiping,
 identity validation before local writes, parentless revision and complete
 catalog construction, ambiguous successful compare-exchanges, write-ahead
 publication ordering, ambiguous provider commits, failed final activation,

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -17,6 +17,7 @@ mod open;
 mod repository;
 mod search;
 mod state;
+mod status;
 mod verifier;
 
 pub use codec::{
@@ -55,6 +56,7 @@ pub use state::{
     ActiveStateV1, AuthorityFingerprint, BootstrapLocator, BootstrapStore, BootstrapStoreError,
     LocalStateStore, LocalStateStoreError, LocalVaultStateV1, PreparedInitV1, PublicationJournalV1,
 };
+pub use status::{VaultStatusStateV1, VaultStatusV1};
 pub use verifier::V1SingleDeviceVerifier;
 
 use core::fmt::{self, Debug, Display, Formatter};

--- a/code/packages/rust/vault-pm-application/src/lifecycle.rs
+++ b/code/packages/rust/vault-pm-application/src/lifecycle.rs
@@ -1,6 +1,6 @@
 use crate::{
     open_active_vault, ApplicationError, ApplicationRepositoryFactory, BootstrapLocator,
-    BootstrapStore, LocalStateStore, UnlockedVaultV1,
+    BootstrapStore, LocalStateStore, UnlockedVaultV1, VaultStatusV1,
 };
 use coding_adventures_zeroize::Zeroizing;
 use core::fmt::{self, Debug, Formatter};
@@ -67,6 +67,19 @@ impl VaultAccessV1 {
             Self::Locked(_) => Err(ApplicationError::Locked),
             Self::Unlocked(session) => Ok(session.as_ref()),
         }
+    }
+
+    /// Return a secret-free low-resolution status projection.
+    ///
+    /// Locked access reads and strictly decodes only the owner-private state
+    /// needed to distinguish absent, prepared, active, and recovery-required
+    /// states. Unlocked access reports authenticated aggregate counts from the
+    /// retained session and does not consult an external provider.
+    pub fn status(
+        &self,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<VaultStatusV1, ApplicationError> {
+        crate::status::status(self, local_state_store)
     }
 
     /// Consume the boundary and return its unlocked session.

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1536,6 +1536,125 @@ mod tests {
     }
 
     #[test]
+    fn status_is_safe_while_locked_and_adds_counts_only_while_unlocked() {
+        let absent_local = MemoryLocalStateStore::default();
+        let absent = crate::VaultAccessV1::locked(BootstrapLocator::new([0x91; 32]));
+        let status = absent.status(&absent_local).unwrap();
+        assert_eq!(status.state(), crate::VaultStatusStateV1::Absent);
+        assert_eq!(status.item_count(), None);
+        assert_eq!(status.candidate_count(), None);
+        assert_eq!(status.conflicted_item_count(), None);
+        assert_eq!(format!("{status:?}"), "VaultStatusV1 { state: Absent }");
+
+        let prepared = prepare_generation_zero(
+            Zeroizing::new(b"prepared passphrase".to_vec()),
+            GenerationZeroPolicyV1::new(8 * 1024, 1, 1, 10).unwrap(),
+            randomness(),
+        )
+        .unwrap();
+        let prepared_locator = prepared.bootstrap_locator();
+        let prepared_local =
+            MemoryLocalStateStore::with_state(prepared.owner_state().encode().unwrap());
+        let status = crate::VaultAccessV1::locked(prepared_locator)
+            .status(&prepared_local)
+            .unwrap();
+        assert_eq!(status.state(), crate::VaultStatusStateV1::Prepared);
+        assert_eq!(status.item_count(), None);
+
+        let (locator, local, bootstrap, factory) = initialized();
+        let mut access = crate::VaultAccessV1::locked(locator);
+        let status = access.status(&local).unwrap();
+        assert_eq!(status.state(), crate::VaultStatusStateV1::Locked);
+        assert_eq!(status.item_count(), None);
+
+        access
+            .unlock(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap();
+        let status = access.status(&local).unwrap();
+        assert_eq!(status.state(), crate::VaultStatusStateV1::Unlocked);
+        assert_eq!(status.item_count(), Some(0));
+        assert_eq!(status.candidate_count(), Some(0));
+        assert_eq!(status.conflicted_item_count(), Some(0));
+        assert_eq!(
+            format!("{status:?}"),
+            "VaultStatusV1 { state: Unlocked, item_count: 0, candidate_count: 0, conflicted_item_count: 0 }"
+        );
+
+        access.lock();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("initialized state must be active")
+        };
+        let pending =
+            LocalVaultStateV1::pending_publication(active.clone(), pending_publication(&active))
+                .unwrap();
+        *local.0.lock().unwrap() = Some(pending.encode().unwrap());
+        let status = access.status(&local).unwrap();
+        assert_eq!(status.state(), crate::VaultStatusStateV1::RecoveryRequired);
+        assert_eq!(status.item_count(), None);
+        assert_eq!(
+            format!("{status:?}"),
+            "VaultStatusV1 { state: RecoveryRequired }"
+        );
+    }
+
+    #[test]
+    fn locked_status_closes_owner_state_failures() {
+        struct FailingLocalStateStore(LocalStateStoreError);
+
+        impl LocalStateStore for FailingLocalStateStore {
+            fn load(
+                &self,
+                _locator: BootstrapLocator,
+            ) -> Result<Option<Vec<u8>>, LocalStateStoreError> {
+                Err(self.0)
+            }
+
+            fn compare_exchange(
+                &self,
+                _locator: BootstrapLocator,
+                _expected: Option<&[u8]>,
+                _replacement: &[u8],
+            ) -> Result<(), LocalStateStoreError> {
+                Err(self.0)
+            }
+        }
+
+        let access = crate::VaultAccessV1::locked(BootstrapLocator::new([0x92; 32]));
+        for (store_error, expected) in [
+            (
+                LocalStateStoreError::Unavailable,
+                ApplicationError::StorageUnavailable,
+            ),
+            (
+                LocalStateStoreError::ConcurrentHost,
+                ApplicationError::ConcurrentHost,
+            ),
+            (
+                LocalStateStoreError::Corruption,
+                ApplicationError::IntegrityFailure,
+            ),
+        ] {
+            assert_eq!(
+                access.status(&FailingLocalStateStore(store_error)),
+                Err(expected)
+            );
+        }
+
+        let corrupt = MemoryLocalStateStore::with_state(vec![0xff]);
+        assert_eq!(
+            access.status(&corrupt),
+            Err(ApplicationError::IntegrityFailure)
+        );
+    }
+
+    #[test]
     fn active_open_materializes_every_current_revision_candidate() {
         let (locator, local, bootstrap, factory) = initialized();
         let exact_active = local.0.lock().unwrap().clone().unwrap();

--- a/code/packages/rust/vault-pm-application/src/status.rs
+++ b/code/packages/rust/vault-pm-application/src/status.rs
@@ -1,0 +1,127 @@
+use crate::{
+    ApplicationError, LocalStateStore, LocalStateStoreError, LocalVaultStateV1, VaultAccessV1,
+};
+use core::fmt::{self, Debug, Formatter};
+
+/// Closed low-resolution lifecycle state returned by the safe status workflow.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VaultStatusStateV1 {
+    /// No owner-private state exists for the configured locator.
+    Absent,
+    /// Generation zero is durably prepared but not yet fully activated.
+    Prepared,
+    /// Stable active owner state exists without a retained live session.
+    Locked,
+    /// A verified live session is retained by the lifecycle boundary.
+    Unlocked,
+    /// An exact pending publication must be recovered before reopening.
+    RecoveryRequired,
+}
+
+/// Secret-free status projection suitable for locked CLI and UI rendering.
+///
+/// Exact item, candidate, and conflicted-item counts are present only for an
+/// already authenticated unlocked session. Every other state omits counts and
+/// never exposes vault, device, item, revision, object, or provider identities.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct VaultStatusV1 {
+    state: VaultStatusStateV1,
+    item_count: Option<usize>,
+    candidate_count: Option<usize>,
+    conflicted_item_count: Option<usize>,
+}
+
+impl VaultStatusV1 {
+    fn without_counts(state: VaultStatusStateV1) -> Self {
+        Self {
+            state,
+            item_count: None,
+            candidate_count: None,
+            conflicted_item_count: None,
+        }
+    }
+
+    fn unlocked(item_count: usize, candidate_count: usize, conflicted_item_count: usize) -> Self {
+        Self {
+            state: VaultStatusStateV1::Unlocked,
+            item_count: Some(item_count),
+            candidate_count: Some(candidate_count),
+            conflicted_item_count: Some(conflicted_item_count),
+        }
+    }
+
+    /// Return the closed coarse lifecycle state.
+    pub const fn state(&self) -> VaultStatusStateV1 {
+        self.state
+    }
+
+    /// Return the authenticated current-item count only while unlocked.
+    pub const fn item_count(&self) -> Option<usize> {
+        self.item_count
+    }
+
+    /// Return the authenticated retained-candidate count only while unlocked.
+    pub const fn candidate_count(&self) -> Option<usize> {
+        self.candidate_count
+    }
+
+    /// Return the authenticated conflicted-item count only while unlocked.
+    pub const fn conflicted_item_count(&self) -> Option<usize> {
+        self.conflicted_item_count
+    }
+}
+
+impl Debug for VaultStatusV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        let mut value = formatter.debug_struct("VaultStatusV1");
+        value.field("state", &self.state);
+        if let (Some(item_count), Some(candidate_count), Some(conflicted_item_count)) = (
+            self.item_count,
+            self.candidate_count,
+            self.conflicted_item_count,
+        ) {
+            value
+                .field("item_count", &item_count)
+                .field("candidate_count", &candidate_count)
+                .field("conflicted_item_count", &conflicted_item_count);
+        }
+        value.finish()
+    }
+}
+
+pub(crate) fn status(
+    access: &VaultAccessV1,
+    local_state_store: &dyn LocalStateStore,
+) -> Result<VaultStatusV1, ApplicationError> {
+    match access {
+        VaultAccessV1::Unlocked(session) => Ok(VaultStatusV1::unlocked(
+            session.item_count(),
+            session.candidate_count(),
+            session.conflicted_item_count(),
+        )),
+        VaultAccessV1::Locked(locked) => {
+            let Some(encoded) = local_state_store
+                .load(locked.locator())
+                .map_err(map_local_state_store)?
+            else {
+                return Ok(VaultStatusV1::without_counts(VaultStatusStateV1::Absent));
+            };
+            let state = match LocalVaultStateV1::decode(&encoded)? {
+                LocalVaultStateV1::PreparedInit(_) => VaultStatusStateV1::Prepared,
+                LocalVaultStateV1::Active(_) => VaultStatusStateV1::Locked,
+                LocalVaultStateV1::PendingPublication { .. } => {
+                    VaultStatusStateV1::RecoveryRequired
+                }
+            };
+            Ok(VaultStatusV1::without_counts(state))
+        }
+    }
+}
+
+fn map_local_state_store(error: LocalStateStoreError) -> ApplicationError {
+    match error {
+        LocalStateStoreError::Unavailable => ApplicationError::StorageUnavailable,
+        LocalStateStoreError::ConcurrentHost => ApplicationError::ConcurrentHost,
+        LocalStateStoreError::Corruption => ApplicationError::IntegrityFailure,
+    }
+}

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1327,7 +1327,10 @@ changelog, focused build, and downstream validation.
        interactive reveal, and warned unsafe non-interactive policy inputs;
    7c-3. host clipboard adapter with ownership-aware timed clear;
    7d. authenticated portable export and restore/import preparation; and
-   7e. audit, status, and doctor workflows; and
+   7e-1. completed safe five-state status workflow, strictly decoding bounded
+       owner state while locked and exposing only authenticated aggregate item,
+       candidate, and conflict counts while unlocked;
+   7e-2. audit verification and doctor workflows; and
    7f. completed stable payload-free VLT-PM05 `Locked` error and compact
        locked/unlocked lifecycle boundary, including failure-stable in-place
        unlock and synchronous live-session drop on idempotent lock.

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -591,7 +591,12 @@ create new object identities.
 ## 12. Audit and status
 
 `status` is safe while locked and reports only `Absent`, `Prepared`, `Locked`,
-`Unlocked`, or `RecoveryRequired`, plus low-resolution counts where safe.
+`Unlocked`, or `RecoveryRequired`. Locked status strictly decodes the bounded
+owner-private state and does not access bootstrap or repository providers.
+Exact item, retained-candidate, and conflicted-item counts are reported only
+from an already authenticated unlocked session; every other state omits them.
+Status never returns vault, device, item, revision, object, locator, or provider
+identities. Owner-state failures use the closed application error taxonomy.
 
 `audit_verify` while unlocked repeats a full VLT-PM04 open, decrypts every
 reachable catalog/current revision, validates all kinds and domain bounds,


### PR DESCRIPTION
## Summary

- add a closed five-state status projection for absent, prepared, locked, unlocked, and recovery-required vaults
- keep locked status storage-agnostic by strictly decoding only bounded owner state without bootstrap or repository access
- expose item, retained-candidate, and conflicted-item counts only from an authenticated unlocked session
- document the completed status slice and retain audit verification plus doctor as the remaining 7e work

## Security properties

- no vault, device, item, revision, object, locator, or provider identities appear in the status value or diagnostics
- counts are omitted outside an authenticated live session
- corrupt owner state and local-store failures use the closed application error taxonomy

## Validation

- package BUILD: 94 tests passed
- strict Clippy: passed with warnings denied
- strict rustdoc: passed with warnings denied
- Tarpaulin LLVM: 2,340 / 2,451 production lines (95.47%); status module 46 / 46
- affected-package planner: 51 BUILD files, 1,001 packages, 1 changed, 21 affected, all 21 built
- origin/main refreshed immediately before push; branch was one ahead and zero behind
