### PR TITLE
fix(gc-core-capi): make 4 flaky conservative-stack-scan smoke tests deterministic

### DIFF
--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this crate are documented here.
 
+## 0.24.1 - 2026-08-10 — fix: deterministic flaky conservative-stack-scan smoke tests
+
+- Four `stack_scan` integration tests (`stack_scan_keeps_live_local_frees_dead`,
+  `precise_collect_keeps_live_local_frees_dead`,
+  `compacting_collect_keeps_live_local_frees_dead`,
+  `incremental_collect_keeps_live_local_frees_dead`) asserted `freed >= 1` on a single
+  tracked "dead" object as their primary safety claim — non-deterministic in an
+  unoptimized debug build, since a discarded temporary's stale stack word is not
+  guaranteed to be scrubbed and can conservatively retain the object regardless of
+  whether any Rust binding still names it (documented previously in `lessons.md`, but
+  not fixed at the time).
+- **Rejected approach, found to be a genuine Catch-22:** verifying a single dead
+  object's fate via `__gc_kind_of` after the collect call requires keeping that
+  object's address alive as a Rust local spanning the call — which is exactly what
+  makes a conservative stack scan *correctly* treat it as a root and retain it.
+  Confirmed empirically: adding the check turned an occasionally-flaky `freed >= 1`
+  into a *deterministic* false "still alive" for all four tests.
+- **Actual fix:** each test now allocates a batch of 64 dead objects, none ever bound
+  to a Rust local that outlives its own loop iteration, and asserts `freed >= 56`
+  (`DEAD_BATCH - STRAY_TOLERANCE`). A debug build's stray stack/register garbage can
+  only accidentally retain a small, bounded number of stale addresses (bounded by how
+  many words a call site can spill — `spill_and_sp` itself bounds a maximal spill at
+  18 words), so among 64 independent, never-named allocations the overwhelming
+  majority are certain to have no stale reference anywhere on the stack. Confirmed via
+  20 consecutive local runs, all clean.
+- Pure test-infrastructure change — no production code touched. `lessons.md` updated
+  with the corrected understanding (the original entry characterized the flakiness but
+  did not yet land a real fix).
+
 ## 0.24.0 - 2026-08-06 — `__gc_safepoint` gains an (opt-in) automatic generational path (AOT00-T8)
 
 - **`__gc_collect_minor_precise()`** — new C ABI entry, the minor-generation analogue of

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.24.0"
+version = "0.24.1"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/src/stack_scan.rs
+++ b/code/packages/rust/gc-core-capi/src/stack_scan.rs
@@ -788,26 +788,50 @@ mod tests {
         core::hint::black_box(big);
     }
 
+    /// A large batch of unreferenced objects, deliberately never bound to any
+    /// *lasting* Rust variable, so no single one's address survives as a local
+    /// across the collect call. Trying to check one **specific** dead object's fate
+    /// via `__gc_kind_of` after collection is a genuine Catch-22 for a
+    /// conservative-stack-scan entry point: keeping that address alive as a Rust
+    /// local long enough to read it back *after* the collect call is exactly what
+    /// a conservative scan correctly treats as a root, so "prove object X
+    /// specifically was reclaimed" is unverifiable by definition here — not a test
+    /// bug, an inherent property of what conservative scanning promises (retain
+    /// when unsure, never silently drop a possible root).
+    ///
+    /// A **batch**, instead of one tracked object, sidesteps this: an unoptimized
+    /// debug build's stray stack/register garbage can only accidentally retain a
+    /// small, *bounded* number of stale addresses (this file's own `spill_and_sp`
+    /// bounds a maximal register spill at `SPILL_SLOTS` = 18 words), so among
+    /// `DEAD_BATCH` independent, never-named allocations, the overwhelming
+    /// majority are certain to have no stale reference anywhere on the stack —
+    /// converting a coin-flip `freed >= 1` into a deterministic, generous
+    /// `freed >= DEAD_BATCH - STRAY_TOLERANCE`.
+    const DEAD_BATCH: i64 = 64;
+    const STRAY_TOLERANCE: i64 = 8;
+
     #[inline(never)]
     fn run_stack_scan_case() {
         // A live pointer on the stack: `kept` holds a real heap address.
         let kept = __gc_alloc(16);
         assert!(kept != 0);
-        // A dead object: nothing references `_dead` after this line, but its
-        // returned address is deliberately dropped so no stack slot retains it.
-        let _ = __gc_alloc(16);
-        assert_eq!(__gc_live_bytes(), 32);
+        for _ in 0..DEAD_BATCH {
+            let d = __gc_alloc(16);
+            assert!(d != 0);
+        }
+        assert_eq!(__gc_live_bytes(), 16 + DEAD_BATCH * 16);
 
         // Write through `kept` so the compiler cannot discard the local.
         unsafe { *(kept as *mut i64) = 0x5eed };
 
         let freed = unsafe { __gc_collect() };
 
-        // `kept` must survive; at least the dead object should be freed. (A
-        // conservative scan may *retain* extra objects if a stray stack word
-        // happens to look like a pointer, so we assert a lower bound on freeing
-        // and that the live object is definitely still there.)
-        assert!(freed >= 1, "the unreferenced object must be reclaimed");
+        assert!(
+            freed >= DEAD_BATCH - STRAY_TOLERANCE,
+            "most of the {DEAD_BATCH} unreferenced objects must be reclaimed \
+             (freed = {freed}); see this file's DEAD_BATCH doc for why a batch, \
+             not a single tracked object, makes this deterministic"
+        );
         assert_eq!(
             unsafe { *(kept as *const i64) },
             0x5eed,
@@ -839,15 +863,24 @@ mod tests {
 
     #[inline(never)]
     fn run_precise_collect_case() {
+        // See the `DEAD_BATCH` doc above `run_stack_scan_case` for why a batch of
+        // never-named allocations, not a single tracked "dead" object, is what
+        // makes this deterministic.
         let kept = __gc_alloc(16);
         assert!(kept != 0);
-        let _ = __gc_alloc(16); // dead: no stack slot retains it
-        assert_eq!(__gc_live_bytes(), 32);
+        for _ in 0..DEAD_BATCH {
+            let d = __gc_alloc(16);
+            assert!(d != 0);
+        }
+        assert_eq!(__gc_live_bytes(), 16 + DEAD_BATCH * 16);
         unsafe { *(kept as *mut i64) = 0x9a11 };
 
         let freed = unsafe { __gc_collect_precise() };
 
-        assert!(freed >= 1, "the unreferenced object must be reclaimed");
+        assert!(
+            freed >= DEAD_BATCH - STRAY_TOLERANCE,
+            "most of the {DEAD_BATCH} unreferenced objects must be reclaimed (freed = {freed})"
+        );
         assert_eq!(
             unsafe { *(kept as *const i64) },
             0x9a11,
@@ -875,15 +908,24 @@ mod tests {
 
     #[inline(never)]
     fn run_compacting_collect_case() {
+        // See the `DEAD_BATCH` doc above `run_stack_scan_case` for why a batch of
+        // never-named allocations, not a single tracked "dead" object, is what
+        // makes this deterministic.
         let kept = __gc_alloc(16);
         assert!(kept != 0);
-        let _ = __gc_alloc(16); // dead: no stack slot retains it
-        assert_eq!(__gc_live_bytes(), 32);
+        for _ in 0..DEAD_BATCH {
+            let d = __gc_alloc(16);
+            assert!(d != 0);
+        }
+        assert_eq!(__gc_live_bytes(), 16 + DEAD_BATCH * 16);
         unsafe { *(kept as *mut i64) = 0x5eed };
 
         let freed = unsafe { __gc_collect_compacting() };
 
-        assert!(freed >= 1, "the unreferenced object must be reclaimed");
+        assert!(
+            freed >= DEAD_BATCH - STRAY_TOLERANCE,
+            "most of the {DEAD_BATCH} unreferenced objects must be reclaimed (freed = {freed})"
+        );
         assert_eq!(
             unsafe { *(kept as *const i64) },
             0x5eed,
@@ -969,10 +1011,16 @@ mod tests {
 
     #[inline(never)]
     fn run_incremental_collect_case() {
+        // See the `DEAD_BATCH` doc above `run_stack_scan_case` for why a batch of
+        // never-named allocations, not a single tracked "dead" object, is what
+        // makes this deterministic.
         let kept = __gc_alloc(16);
         assert!(kept != 0);
-        let _ = __gc_alloc(16); // dead: no stack slot retains it
-        assert_eq!(__gc_live_bytes(), 32);
+        for _ in 0..DEAD_BATCH {
+            let d = __gc_alloc(16);
+            assert!(d != 0);
+        }
+        assert_eq!(__gc_live_bytes(), 16 + DEAD_BATCH * 16);
         unsafe { *(kept as *mut i64) = 0x1ce5 };
 
         // start → step (budget 1, so several slices) to done → finish.
@@ -984,7 +1032,10 @@ mod tests {
         }
         let freed = unsafe { __gc_collect_incremental_finish() };
 
-        assert!(freed >= 1, "the unreferenced object must be reclaimed");
+        assert!(
+            freed >= DEAD_BATCH - STRAY_TOLERANCE,
+            "most of the {DEAD_BATCH} unreferenced objects must be reclaimed (freed = {freed})"
+        );
         assert_eq!(
             unsafe { *(kept as *const i64) },
             0x1ce5,

--- a/lessons.md
+++ b/lessons.md
@@ -2649,6 +2649,31 @@ which does a real `find_header` lookup — no stack scanning involved — so it 
 cases with no better signal available, and don't add new tests that rely on it as the
 primary proof of a specific new behavior.
 
+**Update, having gone back to actually fix the 4 pre-existing flaky tests this entry
+originally just characterized (not fixed):** `__gc_kind_of(dead)` is *not* a valid fix
+for "prove this ONE specific unreferenced object was reclaimed" — it's a genuine
+Catch-22. To read `dead`'s address back *after* the collect call, `dead` must still be
+a live Rust local spanning that call — which means the compiler keeps its value in some
+register or stack slot the conservative scan can see, and a conservative scan *correctly*
+treats any value that looks like a live object's address as a possible root. So keeping
+`dead` around long enough to check it is exactly what makes the scanner (correctly!)
+retain it — confirmed empirically: adding the `__gc_kind_of` check turned an
+occasionally-flaky `freed >= 1` into a *deterministically failing* "still alive" for
+every one of the four affected tests. This is not a bug in the collector; it's what
+conservative scanning is supposed to do.
+
+**Actual fix:** allocate a **batch** of dead objects (`DEAD_BATCH = 64`), none ever
+bound to a Rust local that outlives its own loop iteration — so no *specific* address
+needs to survive the collect call for verification. An unoptimized debug build's stray
+stack/register garbage can only accidentally retain a small, bounded number of stale
+addresses (bounded by how many registers/stack slots a call site can spill — this file's
+own `spill_and_sp` bounds a maximal spill at 18 words), so among 64 independent,
+never-named allocations, the overwhelming majority are certain to have no stale
+reference anywhere on the stack. `freed >= DEAD_BATCH - STRAY_TOLERANCE` (tolerance 8)
+is then a deterministic, generous bound — confirmed via 20 consecutive local runs, all
+clean, after being flaky often enough in CI to get flagged as a known issue in the first
+place. Applied to `gc-core-capi/src/stack_scan.rs`'s four affected tests.
+
 ## A blanket `--testTimeout` override during local verification hides timeout failures
 
 **Context:** `human-language-data`, PR #10043 (second core-verb tranche, +24 lessons).


### PR DESCRIPTION
## Summary

`stack_scan_keeps_live_local_frees_dead`, `precise_collect_keeps_live_local_frees_dead`, `compacting_collect_keeps_live_local_frees_dead`, and `incremental_collect_keeps_live_local_frees_dead` each asserted `freed >= 1` on a single tracked "dead" object as their primary safety claim -- non-deterministic in an unoptimized debug build, since a discarded temporary's stale stack word is not guaranteed to be scrubbed and can conservatively retain the object regardless of whether any Rust binding still names it (documented previously in `lessons.md`, but not fixed at the time).

**Rejected approach, found to be a genuine Catch-22:** verifying a single dead object's fate via `__gc_kind_of` after the collect call requires keeping that object's address alive as a Rust local spanning the call -- which is exactly what makes a conservative stack scan *correctly* treat it as a root and retain it. Confirmed empirically: adding the check turned an occasionally-flaky `freed >= 1` into a *deterministic false "still alive"* for all four tests.

**Actual fix:** each test now allocates a batch of 64 dead objects, none ever bound to a Rust local that outlives its own loop iteration, and asserts `freed >= 56` (`DEAD_BATCH - STRAY_TOLERANCE`). A debug build's stray stack/register garbage can only accidentally retain a small, bounded number of stale addresses (bounded by how many words a call site can spill -- `spill_and_sp` itself bounds a maximal spill at 18 words), so among 64 independent, never-named allocations the overwhelming majority are certain to have no stale reference anywhere on the stack.

Pure test-infrastructure change -- no production code touched. `lessons.md` updated with the corrected understanding.

## Test plan

- [x] `cargo test -p gc-core -p gc-core-capi -p vm-core` -- 146 / 40 / 79 tests green
- [x] `cargo clippy -p gc-core -p gc-core-capi -p vm-core --all-targets -- -D warnings` -- clean
- [x] All 4 previously-flaky tests run **20 consecutive times locally, all clean** (single-threaded, to isolate from shared-heap contamination)
- [x] Confirmed Miri cannot verify this module at all -- `spill_and_sp`'s inline asm is unsupported by Miri (attempted, failed with "inline assembly is not supported"); native repeated-run determinism is the correct and only verification method here

gc-core-capi 0.24.0 → 0.24.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)