### PR TITLE
Add atomic cross-vault portable import

### DIFF
--- a/code/packages/rust/vault-pm-application/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this package are documented here.
 
+## [0.28.0] - 2026-08-10
+
+### Added
+
+- Add one atomic cross-vault import that consumes an authenticated opaque
+  portable snapshot into an untouched empty generation-zero target.
+- Add exact count-derived host-CSPRNG sizing and a non-printable wipe-on-drop
+  entropy container for new item identities plus every revision, catalog, and
+  commit frame.
+
+### Security
+
+- Reject source-vault reuse, mutated or non-empty targets, stale pins,
+  source/target identity collisions, malformed candidate bindings, and imports
+  exceeding the repository's 4,096-object publication bound before activation.
+- Re-identify every item and revision under independent target encryption while
+  preserving complete validated live, tombstone, conflict, CRDT, timestamp, and
+  secret state; source causal identities are deliberately not copied.
+- Reuse the exact write-ahead pending-publication journal for all-or-nothing
+  crash recovery, consume the opaque snapshot on every path, and independently
+  reopen the target to prove source/target identity separation and restored
+  content equality.
+
 ## [0.27.0] - 2026-08-10
 
 ### Added

--- a/code/packages/rust/vault-pm-application/README.md
+++ b/code/packages/rust/vault-pm-application/README.md
@@ -237,9 +237,21 @@ closed authentication failure.
 Success remains inside an opaque non-cloneable application object exposing only
 item and candidate counts. Source identities, bootstrap bytes, metadata, and
 documents have no public accessor; diagnostics are redacted and all intermediate
-secret-bearing buffers and CBOR trees wipe on every path. Cross-vault import is
-still separate: its follow-up must consume the opaque snapshot and create new
-item, revision, object, and encryption identities inside a new target vault.
+secret-bearing buffers and CBOR trees wipe on every path.
+
+An untouched empty generation-zero target can consume that opaque snapshot in
+one atomic cross-vault import. The host asks the application for the exact
+count-derived CSPRNG byte requirement, then supplies the owned entropy block and
+an advisory commit time. Import rejects the source vault, a mutated/non-empty
+target, stale pins, identity collisions, and snapshots that exceed one 4,096
+object publication. It creates a new target item identity per source item and a
+new encrypted target revision per retained live, tombstone, or conflict
+candidate, preserves complete validated record/CRDT/deletion state, intentionally
+drops non-portable source causal-parent identities, and seals a new target
+catalog and signed commit. The ordinary write-ahead pending journal makes the
+complete restore crash-resumable without partial logical visibility. The source
+snapshot, imported plaintexts, and entropy remain non-printable and wipe on
+drop.
 
 The crate accepts key and randomness material from its caller. It does not own
 a filesystem path, provider SDK, network client, process, environment, clock,
@@ -278,9 +290,9 @@ diagnostics; and failure without repair.
 Search tests cover Unicode normalization, short queries, oversized safe-field
 fallback, exact collection filters, deterministic product ordering, every
 record schema's allowlist/denylist, secret exclusion, query/result bounds, and
-conflict closure. The exact Tarpaulin LLVM result is 2,894 of 3,042 production
-lines (95.13%); portable export and opening are 367 of 394, doctor is 44 of 45,
-and status remains 46 of 46.
+conflict closure. The exact Tarpaulin LLVM result is 3,086 of 3,245 production
+lines (95.10%); portable export/opening is 374 of 401, mutation including
+portable import is 475 of 504, doctor is 44 of 45, and status remains 46 of 46.
 Add-item tests cover exact
 entropy partitioning and wiping,
 identity validation before local writes, parentless revision and complete
@@ -297,12 +309,15 @@ tombstone selection, authored merged-secret persistence, complete multi-parent
 causality, immutable live-identity preservation, immutable losing-candidate
 retention, missing/unconflicted/all-tombstone rejection before
 compare-exchange, and entropy redaction/wiping.
-Portable-export/open tests prove the exact canonical encrypted vector, separate
+Portable-export/open/import tests prove the exact canonical encrypted vector, separate
 passphrase authentication, header/ciphertext tamper rejection, exact active
 bootstrap binding, plaintext-secret exclusion, complete snapshot count/hash,
 signed-bootstrap validation, host KDF-ceiling enforcement, candidate identity
 and ordering validation, live-document recovery, bounded credential rejection,
-and lossless retention of every current conflicting tombstone.
+lossless retention of every current conflicting tombstone, exact import entropy
+sizing, cross-vault item/revision re-identification, target-only encryption,
+atomic publication, conflict/deletion preservation, and independent target
+reopen with aggregate and revealed-secret comparison.
 
 ## Development
 

--- a/code/packages/rust/vault-pm-application/src/export.rs
+++ b/code/packages/rust/vault-pm-application/src/export.rs
@@ -8,7 +8,7 @@ use coding_adventures_chacha20_poly1305::{
 };
 use coding_adventures_sha256::sha256;
 use coding_adventures_vault_pm_domain::{ItemCandidate, ItemId, RevisionId};
-use coding_adventures_vault_pm_format::{Argon2idParametersV1, CRYPTO_SUITE_V1};
+use coding_adventures_vault_pm_format::{Argon2idParametersV1, VaultId, CRYPTO_SUITE_V1};
 use coding_adventures_zeroize::{Zeroize, Zeroizing};
 use core::fmt::{self, Debug, Formatter};
 use std::collections::BTreeMap;
@@ -210,6 +210,7 @@ impl Debug for PortableExportArtifactV1 {
 /// decrypted documents have no public accessor and diagnostics are redacted.
 pub struct OpenedPortableSnapshotV1 {
     _exact_bootstrap: Zeroizing<Vec<u8>>,
+    source_vault_id: VaultId,
     candidates: BTreeMap<ItemId, Vec<ItemCandidate>>,
 }
 
@@ -222,6 +223,15 @@ impl OpenedPortableSnapshotV1 {
     /// Return the number of retained current source candidates.
     pub fn candidate_count(&self) -> usize {
         self.candidates.values().map(Vec::len).sum()
+    }
+
+    pub(crate) fn into_import_parts(self) -> (VaultId, BTreeMap<ItemId, Vec<ItemCandidate>>) {
+        let Self {
+            _exact_bootstrap,
+            source_vault_id,
+            candidates,
+        } = self;
+        (source_vault_id, candidates)
     }
 }
 
@@ -359,7 +369,7 @@ fn parse_opened_snapshot(plaintext: &[u8]) -> Result<OpenedPortableSnapshotV1, A
     if snapshot_hash(&exact_bootstrap, &encoded_entries)? != expected_hash {
         return Err(ApplicationError::IntegrityFailure);
     }
-    verify_signed_bootstrap(&exact_bootstrap)?;
+    let source_bootstrap = verify_signed_bootstrap(&exact_bootstrap)?;
 
     let mut entries = entries_value.into_values()?;
     if entries.len() != candidate_count {
@@ -400,6 +410,7 @@ fn parse_opened_snapshot(plaintext: &[u8]) -> Result<OpenedPortableSnapshotV1, A
 
     Ok(OpenedPortableSnapshotV1 {
         _exact_bootstrap: exact_bootstrap,
+        source_vault_id: source_bootstrap.vault_id,
         candidates,
     })
 }

--- a/code/packages/rust/vault-pm-application/src/lib.rs
+++ b/code/packages/rust/vault-pm-application/src/lib.rs
@@ -50,10 +50,10 @@ pub use initialize::{
 };
 pub use lifecycle::{LockedVaultV1, VaultAccessV1};
 pub use mutation::{
-    AddItemRandomnessV1, DeleteItemRandomnessV1, ReplaceItemRandomnessV1,
-    ResolveItemConflictRandomnessV1, RestoreItemRandomnessV1, ADD_ITEM_RANDOM_BYTES,
-    DELETE_ITEM_RANDOM_BYTES, REPLACE_ITEM_RANDOM_BYTES, RESOLVE_ITEM_CONFLICT_RANDOM_BYTES,
-    RESTORE_ITEM_RANDOM_BYTES,
+    portable_import_random_bytes, AddItemRandomnessV1, DeleteItemRandomnessV1,
+    PortableImportRandomnessV1, ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1,
+    RestoreItemRandomnessV1, ADD_ITEM_RANDOM_BYTES, DELETE_ITEM_RANDOM_BYTES,
+    REPLACE_ITEM_RANDOM_BYTES, RESOLVE_ITEM_CONFLICT_RANDOM_BYTES, RESTORE_ITEM_RANDOM_BYTES,
 };
 pub use open::{
     open_active_vault, recover_pending_publication, ItemHistoryViewV1, UnlockedVaultV1,

--- a/code/packages/rust/vault-pm-application/src/mutation.rs
+++ b/code/packages/rust/vault-pm-application/src/mutation.rs
@@ -9,7 +9,7 @@ use coding_adventures_vault_pm_domain::{
     ItemCandidate, ItemDocument, ItemId, ItemState, RevisionId, Tombstone,
 };
 use coding_adventures_vault_pm_format::{AnnouncementV1, CommitV1, Signature};
-use coding_adventures_vault_pm_repository::{OpenReport, PinnedHeads};
+use coding_adventures_vault_pm_repository::{OpenReport, PinnedHeads, MAX_PUBLICATION_OBJECTS};
 use coding_adventures_zeroize::{Zeroize, Zeroizing};
 use core::fmt::{self, Debug, Formatter};
 use std::collections::{BTreeMap, BTreeSet};
@@ -27,6 +27,93 @@ pub const DELETE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
 pub const RESTORE_ITEM_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
 /// Exact caller-filled CSPRNG bytes consumed by one conflict-resolution mutation.
 pub const RESOLVE_ITEM_CONFLICT_RANDOM_BYTES: usize = 3 * OBJECT_RANDOM_BYTES;
+
+/// Return the exact caller-CSPRNG byte count required to import one opened
+/// portable snapshot.
+///
+/// Import allocates one new 16-byte item identity per source item, one fresh
+/// encrypted revision frame per retained candidate, and fresh catalog and
+/// commit frames. Snapshots too large for one atomic repository publication
+/// are rejected before entropy is accepted.
+pub fn portable_import_random_bytes(
+    snapshot: &crate::OpenedPortableSnapshotV1,
+) -> Result<usize, ApplicationError> {
+    portable_import_random_bytes_for_counts(snapshot.item_count(), snapshot.candidate_count())
+}
+
+fn portable_import_random_bytes_for_counts(
+    item_count: usize,
+    candidate_count: usize,
+) -> Result<usize, ApplicationError> {
+    if candidate_count
+        .checked_add(1)
+        .is_none_or(|object_count| object_count > MAX_PUBLICATION_OBJECTS)
+    {
+        return Err(ApplicationError::BoundExceeded);
+    }
+    ITEM_ID_BYTES
+        .checked_mul(item_count)
+        .and_then(|item_bytes| {
+            OBJECT_RANDOM_BYTES
+                .checked_mul(candidate_count.checked_add(2)?)
+                .and_then(|object_bytes| item_bytes.checked_add(object_bytes))
+        })
+        .ok_or(ApplicationError::BoundExceeded)
+}
+
+/// Owned wipe-on-drop entropy for one atomic cross-vault portable import.
+pub struct PortableImportRandomnessV1 {
+    bytes: Vec<u8>,
+    item_count: usize,
+    candidate_count: usize,
+}
+
+impl PortableImportRandomnessV1 {
+    /// Validate and take the exact host-CSPRNG bytes required by `snapshot`.
+    pub fn new(
+        mut bytes: Vec<u8>,
+        snapshot: &crate::OpenedPortableSnapshotV1,
+    ) -> Result<Self, ApplicationError> {
+        let item_count = snapshot.item_count();
+        let candidate_count = snapshot.candidate_count();
+        let expected = match portable_import_random_bytes_for_counts(item_count, candidate_count) {
+            Ok(expected) => expected,
+            Err(error) => {
+                bytes.zeroize();
+                return Err(error);
+            }
+        };
+        if bytes.len() != expected {
+            bytes.zeroize();
+            return Err(ApplicationError::InvalidInput);
+        }
+        Ok(Self {
+            bytes,
+            item_count,
+            candidate_count,
+        })
+    }
+}
+
+impl Zeroize for PortableImportRandomnessV1 {
+    fn zeroize(&mut self) {
+        self.bytes.zeroize();
+        self.item_count = 0;
+        self.candidate_count = 0;
+    }
+}
+
+impl Drop for PortableImportRandomnessV1 {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl Debug for PortableImportRandomnessV1 {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str("PortableImportRandomnessV1(<redacted>)")
+    }
+}
 
 /// Owned wipe-on-drop entropy for one item ID and three encrypted frames.
 pub struct AddItemRandomnessV1 {
@@ -184,6 +271,238 @@ impl Drop for ResolveItemConflictRandomnessV1 {
 impl Debug for ResolveItemConflictRandomnessV1 {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         formatter.write_str("ResolveItemConflictRandomnessV1(<redacted>)")
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn import_opened_portable_snapshot(
+    active: &ActiveStateV1,
+    report: &OpenReport,
+    current_items: &BTreeMap<ItemId, Vec<ItemCandidate>>,
+    keys: &V1Keys,
+    local_secret: &LocalSecretV1,
+    repository: &dyn ApplicationRepository,
+    snapshot: crate::OpenedPortableSnapshotV1,
+    wall_time_ms: u64,
+    randomness: PortableImportRandomnessV1,
+    local_state_store: &dyn LocalStateStore,
+) -> Result<ActiveStateV1, ApplicationError> {
+    if report.heads() != active.pinned_heads() {
+        return Err(ApplicationError::ConcurrentHost);
+    }
+    if active.last_device_counter() != 1 || !current_items.is_empty() {
+        return Err(ApplicationError::InvalidInput);
+    }
+    if randomness.item_count != snapshot.item_count()
+        || randomness.candidate_count != snapshot.candidate_count()
+        || randomness.bytes.len()
+            != portable_import_random_bytes_for_counts(
+                snapshot.item_count(),
+                snapshot.candidate_count(),
+            )?
+    {
+        return Err(ApplicationError::InvalidInput);
+    }
+
+    let (source_vault_id, source_items) = snapshot.into_import_parts();
+    if source_vault_id == active.vault_id() {
+        return Err(ApplicationError::InvalidInput);
+    }
+
+    let publication = prepare_portable_import_publication(
+        active,
+        keys,
+        local_secret,
+        source_items,
+        wall_time_ms,
+        &randomness.bytes,
+    )?;
+    publish_mutation(active, repository, publication, local_state_store)
+}
+
+fn prepare_portable_import_publication(
+    active: &ActiveStateV1,
+    keys: &V1Keys,
+    local_secret: &LocalSecretV1,
+    source_items: BTreeMap<ItemId, Vec<ItemCandidate>>,
+    wall_time_ms: u64,
+    randomness: &[u8],
+) -> Result<PublicationJournalV1, ApplicationError> {
+    let item_count = source_items.len();
+    let candidate_count = source_items.values().map(Vec::len).sum();
+    if randomness.len() != portable_import_random_bytes_for_counts(item_count, candidate_count)? {
+        return Err(ApplicationError::InvalidInput);
+    }
+
+    let device_counter = active
+        .last_device_counter()
+        .checked_add(1)
+        .ok_or(ApplicationError::BoundExceeded)?;
+    let source_item_ids = source_items.keys().copied().collect::<BTreeSet<_>>();
+    let source_revision_ids = source_items
+        .values()
+        .flatten()
+        .map(ItemCandidate::revision_id)
+        .collect::<BTreeSet<_>>();
+    let mut offset = 0;
+    let mut imported_item_ids = BTreeSet::new();
+    let mut item_id_map = BTreeMap::new();
+    for source_item_id in source_items.keys() {
+        let imported_item_id = ItemId::new(take_slice(randomness, &mut offset));
+        if source_item_ids.contains(&imported_item_id)
+            || !imported_item_ids.insert(imported_item_id)
+        {
+            return Err(ApplicationError::InvalidInput);
+        }
+        item_id_map.insert(*source_item_id, imported_item_id);
+    }
+
+    let mut objects = Vec::with_capacity(candidate_count + 1);
+    let mut catalog_entries = BTreeMap::new();
+    let mut added_objects = Vec::with_capacity(candidate_count + 1);
+    for (source_item_id, candidates) in source_items {
+        let imported_item_id = item_id_map[&source_item_id];
+        let mut imported_revision_ids = Vec::with_capacity(candidates.len());
+        for candidate in candidates {
+            if candidate.item_id() != source_item_id {
+                return Err(ApplicationError::IntegrityFailure);
+            }
+            let imported_state = remap_imported_item_state(candidate.state(), imported_item_id)?;
+            let revision_plaintext =
+                Zeroizing::new(encode_item_revision(&BTreeSet::new(), &imported_state)?);
+            let revision_frame = seal_object(
+                keys,
+                ObjectKind::ItemRevision,
+                &revision_plaintext,
+                &take_object_randomness_slice(randomness, &mut offset),
+            )?;
+            let revision_object_id = revision_frame
+                .id()
+                .map_err(|_| ApplicationError::InternalInvariant)?;
+            let revision_id = RevisionId::new(*revision_object_id.as_bytes());
+            if source_revision_ids.contains(&revision_id)
+                || imported_revision_ids.contains(&revision_id)
+                || added_objects.contains(&revision_object_id)
+            {
+                return Err(ApplicationError::InvalidInput);
+            }
+            imported_revision_ids.push(revision_id);
+            added_objects.push(revision_object_id);
+            objects.push(revision_frame);
+        }
+        imported_revision_ids.sort_unstable();
+        catalog_entries.insert(imported_item_id, imported_revision_ids);
+    }
+
+    let catalog_plaintext = Zeroizing::new(CatalogV1::new(catalog_entries)?.encode()?);
+    let catalog_frame = seal_object(
+        keys,
+        ObjectKind::Catalog,
+        &catalog_plaintext,
+        &take_object_randomness_slice(randomness, &mut offset),
+    )?;
+    let catalog_id = catalog_frame
+        .id()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    if added_objects.contains(&catalog_id) {
+        return Err(ApplicationError::InvalidInput);
+    }
+    added_objects.push(catalog_id);
+    objects.push(catalog_frame);
+
+    let mut parents = active.pinned_heads().iter().copied().collect::<Vec<_>>();
+    parents.sort_unstable();
+    added_objects.sort_unstable();
+    added_objects.dedup();
+    if added_objects.len() != objects.len() {
+        return Err(ApplicationError::InternalInvariant);
+    }
+    let (_, device_signing_secret) = generate_keypair(local_secret.device_signing_seed());
+    let device_signing_secret = Zeroizing::new(device_signing_secret);
+    let unsigned_commit = CommitV1 {
+        vault_id: active.vault_id(),
+        device_id: active.device_id(),
+        device_counter,
+        parents,
+        catalog_root: catalog_id,
+        added_objects,
+        tombstone_root: None,
+        wall_time_ms,
+        device_certificate: active.device_certificate_id(),
+        signature: Signature::new([0; 64]),
+    };
+    let commit_preimage = unsigned_commit
+        .signing_preimage()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    let commit = unsigned_commit.with_signature(Signature::new(sign(
+        &commit_preimage,
+        &device_signing_secret,
+    )));
+    let commit_plaintext = Zeroizing::new(encode_signed_commit(&commit)?);
+    let commit_frame = seal_object(
+        keys,
+        ObjectKind::Commit,
+        &commit_plaintext,
+        &take_object_randomness_slice(randomness, &mut offset),
+    )?;
+    debug_assert_eq!(offset, randomness.len());
+    let commit_id = commit_frame
+        .id()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    let unsigned_announcement = AnnouncementV1 {
+        vault_id: active.vault_id(),
+        device_id: active.device_id(),
+        device_counter,
+        commit_id,
+        device_certificate: active.device_certificate_id(),
+        signature: Signature::new([0; 64]),
+    };
+    let announcement_preimage = unsigned_announcement
+        .signing_preimage()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    let announcement = unsigned_announcement
+        .with_signature(Signature::new(sign(
+            &announcement_preimage,
+            &device_signing_secret,
+        )))
+        .encode()
+        .map_err(|_| ApplicationError::InternalInvariant)?;
+    let expected_heads =
+        PinnedHeads::new([commit_id]).map_err(|_| ApplicationError::InternalInvariant)?;
+
+    PublicationJournalV1::new(
+        objects,
+        commit_frame,
+        announcement,
+        active.pinned_heads().clone(),
+        expected_heads,
+        device_counter,
+        catalog_id,
+    )
+}
+
+fn remap_imported_item_state(
+    state: &ItemState,
+    item_id: ItemId,
+) -> Result<ItemState, ApplicationError> {
+    match state {
+        ItemState::Live(document) => ItemDocument::new(
+            item_id,
+            document.schema().clone(),
+            document.created_at_ms(),
+            document.updated_at_ms(),
+            document.favorite().clone(),
+            document.collection_ids().clone(),
+            document.tags().clone(),
+            document.payload().clone(),
+            document.attachments().clone(),
+        )
+        .map(|document| ItemState::Live(Box::new(document)))
+        .map_err(|_| ApplicationError::IntegrityFailure),
+        ItemState::Tombstone(tombstone) => Ok(ItemState::Tombstone(Tombstone {
+            item_id,
+            deleted_at_ms: tombstone.deleted_at_ms,
+        })),
     }
 }
 
@@ -673,11 +992,30 @@ fn take_object_randomness(
     )
 }
 
+fn take_object_randomness_slice(bytes: &[u8], offset: &mut usize) -> ObjectRandomness {
+    ObjectRandomness::new(
+        take_slice(bytes, offset),
+        take_slice(bytes, offset),
+        take_slice(bytes, offset),
+    )
+}
+
 fn take<const N: usize>(bytes: &[u8; REPLACE_ITEM_RANDOM_BYTES], offset: &mut usize) -> [u8; N] {
     let end = *offset + N;
     let value = bytes[*offset..end]
         .try_into()
         .expect("add-item partition lengths are constant");
+    *offset = end;
+    value
+}
+
+fn take_slice<const N: usize>(bytes: &[u8], offset: &mut usize) -> [u8; N] {
+    let end = offset
+        .checked_add(N)
+        .expect("validated import randomness offset cannot overflow");
+    let value = bytes[*offset..end]
+        .try_into()
+        .expect("validated import randomness partition must be exact");
     *offset = end;
     value
 }
@@ -770,6 +1108,33 @@ mod tests {
 
         randomness.zeroize();
         assert!(randomness.bytes.iter().all(|byte| *byte == 0));
+    }
+
+    #[test]
+    fn portable_import_randomness_is_exact_bounded_redacted_and_zeroizing() {
+        assert_eq!(portable_import_random_bytes_for_counts(2, 3), Ok(432));
+        assert_eq!(
+            portable_import_random_bytes_for_counts(1, MAX_PUBLICATION_OBJECTS),
+            Err(ApplicationError::BoundExceeded)
+        );
+        assert_eq!(
+            portable_import_random_bytes_for_counts(usize::MAX, 0),
+            Err(ApplicationError::BoundExceeded)
+        );
+
+        let mut randomness = PortableImportRandomnessV1 {
+            bytes: vec![0x87; 432],
+            item_count: 2,
+            candidate_count: 3,
+        };
+        assert_eq!(
+            format!("{randomness:?}"),
+            "PortableImportRandomnessV1(<redacted>)"
+        );
+        randomness.zeroize();
+        assert!(randomness.bytes.iter().all(|byte| *byte == 0));
+        assert_eq!(randomness.item_count, 0);
+        assert_eq!(randomness.candidate_count, 0);
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-application/src/open.rs
+++ b/code/packages/rust/vault-pm-application/src/open.rs
@@ -1,8 +1,9 @@
 use crate::initialize::{unlock_active_material, UnlockedActiveMaterial};
 use crate::mutation::{
-    add_item, delete_item, merge_item_conflict, replace_item, resolve_item_conflict, restore_item,
-    AddItemRandomnessV1, DeleteItemRandomnessV1, ReplaceItemRandomnessV1,
-    ResolveItemConflictRandomnessV1, RestoreItemRandomnessV1,
+    add_item, delete_item, import_opened_portable_snapshot, merge_item_conflict, replace_item,
+    resolve_item_conflict, restore_item, AddItemRandomnessV1, DeleteItemRandomnessV1,
+    PortableImportRandomnessV1, ReplaceItemRandomnessV1, ResolveItemConflictRandomnessV1,
+    RestoreItemRandomnessV1,
 };
 use crate::search::SearchProjectionV1;
 use crate::{
@@ -209,6 +210,37 @@ impl UnlockedVaultV1 {
             passphrase,
             policy,
             randomness,
+        )
+    }
+
+    /// Consume an authenticated portable snapshot into this untouched target
+    /// vault and return the resulting durable active owner state.
+    ///
+    /// The target must still be the empty generation-zero vault. Every source
+    /// item and retained live, tombstone, or conflicted candidate receives a
+    /// new target item/revision/object identity and is encrypted by the target
+    /// vault's independent keys. Source causal-parent identities are not
+    /// copied. The complete import is one crash-resumable publication, and the
+    /// session, opaque snapshot, and owned randomness are consumed on every
+    /// return path.
+    pub fn import_opened_portable_snapshot(
+        self,
+        snapshot: crate::OpenedPortableSnapshotV1,
+        wall_time_ms: u64,
+        randomness: PortableImportRandomnessV1,
+        local_state_store: &dyn LocalStateStore,
+    ) -> Result<ActiveStateV1, ApplicationError> {
+        import_opened_portable_snapshot(
+            &self.active,
+            &self.report,
+            &self.current_catalog.items,
+            &self._keys,
+            &self._local_secret,
+            self._repository.as_ref(),
+            snapshot,
+            wall_time_ms,
+            randomness,
+            local_state_store,
         )
     }
 
@@ -1306,11 +1338,25 @@ mod tests {
         MemoryBootstrapStore,
         V1ApplicationRepositoryFactory<InMemoryObjectStore>,
     ) {
-        let passphrase = Zeroizing::new(b"active passphrase".to_vec());
+        initialized_with(
+            b"active passphrase",
+            GenerationZeroRandomness::new(generation_zero_bytes()),
+        )
+    }
+
+    fn initialized_with(
+        passphrase: &[u8],
+        randomness: GenerationZeroRandomness,
+    ) -> (
+        BootstrapLocator,
+        MemoryLocalStateStore,
+        MemoryBootstrapStore,
+        V1ApplicationRepositoryFactory<InMemoryObjectStore>,
+    ) {
         let prepared = prepare_generation_zero(
-            passphrase,
+            Zeroizing::new(passphrase.to_vec()),
             GenerationZeroPolicyV1::new(8 * 1024, 1, 1, 10).unwrap(),
-            randomness(),
+            randomness,
         )
         .unwrap();
         let locator = prepared.bootstrap_locator();
@@ -2263,6 +2309,307 @@ mod tests {
             .err(),
             Some(ApplicationError::IntegrityFailure)
         );
+    }
+
+    #[test]
+    fn portable_import_rekeys_an_independently_reopenable_new_vault() {
+        let (source_locator, source_local, source_bootstrap, source_factory) = initialized();
+        let exact_active = source_local.0.lock().unwrap().clone().unwrap();
+        let LocalVaultStateV1::Active(source_active) =
+            LocalVaultStateV1::decode(&exact_active).unwrap()
+        else {
+            panic!("fixture must be active")
+        };
+        let conflicted_source_item = ItemId::new([0x7d; 16]);
+        let (publication, _) = pending_tombstone_publication(
+            &source_active,
+            conflicted_source_item,
+            conflicted_source_item,
+            2,
+            None,
+        );
+        *source_local.0.lock().unwrap() = Some(
+            LocalVaultStateV1::pending_publication(source_active, publication)
+                .unwrap()
+                .encode()
+                .unwrap(),
+        );
+        recover_pending_publication(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            source_locator,
+            &source_local,
+            &source_bootstrap,
+            &source_factory,
+        )
+        .unwrap();
+        let source_session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            source_locator,
+            &source_local,
+            &source_bootstrap,
+            &source_factory,
+        )
+        .unwrap();
+        let live_randomness = add_item_randomness(0x9a);
+        let live_source_item = live_randomness.item_id();
+        source_session
+            .add_item(
+                new_login_document(live_source_item, "Restored portal", "restored-secret"),
+                900,
+                live_randomness,
+                &source_local,
+            )
+            .unwrap();
+        let source_session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            source_locator,
+            &source_local,
+            &source_bootstrap,
+            &source_factory,
+        )
+        .unwrap();
+        assert_eq!(source_session.item_count(), 2);
+        assert_eq!(source_session.candidate_count(), 3);
+        assert_eq!(source_session.conflicted_item_count(), 1);
+        let source_vault_id = source_session.vault_id();
+        let source_item_ids = source_session
+            .current_catalog
+            .items
+            .keys()
+            .copied()
+            .collect::<BTreeSet<_>>();
+        let source_revision_ids = source_session
+            .current_catalog
+            .items
+            .values()
+            .flatten()
+            .map(ItemCandidate::revision_id)
+            .collect::<BTreeSet<_>>();
+        let exact_source_bootstrap = source_bootstrap.0.lock().unwrap().clone().unwrap();
+        let artifact = source_session
+            .export_portable_with_passphrase(
+                &exact_source_bootstrap,
+                Zeroizing::new(b"restore passphrase".to_vec()),
+                crate::PortableExportPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+                crate::PortableExportRandomnessV1::new([0x8b; crate::PORTABLE_EXPORT_RANDOM_BYTES]),
+            )
+            .unwrap();
+        let opened = crate::open_portable_with_passphrase(
+            artifact.as_bytes(),
+            Zeroizing::new(b"restore passphrase".to_vec()),
+            crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+        )
+        .unwrap();
+        let import_random_byte_count = crate::portable_import_random_bytes(&opened).unwrap();
+        assert_eq!(import_random_byte_count, 2 * 16 + 5 * 80);
+        assert_eq!(
+            crate::PortableImportRandomnessV1::new(
+                vec![0x91; import_random_byte_count - 1],
+                &opened,
+            )
+            .err(),
+            Some(ApplicationError::InvalidInput)
+        );
+        let import_randomness_bytes = (0..import_random_byte_count)
+            .map(|index| (index as u8).wrapping_mul(43).wrapping_add(0x91))
+            .collect::<Vec<_>>();
+        let import_randomness =
+            crate::PortableImportRandomnessV1::new(import_randomness_bytes.clone(), &opened)
+                .unwrap();
+        assert_eq!(
+            format!("{import_randomness:?}"),
+            "PortableImportRandomnessV1(<redacted>)"
+        );
+
+        let mut target_generation_zero = generation_zero_bytes();
+        for byte in &mut target_generation_zero {
+            *byte = byte.wrapping_add(0x65);
+        }
+        let (target_locator, target_local, target_bootstrap, target_factory) = initialized_with(
+            b"independent target passphrase",
+            GenerationZeroRandomness::new(target_generation_zero),
+        );
+        let target_session = open_active_vault(
+            Zeroizing::new(b"independent target passphrase".to_vec()),
+            target_locator,
+            &target_local,
+            &target_bootstrap,
+            &target_factory,
+        )
+        .unwrap();
+        assert_ne!(target_session.vault_id(), source_vault_id);
+        target_local.fail_next_compare(LocalStateStoreError::Unavailable);
+        assert_eq!(
+            target_session
+                .import_opened_portable_snapshot(opened, 901, import_randomness, &target_local)
+                .err(),
+            Some(ApplicationError::StorageUnavailable)
+        );
+        let target_session = open_active_vault(
+            Zeroizing::new(b"independent target passphrase".to_vec()),
+            target_locator,
+            &target_local,
+            &target_bootstrap,
+            &target_factory,
+        )
+        .unwrap();
+        assert_eq!(target_session.item_count(), 0);
+        let opened = crate::open_portable_with_passphrase(
+            artifact.as_bytes(),
+            Zeroizing::new(b"restore passphrase".to_vec()),
+            crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+        )
+        .unwrap();
+        let import_randomness =
+            crate::PortableImportRandomnessV1::new(import_randomness_bytes, &opened).unwrap();
+        let imported_active = target_session
+            .import_opened_portable_snapshot(opened, 901, import_randomness, &target_local)
+            .unwrap();
+        assert_eq!(imported_active.last_device_counter(), 2);
+
+        drop(source_session);
+        let restored = open_active_vault(
+            Zeroizing::new(b"independent target passphrase".to_vec()),
+            target_locator,
+            &target_local,
+            &target_bootstrap,
+            &target_factory,
+        )
+        .unwrap();
+        assert_eq!(restored.item_count(), 2);
+        assert_eq!(restored.candidate_count(), 3);
+        assert_eq!(restored.conflicted_item_count(), 1);
+        assert!(restored
+            .current_catalog
+            .items
+            .keys()
+            .all(|item_id| !source_item_ids.contains(item_id)));
+        assert!(restored
+            .current_catalog
+            .items
+            .values()
+            .flatten()
+            .all(|candidate| {
+                !source_revision_ids.contains(&candidate.revision_id())
+                    && candidate.causal_parents().is_empty()
+            }));
+        let mut tombstone_times = Vec::new();
+        let mut restored_login = None;
+        for candidates in restored.current_catalog.items.values() {
+            for candidate in candidates {
+                assert_eq!(candidate.item_id(), candidate.state().item_id());
+                match candidate.state() {
+                    ItemState::Live(document) => {
+                        let AnyRecord::Login(login) = document.payload() else {
+                            panic!("fixture must retain a login")
+                        };
+                        restored_login = Some((login.title.clone(), login.password.clone()));
+                    }
+                    ItemState::Tombstone(tombstone) => {
+                        tombstone_times.push(tombstone.deleted_at_ms);
+                    }
+                }
+            }
+        }
+        tombstone_times.sort_unstable();
+        assert_eq!(tombstone_times, vec![100, 101]);
+        assert_eq!(
+            restored_login,
+            Some(("Restored portal".to_owned(), "restored-secret".to_owned()))
+        );
+        let audit = restored.audit_verify().unwrap();
+        assert_eq!(audit.commit_count(), 2);
+        assert_eq!(audit.catalog_count(), 2);
+        assert_eq!(audit.revision_count(), 3);
+        assert_eq!(audit.item_count(), 2);
+    }
+
+    #[test]
+    fn portable_import_rejects_source_and_mutated_targets_before_local_writes() {
+        let (source_locator, source_local, source_bootstrap, source_factory) = initialized();
+        let source_session = open_active_vault(
+            Zeroizing::new(b"active passphrase".to_vec()),
+            source_locator,
+            &source_local,
+            &source_bootstrap,
+            &source_factory,
+        )
+        .unwrap();
+        let exact_source_bootstrap = source_bootstrap.0.lock().unwrap().clone().unwrap();
+        let artifact = source_session
+            .export_portable_with_passphrase(
+                &exact_source_bootstrap,
+                Zeroizing::new(b"empty restore passphrase".to_vec()),
+                crate::PortableExportPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+                crate::PortableExportRandomnessV1::new([0xa2; crate::PORTABLE_EXPORT_RANDOM_BYTES]),
+            )
+            .unwrap();
+        let opened = crate::open_portable_with_passphrase(
+            artifact.as_bytes(),
+            Zeroizing::new(b"empty restore passphrase".to_vec()),
+            crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(crate::portable_import_random_bytes(&opened), Ok(160));
+        let randomness = crate::PortableImportRandomnessV1::new(vec![0xa3; 160], &opened).unwrap();
+        let source_compare_calls = source_local.3.load(Ordering::SeqCst);
+        assert_eq!(
+            source_session
+                .import_opened_portable_snapshot(opened, 902, randomness, &source_local)
+                .err(),
+            Some(ApplicationError::InvalidInput)
+        );
+        assert_eq!(source_local.3.load(Ordering::SeqCst), source_compare_calls);
+
+        let mut target_generation_zero = generation_zero_bytes();
+        for byte in &mut target_generation_zero {
+            *byte = byte.wrapping_add(0x43);
+        }
+        let (target_locator, target_local, target_bootstrap, target_factory) = initialized_with(
+            b"mutated target passphrase",
+            GenerationZeroRandomness::new(target_generation_zero),
+        );
+        let target_session = open_active_vault(
+            Zeroizing::new(b"mutated target passphrase".to_vec()),
+            target_locator,
+            &target_local,
+            &target_bootstrap,
+            &target_factory,
+        )
+        .unwrap();
+        let add_randomness = add_item_randomness(0xa4);
+        let target_item_id = add_randomness.item_id();
+        target_session
+            .add_item(
+                new_login_document(target_item_id, "Existing target", "target-secret"),
+                903,
+                add_randomness,
+                &target_local,
+            )
+            .unwrap();
+        let target_session = open_active_vault(
+            Zeroizing::new(b"mutated target passphrase".to_vec()),
+            target_locator,
+            &target_local,
+            &target_bootstrap,
+            &target_factory,
+        )
+        .unwrap();
+        let opened = crate::open_portable_with_passphrase(
+            artifact.as_bytes(),
+            Zeroizing::new(b"empty restore passphrase".to_vec()),
+            crate::PortableOpenPolicyV1::new(8 * 1024, 1, 1).unwrap(),
+        )
+        .unwrap();
+        let randomness = crate::PortableImportRandomnessV1::new(vec![0xa5; 160], &opened).unwrap();
+        let target_compare_calls = target_local.3.load(Ordering::SeqCst);
+        assert_eq!(
+            target_session
+                .import_opened_portable_snapshot(opened, 904, randomness, &target_local)
+                .err(),
+            Some(ApplicationError::InvalidInput)
+        );
+        assert_eq!(target_local.3.load(Ordering::SeqCst), target_compare_calls);
     }
 
     #[test]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1140,6 +1140,41 @@ never gains plaintext.
 Every export has a restore test. “Backup completed” is not reported until the
 artifact can be parsed and authenticated.
 
+Portable restore is a cross-vault re-identification operation, not a repository
+copy:
+
+1. authenticate and fully validate the portable artifact through the bounded
+   no-write opener before selecting a target;
+2. initialize a separate target vault with a newly collected target passphrase,
+   fresh generation-zero entropy, and its own repository and owner state;
+3. require the target session to remain the untouched empty generation-zero
+   vault and reject the source vault itself as a target;
+4. derive the exact host-CSPRNG requirement as `16I + 80(C + 2)` bytes, where
+   `I` is the distinct source-item count and `C` is the retained current
+   candidate count, and reject `C + 1` above the repository's 4,096-object
+   atomic-publication bound;
+5. allocate a new target item ID for every source item and a new encrypted
+   revision/object ID for every retained live document, tombstone, and conflict
+   candidate; source item, revision, object, vault, and key identities are never
+   reused;
+6. preserve validated schema, timestamps, complete record payload, CRDT field
+   state, deletion time, and the current candidate grouping, but make imported
+   revisions parentless because source causal identities are intentionally not
+   part of the portable current-state closure;
+7. seal all imported revisions plus one new target catalog and signed commit,
+   persist the exact pending journal before provider publication, and activate
+   it only after exact receipt verification; the import is all-or-nothing and
+   uses the ordinary crash-recovery path; and
+8. discard the consumed opaque source snapshot and entropy, independently open
+   the target from durable state under its own passphrase, compare item,
+   candidate, conflict, schema, timestamp, deletion, and revealed field values,
+   and prove source and target item/revision identities are disjoint.
+
+The source remains untouched. Import into a non-empty or already-mutated target,
+identity collision, stale target pins, an oversized snapshot, or any local or
+provider failure returns the closed application error and never authorizes a
+partial logical restore.
+
 ### 19.4 Garbage collection
 
 GC is mark-and-sweep from all verified heads, retained conflicts, history
@@ -1338,9 +1373,11 @@ changelog, focused build, and downstream validation.
        authentication-before-plaintext parsing, signed-bootstrap and complete
        snapshot validation, opaque secret-bearing custody, and count-only
        diagnostics;
-   7d-2b. consume an opened portable snapshot into a new vault with new item,
-       revision, object, and encryption identities, followed by an independent
-       restore/open comparison; and
+   7d-2b. completed atomic cross-vault portable import, consuming the opaque
+       opened snapshot into an untouched generation-zero vault, allocating new
+       item/revision/object/encryption identities, preserving every current
+       live, tombstone, and conflict candidate, and independently reopening and
+       comparing the restored target; and
    7e-1. completed safe five-state status workflow, strictly decoding bounded
        owner state while locked and exposing only authenticated aggregate item,
        candidate, and conflict counts while unlocked;


### PR DESCRIPTION
## Summary

- consume an authenticated opaque portable snapshot into an untouched generation-zero target
- allocate disjoint target item, revision, object, vault, and encryption identities while preserving every current live, tombstone, and conflict candidate
- publish the complete restore through the existing crash-resumable write-ahead journal and document the exact host-CSPRNG and independent-reopen contract

## Security boundaries

- require an empty unmodified target and reject the source vault, stale pins, identity collisions, malformed bindings, and publications above 4,096 objects
- expose only aggregate snapshot counts; source identities and documents remain inaccessible to the host
- consume and wipe the snapshot plaintext and count-derived entropy on every path
- deliberately omit source causal-parent identities because a portable current-state snapshot does not carry their authenticated closure

## Verification

- 111 vault-pm-application tests pass, including independent restore/open comparison, live secret equality, conflict and tombstone retention, pre-write target rejection, and injected storage failure
- package BUILD passes
- Clippy passes with warnings denied
- affected-package planner validates 1,002 packages, selects 21, and builds all 21
- Tarpaulin LLVM: 3,086 / 3,245 production lines (95.10%)