### PR TITLE
Add authored vault conflict merge

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this package are documented here.
 
+## [0.23.0] - 2026-08-10
+
+### Added
+
+- Add user-authored merged-document conflict resolution for a current item
+  with two or more retained candidates.
+
+### Security
+
+- Require at least one live candidate and preserve the schema and creation time
+  of every retained live candidate before any local write.
+- Publish the complete current candidate set as causal parents, consume the
+  secret-bearing document and session on every path, and retain all immutable
+  candidate bytes as reachable history.
+
 ## [0.22.0] - 2026-08-10
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -140,9 +140,15 @@ same typed redacted live view or tombstone marker as history. Choosing one
 authenticated candidate consumes the session and republishes its complete live
 document or tombstone as a new revision whose direct parents are the entire
 current conflict set. The resolution never selects implicitly, drops a losing
-candidate, rewrites history, or asks the host to round-trip plaintext. A later
-slice will add user-authored merged-document resolution after explicit field
-reveal.
+candidate, rewrites history, or asks the host to round-trip plaintext.
+
+After an explicit host-controlled field-reveal ceremony, a user may instead
+author one complete merged document. The application accepts that owned
+secret-bearing document only for an actual current conflict, requires at least
+one live candidate, preserves every live candidate's immutable schema and
+creation time, and publishes the complete conflict set as causal parents. The
+document and session are consumed on every return path, while all prior
+candidate bytes remain immutable reachable history.
 
 An unlocked session can explicitly reveal one exact reachable live revision.
 The application proves reachability through the same bounded verified history
@@ -184,9 +190,8 @@ device, item, revision, object, locator, or provider identity.
 
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
-credential store, or entropy source. User-authored conflict merging, host field
-clipboard implementation, export, audit verification, and doctor workflows
-land in the next slices.
+credential store, or entropy source. Host field clipboard implementation,
+export, audit verification, and doctor workflows land in the next slices.
 There is no unchecked
 repository verification path: construction decrypts and
 authority-verifies the exact locally pinned certificate frame and object ID,
@@ -203,16 +208,16 @@ parser failures, crash-state relationship checks, diagnostic redaction, and
 explicit key wiping. Status tests prove every coarse lifecycle state,
 unlocked-only counts, diagnostic redaction, strict corrupt-state rejection,
 and closed local-store error translation. Open tests additionally prove empty
-and conflicted current
-catalog materialization plus dangling current-revision, missing-parent, and
+and conflicted current catalog materialization plus dangling current-revision,
+missing-parent, and
 cross-item rejection. Repository tests exercise initialization, publication,
 verified open/read/history, every injected provider operation, constructor
 paths, and complete error translation.
 Search tests cover Unicode normalization, short queries, oversized safe-field
 fallback, exact collection filters, deterministic product ordering, every
 record schema's allowlist/denylist, secret exclusion, query/result bounds, and
-conflict closure. The exact Tarpaulin LLVM result is 2,340 of 2,451 production
-lines (95.47%); the status module is 46 of 46. Add-item tests cover exact
+conflict closure. The exact Tarpaulin LLVM result is 2,381 of 2,493 production
+lines (95.51%); the status module remains 46 of 46. Add-item tests cover exact
 entropy partitioning and wiping,
 identity validation before local writes, parentless revision and complete
 catalog construction, ambiguous successful compare-exchanges, write-ahead
@@ -224,9 +229,10 @@ Deletion tests prove one-parent tombstone causality, advisory timestamp
 separation, ordinary-view omission, repeat/missing rejection before
 compare-exchange, and entropy redaction/wiping.
 Conflict-resolution tests prove deterministic redacted inspection, live and
-tombstone selection, complete multi-parent causality, immutable losing-candidate
-retention, missing/unconflicted rejection before compare-exchange, and entropy
-redaction/wiping.
+tombstone selection, authored merged-secret persistence, complete multi-parent
+causality, immutable live-identity preservation, immutable losing-candidate
+retention, missing/unconflicted/all-tombstone rejection before
+compare-exchange, and entropy redaction/wiping.
 
 ## Development
 

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -426,6 +426,65 @@ pub(crate) fn resolve_item_conflict(
     publish_mutation(active, repository, publication, local_state_store)
 }
 
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn merge_item_conflict(
+    active: &ActiveStateV1,
+    report: &OpenReport,
+    current_items: &BTreeMap<ItemId, Vec<ItemCandidate>>,
+    keys: &V1Keys,
+    local_secret: &LocalSecretV1,
+    repository: &dyn ApplicationRepository,
+    document: ItemDocument,
+    wall_time_ms: u64,
+    randomness: ResolveItemConflictRandomnessV1,
+    local_state_store: &dyn LocalStateStore,
+) -> Result<ActiveStateV1, ApplicationError> {
+    if report.heads() != active.pinned_heads() {
+        return Err(ApplicationError::ConcurrentHost);
+    }
+    document
+        .validate()
+        .map_err(|_| ApplicationError::InvalidInput)?;
+    let candidates = current_items
+        .get(&document.id())
+        .ok_or(ApplicationError::NotFound)?;
+    if candidates.len() < 2 {
+        return Err(ApplicationError::ConflictRequired);
+    }
+
+    let mut live_candidate_count = 0usize;
+    for candidate in candidates {
+        if let ItemState::Live(current) = candidate.state() {
+            live_candidate_count += 1;
+            if current.schema() != document.schema()
+                || current.created_at_ms() != document.created_at_ms()
+            {
+                return Err(ApplicationError::InvalidInput);
+            }
+        }
+    }
+    if live_candidate_count == 0 {
+        return Err(ApplicationError::InvalidInput);
+    }
+
+    let causal_parents = candidates
+        .iter()
+        .map(ItemCandidate::revision_id)
+        .collect::<BTreeSet<_>>();
+    let publication = prepare_item_publication(
+        active,
+        current_items,
+        keys,
+        local_secret,
+        document.id(),
+        ItemState::Live(Box::new(document)),
+        &causal_parents,
+        wall_time_ms,
+        &randomness.bytes,
+    )?;
+    publish_mutation(active, repository, publication, local_state_store)
+}
+
 fn publish_mutation(
     active: &ActiveStateV1,
     repository: &dyn ApplicationRepository,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1,8 +1,8 @@
 use crate::initialize::{unlock_active_material, UnlockedActiveMaterial};
 use crate::mutation::{
-    add_item, delete_item, replace_item, resolve_item_conflict, restore_item, AddItemRandomnessV1,
-    DeleteItemRandomnessV1, ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1,
-    RestoreItemRandomnessV1,
+    add_item, delete_item, merge_item_conflict, replace_item, resolve_item_conflict, restore_item,
+    AddItemRandomnessV1, DeleteItemRandomnessV1, ReplaceItemRandomnessV1,
+    ResolveItemConflictRandomnessV1, RestoreItemRandomnessV1,
 };
 use crate::search::SearchProjectionV1;
 use crate::{
@@ -467,6 +467,35 @@ impl UnlockedVaultV1 {
             &self._local_secret,
             self._repository.as_ref(),
             selected_revision,
+            wall_time_ms,
+            randomness,
+            local_state_store,
+        )
+    }
+
+    /// Resolve one current conflict with a complete caller-authored document.
+    ///
+    /// The document must name an item with at least two current candidates and
+    /// preserve the schema and creation time of every retained live candidate.
+    /// At least one live candidate is required. The new revision names the
+    /// complete current conflict set as direct causal parents, consumes the
+    /// session and owned secret-bearing document, and never deletes immutable
+    /// candidate bytes.
+    pub fn merge_item_conflict(
+        self,
+        document: ItemDocument,
+        wall_time_ms: u64,
+        randomness: ResolveItemConflictRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        merge_item_conflict(
+            &self.active,
+            &self.report,
+            &self.current_catalog.items,
+            &self._keys,
+            &self._local_secret,
+            self._repository.as_ref(),
+            document,
             wall_time_ms,
             randomness,
             local_state_store,
@@ -1071,12 +1100,22 @@ mod tests {
     }
 
     fn new_login_document(item_id: ItemId, title: &str, password: &str) -> ItemDocument {
+        login_document_with_times(item_id, title, password, 300, 300)
+    }
+
+    fn login_document_with_times(
+        item_id: ItemId,
+        title: &str,
+        password: &str,
+        created_at_ms: u64,
+        updated_at_ms: u64,
+    ) -> ItemDocument {
         ItemDocument::new(
             item_id,
             ContentType::new(LOGIN_V1).unwrap(),
-            300,
-            300,
-            LwwRegister::new(false, 300, OperationId::new([0x71; 32])),
+            created_at_ms,
+            updated_at_ms,
+            LwwRegister::new(false, updated_at_ms, OperationId::new([0x71; 32])),
             ObservedSet::new(),
             ObservedSet::new(),
             AnyRecord::Login(Login {
@@ -2003,6 +2042,234 @@ mod tests {
         );
         assert_eq!(commit.added_objects().len(), 2);
         assert_eq!(commit.wall_time_ms(), 401);
+    }
+
+    #[test]
+    fn authored_conflict_merge_publishes_complete_parent_set_and_document() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x25; 16]);
+        let (publication, revisions) = pending_live_conflict_publication(&active, item_id);
+        let pending = LocalVaultStateV1::pending_publication(active, publication).unwrap();
+        *local.0.lock().unwrap() = Some(pending.encode().unwrap());
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let prior_heads = session.local_pins().clone();
+        session
+            .merge_item_conflict(
+                new_login_document(item_id, "Merged result", "merged-secret"),
+                405,
+                resolve_item_conflict_randomness(0x51),
+                &local,
+            )
+            .unwrap();
+
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(reopened.conflicted_item_count(), 0);
+        let [candidate] = reopened.current_catalog.items[&item_id].as_slice() else {
+            panic!("authored merge must become the sole current candidate")
+        };
+        assert_eq!(
+            candidate.causal_parents(),
+            &revisions
+                .iter()
+                .map(|(revision_id, _)| *revision_id)
+                .collect::<BTreeSet<_>>()
+        );
+        let ItemState::Live(document) = candidate.state() else {
+            panic!("authored merge must publish a live document")
+        };
+        let AnyRecord::Login(login) = document.payload() else {
+            panic!("authored merge must retain the input schema")
+        };
+        assert_eq!(login.title, "Merged result");
+        assert_eq!(login.password, "merged-secret");
+        assert_eq!(reopened.item_history(item_id, 100).unwrap().len(), 3);
+        let head = *reopened.open_report().heads().iter().next().unwrap();
+        let commit = reopened._repository.read_commit(head).unwrap();
+        assert_eq!(
+            commit.parents(),
+            prior_heads.iter().copied().collect::<Vec<_>>()
+        );
+        assert_eq!(commit.added_objects().len(), 2);
+        assert_eq!(commit.wall_time_ms(), 405);
+    }
+
+    #[test]
+    fn authored_conflict_merge_rejects_missing_sole_and_changed_identity_before_cas() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let missing = ItemId::new([0x26; 16]);
+        let exact_empty = local.0.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            open_active_vault(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                locator,
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap()
+            .merge_item_conflict(
+                new_login_document(missing, "Missing", "missing-secret"),
+                406,
+                resolve_item_conflict_randomness(0x52),
+                &local,
+            ),
+            Err(ApplicationError::NotFound)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_empty.as_slice())
+        );
+
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_empty).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let sole_id = ItemId::new([0x27; 16]);
+        let publication = pending_live_publication(&active, sole_id, "Sole", "sole-secret");
+        let pending = LocalVaultStateV1::pending_publication(active, publication).unwrap();
+        *local.0.lock().unwrap() = Some(pending.encode().unwrap());
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let exact_sole = local.0.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            open_active_vault(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                locator,
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap()
+            .merge_item_conflict(
+                login_document_with_times(sole_id, "Not a conflict", "secret", 100, 300),
+                407,
+                resolve_item_conflict_randomness(0x53),
+                &local,
+            ),
+            Err(ApplicationError::ConflictRequired)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_sole.as_slice())
+        );
+
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_sole).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let conflict_id = ItemId::new([0x28; 16]);
+        let (publication, _) = pending_live_conflict_publication(&active, conflict_id);
+        let pending = LocalVaultStateV1::pending_publication(active, publication).unwrap();
+        *local.0.lock().unwrap() = Some(pending.encode().unwrap());
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let exact_conflict = local.0.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            open_active_vault(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                locator,
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap()
+            .merge_item_conflict(
+                login_document_with_times(conflict_id, "Changed identity", "secret", 301, 301,),
+                408,
+                resolve_item_conflict_randomness(0x54),
+                &local,
+            ),
+            Err(ApplicationError::InvalidInput)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_conflict.as_slice())
+        );
+    }
+
+    #[test]
+    fn authored_conflict_merge_rejects_all_tombstone_conflict_before_cas() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x29; 16]);
+        let (publication, _) = pending_tombstone_publication(&active, item_id, item_id, 2, None);
+        let pending = LocalVaultStateV1::pending_publication(active, publication).unwrap();
+        *local.0.lock().unwrap() = Some(pending.encode().unwrap());
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let exact_conflict = local.0.lock().unwrap().clone().unwrap();
+
+        assert_eq!(
+            open_active_vault(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                locator,
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap()
+            .merge_item_conflict(
+                new_login_document(item_id, "Cannot revive", "secret"),
+                409,
+                resolve_item_conflict_randomness(0x55),
+                &local,
+            ),
+            Err(ApplicationError::InvalidInput)
+        );
+        assert_eq!(
+            local.0.lock().unwrap().as_deref(),
+            Some(exact_conflict.as_slice())
+        );
     }
 
     #[test]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1318,8 +1318,10 @@ changelog, focused build, and downstream validation.
    7b-4a. completed redacted current-conflict inspection and explicit
        choose-candidate resolution, publishing every retained candidate as a
        causal parent;
-   7b-4b. user-authored merged-document conflict resolution after explicit
-       field reveal;
+   7b-4b. completed user-authored merged-document conflict resolution after
+       explicit field reveal, requiring a real conflict with at least one live
+       candidate, preserving immutable live identity fields, publishing every
+       current candidate as a causal parent, and retaining immutable history;
    7c-1. completed bounded reachable live-revision reveal into a non-printable
        owned zeroizing document wrapper;
    7c-2. completed schema-specific first-party secret-field selection into a

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -536,7 +536,11 @@ publication. Device enrollment defines the later fresh-device ceremony.
   through a schema-specific API after validating clipboard, confirmed
   interactive reveal, or warned unsafe non-interactive intent; and
 - unresolved concurrent candidates return `ConflictRequired` and remain
-  available for a later resolution workflow.
+  available for explicit choose-candidate or caller-authored merged-document
+  resolution. An authored merge follows a host-controlled reveal ceremony,
+  requires at least one live current candidate, preserves every live
+  candidate's schema and creation time, and names the complete current
+  candidate set as causal parents.
 
 Mutation input is owned and zeroized on all return paths. Item IDs, operation
 IDs, and revision randomness come from injected entropy. Timestamps come from


### PR DESCRIPTION
## Summary

- add session-consuming user-authored merged-document resolution for a current vault item conflict
- require an actual conflict with at least one live candidate and preserve every live candidate schema and creation time
- publish the complete current candidate set as direct causal parents while retaining all immutable prior bytes as reachable history
- mark VLT-PM00 7b-4b complete and document the host-controlled reveal responsibility

## Security properties

- the owned secret-bearing merged document and unlocked session are consumed on every return path
- missing, unconflicted, changed-identity, and all-tombstone inputs fail before local compare-exchange
- no candidate is silently selected or discarded

## Validation

- package BUILD: 97 tests passed, including successful merged-secret persistence and complete-parent history
- strict Clippy: passed with warnings denied
- strict rustdoc: passed with warnings denied
- Tarpaulin LLVM: 2,381 / 2,493 production lines (95.51%)
- affected-package planner: 51 BUILD files, 1,001 packages, 1 changed, 21 affected, all 21 built
- rebased without conflict onto refreshed origin/main after unrelated gc-core PR #10386 merged; focused BUILD passed again
