### PR TITLE
test(gc-core): gate AOT00-T5 scale tests behind #[cfg_attr(miri, ignore)]

### DIFF
--- a/code/packages/rust/gc-core/CHANGELOG.md
+++ b/code/packages/rust/gc-core/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog — gc-core
 
-## 0.32.0 — 2026-08-10 — fix: interior pointers in precise ref slots/root slots escaped relocation fixup — live use-after-free in `collect_compacting`
+## 0.32.1 — 2026-08-10 — test: gate the AOT00-T5 scale tests behind `#[cfg_attr(miri, ignore)]`
+
+- `scale_deep_chain_marks_without_stack_overflow` (20,000-object chain) and
+  `scale_wide_ref_array_relocates` (4,000-element ref array) each already carried a doc comment
+  stating "these tests run at counts too large for Miri... here we prove they scale" — but neither
+  actually had a Miri-ignore gate, so `cargo +nightly miri test -p gc-core` ran them at full size
+  anyway. Miri's per-instruction interpretation overhead on tens of thousands of allocations plus a
+  full mark/sweep or compacting traversal made these two tests, alone, the overwhelming majority of
+  the crate's Miri wall-clock cost (observed: 40+ minutes dominated by a single test, confirmed via a
+  live run on 2026-08-10). Neither test exercises a code path the small-scale tests above them don't
+  already cover under Miri — they exist purely to prove O(n) behavior and absence of stack overflow at
+  scale, properties Miri's interpretation doesn't help verify anyway (it can't measure asymptotic
+  complexity, and the worklist-based mark that avoids stack overflow is structurally the same at 10
+  objects as at 20,000).
+- Added `#[cfg_attr(miri, ignore = "...")]` to both, with the ignore reason naming the AOT00-T5 module
+  doc and the specific already-covered mechanics each test scales up. Both still run at full size and
+  full assertion strength under `cargo test` (unaffected — confirmed unchanged pass/fail behavior).
+- **Measured impact**: `cargo +nightly miri test -p gc-core` (full crate, no filters) dropped from
+  40-90+ minutes to ~13-25 seconds. No test coverage lost under Miri — both tests' per-object mechanics
+  (mark, sweep, tenure, tail fixup, relocation) are already exercised by the small-scale tests
+  immediately above them in the same module, which Miri continues to run at full strength.
+- Pure test-infrastructure change — no production code touched.
 
 **Security fix, found by adversarial review of an unrelated in-progress PR (AOT00-T9 PR-3), confirmed
 live and exploitable against already-shipped code, fixed and regression-tested here.**

--- a/code/packages/rust/gc-core/Cargo.toml
+++ b/code/packages/rust/gc-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core"
-version = "0.32.0"
+version = "0.32.1"
 edition = "2021"
 description = "The shared GC engine (FlatHeap) for the LANG pipeline: linked directly by native-AOT backends (via gc-core-capi) and by vm-core."
 license = "MIT"

--- a/code/packages/rust/gc-core/src/flat_heap.rs
+++ b/code/packages/rust/gc-core/src/flat_heap.rs
@@ -4241,6 +4241,9 @@ mod tests {
     /// objects are reclaimed. A recursion-based mark would blow the stack at this depth; the
     /// worklist mark does not.
     #[test]
+    #[cfg_attr(miri, ignore = "too large for Miri; see the AOT00-T5 module doc above — already \
+        covered at small scale by the tests above, which exercise the identical per-object \
+        mechanics (mark, sweep, tenure) this test scales up, not new code paths")]
     fn scale_deep_chain_marks_without_stack_overflow() {
         const N: usize = 20_000;
         let mut heap = FlatHeap::new();
@@ -4283,6 +4286,9 @@ mod tests {
     /// byte-preserved. Proves the tail fixup (the `for_each_ref_slot` tail walk) is correct and
     /// O(len) over a large instance, not just a 2-slot toy.
     #[test]
+    #[cfg_attr(miri, ignore = "too large for Miri; see the AOT00-T5 module doc above — already \
+        covered at small scale by the tests above, which exercise the identical per-object \
+        mechanics (tail fixup, relocation) this test scales up, not new code paths")]
     fn scale_wide_ref_array_relocates() {
         const M: usize = 4_000;
         let mut heap = FlatHeap::new();


### PR DESCRIPTION
## Summary

`scale_deep_chain_marks_without_stack_overflow` (20,000-object chain) and `scale_wide_ref_array_relocates` (4,000-element ref array) each already carried a doc comment stating "these tests run at counts too large for Miri... here we prove they scale" -- but neither actually had a Miri-ignore gate, so `cargo +nightly miri test -p gc-core` ran them at full size anyway, making them the overwhelming majority of the crate's Miri wall-clock cost.

Neither test exercises a code path the small-scale tests immediately above them don't already cover under Miri -- they exist purely to prove O(n) behavior and absence of stack overflow at scale, properties Miri's interpretation doesn't help verify anyway.

**Measured impact**: `cargo +nightly miri test -p gc-core` (full crate, no filters) dropped from 40-90+ minutes to ~13-25 seconds. No coverage lost under Miri -- both tests still run at full size and full assertion strength under `cargo test`.

Pure test-infrastructure change -- no production code touched.

## Test plan

- [x] `cargo test -p gc-core -p gc-core-capi -p vm-core` -- 146 / 40 / 79 tests green
- [x] `cargo clippy -p gc-core -p gc-core-capi -p vm-core --all-targets -- -D warnings` -- clean
- [x] Both scale tests confirmed still running (not skipped) under `cargo test`
- [x] Both scale tests confirmed `ignored` (not run) under `cargo +nightly miri test`
- [x] Full `cargo +nightly miri test -p gc-core` timed: 13-25s (down from 40-90+ min)

gc-core 0.32.0 → 0.32.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)