### PR TITLE
Add authenticated portable vault opening

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this package are documented here.
 
+## [0.27.0] - 2026-08-10
+
+### Added
+
+- Add strict authenticated opening for an untrusted canonical portable export,
+  returning one opaque non-cloneable secret-bearing snapshot with aggregate
+  item and candidate counts only.
+- Add an explicit host-approved Argon2id memory, iteration, and lane ceiling
+  checked before artifact-controlled KDF work.
+
+### Security
+
+- Bound the artifact before canonical decode, authenticate the complete
+  header-bound ciphertext before plaintext parsing, and make wrong credentials
+  indistinguishable from valid-shape tag tampering.
+- Verify the exact snapshot count/hash, embedded authority-signed bootstrap,
+  strict source item/revision ordering, per-item candidate bounds, canonical
+  revisions, and entry/document item binding before returning success.
+- Keep opening free of target-vault or provider writes; expose no source
+  identity or document accessors, redact diagnostics, and wipe all intermediate
+  secret-bearing buffers and CBOR trees on every return path.
+
 ## [0.26.0] - 2026-08-10
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -222,9 +222,24 @@ and search data; public diagnostics reveal no bytes, while passphrase, key,
 plaintext, encoded revisions, and hash preimages are wiped on drop.
 
 The host receives only exact encrypted bytes and remains responsible for an
-explicit destination and safe file replacement. Public import is deliberately
-separate: its follow-up must authenticate and verify the artifact, then create
-new item, revision, object, and encryption identities inside a new target vault.
+explicit destination and safe file replacement.
+
+Untrusted artifacts can now be opened through a separate no-write boundary.
+The caller supplies the owned export passphrase plus an explicit maximum
+Argon2id memory/iteration/lane policy, preventing artifact-controlled resource
+cost beyond host approval. Opening strictly checks the bounded canonical
+header, authenticates header-bound AEAD before plaintext parsing, verifies the
+snapshot count/hash and signed source bootstrap, enforces deterministic unique
+source item/revision order and per-item bounds, and decodes every candidate with
+exact item binding. Wrong credentials and valid-shape tag tampering share the
+closed authentication failure.
+
+Success remains inside an opaque non-cloneable application object exposing only
+item and candidate counts. Source identities, bootstrap bytes, metadata, and
+documents have no public accessor; diagnostics are redacted and all intermediate
+secret-bearing buffers and CBOR trees wipe on every path. Cross-vault import is
+still separate: its follow-up must consume the opaque snapshot and create new
+item, revision, object, and encryption identities inside a new target vault.
 
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
@@ -263,9 +278,9 @@ diagnostics; and failure without repair.
 Search tests cover Unicode normalization, short queries, oversized safe-field
 fallback, exact collection filters, deterministic product ordering, every
 record schema's allowlist/denylist, secret exclusion, query/result bounds, and
-conflict closure. The exact Tarpaulin LLVM result is 2,727 of 2,858 production
-lines (95.42%); portable export is 204 of 214, doctor is 44 of 45, and status
-remains 46 of 46.
+conflict closure. The exact Tarpaulin LLVM result is 2,894 of 3,042 production
+lines (95.13%); portable export and opening are 367 of 394, doctor is 44 of 45,
+and status remains 46 of 46.
 Add-item tests cover exact
 entropy partitioning and wiping,
 identity validation before local writes, parentless revision and complete
@@ -282,11 +297,12 @@ tombstone selection, authored merged-secret persistence, complete multi-parent
 causality, immutable live-identity preservation, immutable losing-candidate
 retention, missing/unconflicted/all-tombstone rejection before
 compare-exchange, and entropy redaction/wiping.
-Portable-export tests prove the exact canonical encrypted vector, separate
+Portable-export/open tests prove the exact canonical encrypted vector, separate
 passphrase authentication, header/ciphertext tamper rejection, exact active
 bootstrap binding, plaintext-secret exclusion, complete snapshot count/hash,
-live-document recovery, bounded credential rejection, and lossless retention
-of every current conflicting tombstone.
+signed-bootstrap validation, host KDF-ceiling enforcement, candidate identity
+and ordering validation, live-document recovery, bounded credential rejection,
+and lossless retention of every current conflicting tombstone.
 
 ## Development
 

--- a/code/packages/rust/vault-pm-application/src/export.rs
+++ b/code/packages/rust/vault-pm-application/src/export.rs
@@ -1,10 +1,13 @@
-use crate::initialize::verify_active_bootstrap;
-use crate::{encode_item_revision, ApplicationError};
+use crate::codec::{MAX_CANDIDATES_PER_ITEM, MAX_CATALOG_ENTRIES};
+use crate::initialize::{verify_active_bootstrap, verify_signed_bootstrap};
+use crate::{decode_item_revision, encode_item_revision, ApplicationError};
 use coding_adventures_argon2id::{argon2id, Options as Argon2idOptions};
-use coding_adventures_canonical_cbor::{encode, CborValue};
-use coding_adventures_chacha20_poly1305::xchacha20_poly1305_aead_encrypt;
+use coding_adventures_canonical_cbor::{decode, encode, CborValue};
+use coding_adventures_chacha20_poly1305::{
+    xchacha20_poly1305_aead_decrypt, xchacha20_poly1305_aead_encrypt,
+};
 use coding_adventures_sha256::sha256;
-use coding_adventures_vault_pm_domain::{ItemCandidate, ItemId};
+use coding_adventures_vault_pm_domain::{ItemCandidate, ItemId, RevisionId};
 use coding_adventures_vault_pm_format::{Argon2idParametersV1, CRYPTO_SUITE_V1};
 use coding_adventures_zeroize::{Zeroize, Zeroizing};
 use core::fmt::{self, Debug, Formatter};
@@ -18,6 +21,7 @@ const SNAPSHOT_HASH_DOMAIN: &[u8] = b"VPM-PORTABLE-SNAPSHOT-v1";
 const EXPORT_AAD_DOMAIN: &[u8] = b"VPM-PORTABLE-EXPORT-AAD-v1";
 const CANDIDATE_ESTIMATE_OVERHEAD: usize = 128;
 const SNAPSHOT_ESTIMATE_OVERHEAD: usize = 1_024;
+const ARTIFACT_OVERHEAD: usize = 4_096;
 
 /// Exact host-supplied CSPRNG bytes consumed by one passphrase export.
 pub const PORTABLE_EXPORT_RANDOM_BYTES: usize = KDF_SALT_BYTES + NONCE_BYTES;
@@ -25,6 +29,9 @@ pub const PORTABLE_EXPORT_RANDOM_BYTES: usize = KDF_SALT_BYTES + NONCE_BYTES;
 pub const MAX_PORTABLE_EXPORT_PASSPHRASE_BYTES: usize = 1_024;
 /// Maximum canonical plaintext snapshot size accepted by V1.
 pub const MAX_PORTABLE_EXPORT_PLAINTEXT_BYTES: usize = 512 * 1024 * 1024;
+/// Maximum encrypted artifact bytes accepted by the V1 opener.
+pub const MAX_PORTABLE_EXPORT_ARTIFACT_BYTES: usize =
+    MAX_PORTABLE_EXPORT_PLAINTEXT_BYTES + ARTIFACT_OVERHEAD;
 
 /// Bounded caller-calibrated Argon2id policy for a portable export.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -75,6 +82,54 @@ impl Debug for PortableExportPolicyV1 {
             .field("memory_kib", &self.memory_kib)
             .field("iterations", &self.iterations)
             .field("lanes", &self.lanes)
+            .finish()
+    }
+}
+
+/// Host-approved resource ceiling for opening an untrusted portable artifact.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct PortableOpenPolicyV1 {
+    max_memory_kib: u32,
+    max_iterations: u32,
+    max_lanes: u8,
+}
+
+impl PortableOpenPolicyV1 {
+    /// Validate one maximum Argon2id resource policy for artifact opening.
+    pub fn new(
+        max_memory_kib: u32,
+        max_iterations: u32,
+        max_lanes: u8,
+    ) -> Result<Self, ApplicationError> {
+        Argon2idParametersV1 {
+            memory_kib: max_memory_kib,
+            iterations: max_iterations,
+            lanes: max_lanes,
+            salt: [0; KDF_SALT_BYTES],
+        }
+        .validate()
+        .map_err(|_| ApplicationError::InvalidInput)?;
+        Ok(Self {
+            max_memory_kib,
+            max_iterations,
+            max_lanes,
+        })
+    }
+
+    fn allows(&self, kdf: &Argon2idParametersV1) -> bool {
+        kdf.memory_kib <= self.max_memory_kib
+            && kdf.iterations <= self.max_iterations
+            && kdf.lanes <= self.max_lanes
+    }
+}
+
+impl Debug for PortableOpenPolicyV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PortableOpenPolicyV1")
+            .field("max_memory_kib", &self.max_memory_kib)
+            .field("max_iterations", &self.max_iterations)
+            .field("max_lanes", &self.max_lanes)
             .finish()
     }
 }
@@ -145,6 +200,215 @@ impl PortableExportArtifactV1 {
 impl Debug for PortableExportArtifactV1 {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         formatter.write_str("PortableExportArtifactV1(<encrypted>)")
+    }
+}
+
+/// Authenticated secret-bearing snapshot retained only inside the application.
+///
+/// The host can inspect aggregate counts before choosing whether to continue a
+/// later import. Source identities, bootstrap bytes, candidate metadata, and
+/// decrypted documents have no public accessor and diagnostics are redacted.
+pub struct OpenedPortableSnapshotV1 {
+    _exact_bootstrap: Zeroizing<Vec<u8>>,
+    candidates: BTreeMap<ItemId, Vec<ItemCandidate>>,
+}
+
+impl OpenedPortableSnapshotV1 {
+    /// Return the number of distinct source item identities in the snapshot.
+    pub fn item_count(&self) -> usize {
+        self.candidates.len()
+    }
+
+    /// Return the number of retained current source candidates.
+    pub fn candidate_count(&self) -> usize {
+        self.candidates.values().map(Vec::len).sum()
+    }
+}
+
+impl Debug for OpenedPortableSnapshotV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("OpenedPortableSnapshotV1(<redacted>)")
+    }
+}
+
+/// Authenticate, decrypt, and strictly validate one untrusted portable artifact.
+///
+/// The caller supplies an owned separately collected passphrase and an explicit
+/// Argon2id resource ceiling. Authentication completes before any plaintext is
+/// parsed. The returned snapshot intentionally exposes only aggregate counts.
+pub fn open_portable_with_passphrase(
+    artifact: &[u8],
+    passphrase: Zeroizing<Vec<u8>>,
+    policy: PortableOpenPolicyV1,
+) -> Result<OpenedPortableSnapshotV1, ApplicationError> {
+    if passphrase.is_empty() || passphrase.len() > MAX_PORTABLE_EXPORT_PASSPHRASE_BYTES {
+        return Err(ApplicationError::InvalidInput);
+    }
+    if artifact.len() > MAX_PORTABLE_EXPORT_ARTIFACT_BYTES {
+        return Err(ApplicationError::BoundExceeded);
+    }
+
+    let mut fields =
+        SecretCborValue::new(decode(artifact).map_err(|_| ApplicationError::IntegrityFailure)?)
+            .into_map()?;
+    fields.require_keys(&[1, 2, 3, 4, 5, 6, 7])?;
+    check_wire_value(fields.take(1)?.into_uint()?, VERSION)?;
+    check_wire_value(fields.take(2)?.into_uint()?, PASSPHRASE_PROTECTION)?;
+    check_wire_value(fields.take(3)?.into_uint()?, CRYPTO_SUITE_V1.into())?;
+    let mut kdf_fields = fields.take(4)?.into_map()?;
+    kdf_fields.require_keys(&[1, 2, 3, 4])?;
+    let kdf = Argon2idParametersV1 {
+        memory_kib: u32::try_from(kdf_fields.take(1)?.into_uint()?)
+            .map_err(|_| ApplicationError::BoundExceeded)?,
+        iterations: u32::try_from(kdf_fields.take(2)?.into_uint()?)
+            .map_err(|_| ApplicationError::BoundExceeded)?,
+        lanes: u8::try_from(kdf_fields.take(3)?.into_uint()?)
+            .map_err(|_| ApplicationError::BoundExceeded)?,
+        salt: kdf_fields.take(4)?.into_fixed()?,
+    };
+    kdf.validate()
+        .map_err(|_| ApplicationError::BoundExceeded)?;
+    if !policy.allows(&kdf) {
+        return Err(ApplicationError::BoundExceeded);
+    }
+    let nonce = fields.take(5)?.into_fixed()?;
+    let ciphertext = Zeroizing::new(fields.take(6)?.into_bytes()?);
+    if ciphertext.len() > MAX_PORTABLE_EXPORT_PLAINTEXT_BYTES {
+        return Err(ApplicationError::BoundExceeded);
+    }
+    let tag = fields.take(7)?.into_fixed()?;
+
+    let derived = Zeroizing::new(
+        argon2id(
+            &passphrase,
+            &kdf.salt,
+            kdf.iterations,
+            kdf.memory_kib,
+            kdf.lanes.into(),
+            32,
+            &Argon2idOptions::default(),
+        )
+        .map_err(|_| ApplicationError::InvalidInput)?,
+    );
+    let mut key = Zeroizing::new([0; 32]);
+    key.copy_from_slice(&derived);
+    let plaintext = Zeroizing::new(
+        xchacha20_poly1305_aead_decrypt(
+            &ciphertext,
+            &key,
+            &nonce,
+            &artifact_aad(&kdf, nonce),
+            &tag,
+        )
+        .ok_or(ApplicationError::AuthenticationFailed)?,
+    );
+    if plaintext.len() > MAX_PORTABLE_EXPORT_PLAINTEXT_BYTES {
+        return Err(ApplicationError::BoundExceeded);
+    }
+    parse_opened_snapshot(&plaintext)
+}
+
+fn encrypt_portable_plaintext(
+    plaintext: &[u8],
+    passphrase: Zeroizing<Vec<u8>>,
+    kdf: &Argon2idParametersV1,
+    nonce: [u8; NONCE_BYTES],
+) -> Result<PortableExportArtifactV1, ApplicationError> {
+    let derived = Zeroizing::new(
+        argon2id(
+            &passphrase,
+            &kdf.salt,
+            kdf.iterations,
+            kdf.memory_kib,
+            kdf.lanes.into(),
+            32,
+            &Argon2idOptions::default(),
+        )
+        .map_err(|_| ApplicationError::InvalidInput)?,
+    );
+    let mut key = Zeroizing::new([0; 32]);
+    key.copy_from_slice(&derived);
+    let aad = artifact_aad(kdf, nonce);
+    let (ciphertext, tag) = xchacha20_poly1305_aead_encrypt(plaintext, &key, &nonce, &aad);
+    let artifact = CborValue::Map(vec![
+        field(1, CborValue::Unsigned(VERSION)),
+        field(2, CborValue::Unsigned(PASSPHRASE_PROTECTION)),
+        field(3, CborValue::Unsigned(CRYPTO_SUITE_V1.into())),
+        field(4, kdf_value(kdf)),
+        field(5, CborValue::Bytes(nonce.to_vec())),
+        field(6, CborValue::Bytes(ciphertext)),
+        field(7, CborValue::Bytes(tag.to_vec())),
+    ]);
+    Ok(PortableExportArtifactV1 {
+        bytes: encode(&artifact),
+    })
+}
+
+fn parse_opened_snapshot(plaintext: &[u8]) -> Result<OpenedPortableSnapshotV1, ApplicationError> {
+    let mut fields =
+        SecretCborValue::new(decode(plaintext).map_err(|_| ApplicationError::IntegrityFailure)?)
+            .into_map()?;
+    fields.require_keys(&[1, 2, 3, 4, 5])?;
+    check_wire_value(fields.take(1)?.into_uint()?, VERSION)?;
+    let exact_bootstrap = Zeroizing::new(fields.take(2)?.into_bytes()?);
+    let entries_value = fields.take(3)?;
+    let encoded_entries = Zeroizing::new(encode(entries_value.get()));
+    let candidate_count = usize::try_from(fields.take(4)?.into_uint()?)
+        .map_err(|_| ApplicationError::BoundExceeded)?;
+    let expected_hash: [u8; 32] = fields.take(5)?.into_fixed()?;
+    if snapshot_hash(&exact_bootstrap, &encoded_entries)? != expected_hash {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+    verify_signed_bootstrap(&exact_bootstrap)?;
+
+    let mut entries = entries_value.into_values()?;
+    if entries.len() != candidate_count {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+    if candidate_count > MAX_CATALOG_ENTRIES * MAX_CANDIDATES_PER_ITEM {
+        return Err(ApplicationError::BoundExceeded);
+    }
+    let mut candidates: BTreeMap<ItemId, Vec<ItemCandidate>> = BTreeMap::new();
+    let mut next_identity = None;
+    while let Some(entry) = entries.pop() {
+        let mut entry = entry.into_map()?;
+        entry.require_keys(&[1, 2, 3])?;
+        let item_id = ItemId::new(entry.take(1)?.into_fixed()?);
+        let revision_id = RevisionId::new(entry.take(2)?.into_fixed()?);
+        let identity = (item_id, revision_id);
+        if next_identity.is_some_and(|next| identity >= next) {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        next_identity = Some(identity);
+        let encoded_revision = Zeroizing::new(entry.take(3)?.into_bytes()?);
+        let candidate = decode_item_revision(revision_id, &encoded_revision)?;
+        if candidate.item_id() != item_id {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        if !candidates.contains_key(&item_id) && candidates.len() == MAX_CATALOG_ENTRIES {
+            return Err(ApplicationError::BoundExceeded);
+        }
+        let item_candidates = candidates.entry(item_id).or_default();
+        if item_candidates.len() == MAX_CANDIDATES_PER_ITEM {
+            return Err(ApplicationError::BoundExceeded);
+        }
+        item_candidates.push(candidate);
+    }
+    for item_candidates in candidates.values_mut() {
+        item_candidates.reverse();
+    }
+
+    Ok(OpenedPortableSnapshotV1 {
+        _exact_bootstrap: exact_bootstrap,
+        candidates,
+    })
+}
+
+fn check_wire_value(actual: u64, expected: u64) -> Result<(), ApplicationError> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(ApplicationError::Unsupported)
     }
 }
 
@@ -219,34 +483,24 @@ pub(crate) fn export_portable_with_passphrase(
         return Err(ApplicationError::BoundExceeded);
     }
 
-    let derived = Zeroizing::new(
-        argon2id(
-            &passphrase,
-            &kdf.salt,
-            kdf.iterations,
-            kdf.memory_kib,
-            kdf.lanes.into(),
-            32,
-            &Argon2idOptions::default(),
-        )
-        .map_err(|_| ApplicationError::InvalidInput)?,
-    );
-    let mut key = Zeroizing::new([0; 32]);
-    key.copy_from_slice(&derived);
-    let aad = artifact_aad(&kdf, nonce);
-    let (ciphertext, tag) = xchacha20_poly1305_aead_encrypt(&plaintext, &key, &nonce, &aad);
-    let artifact = CborValue::Map(vec![
-        field(1, CborValue::Unsigned(VERSION)),
-        field(2, CborValue::Unsigned(PASSPHRASE_PROTECTION)),
-        field(3, CborValue::Unsigned(CRYPTO_SUITE_V1.into())),
-        field(4, kdf_value(&kdf)),
-        field(5, CborValue::Bytes(nonce.to_vec())),
-        field(6, CborValue::Bytes(ciphertext)),
-        field(7, CborValue::Bytes(tag.to_vec())),
-    ]);
-    Ok(PortableExportArtifactV1 {
-        bytes: encode(&artifact),
-    })
+    encrypt_portable_plaintext(&plaintext, passphrase, &kdf, nonce)
+}
+
+#[cfg(test)]
+pub(crate) fn encrypt_portable_for_test(
+    plaintext: &[u8],
+    passphrase: Zeroizing<Vec<u8>>,
+    policy: PortableExportPolicyV1,
+    randomness: PortableExportRandomnessV1,
+) -> PortableExportArtifactV1 {
+    let nonce = randomness.nonce();
+    let kdf = Argon2idParametersV1 {
+        memory_kib: policy.memory_kib,
+        iterations: policy.iterations,
+        lanes: policy.lanes,
+        salt: randomness.salt(),
+    };
+    encrypt_portable_plaintext(plaintext, passphrase, &kdf, nonce).unwrap()
 }
 
 pub(crate) fn snapshot_hash(
@@ -318,6 +572,10 @@ impl SecretCborValues {
     fn into_inner(mut self) -> Vec<CborValue> {
         self.0.take().unwrap_or_default()
     }
+
+    fn pop(&mut self) -> Option<SecretCborValue> {
+        self.0.as_mut()?.pop().map(SecretCborValue::new)
+    }
 }
 
 impl Drop for SecretCborValues {
@@ -342,12 +600,104 @@ impl SecretCborValue {
     fn take(&mut self) -> CborValue {
         self.0.take().expect("secret CBOR value is present")
     }
+
+    fn into_map(mut self) -> Result<SecretCborMap, ApplicationError> {
+        match self.take() {
+            CborValue::Map(entries) => Ok(SecretCborMap::new(entries)),
+            mut value => {
+                zeroize_cbor(&mut value);
+                Err(ApplicationError::IntegrityFailure)
+            }
+        }
+    }
+
+    fn into_values(mut self) -> Result<SecretCborValues, ApplicationError> {
+        match self.take() {
+            CborValue::Array(values) => Ok(SecretCborValues(Some(values))),
+            mut value => {
+                zeroize_cbor(&mut value);
+                Err(ApplicationError::IntegrityFailure)
+            }
+        }
+    }
+
+    fn into_uint(mut self) -> Result<u64, ApplicationError> {
+        match self.take() {
+            CborValue::Unsigned(value) => Ok(value),
+            mut value => {
+                zeroize_cbor(&mut value);
+                Err(ApplicationError::IntegrityFailure)
+            }
+        }
+    }
+
+    fn into_bytes(mut self) -> Result<Vec<u8>, ApplicationError> {
+        match self.take() {
+            CborValue::Bytes(value) => Ok(value),
+            mut value => {
+                zeroize_cbor(&mut value);
+                Err(ApplicationError::IntegrityFailure)
+            }
+        }
+    }
+
+    fn into_fixed<const N: usize>(self) -> Result<[u8; N], ApplicationError> {
+        let mut value = self.into_bytes()?;
+        let result = value
+            .as_slice()
+            .try_into()
+            .map_err(|_| ApplicationError::IntegrityFailure);
+        value.zeroize();
+        result
+    }
 }
 
 impl Drop for SecretCborValue {
     fn drop(&mut self) {
         if let Some(value) = &mut self.0 {
             zeroize_cbor(value);
+        }
+    }
+}
+
+struct SecretCborMap(Option<Vec<(CborValue, CborValue)>>);
+
+impl SecretCborMap {
+    fn new(entries: Vec<(CborValue, CborValue)>) -> Self {
+        Self(Some(entries))
+    }
+
+    fn require_keys(&self, expected: &[u64]) -> Result<(), ApplicationError> {
+        let entries = self.0.as_ref().expect("secret CBOR map is present");
+        if entries.len() != expected.len()
+            || entries.iter().any(
+                |(key, _)| !matches!(key, CborValue::Unsigned(value) if expected.contains(value)),
+            )
+        {
+            return Err(ApplicationError::IntegrityFailure);
+        }
+        Ok(())
+    }
+
+    fn take(&mut self, key: u64) -> Result<SecretCborValue, ApplicationError> {
+        let entries = self.0.as_mut().expect("secret CBOR map is present");
+        let index = entries
+            .iter()
+            .position(|(candidate, _)| candidate == &CborValue::Unsigned(key))
+            .ok_or(ApplicationError::IntegrityFailure)?;
+        let (mut encoded_key, value) = entries.remove(index);
+        zeroize_cbor(&mut encoded_key);
+        Ok(SecretCborValue::new(value))
+    }
+}
+
+impl Drop for SecretCborMap {
+    fn drop(&mut self) {
+        if let Some(entries) = &mut self.0 {
+            for (key, value) in entries {
+                zeroize_cbor(key);
+                zeroize_cbor(value);
+            }
         }
     }
 }
@@ -467,6 +817,19 @@ mod tests {
         assert_eq!(
             PortableExportPolicyV1::new(1, 1, 1),
             Err(ApplicationError::InvalidInput)
+        );
+        let open_policy = PortableOpenPolicyV1::new(8 * 1024, 2, 1).unwrap();
+        assert_eq!(
+            format!("{open_policy:?}"),
+            "PortableOpenPolicyV1 { max_memory_kib: 8192, max_iterations: 2, max_lanes: 1 }"
+        );
+        assert_eq!(
+            PortableOpenPolicyV1::new(1, 1, 1),
+            Err(ApplicationError::InvalidInput)
+        );
+        assert_eq!(
+            MAX_PORTABLE_EXPORT_ARTIFACT_BYTES,
+            MAX_PORTABLE_EXPORT_PLAINTEXT_BYTES + 4_096
         );
 
         let randomness = PortableExportRandomnessV1::new([0x5a; PORTABLE_EXPORT_RANDOM_BYTES]);

--- a/code/packages/rust/vault-pm-application/src/initialize.rs
+++ b/code/packages/rust/vault-pm-application/src/initialize.rs
@@ -477,10 +477,24 @@ pub(crate) fn verify_active_bootstrap(
     active: &ActiveStateV1,
     exact_bootstrap: &[u8],
 ) -> Result<BootstrapV1, ApplicationError> {
-    let bootstrap = BootstrapV1::decode(exact_bootstrap).map_err(map_bootstrap_format)?;
+    let bootstrap = verify_signed_bootstrap(exact_bootstrap)?;
     let bootstrap_id = bootstrap
         .id()
         .map_err(|_| ApplicationError::IntegrityFailure)?;
+    if bootstrap_id != active.bootstrap_id()
+        || bootstrap.vault_id != active.vault_id()
+        || AuthorityFingerprint::for_public_key(bootstrap.authority_public_key)
+            != active.authority_fingerprint()
+    {
+        return Err(ApplicationError::IntegrityFailure);
+    }
+    Ok(bootstrap)
+}
+
+pub(crate) fn verify_signed_bootstrap(
+    exact_bootstrap: &[u8],
+) -> Result<BootstrapV1, ApplicationError> {
+    let bootstrap = BootstrapV1::decode(exact_bootstrap).map_err(map_bootstrap_format)?;
     let bootstrap_preimage = bootstrap
         .signing_preimage()
         .map_err(|_| ApplicationError::IntegrityFailure)?;
@@ -490,10 +504,6 @@ pub(crate) fn verify_active_bootstrap(
             bootstrap.signature.as_bytes(),
             bootstrap.authority_public_key.as_bytes(),
         )
-        || bootstrap_id != active.bootstrap_id()
-        || bootstrap.vault_id != active.vault_id()
-        || AuthorityFingerprint::for_public_key(bootstrap.authority_public_key)
-            != active.authority_fingerprint()
     {
         return Err(ApplicationError::IntegrityFailure);
     }

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -38,9 +38,10 @@ pub use disclosure::{
 };
 pub use doctor::{VaultDoctorReportV1, VaultDoctorStateV1};
 pub use export::{
-    PortableExportArtifactV1, PortableExportPolicyV1, PortableExportRandomnessV1,
-    MAX_PORTABLE_EXPORT_PASSPHRASE_BYTES, MAX_PORTABLE_EXPORT_PLAINTEXT_BYTES,
-    PORTABLE_EXPORT_RANDOM_BYTES,
+    open_portable_with_passphrase, OpenedPortableSnapshotV1, PortableExportArtifactV1,
+    PortableExportPolicyV1, PortableExportRandomnessV1, PortableOpenPolicyV1,
+    MAX_PORTABLE_EXPORT_ARTIFACT_BYTES, MAX_PORTABLE_EXPORT_PASSPHRASE_BYTES,
+    MAX_PORTABLE_EXPORT_PLAINTEXT_BYTES, PORTABLE_EXPORT_RANDOM_BYTES,
 };
 pub use initialize::{
     complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init,

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1184,6 +1184,51 @@ mod tests {
         fields.remove(index).1
     }
 
+    fn replace_cbor_field(fields: &mut [(CborValue, CborValue)], key: u64, replacement: CborValue) {
+        let (_, value) = fields
+            .iter_mut()
+            .find(|(candidate, _)| candidate == &CborValue::Unsigned(key))
+            .unwrap();
+        *value = replacement;
+    }
+
+    fn refresh_portable_snapshot_hash(fields: &mut [(CborValue, CborValue)]) {
+        let CborValue::Bytes(mut bootstrap) = fields
+            .iter()
+            .find(|(key, _)| key == &CborValue::Unsigned(2))
+            .map(|(_, value)| value.clone())
+            .unwrap()
+        else {
+            panic!()
+        };
+        let entries = fields
+            .iter()
+            .find(|(key, _)| key == &CborValue::Unsigned(3))
+            .map(|(_, value)| encode_cbor(value))
+            .unwrap();
+        let hash = crate::export::snapshot_hash(&bootstrap, &entries).unwrap();
+        replace_cbor_field(fields, 5, CborValue::Bytes(hash.to_vec()));
+        bootstrap.zeroize();
+    }
+
+    fn authenticate_portable_snapshot(
+        fields: Vec<(CborValue, CborValue)>,
+        passphrase: &[u8],
+        randomness: u8,
+    ) -> Vec<u8> {
+        let mut plaintext = encode_cbor(&CborValue::Map(fields));
+        let artifact = crate::export::encrypt_portable_for_test(
+            &plaintext,
+            Zeroizing::new(passphrase.to_vec()),
+            crate::PortableExportPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+            crate::PortableExportRandomnessV1::new(
+                [randomness; crate::PORTABLE_EXPORT_RANDOM_BYTES],
+            ),
+        );
+        plaintext.zeroize();
+        artifact.into_bytes()
+    }
+
     fn add_item_randomness(seed: u8) -> AddItemRandomnessV1 {
         let mut bytes = [0; ADD_ITEM_RANDOM_BYTES];
         for (index, byte) in bytes.iter_mut().enumerate() {
@@ -1769,6 +1814,18 @@ mod tests {
                 0x96, 0x53, 0xa1, 0x3a,
             ]
         );
+        let opened = crate::open_portable_with_passphrase(
+            artifact.as_bytes(),
+            Zeroizing::new(b"separate export passphrase".to_vec()),
+            crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(opened.item_count(), 1);
+        assert_eq!(opened.candidate_count(), 1);
+        assert_eq!(
+            format!("{opened:?}"),
+            "OpenedPortableSnapshotV1(<redacted>)"
+        );
         for plaintext in [b"Portable portal".as_slice(), b"portable-export-secret"] {
             assert!(!artifact
                 .as_bytes()
@@ -1780,6 +1837,15 @@ mod tests {
             Zeroizing::new(b"wrong export passphrase".to_vec()),
         )
         .is_none());
+        assert_eq!(
+            crate::open_portable_with_passphrase(
+                artifact.as_bytes(),
+                Zeroizing::new(b"wrong export passphrase".to_vec()),
+                crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+            )
+            .err(),
+            Some(ApplicationError::AuthenticationFailed)
+        );
         let mut tampered = artifact.as_bytes().to_vec();
         let last = tampered.last_mut().unwrap();
         *last ^= 1;
@@ -1788,6 +1854,15 @@ mod tests {
             Zeroizing::new(b"separate export passphrase".to_vec()),
         )
         .is_none());
+        assert_eq!(
+            crate::open_portable_with_passphrase(
+                &tampered,
+                Zeroizing::new(b"separate export passphrase".to_vec()),
+                crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+            )
+            .err(),
+            Some(ApplicationError::AuthenticationFailed)
+        );
 
         let plaintext = crate::export::decrypt_portable_for_test(
             artifact.as_bytes(),
@@ -1849,6 +1924,91 @@ mod tests {
         assert_eq!(login.password, "portable-export-secret");
         encoded_revision.zeroize();
         crate::export::zeroize_cbor(&mut entries);
+
+        let CborValue::Map(mut invalid_count) = decode_cbor(&plaintext).unwrap() else {
+            panic!()
+        };
+        replace_cbor_field(&mut invalid_count, 4, CborValue::Unsigned(2));
+        let invalid_count =
+            authenticate_portable_snapshot(invalid_count, b"separate export passphrase", 0x5c);
+        assert_eq!(
+            crate::open_portable_with_passphrase(
+                &invalid_count,
+                Zeroizing::new(b"separate export passphrase".to_vec()),
+                crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+            )
+            .err(),
+            Some(ApplicationError::IntegrityFailure)
+        );
+
+        let CborValue::Map(mut invalid_hash) = decode_cbor(&plaintext).unwrap() else {
+            panic!()
+        };
+        replace_cbor_field(&mut invalid_hash, 5, CborValue::Bytes(vec![0; 32]));
+        let invalid_hash =
+            authenticate_portable_snapshot(invalid_hash, b"separate export passphrase", 0x5d);
+        assert_eq!(
+            crate::open_portable_with_passphrase(
+                &invalid_hash,
+                Zeroizing::new(b"separate export passphrase".to_vec()),
+                crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+            )
+            .err(),
+            Some(ApplicationError::IntegrityFailure)
+        );
+
+        let CborValue::Map(mut invalid_bootstrap) = decode_cbor(&plaintext).unwrap() else {
+            panic!()
+        };
+        let CborValue::Bytes(bootstrap_bytes) = invalid_bootstrap
+            .iter_mut()
+            .find(|(key, _)| key == &CborValue::Unsigned(2))
+            .map(|(_, value)| value)
+            .unwrap()
+        else {
+            panic!()
+        };
+        *bootstrap_bytes.last_mut().unwrap() ^= 1;
+        refresh_portable_snapshot_hash(&mut invalid_bootstrap);
+        let invalid_bootstrap =
+            authenticate_portable_snapshot(invalid_bootstrap, b"separate export passphrase", 0x5e);
+        assert_eq!(
+            crate::open_portable_with_passphrase(
+                &invalid_bootstrap,
+                Zeroizing::new(b"separate export passphrase".to_vec()),
+                crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+            )
+            .err(),
+            Some(ApplicationError::IntegrityFailure)
+        );
+
+        let CborValue::Map(mut mismatched_item) = decode_cbor(&plaintext).unwrap() else {
+            panic!()
+        };
+        let CborValue::Array(candidate_entries) = mismatched_item
+            .iter_mut()
+            .find(|(key, _)| key == &CborValue::Unsigned(3))
+            .map(|(_, value)| value)
+            .unwrap()
+        else {
+            panic!()
+        };
+        let CborValue::Map(candidate_fields) = &mut candidate_entries[0] else {
+            panic!()
+        };
+        replace_cbor_field(candidate_fields, 1, CborValue::Bytes(vec![0xfe; 16]));
+        refresh_portable_snapshot_hash(&mut mismatched_item);
+        let mismatched_item =
+            authenticate_portable_snapshot(mismatched_item, b"separate export passphrase", 0x5f);
+        assert_eq!(
+            crate::open_portable_with_passphrase(
+                &mismatched_item,
+                Zeroizing::new(b"separate export passphrase".to_vec()),
+                crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+            )
+            .err(),
+            Some(ApplicationError::IntegrityFailure)
+        );
         assert_eq!(
             format!("{artifact:?}"),
             "PortableExportArtifactV1(<encrypted>)"
@@ -1903,6 +2063,92 @@ mod tests {
                 .err(),
             Some(ApplicationError::IntegrityFailure)
         );
+
+        let artifact = session
+            .export_portable_with_passphrase(
+                &exact_bootstrap,
+                Zeroizing::new(b"separate export passphrase".to_vec()),
+                policy,
+                randomness(),
+            )
+            .unwrap();
+        let opened = crate::open_portable_with_passphrase(
+            artifact.as_bytes(),
+            Zeroizing::new(b"separate export passphrase".to_vec()),
+            crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(opened.item_count(), 0);
+        assert_eq!(opened.candidate_count(), 0);
+        assert_eq!(
+            crate::open_portable_with_passphrase(
+                artifact.as_bytes(),
+                Zeroizing::new(Vec::new()),
+                crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+            )
+            .err(),
+            Some(ApplicationError::InvalidInput)
+        );
+        assert_eq!(
+            crate::open_portable_with_passphrase(
+                artifact.as_bytes(),
+                Zeroizing::new(vec![0x61; crate::MAX_PORTABLE_EXPORT_PASSPHRASE_BYTES + 1]),
+                crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+            )
+            .err(),
+            Some(ApplicationError::InvalidInput)
+        );
+
+        let CborValue::Map(mut unsupported_version) = decode_cbor(artifact.as_bytes()).unwrap()
+        else {
+            panic!()
+        };
+        replace_cbor_field(&mut unsupported_version, 1, CborValue::Unsigned(2));
+        assert_eq!(
+            crate::open_portable_with_passphrase(
+                &encode_cbor(&CborValue::Map(unsupported_version)),
+                Zeroizing::new(b"separate export passphrase".to_vec()),
+                crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+            )
+            .err(),
+            Some(ApplicationError::Unsupported)
+        );
+
+        let CborValue::Map(mut excessive_kdf) = decode_cbor(artifact.as_bytes()).unwrap() else {
+            panic!()
+        };
+        let CborValue::Map(kdf_fields) = excessive_kdf
+            .iter_mut()
+            .find(|(key, _)| key == &CborValue::Unsigned(4))
+            .map(|(_, value)| value)
+            .unwrap()
+        else {
+            panic!()
+        };
+        replace_cbor_field(kdf_fields, 1, CborValue::Unsigned(16 * 1024));
+        assert_eq!(
+            crate::open_portable_with_passphrase(
+                &encode_cbor(&CborValue::Map(excessive_kdf)),
+                Zeroizing::new(b"separate export passphrase".to_vec()),
+                crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+            )
+            .err(),
+            Some(ApplicationError::BoundExceeded)
+        );
+
+        let CborValue::Map(mut unknown_field) = decode_cbor(artifact.as_bytes()).unwrap() else {
+            panic!()
+        };
+        unknown_field.push((CborValue::Unsigned(8), CborValue::Null));
+        assert_eq!(
+            crate::open_portable_with_passphrase(
+                &encode_cbor(&CborValue::Map(unknown_field)),
+                Zeroizing::new(b"separate export passphrase".to_vec()),
+                crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+            )
+            .err(),
+            Some(ApplicationError::IntegrityFailure)
+        );
     }
 
     #[test]
@@ -1948,6 +2194,14 @@ mod tests {
                 crate::PortableExportRandomnessV1::new([0x7e; crate::PORTABLE_EXPORT_RANDOM_BYTES]),
             )
             .unwrap();
+        let opened = crate::open_portable_with_passphrase(
+            artifact.as_bytes(),
+            Zeroizing::new(b"conflict export passphrase".to_vec()),
+            crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(opened.item_count(), 1);
+        assert_eq!(opened.candidate_count(), 2);
         let plaintext = crate::export::decrypt_portable_for_test(
             artifact.as_bytes(),
             Zeroizing::new(b"conflict export passphrase".to_vec()),
@@ -1984,6 +2238,31 @@ mod tests {
         }
         assert_eq!(actual_revision_ids, expected_revision_ids);
         crate::export::zeroize_cbor(&mut entries);
+
+        let CborValue::Map(mut reversed_snapshot) = decode_cbor(&plaintext).unwrap() else {
+            panic!()
+        };
+        let CborValue::Array(candidate_entries) = reversed_snapshot
+            .iter_mut()
+            .find(|(key, _)| key == &CborValue::Unsigned(3))
+            .map(|(_, value)| value)
+            .unwrap()
+        else {
+            panic!()
+        };
+        candidate_entries.reverse();
+        refresh_portable_snapshot_hash(&mut reversed_snapshot);
+        let reversed_snapshot =
+            authenticate_portable_snapshot(reversed_snapshot, b"conflict export passphrase", 0x7f);
+        assert_eq!(
+            crate::open_portable_with_passphrase(
+                &reversed_snapshot,
+                Zeroizing::new(b"conflict export passphrase".to_vec()),
+                crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+            )
+            .err(),
+            Some(ApplicationError::IntegrityFailure)
+        );
     }
 
     #[test]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1333,9 +1333,14 @@ changelog, focused build, and downstream validation.
        collected Argon2id passphrase with fresh salt/nonce, header-bound AEAD,
        a signed-bootstrap-bound snapshot hash, identity-free diagnostics,
        wipe-on-drop plaintext, and host-neutral destination handling;
-   7d-2. authenticated portable artifact opening, snapshot verification, and
-       import into a new vault with new item, revision, object, and encryption
-       identities, followed by an independent restore/open comparison; and
+   7d-2a. completed no-write authenticated portable artifact opening with
+       host-approved Argon2id resource ceilings, strict canonical/header bounds,
+       authentication-before-plaintext parsing, signed-bootstrap and complete
+       snapshot validation, opaque secret-bearing custody, and count-only
+       diagnostics;
+   7d-2b. consume an opened portable snapshot into a new vault with new item,
+       revision, object, and encryption identities, followed by an independent
+       restore/open comparison; and
    7e-1. completed safe five-state status workflow, strictly decoding bounded
        owner state while locked and exposing only authenticated aggregate item,
        candidate, and conflict counts while unlocked;

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -634,10 +634,37 @@ types redact their bytes from diagnostics.
 
 Phase 1A returns exact encrypted artifact bytes to the host; it does not choose
 or write a path, overwrite a destination, report backup completion, or retain
-provider authority. Authenticated artifact opening, snapshot-hash verification,
-and cross-vault import are the next paired workflow. Import must create a new
-vault and new item, revision, object, and encryption identities rather than
-publishing source identities into the target repository.
+provider authority.
+
+Artifact opening is a separate no-write boundary. The host passes untrusted
+bytes, an owned separately collected passphrase, and explicit maximum Argon2id
+memory, iteration, and lane costs. The encrypted artifact is bounded to 512 MiB
+plus 4 KiB of framing before CBOR decode. The opener rejects a header whose
+valid KDF cost exceeds the host-approved ceiling before performing Argon2id;
+the ceiling itself must remain inside the V1 Argon2id bounds.
+
+Opening strictly requires the exact closed canonical header above, supported
+version/protection/suite values, exact salt/nonce/tag widths, and ciphertext no
+larger than 512 MiB. It derives the export key and authenticates the complete
+header-bound artifact before decoding any plaintext. A wrong passphrase and a
+valid-shape artifact with a wrong authentication tag both return the same
+closed `AuthenticationFailed` class.
+
+After authentication, the opener strictly decodes the closed snapshot, checks
+the exact candidate count and domain-separated hash, and verifies the embedded
+bootstrap's authority public key and self-signature. Candidate entries must be
+strictly increasing by source item/revision identity, unique, bounded to
+100,000 items and 16 candidates per item, canonically decode as item revisions,
+and reproduce the entry's item identity. Every intermediate plaintext CBOR
+tree, passphrase, derived key, ciphertext copy, bootstrap, encoded revision,
+and hash preimage is wiped on every return path.
+
+Success returns an opaque secret-bearing application object with public item
+and candidate counts only. It has no document, bootstrap, or source-identity
+accessor, cannot be cloned, and redacts diagnostics. Opening does not initialize
+or write a target vault. The next workflow consumes this object and creates a
+new vault with new item, revision, object, and encryption identities rather
+than publishing source identities into the target repository.
 
 ## 12. Audit and status
 
@@ -691,7 +718,8 @@ Additional V1 bounds are checked before allocation:
 | search query | 256 bytes |
 | list/search results | 10,000 |
 | history request | 4,096 |
-| portable export plaintext | 512 MiB |
+| portable export plaintext/ciphertext | 512 MiB |
+| portable encrypted artifact | 512 MiB + 4 KiB framing |
 
 The public error taxonomy is:
 


### PR DESCRIPTION
## Summary

- add a public no-write boundary for authenticating and strictly opening an untrusted portable vault export
- enforce a host-approved Argon2id resource ceiling before artifact-controlled KDF work
- validate the closed canonical header, header-bound AEAD, snapshot count/hash, signed bootstrap, candidate order/bounds, canonical revisions, and item binding
- return a non-cloneable opaque snapshot with aggregate counts only while keeping source identities and documents inaccessible
- split the roadmap so cross-vault re-identification remains the next independently reviewable slice

## Security properties

- bounds the encrypted artifact before decode and the ciphertext/plaintext before allocation or parsing
- authenticates before parsing plaintext; wrong credentials and valid-shape tag tampering share AuthenticationFailed
- zeroizes passphrase, derived keys, plaintext, encoded revisions, bootstrap bytes, and partial secret-bearing CBOR trees on every return path
- performs no target-vault, local-state, repository, provider, or destination writes
- preserves the existing fixed encrypted export vector

## Validation

- cargo fmt --check --package coding_adventures_vault_pm_application
- cargo test -p coding_adventures_vault_pm_application (108 passed)
- cargo clippy -p coding_adventures_vault_pm_application --all-targets -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc -p coding_adventures_vault_pm_application --no-deps
- bash vault-pm-application/BUILD
- cargo tarpaulin LLVM: 2,894 / 3,042 production lines (95.13%); export/opening 367 / 394 (93.15%)
- build planner: 51 Starlark files, 1,001 packages, 1 changed, 21 affected; all 21 built
- git diff --check
