### PR TITLE
test(mosaic): exercise Rust engine through Qt binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       needs_venture_windows: ${{ steps.venture-windows.outputs.required }}
       needs_mosaic_xaml_windows: ${{ steps.mosaic-xaml-windows.outputs.required }}
       needs_mosaic_swift_runtime: ${{ steps.mosaic-swift-runtime.outputs.required }}
+      needs_mosaic_qt_runtime: ${{ steps.mosaic-qt-runtime.outputs.required }}
       diff_base: ${{ steps.diff-base.outputs.base }}
       is_main: ${{ steps.detect-main.outputs.is_main }}
       build_shards: ${{ steps.detect.outputs.build_shards }}
@@ -129,6 +130,7 @@ jobs:
           python3 -m unittest discover -s code/scripts/tests -p 'test_venture_windows_ci_acceptance.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_xaml_windows_ci_acceptance.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_swift_runtime_ci_acceptance.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_qt_runtime_ci_acceptance.py'
           python3 code/scripts/build_tool_conformance.py validate-corpus
           python3 code/scripts/build_tool_conformance_execution.py validate-contract
           python3 code/scripts/package_parity_report.py --format json --fail-on-collisions > /tmp/package-parity-report.json
@@ -237,6 +239,15 @@ jobs:
         shell: bash
         run: |
           python3 code/scripts/mosaic_swift_runtime_ci_acceptance.py \
+            build-plan.json \
+            --repo-root . \
+            --diff-base "${{ steps.diff-base.outputs.base }}" >> "$GITHUB_OUTPUT"
+
+      - name: Detect Mosaic Qt runtime acceptance
+        id: mosaic-qt-runtime
+        shell: bash
+        run: |
+          python3 code/scripts/mosaic_qt_runtime_ci_acceptance.py \
             build-plan.json \
             --repo-root . \
             --diff-base "${{ steps.diff-base.outputs.base }}" >> "$GITHUB_OUTPUT"
@@ -541,7 +552,7 @@ jobs:
           clang --version | head -1
 
       - name: Set up Rust
-        if: needs.detect.outputs.needs_rust == 'true' || needs.detect.outputs.needs_venture_windows == 'true' || needs.detect.outputs.needs_mosaic_xaml_windows == 'true' || needs.detect.outputs.needs_mosaic_swift_runtime == 'true'
+        if: needs.detect.outputs.needs_rust == 'true' || needs.detect.outputs.needs_venture_windows == 'true' || needs.detect.outputs.needs_mosaic_xaml_windows == 'true' || needs.detect.outputs.needs_mosaic_swift_runtime == 'true' || needs.detect.outputs.needs_mosaic_qt_runtime == 'true'
         # Uses the `stable` channel (matching the rest of this repo's Rust CI).
         # NOTE on the -clippy gate: clippy adds/tightens lints on each stable
         # release, so a new Rust release can surface new lints on `main` — treat
@@ -564,7 +575,7 @@ jobs:
           sudo apt-get install -y libcairo2-dev
 
       - name: Install Venture Qt acceptance dependencies
-        if: needs.detect.outputs.needs_venture_windows == 'true' && runner.os == 'Linux'
+        if: (needs.detect.outputs.needs_venture_windows == 'true' || needs.detect.outputs.needs_mosaic_qt_runtime == 'true') && runner.os == 'Linux'
         uses: jurplel/install-qt-action@v4
         with:
           version: '6.8.3'
@@ -939,6 +950,26 @@ jobs:
 
           export MOSAIC_APP_LIBRARY="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.dylib"
           swift run --package-path "$harness" Conformance
+
+      - name: Round-trip Rust engine through standard Qt binding
+        if: runner.os == 'Linux' && needs.detect.outputs.needs_mosaic_qt_runtime == 'true'
+        shell: bash
+        timeout-minutes: 10
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/mosaic-qt-taskapp"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend qt --output "$output" --emit-project
+          cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance
+
+          harness="$RUNNER_TEMP/mosaic-qt-runtime-conformance"
+          cp -R code/packages/rust/mosaic-app-bindings/conformance/qt "$harness"
+          cp "$output/qt/MosaicHost.cpp" "$harness/MosaicHost.cpp"
+          cp "$output/qt/MosaicHost.h" "$harness/MosaicHost.h"
+
+          cmake -S "$harness" -B "$harness/build" -DCMAKE_BUILD_TYPE=Release
+          cmake --build "$harness/build" --config Release --parallel
+          export MOSAIC_APP_LIBRARY="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.so"
+          "$harness/build/mosaic_qt_runtime_conformance"
 
       - name: Build complete Mosaic TaskApp WinUI shell
         if: runner.os == 'Windows' && needs.detect.outputs.needs_mosaic_xaml_windows == 'true'

--- a/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
+++ b/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Execute the generated Qt/QML host against the shared Rust conformance library
+  in headless Linux CI, covering startup, dispatch, snapshot/restore, buffer
+  ownership, and teardown through the real ABI.
 - Execute the generated SwiftUI binding and C loader against the shared Rust
   conformance dylib in macOS CI, covering startup, dispatch, snapshot/restore,
   prop-change notification, buffer ownership, and teardown through the real ABI.

--- a/code/packages/rust/mosaic-app-bindings/README.md
+++ b/code/packages/rust/mosaic-app-bindings/README.md
@@ -38,3 +38,6 @@ platform's conventional `mosaic_app` dynamic-library names.
 For Qt/QML, set `MOSAIC_APP_LIBRARY` to the application library path or package
 it under the platform's conventional `mosaic_app` name. The generated QObject
 host uses only Qt Core APIs and is installed automatically by the artifact builder.
+Linux CI compiles the exact host from a complete generated TaskApp project with
+the shared `mosaic-app-conformance` library, then verifies startup, semantic
+dispatch, snapshot/restore, buffer ownership, and teardown without a display.

--- a/code/packages/rust/mosaic-app-bindings/conformance/qt/CMakeLists.txt
+++ b/code/packages/rust/mosaic-app-bindings/conformance/qt/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.21)
+project(MosaicQtRuntimeConformance LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_AUTOMOC ON)
+
+find_package(Qt6 6.7 REQUIRED COMPONENTS Core)
+
+add_executable(mosaic_qt_runtime_conformance
+  main.cpp
+  MosaicHost.cpp
+  MosaicHost.h
+)
+target_link_libraries(mosaic_qt_runtime_conformance PRIVATE Qt6::Core)

--- a/code/packages/rust/mosaic-app-bindings/conformance/qt/README.md
+++ b/code/packages/rust/mosaic-app-bindings/conformance/qt/README.md
@@ -1,0 +1,10 @@
+# Qt runtime conformance
+
+This headless Qt Core harness compiles the exact `MosaicHost.h/.cpp` emitted into
+a generated Qt/QML project. It loads the shared `mosaic-app-conformance` native
+library and verifies startup, revisions, prop projection, semantic dispatch,
+snapshot/restore, buffer ownership, and teardown.
+
+CI generates the complete TaskApp project, copies its generated binding into
+this harness in a temporary workspace, and runs the result. The binding itself
+is deliberately not duplicated here, and no graphical display is required.

--- a/code/packages/rust/mosaic-app-bindings/conformance/qt/main.cpp
+++ b/code/packages/rust/mosaic-app-bindings/conformance/qt/main.cpp
@@ -1,0 +1,92 @@
+#include "MosaicHost.h"
+
+#include <QCoreApplication>
+#include <QVariantList>
+#include <QVariantMap>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+void require(bool condition, const char *assertion)
+{
+    if (condition) return;
+    std::cerr << "Failed assertion: " << assertion << '\n';
+    std::exit(EXIT_FAILURE);
+}
+
+QVariantMap props(const QVariantMap &update, const char *assertion)
+{
+    require(!update.contains(QStringLiteral("error")), assertion);
+    const auto value = update.value(QStringLiteral("props"));
+    require(value.canConvert<QVariantMap>(), assertion);
+    return value.toMap();
+}
+
+QString expectedPlatform()
+{
+#if defined(Q_OS_MACOS) || defined(Q_OS_IOS)
+    return QStringLiteral("apple");
+#elif defined(Q_OS_WIN)
+    return QStringLiteral("windows");
+#else
+    return QStringLiteral("linux");
+#endif
+}
+}
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication application(argc, argv);
+    MosaicHost host;
+
+    const auto started = host.props();
+    const auto startedProps = props(started, "startup update");
+    require(started.value(QStringLiteral("revision")).toULongLong() == 1,
+            "startup revision");
+    require(startedProps.value(QStringLiteral("count")).toLongLong() == 0,
+            "initial count");
+    require(startedProps.value(QStringLiteral("platform")).toString() == expectedPlatform(),
+            "startup platform");
+    require(startedProps.value(QStringLiteral("status")).toString() ==
+                QStringLiteral("started"),
+            "startup status");
+
+    const QVariantMap event{
+        {QStringLiteral("name"), QStringLiteral("increment")},
+        {QStringLiteral("payload"), QVariantMap{{QStringLiteral("amount"), 4}}},
+    };
+    const auto dispatched = host.handleEvent(event);
+    const auto dispatchedProps = props(dispatched, "dispatch update");
+    require(dispatched.value(QStringLiteral("revision")).toULongLong() == 2,
+            "dispatch revision");
+    require(dispatchedProps.value(QStringLiteral("count")).toLongLong() == 4,
+            "dispatched count");
+    require(dispatchedProps.value(QStringLiteral("status")).toString() ==
+                QStringLiteral("dispatched"),
+            "dispatch status");
+
+    const auto snapshotValue = host.snapshot();
+    require(snapshotValue.canConvert<QVariantMap>(), "snapshot object");
+    const auto snapshot = snapshotValue.toMap();
+    require(snapshot.value(QStringLiteral("schema")).toString() ==
+                QStringLiteral("mosaic-app-conformance/counter"),
+            "snapshot schema");
+    require(snapshot.value(QStringLiteral("version")).toUInt() == 1,
+            "snapshot version");
+    require(snapshot.value(QStringLiteral("bytes")).toList().size() == 8,
+            "snapshot bytes");
+
+    const auto restored = host.restore(snapshot);
+    const auto restoredProps = props(restored, "restore update");
+    require(restored.value(QStringLiteral("revision")).toULongLong() == 3,
+            "restore revision");
+    require(restoredProps.value(QStringLiteral("count")).toLongLong() == 4,
+            "restored count");
+    require(restoredProps.value(QStringLiteral("status")).toString() ==
+                QStringLiteral("restored"),
+            "restore status");
+
+    std::cout << "Mosaic Qt Rust runtime conformance passed\n";
+    return EXIT_SUCCESS;
+}

--- a/code/scripts/mosaic_qt_runtime_ci_acceptance.py
+++ b/code/scripts/mosaic_qt_runtime_ci_acceptance.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Derive the Mosaic Qt runtime conformance flag from a build plan."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+ACCEPTANCE_PACKAGES = frozenset(
+    {
+        "rust/mosaic-app-bindings",
+        "rust/mosaic-app-capi",
+        "rust/mosaic-app-conformance",
+        "rust/mosaic-app-runtime",
+        "rust/mosaic-compile",
+        "rust/mosaic-emit-qt",
+        "rust/mosaic-package-artifact-builder",
+        "rust/moslayout-compiler",
+        "rust/mosmodel-compiler",
+        "rust/mosstyle-compiler",
+        "unknown/programs/task-app",
+    }
+)
+ACCEPTANCE_PACKAGE_PREFIXES = ("unknown/mosaic-pkg-",)
+CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+
+
+def requires_mosaic_qt_runtime(
+    plan: dict[str, Any], *, workflow_changed: bool = False
+) -> bool:
+    """Return whether this plan must exercise the generated Qt binding."""
+
+    if workflow_changed:
+        return True
+    affected = plan.get("affected_packages")
+    if affected is None:
+        return True
+    if not isinstance(affected, list):
+        raise ValueError("affected_packages must be an array or null")
+    return any(
+        package in ACCEPTANCE_PACKAGES
+        or package.startswith(ACCEPTANCE_PACKAGE_PREFIXES)
+        for package in affected
+    )
+
+
+def workflow_changed(repo_root: Path, diff_base: str) -> bool:
+    """Return whether the main CI workflow differs from the selected base."""
+
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--quiet",
+            f"{diff_base}...HEAD",
+            "--",
+            CI_WORKFLOW_PATH,
+        ],
+        cwd=repo_root,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        raise RuntimeError(f"git diff exited with status {result.returncode}")
+    return result.returncode == 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("plan", type=Path)
+    parser.add_argument("--repo-root", type=Path)
+    parser.add_argument("--diff-base")
+    args = parser.parse_args()
+
+    if (args.repo_root is None) != (args.diff_base is None):
+        parser.error("--repo-root and --diff-base must be provided together")
+
+    with args.plan.open(encoding="utf-8") as handle:
+        plan = json.load(handle)
+    if not isinstance(plan, dict):
+        raise ValueError("build plan root must be an object")
+
+    changed = False
+    if args.repo_root is not None and args.diff_base is not None:
+        changed = workflow_changed(args.repo_root, args.diff_base)
+
+    required = requires_mosaic_qt_runtime(plan, workflow_changed=changed)
+    print(f"required={'true' if required else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/tests/test_mosaic_qt_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_qt_runtime_ci_acceptance.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "mosaic_qt_runtime_ci_acceptance.py"
+WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "ci.yml"
+QT_CONFORMANCE = (
+    Path(__file__).resolve().parents[2]
+    / "packages"
+    / "rust"
+    / "mosaic-app-bindings"
+    / "conformance"
+    / "qt"
+)
+SPEC = importlib.util.spec_from_file_location("mosaic_qt_runtime_ci_acceptance", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class MosaicQtRuntimeCIAcceptanceTests(unittest.TestCase):
+    def test_force_plan_requires_acceptance(self) -> None:
+        self.assertTrue(MODULE.requires_mosaic_qt_runtime({"affected_packages": None}))
+
+    def test_qt_emitter_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_qt_runtime(
+                {"affected_packages": ["rust/mosaic-emit-qt"]}
+            )
+        )
+
+    def test_standard_runtime_binding_requires_acceptance(self) -> None:
+        for package in (
+            "rust/mosaic-app-bindings",
+            "rust/mosaic-app-capi",
+            "rust/mosaic-app-conformance",
+            "rust/mosaic-app-runtime",
+        ):
+            with self.subTest(package=package):
+                self.assertTrue(
+                    MODULE.requires_mosaic_qt_runtime(
+                        {"affected_packages": [package]}
+                    )
+                )
+
+    def test_task_app_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_qt_runtime(
+                {"affected_packages": ["unknown/programs/task-app"]}
+            )
+        )
+
+    def test_standard_mosaic_package_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_qt_runtime(
+                {"affected_packages": ["unknown/mosaic-pkg-grid"]}
+            )
+        )
+
+    def test_unrelated_plan_skips_acceptance(self) -> None:
+        self.assertFalse(
+            MODULE.requires_mosaic_qt_runtime(
+                {"affected_packages": ["rust/html-parser"]}
+            )
+        )
+
+    def test_workflow_change_self_tests_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_qt_runtime(
+                {"affected_packages": []}, workflow_changed=True
+            )
+        )
+
+    def test_invalid_affected_packages_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "array or null"):
+            MODULE.requires_mosaic_qt_runtime({"affected_packages": "all"})
+
+    def test_cli_emits_github_output_value(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            plan = Path(directory) / "build-plan.json"
+            plan.write_text(
+                '{"affected_packages":["rust/mosaic-emit-qt"]}',
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), str(plan)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.stdout, "required=true\n")
+
+    def test_workflow_routes_rust_qt_and_acceptance(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "needs_mosaic_qt_runtime: "
+            "${{ steps.mosaic-qt-runtime.outputs.required }}",
+            workflow,
+        )
+        self.assertIn(
+            "python3 code/scripts/mosaic_qt_runtime_ci_acceptance.py",
+            workflow,
+        )
+        self.assertIn("Round-trip Rust engine through standard Qt binding", workflow)
+        self.assertIn("needs_mosaic_qt_runtime == 'true'", workflow)
+        self.assertIn("timeout-minutes: 10", workflow)
+        self.assertIn("--backend qt --output \"$output\" --emit-project", workflow)
+        self.assertIn(
+            "cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance",
+            workflow,
+        )
+        self.assertIn("qt/MosaicHost.cpp", workflow)
+        self.assertIn("cmake --build \"$harness/build\"", workflow)
+        self.assertIn("MOSAIC_APP_LIBRARY", workflow)
+
+    def test_harness_does_not_duplicate_the_generated_binding(self) -> None:
+        self.assertTrue((QT_CONFORMANCE / "main.cpp").is_file())
+        self.assertFalse((QT_CONFORMANCE / "MosaicHost.cpp").exists())
+        self.assertFalse((QT_CONFORMANCE / "MosaicHost.h").exists())
+        cmake = (QT_CONFORMANCE / "CMakeLists.txt").read_text(encoding="utf-8")
+        self.assertIn("Qt6::Core", cmake)
+        self.assertIn("CMAKE_AUTOMOC", cmake)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -306,8 +306,10 @@ unblocks multiple downstream targets; never count source generation as completio
     typed props, semantic dispatch, revised props, buffers, and teardown.
   - [x] SwiftUI/Foundation loads the shared Rust conformance dylib and round-trips
     startup, dispatch, snapshot/restore, notification, and teardown in macOS CI.
-  - [ ] Promote the same shared Rust fixture through Qt/QML, Compose, and Flutter
-    standard bindings.
+  - [x] Qt/QML loads the shared Rust conformance library and round-trips startup,
+    dispatch, snapshot/restore, buffers, and teardown in headless Linux CI.
+  - [ ] Promote the same shared Rust fixture through Compose and Flutter standard
+    bindings.
 - [x] Gate the complete package-expanded XAML TaskApp on GitHub-hosted Windows
   with real WinUI compilation and executable production.
   - [x] Allocate `For` row-view-model and projection names per loop rather than


### PR DESCRIPTION
## Summary

- add a headless Qt Core conformance harness that compiles the exact generated Qt/QML runtime host
- round-trip the shared Rust fixture through startup, dispatch, snapshot/restore, buffer ownership, and teardown
- route relevant Mosaic package changes through pinned Qt CI and update the UI38 completion backlog

## Validation

- generated TaskApp Qt project + `mosaic-app-conformance` dylib + CMake build/run of the copied host
- `python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_qt_runtime_ci_acceptance.py'`\n- neighboring SwiftUI, XAML, and Venture CI-routing unit tests\n- `cargo test -p mosaic-app-bindings`\n- `cargo test -p mosaic-app-conformance`\n- `cargo test -p mosaic-emit-qt --lib`\n- workflow YAML parse, clang-format check, and `git diff --check`