### PR TITLE
feat(hl-tamil): teach உ and ஊ; keep the chapter 33-38 sections, with the measurement

### DIFF
--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -124,7 +124,7 @@ enter cross-language review only after focused retrieval.
 | [German](./german/README.md) | Germanic / Latin | 106 | 91 | 31 chapters; through Ch. 31; 15 generated |
 | [Arabic](./arabic/README.md) | Semitic / Arabic | 100 | 98 | 36 chapters; through Ch. 36; 34 generated |
 | [Hindi](./hindi/README.md) | Indo-Aryan / Devanagari | 109 | 103 | 39 chapters; through Ch. 39; 34 generated |
-| [Tamil](./tamil/README.md) | Dravidian / Tamil | 125 | 121 | 38 chapters; through Ch. 38; 33 generated |
+| [Tamil](./tamil/README.md) | Dravidian / Tamil | 127 | 123 | 38 chapters; through Ch. 38; 33 generated |
 | [Kannada](./kannada/README.md) | Dravidian / Kannada | 88 | 84 | 40 chapters; through Ch. 40; 35 generated |
 | [Telugu](./telugu/README.md) | Dravidian / Telugu | 74 | 70 | 34 chapters; through Ch. 34; 29 generated |
 | [Malayalam](./malayalam/README.md) | Dravidian / Malayalam | 78 | 74 | 34 chapters; through Ch. 34; 29 generated |

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -4043,7 +4043,7 @@
     {
       "language": "tamil",
       "chapter": 33,
-      "sourceHash": "fnv1a64:c9ee25acee4c3a7f",
+      "sourceHash": "fnv1a64:cf745e4b20acebec",
       "lessonIds": [
         "TA-C33-ninai",
         "TA-C33-puri",
@@ -4082,11 +4082,12 @@
     {
       "language": "tamil",
       "chapter": 36,
-      "sourceHash": "fnv1a64:aba8bf386dab3a06",
+      "sourceHash": "fnv1a64:d5a336d86b5196ce",
       "lessonIds": [
         "TA-C36-teneer",
         "TA-C36-paal",
         "TA-C36-unavu",
+        "TA-W17-read-unavu",
         "TA-C36-tavaru"
       ],
       "tex": "tamil/book/chapters/ch36-what-you-are-offered.tex"
@@ -4094,10 +4095,11 @@
     {
       "language": "tamil",
       "chapter": 37,
-      "sourceHash": "fnv1a64:86603e82eee0d338",
+      "sourceHash": "fnv1a64:0e330365cba813ff",
       "lessonIds": [
         "TA-C37-uur",
         "TA-C37-nanban",
+        "TA-W18-read-uur",
         "TA-C37-ivar",
         "TA-C37-ivar-en-nanbar"
       ],

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -7540,7 +7540,7 @@
     {
       "language": "tamil",
       "chapter": 33,
-      "sourceHash": "fnv1a64:1692ee153a91024f",
+      "sourceHash": "fnv1a64:d442d66ccc91878e",
       "lessonIds": [
         "TA-C33-ninai",
         "TA-C33-puri",
@@ -7552,8 +7552,8 @@
       "drivablePrefix": 0,
       "text": "tamil/narration/ch33.txt",
       "json": "tamil/narration/ch33.json",
-      "textHash": "fnv1a64:70dee08f58a6d6a0",
-      "jsonHash": "fnv1a64:dc9c376c15fc5184"
+      "textHash": "fnv1a64:4afca61efbc345fb",
+      "jsonHash": "fnv1a64:c81de2b280170ecd"
     },
     {
       "language": "tamil",
@@ -7594,27 +7594,29 @@
     {
       "language": "tamil",
       "chapter": 36,
-      "sourceHash": "fnv1a64:402bf0320fcdb2c7",
+      "sourceHash": "fnv1a64:0c4b08a654ae45b6",
       "lessonIds": [
         "TA-C36-teneer",
         "TA-C36-paal",
         "TA-C36-unavu",
+        "TA-W17-read-unavu",
         "TA-C36-tavaru"
       ],
       "voiceLessons": 0,
       "drivablePrefix": 0,
       "text": "tamil/narration/ch36.txt",
       "json": "tamil/narration/ch36.json",
-      "textHash": "fnv1a64:0939422c53d55470",
-      "jsonHash": "fnv1a64:6923acb60ff29cd2"
+      "textHash": "fnv1a64:952d52c201fd0ca8",
+      "jsonHash": "fnv1a64:30e98ca2b6f0ebb0"
     },
     {
       "language": "tamil",
       "chapter": 37,
-      "sourceHash": "fnv1a64:f9fc24867a2d77c3",
+      "sourceHash": "fnv1a64:35ab5bef10c8172b",
       "lessonIds": [
         "TA-C37-uur",
         "TA-C37-nanban",
+        "TA-W18-read-uur",
         "TA-C37-ivar",
         "TA-C37-ivar-en-nanbar"
       ],
@@ -7622,8 +7624,8 @@
       "drivablePrefix": 0,
       "text": "tamil/narration/ch37.txt",
       "json": "tamil/narration/ch37.json",
-      "textHash": "fnv1a64:ac8790b0e34fcd44",
-      "jsonHash": "fnv1a64:971f62277de17d49"
+      "textHash": "fnv1a64:a39abe3d69af2f8c",
+      "jsonHash": "fnv1a64:d13059d30d302ffa"
     },
     {
       "language": "tamil",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,12 +7,12 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:d6e3ba9e6a7c8cf2",
+  "sourceHash": "fnv1a64:20e6a728d8039764",
   "summary": {
-    "totalLessons": 1687,
+    "totalLessons": 1689,
     "voice": 1114,
     "sight": 508,
-    "pen": 65,
+    "pen": 67,
     "drivableLessons": 1114,
     "drivablePercent": 66,
     "trackCount": 22,
@@ -7548,11 +7548,11 @@
     },
     {
       "language": "tamil",
-      "lessonCount": 125,
+      "lessonCount": 127,
       "voice": 76,
       "sight": 29,
-      "pen": 20,
-      "drivablePercent": 61,
+      "pen": 22,
+      "drivablePercent": 60,
       "drivablePrefixTotal": 60,
       "modalities": [
         "voice",
@@ -8180,12 +8180,13 @@
         },
         {
           "chapter": 36,
-          "lessonCount": 4,
+          "lessonCount": 5,
           "voice": 0,
           "sight": 4,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "sight"
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 0,
           "firstNonVoiceLesson": "TA-C36-teneer",
@@ -8194,12 +8195,13 @@
         },
         {
           "chapter": 37,
-          "lessonCount": 4,
+          "lessonCount": 5,
           "voice": 0,
           "sight": 4,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "sight"
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 0,
           "firstNonVoiceLesson": "TA-C37-uur",
@@ -38018,7 +38020,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:3da01ee3c6063b7b",
+      "sourceHash": "fnv1a64:df3eb8d967d164b5",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -38060,7 +38062,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:7eae469fe811e74e",
+      "sourceHash": "fnv1a64:36ae56781169eff6",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -38105,7 +38107,7 @@
         "no-visual-dependency"
       ],
       "coreDrivable": true,
-      "sourceHash": "fnv1a64:3cbfae9f73f99b68",
+      "sourceHash": "fnv1a64:bdda9249c003f94c",
       "detachableSegments": [
         "The letters in this word"
       ]
@@ -38387,6 +38389,30 @@
       ]
     },
     {
+      "id": "TA-W17-read-unavu",
+      "language": "tamil",
+      "chapter": 36,
+      "sequence": 1085,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:695185032432fcaf",
+      "detachableSegments": [
+        "Script you'll notice: உ",
+        "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
+    },
+    {
       "id": "TA-C36-tavaru",
       "language": "tamil",
       "chapter": 36,
@@ -38448,6 +38474,30 @@
       "detachableSegments": [
         "The letters in this word"
       ]
+    },
+    {
+      "id": "TA-W18-read-uur",
+      "language": "tamil",
+      "chapter": 37,
+      "sequence": 1115,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:a4d00dabaf8d79bf",
+      "detachableSegments": [
+        "Script you'll notice: ஊ",
+        "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
     },
     {
       "id": "TA-C37-ivar",

--- a/code/learning/human-languages/tamil/README.md
+++ b/code/learning/human-languages/tamil/README.md
@@ -99,9 +99,12 @@ through.
   native நலம்), and விடை (*viḍai*) — which the Dravidian dictionary files
   in the **same entry as வீடு**, so the arc walks in through the house and out
   through the leave on one root. In the book, Chapters 35–38.
-- **Writing W01–W04** ([`lessons/TA-W*`](./lessons/)): eight gentle steps teach
-  curves, the abugida, retroflexion, the three Tamil n letters, the puḷḷi,
-  vowel signs, and whole-word writing for **வணக்கம்** and **நன்றி**.
+- **The script strand, W01–W18** ([`lessons/TA-W*`](./lessons/)): 22 lessons
+  marked `delivery: script`, one after roughly every third speaking lesson from
+  Chapter 4 to Chapter 37. They teach curves, the abugida, retroflexion, the
+  three Tamil n letters, the puḷḷi, the vowel signs, and then spell — one word
+  per lesson — words the learner has already been saying, from **வணக்கம்** to
+  **தமிழ்**. Chapters 1–3 hold no writing lesson at all, on purpose.
 
 ---
 
@@ -123,15 +126,14 @@ validator may rewrite it.
 
 Two things about this track's ledger are worth knowing before reading it:
 
-- **Chapters 2–5 have no entry, on purpose.** Their lessons are still schema v1
-  with no `practises.knowledge`, so a payoff there could not name a single real
-  atom. The gap is left visible rather than stubbed, because the HL05 gap
-  report's whole job is to measure exactly this kind of debt.
-- **Every payoff is a chapter's last lesson by `sequence`,** because no Tamil
-  chapter yet ends on a schema-v2 `practice` or `practice-mix`. Where that last
-  lesson is one of the eight inline `writing` lessons, or an etymology lesson
-  whose closing work is weighing evidence, `payoff.kind` is `task` and the
-  summary describes that work plainly instead of dressing it up as an exchange.
+- **A payoff is usually a chapter's last lesson by `sequence`,** because no
+  Tamil chapter yet ends on a schema-v2 `practice` or `practice-mix`. It is not
+  always: interleaving the script strand put a `delivery: script` lesson after
+  the payoff in several chapters, so read `payoff.lesson` rather than assuming
+  the last one. Where the payoff lesson is a `writing` lesson, or an etymology
+  lesson whose closing work is weighing evidence, `payoff.kind` is `task` and
+  the summary describes that work plainly instead of dressing it up as an
+  exchange.
 
 The `canDo` statements are pitched at this track's real reader — fluent and
 literate in Tamil, but never formally taught its grammar — so they claim

--- a/code/learning/human-languages/tamil/book/chapter-modalities.tex
+++ b/code/learning/human-languages/tamil/book/chapter-modalities.tex
@@ -275,15 +275,15 @@
 
 \expandafter\def\csname hlchaptermodality36\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (4)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} all 4 lessons.%
+    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (4) \quad \hlpensign{}~\textbf{pen} (1)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 3 of 5 lessons.%
     \par}\medskip
 }
 
 \expandafter\def\csname hlchaptermodality37\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (4)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} all 4 lessons.%
+    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (4) \quad \hlpensign{}~\textbf{pen} (1)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 2 of 5 lessons.%
     \par}\medskip
 }
 

--- a/code/learning/human-languages/tamil/book/chapters/appendix-index.tex
+++ b/code/learning/human-languages/tamil/book/chapters/appendix-index.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons or chapters.json, then run npm run generate:books.
-% canonical-index-candidates: 158
-% canonical-index-entries: 158
+% canonical-index-candidates: 160
+% canonical-index-entries: 160
 
 \chapter*{Index}
 \addcontentsline{toc}{chapter}{Index}
@@ -864,6 +864,18 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{-\ta{உக்கு} — one carriage in a suffix train}\par
 \footnotesize grammar topic; explicit focus: grammar; \hyperref[ch:ta-dative-case]{Chapter~6, p.~\pageref*{ch:ta-dative-case}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{உணவு} — the same vowel, twice, two ways}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ta-what-you-are-offered]{Chapter~36, p.~\pageref*{ch:ta-what-you-are-offered}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{ஊர்} — the long partner}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ta-your-town-your-friend]{Chapter~37, p.~\pageref*{ch:ta-your-town-your-friend}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}

--- a/code/learning/human-languages/tamil/book/chapters/ch33-verbs-of-the-mind.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch33-verbs-of-the-mind.tex
@@ -1,5 +1,5 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:c9ee25acee4c3a7f
+% canonical-source-hash: fnv1a64:cf745e4b20acebec
 % canonical-lessons: TA-C33-ninai, TA-C33-puri, TA-C33-padi, TA-W16-read-tamizh, TA-C33-ezhutu
 
 \chapter{Four Verbs of the Mind}
@@ -30,7 +30,7 @@ Say \ta{நான்} \ta{தமிழ்} \ta{எழுதுகிறேன்
 Two light beats, \emph{ni-nai}. Threaded up: \textbf{\ta{நினைக்கிறேன்}} (\emph{ninaikkiṟēṉ}), \textquotedblleft{}I think\textquotedblright{} — stem, tense, person, with nothing new in the machine.
 
 \subsection*{The letters in this word}
-\textbf{\ta{நி}} is the \textbf{dental \ta{ந}} with the \emph{i} sign \textbf{\ta{ி}}; \textbf{\ta{னை}} is the \textbf{alveolar \ta{ன}} with the \emph{ai} sign \textbf{\ta{ை}}. Two of Tamil's three n-letters in one word, and not interchangeable: the first sits on the teeth, the second on the ridge behind them. Chapter 1 mapped all three — \textbf{\ta{ந}}, \textbf{\ta{ன}}, \textbf{\ta{ண}}.
+\textbf{\ta{நி}} is the \textbf{dental \ta{ந}} with the \emph{i} sign \textbf{\ta{ி}}; \textbf{\ta{னை}} is the \textbf{alveolar \ta{ன}} with the \emph{ai} sign \textbf{\ta{ை}}. Two of Tamil's three n-letters in one word, and not interchangeable: the first sits on the teeth, the second on the ridge behind them. Chapter 6's three-n lesson mapped all three — \textbf{\ta{ந}}, \textbf{\ta{ன}}, \textbf{\ta{ண}}.
 
 \begin{grammarlens}[title={Grammar Lens: it doubles, so it is strong}]
 The \textbf{k} in \emph{ninaikkiṟēṉ} is held long — \emph{ninaik-ki} — as it was in \emph{irukkiṟēṉ} and \emph{pārkkiṟēṉ}, and not as it was in \emph{pōgiṟēṉ}. So \textbf{\ta{நினை} is strong}, and its past is \textbf{\ta{நினைத்தேன்}} (\emph{ninaittēṉ}), with the strong verb's doubled \emph{t}.
@@ -158,7 +158,7 @@ Tamil does not split reading from studying: \textbf{\ta{படிப்பு}} 
 \subsection*{The letters in this word}
 \textbf{\ta{ப}} (\emph{pa}) + \textbf{\ta{டி}}, which is \textbf{\ta{ட}} wearing the \emph{i} sign \textbf{\ta{ி}}.
 
-Now a mystery worth clearing up. The letter is \textbf{\ta{ட}}, named \emph{ṭa}, yet the word is written here \emph{paḍi}, with a \textbf{d}. Nothing is inconsistent: \textbf{Tamil marks no voicing.} One letter covers both sounds and \textbf{position decides} — hard word-initially or doubled, soft between vowels. That is Chapter 1's rule for \textbf{\ta{க}}, which spells \emph{k}, \emph{g} and a soft \emph{h} without changing shape.
+Now a mystery worth clearing up. The letter is \textbf{\ta{ட}}, named \emph{ṭa}, yet the word is written here \emph{paḍi}, with a \textbf{d}. Nothing is inconsistent: \textbf{Tamil marks no voicing.} One letter covers both sounds and \textbf{position decides} — hard word-initially or doubled, soft between vowels. That is Chapter 5's rule for \textbf{\ta{க}}, which spells \emph{k}, \emph{g} and a soft \emph{h} without changing shape.
 
 So \textbf{\ta{ட}} is soft between the vowels of \emph{paḍi} and hard in the doubled \textbf{\ta{ட்ட}} of \emph{paḍittēṉ}. It is why \emph{pō} becomes \emph{pōgiṟēṉ}, why \emph{sāppiḍu} has a \emph{ḍ}, and why every romanization here softens where a speaker softens.
 
@@ -269,7 +269,7 @@ Read \textbf{\ta{தமிழ்}}. Which letter is \textbf{\ta{த}}'s retrofle
 \subsection*{The letters in this word}
 \textbf{\ta{எ}} is the standing vowel \emph{e}; \textbf{\ta{ழு}} is \textbf{\ta{ழ}} with the \emph{u} sign and \textbf{\ta{து}} is \textbf{\ta{த}} with the same sign.
 
-The dot returns in the noun \textbf{\ta{எழுத்து}} (\emph{eḻuttu}), \textquotedblleft{}\textbf{a letter of the alphabet},\textquotedblright{} spelled \textbf{\ta{எ} \ta{ழு} \ta{த்} \ta{து}}: a \textbf{puḷḷi} strips the vowel from the first \textbf{\ta{த்}} and the second \textbf{\ta{து}} stands whole beside it. Two full letters and a visible dot, never a fused shape: Chapter 1's bargain.
+The dot returns in the noun \textbf{\ta{எழுத்து}} (\emph{eḻuttu}), \textquotedblleft{}\textbf{a letter of the alphabet},\textquotedblright{} spelled \textbf{\ta{எ} \ta{ழு} \ta{த்} \ta{து}}: a \textbf{puḷḷi} strips the vowel from the first \textbf{\ta{த்}} and the second \textbf{\ta{து}} stands whole beside it. Two full letters and a visible dot, never a fused shape: the puḷḷi lesson's bargain.
 
 \begin{sounds}
 \textbf{\ta{ழ}} — written \emph{ḻ} — is the sound in \textbf{\ta{தமிழ்}} (\emph{tamiḻ}) itself and in \textbf{\ta{வாழ்}} (\emph{vāḻ}), \textquotedblleft{}to live,\textquotedblright{} and is reputed to be the language's hardest.

--- a/code/learning/human-languages/tamil/book/chapters/ch36-what-you-are-offered.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch36-what-you-are-offered.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:aba8bf386dab3a06
-% canonical-lessons: TA-C36-teneer, TA-C36-paal, TA-C36-unavu, TA-C36-tavaru
+% canonical-source-hash: fnv1a64:d5a336d86b5196ce
+% canonical-lessons: TA-C36-teneer, TA-C36-paal, TA-C36-unavu, TA-W17-read-unavu, TA-C36-tavaru
 
 \chapter{What You Are Offered}
 \label{ch:ta-what-you-are-offered}
@@ -186,6 +186,65 @@ Say these aloud:
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 What verb is \emph{uṇavu} built on, and where does your tongue go for \textbf{\ta{ண}}? (\textbf{\ta{உண்}}; \textbf{curled back}.) Which eating verb would you use at a table, and how sure is anyone where it came from? (\textbf{\ta{சாப்பிடு}} — \textbf{not at all}: the Dravidian dictionary has no entry.) Give the raw grain and the cooked meal. (\emph{Arisi}; \emph{sātam}.)
+\end{tcolorbox}
+\section[uṇavu]{\ta{உணவு} — the same vowel, twice, two ways}
+
+\label{lesson:TA-W17-read-unavu}
+
+
+
+\begin{quote}
+You have the \textbf{\ta{ு}} sign — the \emph{u} that hangs off a consonant, as in \textbf{\ta{ரு}}. But a word that \emph{starts} on \emph{u} has no consonant to hang it from, and by now you know what Tamil does about that.
+\end{quote}
+
+\subsection*{Script you'll notice: \ta{உ}}
+\textbf{\ta{உ}} is the standing letter for short \emph{u}. It is the rule you met with \textbf{\ta{ஆ}} in \textbf{\ta{ஆம்}}, working again: a vowel that opens a word is written as a \textbf{full letter}, never as a sign.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{உ}} & the letter — opens a word \\
+\textbf{\ta{ு}} & the sign — rides a consonant \\
+\bottomrule
+\end{tabularx}
+
+The word you already say holds both. That is the whole lesson.
+
+\begin{quote}
+Read it; do not draw it yet. \textbf{\ta{உ}} has no entry in this book's script data, so it gets no stroke order here.
+\end{quote}
+
+\subsection*{Script you'll notice: build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{உ}} & \emph{u} & independent — the word opens on a vowel \\
+\textbf{\ta{ண}} & \emph{ṇa}, the retroflex \emph{n} & first met beside \textbf{\ta{ம}} \\
+\textbf{\ta{வு}} & \emph{vu} — \textbf{\ta{வ}} with the \textbf{\ta{ு}} sign & \ta{வ} was your first letter \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{உ} · \ta{ண} · \ta{வு} $\to$ \ta{உணவு}}
+\end{quote}
+
+Three pieces, and the first and last are the same vowel doing its two jobs: once standing on its own, once hanging off \textbf{\ta{வ}}. The page keeps them apart so your eye can.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \textbf{\ta{உ}} — then \textbf{\ta{உணவு}}
+  \item \emph{Say it:} \textquotedblleft{}uṇavu\textquotedblright{} — \textquotedblleft{}food\textquotedblright{}
+  \item \emph{Contrast:} \textbf{\ta{உ}} and \textbf{\ta{வு}} — the letter that opens, the sign that rides
+  \item \emph{Contrast:} \textbf{\ta{ஆம்}} and \textbf{\ta{உணவு}} — the same opening rule, two vowels apart
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read \textbf{\ta{உணவு}}. Why does it open with \textbf{\ta{உ}} rather than the \textbf{\ta{ு}} sign? (\textbf{The word starts on a vowel} — there is nothing for a sign to hang on.) Where else in the same word does that vowel appear, and in which form? (\textbf{On \ta{வு}}, as the \textbf{\ta{ு}} sign.) Which earlier word set this rule? (\textbf{\ta{ஆம்}}.) Next: the word for a mistake.
 \end{tcolorbox}
 \section[tavaṟu]{\ta{தவறு} (tavaṟu) — \textquotedblleft{}a mistake,\textquotedblright{} and the rest of the apology}
 

--- a/code/learning/human-languages/tamil/book/chapters/ch37-your-town-your-friend.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch37-your-town-your-friend.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:86603e82eee0d338
-% canonical-lessons: TA-C37-uur, TA-C37-nanban, TA-C37-ivar, TA-C37-ivar-en-nanbar
+% canonical-source-hash: fnv1a64:0e330365cba813ff
+% canonical-lessons: TA-C37-uur, TA-C37-nanban, TA-W18-read-uur, TA-C37-ivar, TA-C37-ivar-en-nanbar
 
 \chapter{Your Town, Your Friend}
 \label{ch:ta-your-town-your-friend}
@@ -149,6 +149,62 @@ Say these aloud:
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Give the friend-word for a woman, a man, and someone you respect. (\emph{Naṇbi}; \emph{naṇbaṉ}; \emph{naṇbar}.) Which axis do the friend words split on, and which do the brother words? (\textbf{Sex and respect}; \textbf{age}.) Why is \textbf{\ta{ப}} heard as \emph{b}, and are \textbf{\ta{அப்பா}} and \textbf{\ta{அம்மா}} built from a root the way \emph{naṇbaṉ} is? (\textbf{A nasal voices the stop after it}; \textbf{no}.)
+\end{tcolorbox}
+\section[ūr]{\ta{ஊர்} — the long partner}
+
+\label{lesson:TA-W18-read-uur}
+
+
+
+\begin{quote}
+\textbf{\ta{உ}} opened \textbf{\ta{உணவு}} last chapter. Tamil writes its long vowels as separate letters from the short ones, so \emph{ū} gets a letter of its own.
+\end{quote}
+
+\subsection*{Script you'll notice: \ta{ஊ}}
+\textbf{\ta{ஊ}} is the standing letter for long \emph{ū}, and it is the long partner of \textbf{\ta{உ}} — the fourth short-and-long pair the strand has handed you, after \textbf{\ta{அ}}/\textbf{\ta{ஆ}}, \textbf{\ta{ி}}/\textbf{\ta{ீ}} and \textbf{\ta{ெ}}/\textbf{\ta{ே}}.
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{உ}} & short \emph{u} \\
+\textbf{\ta{ஊ}} & long \emph{ū} \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+Read it; do not draw it yet. \textbf{\ta{ஊ}} has no entry in this book's script data, and neither has \textbf{\ta{உ}} — so neither gets a stroke order, and the pairing above, like the way the shorter letter sits inside the longer one, is what the page shows rather than something the data states.
+\end{quote}
+
+\subsection*{Script you'll notice: build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{ஊ}} & \emph{ū} & independent — the word opens on a vowel \\
+\textbf{\ta{ர்}} & bare \emph{r} — \textbf{\ta{ர}} under a puḷḷi & \ta{ர} from \textbf{\ta{சரி}} \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{ஊ} · \ta{ர்} $\to$ \ta{ஊர்}}
+\end{quote}
+
+Two pieces, and both were waiting for you. \textbf{\ta{ஊர்}} is the word for your own town, and holding it against \textbf{\ta{உணவு}} shows the length doing real work: change the vowel and you change the word.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \textbf{\ta{ஊ}} — then \textbf{\ta{ஊர்}}
+  \item \emph{Say it:} \textquotedblleft{}ūr\textquotedblright{} — \textquotedblleft{}town\textquotedblright{}
+  \item \emph{Contrast:} \textbf{\ta{உ}} and \textbf{\ta{ஊ}} — short and long, two letters
+  \item \emph{Read it:} \textbf{\ta{உணவு}} and \textbf{\ta{ஊர்}} together — the pair, side by side
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read \textbf{\ta{ஊர்}}. Which letter is \textbf{\ta{ஊ}}'s short partner, and where did you read it? (\textbf{\ta{உ}}, opening \textbf{\ta{உணவு}}.) Why is the vowel a full letter here rather than a sign? (\textbf{The word starts on it}.) What is the dot on \textbf{\ta{ர்}} doing? (\textbf{Removing the built-in \emph{a}}.) Next: pointing someone out politely.
 \end{tcolorbox}
 \section[ivar]{\ta{இவர்} (ivar) — \textquotedblleft{}this person,\textquotedblright{} and Tamil's pointing system}
 

--- a/code/learning/human-languages/tamil/curriculum.json
+++ b/code/learning/human-languages/tamil/curriculum.json
@@ -49,7 +49,9 @@
         "TA-W13-read-irukkirirgal",
         "TA-W16-read-tamizh",
         "TA-W14-read-pesu",
-        "TA-W15-read-po"
+        "TA-W15-read-po",
+        "TA-W17-read-unavu",
+        "TA-W18-read-uur"
       ],
       "before": [],
       "inline": [
@@ -898,7 +900,9 @@
         "TA-W13-read-irukkirirgal",
         "TA-W16-read-tamizh",
         "TA-W14-read-pesu",
-        "TA-W15-read-po"
+        "TA-W15-read-po",
+        "TA-W17-read-unavu",
+        "TA-W18-read-uur"
       ]
     },
     {

--- a/code/learning/human-languages/tamil/lessons/TA-C33-ezhutu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C33-ezhutu.md
@@ -56,7 +56,7 @@ softened *-giṟ-***, so **எழுது is weak**, like *pō* and *sāppiḍu
 The dot returns in the noun **எழுத்து** (*eḻuttu*), "**a letter of the
 alphabet**," spelled **எ ழு த் து**: a **puḷḷi** strips the vowel from the first
 **த்** and the second **து** stands whole beside it. Two full letters and a
-visible dot, never a fused shape: Chapter 1's bargain.
+visible dot, never a fused shape: the puḷḷi lesson's bargain.
 
 ## Sounds you'll need: ழ, and how to stop chasing it
 <!-- hl-knowledge: introduces=[TA-SOUND-EZHUTU-02]; assesses=[TA-ETYMON-NUMBERS-6-10-FAMILY-01] -->

--- a/code/learning/human-languages/tamil/lessons/TA-C33-ninai.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C33-ninai.md
@@ -51,7 +51,7 @@ think" — stem, tense, person, with nothing new in the machine.
 **நி** is the **dental ந** with the *i* sign **ி**; **னை** is the **alveolar
 ன** with the *ai* sign **ை**. Two of Tamil's three n-letters in one word, and
 not interchangeable: the first sits on the teeth, the second on the ridge
-behind them. Chapter 1 mapped all three — **ந**, **ன**, **ண**.
+behind them. Chapter 6's three-n lesson mapped all three — **ந**, **ன**, **ண**.
 
 ## Grammar Lens: it doubles, so it is strong
 <!-- hl-knowledge: introduces=[]; assesses=[TA-GRAMMAR-PAAR-02, TA-GRAMMAR-IRU-02, TA-LEX-NINAI-01] -->

--- a/code/learning/human-languages/tamil/lessons/TA-C33-padi.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C33-padi.md
@@ -58,7 +58,7 @@ Tamil does not split reading from studying: **படிப்பு** (*paḍipp
 Now a mystery worth clearing up. The letter is **ட**, named *ṭa*, yet the word
 is written here *paḍi*, with a **d**. Nothing is inconsistent: **Tamil marks no
 voicing.** One letter covers both sounds and **position decides** — hard
-word-initially or doubled, soft between vowels. That is Chapter 1's rule for
+word-initially or doubled, soft between vowels. That is Chapter 5's rule for
 **க**, which spells *k*, *g* and a soft *h* without changing shape.
 
 So **ட** is soft between the vowels of *paḍi* and hard in the doubled **ட்ட** of

--- a/code/learning/human-languages/tamil/lessons/TA-W17-read-unavu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W17-read-unavu.md
@@ -1,0 +1,88 @@
+---
+schema_version: 2
+id: TA-W17-read-unavu
+spine_node: SPINE-MEET-GREET
+sequence: 1085
+delivery: script
+chapter: 36
+type: writing
+headword: "உணவு"
+gloss: உ, the standing short u, against the ு sign that hangs off a consonant
+romanization: "uṇavu"
+prerequisites: [TA-W15-read-po, TA-W13-read-irukkirirgal]
+sounds: [independent-vowel-u, matra-u]
+roots: []
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-SCRIPT-READ-PO-02, TA-SCRIPT-U-SIGN-01, TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-WRITE-AAM-02, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SCRIPT-ABUGIDA-VA-KA-02]
+introduces:
+  knowledge: [TA-SCRIPT-U-VOWEL-01, TA-SCRIPT-READ-UNAVU-02]
+practises:
+  knowledge: [TA-SCRIPT-U-SIGN-01, TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-WRITE-AAM-02, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SCRIPT-ABUGIDA-VA-KA-02, TA-SCRIPT-U-VOWEL-01, TA-SCRIPT-READ-UNAVU-02]
+skills: [reading]
+modes: [interpretive]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W13-read-irukkirirgal, TA-W05-write-aam, TA-C36-unavu]
+---
+
+# உணவு — the same vowel, twice, two ways
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-U-SIGN-01, TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-CA-ONE-LETTER-01] -->
+
+[PAUSE 2s] You have the **ு** sign — the *u* that hangs off a consonant, as in
+**ரு**. But a word that *starts* on *u* has no consonant to hang it from, and by
+now you know what Tamil does about that.
+
+## Script you'll notice: உ
+<!-- hl-knowledge: introduces=[TA-SCRIPT-U-VOWEL-01]; assesses=[TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-U-SIGN-01, TA-SCRIPT-WRITE-AAM-02] -->
+
+**உ** is the standing letter for short *u*. It is the rule you met with **ஆ** in
+**ஆம்**, working again: a vowel that opens a word is written as a **full
+letter**, never as a sign.
+
+| | |
+|---|---|
+| **உ** | the letter — opens a word |
+| **ு** | the sign — rides a consonant |
+
+The word you already say holds both. That is the whole lesson.
+
+> Read it; do not draw it yet. **உ** has no entry in this book's script data, so
+> it gets no stroke order here.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-READ-UNAVU-02]; assesses=[TA-SCRIPT-U-VOWEL-01, TA-SCRIPT-U-SIGN-01, TA-SCRIPT-MA-RETROFLEX-NA-02, TA-SCRIPT-ABUGIDA-VA-KA-02] -->
+
+| piece | | |
+|---|---|---|
+| **உ** | *u* | independent — the word opens on a vowel |
+| **ண** | *ṇa*, the retroflex *n* | first met beside **ம** |
+| **வு** | *vu* — **வ** with the **ு** sign | வ was your first letter |
+
+> **உ · ண · வு → உணவு**
+
+Three pieces, and the first and last are the same vowel doing its two jobs: once
+standing on its own, once hanging off **வ**. The page keeps them apart so your
+eye can.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-U-VOWEL-01, TA-SCRIPT-READ-UNAVU-02, TA-SCRIPT-U-SIGN-01] -->
+
+[PAUSE 1s]
+- [YOU READ: **உ** — then **உணவு**]
+- [YOU SAY: "uṇavu" — "food"]
+- [YOU CONTRAST: **உ** and **வு** — the letter that opens, the sign that rides]
+- [YOU CONTRAST: **ஆம்** and **உணவு** — the same opening rule, two vowels apart]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-U-VOWEL-01, TA-SCRIPT-READ-UNAVU-02, TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-WRITE-AAM-02] -->
+
+[PAUSE 3s] Read **உணவு**. Why does it open with **உ** rather than the **ு**
+sign? (**The word starts on a vowel** — there is nothing for a sign to hang on.)
+Where else in the same word does that vowel appear, and in which form? (**On வு**,
+as the **ு** sign.) Which earlier word set this rule? (**ஆம்**.)
+Next: the word for a mistake.

--- a/code/learning/human-languages/tamil/lessons/TA-W18-read-uur.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W18-read-uur.md
@@ -1,0 +1,85 @@
+---
+schema_version: 2
+id: TA-W18-read-uur
+spine_node: SPINE-MEET-GREET
+sequence: 1115
+delivery: script
+chapter: 37
+type: writing
+headword: "ஊர்"
+gloss: ஊ, the long partner of the உ you read last chapter
+romanization: "ūr"
+prerequisites: [TA-W17-read-unavu, TA-W07-write-sari]
+sounds: [independent-vowel-uu, pulli]
+roots: []
+duration:
+  max_seconds: 240
+requires:
+  knowledge: [TA-SCRIPT-U-VOWEL-01, TA-SCRIPT-READ-UNAVU-02, TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-PULLI-VANAKKAM-01]
+introduces:
+  knowledge: [TA-SCRIPT-UU-VOWEL-01, TA-SCRIPT-READ-UUR-02]
+practises:
+  knowledge: [TA-SCRIPT-U-VOWEL-01, TA-SCRIPT-READ-UNAVU-02, TA-SCRIPT-INDEPENDENT-VOWEL-AA-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-UU-VOWEL-01, TA-SCRIPT-READ-UUR-02]
+skills: [reading]
+modes: [interpretive]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W17-read-unavu, TA-W05-write-aam, TA-C37-uur]
+---
+
+# ஊர் — the long partner
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-U-VOWEL-01, TA-SCRIPT-READ-UNAVU-02] -->
+
+[PAUSE 2s] **உ** opened **உணவு** last chapter. Tamil writes its long vowels as
+separate letters from the short ones, so *ū* gets a letter of its own.
+
+## Script you'll notice: ஊ
+<!-- hl-knowledge: introduces=[TA-SCRIPT-UU-VOWEL-01]; assesses=[TA-SCRIPT-U-VOWEL-01, TA-SCRIPT-INDEPENDENT-VOWEL-AA-01] -->
+
+**ஊ** is the standing letter for long *ū*, and it is the long partner of **உ** —
+the fourth short-and-long pair the strand has handed you, after **அ**/**ஆ**,
+**ி**/**ீ** and **ெ**/**ே**.
+
+| | |
+|---|---|
+| **உ** | short *u* |
+| **ஊ** | long *ū* |
+
+> Read it; do not draw it yet. **ஊ** has no entry in this book's script data, and
+> neither has **உ** — so neither gets a stroke order, and the pairing above, like
+> the way the shorter letter sits inside the longer one, is what the page shows
+> rather than something the data states.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-READ-UUR-02]; assesses=[TA-SCRIPT-UU-VOWEL-01, TA-SCRIPT-CA-ONE-LETTER-01, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+| piece | | |
+|---|---|---|
+| **ஊ** | *ū* | independent — the word opens on a vowel |
+| **ர்** | bare *r* — **ர** under a puḷḷi | ர from **சரி** |
+
+> **ஊ · ர் → ஊர்**
+
+Two pieces, and both were waiting for you. **ஊர்** is the word for your own
+town, and holding it against **உணவு** shows the length doing real work: change
+the vowel and you change the word.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-UU-VOWEL-01, TA-SCRIPT-READ-UUR-02, TA-SCRIPT-U-VOWEL-01, TA-SCRIPT-READ-UNAVU-02] -->
+
+[PAUSE 1s]
+- [YOU READ: **ஊ** — then **ஊர்**]
+- [YOU SAY: "ūr" — "town"]
+- [YOU CONTRAST: **உ** and **ஊ** — short and long, two letters]
+- [YOU READ: **உணவு** and **ஊர்** together — the pair, side by side]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-UU-VOWEL-01, TA-SCRIPT-READ-UUR-02, TA-SCRIPT-U-VOWEL-01, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+[PAUSE 3s] Read **ஊர்**. Which letter is **ஊ**'s short partner, and where did
+you read it? (**உ**, opening **உணவு**.) Why is the vowel a full letter here
+rather than a sign? (**The word starts on it**.) What is the dot on **ர்**
+doing? (**Removing the built-in *a***.) Next: pointing someone out politely.

--- a/code/learning/human-languages/tamil/narration/ch33.json
+++ b/code/learning/human-languages/tamil/narration/ch33.json
@@ -4,7 +4,7 @@
   "chapter": 33,
   "title": "Four Verbs of the Mind",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:1692ee153a91024f",
+  "sourceHash": "fnv1a64:d442d66ccc91878e",
   "lessons": [
     {
       "id": "TA-C33-ninai",
@@ -19,7 +19,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3da01ee3c6063b7b",
+      "sourceHash": "fnv1a64:df3eb8d967d164b5",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -70,7 +70,7 @@
           "segments": [
             {
               "kind": "speech",
-              "text": "நி is the dental ந with the i sign ி; னை is the alveolar ன with the ai sign ை. Two of Tamil's three n-letters in one word, and not interchangeable: the first sits on the teeth, the second on the ridge behind them. Chapter 1 mapped all three — ந, ன, ண."
+              "text": "நி is the dental ந with the i sign ி; னை is the alveolar ன with the ai sign ை. Two of Tamil's three n-letters in one word, and not interchangeable: the first sits on the teeth, the second on the ridge behind them. Chapter 6's three-n lesson mapped all three — ந, ன, ண."
             }
           ]
         },
@@ -395,7 +395,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:7eae469fe811e74e",
+      "sourceHash": "fnv1a64:36ae56781169eff6",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -458,7 +458,7 @@
             },
             {
               "kind": "speech",
-              "text": "Now a mystery worth clearing up. The letter is ட, named ṭa, yet the word is written here paḍi, with a d. Nothing is inconsistent: Tamil marks no voicing. One letter covers both sounds and position decides — hard word-initially or doubled, soft between vowels. That is Chapter 1's rule for க, which spells k, g and a soft h without changing shape."
+              "text": "Now a mystery worth clearing up. The letter is ட, named ṭa, yet the word is written here paḍi, with a d. Nothing is inconsistent: Tamil marks no voicing. One letter covers both sounds and position decides — hard word-initially or doubled, soft between vowels. That is Chapter 5's rule for க, which spells k, g and a soft h without changing shape."
             },
             {
               "kind": "speech",
@@ -745,7 +745,7 @@
       "modalityReasons": [
         "script-block"
       ],
-      "sourceHash": "fnv1a64:3cbfae9f73f99b68",
+      "sourceHash": "fnv1a64:bdda9249c003f94c",
       "notice": {
         "modality": "sight",
         "needs": [
@@ -804,7 +804,7 @@
             },
             {
               "kind": "speech",
-              "text": "The dot returns in the noun எழுத்து (eḻuttu), \"a letter of the alphabet,\" spelled எ ழு த் து: a puḷḷi strips the vowel from the first த் and the second து stands whole beside it. Two full letters and a visible dot, never a fused shape: Chapter 1's bargain."
+              "text": "The dot returns in the noun எழுத்து (eḻuttu), \"a letter of the alphabet,\" spelled எ ழு த் து: a puḷḷi strips the vowel from the first த் and the second து stands whole beside it. Two full letters and a visible dot, never a fused shape: the puḷḷi lesson's bargain."
             }
           ]
         },

--- a/code/learning/human-languages/tamil/narration/ch33.txt
+++ b/code/learning/human-languages/tamil/narration/ch33.txt
@@ -16,7 +16,7 @@ You'll want to know: நினை.
 Two light beats, ni-nai. Threaded up: நினைக்கிறேன் (ninaikkiṟēṉ), "I think" — stem, tense, person, with nothing new in the machine.
 
 The letters in this word.
-நி is the dental ந with the i sign ி; னை is the alveolar ன with the ai sign ை. Two of Tamil's three n-letters in one word, and not interchangeable: the first sits on the teeth, the second on the ridge behind them. Chapter 1 mapped all three — ந, ன, ண.
+நி is the dental ந with the i sign ி; னை is the alveolar ன with the ai sign ை. Two of Tamil's three n-letters in one word, and not interchangeable: the first sits on the teeth, the second on the ridge behind them. Chapter 6's three-n lesson mapped all three — ந, ன, ண.
 
 Grammar Lens: it doubles, so it is strong.
 The k in ninaikkiṟēṉ is held long — ninaik-ki — as it was in irukkiṟēṉ and pārkkiṟēṉ, and not as it was in pōgiṟēṉ. So நினை is strong, and its past is நினைத்தேன் (ninaittēṉ), with the strong verb's doubled t.
@@ -110,7 +110,7 @@ Tamil does not split reading from studying: படிப்பு (paḍippu) is
 
 The letters in this word.
 ப (pa) + டி, which is ட wearing the i sign ி.
-Now a mystery worth clearing up. The letter is ட, named ṭa, yet the word is written here paḍi, with a d. Nothing is inconsistent: Tamil marks no voicing. One letter covers both sounds and position decides — hard word-initially or doubled, soft between vowels. That is Chapter 1's rule for க, which spells k, g and a soft h without changing shape.
+Now a mystery worth clearing up. The letter is ட, named ṭa, yet the word is written here paḍi, with a d. Nothing is inconsistent: Tamil marks no voicing. One letter covers both sounds and position decides — hard word-initially or doubled, soft between vowels. That is Chapter 5's rule for க, which spells k, g and a soft h without changing shape.
 So ட is soft between the vowels of paḍi and hard in the doubled ட்ட of paḍittēṉ. It is why pō becomes pōgiṟēṉ, why sāppiḍu has a ḍ, and why every romanization here softens where a speaker softens.
 ட is also retroflex, made where ண is: tongue tip curled back to the roof of the mouth. That curl matters more than the d-versus-t.
 
@@ -192,7 +192,7 @@ You'll want to know: எழுது.
 
 The letters in this word.
 எ is the standing vowel e; ழு is ழ with the u sign and து is த with the same sign.
-The dot returns in the noun எழுத்து (eḻuttu), "a letter of the alphabet," spelled எ ழு த் து: a puḷḷi strips the vowel from the first த் and the second து stands whole beside it. Two full letters and a visible dot, never a fused shape: Chapter 1's bargain.
+The dot returns in the noun எழுத்து (eḻuttu), "a letter of the alphabet," spelled எ ழு த் து: a puḷḷi strips the vowel from the first த் and the second து stands whole beside it. Two full letters and a visible dot, never a fused shape: the puḷḷi lesson's bargain.
 
 Sounds you'll need: ழ, and how to stop chasing it.
 ழ — written ḻ — is the sound in தமிழ் (tamiḻ) itself and in வாழ் (vāḻ), "to live," and is reputed to be the language's hardest.

--- a/code/learning/human-languages/tamil/narration/ch36.json
+++ b/code/learning/human-languages/tamil/narration/ch36.json
@@ -4,7 +4,7 @@
   "chapter": 36,
   "title": "What You Are Offered",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:402bf0320fcdb2c7",
+  "sourceHash": "fnv1a64:0c4b08a654ae45b6",
   "lessons": [
     {
       "id": "TA-C36-teneer",
@@ -540,6 +540,181 @@
             {
               "kind": "speech",
               "text": "What verb is uṇavu built on, and where does your tongue go for ண? (உண்; curled back.) Which eating verb would you use at a table, and how sure is anyone where it came from? (சாப்பிடு — not at all: the Dravidian dictionary has no entry.) Give the raw grain and the cooked meal. (Arisi; sātam.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W17-read-unavu",
+      "sequence": 1085,
+      "title": "உணவு (uṇavu) — the same vowel, twice, two ways",
+      "headword": "உணவு",
+      "romanization": "uṇavu",
+      "gloss": "உ, the standing short u, against the ு sign that hangs off a consonant",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:695185032432fcaf",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: உ",
+          "Script you'll notice: build the word"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: உ and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "You have the ு sign — the u that hangs off a consonant, as in ரு. But a word that starts on u has no consonant to hang it from, and by now you know what Tamil does about that."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: உ",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "உ is the standing letter for short u. It is the rule you met with ஆ in ஆம், working again: a vowel that opens a word is written as a full letter, never as a sign."
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "உ, the letter — opens a word.",
+                "ு, the sign — rides a consonant."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "The word you already say holds both. That is the whole lesson."
+            },
+            {
+              "kind": "speech",
+              "text": "Read it; do not draw it yet. உ has no entry in this book's script data, so it gets no stroke order here."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "piece: உ, u, independent — the word opens on a vowel.",
+                "piece: ண, ṇa, the retroflex n, first met beside ம.",
+                "piece: வு, vu — வ with the ு sign, வ was your first letter."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "உ, ண, வு becomes உணவு (uṇavu)."
+            },
+            {
+              "kind": "speech",
+              "text": "Three pieces, and the first and last are the same vowel doing its two jobs: once standing on its own, once hanging off வ. The page keeps them apart so your eye can."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "உ — then உணவு (uṇavu)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **உ** — then **உணவு**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"uṇavu\" — \"food\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"uṇavu\" — \"food\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "உ and வு — the letter that opens, the sign that rides",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **உ** and **வு** — the letter that opens, the sign that rides]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "ஆம் and உணவு (uṇavu) — the same opening rule, two vowels apart",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **ஆம்** and **உணவு** — the same opening rule, two vowels apart]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read உணவு (uṇavu). Why does it open with உ rather than the ு sign? (The word starts on a vowel — there is nothing for a sign to hang on.) Where else in the same word does that vowel appear, and in which form? (On வு, as the ு sign.) Which earlier word set this rule? (ஆம்.) Next: the word for a mistake."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch36.txt
+++ b/code/learning/human-languages/tamil/narration/ch36.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 36: What You Are Offered.
-4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
-Lesson 1 of 4.
+Lesson 1 of 5.
 தேநீர் (tēnīr) — "tea," half of it already yours.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -43,7 +43,7 @@ Wrap-up Recall.
 Name the second half of tēnīr and the word that shares it, then ask for tea politely. (நீர், inside தண்ணீர்; tēnīr, tayavuseytu.) Why do some languages say te and others cha, and which is better established — the tea split or arisi-to-rice? (The route the tea travelled; and the tea split.)
 
 
-Lesson 2 of 4.
+Lesson 2 of 5.
 பால் (pāl) — "milk," and a p that becomes an h next door.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -87,7 +87,7 @@ Wrap-up Recall.
 Say "milk tea," then say what the dot on ல் is doing and what the word would be without it. (Pāl tēnīr; it removes the built-in vowel, and without it, pāla.) What does Kannada put at the front instead of p, and is it a one-off? (h — hālu; regular, from the tenth century to the fourteenth.) Name the other Kannada front-swap. (v to b — vīḍu, bīḍu.)
 
 
-Lesson 3 of 4.
+Lesson 3 of 5.
 உணவு (uṇavu) — "food," from the verb underneath it.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -132,7 +132,48 @@ Wrap-up Recall.
 What verb is uṇavu built on, and where does your tongue go for ண? (உண்; curled back.) Which eating verb would you use at a table, and how sure is anyone where it came from? (சாப்பிடு — not at all: the Dravidian dictionary has no entry.) Give the raw grain and the cooked meal. (Arisi; sātam.)
 
 
-Lesson 4 of 4.
+Lesson 4 of 5.
+உணவு (uṇavu) — the same vowel, twice, two ways.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: உ and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+You have the ு sign — the u that hangs off a consonant, as in ரு. But a word that starts on u has no consonant to hang it from, and by now you know what Tamil does about that.
+
+Script you'll notice: உ.
+உ is the standing letter for short u. It is the rule you met with ஆ in ஆம், working again: a vowel that opens a word is written as a full letter, never as a sign.
+[a table of 2 rows, read aloud]
+உ, the letter — opens a word.
+ு, the sign — rides a consonant.
+The word you already say holds both. That is the whole lesson.
+Read it; do not draw it yet. உ has no entry in this book's script data, so it gets no stroke order here.
+
+Script you'll notice: build the word.
+[a table of 3 rows, read aloud]
+piece: உ, u, independent — the word opens on a vowel.
+piece: ண, ṇa, the retroflex n, first met beside ம.
+piece: வு, vu — வ with the ு sign, வ was your first letter.
+உ, ண, வு becomes உணவு (uṇavu).
+Three pieces, and the first and last are the same vowel doing its two jobs: once standing on its own, once hanging off வ. The page keeps them apart so your eye can.
+
+Guided Practice.
+[pause 1 second]
+[your turn — read: உ — then உணவு (uṇavu)]
+[pause 8 seconds for the answer]
+[your turn — say: "uṇavu" — "food"]
+[pause 8 seconds for the answer]
+[your turn — contrast: உ and வு — the letter that opens, the sign that rides]
+[pause 8 seconds for the answer]
+[your turn — contrast: ஆம் and உணவு (uṇavu) — the same opening rule, two vowels apart]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read உணவு (uṇavu). Why does it open with உ rather than the ு sign? (The word starts on a vowel — there is nothing for a sign to hang on.) Where else in the same word does that vowel appear, and in which form? (On வு, as the ு sign.) Which earlier word set this rule? (ஆம்.) Next: the word for a mistake.
+
+
+Lesson 5 of 5.
 தவறு (tavaṟu) — "a mistake," and the rest of the apology.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.

--- a/code/learning/human-languages/tamil/narration/ch37.json
+++ b/code/learning/human-languages/tamil/narration/ch37.json
@@ -4,7 +4,7 @@
   "chapter": 37,
   "title": "Your Town, Your Friend",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:f9fc24867a2d77c3",
+  "sourceHash": "fnv1a64:35ab5bef10c8172b",
   "lessons": [
     {
       "id": "TA-C37-uur",
@@ -398,6 +398,176 @@
             {
               "kind": "speech",
               "text": "Give the friend-word for a woman, a man, and someone you respect. (Naṇbi; naṇbaṉ; naṇbar.) Which axis do the friend words split on, and which do the brother words? (Sex and respect; age.) Why is ப heard as b, and are அப்பா and அம்மா built from a root the way naṇbaṉ is? (A nasal voices the stop after it; no.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W18-read-uur",
+      "sequence": 1115,
+      "title": "ஊர் (ūr) — the long partner",
+      "headword": "ஊர்",
+      "romanization": "ūr",
+      "gloss": "ஊ, the long partner of the உ you read last chapter",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:a4d00dabaf8d79bf",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: ஊ",
+          "Script you'll notice: build the word"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ஊ and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "உ opened உணவு last chapter. Tamil writes its long vowels as separate letters from the short ones, so ū gets a letter of its own."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: ஊ",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ஊ is the standing letter for long ū, and it is the long partner of உ — the fourth short-and-long pair the strand has handed you, after அ/ஆ, ி/ீ and ெ/ே."
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                ""
+              ],
+              "columns": 2,
+              "rowCount": 2,
+              "utterances": [
+                "உ, short u.",
+                "ஊ, long ū."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "Read it; do not draw it yet. ஊ has no entry in this book's script data, and neither has உ — so neither gets a stroke order, and the pairing above, like the way the shorter letter sits inside the longer one, is what the page shows rather than something the data states."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 2,
+              "utterances": [
+                "piece: ஊ, ū, independent — the word opens on a vowel.",
+                "piece: ர், bare r — ர under a puḷḷi, ர from சரி."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "ஊ, ர் becomes ஊர் (ūr)."
+            },
+            {
+              "kind": "speech",
+              "text": "Two pieces, and both were waiting for you. ஊர் (ūr) is the word for your own town, and holding it against உணவு shows the length doing real work: change the vowel and you change the word."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "ஊ — then ஊர் (ūr)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **ஊ** — then **ஊர்**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"ūr\" — \"town\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"ūr\" — \"town\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "உ and ஊ — short and long, two letters",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **உ** and **ஊ** — short and long, two letters]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "உணவு and ஊர் (ūr) together — the pair, side by side",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **உணவு** and **ஊர்** together — the pair, side by side]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read ஊர் (ūr). Which letter is ஊ's short partner, and where did you read it? (உ, opening உணவு.) Why is the vowel a full letter here rather than a sign? (The word starts on it.) What is the dot on ர் doing? (Removing the built-in a.) Next: pointing someone out politely."
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch37.txt
+++ b/code/learning/human-languages/tamil/narration/ch37.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 37: Your Town, Your Friend.
-4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+5 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
-Lesson 1 of 4.
+Lesson 1 of 5.
 ஊர் (ūr) — "town," and the question Tamil asks early.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -53,7 +53,7 @@ Wrap-up Recall.
 Ask a stranger where they are from, then a friend, and say what ஊர் means beyond "town." (Uṅgaḷ ūr eṉṉa; uṉ ūr eṉṉa; your native place.) Which earlier question has this shape, and is -ore in Tanjore really this word? (உன் வயசு என்ன; yes.) How sure are we there, next to arisi and rice? (Much surer.)
 
 
-Lesson 2 of 4.
+Lesson 2 of 5.
 நண்பன் (naṇbaṉ) — "friend," with the ending doing the work.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -99,7 +99,46 @@ Wrap-up Recall.
 Give the friend-word for a woman, a man, and someone you respect. (Naṇbi; naṇbaṉ; naṇbar.) Which axis do the friend words split on, and which do the brother words? (Sex and respect; age.) Why is ப heard as b, and are அப்பா and அம்மா built from a root the way naṇbaṉ is? (A nasal voices the stop after it; no.)
 
 
-Lesson 3 of 4.
+Lesson 3 of 5.
+ஊர் (ūr) — the long partner.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: ஊ and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+உ opened உணவு last chapter. Tamil writes its long vowels as separate letters from the short ones, so ū gets a letter of its own.
+
+Script you'll notice: ஊ.
+ஊ is the standing letter for long ū, and it is the long partner of உ — the fourth short-and-long pair the strand has handed you, after அ/ஆ, ி/ீ and ெ/ே.
+[a table of 2 rows, read aloud]
+உ, short u.
+ஊ, long ū.
+Read it; do not draw it yet. ஊ has no entry in this book's script data, and neither has உ — so neither gets a stroke order, and the pairing above, like the way the shorter letter sits inside the longer one, is what the page shows rather than something the data states.
+
+Script you'll notice: build the word.
+[a table of 2 rows, read aloud]
+piece: ஊ, ū, independent — the word opens on a vowel.
+piece: ர், bare r — ர under a puḷḷi, ர from சரி.
+ஊ, ர் becomes ஊர் (ūr).
+Two pieces, and both were waiting for you. ஊர் (ūr) is the word for your own town, and holding it against உணவு shows the length doing real work: change the vowel and you change the word.
+
+Guided Practice.
+[pause 1 second]
+[your turn — read: ஊ — then ஊர் (ūr)]
+[pause 8 seconds for the answer]
+[your turn — say: "ūr" — "town"]
+[pause 8 seconds for the answer]
+[your turn — contrast: உ and ஊ — short and long, two letters]
+[pause 8 seconds for the answer]
+[your turn — read: உணவு and ஊர் (ūr) together — the pair, side by side]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read ஊர் (ūr). Which letter is ஊ's short partner, and where did you read it? (உ, opening உணவு.) Why is the vowel a full letter here rather than a sign? (The word starts on it.) What is the dot on ர் doing? (Removing the built-in a.) Next: pointing someone out politely.
+
+
+Lesson 4 of 5.
 இவர் (ivar) — "this person," and Tamil's pointing system.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -142,7 +181,7 @@ Wrap-up Recall.
 What do இ-, அ- and எ- do at the front of a word, and which question word you already knew is built on எ-? (Near; away; asks — and என்ன.) Does இவர் (ivar) tell you whether the person is a man or a woman? (No — it marks respect; spoken Tamil leans இவங்க for a woman.) How firmly should you hold the palm-leaf explanation for the curves? (As the standard account, not a settled fact.)
 
 
-Lesson 4 of 4.
+Lesson 5 of 5.
 இவர் என் நண்பர் (ivar eṉ naṇbar) — "this is my friend".
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -333,6 +333,146 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 - Add `generate:progress` and the byte-for-byte `check:progress` publication gate;
   a new registered language appears even when it has no lessons or book yet.
 
+### Added — உ and ஊ, and two findings that stopped the next tranche
+
+The plan after chapters 4-5 was to keep going: 22 lessons in the generated chapters
+33-38 still carry a `## The letters in this word` section, and the obvious next step was
+to strip them the way chapters 2-5 were stripped. Measuring first says otherwise, and
+the measurement is the substance of this entry.
+
+**Chapters 33-38 are not the same problem.** Running the strict taught-test over all 22
+sections: **every glyph in them is already taught by the strand, except two** — **உ**
+and **ஊ**. That is the opposite of chapters 2-5, where the sections were the *only*
+place their glyphs were explained. Most of these sections review letters the reader has
+already been taught, thirty-odd chapters into a track whose script strand starts at
+chapter 4.
+
+With one exception this tranche does **not** fix. `TA-C34-utavu` (sequence 1000) says
+"**உ** is the standing vowel *u*, used when a word begins with it" — introducing the
+glyph 85 sequence units *ahead* of `TA-W17`, and `TA-C36-unavu` and `TA-C37-uur` do the
+same a little later. The strand cannot get there earlier without spelling a word the
+learner has not been given, which is the rule it exists to keep. Nothing detects this,
+either: those sections declare no atom for **உ**, so `forwardReferences` holding at 423
+is not evidence against it.
+
+**They also already cost the speaking learner nothing.** All 22 record
+`detachableSegments: ["The letters in this word"]` with `coreModality: voice` and
+`coreDrivable: true` in the generated manifest. The spoken-only edition those markers
+exist for can already drop them. They are 22 of the 414 lessons corpus-wide where
+`drivable` and `coreDrivable` disagree — a small share of a seam that exists across many
+tracks, and working as designed in all of them.
+
+**What they carry is mostly reinforcement, and one genuinely new thing.** An earlier
+draft of this entry claimed the strand does not teach the no-fusion rule or positional
+softening. That was wrong, and the fix below proves it wrong: `TA-W03-pulli-vanakkam`
+has a whole "What Tamil does *not* do" section with the Devanagari contrast
+(`TA-SCRIPT-PULLI-VANAKKAM-02`), and `TA-W01-abugida-va-ka` states the positional rule
+outright (`TA-SOUND-ABUGIDA-VA-KA-04`). The chapter 33-38 sections *declare* those very
+atoms in their own `assesses` lists — the corpus already says they are reinforcing the
+strand, not replacing it.
+
+What they add is thinner than that, and worth stating exactly. **ட**'s softening is
+already in the strand too — `TA-W12-read-eppadi` says it outright, and both chapter 33-34
+lessons that repeat it come later. What is genuinely new is **த**'s softening (the strand
+teaches **த** in `TA-W16` without it), **ற்கா** as a second place two consonants refuse
+to fuse, and one framing the strand does not have anywhere: `TA-C36-paal`'s minimal pair,
+that a single dot is the whole difference between **பால்** and a non-word.
+
+So the case for keeping them is narrower than the first draft claimed, but it holds:
+they cost the spoken edition nothing, they reinforce atoms they correctly declare, and
+they extend rules to letters the strand introduces later. Deleting all 22 would move
+`sight` down by 22 and `voice` up by 22 — which reads as progress on the headline
+modality numbers while losing that. That is the "a net that matches does not mean the
+story is right" trap this changelog keeps recording, so the sections stay and this entry
+records what was measured instead.
+
+What was genuinely wrong is smaller, and is fixed here.
+
+- **`TA-W17-read-unavu`** (chapter 36) — **உ**, the standing short *u*, spelling
+  **உணவு**. The lesson's whole point is that the word holds the same vowel twice in its
+  two forms: the letter that opens a word, and the **ு** sign that rides **வ**.
+- **`TA-W18-read-uur`** (chapter 37) — **ஊ**, its long partner, spelling **ஊர்**.
+
+**The second finding: those were the last two glyphs *in chapters 33-38*, not in the
+corpus.** A census of every Tamil codepoint in every Tamil lesson against the strand's
+taught set leaves **19** glyphs still used but never taught, and the cluster is nowhere
+near chapter 33:
+
+| glyph | lessons using it | earliest |
+|---|---|---|
+| **ூ** (long-*ū* sign) | 5 | ch7, **மூன்று** |
+| **ஏ** | 4 | ch5 |
+| **ஞ** | 4 | ch10, **ஞாயிறு** |
+| **ஐ**, **ஒ** | 3 each | ch7, **ஐந்து** / **ஒன்று** |
+| **ொ** | 2 | ch8 |
+| **ஸ** | 2 | ch1 |
+| **ஃ**, **ஷ** | 1 each | ch7 |
+| Tamil digits **௧**-**௰** | 1 each | ch7 |
+
+Chapter 7's numbers alone account for thirteen of them. That, not chapters 33-38, is
+where the strand's remaining debt actually is.
+
+Neither **உ** nor **ஊ** has an entry in `tamil.json`, so neither gets a stroke order,
+and the note that the shorter letter sits inside the longer one is marked as what the
+page shows rather than something the data states.
+
+Both new lessons are placed **after** the speaking lesson that teaches their word — `TA-C36-unavu`
+at sequence 1080, `TA-C37-uur` at 1100 — because spelling a word the learner has not yet
+been given inverts the strand's own rule. A first draft put a single combined lesson at
+1055, which would have spelled both words before either was spoken and pointed
+`reviews_of` at a lesson 45 sequence units ahead; `forwardReviews` caught the second
+half of that. Splitting in two costs one six-lesson gap in the 3:1 cadence, which is
+what waiting for the words costs.
+
+### Fixed — three stale chapter references left by the speaking-first restructure
+
+Moving the script strand out of chapter 1 left three lessons pointing at teaching that
+is no longer there. All three are in chapter 33 and all three were silently wrong:
+
+| lesson | said | actually |
+|---|---|---|
+| `TA-C33-ninai` | "Chapter 1 mapped all three — ந, ன, ண" | `TA-W02-three-ns`, chapter **6** |
+| `TA-C33-padi` | "That is Chapter 1's rule for க" | `TA-W01-abugida-va-ka`, chapter **5** |
+| `TA-C33-ezhutu` | "never a fused shape: Chapter 1's bargain" | `TA-W03-pulli-vanakkam`, chapter **7** |
+
+The word-level "Chapter 1" references elsewhere (வணக்கம், நன்றி) are still correct and
+are left alone.
+
+### Fixed — three stale README claims the strand work invalidated
+
+`tamil/README.md` still described the strand as "**Writing W01–W04** … eight gentle
+steps"; there are 22 lessons, W01–W18, and they now run to chapter 37. It also said
+chapters 2–5 have no `chapters.json` entry, which stopped being true, and stated flatly
+that "every payoff is a chapter's last lesson by `sequence`" — interleaving put a
+`delivery: script` lesson after the payoff in several chapters, so that is now a
+"usually", with a pointer to read `payoff.lesson` instead of assuming.
+
+### Measured
+
+- `totalLessons` 1687 → 1689, `pen` 65 → 67 — the two new lessons.
+- `atomsTaught` 2646 → 2650.
+- `atomsNeverRevisited` 470 → 472 — both `TA-W18`'s, orphans by construction because
+  no later lesson practises script atoms. `TA-W17`'s two are not, because `TA-W18`
+  re-reads **உணவு** beside **ஊர்**.
+- `missedByWindow.R1` 880 → 884 — the four new atoms, nothing out.
+- `missedByWindow.R2` 1804 → 1809, and only four of those five are new atoms. The fifth
+  is a **regression this tranche causes**, and it belongs in the open rather than filed
+  under measurement: `TA-LEX-VEEDU-01` is introduced by `TA-C35-veedu` and revisited far
+  away by exactly one lesson, `TA-C38-vidai`. That revisit sat at offset **15** — the
+  last position R2's 5-15 window counts. The two new lessons pushed it to **17**, so an
+  atom that was passing R2 now misses it.
+- `missedByWindow.R3` 1304 → 1307 is **five in, two out**, and `.R4` 240 → 242 is **three
+  in, one out**. The arrivals are genuinely newly measurable — a longer track means far
+  windows exist for atoms that previously had no room for them. The departures are the
+  tranche's only reinforcement wins and were nearly lost to a net: `TA-SCRIPT-U-SIGN-01`
+  and `TA-SCRIPT-WRITE-AAM-02` leave R3, and `TA-SCRIPT-PULLI-VANAKKAM-01` leaves R4,
+  because `TA-W17` and `TA-W18` re-read the ு sign, **ஆம்** and the puḷḷi at exactly the
+  distances those windows are looking for.
+- `voice`, `sight`, `drivableLessons`, `drivablePrefixTotal`, `fullyDrivableChapters`,
+  `unstartableChapters`, `payoffsNotRepresentative`, `chapterViolations` and
+  `forwardReferences` **all hold**. This tranche adds lessons and removes no section, so
+  nothing flips.
+
 ### Added — the Tamil writing strand reaches chapters 4-5, and stops at chapter 32
 
 Chapters 4 and 5 were the last hand-authored Tamil chapters still teaching script

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -388,7 +388,11 @@ describe("the real corpus", () => {
     // +9: the four lessons that extend the Tamil writing strand to chapters 2-3's
     // glyphs introduce 2 + 3 + 2 + 2 atoms (TA-W10/11/12/13).
     // +6 more: TA-W14/15/16 close chapters 4-5's glyphs at 2 atoms each.
-    expect(report.summary.atomsTaught).toBe(2646);
+    // +4 more: TA-W17 and TA-W18 teach உ and ஊ — the last two untaught glyphs in the
+    // chapter 33-38 sections, NOT in the corpus. A census against the strand's taught
+    // set leaves 19 still used and never taught, thirteen of them in chapter 7's
+    // numbers (ஐ, ஒ, ூ and the digits ௧-௰). That is where the real debt is.
+    expect(report.summary.atomsTaught).toBe(2650);
     // +2, and it goes UP, which is worth stating plainly. Three of the five new atoms
     // are TA-W09's and nothing follows TA-W09, so they are orphans by construction:
     // PA-YA-01, E-SIGN-02, READ-PEYAR-03. TA-W08's two are revisited by TA-W09.
@@ -414,7 +418,10 @@ describe("the real corpus", () => {
     // TA-W16's, orphans by construction because nothing follows it. Two out — TTA-01
     // and U-SIGN-01, which TA-W16 and TA-W14 genuinely re-use (the ட/த contrast, and
     // the ு of சு).
-    expect(report.summary.atomsNeverRevisited).toBe(470);
+    // +2 for உ/ஊ, and both are TA-W18's: UU-VOWEL-01 and READ-UUR-02. Nothing follows
+    // TA-W18 in the strand, so they are orphans by construction. TA-W17's two are not —
+    // TA-W18 re-reads உணவு beside ஊர், which is the point of the pair. Two in, none out.
+    expect(report.summary.atomsNeverRevisited).toBe(472);
     expect(report.summary.neverRevisitedPercent).toBe(18);
 
     // 509 -> 517, and the eight split into TWO DIFFERENT PHENOMENA this number conflates.
@@ -555,7 +562,10 @@ describe("the real corpus", () => {
     // past R1 ([R2,R3] -> [R1,R2,R3]). No atom gains R1 reinforcement here.
     // +6 for chapters 4-5: all six of TA-W14/15/16's atoms miss R1 and nothing leaves,
     // the same cadence arithmetic as above.
-    expect(report.summary.missedByWindow.R1).toBe(880);
+    // +4: all four new atoms miss R1, and nothing leaves. TA-W17 and TA-W18 are 3
+    // speaking lessons apart, so the gap is 4 in reading order, outside the 1-3 window
+    // as everywhere else in the strand.
+    expect(report.summary.missedByWindow.R1).toBe(884);
     // +2 net, and the composition is the interesting part: all FIVE new atoms miss R2
     // as well, offset by THREE pre-existing atoms that TA-W09 pulls back into it.
     // TA-W09 sits 12 lessons after TA-W06 and 8 after TA-W07, both inside R2's 5-15
@@ -595,7 +605,13 @@ describe("the real corpus", () => {
     // but also short of R2's 5-15 — so nothing any of the three introduces can be
     // reinforced at R2 distance by the next one. TWO leave: TTA-01 and U-SIGN-01, both
     // genuinely re-used far enough back to land inside the window. Six in, two out.
-    expect(report.summary.missedByWindow.R2).toBe(1804);
+    // +5 for உ/ஊ, and only four of those are the new atoms. The fifth is a REGRESSION
+    // this tranche causes, and it is worth naming rather than filing under measurement.
+    // TA-LEX-VEEDU-01 is introduced by TA-C35-veedu and revisited far away by exactly
+    // one lesson, TA-C38-vidai. That revisit sat at offset 15 — the LAST position R2's
+    // 5-15 window counts. Inserting TA-W17 and TA-W18 between them pushed it to 17, so
+    // an atom that was passing R2 now misses it. Nothing leaves.
+    expect(report.summary.missedByWindow.R2).toBe(1809);
   });
 
   it("shows what a declared reading order was worth", () => {

--- a/code/packages/typescript/human-language-data/tests/levels.test.ts
+++ b/code/packages/typescript/human-language-data/tests/levels.test.ts
@@ -221,7 +221,8 @@ describe("corpus snapshot", () => {
     // the existing pre-A1 social spine.
     // +4: TA-W10..TA-W13, the Tamil writing strand's extension, all sit at pre-A1.
     // +3 more: TA-W14/15/16, closing chapters 4-5, sit there too.
-    expect(summary.byLevel["pre-A1"]).toBe(875);
+    // +2: TA-W17-read-unavu and TA-W18-read-uur.
+    expect(summary.byLevel["pre-A1"]).toBe(877);
     // Chapter 10 adds singular ir and possessives at A1. Chapter 11 adds one more
     // definite-reference lesson there; its other work is A2. Chapter 12 adds its
     // newly mapped terminal checkpoints at A2 on SPINE-SAY-WHAT-I-DO.
@@ -297,7 +298,8 @@ describe("corpus snapshot", () => {
     // TA-W13-read-irukkirirgal are the only lessons that join.
     // +3: TA-W14-read-pesu, TA-W15-read-po and TA-W16-read-tamizh, likewise the only
     // lessons that join.
-    expect(ramp).toHaveLength(1184);
+    // +2: TA-W17-read-unavu and TA-W18-read-uur, the only lessons that join.
+    expect(ramp).toHaveLength(1186);
     expect(ramp.length).toBeLessThan(lessons.length);
   });
 });

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -882,7 +882,8 @@ describe("corpus regression", () => {
       // +4: TA-W10-read-naan, TA-W11-read-niingal, TA-W12-read-eppadi and
       // TA-W13-read-irukkirirgal extend the writing strand over chapters 2-3's glyphs.
       // +3: TA-W14-read-pesu, TA-W15-read-po and TA-W16-read-tamizh close chapters 4-5.
-      totalLessons: 1687,
+      // +2: TA-W17-read-unavu and TA-W18-read-uur close the last two untaught glyphs.
+      totalLessons: 1689,
       // Chapters 10 and 13 replace wide legacy tables with small singular-only
       // comparisons, so three more lessons move from sight to voice.
       // All seven Chapter-16 teaching steps are voice-first. Generating the book
@@ -922,7 +923,10 @@ describe("corpus regression", () => {
       // +4: TA-W10..TA-W13 are `type: writing` too, so rule 1 makes them pen even
       // though all four are reading-only and give no stroke order.
       // +3: TA-W14/15/16 are `type: writing` too.
-      pen: 65,
+      // +2: both new lessons are `type: writing`. voice, sight, drivableLessons,
+      // drivablePrefixTotal, fullyDrivableChapters and unstartableChapters ALL hold —
+      // this tranche adds lessons and removes no inline section, so nothing flips.
+      pen: 67,
       // +6: exactly the six lessons that moved sight -> voice; no other lesson changes.
       // +8: exactly the eight lessons that moved sight -> voice.
       drivableLessons: 1114,


### PR DESCRIPTION
Item (c) was "strip the `## The letters in this word` sections from the 22 lessons in
generated chapters 33-38, same job as chapters 2-5 but larger." **Measuring first says it
is a different problem**, and that measurement is most of this PR.

## Why the 22 sections stay

**Every glyph in them is already taught by the strand, except two.** Strict taught-test
(own heading, own table row, or an "X is Y" sentence; a promise doesn't count) over all
22: only **உ** and **ஊ** are untaught. That is the *opposite* of chapters 2-5, where the
sections were the only place their glyphs were explained.

**They already cost the spoken learner nothing.** All 22 record
`detachableSegments: ["The letters in this word"]` with `coreModality: voice` and
`coreDrivable: true`. The spoken-only edition those markers exist for can already drop
them.

**What they add is thin but real** — and thinner than my first draft of this entry
claimed. That draft said the strand doesn't teach the no-fusion rule or positional
softening; it does (`TA-W03-pulli-vanakkam`, `TA-W01-abugida-va-ka`), and this PR's own
stale-reference fix points at those very lessons. Corrected: what's genuinely new is
**த**'s softening, **ற்கா** as a second no-fusion instance, and `TA-C36-paal`'s minimal
pair (a single dot is the whole difference between **பால்** and a non-word).

Deleting all 22 would move `sight` down 22 and `voice` up 22 — progress on the headline
numbers, bought by losing that. So they stay.

## What this PR does instead

| lesson | ch | teaches | spells |
|---|---|---|---|
| `TA-W17-read-unavu` | 36 | **உ**, the standing short *u* | உணவு |
| `TA-W18-read-uur` | 37 | **ஊ**, its long partner | ஊர் |

Both placed **after** the speaking lesson that teaches their word (1080, 1100), because
spelling a word the learner hasn't been given inverts the strand's own rule. A first
draft put one combined lesson ahead of both and pointed `reviews_of` forward;
`forwardReviews` caught half of that.

Also fixes **three stale "Chapter 1" references** to script teaching the speaking-first
restructure moved to chapters 5/6/7, and **three stale README claims** ("Writing W01–W04
… eight gentle steps" — there are 22; "chapters 2–5 have no entry" — they do; "every
payoff is a chapter's last lesson" — interleaving broke that).

## The bigger finding

Those were the last two untaught glyphs **in chapters 33-38**, not in the corpus. A
census of every Tamil codepoint in every Tamil lesson against the strand's taught set
leaves **19** still used and never taught:

| glyph | lessons | earliest |
|---|---|---|
| **ூ** | 5 | ch7, **மூன்று** |
| **ஏ** | 4 | ch5 |
| **ஞ** | 4 | ch10, **ஞாயிறு** |
| **ஐ**, **ஒ** | 3 each | ch7, **ஐந்து** / **ஒன்று** |
| **ொ** | 2 | ch8 |
| **ஸ** | 2 | ch1 |
| **ஃ**, **ஷ** | 1 each | ch7 |
| digits **௧**-**௰** | 1 each | ch7 |

**Chapter 7's numbers alone account for thirteen.** That, not chapters 33-38, is where
the strand's remaining debt is.

## Verification

Set differences against the pre-change corpus, same build both sides.

- `totalLessons` 1687 → 1689, `pen` 65 → 67, `atomsTaught` 2646 → 2650, pre-A1 875 → 877,
  ramp 1184 → 1186.
- `atomsNeverRevisited` 470 → 472 — both `TA-W18`'s.
- `missedByWindow.R1` 880 → 884 (the four new atoms, nothing out).
- **`missedByWindow.R2` 1804 → 1809 contains a regression this PR causes**, stated rather
  than filed under measurement: `TA-LEX-VEEDU-01`'s only far revisit (`TA-C38-vidai`) sat
  at offset **15** — the last position R2's 5-15 window counts — and the two new lessons
  pushed it to **17**.
- `R3` 1304 → 1307 is five in / two out and `R4` 240 → 242 is three in / one out. The
  departures are the tranche's only reinforcement wins and were nearly lost to a net:
  `U-SIGN-01` and `WRITE-AAM-02` leave R3, `PULLI-VANAKKAM-01` leaves R4.
- `voice`, `sight`, `drivableLessons`, `drivablePrefixTotal`, `fullyDrivableChapters`,
  `unstartableChapters`, `payoffsNotRepresentative`, `chapterViolations` and
  `forwardReferences` all hold — this tranche adds lessons and removes no section.

460/460 tests pass; all five generator `check:*` gates clean.

## Still open, and honestly

Three of the 22 sections (`TA-C34-utavu`, `TA-C36-unavu`, `TA-C37-uur`) introduce **உ**
*ahead* of the strand — `TA-C34-utavu` by 85 sequence units. The strand can't get there
earlier without spelling a word the learner hasn't been given. Nothing detects it either:
those sections declare no atom for உ, so `forwardReferences` holding is not evidence
against it.

## Review

Two adversarial passes, 8 and 10 findings. The second caught that my "teaching the strand
does not" argument was false for two of its three items, that "the last two glyphs" was
wrong corpus-wide, and that I had described a regression I caused as a measurement
artifact. It also caught a reworded sentence pushing `TA-C33-ezhutu` to 301s, one second
over the hard cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)