### PR TITLE
feat(adj-formula-stdlib): Wave 3 continuation -- solve KE=0.5mv^2 for mass

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_energy_work_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_energy_work_e2e.rs
@@ -131,3 +131,38 @@ fn solves_for_distance_from_work_with_the_same_citation() {
         "carries the same NASA citation as the forward work formula: {s}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// KE = ½ m v², solved for mass (ADJ-FORMULA-LIBRARIES FL-10, §3D rung-0
+// CAS-wiring companion) — the SAME cited HyperPhysics equation as
+// `kinetic_energy` above, rearranged rather than computed forward. Linear
+// despite the nested `0.5 * mass * velocity * velocity` shape, since mass
+// appears exactly once once velocity is bound.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn solves_for_mass_from_kinetic_energy_with_the_same_citation() {
+    let dir = scratch("mass_ke_solve");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"energy-work.adj\"\n\
+         observe kinetic_energy(9)\n\
+         observe velocity(3)\n\
+         ? mass_from_kinetic_energy(kinetic_energy, velocity)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 9 = 0.5 * m * 3 * 3 = 4.5 * m  =>  m = 2.
+    assert!(
+        s.contains("\"name\":\"mass_from_kinetic_energy\"") && s.contains("\"value\":2"),
+        "mass_from_kinetic_energy(9, 3) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("hyperphysics.gsu.edu"),
+        "carries the same HyperPhysics citation as the forward kinetic_energy formula: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-formula-stdlib/CHANGELOG.md
@@ -120,3 +120,14 @@ landed and why, not a semver-tracked API.
   gap in `mechanics-laws.adj` itself. New manifest objective
   `adj.math.algebra.rearrange_mechanics_force`. New e2e test `formula_mechanics_force_e2e.rs`
   (3 tests — this library had none before).
+- `physics/energy-work.adj` — a fifth Wave 3 rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES
+  FL-10, §3D): `mass_from_kinetic_energy`, solving the SAME cited HyperPhysics `KE = ½ m v²`
+  equation as the forward `kinetic_energy` formula for mass — the gap this library's own header
+  comment flagged when `force_from_work`/`distance_from_work` shipped. Linear despite the nested
+  `0.5 * mass * velocity * velocity` shape: once `velocity` is bound, `mass` still appears exactly
+  once, multiplied only by constant factors, confirmed empirically via the CLI before writing.
+  Solving for velocity instead (the formula's OTHER unknown) remains deliberately absent: velocity
+  appears squared, which is quadratic and out of rung-0's linear-only scope, the direct sibling of
+  `geometry-formulas.adj`'s `square_area` boundary case. New manifest objective
+  `adj.math.algebra.rearrange_kinetic_energy`. Extended the existing `formula_energy_work_e2e.rs`
+  with 1 new test rather than adding a new test file.

--- a/code/specs/data/adj-formula-stdlib/physics/energy-work.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/energy-work.adj
@@ -30,21 +30,26 @@
 % the same provenance envelope every shipped grounded clause carries; the linter
 % rejects an unsourced one.
 %
-% This library also carries two rung-0 CAS-wiring companions (ADJ-FORMULA-
+% This library also carries three rung-0 CAS-wiring companions (ADJ-FORMULA-
 % LIBRARIES FL-10, §3D — continuing Wave 3's algebra-applied-to-science thread):
 % `force_from_work` and `distance_from_work` solve the SAME cited NASA equation
-% (`W = F d`) as the forward `work` formula for a different unknown, through
+% (`W = F d`) as the forward `work` formula for a different unknown, and
+% `mass_from_kinetic_energy` solves the SAME cited HyperPhysics equation
+% (`KE = ½ m v²`) as the forward `kinetic_energy` formula for mass, through
 % `cas-solve`'s real linear-equation solver — the exact discipline `electricity.
 % adj`'s `resistance_from_ohms_law` and `kinematics.adj`'s `acceleration_from_
 % final_velocity`/`time_from_final_velocity` already established. Each new
 % symbolic names its OWN target finding (`force_from_work`, not `force`) rather
-% than reusing the forward formula's plain parameter name, so both new solves
-% coexist with the original forward example in one query file — no target-
-% collision, no file-splitting needed. `kinetic_energy`'s inverse is deliberately
-% absent here: solving for velocity is quadratic (out of rung-0's linear-only
-% scope); solving for mass is linear but is a genuinely different nested-
-% multiplication shape (mass sits between two constant factors once velocity is
-% bound) left for a later pass, to keep this change scoped to one law.
+% than reusing the forward formula's plain parameter name, so all new solves
+% coexist with the original forward examples in one query file — no target-
+% collision, no file-splitting needed. Solving `mass_from_kinetic_energy` is
+% linear despite the nested `0.5 * mass * velocity * velocity` shape: once
+% `velocity` is bound, `mass` still appears exactly once, multiplied only by
+% constant factors — the exact discipline confirmed empirically before writing
+% this content. `kinetic_energy`'s OTHER inverse — solving for velocity — is
+% deliberately absent: velocity appears squared, which is quadratic and out of
+% rung-0's linear-only scope (the direct sibling of `geometry-formulas.adj`'s
+% `square_area` boundary case).
 % ============================================================================
 
 % ----------------------------------------------------------------------------
@@ -68,6 +73,7 @@ dictionary physics_vocab {
 
     define force_from_work    : finding  surface "missing force", "unknown force"
     define distance_from_work : finding  surface "missing distance", "unknown distance"
+    define mass_from_kinetic_energy : finding  surface "missing mass", "unknown mass"
 }
 
 % ----------------------------------------------------------------------------
@@ -106,6 +112,14 @@ formulabook physics_energy {
     % State University's HyperPhysics states "The kinetic energy of a point mass m
     % is given by" the equation KE = (1/2) m v².
     formula kinetic_energy(mass, velocity) = 0.5 * mass * velocity * velocity
+        source "The kinetic energy of a point mass m is given by"
+        locator "https://hyperphysics.gsu.edu/hbase/ke.html"
+        trust authoritative
+
+    % KE = ½ m v², SOLVED FOR MASS instead of computed forward — the same cited
+    % HyperPhysics equation. Linear in mass once velocity is bound (mass appears
+    % exactly once, multiplied only by the constant factors 0.5 and velocity²).
+    symbolic mass_from_kinetic_energy(kinetic_energy, velocity) { kinetic_energy == 0.5 * mass_from_kinetic_energy * velocity * velocity } for mass_from_kinetic_energy
         source "The kinetic energy of a point mass m is given by"
         locator "https://hyperphysics.gsu.edu/hbase/ke.html"
         trust authoritative

--- a/code/specs/data/adj-formula-stdlib/physics/energy-work.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/energy-work.query.adj
@@ -35,3 +35,9 @@ observe distance(3)                    % "…pushing a crate 3 m…"     (span c
 observe work(30)                       % "…did 30 J of work…"        (span cited)
 observe force(10)                      % "…a 10 N force…"            (span cited)
 ? distance_from_work(work, force)      % engine → 3 (NASA, authoritative)
+
+% --- KE = ½ m v², SOLVED FOR MASS (rung-0 CAS-wiring, FL-10). "A mass moving at
+% 3 m/s has 9 J of kinetic energy. What is its mass?" ---
+observe kinetic_energy(9)              % "…has 9 J of kinetic energy…" (span cited)
+observe velocity(3)                    % "…moving at 3 m/s…"           (span cited)
+? mass_from_kinetic_energy(kinetic_energy, velocity)  % engine → 2 (HyperPhysics, authoritative)

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1232,6 +1232,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.math.algebra.rearrange_kinetic_energy",
+      "title": "Solve KE = 1/2 m v^2 for mass, given the kinetic energy and the velocity",
+      "band": "9-12",
+      "domain": "mathematics",
+      "competency": "compute",
+      "coverage_roots": ["ccss.math"],
+      "standards": [],
+      "prerequisites": ["adj.science.physics.energy_work"],
+      "libraries": ["code/specs/data/adj-formula-stdlib/physics/energy-work.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES FL-10, §3D — Wave 3 continuation) to `physics/energy-work.adj`: `mass_from_kinetic_energy`, solving the same cited HyperPhysics `KE = ½ m v²` equation as the forward `kinetic_energy` formula for mass — the gap this library's own header comment flagged when `force_from_work`/`distance_from_work` shipped.
- Linear despite the nested `0.5 * mass * velocity * velocity` shape: once `velocity` is bound, `mass` still appears exactly once, multiplied only by constant factors. Confirmed empirically via the CLI before writing (`mass_from_kinetic_energy(9, 3) = 2`).
- Solving for velocity instead (the formula's other unknown) remains deliberately absent: velocity appears squared, quadratic and out of rung-0's linear-only scope — the direct sibling of `geometry-formulas.adj`'s `square_area` boundary case.
- New manifest objective `adj.math.algebra.rearrange_kinetic_energy` (band 9-12, prerequisite `adj.science.physics.energy_work`).
- Extended the existing `formula_energy_work_e2e.rs` with 1 new test (4 total) rather than adding a new test file.

This closes out the currently-known Wave 3 rung-0 CAS-wiring gaps identified from the original sweep of `physics/*.adj` (kinematics, geometry, work, mechanics-force, kinetic-energy all now shipped).

Part of the autonomous ADJ curriculum loop (`ADJ-STDLIB-COVERAGE.md#7-delivery-order`).

## Test plan
- [x] Solve direction empirically verified via the CLI in a scratch dir before writing real content.
- [x] `cargo test -p adj-lang-cli --test formula_energy_work_e2e` — 4/4 passed.
- [x] `cargo test -p adj-lang -p adj-lang-cli` — full suite green, no regressions.
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean.
- [x] `adj_stdlib_manifest.py --validate-json-schema` — 78 objectives, 0 errors, valid.
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` — exit 0, no new gaps introduced.
- [x] Python unittest suite (manifest/report subset) — 87 passed.
- [x] Security review — passed, no findings.