### PR TITLE
Add authenticated portable vault export

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this package are documented here.
 
+## [0.26.0] - 2026-08-10
+
+### Added
+
+- Add canonical authenticated passphrase-encrypted portable export from an
+  unlocked session, retaining every current live, tombstone, and conflict
+  candidate in deterministic source item/revision order.
+- Bind the exact active signed bootstrap, candidate count, and
+  domain-separated snapshot hash inside the encrypted 512 MiB-bounded
+  plaintext; authenticate all artifact header parameters as AEAD associated
+  data.
+
+### Security
+
+- Require a separately collected non-empty bounded passphrase, caller-validated
+  Argon2id policy, and fresh host-supplied salt and XChaCha20 nonce rather than
+  implicitly reusing the live VRK or unlock credential.
+- Exclude owner-private state, private seeds, provider credentials, local pins,
+  journals, and search data; redact public diagnostics and wipe temporary
+  passphrase, key, plaintext, revision, and hash-preimage buffers on drop.
+- Return only encrypted bytes and leave path choice, overwrite policy, and
+  persistence authority to the host. Authenticated import and cross-vault
+  re-identification remain a separate follow-up workflow.
+
 ## [0.25.0] - 2026-08-10
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -209,10 +209,27 @@ healthy, repository-unavailable, unsupported, and integrity-failure states.
 The report carries no counts or vault, device, item, revision, object, locator,
 or provider identities, and the workflow never repairs state or accepts pins.
 
+An unlocked session can now produce one canonical authenticated portable
+export. The caller supplies the exact active signed bootstrap, a separately
+collected owned passphrase, a bounded Argon2id policy, and exactly 40 host-CSPRNG
+bytes for the fresh salt and XChaCha20 nonce. The encrypted snapshot retains
+every current live, tombstone, and conflict candidate in deterministic
+item/revision order and binds its exact bootstrap, candidate count, and
+domain-separated snapshot hash. Header-bound AEAD authenticates the version,
+protection mode, suite, KDF policy, salt, and nonce. The artifact excludes
+owner-private state, private seeds, provider credentials, local pins, journals,
+and search data; public diagnostics reveal no bytes, while passphrase, key,
+plaintext, encoded revisions, and hash preimages are wiped on drop.
+
+The host receives only exact encrypted bytes and remains responsible for an
+explicit destination and safe file replacement. Public import is deliberately
+separate: its follow-up must authenticate and verify the artifact, then create
+new item, revision, object, and encryption identities inside a new target vault.
+
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
 credential store, or entropy source. Host field clipboard implementation,
-portable export/restore preparation, and richer host-side path, authorization,
+portable import/restore, and richer host-side path, authorization,
 quota, and cache checks land in later slices.
 There is no unchecked
 repository verification path: construction decrypts and
@@ -246,8 +263,9 @@ diagnostics; and failure without repair.
 Search tests cover Unicode normalization, short queries, oversized safe-field
 fallback, exact collection filters, deterministic product ordering, every
 record schema's allowlist/denylist, secret exclusion, query/result bounds, and
-conflict closure. The exact Tarpaulin LLVM result is 2,516 of 2,637 production
-lines (95.41%); the doctor module is 44 of 45 and status remains 46 of 46.
+conflict closure. The exact Tarpaulin LLVM result is 2,727 of 2,858 production
+lines (95.42%); portable export is 204 of 214, doctor is 44 of 45, and status
+remains 46 of 46.
 Add-item tests cover exact
 entropy partitioning and wiping,
 identity validation before local writes, parentless revision and complete
@@ -264,6 +282,11 @@ tombstone selection, authored merged-secret persistence, complete multi-parent
 causality, immutable live-identity preservation, immutable losing-candidate
 retention, missing/unconflicted/all-tombstone rejection before
 compare-exchange, and entropy redaction/wiping.
+Portable-export tests prove the exact canonical encrypted vector, separate
+passphrase authentication, header/ciphertext tamper rejection, exact active
+bootstrap binding, plaintext-secret exclusion, complete snapshot count/hash,
+live-document recovery, bounded credential rejection, and lossless retention
+of every current conflicting tombstone.
 
 ## Development
 

--- a/code/packages/rust/vault-pm-application/src/export.rs
+++ b/code/packages/rust/vault-pm-application/src/export.rs
@@ -1,0 +1,512 @@
+use crate::initialize::verify_active_bootstrap;
+use crate::{encode_item_revision, ApplicationError};
+use coding_adventures_argon2id::{argon2id, Options as Argon2idOptions};
+use coding_adventures_canonical_cbor::{encode, CborValue};
+use coding_adventures_chacha20_poly1305::xchacha20_poly1305_aead_encrypt;
+use coding_adventures_sha256::sha256;
+use coding_adventures_vault_pm_domain::{ItemCandidate, ItemId};
+use coding_adventures_vault_pm_format::{Argon2idParametersV1, CRYPTO_SUITE_V1};
+use coding_adventures_zeroize::{Zeroize, Zeroizing};
+use core::fmt::{self, Debug, Formatter};
+use std::collections::BTreeMap;
+
+const VERSION: u64 = 1;
+const PASSPHRASE_PROTECTION: u64 = 1;
+const KDF_SALT_BYTES: usize = 16;
+const NONCE_BYTES: usize = 24;
+const SNAPSHOT_HASH_DOMAIN: &[u8] = b"VPM-PORTABLE-SNAPSHOT-v1";
+const EXPORT_AAD_DOMAIN: &[u8] = b"VPM-PORTABLE-EXPORT-AAD-v1";
+const CANDIDATE_ESTIMATE_OVERHEAD: usize = 128;
+const SNAPSHOT_ESTIMATE_OVERHEAD: usize = 1_024;
+
+/// Exact host-supplied CSPRNG bytes consumed by one passphrase export.
+pub const PORTABLE_EXPORT_RANDOM_BYTES: usize = KDF_SALT_BYTES + NONCE_BYTES;
+/// Maximum separately collected export-passphrase bytes accepted by V1.
+pub const MAX_PORTABLE_EXPORT_PASSPHRASE_BYTES: usize = 1_024;
+/// Maximum canonical plaintext snapshot size accepted by V1.
+pub const MAX_PORTABLE_EXPORT_PLAINTEXT_BYTES: usize = 512 * 1024 * 1024;
+
+/// Bounded caller-calibrated Argon2id policy for a portable export.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct PortableExportPolicyV1 {
+    memory_kib: u32,
+    iterations: u32,
+    lanes: u8,
+}
+
+impl PortableExportPolicyV1 {
+    /// Validate and retain one V1 export-passphrase policy.
+    pub fn new(memory_kib: u32, iterations: u32, lanes: u8) -> Result<Self, ApplicationError> {
+        Argon2idParametersV1 {
+            memory_kib,
+            iterations,
+            lanes,
+            salt: [0; KDF_SALT_BYTES],
+        }
+        .validate()
+        .map_err(|_| ApplicationError::InvalidInput)?;
+        Ok(Self {
+            memory_kib,
+            iterations,
+            lanes,
+        })
+    }
+
+    /// Return the Argon2id memory cost in KiB.
+    pub const fn memory_kib(&self) -> u32 {
+        self.memory_kib
+    }
+
+    /// Return the Argon2id iteration count.
+    pub const fn iterations(&self) -> u32 {
+        self.iterations
+    }
+
+    /// Return the Argon2id lane count.
+    pub const fn lanes(&self) -> u8 {
+        self.lanes
+    }
+}
+
+impl Debug for PortableExportPolicyV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PortableExportPolicyV1")
+            .field("memory_kib", &self.memory_kib)
+            .field("iterations", &self.iterations)
+            .field("lanes", &self.lanes)
+            .finish()
+    }
+}
+
+/// One owned wipe-on-drop CSPRNG block for export salt and nonce.
+pub struct PortableExportRandomnessV1 {
+    bytes: [u8; PORTABLE_EXPORT_RANDOM_BYTES],
+}
+
+impl PortableExportRandomnessV1 {
+    /// Take one exact block filled by the host cryptographic entropy source.
+    pub const fn new(bytes: [u8; PORTABLE_EXPORT_RANDOM_BYTES]) -> Self {
+        Self { bytes }
+    }
+
+    fn salt(&self) -> [u8; KDF_SALT_BYTES] {
+        self.bytes[..KDF_SALT_BYTES]
+            .try_into()
+            .expect("portable export salt partition is constant")
+    }
+
+    fn nonce(&self) -> [u8; NONCE_BYTES] {
+        self.bytes[KDF_SALT_BYTES..]
+            .try_into()
+            .expect("portable export nonce partition is constant")
+    }
+}
+
+impl Zeroize for PortableExportRandomnessV1 {
+    fn zeroize(&mut self) {
+        self.bytes.zeroize();
+    }
+}
+
+impl Drop for PortableExportRandomnessV1 {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl Debug for PortableExportRandomnessV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("PortableExportRandomnessV1(<redacted>)")
+    }
+}
+
+/// One canonical authenticated encrypted portable export artifact.
+///
+/// The bytes contain no plaintext vault record, owner-private state, local
+/// pins, provider credential, or search projection. The host may write them to
+/// an explicitly selected destination without interpreting their contents.
+pub struct PortableExportArtifactV1 {
+    bytes: Vec<u8>,
+}
+
+impl PortableExportArtifactV1 {
+    /// Borrow the exact canonical encrypted artifact bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Consume the wrapper and return the exact bytes for host persistence.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+impl Debug for PortableExportArtifactV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("PortableExportArtifactV1(<encrypted>)")
+    }
+}
+
+pub(crate) fn export_portable_with_passphrase(
+    candidates: &BTreeMap<ItemId, Vec<ItemCandidate>>,
+    active: &crate::ActiveStateV1,
+    exact_bootstrap: &[u8],
+    passphrase: Zeroizing<Vec<u8>>,
+    policy: PortableExportPolicyV1,
+    randomness: PortableExportRandomnessV1,
+) -> Result<PortableExportArtifactV1, ApplicationError> {
+    if passphrase.is_empty() || passphrase.len() > MAX_PORTABLE_EXPORT_PASSPHRASE_BYTES {
+        return Err(ApplicationError::InvalidInput);
+    }
+    verify_active_bootstrap(active, exact_bootstrap)?;
+
+    let salt = randomness.salt();
+    let nonce = randomness.nonce();
+    let kdf = Argon2idParametersV1 {
+        memory_kib: policy.memory_kib,
+        iterations: policy.iterations,
+        lanes: policy.lanes,
+        salt,
+    };
+    kdf.validate().map_err(|_| ApplicationError::InvalidInput)?;
+
+    let mut entries = SecretCborValues::default();
+    let mut estimated_size = exact_bootstrap
+        .len()
+        .checked_add(SNAPSHOT_ESTIMATE_OVERHEAD)
+        .ok_or(ApplicationError::BoundExceeded)?;
+    for (item_id, item_candidates) in candidates {
+        let mut ordered = item_candidates.iter().collect::<Vec<_>>();
+        ordered.sort_unstable_by_key(|candidate| candidate.revision_id());
+        for candidate in ordered {
+            if candidate.item_id() != *item_id {
+                return Err(ApplicationError::IntegrityFailure);
+            }
+            let revision = Zeroizing::new(encode_item_revision(
+                candidate.causal_parents(),
+                candidate.state(),
+            )?);
+            estimated_size = estimated_size
+                .checked_add(revision.len())
+                .and_then(|size| size.checked_add(CANDIDATE_ESTIMATE_OVERHEAD))
+                .ok_or(ApplicationError::BoundExceeded)?;
+            if estimated_size > MAX_PORTABLE_EXPORT_PLAINTEXT_BYTES {
+                return Err(ApplicationError::BoundExceeded);
+            }
+            entries.push(CborValue::Map(vec![
+                field(1, bytes(item_id.as_bytes())),
+                field(2, bytes(candidate.revision_id().as_bytes())),
+                field(3, CborValue::Bytes(revision.into_inner())),
+            ]));
+        }
+    }
+
+    let candidate_count =
+        u64::try_from(entries.len()).map_err(|_| ApplicationError::BoundExceeded)?;
+    let mut entries_value = SecretCborValue::new(CborValue::Array(entries.into_inner()));
+    let encoded_entries = Zeroizing::new(encode(entries_value.get()));
+    let snapshot_hash = snapshot_hash(exact_bootstrap, &encoded_entries)?;
+    let snapshot = SecretCborValue::new(CborValue::Map(vec![
+        field(1, CborValue::Unsigned(VERSION)),
+        field(2, CborValue::Bytes(exact_bootstrap.to_vec())),
+        field(3, entries_value.take()),
+        field(4, CborValue::Unsigned(candidate_count)),
+        field(5, CborValue::Bytes(snapshot_hash.to_vec())),
+    ]));
+    let plaintext = Zeroizing::new(encode(snapshot.get()));
+    if plaintext.len() > MAX_PORTABLE_EXPORT_PLAINTEXT_BYTES {
+        return Err(ApplicationError::BoundExceeded);
+    }
+
+    let derived = Zeroizing::new(
+        argon2id(
+            &passphrase,
+            &kdf.salt,
+            kdf.iterations,
+            kdf.memory_kib,
+            kdf.lanes.into(),
+            32,
+            &Argon2idOptions::default(),
+        )
+        .map_err(|_| ApplicationError::InvalidInput)?,
+    );
+    let mut key = Zeroizing::new([0; 32]);
+    key.copy_from_slice(&derived);
+    let aad = artifact_aad(&kdf, nonce);
+    let (ciphertext, tag) = xchacha20_poly1305_aead_encrypt(&plaintext, &key, &nonce, &aad);
+    let artifact = CborValue::Map(vec![
+        field(1, CborValue::Unsigned(VERSION)),
+        field(2, CborValue::Unsigned(PASSPHRASE_PROTECTION)),
+        field(3, CborValue::Unsigned(CRYPTO_SUITE_V1.into())),
+        field(4, kdf_value(&kdf)),
+        field(5, CborValue::Bytes(nonce.to_vec())),
+        field(6, CborValue::Bytes(ciphertext)),
+        field(7, CborValue::Bytes(tag.to_vec())),
+    ]);
+    Ok(PortableExportArtifactV1 {
+        bytes: encode(&artifact),
+    })
+}
+
+pub(crate) fn snapshot_hash(
+    exact_bootstrap: &[u8],
+    encoded_entries: &[u8],
+) -> Result<[u8; 32], ApplicationError> {
+    let bootstrap_len =
+        u64::try_from(exact_bootstrap.len()).map_err(|_| ApplicationError::BoundExceeded)?;
+    let mut preimage = Zeroizing::new(Vec::with_capacity(
+        SNAPSHOT_HASH_DOMAIN.len() + 8 + exact_bootstrap.len() + encoded_entries.len(),
+    ));
+    preimage.extend_from_slice(SNAPSHOT_HASH_DOMAIN);
+    preimage.extend_from_slice(&bootstrap_len.to_be_bytes());
+    preimage.extend_from_slice(exact_bootstrap);
+    preimage.extend_from_slice(encoded_entries);
+    Ok(sha256(&preimage))
+}
+
+fn artifact_aad(kdf: &Argon2idParametersV1, nonce: [u8; NONCE_BYTES]) -> Vec<u8> {
+    let header = CborValue::Map(vec![
+        field(1, CborValue::Unsigned(VERSION)),
+        field(2, CborValue::Unsigned(PASSPHRASE_PROTECTION)),
+        field(3, CborValue::Unsigned(CRYPTO_SUITE_V1.into())),
+        field(4, kdf_value(kdf)),
+        field(5, CborValue::Bytes(nonce.to_vec())),
+    ]);
+    let encoded = encode(&header);
+    let mut aad = Vec::with_capacity(EXPORT_AAD_DOMAIN.len() + encoded.len());
+    aad.extend_from_slice(EXPORT_AAD_DOMAIN);
+    aad.extend_from_slice(&encoded);
+    aad
+}
+
+fn kdf_value(kdf: &Argon2idParametersV1) -> CborValue {
+    CborValue::Map(vec![
+        field(1, CborValue::Unsigned(kdf.memory_kib.into())),
+        field(2, CborValue::Unsigned(kdf.iterations.into())),
+        field(3, CborValue::Unsigned(kdf.lanes.into())),
+        field(4, CborValue::Bytes(kdf.salt.to_vec())),
+    ])
+}
+
+fn field(key: u64, value: CborValue) -> (CborValue, CborValue) {
+    (CborValue::Unsigned(key), value)
+}
+
+fn bytes<const N: usize>(value: &[u8; N]) -> CborValue {
+    CborValue::Bytes(value.to_vec())
+}
+
+fn zeroize_cbor_values(values: &mut [CborValue]) {
+    for value in values {
+        zeroize_cbor(value);
+    }
+}
+
+#[derive(Default)]
+struct SecretCborValues(Option<Vec<CborValue>>);
+
+impl SecretCborValues {
+    fn push(&mut self, value: CborValue) {
+        self.0.get_or_insert_with(Vec::new).push(value);
+    }
+
+    fn len(&self) -> usize {
+        self.0.as_ref().map_or(0, Vec::len)
+    }
+
+    fn into_inner(mut self) -> Vec<CborValue> {
+        self.0.take().unwrap_or_default()
+    }
+}
+
+impl Drop for SecretCborValues {
+    fn drop(&mut self) {
+        if let Some(values) = &mut self.0 {
+            zeroize_cbor_values(values);
+        }
+    }
+}
+
+struct SecretCborValue(Option<CborValue>);
+
+impl SecretCborValue {
+    fn new(value: CborValue) -> Self {
+        Self(Some(value))
+    }
+
+    fn get(&self) -> &CborValue {
+        self.0.as_ref().expect("secret CBOR value is present")
+    }
+
+    fn take(&mut self) -> CborValue {
+        self.0.take().expect("secret CBOR value is present")
+    }
+}
+
+impl Drop for SecretCborValue {
+    fn drop(&mut self) {
+        if let Some(value) = &mut self.0 {
+            zeroize_cbor(value);
+        }
+    }
+}
+
+pub(crate) fn zeroize_cbor(value: &mut CborValue) {
+    match value {
+        CborValue::Bytes(bytes) => bytes.zeroize(),
+        CborValue::Text(text) => text.zeroize(),
+        CborValue::Array(values) => zeroize_cbor_values(values),
+        CborValue::Map(entries) => {
+            for (key, value) in entries {
+                zeroize_cbor(key);
+                zeroize_cbor(value);
+            }
+        }
+        CborValue::Tag(_, value) => zeroize_cbor(value),
+        CborValue::Unsigned(_) | CborValue::Negative(_) | CborValue::Bool(_) | CborValue::Null => {}
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn decrypt_portable_for_test(
+    artifact: &[u8],
+    passphrase: Zeroizing<Vec<u8>>,
+) -> Option<Zeroizing<Vec<u8>>> {
+    use coding_adventures_canonical_cbor::decode;
+    use coding_adventures_chacha20_poly1305::xchacha20_poly1305_aead_decrypt;
+
+    let CborValue::Map(mut fields) = decode(artifact).ok()? else {
+        return None;
+    };
+    let version = take_test_uint(&mut fields, 1)?;
+    let protection = take_test_uint(&mut fields, 2)?;
+    let suite = take_test_uint(&mut fields, 3)?;
+    if version != VERSION
+        || protection != PASSPHRASE_PROTECTION
+        || suite != u64::from(CRYPTO_SUITE_V1)
+    {
+        return None;
+    }
+    let CborValue::Map(mut kdf_fields) = take_test_field(&mut fields, 4)? else {
+        return None;
+    };
+    let memory_kib = u32::try_from(take_test_uint(&mut kdf_fields, 1)?).ok()?;
+    let iterations = u32::try_from(take_test_uint(&mut kdf_fields, 2)?).ok()?;
+    let lanes = u8::try_from(take_test_uint(&mut kdf_fields, 3)?).ok()?;
+    let salt = take_test_bytes(&mut kdf_fields, 4)?.try_into().ok()?;
+    let kdf = Argon2idParametersV1 {
+        memory_kib,
+        iterations,
+        lanes,
+        salt,
+    };
+    kdf.validate().ok()?;
+    let nonce = take_test_bytes(&mut fields, 5)?.try_into().ok()?;
+    let ciphertext = take_test_bytes(&mut fields, 6)?;
+    let tag = take_test_bytes(&mut fields, 7)?.try_into().ok()?;
+    if !fields.is_empty() || !kdf_fields.is_empty() {
+        return None;
+    }
+    let derived = Zeroizing::new(
+        argon2id(
+            &passphrase,
+            &kdf.salt,
+            kdf.iterations,
+            kdf.memory_kib,
+            kdf.lanes.into(),
+            32,
+            &Argon2idOptions::default(),
+        )
+        .ok()?,
+    );
+    let mut key = Zeroizing::new([0; 32]);
+    key.copy_from_slice(&derived);
+    xchacha20_poly1305_aead_decrypt(&ciphertext, &key, &nonce, &artifact_aad(&kdf, nonce), &tag)
+        .map(Zeroizing::new)
+}
+
+#[cfg(test)]
+fn take_test_field(fields: &mut Vec<(CborValue, CborValue)>, key: u64) -> Option<CborValue> {
+    let index = fields
+        .iter()
+        .position(|(candidate, _)| candidate == &CborValue::Unsigned(key))?;
+    Some(fields.remove(index).1)
+}
+
+#[cfg(test)]
+fn take_test_uint(fields: &mut Vec<(CborValue, CborValue)>, key: u64) -> Option<u64> {
+    match take_test_field(fields, key)? {
+        CborValue::Unsigned(value) => Some(value),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+fn take_test_bytes(fields: &mut Vec<(CborValue, CborValue)>, key: u64) -> Option<Vec<u8>> {
+    match take_test_field(fields, key)? {
+        CborValue::Bytes(value) => Some(value),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_randomness_and_artifact_diagnostics_are_closed() {
+        let policy = PortableExportPolicyV1::new(8 * 1024, 1, 1).unwrap();
+        assert_eq!(policy.memory_kib(), 8 * 1024);
+        assert_eq!(policy.iterations(), 1);
+        assert_eq!(policy.lanes(), 1);
+        assert_eq!(
+            format!("{policy:?}"),
+            "PortableExportPolicyV1 { memory_kib: 8192, iterations: 1, lanes: 1 }"
+        );
+        assert_eq!(
+            PortableExportPolicyV1::new(1, 1, 1),
+            Err(ApplicationError::InvalidInput)
+        );
+
+        let randomness = PortableExportRandomnessV1::new([0x5a; PORTABLE_EXPORT_RANDOM_BYTES]);
+        assert_eq!(
+            format!("{randomness:?}"),
+            "PortableExportRandomnessV1(<redacted>)"
+        );
+        let artifact = PortableExportArtifactV1 {
+            bytes: vec![1, 2, 3],
+        };
+        assert_eq!(
+            format!("{artifact:?}"),
+            "PortableExportArtifactV1(<encrypted>)"
+        );
+        assert_eq!(artifact.as_bytes(), &[1, 2, 3]);
+        assert_eq!(artifact.into_bytes(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn recursive_cbor_wipe_clears_secret_shaped_allocations() {
+        let mut value = CborValue::Map(vec![field(
+            1,
+            CborValue::Array(vec![
+                CborValue::Bytes(b"secret bytes".to_vec()),
+                CborValue::Text("secret text".to_owned()),
+                CborValue::Tag(7, Box::new(CborValue::Bytes(vec![9; 8]))),
+            ]),
+        )]);
+        zeroize_cbor(&mut value);
+        let CborValue::Map(entries) = value else {
+            panic!()
+        };
+        let CborValue::Array(values) = &entries[0].1 else {
+            panic!()
+        };
+        assert_eq!(values[0], CborValue::Bytes(Vec::new()));
+        assert_eq!(values[1], CborValue::Text(String::new()));
+        assert_eq!(
+            values[2],
+            CborValue::Tag(7, Box::new(CborValue::Bytes(Vec::new())))
+        );
+    }
+}

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -12,6 +12,7 @@ mod codec;
 mod crypto;
 mod disclosure;
 mod doctor;
+mod export;
 mod initialize;
 mod lifecycle;
 mod mutation;
@@ -36,6 +37,11 @@ pub use disclosure::{
     RevealedSecretEncodingV1, RevealedSecretV1, SecretDisclosureIntentV1, SecretFieldV1,
 };
 pub use doctor::{VaultDoctorReportV1, VaultDoctorStateV1};
+pub use export::{
+    PortableExportArtifactV1, PortableExportPolicyV1, PortableExportRandomnessV1,
+    MAX_PORTABLE_EXPORT_PASSPHRASE_BYTES, MAX_PORTABLE_EXPORT_PLAINTEXT_BYTES,
+    PORTABLE_EXPORT_RANDOM_BYTES,
+};
 pub use initialize::{
     complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init,
     GenerationZeroPolicyV1, GenerationZeroRandomness, PreparedGenerationZero,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -188,6 +188,30 @@ impl UnlockedVaultV1 {
         crate::audit::audit_verify(&self.active, &self._keys, self._repository.as_ref())
     }
 
+    /// Build one canonical authenticated encrypted snapshot for host persistence.
+    ///
+    /// The passphrase must be collected separately from the live vault
+    /// passphrase. The host supplies fresh salt/nonce randomness and chooses the
+    /// destination only after this method returns. Every current live,
+    /// tombstone, and conflicted candidate is included; local private state,
+    /// provider credentials, pins, and search projections are excluded.
+    pub fn export_portable_with_passphrase(
+        &self,
+        exact_bootstrap: &[u8],
+        passphrase: Zeroizing<Vec<u8>>,
+        policy: crate::PortableExportPolicyV1,
+        randomness: crate::PortableExportRandomnessV1,
+    ) -> Result<crate::PortableExportArtifactV1, ApplicationError> {
+        crate::export::export_portable_with_passphrase(
+            &self.current_catalog.items,
+            &self.active,
+            exact_bootstrap,
+            passphrase,
+            policy,
+            randomness,
+        )
+    }
+
     /// Return the ordinary redacted view for one unambiguous live item.
     ///
     /// A missing item and a current tombstone both return `None`. Multiple
@@ -1152,6 +1176,14 @@ mod tests {
         encode_cbor(&CborValue::Map(fields))
     }
 
+    fn take_cbor_field(fields: &mut Vec<(CborValue, CborValue)>, key: u64) -> CborValue {
+        let index = fields
+            .iter()
+            .position(|(candidate, _)| candidate == &CborValue::Unsigned(key))
+            .unwrap();
+        fields.remove(index).1
+    }
+
     fn add_item_randomness(seed: u8) -> AddItemRandomnessV1 {
         let mut bytes = [0; ADD_ITEM_RANDOM_BYTES];
         for (index, byte) in bytes.iter_mut().enumerate() {
@@ -1678,6 +1710,280 @@ mod tests {
         assert_eq!(report.catalog_count(), 3);
         assert_eq!(report.revision_count(), 2);
         assert_eq!(report.item_count(), 1);
+    }
+
+    #[test]
+    fn portable_export_encrypts_every_current_candidate_under_a_separate_passphrase() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let randomness = add_item_randomness(0xaa);
+        let item_id = randomness.item_id();
+        session
+            .add_item(
+                new_login_document(item_id, "Portable portal", "portable-export-secret"),
+                800,
+                randomness,
+                &local,
+            )
+            .unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let exact_bootstrap = bootstrap.0.lock().unwrap().clone().unwrap();
+        let policy = crate::PortableExportPolicyV1::new(8 * 1024, 1, 1).unwrap();
+        let export_randomness = [0x5b; crate::PORTABLE_EXPORT_RANDOM_BYTES];
+        let artifact = session
+            .export_portable_with_passphrase(
+                &exact_bootstrap,
+                Zeroizing::new(b"separate export passphrase".to_vec()),
+                policy,
+                crate::PortableExportRandomnessV1::new(export_randomness),
+            )
+            .unwrap();
+        let repeated = session
+            .export_portable_with_passphrase(
+                &exact_bootstrap,
+                Zeroizing::new(b"separate export passphrase".to_vec()),
+                policy,
+                crate::PortableExportRandomnessV1::new(export_randomness),
+            )
+            .unwrap();
+        assert_eq!(artifact.as_bytes(), repeated.as_bytes());
+        assert_eq!(
+            coding_adventures_sha256::sha256(artifact.as_bytes()),
+            [
+                0xb8, 0xb7, 0x05, 0x87, 0xea, 0x11, 0x3b, 0x11, 0xea, 0x23, 0xa7, 0x7a, 0x9b, 0x36,
+                0xe6, 0xc4, 0x0e, 0x51, 0x04, 0x86, 0x99, 0x60, 0xb9, 0x38, 0x98, 0x93, 0xaf, 0x5e,
+                0x96, 0x53, 0xa1, 0x3a,
+            ]
+        );
+        for plaintext in [b"Portable portal".as_slice(), b"portable-export-secret"] {
+            assert!(!artifact
+                .as_bytes()
+                .windows(plaintext.len())
+                .any(|window| window == plaintext));
+        }
+        assert!(crate::export::decrypt_portable_for_test(
+            artifact.as_bytes(),
+            Zeroizing::new(b"wrong export passphrase".to_vec()),
+        )
+        .is_none());
+        let mut tampered = artifact.as_bytes().to_vec();
+        let last = tampered.last_mut().unwrap();
+        *last ^= 1;
+        assert!(crate::export::decrypt_portable_for_test(
+            &tampered,
+            Zeroizing::new(b"separate export passphrase".to_vec()),
+        )
+        .is_none());
+
+        let plaintext = crate::export::decrypt_portable_for_test(
+            artifact.as_bytes(),
+            Zeroizing::new(b"separate export passphrase".to_vec()),
+        )
+        .unwrap();
+        let CborValue::Map(mut snapshot) = decode_cbor(&plaintext).unwrap() else {
+            panic!("portable snapshot must be a canonical map")
+        };
+        assert_eq!(take_cbor_field(&mut snapshot, 1), CborValue::Unsigned(1));
+        let CborValue::Bytes(exported_bootstrap) = take_cbor_field(&mut snapshot, 2) else {
+            panic!()
+        };
+        assert_eq!(exported_bootstrap, exact_bootstrap);
+        let mut entries = take_cbor_field(&mut snapshot, 3);
+        let encoded_entries = encode_cbor(&entries);
+        let CborValue::Unsigned(candidate_count) = take_cbor_field(&mut snapshot, 4) else {
+            panic!()
+        };
+        assert_eq!(candidate_count, 1);
+        let CborValue::Bytes(exported_hash) = take_cbor_field(&mut snapshot, 5) else {
+            panic!()
+        };
+        assert_eq!(
+            exported_hash,
+            crate::export::snapshot_hash(&exact_bootstrap, &encoded_entries)
+                .unwrap()
+                .to_vec()
+        );
+        assert!(snapshot.is_empty());
+
+        let CborValue::Array(exported_candidates) = &mut entries else {
+            panic!()
+        };
+        assert_eq!(exported_candidates.len(), 1);
+        let CborValue::Map(mut entry) = exported_candidates.remove(0) else {
+            panic!()
+        };
+        let CborValue::Bytes(exported_item_id) = take_cbor_field(&mut entry, 1) else {
+            panic!()
+        };
+        assert_eq!(exported_item_id, item_id.as_bytes());
+        let CborValue::Bytes(exported_revision_id) = take_cbor_field(&mut entry, 2) else {
+            panic!()
+        };
+        let revision_id = RevisionId::new(exported_revision_id.try_into().unwrap());
+        let CborValue::Bytes(mut encoded_revision) = take_cbor_field(&mut entry, 3) else {
+            panic!()
+        };
+        assert!(entry.is_empty());
+        let candidate = crate::decode_item_revision(revision_id, &encoded_revision).unwrap();
+        let ItemState::Live(document) = candidate.state() else {
+            panic!()
+        };
+        let AnyRecord::Login(login) = document.payload() else {
+            panic!()
+        };
+        assert_eq!(login.title, "Portable portal");
+        assert_eq!(login.password, "portable-export-secret");
+        encoded_revision.zeroize();
+        crate::export::zeroize_cbor(&mut entries);
+        assert_eq!(
+            format!("{artifact:?}"),
+            "PortableExportArtifactV1(<encrypted>)"
+        );
+    }
+
+    #[test]
+    fn portable_export_rejects_credential_and_bootstrap_misuse() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let exact_bootstrap = bootstrap.0.lock().unwrap().clone().unwrap();
+        let policy = crate::PortableExportPolicyV1::new(8 * 1024, 1, 1).unwrap();
+        let randomness =
+            || crate::PortableExportRandomnessV1::new([0x6c; crate::PORTABLE_EXPORT_RANDOM_BYTES]);
+        assert_eq!(
+            session
+                .export_portable_with_passphrase(
+                    &exact_bootstrap,
+                    Zeroizing::new(Vec::new()),
+                    policy,
+                    randomness(),
+                )
+                .err(),
+            Some(ApplicationError::InvalidInput)
+        );
+        assert_eq!(
+            session
+                .export_portable_with_passphrase(
+                    &exact_bootstrap,
+                    Zeroizing::new(vec![0x61; crate::MAX_PORTABLE_EXPORT_PASSPHRASE_BYTES + 1]),
+                    policy,
+                    randomness(),
+                )
+                .err(),
+            Some(ApplicationError::InvalidInput)
+        );
+        assert_eq!(
+            session
+                .export_portable_with_passphrase(
+                    &[0xff],
+                    Zeroizing::new(b"separate export passphrase".to_vec()),
+                    policy,
+                    randomness(),
+                )
+                .err(),
+            Some(ApplicationError::IntegrityFailure)
+        );
+    }
+
+    #[test]
+    fn portable_export_preserves_every_current_conflict_tombstone() {
+        let (locator, local, bootstrap, factory) = initialized();
+        let exact_active = local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(active) = LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let item_id = ItemId::new([0x7d; 16]);
+        let (publication, expected_revision_ids) =
+            pending_tombstone_publication(&active, item_id, item_id, 2, None);
+        *local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        let session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            locator,
+            &local,
+            &bootstrap,
+            &factory,
+        )
+        .unwrap();
+        assert_eq!(session.conflicted_item_count(), 1);
+        let exact_bootstrap = bootstrap.0.lock().unwrap().clone().unwrap();
+        let artifact = session
+            .export_portable_with_passphrase(
+                &exact_bootstrap,
+                Zeroizing::new(b"conflict export passphrase".to_vec()),
+                crate::PortableExportPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+                crate::PortableExportRandomnessV1::new([0x7e; crate::PORTABLE_EXPORT_RANDOM_BYTES]),
+            )
+            .unwrap();
+        let plaintext = crate::export::decrypt_portable_for_test(
+            artifact.as_bytes(),
+            Zeroizing::new(b"conflict export passphrase".to_vec()),
+        )
+        .unwrap();
+        let CborValue::Map(mut snapshot) = decode_cbor(&plaintext).unwrap() else {
+            panic!()
+        };
+        let mut entries = take_cbor_field(&mut snapshot, 3);
+        assert_eq!(take_cbor_field(&mut snapshot, 4), CborValue::Unsigned(2));
+        let CborValue::Array(exported_candidates) = &mut entries else {
+            panic!()
+        };
+        let mut actual_revision_ids = Vec::new();
+        for value in exported_candidates.drain(..) {
+            let CborValue::Map(mut entry) = value else {
+                panic!()
+            };
+            assert_eq!(
+                take_cbor_field(&mut entry, 1),
+                CborValue::Bytes(item_id.as_bytes().to_vec())
+            );
+            let CborValue::Bytes(revision_id) = take_cbor_field(&mut entry, 2) else {
+                panic!()
+            };
+            let revision_id = RevisionId::new(revision_id.try_into().unwrap());
+            actual_revision_ids.push(revision_id);
+            let CborValue::Bytes(mut encoded_revision) = take_cbor_field(&mut entry, 3) else {
+                panic!()
+            };
+            let candidate = crate::decode_item_revision(revision_id, &encoded_revision).unwrap();
+            assert!(matches!(candidate.state(), ItemState::Tombstone(_)));
+            encoded_revision.zeroize();
+        }
+        assert_eq!(actual_revision_ids, expected_revision_ids);
+        crate::export::zeroize_cbor(&mut entries);
     }
 
     #[test]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1328,7 +1328,14 @@ changelog, focused build, and downstream validation.
        non-printable wipe-on-drop value, with explicit clipboard, confirmed
        interactive reveal, and warned unsafe non-interactive policy inputs;
    7c-3. host clipboard adapter with ownership-aware timed clear;
-   7d. authenticated portable export and restore/import preparation; and
+   7d-1. completed authenticated canonical portable export, preserving every
+       current live, tombstone, and conflict candidate under a separately
+       collected Argon2id passphrase with fresh salt/nonce, header-bound AEAD,
+       a signed-bootstrap-bound snapshot hash, identity-free diagnostics,
+       wipe-on-drop plaintext, and host-neutral destination handling;
+   7d-2. authenticated portable artifact opening, snapshot verification, and
+       import into a new vault with new item, revision, object, and encryption
+       identities, followed by an independent restore/open comparison; and
    7e-1. completed safe five-state status workflow, strictly decoding bounded
        owner state while locked and exposing only authenticated aggregate item,
        candidate, and conflict counts while unlocked;

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -582,15 +582,62 @@ field API as current items. Restore always creates a new revision and commit;
 it never rewinds repository heads or mutates historical bytes.
 
 Portable export is one authenticated encrypted artifact containing a canonical
-snapshot of all current candidates, complete live documents/tombstones,
-bootstrap public metadata required for import, and a manifest count/hash. It is
-encrypted under a fresh export key or a separately collected export
-passphrase—never implicitly under the live VRK. Export excludes local device
-private state, provider credentials, local pins, and search indexes.
+snapshot of all current candidates, complete live documents/tombstones, the
+exact signed bootstrap needed to interpret the source, and a manifest
+count/hash. It is encrypted under a separately collected export passphrase,
+never implicitly under the live VRK or unlock passphrase. The host supplies the
+bounded Argon2id policy and exactly 40 fresh CSPRNG bytes: 16 bytes of salt,
+followed by a 24-byte XChaCha20 nonce. Empty passphrases and passphrases over
+1,024 bytes are rejected.
 
-Phase 1A returns export bytes to the host; it does not choose or write a path.
-Import and cross-vault re-identification are the next paired workflow and must
-create new object identities.
+The V1 artifact is closed canonical CBOR with integer keys:
+
+| Key | Value |
+|---:|---|
+| 1 | version `1` |
+| 2 | protection `1` (passphrase) |
+| 3 | crypto suite `1` |
+| 4 | Argon2id map `{1: memory_kib, 2: iterations, 3: lanes, 4: 16-byte salt}` |
+| 5 | 24-byte nonce |
+| 6 | XChaCha20-Poly1305 ciphertext |
+| 7 | 16-byte authentication tag |
+
+The 32-byte export key is the direct Argon2id output for the supplied
+passphrase and key-4 parameters. AEAD associated data is
+`"VPM-PORTABLE-EXPORT-AAD-v1" || canonical_cbor(header)`, where `header` is
+the artifact map containing exactly keys 1–5. Changing a version, protection
+mode, suite, KDF parameter, salt, or nonce therefore fails authentication.
+
+Authenticated plaintext is a closed canonical CBOR map:
+
+| Key | Value |
+|---:|---|
+| 1 | snapshot version `1` |
+| 2 | exact signed bootstrap bytes accepted by the active session |
+| 3 | candidate array |
+| 4 | candidate-array length |
+| 5 | 32-byte snapshot hash |
+
+Every candidate entry is `{1: source_item_id, 2: source_revision_id, 3:
+canonical_item_revision}`. Entries are ordered first by exact 16-byte item ID
+and then by exact 32-byte revision ID. Every current live, tombstone, and
+conflicting candidate is retained. The hash is
+`SHA-256("VPM-PORTABLE-SNAPSHOT-v1" || bootstrap_length_u64_be ||
+exact_bootstrap || canonical_cbor(candidate_array))`. The complete canonical
+plaintext is limited to 512 MiB.
+
+Export excludes owner-private local state, authority/device private seeds,
+provider credentials, local pins, recovery journals, and the rebuildable
+search projection. All passphrase, derived-key, plaintext, candidate-encoding,
+and hash-preimage buffers are owned by wipe-on-drop containers. Public export
+types redact their bytes from diagnostics.
+
+Phase 1A returns exact encrypted artifact bytes to the host; it does not choose
+or write a path, overwrite a destination, report backup completion, or retain
+provider authority. Authenticated artifact opening, snapshot-hash verification,
+and cross-vault import are the next paired workflow. Import must create a new
+vault and new item, revision, object, and encryption identities rather than
+publishing source identities into the target repository.
 
 ## 12. Audit and status
 


### PR DESCRIPTION
## Summary

- add a host-neutral, passphrase-encrypted canonical portable export from an unlocked vault
- preserve every current live, tombstone, and conflict candidate with exact signed-bootstrap and snapshot-hash binding
- authenticate version, suite, Argon2id parameters, salt, and nonce as AEAD associated data
- redact public diagnostics and wipe passphrase, derived key, plaintext, revision encoding, and hash-preimage buffers
- split authenticated import and cross-vault re-identification into explicit roadmap item VLT-PM00 7d-2

## Security boundary

The application returns only encrypted bytes. It does not choose or overwrite a path, retain provider authority, include owner-private state or provider credentials, or claim restore completion. Import must create new item, revision, object, and encryption identities in a new target vault.

## Validation

- `bash code/packages/rust/vault-pm-application/BUILD` (108 tests)
- warnings-as-errors Clippy for all targets
- strict rustdoc with warnings denied
- Tarpaulin LLVM: 2,727/2,858 production lines (95.42%); export module 204/214 (95.33%)
- fixed deterministic artifact SHA-256 vector plus wrong-passphrase, tamper, plaintext-exclusion, bootstrap-binding, and conflict/tombstone retention tests
- monorepo build planner: 51 Starlark files, 1,003 packages, 1 changed, 2 affected, both built
