### PR TITLE
Add coarse vault doctor workflow

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this package are documented here.
 
+## [0.25.0] - 2026-08-10
+
+### Added
+
+- Add a read-only locked/unlocked `doctor` workflow with one closed,
+  identity-free coarse report.
+- Distinguish initialization required, recovery required, local-state,
+  bootstrap, and repository unavailability, unsupported versions or suites,
+  authentication required, integrity failure, and authenticated health.
+
+### Security
+
+- Require exact durable active-state and signed-bootstrap binding before an
+  unlocked complete audit can report healthy.
+- Never repair owner state, accept new pins, expose provider detail, or return
+  counts and identities through doctor diagnostics.
+
 ## [0.24.0] - 2026-08-10
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -198,10 +198,22 @@ revision, and item counts plus `integrity_verified = true`; any provider,
 format, graph, anchor, cryptographic, or domain failure returns the closed
 application error taxonomy without a partial report.
 
+The lifecycle boundary also exposes a read-only `doctor` workflow with one
+closed coarse outcome. Locked checks distinguish absent/prepared
+initialization, pending-publication recovery, owner-state availability,
+bootstrap availability, unsupported persisted versions or suites, integrity
+failure, and the authentication required before repository verification.
+Unlocked checks first require the exact durable active state and signed
+bootstrap retained by the session, then run the complete audit to distinguish
+healthy, repository-unavailable, unsupported, and integrity-failure states.
+The report carries no counts or vault, device, item, revision, object, locator,
+or provider identities, and the workflow never repairs state or accepts pins.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
 credential store, or entropy source. Host field clipboard implementation,
-export and doctor workflows land in the next slices.
+portable export/restore preparation, and richer host-side path, authorization,
+quota, and cache checks land in later slices.
 There is no unchecked
 repository verification path: construction decrypts and
 authority-verifies the exact locally pinned certificate frame and object ID,
@@ -227,11 +239,16 @@ Audit tests cover complete re-discovery and ancestry traversal, aggregate-only
 diagnostics, historical catalog/revision counts, and exact local-anchor
 rejection. Repository tests also prove the complete security-history seam uses
 the same deterministic order as bounded interactive history.
+Doctor tests cover absent, prepared, recovery-required, locked-authentication,
+healthy, local/bootstrap/repository unavailable, unsupported-version, and
+integrity-failure outcomes; exact durable session binding; aggregate-free
+diagnostics; and failure without repair.
 Search tests cover Unicode normalization, short queries, oversized safe-field
 fallback, exact collection filters, deterministic product ordering, every
 record schema's allowlist/denylist, secret exclusion, query/result bounds, and
-conflict closure. The exact Tarpaulin LLVM result is 2,459 of 2,582 production
-lines (95.23%); the status module remains 46 of 46. Add-item tests cover exact
+conflict closure. The exact Tarpaulin LLVM result is 2,516 of 2,637 production
+lines (95.41%); the doctor module is 44 of 45 and status remains 46 of 46.
+Add-item tests cover exact
 entropy partitioning and wiping,
 identity validation before local writes, parentless revision and complete
 catalog construction, ambiguous successful compare-exchanges, write-ahead

--- a/code/packages/rust/vault-pm-application/src/doctor.rs
+++ b/code/packages/rust/vault-pm-application/src/doctor.rs
@@ -1,0 +1,137 @@
+use crate::initialize::verify_active_bootstrap;
+use crate::{
+    ApplicationError, BootstrapStore, BootstrapStoreError, LocalStateStore, LocalStateStoreError,
+    LocalVaultStateV1, VaultAccessV1,
+};
+use core::fmt::{self, Debug, Formatter};
+
+/// Closed coarse outcome from the read-only doctor workflow.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VaultDoctorStateV1 {
+    /// Every check available to an authenticated session passed.
+    Healthy,
+    /// No active vault exists yet, or initialization is still prepared.
+    InitializationRequired,
+    /// A durable pending publication must be replayed before ordinary open.
+    RecoveryRequired,
+    /// The owner-private state provider could not be read.
+    LocalStateUnavailable,
+    /// The public bootstrap provider could not be read.
+    BootstrapUnavailable,
+    /// The encrypted immutable repository could not be read.
+    RepositoryUnavailable,
+    /// A required provider capability or persisted version is unsupported.
+    UnsupportedCapability,
+    /// Repository integrity cannot be checked until the vault is unlocked.
+    AuthenticationRequired,
+    /// Persisted state, authenticated bytes, identities, pins, or graph failed closed.
+    IntegrityFailure,
+}
+
+/// Secret-free doctor report suitable for CLI and later UI rendering.
+///
+/// The report intentionally contains one coarse state only. It never includes
+/// vault, device, item, revision, object, locator, or provider identities.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct VaultDoctorReportV1 {
+    state: VaultDoctorStateV1,
+}
+
+impl VaultDoctorReportV1 {
+    const fn new(state: VaultDoctorStateV1) -> Self {
+        Self { state }
+    }
+
+    /// Return the closed coarse doctor state.
+    pub const fn state(&self) -> VaultDoctorStateV1 {
+        self.state
+    }
+}
+
+impl Debug for VaultDoctorReportV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("VaultDoctorReportV1")
+            .field("state", &self.state)
+            .finish()
+    }
+}
+
+pub(crate) fn doctor(
+    access: &VaultAccessV1,
+    local_state_store: &dyn LocalStateStore,
+    bootstrap_store: &dyn BootstrapStore,
+) -> VaultDoctorReportV1 {
+    let locator = match access {
+        VaultAccessV1::Locked(locked) => locked.locator(),
+        VaultAccessV1::Unlocked(session) => session.bootstrap_locator(),
+    };
+    let exact_local = match local_state_store.load(locator) {
+        Ok(Some(value)) => value,
+        Ok(None) => {
+            return VaultDoctorReportV1::new(match access {
+                VaultAccessV1::Locked(_) => VaultDoctorStateV1::InitializationRequired,
+                VaultAccessV1::Unlocked(_) => VaultDoctorStateV1::IntegrityFailure,
+            })
+        }
+        Err(LocalStateStoreError::Unavailable) => {
+            return VaultDoctorReportV1::new(VaultDoctorStateV1::LocalStateUnavailable)
+        }
+        Err(LocalStateStoreError::ConcurrentHost | LocalStateStoreError::Corruption) => {
+            return VaultDoctorReportV1::new(VaultDoctorStateV1::IntegrityFailure)
+        }
+    };
+    let local = match LocalVaultStateV1::decode(&exact_local) {
+        Ok(value) => value,
+        Err(ApplicationError::Unsupported) => {
+            return VaultDoctorReportV1::new(VaultDoctorStateV1::UnsupportedCapability)
+        }
+        Err(_) => return VaultDoctorReportV1::new(VaultDoctorStateV1::IntegrityFailure),
+    };
+    let active = match (&local, access) {
+        (LocalVaultStateV1::PreparedInit(_), VaultAccessV1::Locked(_)) => {
+            return VaultDoctorReportV1::new(VaultDoctorStateV1::InitializationRequired)
+        }
+        (LocalVaultStateV1::PendingPublication { .. }, VaultAccessV1::Locked(_)) => {
+            return VaultDoctorReportV1::new(VaultDoctorStateV1::RecoveryRequired)
+        }
+        (LocalVaultStateV1::Active(active), VaultAccessV1::Locked(_)) => active,
+        (LocalVaultStateV1::Active(active), VaultAccessV1::Unlocked(session))
+            if active == session.active_state() =>
+        {
+            active
+        }
+        _ => return VaultDoctorReportV1::new(VaultDoctorStateV1::IntegrityFailure),
+    };
+
+    let exact_bootstrap = match bootstrap_store.load_latest(locator) {
+        Ok(Some(value)) => value,
+        Ok(None) => return VaultDoctorReportV1::new(VaultDoctorStateV1::IntegrityFailure),
+        Err(BootstrapStoreError::Unavailable) => {
+            return VaultDoctorReportV1::new(VaultDoctorStateV1::BootstrapUnavailable)
+        }
+        Err(BootstrapStoreError::Conflict | BootstrapStoreError::Corruption) => {
+            return VaultDoctorReportV1::new(VaultDoctorStateV1::IntegrityFailure)
+        }
+    };
+    if let Err(error) = verify_active_bootstrap(active, &exact_bootstrap) {
+        return VaultDoctorReportV1::new(match error {
+            ApplicationError::Unsupported => VaultDoctorStateV1::UnsupportedCapability,
+            _ => VaultDoctorStateV1::IntegrityFailure,
+        });
+    }
+
+    let VaultAccessV1::Unlocked(session) = access else {
+        return VaultDoctorReportV1::new(VaultDoctorStateV1::AuthenticationRequired);
+    };
+    match session.audit_verify() {
+        Ok(_) => VaultDoctorReportV1::new(VaultDoctorStateV1::Healthy),
+        Err(ApplicationError::StorageUnavailable) => {
+            VaultDoctorReportV1::new(VaultDoctorStateV1::RepositoryUnavailable)
+        }
+        Err(ApplicationError::Unsupported) => {
+            VaultDoctorReportV1::new(VaultDoctorStateV1::UnsupportedCapability)
+        }
+        Err(_) => VaultDoctorReportV1::new(VaultDoctorStateV1::IntegrityFailure),
+    }
+}

--- a/code/packages/rust/vault-pm-application/src/initialize.rs
+++ b/code/packages/rust/vault-pm-application/src/initialize.rs
@@ -13,7 +13,7 @@ use coding_adventures_chacha20_poly1305::{
 use coding_adventures_ed25519::{generate_keypair, is_valid_public_key, sign, verify};
 use coding_adventures_vault_pm_format::{
     AeadEnvelopeV1, AnnouncementV1, Argon2idParametersV1, BootstrapV1, CommitV1,
-    DeviceCertificateV1, DeviceId, PublicKey, Signature, VaultId, CRYPTO_SUITE_V1,
+    DeviceCertificateV1, DeviceId, FormatError, PublicKey, Signature, VaultId, CRYPTO_SUITE_V1,
 };
 use coding_adventures_vault_pm_repository::{PinnedHeads, RepositoryAddress};
 use coding_adventures_x25519::generate_keypair as generate_x25519_public_key;
@@ -417,28 +417,7 @@ pub(crate) fn unlock_active_material(
     active: &ActiveStateV1,
     exact_bootstrap: &[u8],
 ) -> Result<UnlockedActiveMaterial, ApplicationError> {
-    let bootstrap =
-        BootstrapV1::decode(exact_bootstrap).map_err(|_| ApplicationError::IntegrityFailure)?;
-    let bootstrap_id = bootstrap
-        .id()
-        .map_err(|_| ApplicationError::IntegrityFailure)?;
-    let bootstrap_preimage = bootstrap
-        .signing_preimage()
-        .map_err(|_| ApplicationError::IntegrityFailure)?;
-    if !is_valid_public_key(bootstrap.authority_public_key.as_bytes())
-        || !verify(
-            &bootstrap_preimage,
-            bootstrap.signature.as_bytes(),
-            bootstrap.authority_public_key.as_bytes(),
-        )
-        || bootstrap_id != active.bootstrap_id()
-        || bootstrap.vault_id != active.vault_id()
-        || AuthorityFingerprint::for_public_key(bootstrap.authority_public_key)
-            != active.authority_fingerprint()
-    {
-        return Err(ApplicationError::IntegrityFailure);
-    }
-
+    let bootstrap = verify_active_bootstrap(active, exact_bootstrap)?;
     let vault_root_key = unwrap_root_key(&passphrase, &bootstrap)?;
     let keys = V1Keys::derive(bootstrap.vault_id, &vault_root_key)?;
     let verifier_keys = V1Keys::derive(bootstrap.vault_id, &vault_root_key)?;
@@ -492,6 +471,42 @@ pub(crate) fn unlock_active_material(
         local_secret,
         verifier,
     })
+}
+
+pub(crate) fn verify_active_bootstrap(
+    active: &ActiveStateV1,
+    exact_bootstrap: &[u8],
+) -> Result<BootstrapV1, ApplicationError> {
+    let bootstrap = BootstrapV1::decode(exact_bootstrap).map_err(map_bootstrap_format)?;
+    let bootstrap_id = bootstrap
+        .id()
+        .map_err(|_| ApplicationError::IntegrityFailure)?;
+    let bootstrap_preimage = bootstrap
+        .signing_preimage()
+        .map_err(|_| ApplicationError::IntegrityFailure)?;
+    if !is_valid_public_key(bootstrap.authority_public_key.as_bytes())
+        || !verify(
+            &bootstrap_preimage,
+            bootstrap.signature.as_bytes(),
+            bootstrap.authority_public_key.as_bytes(),
+        )
+        || bootstrap_id != active.bootstrap_id()
+        || bootstrap.vault_id != active.vault_id()
+        || AuthorityFingerprint::for_public_key(bootstrap.authority_public_key)
+            != active.authority_fingerprint()
+    {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+    Ok(bootstrap)
+}
+
+fn map_bootstrap_format(error: FormatError) -> ApplicationError {
+    match error {
+        FormatError::UnsupportedVersion | FormatError::UnsupportedSuite => {
+            ApplicationError::Unsupported
+        }
+        _ => ApplicationError::IntegrityFailure,
+    }
 }
 
 /// Durably install and idempotently complete one exact generation-zero

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -11,6 +11,7 @@ mod audit;
 mod codec;
 mod crypto;
 mod disclosure;
+mod doctor;
 mod initialize;
 mod lifecycle;
 mod mutation;
@@ -34,6 +35,7 @@ pub use crypto::{
 pub use disclosure::{
     RevealedSecretEncodingV1, RevealedSecretV1, SecretDisclosureIntentV1, SecretFieldV1,
 };
+pub use doctor::{VaultDoctorReportV1, VaultDoctorStateV1};
 pub use initialize::{
     complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init,
     GenerationZeroPolicyV1, GenerationZeroRandomness, PreparedGenerationZero,

--- a/code/packages/rust/vault-pm-application/src/lifecycle.rs
+++ b/code/packages/rust/vault-pm-application/src/lifecycle.rs
@@ -82,6 +82,20 @@ impl VaultAccessV1 {
         crate::status::status(self, local_state_store)
     }
 
+    /// Run read-only low-resolution health checks without repairing state.
+    ///
+    /// Locked access checks owner-state and public-bootstrap availability, then
+    /// reports `AuthenticationRequired` because repository addressing and
+    /// verification require authenticated secrets. Unlocked access additionally
+    /// rechecks exact local/bootstrap binding and runs the complete vault audit.
+    pub fn doctor(
+        &self,
+        local_state_store: &dyn LocalStateStore,
+        bootstrap_store: &dyn BootstrapStore,
+    ) -> crate::VaultDoctorReportV1 {
+        crate::doctor::doctor(self, local_state_store, bootstrap_store)
+    }
+
     /// Consume the boundary and return its unlocked session.
     ///
     /// A locked boundary fails with the stable `Locked` class and retains no

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -133,6 +133,10 @@ pub struct UnlockedVaultV1 {
 }
 
 impl UnlockedVaultV1 {
+    pub(crate) const fn active_state(&self) -> &ActiveStateV1 {
+        &self.active
+    }
+
     pub(crate) const fn bootstrap_locator(&self) -> BootstrapLocator {
         self.active.bootstrap_locator()
     }
@@ -938,6 +942,9 @@ mod tests {
         GENERATION_ZERO_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES,
         RESOLVE_ITEM_CONFLICT_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
     };
+    use coding_adventures_canonical_cbor::{
+        decode as decode_cbor, encode as encode_cbor, CborValue,
+    };
     use coding_adventures_ed25519::{generate_keypair, sign};
     use coding_adventures_vault_pm_domain::{
         ContentType, ItemDocument, ItemState, LwwRegister, ObservedSet, OperationId,
@@ -953,6 +960,66 @@ mod tests {
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc, Mutex,
     };
+
+    struct FailingAuditRepository(ApplicationRepositoryError);
+
+    impl ApplicationRepository for FailingAuditRepository {
+        fn initialize(&self) -> Result<(), ApplicationRepositoryError> {
+            Err(self.0)
+        }
+
+        fn open(&self, _pins: &PinnedHeads) -> Result<OpenReport, ApplicationRepositoryError> {
+            Err(self.0)
+        }
+
+        fn publish(
+            &self,
+            _publication: coding_adventures_vault_pm_repository::Publication,
+            _current_heads: &PinnedHeads,
+        ) -> Result<
+            coding_adventures_vault_pm_repository::PublicationReceipt,
+            ApplicationRepositoryError,
+        > {
+            Err(self.0)
+        }
+
+        fn read_object(
+            &self,
+            _id: ObjectId,
+        ) -> Result<coding_adventures_vault_pm_repository::VerifiedObject, ApplicationRepositoryError>
+        {
+            Err(self.0)
+        }
+
+        fn read_commit(
+            &self,
+            _id: ObjectId,
+        ) -> Result<coding_adventures_vault_pm_repository::CommitSummary, ApplicationRepositoryError>
+        {
+            Err(self.0)
+        }
+
+        fn history(
+            &self,
+            _start: ObjectId,
+            _limit: usize,
+        ) -> Result<
+            Vec<coding_adventures_vault_pm_repository::CommitSummary>,
+            ApplicationRepositoryError,
+        > {
+            Err(self.0)
+        }
+
+        fn complete_history(
+            &self,
+            _start: ObjectId,
+        ) -> Result<
+            Vec<coding_adventures_vault_pm_repository::CommitSummary>,
+            ApplicationRepositoryError,
+        > {
+            Err(self.0)
+        }
+    }
 
     #[derive(Default)]
     struct MemoryLocalStateStore(
@@ -1067,6 +1134,22 @@ mod tests {
 
     fn randomness() -> GenerationZeroRandomness {
         GenerationZeroRandomness::new(generation_zero_bytes())
+    }
+
+    fn replace_top_level_version(encoded: &[u8], version: u64) -> Vec<u8> {
+        let CborValue::Map(mut fields) = decode_cbor(encoded).unwrap() else {
+            panic!("fixture must be a CBOR map")
+        };
+        let mut replaced = false;
+        for (key, value) in &mut fields {
+            if key == &CborValue::Unsigned(1) {
+                *value = CborValue::Unsigned(version);
+                replaced = true;
+                break;
+            }
+        }
+        assert!(replaced);
+        encode_cbor(&CborValue::Map(fields))
     }
 
     fn add_item_randomness(seed: u8) -> AddItemRandomnessV1 {
@@ -1763,6 +1846,254 @@ mod tests {
         assert_eq!(
             format!("{status:?}"),
             "VaultStatusV1 { state: RecoveryRequired }"
+        );
+    }
+
+    #[test]
+    fn doctor_reports_coarse_locked_and_unlocked_health_states() {
+        let absent_local = MemoryLocalStateStore::default();
+        let absent_bootstrap = MemoryBootstrapStore::default();
+        let absent = crate::VaultAccessV1::locked(BootstrapLocator::new([0x93; 32]));
+        assert_eq!(
+            absent.doctor(&absent_local, &absent_bootstrap).state(),
+            crate::VaultDoctorStateV1::InitializationRequired
+        );
+
+        let prepared = prepare_generation_zero(
+            Zeroizing::new(b"prepared passphrase".to_vec()),
+            GenerationZeroPolicyV1::new(8 * 1024, 1, 1, 10).unwrap(),
+            randomness(),
+        )
+        .unwrap();
+        let prepared_locator = prepared.bootstrap_locator();
+        let prepared_local =
+            MemoryLocalStateStore::with_state(prepared.owner_state().encode().unwrap());
+        assert_eq!(
+            crate::VaultAccessV1::locked(prepared_locator)
+                .doctor(&prepared_local, &absent_bootstrap)
+                .state(),
+            crate::VaultDoctorStateV1::InitializationRequired
+        );
+
+        let (locator, local, bootstrap, factory) = initialized();
+        let mut access = crate::VaultAccessV1::locked(locator);
+        let locked_report = access.doctor(&local, &bootstrap);
+        assert_eq!(
+            locked_report.state(),
+            crate::VaultDoctorStateV1::AuthenticationRequired
+        );
+        assert_eq!(
+            format!("{locked_report:?}"),
+            "VaultDoctorReportV1 { state: AuthenticationRequired }"
+        );
+
+        access
+            .unlock(
+                Zeroizing::new(b"active passphrase".to_vec()),
+                &local,
+                &bootstrap,
+                &factory,
+            )
+            .unwrap();
+        assert_eq!(
+            access.doctor(&local, &bootstrap).state(),
+            crate::VaultDoctorStateV1::Healthy
+        );
+
+        access.lock();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("initialized state must be active")
+        };
+        let pending =
+            LocalVaultStateV1::pending_publication(active.clone(), pending_publication(&active))
+                .unwrap();
+        *local.0.lock().unwrap() = Some(pending.encode().unwrap());
+        assert_eq!(
+            access.doctor(&local, &bootstrap).state(),
+            crate::VaultDoctorStateV1::RecoveryRequired
+        );
+    }
+
+    #[test]
+    fn doctor_closes_store_version_and_integrity_failures_without_detail() {
+        struct FailingLocalStateStore(LocalStateStoreError);
+
+        impl LocalStateStore for FailingLocalStateStore {
+            fn load(
+                &self,
+                _locator: BootstrapLocator,
+            ) -> Result<Option<Vec<u8>>, LocalStateStoreError> {
+                Err(self.0)
+            }
+
+            fn compare_exchange(
+                &self,
+                _locator: BootstrapLocator,
+                _expected: Option<&[u8]>,
+                _replacement: &[u8],
+            ) -> Result<(), LocalStateStoreError> {
+                Err(self.0)
+            }
+        }
+
+        struct FailingBootstrapStore(BootstrapStoreError);
+
+        impl BootstrapStore for FailingBootstrapStore {
+            fn load_latest(
+                &self,
+                _locator: BootstrapLocator,
+            ) -> Result<Option<Vec<u8>>, BootstrapStoreError> {
+                Err(self.0)
+            }
+
+            fn put_generation(
+                &self,
+                _locator: BootstrapLocator,
+                _expected_previous: Option<BootstrapId>,
+                _exact_bootstrap: &[u8],
+            ) -> Result<(), BootstrapStoreError> {
+                Err(self.0)
+            }
+        }
+
+        let locator = BootstrapLocator::new([0x94; 32]);
+        let access = crate::VaultAccessV1::locked(locator);
+        assert_eq!(
+            access
+                .doctor(
+                    &FailingLocalStateStore(LocalStateStoreError::Unavailable),
+                    &MemoryBootstrapStore::default(),
+                )
+                .state(),
+            crate::VaultDoctorStateV1::LocalStateUnavailable
+        );
+        assert_eq!(
+            access
+                .doctor(
+                    &FailingLocalStateStore(LocalStateStoreError::ConcurrentHost),
+                    &MemoryBootstrapStore::default(),
+                )
+                .state(),
+            crate::VaultDoctorStateV1::IntegrityFailure
+        );
+        assert_eq!(
+            access
+                .doctor(
+                    &MemoryLocalStateStore::with_state(vec![0xff]),
+                    &MemoryBootstrapStore::default(),
+                )
+                .state(),
+            crate::VaultDoctorStateV1::IntegrityFailure
+        );
+
+        let (locator, local, bootstrap, _) = initialized();
+        let access = crate::VaultAccessV1::locked(locator);
+        assert_eq!(
+            access
+                .doctor(
+                    &local,
+                    &FailingBootstrapStore(BootstrapStoreError::Unavailable),
+                )
+                .state(),
+            crate::VaultDoctorStateV1::BootstrapUnavailable
+        );
+        assert_eq!(
+            access
+                .doctor(
+                    &local,
+                    &FailingBootstrapStore(BootstrapStoreError::Conflict),
+                )
+                .state(),
+            crate::VaultDoctorStateV1::IntegrityFailure
+        );
+        assert_eq!(
+            access
+                .doctor(&local, &MemoryBootstrapStore::default())
+                .state(),
+            crate::VaultDoctorStateV1::IntegrityFailure
+        );
+        assert_eq!(
+            access
+                .doctor(&local, &MemoryBootstrapStore(Mutex::new(Some(vec![0xff]))),)
+                .state(),
+            crate::VaultDoctorStateV1::IntegrityFailure
+        );
+
+        let unsupported_local =
+            replace_top_level_version(local.0.lock().unwrap().as_deref().unwrap(), 2);
+        let unsupported_local = MemoryLocalStateStore::with_state(unsupported_local);
+        assert_eq!(
+            access.doctor(&unsupported_local, &bootstrap).state(),
+            crate::VaultDoctorStateV1::UnsupportedCapability
+        );
+
+        let unsupported_bootstrap =
+            replace_top_level_version(bootstrap.0.lock().unwrap().as_deref().unwrap(), 2);
+        let unsupported_bootstrap = MemoryBootstrapStore(Mutex::new(Some(unsupported_bootstrap)));
+        assert_eq!(
+            access.doctor(&local, &unsupported_bootstrap).state(),
+            crate::VaultDoctorStateV1::UnsupportedCapability
+        );
+    }
+
+    #[test]
+    fn unlocked_doctor_distinguishes_repository_unavailability_from_integrity() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let mut unavailable = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        unavailable._repository = Box::new(FailingAuditRepository(
+            ApplicationRepositoryError::StorageUnavailable,
+        ));
+        let unavailable = crate::VaultAccessV1::Unlocked(Box::new(unavailable));
+        assert_eq!(
+            unavailable.doctor(&local, &bootstrap).state(),
+            crate::VaultDoctorStateV1::RepositoryUnavailable
+        );
+
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("initialized state must be active")
+        };
+        let pending =
+            LocalVaultStateV1::pending_publication(active.clone(), pending_publication(&active))
+                .unwrap();
+        *local.0.lock().unwrap() = Some(pending.encode().unwrap());
+        assert_eq!(
+            unavailable.doctor(&local, &bootstrap).state(),
+            crate::VaultDoctorStateV1::IntegrityFailure
+        );
+        *local.0.lock().unwrap() = Some(exact_active);
+
+        let mut corrupt = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        corrupt._repository = Box::new(FailingAuditRepository(
+            ApplicationRepositoryError::IntegrityFailure,
+        ));
+        let corrupt = crate::VaultAccessV1::Unlocked(Box::new(corrupt));
+        assert_eq!(
+            corrupt.doctor(&local, &bootstrap).state(),
+            crate::VaultDoctorStateV1::IntegrityFailure
+        );
+
+        *local.0.lock().unwrap() = None;
+        assert_eq!(
+            corrupt.doctor(&local, &bootstrap).state(),
+            crate::VaultDoctorStateV1::IntegrityFailure
         );
     }
 

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1336,8 +1336,10 @@ changelog, focused build, and downstream validation.
        discovery, proving the exact local counter/catalog/certificate anchor,
        walking complete bounded ancestry, decrypting every distinct reachable
        catalog and referenced revision, and returning aggregate-only counts;
-   7e-2b. locked/unlocked doctor workflow with coarse provider and integrity
-       classifications; and
+   7e-2b. completed read-only locked/unlocked doctor workflow with nine coarse
+       lifecycle, availability, unsupported, authentication, integrity, and
+       healthy classifications, exact durable session binding, no repair, and
+       no provider or identity detail; and
    7f. completed stable payload-free VLT-PM05 `Locked` error and compact
        locked/unlocked lifecycle boundary, including failure-stable in-place
        unlock and synchronous live-session drop on idempotent lock.

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -611,10 +611,24 @@ counts. A report exists only after the complete audit succeeds and therefore
 has `integrity_verified = true`; any failure returns the closed application
 error taxonomy without a partial report. It never returns object or item IDs.
 
-`doctor` distinguishes local state availability, bootstrap availability,
-repository availability, unsupported capability, authentication required, and
-integrity failure without including provider detail. It must not weaken open or
-accept new pins as a repair side effect.
+`doctor` is read-only and returns exactly one of `Healthy`,
+`InitializationRequired`, `RecoveryRequired`, `LocalStateUnavailable`,
+`BootstrapUnavailable`, `RepositoryUnavailable`, `UnsupportedCapability`,
+`AuthenticationRequired`, or `IntegrityFailure`. While locked, it strictly
+decodes the bounded owner state, verifies an active state's exact signed
+bootstrap binding, and returns `AuthenticationRequired` before repository
+access because its opaque address and verifier require authenticated secrets.
+Prepared state returns `InitializationRequired`; pending publication returns
+`RecoveryRequired`. While unlocked, it additionally requires the exact durable
+active state retained by the session and runs the complete audit before
+returning `Healthy`. Unsupported persisted versions or mandatory suites remain
+distinct from malformed or unauthenticated integrity failures.
+
+The report contains no counts or vault, device, item, revision, object,
+locator, or provider identity. Provider-specific path, authorization, quota,
+and cache diagnostics belong to host adapters and may only be collapsed into
+the same coarse vocabulary. `doctor` must not repair state, publish bytes,
+weaken open, or accept new pins as a side effect.
 
 ## 13. Bounds and errors
 


### PR DESCRIPTION
## Summary
- add a read-only nine-state doctor report for locked and unlocked lifecycle checks
- verify exact durable owner-state and signed-bootstrap binding before full unlocked audit health
- keep reports identity-free, provider-neutral, and incapable of repair or pin acceptance
- document the host-adapter boundary and mark roadmap item 7e-2b complete

## Verification
- cargo test --manifest-path code/packages/rust/vault-pm-application/Cargo.toml
- cargo clippy --manifest-path code/packages/rust/vault-pm-application/Cargo.toml --all-targets -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc --manifest-path code/packages/rust/vault-pm-application/Cargo.toml --no-deps
- cargo tarpaulin -p coding_adventures_vault_pm_application --engine llvm: 2516/2637 lines, 95.41 percent
- ./build-tool -root . -diff-base origin/main -dry-run -validate-build-files
- ./build-tool -root . -diff-base origin/main -validate-build-files: 21/21 affected packages built