### PR TITLE
Add complete vault audit verification

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this package are documented here.
 
+## [0.24.0] - 2026-08-10
+
+### Added
+
+- Add unlocked `audit_verify` with a secret-free aggregate report covering
+  announcements, commits, catalogs, item revisions, and item identities.
+
+### Security
+
+- Repeat repository discovery from durable pins, require an exact local
+  counter/catalog/certificate anchor, traverse complete bounded ancestry, and
+  authenticate/decrypt every distinct reachable catalog and referenced item
+  revision before returning a successful report.
+- Return no partial report on failure and keep ordinary diagnostics free of
+  vault, device, item, revision, object, locator, and provider identities.
+
 ## [0.23.0] - 2026-08-10
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -188,10 +188,20 @@ authenticated aggregate item, candidate, and conflicted-item counts. Counts
 are omitted in every other state, and status diagnostics contain no vault,
 device, item, revision, object, locator, or provider identity.
 
+An unlocked session can now run a complete read-only integrity audit. The
+workflow repeats verified repository discovery relative to durable local pins,
+requires one exact pinned commit matching the local device counter, catalog,
+and certificate, walks complete bounded ancestry from every current head, and
+authenticates and decrypts every distinct reachable catalog and catalog-named
+item revision. Success returns only aggregate announcement, commit, catalog,
+revision, and item counts plus `integrity_verified = true`; any provider,
+format, graph, anchor, cryptographic, or domain failure returns the closed
+application error taxonomy without a partial report.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
 credential store, or entropy source. Host field clipboard implementation,
-export, audit verification, and doctor workflows land in the next slices.
+export and doctor workflows land in the next slices.
 There is no unchecked
 repository verification path: construction decrypts and
 authority-verifies the exact locally pinned certificate frame and object ID,
@@ -213,11 +223,15 @@ missing-parent, and
 cross-item rejection. Repository tests exercise initialization, publication,
 verified open/read/history, every injected provider operation, constructor
 paths, and complete error translation.
+Audit tests cover complete re-discovery and ancestry traversal, aggregate-only
+diagnostics, historical catalog/revision counts, and exact local-anchor
+rejection. Repository tests also prove the complete security-history seam uses
+the same deterministic order as bounded interactive history.
 Search tests cover Unicode normalization, short queries, oversized safe-field
 fallback, exact collection filters, deterministic product ordering, every
 record schema's allowlist/denylist, secret exclusion, query/result bounds, and
-conflict closure. The exact Tarpaulin LLVM result is 2,381 of 2,493 production
-lines (95.51%); the status module remains 46 of 46. Add-item tests cover exact
+conflict closure. The exact Tarpaulin LLVM result is 2,459 of 2,582 production
+lines (95.23%); the status module remains 46 of 46. Add-item tests cover exact
 entropy partitioning and wiping,
 identity validation before local writes, parentless revision and complete
 catalog construction, ambiguous successful compare-exchanges, write-ahead

--- a/code/packages/rust/vault-pm-application/src/audit.rs
+++ b/code/packages/rust/vault-pm-application/src/audit.rs
@@ -1,0 +1,194 @@
+use crate::{
+    open_object, ActiveStateV1, ApplicationError, ApplicationRepository,
+    ApplicationRepositoryError, CatalogV1, ObjectKind, V1Keys,
+};
+use coding_adventures_vault_pm_domain::{ItemId, RevisionId};
+use core::fmt::{self, Debug, Formatter};
+use std::collections::BTreeSet;
+
+/// Secret-free result of a complete unlocked vault integrity audit.
+///
+/// A report exists only after every check succeeds. Failures return the closed
+/// [`ApplicationError`] taxonomy instead of a partial or falsely clean report.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct AuditVerificationV1 {
+    announcement_count: usize,
+    commit_count: usize,
+    catalog_count: usize,
+    revision_count: usize,
+    item_count: usize,
+}
+
+impl AuditVerificationV1 {
+    /// Return true for a completely verified report.
+    pub const fn integrity_verified(&self) -> bool {
+        true
+    }
+
+    /// Return the number of unique signed announcements verified.
+    pub const fn announcement_count(&self) -> usize {
+        self.announcement_count
+    }
+
+    /// Return the number of reachable signed commits verified.
+    pub const fn commit_count(&self) -> usize {
+        self.commit_count
+    }
+
+    /// Return the number of distinct reachable catalogs decrypted.
+    pub const fn catalog_count(&self) -> usize {
+        self.catalog_count
+    }
+
+    /// Return the number of distinct catalog-referenced revisions decrypted.
+    pub const fn revision_count(&self) -> usize {
+        self.revision_count
+    }
+
+    /// Return the number of distinct item identities found across those catalogs.
+    pub const fn item_count(&self) -> usize {
+        self.item_count
+    }
+}
+
+impl Debug for AuditVerificationV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuditVerificationV1")
+            .field("integrity_verified", &true)
+            .field("announcement_count", &self.announcement_count)
+            .field("commit_count", &self.commit_count)
+            .field("catalog_count", &self.catalog_count)
+            .field("revision_count", &self.revision_count)
+            .field("item_count", &self.item_count)
+            .finish()
+    }
+}
+
+pub(crate) fn audit_verify(
+    active: &ActiveStateV1,
+    keys: &V1Keys,
+    repository: &dyn ApplicationRepository,
+) -> Result<AuditVerificationV1, ApplicationError> {
+    let report = repository
+        .open(active.pinned_heads())
+        .map_err(map_repository)?;
+    if report.fresh_device_unanchored() || report.heads().is_empty() {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+
+    let mut commits = BTreeSet::new();
+    let mut catalogs = BTreeSet::new();
+    let mut revisions = BTreeSet::<RevisionId>::new();
+    let mut items = BTreeSet::<ItemId>::new();
+    let mut local_anchor_verified = false;
+
+    for head_id in report.heads().iter().copied() {
+        let history = repository
+            .complete_history(head_id)
+            .map_err(map_repository)?;
+        if history.first().map(|commit| commit.id()) != Some(head_id) {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        for commit in history {
+            if !commits.insert(commit.id()) {
+                continue;
+            }
+            if commit.vault_id() != active.vault_id() {
+                return Err(ApplicationError::IntegrityFailure);
+            }
+            if active.pinned_heads().iter().any(|pin| *pin == commit.id())
+                && commit.device_id() == active.device_id()
+                && commit.device_counter() == active.last_device_counter()
+                && commit.catalog_root() == active.catalog_root()
+                && commit.device_certificate() == active.device_certificate_id()
+            {
+                local_anchor_verified = true;
+            }
+
+            let catalog_id = commit.catalog_root();
+            if !catalogs.insert(catalog_id) {
+                continue;
+            }
+            let catalog_object = repository.read_object(catalog_id).map_err(map_repository)?;
+            if catalog_object.id() != catalog_id {
+                return Err(ApplicationError::IntegrityFailure);
+            }
+            let plaintext = open_object(keys, ObjectKind::Catalog, catalog_object.frame())?;
+            let catalog = CatalogV1::decode(&plaintext)?;
+            for (item_id, revision_ids) in catalog.entries() {
+                items.insert(*item_id);
+                for revision_id in revision_ids {
+                    if !revisions.insert(*revision_id) {
+                        continue;
+                    }
+                    let candidate = crate::open::read_candidate(keys, repository, *revision_id)?;
+                    if candidate.item_id() != *item_id {
+                        return Err(ApplicationError::IntegrityFailure);
+                    }
+                    for parent_id in candidate.causal_parents() {
+                        let parent = crate::open::read_candidate(keys, repository, *parent_id)?;
+                        if parent.item_id() != *item_id {
+                            return Err(ApplicationError::IntegrityFailure);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if !local_anchor_verified || commits.len() != report.commit_count() {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+    Ok(AuditVerificationV1 {
+        announcement_count: report.announcement_count(),
+        commit_count: commits.len(),
+        catalog_count: catalogs.len(),
+        revision_count: revisions.len(),
+        item_count: items.len(),
+    })
+}
+
+fn map_repository(error: ApplicationRepositoryError) -> ApplicationError {
+    match error {
+        ApplicationRepositoryError::NotInitialized => ApplicationError::NotInitialized,
+        ApplicationRepositoryError::InvalidInput => ApplicationError::InvalidInput,
+        ApplicationRepositoryError::BoundExceeded => ApplicationError::BoundExceeded,
+        ApplicationRepositoryError::StorageUnavailable => ApplicationError::StorageUnavailable,
+        ApplicationRepositoryError::IntegrityFailure => ApplicationError::IntegrityFailure,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audit_repository_errors_use_the_closed_application_taxonomy() {
+        let cases = [
+            (
+                ApplicationRepositoryError::NotInitialized,
+                ApplicationError::NotInitialized,
+            ),
+            (
+                ApplicationRepositoryError::InvalidInput,
+                ApplicationError::InvalidInput,
+            ),
+            (
+                ApplicationRepositoryError::BoundExceeded,
+                ApplicationError::BoundExceeded,
+            ),
+            (
+                ApplicationRepositoryError::StorageUnavailable,
+                ApplicationError::StorageUnavailable,
+            ),
+            (
+                ApplicationRepositoryError::IntegrityFailure,
+                ApplicationError::IntegrityFailure,
+            ),
+        ];
+        for (source, expected) in cases {
+            assert_eq!(map_repository(source), expected);
+        }
+    }
+}

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -7,6 +7,7 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
+mod audit;
 mod codec;
 mod crypto;
 mod disclosure;
@@ -20,6 +21,7 @@ mod state;
 mod status;
 mod verifier;
 
+pub use audit::AuditVerificationV1;
 pub use codec::{
     decode_device_certificate, decode_item_revision, decode_signed_commit,
     encode_device_certificate, encode_item_revision, encode_signed_commit, CatalogV1,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -174,6 +174,16 @@ impl UnlockedVaultV1 {
         self.current_catalog.conflicted_item_count()
     }
 
+    /// Re-verify the complete reachable vault and return aggregate counts.
+    ///
+    /// This repeats repository discovery relative to durable local pins,
+    /// checks the local writer counter/catalog anchor, walks complete verified
+    /// ancestry from every head, and decrypts every distinct catalog and
+    /// catalog-referenced revision. It returns no identities or item metadata.
+    pub fn audit_verify(&self) -> Result<crate::AuditVerificationV1, ApplicationError> {
+        crate::audit::audit_verify(&self.active, &self._keys, self._repository.as_ref())
+    }
+
     /// Return the ordinary redacted view for one unambiguous live item.
     ///
     /// A missing item and a current tombstone both return `None`. Multiple
@@ -656,7 +666,7 @@ fn materialize_current_catalog(
     })
 }
 
-fn read_candidate(
+pub(crate) fn read_candidate(
     keys: &V1Keys,
     repository: &dyn ApplicationRepository,
     revision_id: RevisionId,
@@ -1502,6 +1512,119 @@ mod tests {
         assert_eq!(
             format!("{session:?}"),
             "UnlockedVaultV1 { local_pin_count: 1, verified_head_count: 1, item_count: 0, candidate_count: 0, conflicted_item_count: 0, search_item_count: 0, .. }"
+        );
+    }
+
+    #[test]
+    fn audit_verify_reopens_complete_ancestry_and_reports_only_counts() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let initial = session.audit_verify().unwrap();
+        assert!(initial.integrity_verified());
+        assert_eq!(initial.announcement_count(), 1);
+        assert_eq!(initial.commit_count(), 1);
+        assert_eq!(initial.catalog_count(), 1);
+        assert_eq!(initial.revision_count(), 0);
+        assert_eq!(initial.item_count(), 0);
+
+        let randomness = add_item_randomness(0xa8);
+        let item_id = randomness.item_id();
+        session
+            .add_item(
+                new_login_document(item_id, "Audited login", "audit-secret"),
+                700,
+                randomness,
+                &local,
+            )
+            .unwrap();
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let report = reopened.audit_verify().unwrap();
+        assert_eq!(report.announcement_count(), 2);
+        assert_eq!(report.commit_count(), 2);
+        assert_eq!(report.catalog_count(), 2);
+        assert_eq!(report.revision_count(), 1);
+        assert_eq!(report.item_count(), 1);
+        assert_eq!(
+            format!("{report:?}"),
+            "AuditVerificationV1 { integrity_verified: true, announcement_count: 2, commit_count: 2, catalog_count: 2, revision_count: 1, item_count: 1 }"
+        );
+        assert!(!format!("{report:?}").contains("Audited login"));
+        assert!(!format!("{report:?}").contains("audit-secret"));
+
+        let expected_revision = reopened.current_catalog.items[&item_id][0].revision_id();
+        reopened
+            .replace_item(
+                expected_revision,
+                login_document_with_times(
+                    item_id,
+                    "Audited login updated",
+                    "audit-secret-updated",
+                    300,
+                    701,
+                ),
+                702,
+                replace_item_randomness(0xa9),
+                &local,
+            )
+            .unwrap();
+        let reopened = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let report = reopened.audit_verify().unwrap();
+        assert_eq!(report.announcement_count(), 3);
+        assert_eq!(report.commit_count(), 3);
+        assert_eq!(report.catalog_count(), 3);
+        assert_eq!(report.revision_count(), 2);
+        assert_eq!(report.item_count(), 1);
+    }
+
+    #[test]
+    fn audit_verify_rejects_a_local_counter_without_an_exact_pinned_anchor() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let mut session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        session.active = ActiveStateV1::new(
+            session.active.bootstrap_locator(),
+            session.active.vault_id(),
+            session.active.bootstrap_id(),
+            session.active.authority_fingerprint(),
+            session.active.device_id(),
+            session.active.device_certificate_id(),
+            session.active.device_certificate_frame().clone(),
+            session.active.local_secret().clone(),
+            session.active.pinned_heads().clone(),
+            session.active.last_device_counter() + 1,
+            session.active.catalog_root(),
+        )
+        .unwrap();
+        assert_eq!(
+            session.audit_verify(),
+            Err(ApplicationError::IntegrityFailure)
         );
     }
 

--- a/code/packages/rust/vault-pm-application/src/repository.rs
+++ b/code/packages/rust/vault-pm-application/src/repository.rs
@@ -80,6 +80,12 @@ pub trait ApplicationRepository: Send + Sync {
         start: ObjectId,
         limit: usize,
     ) -> Result<Vec<CommitSummary>, ApplicationRepositoryError>;
+
+    /// Walk complete bounded verified ancestry from one commit for audits.
+    fn complete_history(
+        &self,
+        start: ObjectId,
+    ) -> Result<Vec<CommitSummary>, ApplicationRepositoryError>;
 }
 
 /// Host-injected constructor used only after unlock derives address and verifier.
@@ -173,6 +179,15 @@ impl<S: VaultObjectStore + 'static> ApplicationRepository for V1ApplicationRepos
     ) -> Result<Vec<CommitSummary>, ApplicationRepositoryError> {
         self.repository
             .history(start, limit)
+            .map_err(map_repository)
+    }
+
+    fn complete_history(
+        &self,
+        start: ObjectId,
+    ) -> Result<Vec<CommitSummary>, ApplicationRepositoryError> {
+        self.repository
+            .complete_history(start)
             .map_err(map_repository)
     }
 }
@@ -384,6 +399,7 @@ mod tests {
         assert_eq!(repository.read_object(catalog_id).unwrap().id(), catalog_id);
         assert_eq!(repository.read_commit(commit_id).unwrap().id(), commit_id);
         assert_eq!(repository.history(commit_id, 1).unwrap().len(), 1);
+        assert_eq!(repository.complete_history(commit_id).unwrap().len(), 1);
         assert_eq!(
             repository.read_object(ObjectId::new([0xff; 32])).err(),
             Some(ApplicationRepositoryError::IntegrityFailure)

--- a/code/packages/rust/vault-pm-repository/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-repository/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package are documented here.
 
+## [0.2.0] - 2026-08-10
+
+### Added
+
+- Add a complete deterministic verified-ancestry read for security audits that
+  remains bounded by the repository graph limit instead of the interactive
+  history limit.
+
 ## [0.1.0] - 2026-08-09
 
 ### Added

--- a/code/packages/rust/vault-pm-repository/Cargo.toml
+++ b/code/packages/rust/vault-pm-repository/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding_adventures_vault_pm_repository"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Verified immutable repository DAG for the local-first password manager"
 

--- a/code/packages/rust/vault-pm-repository/README.md
+++ b/code/packages/rust/vault-pm-repository/README.md
@@ -4,8 +4,8 @@ The VLT-PM04 storage-agnostic immutable repository for the local-first password
 manager. It publishes opaque object frames in dependency order, verifies every
 read and signed commit/announcement through a mandatory injected verifier,
 reconstructs the commit DAG, enforces local head pins, provides deterministic
-ancestry history, and produces conservative plan-only garbage-collection
-reports.
+bounded interactive history plus complete graph-bounded audit history, and
+produces conservative plan-only garbage-collection reports.
 
 The crate owns no filesystem path, provider client, key, entropy source, clock,
 or plaintext codec. Those authorities stay in the host and unlocked
@@ -17,8 +17,8 @@ The package has 15 tests covering address vectors, ordered publication,
 ambiguous-write retry, restart/open, branches and merges, pinned-head
 withholding, direct and interleaved counter equivocation, iterative cycle
 detection, malformed provider responses, explicit verified reads,
-deterministic history, and plan-only GC. Tarpaulin's LLVM engine measures 474
-of 494 production lines covered (95.95%).
+deterministic bounded/complete history, and plan-only GC. Tarpaulin's LLVM
+engine measures 487 of 507 production lines covered (96.05%).
 
 ## Development
 

--- a/code/packages/rust/vault-pm-repository/src/lib.rs
+++ b/code/packages/rust/vault-pm-repository/src/lib.rs
@@ -727,6 +727,31 @@ impl<S: VaultObjectStore, V: RepositoryVerifier> Repository<S, V> {
         Ok(order)
     }
 
+    /// Return complete deterministic verified ancestry beginning with `start`.
+    ///
+    /// Unlike [`Self::history`], this security-oriented traversal is not
+    /// truncated at the interactive history limit. It remains bounded by
+    /// [`MAX_GRAPH_COMMITS`] while loading and validating the complete graph.
+    pub fn complete_history(
+        &self,
+        start: FormatObjectId,
+    ) -> Result<Vec<CommitSummary>, RepositoryError> {
+        self.ensure_initialized()?;
+        let graph = self.load_graph([start])?;
+        let mut order = Vec::with_capacity(graph.commits.len());
+        let mut frontier = BTreeSet::from([start]);
+        let mut visited = BTreeSet::new();
+        while let Some(id) = frontier.pop_first() {
+            if !visited.insert(id) {
+                continue;
+            }
+            let commit = graph.commits.get(&id).ok_or(RepositoryError::Corruption)?;
+            order.push(CommitSummary::from_commit(id, commit));
+            frontier.extend(commit.parents.iter().copied());
+        }
+        Ok(order)
+    }
+
     /// Build a complete conservative reachability plan without deleting bytes.
     pub fn plan_gc(&self, retained_heads: &PinnedHeads) -> Result<GcPlan, RepositoryError> {
         self.ensure_initialized()?;
@@ -1349,6 +1374,10 @@ mod tests {
             Err(RepositoryError::NotInitialized)
         );
         assert_eq!(
+            repository.complete_history(FormatObjectId::new([1; 32])),
+            Err(RepositoryError::NotInitialized)
+        );
+        assert_eq!(
             repository.plan_gc(&PinnedHeads::empty()),
             Err(RepositoryError::NotInitialized)
         );
@@ -1583,6 +1612,9 @@ mod tests {
         assert!(history.iter().any(|summary| summary.id() == genesis_id));
         assert_eq!(history[0].parents(), sorted(vec![id_a, id_b]));
         assert!(format!("{:?}", history[0]).contains("parent_count: 2"));
+
+        let complete = repository.complete_history(merge_id).unwrap();
+        assert_eq!(complete, history);
     }
 
     #[test]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1332,7 +1332,12 @@ changelog, focused build, and downstream validation.
    7e-1. completed safe five-state status workflow, strictly decoding bounded
        owner state while locked and exposing only authenticated aggregate item,
        candidate, and conflict counts while unlocked;
-   7e-2. audit verification and doctor workflows; and
+   7e-2a. completed unlocked audit verification, repeating pinned repository
+       discovery, proving the exact local counter/catalog/certificate anchor,
+       walking complete bounded ancestry, decrypting every distinct reachable
+       catalog and referenced revision, and returning aggregate-only counts;
+   7e-2b. locked/unlocked doctor workflow with coarse provider and integrity
+       classifications; and
    7f. completed stable payload-free VLT-PM05 `Locked` error and compact
        locked/unlocked lifecycle boundary, including failure-stable in-place
        unlock and synchronous live-session drop on idempotent lock.

--- a/code/specs/VLT-PM04-repository.md
+++ b/code/specs/VLT-PM04-repository.md
@@ -228,6 +228,9 @@ History is deterministic graph ancestry, not wall-clock ordering. Starting
 from one commit, `history(limit)` returns the start node followed by a bounded
 reverse traversal whose frontier is ordered by commit object ID. Advisory wall
 time is returned as metadata but never changes ancestry or security decisions.
+`complete_history` uses the same ordering but returns the entire verified graph
+up to the repository graph bound for integrity audits; it is not an ordinary
+interactive-history API.
 
 ## 9. Conservative GC planning
 

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -605,7 +605,11 @@ identities. Owner-state failures use the closed application error taxonomy.
 `audit_verify` while unlocked repeats a full VLT-PM04 open, decrypts every
 reachable catalog/current revision, validates all kinds and domain bounds,
 checks local pins/counter/bootstrap ancestry, and returns counts plus boolean
-integrity status. It never returns object or item IDs.
+integrity status. The V1 report contains announcement, commit, distinct
+catalog, distinct catalog-referenced revision, and distinct item-identity
+counts. A report exists only after the complete audit succeeds and therefore
+has `integrity_verified = true`; any failure returns the closed application
+error taxonomy without a partial report. It never returns object or item IDs.
 
 `doctor` distinguishes local state availability, bootstrap availability,
 repository availability, unsupported capability, authentication required, and


### PR DESCRIPTION
## Summary

- add unlocked `audit_verify` with a secret-free aggregate integrity report
- repeat repository discovery from durable pins and require an exact local counter/catalog/certificate anchor
- add a graph-bounded complete-history repository seam so audits are not truncated by the 4,096-entry interactive history limit
- decrypt and validate every distinct reachable catalog and catalog-referenced revision before returning success
- split the roadmap so audit verification is complete and `doctor` remains the next independent diagnostic slice

## Security properties

- no partial or falsely clean report is returned on failure
- report diagnostics contain aggregate counts only, never vault, device, item, revision, object, locator, or provider identities
- repository graph cardinality must match the repeated verified-open report
- historical causal parents are authenticated and checked for item binding

## Verification

- `vault-pm-application`: 100 tests pass
- `vault-pm-repository`: 15 tests pass
- strict Clippy and rustdoc pass for both packages
- Tarpaulin LLVM application coverage: 2,459 / 2,582 production lines (95.23%)
- Tarpaulin LLVM repository coverage: 487 / 507 production lines (96.05%)
- build planner: 51 Starlark BUILD files, 1,001 packages, 2 changed, 21 affected, all 21 built
