### PR TITLE
Add durable bootstrap and owner-state adapters

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1064,4 +1064,5 @@ members = [
   "vault-pm-storage-storage-core",
   "vault-pm-repository",
   "vault-pm-application",
+  "vault-pm-application-storage-core",
 ]

--- a/code/packages/rust/vault-pm-application-storage-core/BUILD
+++ b/code/packages/rust/vault-pm-application-storage-core/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding_adventures_vault_pm_application_storage_core -- --nocapture

--- a/code/packages/rust/vault-pm-application-storage-core/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-application-storage-core/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.1.0
+
+- Added provider-neutral `storage-core` implementations of the VLT-PM05
+  bootstrap and local owner-state store contracts.
+- Preserved immutable bootstrap generations behind an atomic latest pointer.
+- Added exact, bounded, read-back-verified local-state compare-and-exchange.
+- Serialized application-store writes within the supported backend instance so
+  restart-local revision tokens cannot admit an exact stale value.
+- Added in-memory race coverage and filesystem restart coverage.

--- a/code/packages/rust/vault-pm-application-storage-core/Cargo.toml
+++ b/code/packages/rust/vault-pm-application-storage-core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "coding_adventures_vault_pm_application_storage_core"
+version = "0.1.0"
+edition = "2021"
+description = "Storage-core adapters for password-manager bootstrap and owner state"
+
+[dependencies]
+coding-adventures-json-value = { path = "../json-value" }
+coding_adventures_sha256 = { path = "../sha256" }
+coding_adventures_vault_pm_application = { path = "../vault-pm-application" }
+coding_adventures_vault_pm_format = { path = "../vault-pm-format" }
+storage-core = { path = "../storage-core" }
+
+[dev-dependencies]
+coding_adventures_storage_fs = { path = "../storage-fs" }

--- a/code/packages/rust/vault-pm-application-storage-core/README.md
+++ b/code/packages/rust/vault-pm-application-storage-core/README.md
@@ -1,0 +1,46 @@
+# `coding_adventures_vault_pm_application_storage_core`
+
+This crate supplies the missing durable-host bridge between the host-neutral
+VLT-PM05 application and an injected `storage-core` backend. It implements:
+
+- `BootstrapStore`, with immutable signed generations and one atomic latest
+  pointer per random bootstrap locator; and
+- `LocalStateStore`, with exact byte compare-and-exchange for owner-private
+  initialization and publication journals.
+
+Names are domain-separated hashes or lowercase hex of random/content-derived
+identifiers. Record metadata is empty, diagnostics are closed, and no vault ID,
+title, username, record type, provider path, or state bytes enter storage names
+or errors.
+
+The adapter owns no filesystem path. A local CLI composes it over a separately
+permission-checked `FsStorageBackend`; a future SQLite or native-preferences
+host can reuse the same VLT-PM05 traits without changing the application.
+
+## Crash and race behavior
+
+Bootstrap generations are written immutably before the latest pointer moves.
+An interruption can therefore leave only an unreachable generation, never a
+pointer to missing bytes. Pointer races re-read the winner, making exact retries
+idempotent while rejecting a different successor.
+
+Local owner state uses the backend's atomic conditional create or revision CAS.
+The adapter compares complete bytes before every replacement and reads back the
+committed value. One adapter-level write lock keeps that read/condition/write
+sequence indivisible even when a backend restarts its revision-token sequence.
+It never overwrites a different winner. Phase 1A still requires one adapter
+instance and the CLI host's documented single-writer process exclusion because
+`storage-core` does not promote conditions across backend instances.
+
+## Verification
+
+Eleven tests cover generation-zero installation, rotation, idempotent retry,
+stale and competing predecessors, malformed generation/pointer data, exact
+local-state CAS, concurrent writers, closed errors, and filesystem
+reconstruction. Tarpaulin's LLVM engine measures 225 of 236 production lines
+covered (95.34%).
+
+```bash
+bash BUILD
+cargo clippy -p coding_adventures_vault_pm_application_storage_core --all-targets -- -D warnings
+```

--- a/code/packages/rust/vault-pm-application-storage-core/required_capabilities.json
+++ b/code/packages/rust/vault-pm-application-storage-core/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/vault-pm-application-storage-core",
+  "capabilities": [],
+  "justification": "Pure adapters over an injected storage-core backend. They own no filesystem path, network client, process, environment, clock, entropy, cryptography, key, or custody authority."
+}

--- a/code/packages/rust/vault-pm-application-storage-core/src/lib.rs
+++ b/code/packages/rust/vault-pm-application-storage-core/src/lib.rs
@@ -1,0 +1,1025 @@
+//! VLT-PM05 bootstrap and owner-state stores over an injected `storage-core` backend.
+//!
+//! The adapters retain the application's exact byte contracts while leaving
+//! filesystem paths, provider SDKs, and platform permission policy to the host.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use coding_adventures_json_value::JsonValue;
+use coding_adventures_sha256::sha256;
+use coding_adventures_vault_pm_application::{
+    BootstrapLocator, BootstrapStore, BootstrapStoreError, LocalStateStore, LocalStateStoreError,
+};
+use coding_adventures_vault_pm_format::{BootstrapId, BootstrapV1};
+use core::fmt::{self, Debug, Formatter};
+use std::sync::Mutex;
+use storage_core::{StorageBackend, StorageError, StoragePutInput, StorageRecord};
+
+const BOOTSTRAP_LATEST_NAMESPACE_DOMAIN: &[u8] =
+    b"vault-pm/application-storage-core/bootstrap-latest/v1";
+const BOOTSTRAP_GENERATION_NAMESPACE_DOMAIN: &[u8] =
+    b"vault-pm/application-storage-core/bootstrap-generation/v1";
+const LOCAL_STATE_NAMESPACE_DOMAIN: &[u8] = b"vault-pm/application-storage-core/local-state/v1";
+const OPAQUE_CONTENT_TYPE: &str = "application/octet-stream";
+const MAX_BOOTSTRAP_BYTES: usize = 1024 * 1024;
+const MAX_LOCAL_STATE_BYTES: usize = 32 * 1024 * 1024;
+
+/// VLT-PM05 bootstrap and owner-private local-state stores over one backend.
+///
+/// A host should use a backend instance dedicated to this adapter. The local
+/// CLI will use a separately permission-checked root from the immutable object
+/// repository so application state remains private and independently movable.
+pub struct StorageCoreApplicationStore<B: StorageBackend> {
+    backend: B,
+    write_lock: Mutex<()>,
+}
+
+impl<B: StorageBackend> StorageCoreApplicationStore<B> {
+    /// Construct both application stores over one injected backend.
+    pub const fn new(backend: B) -> Self {
+        Self {
+            backend,
+            write_lock: Mutex::new(()),
+        }
+    }
+
+    /// Borrow the injected backend for host composition and diagnostics.
+    pub const fn backend(&self) -> &B {
+        &self.backend
+    }
+
+    /// Consume the adapter and return its injected backend.
+    pub fn into_backend(self) -> B {
+        self.backend
+    }
+
+    fn initialize_bootstrap(&self) -> Result<(), BootstrapStoreError> {
+        self.backend.initialize().map_err(map_bootstrap_read)
+    }
+
+    fn initialize_local(&self) -> Result<(), LocalStateStoreError> {
+        self.backend.initialize().map_err(map_local_read)
+    }
+
+    fn read_bootstrap_record(
+        &self,
+        namespace: &str,
+        key: &str,
+        maximum_body_bytes: usize,
+    ) -> Result<Option<StorageRecord>, BootstrapStoreError> {
+        let record = self
+            .backend
+            .get(namespace, key)
+            .map_err(map_bootstrap_read)?;
+        record
+            .map(|record| {
+                validate_record(&record, namespace, key, maximum_body_bytes)
+                    .map_err(|()| BootstrapStoreError::Corruption)?;
+                Ok(record)
+            })
+            .transpose()
+    }
+
+    fn read_generation(
+        &self,
+        locator: BootstrapLocator,
+        id: BootstrapId,
+    ) -> Result<(BootstrapV1, Vec<u8>), BootstrapStoreError> {
+        let namespace = generation_namespace(locator);
+        let key = hex_bytes(id.as_bytes());
+        let record = self
+            .read_bootstrap_record(&namespace, &key, MAX_BOOTSTRAP_BYTES)?
+            .ok_or(BootstrapStoreError::Corruption)?;
+        let bootstrap = decode_bootstrap(&record.body)?;
+        if bootstrap
+            .id()
+            .map_err(|_| BootstrapStoreError::Corruption)?
+            != id
+        {
+            return Err(BootstrapStoreError::Corruption);
+        }
+        Ok((bootstrap, record.body))
+    }
+
+    fn read_latest(
+        &self,
+        locator: BootstrapLocator,
+    ) -> Result<Option<LatestBootstrap>, BootstrapStoreError> {
+        let namespace = latest_namespace();
+        let key = locator_key(locator);
+        let Some(pointer) = self.read_bootstrap_record(&namespace, &key, 32)? else {
+            return Ok(None);
+        };
+        let id = BootstrapId::new(
+            pointer
+                .body
+                .as_slice()
+                .try_into()
+                .map_err(|_| BootstrapStoreError::Corruption)?,
+        );
+        let (bootstrap, bytes) = self.read_generation(locator, id)?;
+        Ok(Some(LatestBootstrap {
+            pointer,
+            id,
+            bootstrap,
+            bytes,
+        }))
+    }
+
+    fn install_generation(
+        &self,
+        locator: BootstrapLocator,
+        id: BootstrapId,
+        exact_bootstrap: &[u8],
+    ) -> Result<(), BootstrapStoreError> {
+        let namespace = generation_namespace(locator);
+        let key = hex_bytes(id.as_bytes());
+        let input = put_input(&namespace, &key, exact_bootstrap.to_vec())
+            .map_err(|_| BootstrapStoreError::Corruption)?
+            .with_if_absent();
+        match self.backend.put(input) {
+            Ok(record) => validate_record(&record, &namespace, &key, MAX_BOOTSTRAP_BYTES)
+                .and_then(|()| (record.body == exact_bootstrap).then_some(()).ok_or(()))
+                .map_err(|()| BootstrapStoreError::Corruption),
+            Err(StorageError::Conflict { .. }) => {
+                let existing = self
+                    .read_bootstrap_record(&namespace, &key, MAX_BOOTSTRAP_BYTES)?
+                    .ok_or(BootstrapStoreError::Corruption)?;
+                if existing.body == exact_bootstrap {
+                    Ok(())
+                } else {
+                    Err(BootstrapStoreError::Corruption)
+                }
+            }
+            Err(error) => Err(map_bootstrap_write(error)),
+        }
+    }
+
+    fn advance_latest(
+        &self,
+        locator: BootstrapLocator,
+        current: Option<&StorageRecord>,
+        intended: BootstrapId,
+        exact_bootstrap: &[u8],
+    ) -> Result<(), BootstrapStoreError> {
+        let namespace = latest_namespace();
+        let key = locator_key(locator);
+        let input = put_input(&namespace, &key, intended.as_bytes().to_vec())
+            .map_err(|_| BootstrapStoreError::Corruption)?;
+        let input = match current {
+            Some(record) => input.with_if_revision(Some(record.revision.clone())),
+            None => input.with_if_absent(),
+        };
+        match self.backend.put(input) {
+            Ok(record) => {
+                validate_record(&record, &namespace, &key, 32)
+                    .map_err(|()| BootstrapStoreError::Corruption)?;
+                if record.body.as_slice() != intended.as_bytes() {
+                    return Err(BootstrapStoreError::Corruption);
+                }
+            }
+            Err(StorageError::Conflict { .. }) => {
+                let winner = self
+                    .read_latest(locator)?
+                    .ok_or(BootstrapStoreError::Conflict)?;
+                if winner.id == intended && winner.bytes == exact_bootstrap {
+                    return Ok(());
+                }
+                return Err(BootstrapStoreError::Conflict);
+            }
+            Err(error) => return Err(map_bootstrap_write(error)),
+        }
+        let readback = self
+            .read_latest(locator)?
+            .ok_or(BootstrapStoreError::Corruption)?;
+        if readback.id == intended && readback.bytes == exact_bootstrap {
+            Ok(())
+        } else {
+            Err(BootstrapStoreError::Corruption)
+        }
+    }
+
+    fn read_local_record(
+        &self,
+        locator: BootstrapLocator,
+    ) -> Result<Option<StorageRecord>, LocalStateStoreError> {
+        let namespace = local_namespace();
+        let key = locator_key(locator);
+        let record = self.backend.get(&namespace, &key).map_err(map_local_read)?;
+        record
+            .map(|record| {
+                validate_record(&record, &namespace, &key, MAX_LOCAL_STATE_BYTES)
+                    .and_then(|()| (!record.body.is_empty()).then_some(()).ok_or(()))
+                    .map_err(|()| LocalStateStoreError::Corruption)?;
+                Ok(record)
+            })
+            .transpose()
+    }
+}
+
+impl<B: StorageBackend> Debug for StorageCoreApplicationStore<B> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorageCoreApplicationStore")
+            .field("backend", &"<redacted>")
+            .finish()
+    }
+}
+
+impl<B: StorageBackend> BootstrapStore for StorageCoreApplicationStore<B> {
+    fn load_latest(
+        &self,
+        locator: BootstrapLocator,
+    ) -> Result<Option<Vec<u8>>, BootstrapStoreError> {
+        self.initialize_bootstrap()?;
+        Ok(self.read_latest(locator)?.map(|latest| latest.bytes))
+    }
+
+    fn put_generation(
+        &self,
+        locator: BootstrapLocator,
+        expected_previous: Option<BootstrapId>,
+        exact_bootstrap: &[u8],
+    ) -> Result<(), BootstrapStoreError> {
+        let _write = self
+            .write_lock
+            .lock()
+            .map_err(|_| BootstrapStoreError::Unavailable)?;
+        self.initialize_bootstrap()?;
+        let intended = decode_bootstrap(exact_bootstrap)?;
+        let intended_id = intended.id().map_err(|_| BootstrapStoreError::Corruption)?;
+        if intended.previous_bootstrap != expected_previous {
+            return Err(BootstrapStoreError::Conflict);
+        }
+
+        let current = self.read_latest(locator)?;
+        if let Some(current) = &current {
+            if current.id == intended_id {
+                return if current.bytes == exact_bootstrap {
+                    Ok(())
+                } else {
+                    Err(BootstrapStoreError::Corruption)
+                };
+            }
+            if expected_previous != Some(current.id)
+                || intended.generation
+                    != current
+                        .bootstrap
+                        .generation
+                        .checked_add(1)
+                        .ok_or(BootstrapStoreError::Corruption)?
+                || intended.vault_id != current.bootstrap.vault_id
+            {
+                return Err(BootstrapStoreError::Conflict);
+            }
+        } else if expected_previous.is_some()
+            || intended.generation != 0
+            || intended.previous_bootstrap.is_some()
+        {
+            return Err(BootstrapStoreError::Conflict);
+        }
+
+        self.install_generation(locator, intended_id, exact_bootstrap)?;
+        self.advance_latest(
+            locator,
+            current.as_ref().map(|latest| &latest.pointer),
+            intended_id,
+            exact_bootstrap,
+        )
+    }
+}
+
+impl<B: StorageBackend> LocalStateStore for StorageCoreApplicationStore<B> {
+    fn load(&self, locator: BootstrapLocator) -> Result<Option<Vec<u8>>, LocalStateStoreError> {
+        self.initialize_local()?;
+        Ok(self.read_local_record(locator)?.map(|record| record.body))
+    }
+
+    fn compare_exchange(
+        &self,
+        locator: BootstrapLocator,
+        expected: Option<&[u8]>,
+        replacement: &[u8],
+    ) -> Result<(), LocalStateStoreError> {
+        let _write = self
+            .write_lock
+            .lock()
+            .map_err(|_| LocalStateStoreError::Unavailable)?;
+        self.initialize_local()?;
+        validate_local_bytes(replacement)?;
+        if let Some(expected) = expected {
+            validate_local_bytes(expected)?;
+        }
+        let current = self.read_local_record(locator)?;
+        match (expected, current.as_ref()) {
+            (None, None) => {}
+            (Some(expected), Some(record)) if record.body == expected => {}
+            _ => return Err(LocalStateStoreError::ConcurrentHost),
+        }
+
+        let namespace = local_namespace();
+        let key = locator_key(locator);
+        let input = put_input(&namespace, &key, replacement.to_vec())
+            .map_err(|_| LocalStateStoreError::Corruption)?;
+        let input = match current {
+            Some(record) => input.with_if_revision(Some(record.revision)),
+            None => input.with_if_absent(),
+        };
+        let written = match self.backend.put(input) {
+            Ok(record) => record,
+            Err(StorageError::Conflict { .. }) => return Err(LocalStateStoreError::ConcurrentHost),
+            Err(error) => return Err(map_local_write(error)),
+        };
+        validate_record(&written, &namespace, &key, MAX_LOCAL_STATE_BYTES)
+            .map_err(|()| LocalStateStoreError::Corruption)?;
+        if written.body != replacement {
+            return Err(LocalStateStoreError::Corruption);
+        }
+        let readback = self
+            .read_local_record(locator)?
+            .ok_or(LocalStateStoreError::Corruption)?;
+        if readback.body == replacement {
+            Ok(())
+        } else {
+            Err(LocalStateStoreError::Corruption)
+        }
+    }
+}
+
+struct LatestBootstrap {
+    pointer: StorageRecord,
+    id: BootstrapId,
+    bootstrap: BootstrapV1,
+    bytes: Vec<u8>,
+}
+
+fn decode_bootstrap(bytes: &[u8]) -> Result<BootstrapV1, BootstrapStoreError> {
+    if bytes.is_empty() || bytes.len() > MAX_BOOTSTRAP_BYTES {
+        return Err(BootstrapStoreError::Corruption);
+    }
+    BootstrapV1::decode(bytes).map_err(|_| BootstrapStoreError::Corruption)
+}
+
+fn validate_local_bytes(bytes: &[u8]) -> Result<(), LocalStateStoreError> {
+    if bytes.is_empty() || bytes.len() > MAX_LOCAL_STATE_BYTES {
+        Err(LocalStateStoreError::Corruption)
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_record(
+    record: &StorageRecord,
+    namespace: &str,
+    key: &str,
+    maximum_body_bytes: usize,
+) -> Result<(), ()> {
+    if record.namespace != namespace
+        || record.key != key
+        || record.content_type != OPAQUE_CONTENT_TYPE
+        || record.metadata != empty_metadata()
+        || record.body.len() > maximum_body_bytes
+    {
+        Err(())
+    } else {
+        Ok(())
+    }
+}
+
+fn put_input(namespace: &str, key: &str, body: Vec<u8>) -> Result<StoragePutInput, StorageError> {
+    StoragePutInput::new(namespace, key, OPAQUE_CONTENT_TYPE, empty_metadata(), body)
+}
+
+fn latest_namespace() -> String {
+    hex_bytes(&sha256(BOOTSTRAP_LATEST_NAMESPACE_DOMAIN))
+}
+
+fn local_namespace() -> String {
+    hex_bytes(&sha256(LOCAL_STATE_NAMESPACE_DOMAIN))
+}
+
+fn generation_namespace(locator: BootstrapLocator) -> String {
+    let mut preimage = Vec::with_capacity(BOOTSTRAP_GENERATION_NAMESPACE_DOMAIN.len() + 32);
+    preimage.extend_from_slice(BOOTSTRAP_GENERATION_NAMESPACE_DOMAIN);
+    preimage.extend_from_slice(locator.as_bytes());
+    hex_bytes(&sha256(&preimage))
+}
+
+fn locator_key(locator: BootstrapLocator) -> String {
+    hex_bytes(locator.as_bytes())
+}
+
+fn hex_bytes(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+fn empty_metadata() -> JsonValue {
+    JsonValue::Object(Vec::new())
+}
+
+fn map_bootstrap_read(error: StorageError) -> BootstrapStoreError {
+    match error {
+        StorageError::Unavailable { .. } => BootstrapStoreError::Unavailable,
+        StorageError::Conflict { .. }
+        | StorageError::NotFound { .. }
+        | StorageError::LeaseDenied { .. }
+        | StorageError::Validation { .. }
+        | StorageError::Backend { .. } => BootstrapStoreError::Corruption,
+    }
+}
+
+fn map_bootstrap_write(error: StorageError) -> BootstrapStoreError {
+    match error {
+        StorageError::Unavailable { .. } => BootstrapStoreError::Unavailable,
+        StorageError::Conflict { .. } => BootstrapStoreError::Conflict,
+        StorageError::NotFound { .. }
+        | StorageError::LeaseDenied { .. }
+        | StorageError::Validation { .. }
+        | StorageError::Backend { .. } => BootstrapStoreError::Corruption,
+    }
+}
+
+fn map_local_read(error: StorageError) -> LocalStateStoreError {
+    match error {
+        StorageError::Unavailable { .. } => LocalStateStoreError::Unavailable,
+        StorageError::Conflict { .. }
+        | StorageError::NotFound { .. }
+        | StorageError::LeaseDenied { .. }
+        | StorageError::Validation { .. }
+        | StorageError::Backend { .. } => LocalStateStoreError::Corruption,
+    }
+}
+
+fn map_local_write(error: StorageError) -> LocalStateStoreError {
+    match error {
+        StorageError::Unavailable { .. } => LocalStateStoreError::Unavailable,
+        StorageError::Conflict { .. } => LocalStateStoreError::ConcurrentHost,
+        StorageError::NotFound { .. }
+        | StorageError::LeaseDenied { .. }
+        | StorageError::Validation { .. }
+        | StorageError::Backend { .. } => LocalStateStoreError::Corruption,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coding_adventures_storage_fs::FsStorageBackend;
+    use coding_adventures_vault_pm_format::{
+        AeadEnvelopeV1, Argon2idParametersV1, PublicKey, Signature, VaultId, CRYPTO_SUITE_V1,
+    };
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use storage_core::{InMemoryStorageBackend, Revision, StorageBackend, StorageError};
+
+    fn locator(seed: u8) -> BootstrapLocator {
+        BootstrapLocator::new([seed; 32])
+    }
+
+    fn bootstrap(
+        generation: u64,
+        previous_bootstrap: Option<BootstrapId>,
+        vault_seed: u8,
+        signature_seed: u8,
+    ) -> Vec<u8> {
+        BootstrapV1 {
+            vault_id: VaultId::new([vault_seed; 16]),
+            generation,
+            previous_bootstrap,
+            crypto_suite: CRYPTO_SUITE_V1,
+            kdf: Argon2idParametersV1 {
+                memory_kib: 8 * 1024,
+                iterations: 1,
+                lanes: 1,
+                salt: [3; 16],
+            },
+            passphrase_root_wrap: AeadEnvelopeV1 {
+                suite: CRYPTO_SUITE_V1,
+                nonce: [4; 24],
+                ciphertext: vec![5; 32],
+                tag: [6; 16],
+            },
+            authority_public_key: PublicKey::new([7; 32]),
+            recovery_wraps: Vec::new(),
+            signature: Signature::new([signature_seed; 64]),
+        }
+        .encode()
+        .unwrap()
+    }
+
+    fn bootstrap_id(bytes: &[u8]) -> BootstrapId {
+        BootstrapV1::decode(bytes).unwrap().id().unwrap()
+    }
+
+    #[test]
+    fn generation_zero_and_rotation_round_trip_with_exact_idempotent_retries() {
+        let store = StorageCoreApplicationStore::new(InMemoryStorageBackend::new());
+        let locator = locator(1);
+        let first = bootstrap(0, None, 9, 10);
+        assert_eq!(store.load_latest(locator).unwrap(), None);
+        store.put_generation(locator, None, &first).unwrap();
+        store.put_generation(locator, None, &first).unwrap();
+        assert_eq!(store.load_latest(locator).unwrap(), Some(first.clone()));
+
+        let first_id = bootstrap_id(&first);
+        let second = bootstrap(1, Some(first_id), 9, 11);
+        store
+            .put_generation(locator, Some(first_id), &second)
+            .unwrap();
+        store
+            .put_generation(locator, Some(first_id), &second)
+            .unwrap();
+        assert_eq!(store.load_latest(locator).unwrap(), Some(second));
+    }
+
+    #[test]
+    fn bootstrap_rejects_stale_wrong_vault_skipped_and_malformed_successors() {
+        let store = StorageCoreApplicationStore::new(InMemoryStorageBackend::new());
+        let selected = locator(2);
+        let first = bootstrap(0, None, 9, 12);
+        let first_id = bootstrap_id(&first);
+        store.put_generation(selected, None, &first).unwrap();
+
+        let wrong_previous = bootstrap(1, Some(BootstrapId::new([99; 32])), 9, 13);
+        assert_eq!(
+            store.put_generation(selected, Some(first_id), &wrong_previous),
+            Err(BootstrapStoreError::Conflict)
+        );
+        let wrong_vault = bootstrap(1, Some(first_id), 8, 14);
+        assert_eq!(
+            store.put_generation(selected, Some(first_id), &wrong_vault),
+            Err(BootstrapStoreError::Conflict)
+        );
+        let skipped = bootstrap(2, Some(first_id), 9, 15);
+        assert_eq!(
+            store.put_generation(selected, Some(first_id), &skipped),
+            Err(BootstrapStoreError::Conflict)
+        );
+        assert_eq!(
+            store.put_generation(selected, Some(first_id), b"not canonical bootstrap"),
+            Err(BootstrapStoreError::Corruption)
+        );
+        assert_eq!(store.load_latest(selected).unwrap(), Some(first));
+
+        let empty_store = StorageCoreApplicationStore::new(InMemoryStorageBackend::new());
+        assert_eq!(
+            empty_store.put_generation(locator(22), Some(first_id), &skipped),
+            Err(BootstrapStoreError::Conflict)
+        );
+        assert_eq!(
+            empty_store.put_generation(locator(22), None, b""),
+            Err(BootstrapStoreError::Corruption)
+        );
+    }
+
+    #[test]
+    fn immutable_generation_and_pointer_races_are_exact_and_idempotent() {
+        let store = StorageCoreApplicationStore::new(InMemoryStorageBackend::new());
+        let selected = locator(23);
+        let first = bootstrap(0, None, 9, 23);
+        let first_id = bootstrap_id(&first);
+        store.initialize_bootstrap().unwrap();
+        store
+            .install_generation(selected, first_id, &first)
+            .unwrap();
+        store
+            .install_generation(selected, first_id, &first)
+            .unwrap();
+        store
+            .advance_latest(selected, None, first_id, &first)
+            .unwrap();
+        store
+            .advance_latest(selected, None, first_id, &first)
+            .unwrap();
+
+        let competitor = bootstrap(0, None, 8, 24);
+        let competitor_id = bootstrap_id(&competitor);
+        store
+            .install_generation(selected, competitor_id, &competitor)
+            .unwrap();
+        assert_eq!(
+            store.advance_latest(selected, None, competitor_id, &competitor),
+            Err(BootstrapStoreError::Conflict)
+        );
+
+        let corrupt_locator = locator(24);
+        let namespace = generation_namespace(corrupt_locator);
+        let key = hex_bytes(first_id.as_bytes());
+        store
+            .backend()
+            .put(
+                put_input(&namespace, &key, b"different generation bytes".to_vec())
+                    .unwrap()
+                    .with_if_absent(),
+            )
+            .unwrap();
+        assert_eq!(
+            store.install_generation(corrupt_locator, first_id, &first),
+            Err(BootstrapStoreError::Corruption)
+        );
+    }
+
+    #[test]
+    fn malformed_pointer_generation_and_record_envelopes_fail_closed() {
+        let store = StorageCoreApplicationStore::new(InMemoryStorageBackend::new());
+        store.initialize_bootstrap().unwrap();
+        let selected = locator(25);
+        let first = bootstrap(0, None, 9, 25);
+        let first_id = bootstrap_id(&first);
+        let different = bootstrap(0, None, 8, 26);
+        let generation_namespace = generation_namespace(selected);
+        store
+            .backend()
+            .put(
+                put_input(
+                    &generation_namespace,
+                    &hex_bytes(first_id.as_bytes()),
+                    different,
+                )
+                .unwrap()
+                .with_if_absent(),
+            )
+            .unwrap();
+        store
+            .backend()
+            .put(
+                put_input(
+                    &latest_namespace(),
+                    &locator_key(selected),
+                    first_id.as_bytes().to_vec(),
+                )
+                .unwrap()
+                .with_if_absent(),
+            )
+            .unwrap();
+        assert_eq!(
+            store.load_latest(selected),
+            Err(BootstrapStoreError::Corruption)
+        );
+
+        let malformed_locator = locator(26);
+        store
+            .backend()
+            .put(
+                StoragePutInput::new(
+                    latest_namespace(),
+                    locator_key(malformed_locator),
+                    "text/plain",
+                    empty_metadata(),
+                    vec![0; 32],
+                )
+                .unwrap()
+                .with_if_absent(),
+            )
+            .unwrap();
+        assert_eq!(
+            store.load_latest(malformed_locator),
+            Err(BootstrapStoreError::Corruption)
+        );
+
+        let empty_local_locator = locator(27);
+        store
+            .backend()
+            .put(
+                put_input(
+                    &local_namespace(),
+                    &locator_key(empty_local_locator),
+                    Vec::new(),
+                )
+                .unwrap()
+                .with_if_absent(),
+            )
+            .unwrap();
+        assert_eq!(
+            store.load(empty_local_locator),
+            Err(LocalStateStoreError::Corruption)
+        );
+    }
+
+    #[test]
+    fn competing_bootstrap_successors_leave_exactly_one_latest_winner() {
+        let store = Arc::new(StorageCoreApplicationStore::new(
+            InMemoryStorageBackend::new(),
+        ));
+        let locator = locator(3);
+        let first = bootstrap(0, None, 9, 16);
+        let first_id = bootstrap_id(&first);
+        store.put_generation(locator, None, &first).unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+        let candidates = [
+            bootstrap(1, Some(first_id), 9, 17),
+            bootstrap(1, Some(first_id), 9, 18),
+        ];
+        let workers: Vec<_> = candidates
+            .iter()
+            .cloned()
+            .map(|candidate| {
+                let store = Arc::clone(&store);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    (
+                        candidate.clone(),
+                        store.put_generation(locator, Some(first_id), &candidate),
+                    )
+                })
+            })
+            .collect();
+        let results: Vec<_> = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap())
+            .collect();
+        assert_eq!(
+            results.iter().filter(|(_, result)| result.is_ok()).count(),
+            1
+        );
+        assert_eq!(
+            results
+                .iter()
+                .filter(|(_, result)| *result == Err(BootstrapStoreError::Conflict))
+                .count(),
+            1
+        );
+        let latest = store.load_latest(locator).unwrap().unwrap();
+        assert!(results
+            .iter()
+            .any(|(candidate, result)| result.is_ok() && candidate == &latest));
+    }
+
+    #[test]
+    fn local_state_create_replace_and_stale_compare_exchange_are_exact() {
+        let store = StorageCoreApplicationStore::new(InMemoryStorageBackend::new());
+        let locator = locator(4);
+        let first = b"canonical-owner-state-a";
+        let second = b"canonical-owner-state-b";
+        assert_eq!(store.load(locator).unwrap(), None);
+        store.compare_exchange(locator, None, first).unwrap();
+        assert_eq!(store.load(locator).unwrap(), Some(first.to_vec()));
+        assert_eq!(
+            store.compare_exchange(locator, None, second),
+            Err(LocalStateStoreError::ConcurrentHost)
+        );
+        assert_eq!(
+            store.compare_exchange(locator, Some(b"stale"), second),
+            Err(LocalStateStoreError::ConcurrentHost)
+        );
+        store
+            .compare_exchange(locator, Some(first), second)
+            .unwrap();
+        assert_eq!(store.load(locator).unwrap(), Some(second.to_vec()));
+    }
+
+    #[test]
+    fn concurrent_local_state_writers_have_one_winner() {
+        let store = Arc::new(StorageCoreApplicationStore::new(
+            InMemoryStorageBackend::new(),
+        ));
+        let locator = locator(5);
+        let initial = b"initial-owner-state";
+        store.compare_exchange(locator, None, initial).unwrap();
+        let barrier = Arc::new(Barrier::new(8));
+        let workers: Vec<_> = (0..8)
+            .map(|index| {
+                let store = Arc::clone(&store);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    let replacement = format!("replacement-owner-state-{index}").into_bytes();
+                    barrier.wait();
+                    let result = store.compare_exchange(locator, Some(initial), &replacement);
+                    (replacement, result)
+                })
+            })
+            .collect();
+        let results: Vec<_> = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap())
+            .collect();
+        assert_eq!(
+            results.iter().filter(|(_, result)| result.is_ok()).count(),
+            1
+        );
+        assert_eq!(
+            results
+                .iter()
+                .filter(|(_, result)| *result == Err(LocalStateStoreError::ConcurrentHost))
+                .count(),
+            7
+        );
+        let winner = store.load(locator).unwrap().unwrap();
+        assert!(results
+            .iter()
+            .any(|(replacement, result)| result.is_ok() && replacement == &winner));
+    }
+
+    #[test]
+    fn local_state_rejects_empty_and_oversized_values_without_writing() {
+        let store = StorageCoreApplicationStore::new(InMemoryStorageBackend::new());
+        let locator = locator(6);
+        assert_eq!(
+            store.compare_exchange(locator, None, b""),
+            Err(LocalStateStoreError::Corruption)
+        );
+        assert_eq!(
+            store.compare_exchange(locator, None, &vec![0; MAX_LOCAL_STATE_BYTES + 1]),
+            Err(LocalStateStoreError::Corruption)
+        );
+        assert_eq!(store.load(locator).unwrap(), None);
+    }
+
+    #[test]
+    fn filesystem_reconstruction_preserves_bootstrap_history_and_owner_state() {
+        let root = temporary_root("restart");
+        let locator = locator(7);
+        let first = bootstrap(0, None, 9, 19);
+        let first_id = bootstrap_id(&first);
+        let second = bootstrap(1, Some(first_id), 9, 20);
+        {
+            let store = StorageCoreApplicationStore::new(FsStorageBackend::new(&root));
+            store.put_generation(locator, None, &first).unwrap();
+            store
+                .put_generation(locator, Some(first_id), &second)
+                .unwrap();
+            store
+                .compare_exchange(locator, None, b"durable-owner-state")
+                .unwrap();
+        }
+        {
+            let reopened = StorageCoreApplicationStore::new(FsStorageBackend::new(&root));
+            assert_eq!(reopened.load_latest(locator).unwrap(), Some(second));
+            assert_eq!(
+                reopened.load(locator).unwrap(),
+                Some(b"durable-owner-state".to_vec())
+            );
+            reopened
+                .compare_exchange(
+                    locator,
+                    Some(b"durable-owner-state"),
+                    b"first-state-after-restart",
+                )
+                .unwrap();
+            assert_eq!(
+                reopened.compare_exchange(
+                    locator,
+                    Some(b"durable-owner-state"),
+                    b"stale-state-after-restart",
+                ),
+                Err(LocalStateStoreError::ConcurrentHost)
+            );
+            assert_eq!(
+                reopened.load(locator).unwrap(),
+                Some(b"first-state-after-restart".to_vec())
+            );
+        }
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn diagnostics_and_names_do_not_expose_payloads_or_backend_details() {
+        let store = StorageCoreApplicationStore::new(InMemoryStorageBackend::new());
+        assert_eq!(
+            format!("{store:?}"),
+            "StorageCoreApplicationStore { backend: \"<redacted>\" }"
+        );
+        let secret = "never-log-this-owner-state";
+        for error in [
+            BootstrapStoreError::Unavailable,
+            BootstrapStoreError::Conflict,
+            BootstrapStoreError::Corruption,
+        ] {
+            assert!(!format!("{error:?} {error}").contains(secret));
+        }
+        for error in [
+            LocalStateStoreError::Unavailable,
+            LocalStateStoreError::ConcurrentHost,
+            LocalStateStoreError::Corruption,
+        ] {
+            assert!(!format!("{error:?} {error}").contains(secret));
+        }
+        assert_eq!(latest_namespace().len(), 64);
+        assert_eq!(local_namespace().len(), 64);
+        assert_eq!(generation_namespace(locator(8)).len(), 64);
+        assert_eq!(locator_key(locator(8)).len(), 64);
+
+        let backend = StorageCoreApplicationStore::new(InMemoryStorageBackend::new());
+        let _ = backend.backend();
+        let _ = backend.into_backend();
+    }
+
+    #[test]
+    fn storage_error_translation_is_closed_and_payload_blind() {
+        let not_found = StorageError::NotFound {
+            namespace: "secret namespace".to_string(),
+            key: "secret key".to_string(),
+        };
+        let conflict = StorageError::Conflict {
+            namespace: "secret namespace".to_string(),
+            key: "secret key".to_string(),
+            expected_revision: Some("secret expected".to_string()),
+            actual_revision: Some("secret actual".to_string()),
+        };
+        let unavailable = StorageError::Unavailable {
+            message: "secret unavailable".to_string(),
+        };
+        let lease = StorageError::LeaseDenied {
+            name: "secret lease".to_string(),
+        };
+        let validation = StorageError::Validation {
+            field: "secret field".to_string(),
+            message: "secret validation".to_string(),
+        };
+        let backend = StorageError::Backend {
+            message: "secret backend".to_string(),
+        };
+
+        assert_eq!(
+            map_bootstrap_read(unavailable.clone()),
+            BootstrapStoreError::Unavailable
+        );
+        for error in [
+            not_found.clone(),
+            conflict.clone(),
+            lease.clone(),
+            validation.clone(),
+            backend.clone(),
+        ] {
+            assert_eq!(map_bootstrap_read(error), BootstrapStoreError::Corruption);
+        }
+        assert_eq!(
+            map_bootstrap_write(unavailable.clone()),
+            BootstrapStoreError::Unavailable
+        );
+        assert_eq!(
+            map_bootstrap_write(conflict.clone()),
+            BootstrapStoreError::Conflict
+        );
+        for error in [
+            not_found.clone(),
+            lease.clone(),
+            validation.clone(),
+            backend.clone(),
+        ] {
+            assert_eq!(map_bootstrap_write(error), BootstrapStoreError::Corruption);
+        }
+        assert_eq!(
+            map_local_read(unavailable.clone()),
+            LocalStateStoreError::Unavailable
+        );
+        for error in [
+            not_found.clone(),
+            conflict.clone(),
+            lease.clone(),
+            validation.clone(),
+            backend.clone(),
+        ] {
+            assert_eq!(map_local_read(error), LocalStateStoreError::Corruption);
+        }
+        assert_eq!(
+            map_local_write(unavailable),
+            LocalStateStoreError::Unavailable
+        );
+        assert_eq!(
+            map_local_write(conflict),
+            LocalStateStoreError::ConcurrentHost
+        );
+        for error in [not_found, lease, validation, backend] {
+            assert_eq!(map_local_write(error), LocalStateStoreError::Corruption);
+        }
+
+        let malformed = StorageRecord::new(
+            "wrong-namespace",
+            "wrong-key",
+            Revision::new("r1").unwrap(),
+            OPAQUE_CONTENT_TYPE,
+            empty_metadata(),
+            Vec::new(),
+            1,
+            1,
+        )
+        .unwrap();
+        assert_eq!(
+            validate_record(&malformed, "expected", "expected", 1),
+            Err(())
+        );
+    }
+
+    fn temporary_root(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "vault-pm-application-storage-core-{label}-{}-{nanos}",
+            std::process::id()
+        ))
+    }
+}

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -804,6 +804,8 @@ code/packages/rust/vault-pm-domain       product record model and merge policy
 code/packages/rust/vault-pm-storage      VaultObjectStore contract + fixtures
 code/packages/rust/vault-pm-repository   immutable DAG, publication, sync, GC
 code/packages/rust/vault-pm-application  use cases and redacted view models
+code/packages/rust/vault-pm-application-storage-core
+                                         durable bootstrap/owner-state adapters
 code/packages/rust/vault-pm-cli          product parser/driver/renderer
 code/programs/rust/vault-pm-cli          executable composition root
 ```
@@ -1392,6 +1394,12 @@ changelog, focused build, and downstream validation.
    7f. completed stable payload-free VLT-PM05 `Locked` error and compact
        locked/unlocked lifecycle boundary, including failure-stable in-place
        unlock and synchronous live-session drop on idempotent lock.
+8a. `vault-pm-application-storage-core`: durable injected-backend adapters for
+    immutable signed-bootstrap generations, an atomic latest-generation
+    pointer, and exact owner-private local-state compare-exchange. The adapter
+    owns no filesystem path or platform policy; Phase 1A composes it over a
+    separately permission-checked `FsStorageBackend` root and retains the
+    single-writer process rule required by `storage-core` conditions.
 9. `vault-pm-cli` + real executable and pseudo-terminal E2E suite.
 10. Crash/fault matrix and local restore drill.
 

--- a/code/specs/VLT-PM05-application.md
+++ b/code/specs/VLT-PM05-application.md
@@ -774,6 +774,11 @@ import, password rotation UI, OS custody, device enrollment/revocation,
 multi-replica transfer, automatic conflict resolution, physical GC execution,
 or provider-specific diagnostics. Those compose above or extend this contract.
 
+The separate `vault-pm-application-storage-core` package now implements these
+byte-oriented store traits over an injected `storage-core` backend. It does not
+change this host-neutral contract or own the filesystem path, permissions, or
+cross-process exclusion required by a CLI composition.
+
 ---
 
 *End of VLT-PM05.*


### PR DESCRIPTION
## Summary

- add `vault-pm-application-storage-core`, implementing the VLT-PM05 `BootstrapStore` and `LocalStateStore` contracts over an injected `storage-core` backend
- persist signed bootstrap generations immutably, advance an atomic latest pointer, and preserve exact idempotent retry semantics
- provide bounded, read-back-verified owner-state compare-and-exchange with in-instance serialization for restart-local revision tokens
- keep filesystem paths, permissions, cross-process exclusion, provider SDKs, and other host authority outside the adapter
- record the newly discovered durable-host prerequisite in the Phase 1A roadmap

## Security properties

- storage names contain only domain-separated hashes or lowercase hex of random/content-derived identifiers
- bootstrap generations remain immutable; interruption before pointer advancement leaves only an unreachable generation
- stale local-state bytes never overwrite a different winner inside the supported single-backend-instance model
- errors and `Debug` output remain closed and payload-blind
- the capability manifest declares no direct host capabilities

## Verification

- `bash code/packages/rust/vault-pm-application-storage-core/BUILD` (11 tests)
- `cargo clippy -p coding_adventures_vault_pm_application_storage_core --all-targets -- -D warnings`
- Tarpaulin LLVM: 225/236 production lines (95.34%)
- monorepo build-tool: 1 changed package, 2 affected packages, both built
- `git diff --check origin/main...HEAD`
