### PR TITLE
test(mosaic): exercise Rust engine through SwiftUI binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
       needs_cpp: ${{ steps.toolchains.outputs.needs_cpp }}
       needs_venture_windows: ${{ steps.venture-windows.outputs.required }}
       needs_mosaic_xaml_windows: ${{ steps.mosaic-xaml-windows.outputs.required }}
+      needs_mosaic_swift_runtime: ${{ steps.mosaic-swift-runtime.outputs.required }}
       diff_base: ${{ steps.diff-base.outputs.base }}
       is_main: ${{ steps.detect-main.outputs.is_main }}
       build_shards: ${{ steps.detect.outputs.build_shards }}
@@ -127,6 +128,7 @@ jobs:
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_linux_oci.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_venture_windows_ci_acceptance.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_xaml_windows_ci_acceptance.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_swift_runtime_ci_acceptance.py'
           python3 code/scripts/build_tool_conformance.py validate-corpus
           python3 code/scripts/build_tool_conformance_execution.py validate-contract
           python3 code/scripts/package_parity_report.py --format json --fail-on-collisions > /tmp/package-parity-report.json
@@ -226,6 +228,15 @@ jobs:
         shell: bash
         run: |
           python3 code/scripts/mosaic_xaml_windows_ci_acceptance.py \
+            build-plan.json \
+            --repo-root . \
+            --diff-base "${{ steps.diff-base.outputs.base }}" >> "$GITHUB_OUTPUT"
+
+      - name: Detect Mosaic Swift runtime acceptance
+        id: mosaic-swift-runtime
+        shell: bash
+        run: |
+          python3 code/scripts/mosaic_swift_runtime_ci_acceptance.py \
             build-plan.json \
             --repo-root . \
             --diff-base "${{ steps.diff-base.outputs.base }}" >> "$GITHUB_OUTPUT"
@@ -530,7 +541,7 @@ jobs:
           clang --version | head -1
 
       - name: Set up Rust
-        if: needs.detect.outputs.needs_rust == 'true' || needs.detect.outputs.needs_venture_windows == 'true' || needs.detect.outputs.needs_mosaic_xaml_windows == 'true'
+        if: needs.detect.outputs.needs_rust == 'true' || needs.detect.outputs.needs_venture_windows == 'true' || needs.detect.outputs.needs_mosaic_xaml_windows == 'true' || needs.detect.outputs.needs_mosaic_swift_runtime == 'true'
         # Uses the `stable` channel (matching the rest of this repo's Rust CI).
         # NOTE on the -clippy gate: clippy adds/tightens lints on each stable
         # release, so a new Rust release can surface new lints on `main` — treat
@@ -908,6 +919,26 @@ jobs:
           set -euo pipefail
           cd code/packages/rust
           cargo test -p venture-browser-macos
+
+      - name: Round-trip Rust engine through standard SwiftUI binding
+        if: runner.os == 'macOS' && needs.detect.outputs.needs_mosaic_swift_runtime == 'true'
+        shell: bash
+        timeout-minutes: 10
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/mosaic-swift-taskapp"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend swiftui --output "$output" --emit-project
+          cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance
+
+          harness="$RUNNER_TEMP/mosaic-swift-runtime-conformance"
+          cp -R code/packages/rust/mosaic-app-bindings/conformance/swiftui "$harness"
+          mkdir -p "$harness/Sources/CMosaicRuntime/include"
+          cp "$output/swiftui/Sources/App/MosaicRuntimeHost.swift" "$harness/Sources/Conformance/MosaicRuntimeHost.swift"
+          cp "$output/swiftui/Sources/CMosaicRuntime/CMosaicRuntime.c" "$harness/Sources/CMosaicRuntime/CMosaicRuntime.c"
+          cp "$output/swiftui/Sources/CMosaicRuntime/include/CMosaicRuntime.h" "$harness/Sources/CMosaicRuntime/include/CMosaicRuntime.h"
+
+          export MOSAIC_APP_LIBRARY="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.dylib"
+          swift run --package-path "$harness" Conformance
 
       - name: Build complete Mosaic TaskApp WinUI shell
         if: runner.os == 'Windows' && needs.detect.outputs.needs_mosaic_xaml_windows == 'true'

--- a/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
+++ b/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Execute the generated SwiftUI binding and C loader against the shared Rust
+  conformance dylib in macOS CI, covering startup, dispatch, snapshot/restore,
+  prop-change notification, buffer ownership, and teardown through the real ABI.
 - Make the XAML Rust-runtime conformance executable independent of WinUI desktop
   initialization after the complete generated TaskApp has compiled against the
   real Windows App SDK, and bound the CI execution with an explicit timeout.

--- a/code/packages/rust/mosaic-app-bindings/README.md
+++ b/code/packages/rust/mosaic-app-bindings/README.md
@@ -19,6 +19,10 @@ variable to a library name or absolute path. The conventional fallback name is
 For SwiftUI, set `MOSAIC_APP_LIBRARY` to the application dylib path. Without an
 explicit path the loader first checks symbols linked into the process, then tries
 `libmosaic_app.dylib` and `mosaic_app.dylib`.
+macOS CI compiles the exact binding and C loader from a complete generated
+TaskApp project with the shared `mosaic-app-conformance` dylib, then verifies
+startup, semantic dispatch, snapshot/restore, notification, buffer ownership,
+and teardown.
 
 For XAML, set `MOSAIC_APP_LIBRARY` to the application DLL path or place
 `mosaic_app.dll` beside the emitted project. The project copies native DLLs next

--- a/code/packages/rust/mosaic-app-bindings/conformance/swiftui/Package.swift
+++ b/code/packages/rust/mosaic-app-bindings/conformance/swiftui/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.10
+import PackageDescription
+
+let package = Package(
+  name: "MosaicSwiftRuntimeConformance",
+  platforms: [.macOS(.v13)],
+  targets: [
+    .target(
+      name: "CMosaicRuntime",
+      path: "Sources/CMosaicRuntime",
+      publicHeadersPath: "include",
+      linkerSettings: [.linkedLibrary("dl")]
+    ),
+    .executableTarget(
+      name: "Conformance",
+      dependencies: ["CMosaicRuntime"],
+      path: "Sources/Conformance"
+    ),
+  ]
+)

--- a/code/packages/rust/mosaic-app-bindings/conformance/swiftui/README.md
+++ b/code/packages/rust/mosaic-app-bindings/conformance/swiftui/README.md
@@ -1,0 +1,12 @@
+# SwiftUI runtime conformance
+
+This macOS console harness compiles the exact `MosaicRuntimeHost.swift`, C loader,
+and C header emitted into a generated SwiftUI project. It loads the shared
+`mosaic-app-conformance` dylib and verifies startup, revisions, prop projection,
+semantic dispatch, snapshot/restore, prop-change notification, and teardown.
+
+CI generates the complete TaskApp project, copies its generated binding sources
+into this harness in a temporary workspace, and runs the result. The binding and
+loader are deliberately not duplicated here. The harness declares only the
+source-compatible host protocol that the generated TaskApp normally owns, so it
+can exercise the unchanged runtime host without launching a SwiftUI window.

--- a/code/packages/rust/mosaic-app-bindings/conformance/swiftui/Sources/Conformance/Program.swift
+++ b/code/packages/rust/mosaic-app-bindings/conformance/swiftui/Sources/Conformance/Program.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+@objc protocol MosaicHostBridgeObject {
+  func applyProps() -> NSDictionary?
+  func handleEvent(_ envelope: NSDictionary, name: NSString) -> NSDictionary?
+  @objc optional func node(named name: NSString) -> NSObject?
+  @objc optional func setPropsChangedHandler(_ handler: @escaping () -> Void)
+}
+
+private func require(_ condition: @autoclosure () -> Bool, _ assertion: String) {
+  guard condition() else { fatalError("Failed assertion: \(assertion)") }
+}
+
+private func object(_ value: NSDictionary?, _ assertion: String) -> NSDictionary {
+  guard let value else { fatalError("Failed assertion: \(assertion) was nil") }
+  require(value["error"] == nil, "\(assertion) returned an error")
+  return value
+}
+
+private func integer(_ value: Any?, _ assertion: String) -> Int64 {
+  guard let number = value as? NSNumber else {
+    fatalError("Failed assertion: \(assertion) was not numeric")
+  }
+  return number.int64Value
+}
+
+private func props(_ update: NSDictionary, _ assertion: String) -> NSDictionary {
+  guard let value = update["props"] as? NSDictionary else {
+    fatalError("Failed assertion: \(assertion) props were missing")
+  }
+  return value
+}
+
+private func run() {
+  guard let host = MosaicRuntimeHost.load() else {
+    fatalError("standard SwiftUI binding did not load the Rust app")
+  }
+  defer { host.close() }
+
+  let started = object(host.applyProps(), "startup update")
+  let startedProps = props(started, "startup update")
+  require(integer(started["revision"], "startup revision") == 1, "startup revision")
+  require(integer(startedProps["count"], "initial count") == 0, "initial count")
+  require(startedProps["platform"] as? String == "apple", "startup platform")
+  require(startedProps["status"] as? String == "started", "startup status")
+
+  var notificationCount = 0
+  host.setPropsChangedHandler { notificationCount += 1 }
+
+  let event: NSDictionary = ["payload": ["amount": 4]]
+  let dispatched = object(
+    host.handleEvent(event, name: "increment" as NSString),
+    "dispatch update"
+  )
+  let dispatchedProps = props(dispatched, "dispatch update")
+  require(integer(dispatched["revision"], "dispatch revision") == 2, "dispatch revision")
+  require(integer(dispatchedProps["count"], "dispatched count") == 4, "dispatched count")
+  require(dispatchedProps["status"] as? String == "dispatched", "dispatch status")
+  require(notificationCount == 1, "dispatch props-change notification")
+
+  let snapshot = object(host.snapshot(), "snapshot")
+  require(snapshot["schema"] as? String == "mosaic-app-conformance/counter", "snapshot schema")
+  require(integer(snapshot["version"], "snapshot version") == 1, "snapshot version")
+  require((snapshot["bytes"] as? NSArray)?.count == 8, "snapshot bytes")
+
+  let restored = object(host.restore(snapshot), "restore update")
+  let restoredProps = props(restored, "restore update")
+  require(integer(restored["revision"], "restore revision") == 3, "restore revision")
+  require(integer(restoredProps["count"], "restored count") == 4, "restored count")
+  require(restoredProps["status"] as? String == "restored", "restore status")
+  require(notificationCount == 2, "restore props-change notification")
+
+  print("Mosaic SwiftUI Rust runtime conformance passed")
+}
+
+@main
+private enum ConformanceMain {
+  static func main() {
+    run()
+  }
+}

--- a/code/scripts/mosaic_swift_runtime_ci_acceptance.py
+++ b/code/scripts/mosaic_swift_runtime_ci_acceptance.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Derive the Mosaic Swift runtime conformance flag from a build plan."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+ACCEPTANCE_PACKAGES = frozenset(
+    {
+        "rust/mosaic-app-bindings",
+        "rust/mosaic-app-capi",
+        "rust/mosaic-app-conformance",
+        "rust/mosaic-app-runtime",
+        "rust/mosaic-compile",
+        "rust/mosaic-emit-swiftui",
+        "rust/mosaic-package-artifact-builder",
+        "rust/moslayout-compiler",
+        "rust/mosmodel-compiler",
+        "rust/mosstyle-compiler",
+        "unknown/programs/task-app",
+    }
+)
+ACCEPTANCE_PACKAGE_PREFIXES = ("unknown/mosaic-pkg-",)
+CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+
+
+def requires_mosaic_swift_runtime(
+    plan: dict[str, Any], *, workflow_changed: bool = False
+) -> bool:
+    """Return whether this plan must exercise the generated Swift binding."""
+
+    if workflow_changed:
+        return True
+    affected = plan.get("affected_packages")
+    if affected is None:
+        return True
+    if not isinstance(affected, list):
+        raise ValueError("affected_packages must be an array or null")
+    return any(
+        package in ACCEPTANCE_PACKAGES
+        or package.startswith(ACCEPTANCE_PACKAGE_PREFIXES)
+        for package in affected
+    )
+
+
+def workflow_changed(repo_root: Path, diff_base: str) -> bool:
+    """Return whether the main CI workflow differs from the selected base."""
+
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--quiet",
+            f"{diff_base}...HEAD",
+            "--",
+            CI_WORKFLOW_PATH,
+        ],
+        cwd=repo_root,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        raise RuntimeError(f"git diff exited with status {result.returncode}")
+    return result.returncode == 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("plan", type=Path)
+    parser.add_argument("--repo-root", type=Path)
+    parser.add_argument("--diff-base")
+    args = parser.parse_args()
+
+    if (args.repo_root is None) != (args.diff_base is None):
+        parser.error("--repo-root and --diff-base must be provided together")
+
+    with args.plan.open(encoding="utf-8") as handle:
+        plan = json.load(handle)
+    if not isinstance(plan, dict):
+        raise ValueError("build plan root must be an object")
+
+    changed = False
+    if args.repo_root is not None and args.diff_base is not None:
+        changed = workflow_changed(args.repo_root, args.diff_base)
+
+    required = requires_mosaic_swift_runtime(plan, workflow_changed=changed)
+    print(f"required={'true' if required else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/tests/test_mosaic_swift_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_swift_runtime_ci_acceptance.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "mosaic_swift_runtime_ci_acceptance.py"
+WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "ci.yml"
+SWIFT_CONFORMANCE = (
+    Path(__file__).resolve().parents[2]
+    / "packages"
+    / "rust"
+    / "mosaic-app-bindings"
+    / "conformance"
+    / "swiftui"
+)
+SPEC = importlib.util.spec_from_file_location("mosaic_swift_runtime_ci_acceptance", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class MosaicSwiftRuntimeCIAcceptanceTests(unittest.TestCase):
+    def test_force_plan_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_swift_runtime({"affected_packages": None})
+        )
+
+    def test_swift_emitter_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_swift_runtime(
+                {"affected_packages": ["rust/mosaic-emit-swiftui"]}
+            )
+        )
+
+    def test_standard_runtime_binding_requires_acceptance(self) -> None:
+        for package in (
+            "rust/mosaic-app-bindings",
+            "rust/mosaic-app-capi",
+            "rust/mosaic-app-conformance",
+            "rust/mosaic-app-runtime",
+        ):
+            with self.subTest(package=package):
+                self.assertTrue(
+                    MODULE.requires_mosaic_swift_runtime(
+                        {"affected_packages": [package]}
+                    )
+                )
+
+    def test_task_app_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_swift_runtime(
+                {"affected_packages": ["unknown/programs/task-app"]}
+            )
+        )
+
+    def test_standard_mosaic_package_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_swift_runtime(
+                {"affected_packages": ["unknown/mosaic-pkg-grid"]}
+            )
+        )
+
+    def test_unrelated_plan_skips_acceptance(self) -> None:
+        self.assertFalse(
+            MODULE.requires_mosaic_swift_runtime(
+                {"affected_packages": ["rust/html-parser"]}
+            )
+        )
+
+    def test_workflow_change_self_tests_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_swift_runtime(
+                {"affected_packages": []}, workflow_changed=True
+            )
+        )
+
+    def test_invalid_affected_packages_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "array or null"):
+            MODULE.requires_mosaic_swift_runtime({"affected_packages": "all"})
+
+    def test_cli_emits_github_output_value(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            plan = Path(directory) / "build-plan.json"
+            plan.write_text(
+                '{"affected_packages":["rust/mosaic-emit-swiftui"]}',
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), str(plan)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.stdout, "required=true\n")
+
+    def test_workflow_routes_rust_and_swift_acceptance(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "needs_mosaic_swift_runtime: "
+            "${{ steps.mosaic-swift-runtime.outputs.required }}",
+            workflow,
+        )
+        self.assertIn(
+            "python3 code/scripts/mosaic_swift_runtime_ci_acceptance.py",
+            workflow,
+        )
+        self.assertIn(
+            "needs_mosaic_swift_runtime == 'true'", workflow
+        )
+        self.assertIn(
+            "Round-trip Rust engine through standard SwiftUI binding", workflow
+        )
+        self.assertIn("timeout-minutes: 10", workflow)
+        self.assertIn(
+            "mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app",
+            workflow,
+        )
+        self.assertIn("--backend swiftui --output \"$output\" --emit-project", workflow)
+        self.assertIn(
+            "cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance",
+            workflow,
+        )
+        self.assertIn("Sources/App/MosaicRuntimeHost.swift", workflow)
+        self.assertIn("Sources/CMosaicRuntime/CMosaicRuntime.c", workflow)
+        self.assertIn("swift run --package-path \"$harness\" Conformance", workflow)
+        self.assertIn("MOSAIC_APP_LIBRARY", workflow)
+
+    def test_harness_does_not_duplicate_the_generated_binding(self) -> None:
+        program = SWIFT_CONFORMANCE / "Sources" / "Conformance" / "Program.swift"
+        package = (SWIFT_CONFORMANCE / "Package.swift").read_text(encoding="utf-8")
+        self.assertTrue(program.is_file())
+        self.assertFalse(
+            (
+                SWIFT_CONFORMANCE
+                / "Sources"
+                / "Conformance"
+                / "MosaicRuntimeHost.swift"
+            ).exists()
+        )
+        self.assertIn('name: "CMosaicRuntime"', package)
+        self.assertIn('name: "Conformance"', package)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -304,8 +304,10 @@ unblocks multiple downstream targets; never count source generation as completio
 - [ ] Add launch-and-dispatch conformance fixtures for every native backend.
   - [x] XAML/.NET loads the shared Rust conformance DLL and round-trips startup,
     typed props, semantic dispatch, revised props, buffers, and teardown.
-  - [ ] Promote the same shared Rust fixture through SwiftUI, Qt/QML, Compose,
-    and Flutter standard bindings.
+  - [x] SwiftUI/Foundation loads the shared Rust conformance dylib and round-trips
+    startup, dispatch, snapshot/restore, notification, and teardown in macOS CI.
+  - [ ] Promote the same shared Rust fixture through Qt/QML, Compose, and Flutter
+    standard bindings.
 - [x] Gate the complete package-expanded XAML TaskApp on GitHub-hosted Windows
   with real WinUI compilation and executable production.
   - [x] Allocate `For` row-view-model and projection names per loop rather than


### PR DESCRIPTION
## Summary

- add a macOS conformance harness that compiles the exact generated SwiftUI runtime binding and C loader
- round-trip the shared Rust fixture through startup, dispatch, snapshot/restore, notification, buffer ownership, and teardown
- route relevant Mosaic package changes into the acceptance gate and update the UI38 completion backlog

## Validation

- generated TaskApp SwiftUI project + `mosaic-app-conformance` dylib + `swift run` conformance round trip
- `python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_swift_runtime_ci_acceptance.py'`\n- neighboring XAML and Venture CI-routing unit tests\n- `cargo test -p mosaic-app-bindings`\n- `cargo test -p mosaic-app-conformance`\n- `cargo test -p mosaic-emit-swiftui --lib` plus TaskApp and Venture SwiftUI integration suites\n- `cargo test -p mosaic-package-artifact-builder --lib`\n- workflow YAML parse and `git diff --check`