### PR TITLE
feat(adj-formula-stdlib): Wave 3 continuation -- solve F=ma for mass/acceleration

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_mechanics_force_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_mechanics_force_e2e.rs
@@ -1,0 +1,122 @@
+//! End-to-end tests for `physics/mechanics-laws.adj` — the forward Newton's
+//! second law (`force`), plus this session's two new rung-0 CAS-wiring
+//! companions (ADJ-FORMULA-LIBRARIES FL-10, §3D): `mass_from_force` and
+//! `acceleration_from_force`, solving the SAME cited NASA `F = m a` equation
+//! as the forward `force` formula for a different unknown. Driven through the
+//! built CLI binary against the SHIPPED stdlib.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn shipped_mechanics_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/physics/mechanics-laws.adj")
+        .canonicalize()
+        .expect("shipped mechanics-laws.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_mechanics_force_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_mechanics_lib()).unwrap();
+    std::fs::write(dir.join("mechanics-laws.adj"), lib).unwrap();
+}
+
+#[test]
+fn imports_mechanics_library_and_computes_force_forward() {
+    let dir = scratch("forward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"mechanics-laws.adj\"\n\
+         observe mass(2)\n\
+         observe acceleration(3)\n\
+         ? force(mass, acceleration)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    assert!(
+        s.contains("\"name\":\"force\"") && s.contains("\"value\":6"),
+        "force(2, 3) = 6: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("grc.nasa.gov"),
+        "force carries its NASA provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// F = m a, solved for a different unknown (ADJ-FORMULA-LIBRARIES FL-10, §3D
+// rung-0 CAS-wiring companions) — the SAME cited NASA equation as `force`
+// above, rearranged rather than computed forward.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn solves_for_mass_from_force_with_the_same_citation() {
+    let dir = scratch("mass_solve");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"mechanics-laws.adj\"\n\
+         observe force(12)\n\
+         observe acceleration(3)\n\
+         ? mass_from_force(force, acceleration)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 12 = m * 3  =>  m = 4.
+    assert!(
+        s.contains("\"name\":\"mass_from_force\"") && s.contains("\"value\":4"),
+        "mass_from_force(12, 3) = 4: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("grc.nasa.gov"),
+        "carries the same NASA citation as the forward force formula: {s}"
+    );
+}
+
+#[test]
+fn solves_for_acceleration_from_force_with_the_same_citation() {
+    let dir = scratch("acceleration_solve");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"mechanics-laws.adj\"\n\
+         observe force(12)\n\
+         observe mass(4)\n\
+         ? acceleration_from_force(force, mass)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 12 = 4 * a  =>  a = 3.
+    assert!(
+        s.contains("\"name\":\"acceleration_from_force\"") && s.contains("\"value\":3"),
+        "acceleration_from_force(12, 4) = 3: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("grc.nasa.gov"),
+        "carries the same NASA citation as the forward force formula: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-formula-stdlib/CHANGELOG.md
@@ -107,3 +107,16 @@ landed and why, not a semver-tracked API.
   shape (mass sits between two constant factors once velocity is bound), left for a later pass to
   keep this change scoped to one law. New manifest objective `adj.math.algebra.rearrange_work`.
   New e2e test `formula_energy_work_e2e.rs` (3 tests — this library had none before).
+- `physics/mechanics-laws.adj` — a fourth Wave 3 rung-0 CAS-wiring pair (ADJ-FORMULA-LIBRARIES
+  FL-10, §3D): `mass_from_force` and `acceleration_from_force`, solving the SAME cited NASA
+  `F = m a` equation as the forward `force` formula for a different unknown. Named each new
+  symbolic's target distinctly from the forward formula's plain parameter names
+  (`mass_from_force`, not `mass`) — the same collision-avoidance discipline established by
+  `kinematics.adj`/`energy-work.adj`'s companions — so both new solves coexist with the original
+  forward example in one query file. This library's other two laws already have their solve
+  directions covered elsewhere in the physics track (`electricity.adj`'s
+  `resistance_from_ohms_law` for Ohm's law; `density.adj`'s own forward `mass(density, volume)`
+  for density), and average speed is left for a later pass, so this pair closes the one remaining
+  gap in `mechanics-laws.adj` itself. New manifest objective
+  `adj.math.algebra.rearrange_mechanics_force`. New e2e test `formula_mechanics_force_e2e.rs`
+  (3 tests — this library had none before).

--- a/code/specs/data/adj-formula-stdlib/physics/mechanics-laws.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/mechanics-laws.adj
@@ -31,6 +31,21 @@
 % falls back to an encyclopedia (Wikipedia) for the clean V = IR product form →
 % `consensus`. Provenance travels per-formula, so the tiers differ by law.
 %
+% This library also carries a rung-0 CAS-wiring pair (ADJ-FORMULA-LIBRARIES FL-10,
+% §3D — a Wave 3 continuation): `mass_from_force` and `acceleration_from_force`
+% solve the SAME cited NASA equation (F = m·a) as the forward `force` formula for
+% a different unknown, through `cas-solve`'s real linear-equation solver — the
+% exact discipline `electricity.adj`'s `resistance_from_ohms_law` and
+% `energy-work.adj`'s `force_from_work`/`distance_from_work` already established.
+% Each new symbolic names its OWN target finding (`mass_from_force`, not `mass`)
+% rather than reusing the forward formula's plain parameter name, so both new
+% solves coexist with the original forward example in one query file — no
+% target-collision, no file-splitting needed. Ohm's law and density already have
+% their own solve directions covered elsewhere in the physics track
+% (`electricity.adj`'s `resistance_from_ohms_law`; `density.adj`'s own forward
+% `mass(density, volume)`), and average speed is left for a later pass, so this
+% pair closes the one remaining gap in this particular library.
+%
 % Run a worked consumer (from a directory it can resolve this import from):
 %     adj-lang-cli mechanics-laws.query.adj
 % ============================================================================
@@ -63,6 +78,8 @@ dictionary physics_vocab {
     define mass         : finding  surface "mass", "m"                                         % mass, e.g. kg
     define acceleration : finding  surface "acceleration", "a", "rate of change of velocity"   % length / time²
     define force        : finding  surface "force", "net force", "F"                           % mass · length / time² (newtons)
+    define mass_from_force         : finding  surface "missing mass", "unknown mass"
+    define acceleration_from_force : finding  surface "missing acceleration", "unknown acceleration"
 
     % --- electricity: Ohm's law, V = I·R ---
     define current      : finding  surface "current", "electric current", "I"                  % electric current (amperes)
@@ -95,6 +112,20 @@ formulabook physics_laws {
     % acceleration.  F = m · a.  Source: NASA Glenn Research Center, Beginners'
     % Guide to Aeronautics (primary .gov physics reference) → authoritative.
     formula force(mass, acceleration) = mass * acceleration
+        source "The second law then reduces to the more familiar product of a mass and an acceleration: F = m · a"
+        locator "https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/newtons-laws-of-motion/"
+        trust authoritative
+
+    % Newton's second law again, SOLVED FOR MASS instead of computed forward —
+    % the same cited equation, only which quantity is bound and which is unknown
+    % differs.
+    symbolic mass_from_force(force, acceleration) { force == mass_from_force * acceleration } for mass_from_force
+        source "The second law then reduces to the more familiar product of a mass and an acceleration: F = m · a"
+        locator "https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/newtons-laws-of-motion/"
+        trust authoritative
+
+    % Newton's second law again, SOLVED FOR ACCELERATION. The same cited equation.
+    symbolic acceleration_from_force(force, mass) { force == mass * acceleration_from_force } for acceleration_from_force
         source "The second law then reduces to the more familiar product of a mass and an acceleration: F = m · a"
         locator "https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/newtons-laws-of-motion/"
         trust authoritative

--- a/code/specs/data/adj-formula-stdlib/physics/mechanics-laws.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/mechanics-laws.query.adj
@@ -26,3 +26,15 @@ observe acceleration(3)                % "…accelerates at 3 m/s²…" (span ci
 observe current(4)                     % "…a current of 4 amperes…"   (span cited)
 observe resistance(5)                  % "…a 5 ohm resistor…"         (span cited)
 ? voltage(current, resistance)         % engine → 20 (V = I·R, Wikipedia, consensus)
+
+% --- F = m a, SOLVED FOR MASS (rung-0 CAS-wiring, FL-10). "A net force of 12 N
+% accelerates an object at 3 m/s². What is its mass?" ---
+observe force(12)                      % "…a net force of 12 N…"      (span cited)
+observe acceleration(3)                % "…accelerates … at 3 m/s²…"  (span cited)
+? mass_from_force(force, acceleration) % engine → 4 (NASA, authoritative)
+
+% --- F = m a, SOLVED FOR ACCELERATION. "A 12 N force acts on a 4 kg mass. What
+% acceleration results?" ---
+observe force(12)                      % "…a 12 N force…"             (span cited)
+observe mass(4)                        % "…a 4 kg mass…"              (span cited)
+? acceleration_from_force(force, mass) % engine → 3 (NASA, authoritative)

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1217,6 +1217,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.math.algebra.rearrange_mechanics_force",
+      "title": "Solve F = m a for mass or acceleration, given the force and the other quantity",
+      "band": "9-12",
+      "domain": "mathematics",
+      "competency": "compute",
+      "coverage_roots": ["ccss.math"],
+      "standards": [],
+      "prerequisites": ["adj.science.physics.mechanics_laws"],
+      "libraries": ["code/specs/data/adj-formula-stdlib/physics/mechanics-laws.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds rung-0 CAS-wiring companions (ADJ-FORMULA-LIBRARIES FL-10, §3D — Wave 3 continuation) to `physics/mechanics-laws.adj`: `mass_from_force` and `acceleration_from_force`, solving the same cited NASA `F = m a` equation as the forward `force` formula for a different unknown, through `cas-solve`'s real linear-equation solver.
- This closes the one remaining solve-direction gap in `mechanics-laws.adj`: Ohm's law already has `resistance_from_ohms_law` (`electricity.adj`) and density already has its own forward `mass(density, volume)` (`density.adj`) elsewhere in the physics track.
- New symbolic targets are named distinctly from the forward formula's parameter names (`mass_from_force`, not `mass`) — the collision-avoidance discipline established by the three prior Wave 3 items — so the new solves coexist with the original forward example in one query file.
- New manifest objective `adj.math.algebra.rearrange_mechanics_force` (band 9-12, prerequisite `adj.science.physics.mechanics_laws`).
- New e2e test `formula_mechanics_force_e2e.rs` (3 tests, this library had none before).

Part of the autonomous ADJ curriculum loop (`ADJ-STDLIB-COVERAGE.md#7-delivery-order`).

## Test plan
- [x] Both solve directions empirically verified via the CLI in a scratch dir before writing real content (`mass_from_force(12,3)=4`, `acceleration_from_force(12,4)=3`).
- [x] `cargo test -p adj-lang-cli --test formula_mechanics_force_e2e` — 3/3 passed.
- [x] `cargo test -p adj-lang -p adj-lang-cli` — full suite green, no regressions.
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean.
- [x] `adj_stdlib_manifest.py --validate-json-schema` — 77 objectives, 0 errors, valid.
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` — exit 0, no new gaps introduced.
- [x] Python unittest suite (manifest/report subset) — 87 passed.
- [x] Security review — passed, no findings.