### PR TITLE
test(mosaic): exercise Rust engine through Flutter binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
       needs_mosaic_xaml_windows: ${{ steps.mosaic-xaml-windows.outputs.required }}
       needs_mosaic_swift_runtime: ${{ steps.mosaic-swift-runtime.outputs.required }}
       needs_mosaic_qt_runtime: ${{ steps.mosaic-qt-runtime.outputs.required }}
+      needs_mosaic_flutter_runtime: ${{ steps.mosaic-flutter-runtime.outputs.required }}
       diff_base: ${{ steps.diff-base.outputs.base }}
       is_main: ${{ steps.detect-main.outputs.is_main }}
       build_shards: ${{ steps.detect.outputs.build_shards }}
@@ -131,6 +132,7 @@ jobs:
           python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_xaml_windows_ci_acceptance.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_swift_runtime_ci_acceptance.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_qt_runtime_ci_acceptance.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_flutter_runtime_ci_acceptance.py'
           python3 code/scripts/build_tool_conformance.py validate-corpus
           python3 code/scripts/build_tool_conformance_execution.py validate-contract
           python3 code/scripts/package_parity_report.py --format json --fail-on-collisions > /tmp/package-parity-report.json
@@ -248,6 +250,15 @@ jobs:
         shell: bash
         run: |
           python3 code/scripts/mosaic_qt_runtime_ci_acceptance.py \
+            build-plan.json \
+            --repo-root . \
+            --diff-base "${{ steps.diff-base.outputs.base }}" >> "$GITHUB_OUTPUT"
+
+      - name: Detect Mosaic Flutter runtime acceptance
+        id: mosaic-flutter-runtime
+        shell: bash
+        run: |
+          python3 code/scripts/mosaic_flutter_runtime_ci_acceptance.py \
             build-plan.json \
             --repo-root . \
             --diff-base "${{ steps.diff-base.outputs.base }}" >> "$GITHUB_OUTPUT"
@@ -552,7 +563,7 @@ jobs:
           clang --version | head -1
 
       - name: Set up Rust
-        if: needs.detect.outputs.needs_rust == 'true' || needs.detect.outputs.needs_venture_windows == 'true' || needs.detect.outputs.needs_mosaic_xaml_windows == 'true' || needs.detect.outputs.needs_mosaic_swift_runtime == 'true' || needs.detect.outputs.needs_mosaic_qt_runtime == 'true'
+        if: needs.detect.outputs.needs_rust == 'true' || needs.detect.outputs.needs_venture_windows == 'true' || needs.detect.outputs.needs_mosaic_xaml_windows == 'true' || needs.detect.outputs.needs_mosaic_swift_runtime == 'true' || needs.detect.outputs.needs_mosaic_qt_runtime == 'true' || needs.detect.outputs.needs_mosaic_flutter_runtime == 'true'
         # Uses the `stable` channel (matching the rest of this repo's Rust CI).
         # NOTE on the -clippy gate: clippy adds/tightens lints on each stable
         # release, so a new Rust release can surface new lints on `main` — treat
@@ -598,7 +609,7 @@ jobs:
           version-type: strict
 
       - name: Set up Dart
-        if: needs.detect.outputs.needs_dart == 'true'
+        if: needs.detect.outputs.needs_dart == 'true' || needs.detect.outputs.needs_mosaic_flutter_runtime == 'true'
         uses: dart-lang/setup-dart@v1
 
       - name: Set up Swift (Windows)
@@ -970,6 +981,29 @@ jobs:
           cmake --build "$harness/build" --config Release --parallel
           export MOSAIC_APP_LIBRARY="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.so"
           "$harness/build/mosaic_qt_runtime_conformance"
+
+      - name: Round-trip Rust engine through standard Flutter binding
+        if: runner.os == 'Linux' && needs.detect.outputs.needs_mosaic_flutter_runtime == 'true'
+        shell: bash
+        timeout-minutes: 10
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/mosaic-flutter-taskapp"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend flutter --output "$output" --emit-project
+          cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance
+
+          harness="$RUNNER_TEMP/mosaic-flutter-runtime-conformance"
+          cp -R code/packages/rust/mosaic-app-bindings/conformance/flutter "$harness"
+          mkdir -p "$harness/lib"
+          cp "$output/flutter/lib/mosaic_host.dart" "$harness/lib/mosaic_host.dart"
+
+          export MOSAIC_APP_LIBRARY="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.so"
+          (
+            cd "$harness"
+            dart pub get
+            dart analyze
+            dart run bin/conformance.dart
+          )
 
       - name: Build complete Mosaic TaskApp WinUI shell
         if: runner.os == 'Windows' && needs.detect.outputs.needs_mosaic_xaml_windows == 'true'

--- a/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
+++ b/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Execute the generated Flutter/Dart FFI host against the shared Rust
+  conformance library in Linux CI, covering startup, dispatch,
+  snapshot/restore, notification, buffer ownership, and teardown.
 - Execute the generated Qt/QML host against the shared Rust conformance library
   in headless Linux CI, covering startup, dispatch, snapshot/restore, buffer
   ownership, and teardown through the real ABI.

--- a/code/packages/rust/mosaic-app-bindings/README.md
+++ b/code/packages/rust/mosaic-app-bindings/README.md
@@ -34,6 +34,9 @@ semantic dispatch, revision application, buffer ownership, and teardown.
 For Flutter, set `MOSAIC_APP_LIBRARY` to the application library path. Without
 an explicit path the host checks symbols linked into the process, then the
 platform's conventional `mosaic_app` dynamic-library names.
+Linux CI runs the exact binding from a complete generated TaskApp project with
+the shared `mosaic-app-conformance` library, verifying startup, semantic
+dispatch, snapshot/restore, notification, buffer ownership, and teardown.
 
 For Qt/QML, set `MOSAIC_APP_LIBRARY` to the application library path or package
 it under the platform's conventional `mosaic_app` name. The generated QObject

--- a/code/packages/rust/mosaic-app-bindings/conformance/flutter/README.md
+++ b/code/packages/rust/mosaic-app-bindings/conformance/flutter/README.md
@@ -1,0 +1,10 @@
+# Flutter runtime conformance
+
+This headless Dart harness compiles the exact `mosaic_host.dart` emitted into a
+generated Flutter project. It loads the shared `mosaic-app-conformance` native
+library and verifies startup, revisions, prop projection, semantic dispatch,
+snapshot/restore, notification, buffer ownership, and teardown.
+
+CI generates the complete TaskApp project, copies its generated binding into
+this package in a temporary workspace, and runs it with the Dart VM. The binding
+itself is deliberately not duplicated here, and no Flutter engine is required.

--- a/code/packages/rust/mosaic-app-bindings/conformance/flutter/bin/conformance.dart
+++ b/code/packages/rust/mosaic-app-bindings/conformance/flutter/bin/conformance.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:mosaic_flutter_runtime_conformance/mosaic_host.dart';
+
+Never _fail(String assertion) =>
+    throw StateError('Failed assertion: $assertion');
+
+void _require(bool condition, String assertion) {
+  if (!condition) _fail(assertion);
+}
+
+Map<String, Object?> _object(Object? value, String assertion) {
+  if (value is! Map) _fail('$assertion was not an object');
+  final object = Map<String, Object?>.from(value);
+  _require(!object.containsKey('error'), '$assertion returned an error');
+  return object;
+}
+
+Map<String, Object?> _props(Map<String, Object?> update, String assertion) =>
+    _object(update['props'], '$assertion props');
+
+int _integer(Object? value, String assertion) {
+  if (value is! num) _fail('$assertion was not numeric');
+  return value.toInt();
+}
+
+String _expectedPlatform() {
+  if (Platform.isMacOS || Platform.isIOS) return 'apple';
+  if (Platform.isWindows) return 'windows';
+  return 'linux';
+}
+
+Future<void> main() async {
+  final host = MosaicHost.load();
+  if (host == null) _fail('standard Flutter binding did not load the Rust app');
+
+  try {
+    final started = _object(await host.props(), 'startup update');
+    final startedProps = _props(started, 'startup update');
+    _require(
+      _integer(started['revision'], 'startup revision') == 1,
+      'startup revision',
+    );
+    _require(
+      _integer(startedProps['count'], 'initial count') == 0,
+      'initial count',
+    );
+    _require(
+      startedProps['platform'] == _expectedPlatform(),
+      'startup platform',
+    );
+    _require(startedProps['status'] == 'started', 'startup status');
+
+    var notificationCount = 0;
+    host.setPropsChangedHandler(() => notificationCount += 1);
+
+    final dispatched = _object(
+      await host.handleEvent(<String, Object?>{
+        'name': 'increment',
+        'payload': <String, Object?>{'amount': 4},
+      }),
+      'dispatch update',
+    );
+    final dispatchedProps = _props(dispatched, 'dispatch update');
+    _require(
+      _integer(dispatched['revision'], 'dispatch revision') == 2,
+      'dispatch revision',
+    );
+    _require(
+      _integer(dispatchedProps['count'], 'dispatched count') == 4,
+      'dispatched count',
+    );
+    _require(dispatchedProps['status'] == 'dispatched', 'dispatch status');
+
+    final snapshot = _object(host.snapshot(), 'snapshot');
+    _require(
+      snapshot['schema'] == 'mosaic-app-conformance/counter',
+      'snapshot schema',
+    );
+    _require(
+      _integer(snapshot['version'], 'snapshot version') == 1,
+      'snapshot version',
+    );
+    _require(
+      (snapshot['bytes'] as List<Object?>).length == 8,
+      'snapshot bytes',
+    );
+
+    final restored = _object(host.restore(snapshot), 'restore update');
+    final restoredProps = _props(restored, 'restore update');
+    _require(
+      _integer(restored['revision'], 'restore revision') == 3,
+      'restore revision',
+    );
+    _require(
+      _integer(restoredProps['count'], 'restored count') == 4,
+      'restored count',
+    );
+    _require(restoredProps['status'] == 'restored', 'restore status');
+    _require(notificationCount == 1, 'restore props-change notification');
+  } finally {
+    host.dispose();
+  }
+
+  stdout.writeln('Mosaic Flutter Rust runtime conformance passed');
+}

--- a/code/packages/rust/mosaic-app-bindings/conformance/flutter/pubspec.yaml
+++ b/code/packages/rust/mosaic-app-bindings/conformance/flutter/pubspec.yaml
@@ -1,0 +1,10 @@
+name: mosaic_flutter_runtime_conformance
+description: Headless conformance for Mosaic's generated Flutter Rust binding.
+publish_to: none
+version: 0.0.0
+
+environment:
+  sdk: '>=3.5.0 <4.0.0'
+
+dependencies:
+  ffi: '>=2.1.0 <3.0.0'

--- a/code/scripts/mosaic_flutter_runtime_ci_acceptance.py
+++ b/code/scripts/mosaic_flutter_runtime_ci_acceptance.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Derive the Mosaic Flutter runtime conformance flag from a build plan."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+ACCEPTANCE_PACKAGES = frozenset(
+    {
+        "rust/mosaic-app-bindings",
+        "rust/mosaic-app-capi",
+        "rust/mosaic-app-conformance",
+        "rust/mosaic-app-runtime",
+        "rust/mosaic-compile",
+        "rust/mosaic-emit-flutter",
+        "rust/mosaic-package-artifact-builder",
+        "rust/moslayout-compiler",
+        "rust/mosmodel-compiler",
+        "rust/mosstyle-compiler",
+        "unknown/programs/task-app",
+    }
+)
+ACCEPTANCE_PACKAGE_PREFIXES = ("unknown/mosaic-pkg-",)
+CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+
+
+def requires_mosaic_flutter_runtime(
+    plan: dict[str, Any], *, workflow_changed: bool = False
+) -> bool:
+    """Return whether this plan must exercise the generated Flutter binding."""
+
+    if workflow_changed:
+        return True
+    affected = plan.get("affected_packages")
+    if affected is None:
+        return True
+    if not isinstance(affected, list):
+        raise ValueError("affected_packages must be an array or null")
+    return any(
+        package in ACCEPTANCE_PACKAGES
+        or package.startswith(ACCEPTANCE_PACKAGE_PREFIXES)
+        for package in affected
+    )
+
+
+def workflow_changed(repo_root: Path, diff_base: str) -> bool:
+    """Return whether the main CI workflow differs from the selected base."""
+
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--quiet",
+            f"{diff_base}...HEAD",
+            "--",
+            CI_WORKFLOW_PATH,
+        ],
+        cwd=repo_root,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        raise RuntimeError(f"git diff exited with status {result.returncode}")
+    return result.returncode == 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("plan", type=Path)
+    parser.add_argument("--repo-root", type=Path)
+    parser.add_argument("--diff-base")
+    args = parser.parse_args()
+
+    if (args.repo_root is None) != (args.diff_base is None):
+        parser.error("--repo-root and --diff-base must be provided together")
+
+    with args.plan.open(encoding="utf-8") as handle:
+        plan = json.load(handle)
+    if not isinstance(plan, dict):
+        raise ValueError("build plan root must be an object")
+
+    changed = False
+    if args.repo_root is not None and args.diff_base is not None:
+        changed = workflow_changed(args.repo_root, args.diff_base)
+
+    required = requires_mosaic_flutter_runtime(plan, workflow_changed=changed)
+    print(f"required={'true' if required else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/tests/test_mosaic_flutter_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_flutter_runtime_ci_acceptance.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "mosaic_flutter_runtime_ci_acceptance.py"
+WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "ci.yml"
+FLUTTER_CONFORMANCE = (
+    Path(__file__).resolve().parents[2]
+    / "packages"
+    / "rust"
+    / "mosaic-app-bindings"
+    / "conformance"
+    / "flutter"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "mosaic_flutter_runtime_ci_acceptance", SCRIPT
+)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class MosaicFlutterRuntimeCIAcceptanceTests(unittest.TestCase):
+    def test_force_plan_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_flutter_runtime({"affected_packages": None})
+        )
+
+    def test_flutter_emitter_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_flutter_runtime(
+                {"affected_packages": ["rust/mosaic-emit-flutter"]}
+            )
+        )
+
+    def test_standard_runtime_binding_requires_acceptance(self) -> None:
+        for package in (
+            "rust/mosaic-app-bindings",
+            "rust/mosaic-app-capi",
+            "rust/mosaic-app-conformance",
+            "rust/mosaic-app-runtime",
+        ):
+            with self.subTest(package=package):
+                self.assertTrue(
+                    MODULE.requires_mosaic_flutter_runtime(
+                        {"affected_packages": [package]}
+                    )
+                )
+
+    def test_task_app_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_flutter_runtime(
+                {"affected_packages": ["unknown/programs/task-app"]}
+            )
+        )
+
+    def test_standard_mosaic_package_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_flutter_runtime(
+                {"affected_packages": ["unknown/mosaic-pkg-grid"]}
+            )
+        )
+
+    def test_unrelated_plan_skips_acceptance(self) -> None:
+        self.assertFalse(
+            MODULE.requires_mosaic_flutter_runtime(
+                {"affected_packages": ["rust/html-parser"]}
+            )
+        )
+
+    def test_workflow_change_self_tests_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_flutter_runtime(
+                {"affected_packages": []}, workflow_changed=True
+            )
+        )
+
+    def test_invalid_affected_packages_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "array or null"):
+            MODULE.requires_mosaic_flutter_runtime({"affected_packages": "all"})
+
+    def test_cli_emits_github_output_value(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            plan = Path(directory) / "build-plan.json"
+            plan.write_text(
+                '{"affected_packages":["rust/mosaic-emit-flutter"]}',
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), str(plan)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.stdout, "required=true\n")
+
+    def test_workflow_routes_rust_dart_and_acceptance(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "needs_mosaic_flutter_runtime: "
+            "${{ steps.mosaic-flutter-runtime.outputs.required }}",
+            workflow,
+        )
+        self.assertIn(
+            "python3 code/scripts/mosaic_flutter_runtime_ci_acceptance.py",
+            workflow,
+        )
+        self.assertIn("Round-trip Rust engine through standard Flutter binding", workflow)
+        self.assertIn("needs_mosaic_flutter_runtime == 'true'", workflow)
+        self.assertIn("timeout-minutes: 10", workflow)
+        self.assertIn("--backend flutter --output \"$output\" --emit-project", workflow)
+        self.assertIn(
+            "cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance",
+            workflow,
+        )
+        self.assertIn("flutter/lib/mosaic_host.dart", workflow)
+        self.assertIn("dart analyze", workflow)
+        self.assertIn("dart run bin/conformance.dart", workflow)
+        self.assertIn("MOSAIC_APP_LIBRARY", workflow)
+
+    def test_harness_does_not_duplicate_the_generated_binding(self) -> None:
+        self.assertTrue(
+            (FLUTTER_CONFORMANCE / "bin" / "conformance.dart").is_file()
+        )
+        self.assertFalse((FLUTTER_CONFORMANCE / "lib" / "mosaic_host.dart").exists())
+        pubspec = (FLUTTER_CONFORMANCE / "pubspec.yaml").read_text(encoding="utf-8")
+        self.assertIn("ffi:", pubspec)
+        self.assertNotIn("sdk: flutter", pubspec)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -308,8 +308,10 @@ unblocks multiple downstream targets; never count source generation as completio
     startup, dispatch, snapshot/restore, notification, and teardown in macOS CI.
   - [x] Qt/QML loads the shared Rust conformance library and round-trips startup,
     dispatch, snapshot/restore, buffers, and teardown in headless Linux CI.
-  - [ ] Promote the same shared Rust fixture through Compose and Flutter standard
-    bindings.
+  - [x] Flutter/Dart FFI loads the shared Rust conformance library and round-trips
+    startup, dispatch, snapshot/restore, notification, buffers, and teardown in
+    headless Linux CI.
+  - [ ] Promote the same shared Rust fixture through the Compose standard binding.
 - [x] Gate the complete package-expanded XAML TaskApp on GitHub-hosted Windows
   with real WinUI compilation and executable production.
   - [x] Allocate `For` row-view-model and projection names per loop rather than


### PR DESCRIPTION
## Summary

- add a headless Dart conformance package that analyzes and runs the exact generated Flutter FFI host
- round-trip the shared Rust fixture through startup, dispatch, snapshot/restore, notification, buffer ownership, and teardown
- route relevant Mosaic package changes through Dart CI and update the UI38 completion backlog

## Validation

- generated TaskApp Flutter project + `mosaic-app-conformance` dylib + `dart pub get`, `dart analyze`, and real conformance run
- `python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_flutter_runtime_ci_acceptance.py'`\n- neighboring Qt, SwiftUI, XAML, and Venture CI-routing unit tests\n- `cargo test -p mosaic-app-bindings`\n- `cargo test -p mosaic-app-conformance`\n- `cargo test -p mosaic-emit-flutter --lib`\n- `cargo test -p mosaic-package-artifact-builder --lib`\n- workflow YAML parse, Dart formatting check, and `git diff --check`