### PR TITLE
feat(mosaic): prove Compose Rust runtime path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
       needs_mosaic_swift_runtime: ${{ steps.mosaic-swift-runtime.outputs.required }}
       needs_mosaic_qt_runtime: ${{ steps.mosaic-qt-runtime.outputs.required }}
       needs_mosaic_flutter_runtime: ${{ steps.mosaic-flutter-runtime.outputs.required }}
+      needs_mosaic_compose_runtime: ${{ steps.mosaic-compose-runtime.outputs.required }}
       diff_base: ${{ steps.diff-base.outputs.base }}
       is_main: ${{ steps.detect-main.outputs.is_main }}
       build_shards: ${{ steps.detect.outputs.build_shards }}
@@ -133,6 +134,7 @@ jobs:
           python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_swift_runtime_ci_acceptance.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_qt_runtime_ci_acceptance.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_flutter_runtime_ci_acceptance.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_mosaic_compose_runtime_ci_acceptance.py'
           python3 code/scripts/build_tool_conformance.py validate-corpus
           python3 code/scripts/build_tool_conformance_execution.py validate-contract
           python3 code/scripts/package_parity_report.py --format json --fail-on-collisions > /tmp/package-parity-report.json
@@ -259,6 +261,15 @@ jobs:
         shell: bash
         run: |
           python3 code/scripts/mosaic_flutter_runtime_ci_acceptance.py \
+            build-plan.json \
+            --repo-root . \
+            --diff-base "${{ steps.diff-base.outputs.base }}" >> "$GITHUB_OUTPUT"
+
+      - name: Detect Mosaic Compose runtime acceptance
+        id: mosaic-compose-runtime
+        shell: bash
+        run: |
+          python3 code/scripts/mosaic_compose_runtime_ci_acceptance.py \
             build-plan.json \
             --repo-root . \
             --diff-base "${{ steps.diff-base.outputs.base }}" >> "$GITHUB_OUTPUT"
@@ -563,7 +574,7 @@ jobs:
           clang --version | head -1
 
       - name: Set up Rust
-        if: needs.detect.outputs.needs_rust == 'true' || needs.detect.outputs.needs_venture_windows == 'true' || needs.detect.outputs.needs_mosaic_xaml_windows == 'true' || needs.detect.outputs.needs_mosaic_swift_runtime == 'true' || needs.detect.outputs.needs_mosaic_qt_runtime == 'true' || needs.detect.outputs.needs_mosaic_flutter_runtime == 'true'
+        if: needs.detect.outputs.needs_rust == 'true' || needs.detect.outputs.needs_venture_windows == 'true' || needs.detect.outputs.needs_mosaic_xaml_windows == 'true' || needs.detect.outputs.needs_mosaic_swift_runtime == 'true' || needs.detect.outputs.needs_mosaic_qt_runtime == 'true' || needs.detect.outputs.needs_mosaic_flutter_runtime == 'true' || needs.detect.outputs.needs_mosaic_compose_runtime == 'true'
         # Uses the `stable` channel (matching the rest of this repo's Rust CI).
         # NOTE on the -clippy gate: clippy adds/tightens lints on each stable
         # release, so a new Rust release can surface new lints on `main` — treat
@@ -708,14 +719,14 @@ jobs:
       # A single JDK + Gradle setup covers all three cases.
 
       - name: Set up JDK 21
-        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true' || needs.detect.outputs.needs_venture_windows == 'true'
+        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true' || needs.detect.outputs.needs_venture_windows == 'true' || (needs.detect.outputs.needs_mosaic_compose_runtime == 'true' && runner.os == 'Linux')
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Set up Gradle
-        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true' || needs.detect.outputs.needs_venture_windows == 'true'
+        if: needs.detect.outputs.needs_java == 'true' || needs.detect.outputs.needs_kotlin == 'true' || needs.detect.outputs.needs_venture_windows == 'true' || (needs.detect.outputs.needs_mosaic_compose_runtime == 'true' && runner.os == 'Linux')
         uses: gradle/actions/setup-gradle@v4
 
       - name: Disable long-lived Gradle services on Windows CI
@@ -1004,6 +1015,23 @@ jobs:
             dart analyze
             dart run bin/conformance.dart
           )
+
+      - name: Round-trip Rust engine through standard Compose binding
+        if: runner.os == 'Linux' && needs.detect.outputs.needs_mosaic_compose_runtime == 'true'
+        shell: bash
+        timeout-minutes: 10
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/mosaic-compose-taskapp"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/programs/mosaic/task-app --backend compose --output "$output" --emit-project
+          cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance
+
+          harness="$RUNNER_TEMP/mosaic-compose-runtime-conformance"
+          cp -R code/packages/rust/mosaic-app-bindings/conformance/compose "$harness"
+          cp "$output/compose/src/main/kotlin/MosaicRuntimeHost.kt" "$harness/src/main/kotlin/MosaicRuntimeHost.kt"
+
+          export MOSAIC_APP_LIBRARY="$(pwd)/code/packages/rust/target/debug/libmosaic_app_conformance.so"
+          gradle --no-daemon --stacktrace -p "$harness" run
 
       - name: Build complete Mosaic TaskApp WinUI shell
         if: runner.os == 'Windows' && needs.detect.outputs.needs_mosaic_xaml_windows == 'true'

--- a/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
+++ b/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Execute the generated Compose/JNA host against the shared Rust conformance
+  library in Linux CI, covering startup, dispatch, snapshot/restore,
+  notification, buffer ownership, and teardown on the JVM.
+- Expose the generated Compose ABI carrier constructors to JNA reflection;
+  Kotlin file-private `size_t` and structure classes compiled but failed when
+  the standard host first attempted to load a real Rust library.
 - Execute the generated Flutter/Dart FFI host against the shared Rust
   conformance library in Linux CI, covering startup, dispatch,
   snapshot/restore, notification, buffer ownership, and teardown.

--- a/code/packages/rust/mosaic-app-bindings/README.md
+++ b/code/packages/rust/mosaic-app-bindings/README.md
@@ -15,6 +15,10 @@ semantic events, and return decoded updates to the generated view.
 Set the `mosaic.app.library` JVM property or `MOSAIC_APP_LIBRARY` environment
 variable to a library name or absolute path. The conventional fallback name is
 `mosaic_app`.
+Linux CI compiles the exact Compose/JNA binding from a complete generated
+TaskApp project with the shared `mosaic-app-conformance` library, then verifies
+startup, semantic dispatch, snapshot/restore, notification, buffer ownership,
+and teardown on the JVM.
 
 For SwiftUI, set `MOSAIC_APP_LIBRARY` to the application dylib path. Without an
 explicit path the loader first checks symbols linked into the process, then tries

--- a/code/packages/rust/mosaic-app-bindings/conformance/compose/README.md
+++ b/code/packages/rust/mosaic-app-bindings/conformance/compose/README.md
@@ -1,0 +1,10 @@
+# Compose runtime conformance
+
+This JVM console harness compiles the exact `MosaicRuntimeHost.kt` emitted into a
+generated Compose Desktop project. It loads the shared `mosaic-app-conformance`
+native library through JNA and verifies startup, revisions, prop projection,
+semantic dispatch, snapshot/restore, notification, buffer ownership, and teardown.
+
+CI generates the complete TaskApp project, copies its generated binding into
+this harness in a temporary workspace, and runs the result. The binding itself
+is deliberately not duplicated here, and no Compose UI runtime is required.

--- a/code/packages/rust/mosaic-app-bindings/conformance/compose/build.gradle.kts
+++ b/code/packages/rust/mosaic-app-bindings/conformance/compose/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    kotlin("jvm") version "2.3.21"
+    application
+}
+
+dependencies {
+    implementation("net.java.dev.jna:jna:5.19.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+application {
+    mainClass = "ConformanceKt"
+}

--- a/code/packages/rust/mosaic-app-bindings/conformance/compose/settings.gradle.kts
+++ b/code/packages/rust/mosaic-app-bindings/conformance/compose/settings.gradle.kts
@@ -1,0 +1,15 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "mosaic-compose-runtime-conformance"

--- a/code/packages/rust/mosaic-app-bindings/conformance/compose/src/main/kotlin/Conformance.kt
+++ b/code/packages/rust/mosaic-app-bindings/conformance/compose/src/main/kotlin/Conformance.kt
@@ -1,0 +1,91 @@
+interface MosaicComposeHost : AutoCloseable {
+    fun props(): Map<String, Any?>?
+    fun handleEvent(event: Map<String, Any?>): Map<String, Any?>?
+    fun setPropsChangedHandler(handler: (() -> Unit)?) {}
+    override fun close() {}
+}
+
+private fun requireConformance(condition: Boolean, assertion: String) {
+    check(condition) { "Failed assertion: $assertion" }
+}
+
+private fun objectMap(value: Any?, assertion: String): Map<String, Any?> {
+    requireConformance(value is Map<*, *>, "$assertion was not an object")
+    @Suppress("UNCHECKED_CAST")
+    val result = value as Map<String, Any?>
+    requireConformance("error" !in result, "$assertion returned an error")
+    return result
+}
+
+private fun props(update: Map<String, Any?>, assertion: String): Map<String, Any?> =
+    objectMap(update["props"], "$assertion props")
+
+private fun integer(value: Any?, assertion: String): Long {
+    requireConformance(value is Number, "$assertion was not numeric")
+    return (value as Number).toLong()
+}
+
+private fun expectedPlatform(): String {
+    val os = System.getProperty("os.name", "").lowercase()
+    return when {
+        "mac" in os || "darwin" in os -> "apple"
+        "win" in os -> "windows"
+        else -> "linux"
+    }
+}
+
+fun main() {
+    val host = checkNotNull(MosaicRuntimeHost.load()) {
+        "standard Compose binding did not load the Rust app"
+    }
+    try {
+        val started = objectMap(host.props(), "startup update")
+        val startedProps = props(started, "startup update")
+        requireConformance(integer(started["revision"], "startup revision") == 1L,
+            "startup revision")
+        requireConformance(integer(startedProps["count"], "initial count") == 0L,
+            "initial count")
+        requireConformance(startedProps["platform"] == expectedPlatform(), "startup platform")
+        requireConformance(startedProps["status"] == "started", "startup status")
+
+        var notificationCount = 0
+        host.setPropsChangedHandler { notificationCount += 1 }
+
+        val dispatched = objectMap(
+            host.handleEvent(
+                mapOf(
+                    "name" to "increment",
+                    "payload" to mapOf("amount" to 4),
+                ),
+            ),
+            "dispatch update",
+        )
+        val dispatchedProps = props(dispatched, "dispatch update")
+        requireConformance(integer(dispatched["revision"], "dispatch revision") == 2L,
+            "dispatch revision")
+        requireConformance(integer(dispatchedProps["count"], "dispatched count") == 4L,
+            "dispatched count")
+        requireConformance(dispatchedProps["status"] == "dispatched", "dispatch status")
+        requireConformance(notificationCount == 1, "dispatch props-change notification")
+
+        val snapshot = objectMap(host.snapshot(), "snapshot")
+        requireConformance(snapshot["schema"] == "mosaic-app-conformance/counter",
+            "snapshot schema")
+        requireConformance(integer(snapshot["version"], "snapshot version") == 1L,
+            "snapshot version")
+        requireConformance((snapshot["bytes"] as? List<*>)?.size == 8, "snapshot bytes")
+
+        val restored = objectMap(host.restore(snapshot), "restore update")
+        val restoredProps = props(restored, "restore update")
+        requireConformance(integer(restored["revision"], "restore revision") == 3L,
+            "restore revision")
+        requireConformance(integer(restoredProps["count"], "restored count") == 4L,
+            "restored count")
+        requireConformance(restoredProps["status"] == "restored", "restore status")
+        requireConformance(notificationCount == 2, "restore props-change notification")
+    } finally {
+        host.close()
+    }
+
+    println("Mosaic Compose Rust runtime conformance passed")
+}

--- a/code/packages/rust/mosaic-app-bindings/src/lib.rs
+++ b/code/packages/rust/mosaic-app-bindings/src/lib.rs
@@ -110,6 +110,14 @@ mod tests {
     #[test]
     fn compose_binding_owns_the_full_c_abi_lifecycle() {
         let source = compose_jna_binding();
+        assert!(source.contains("class MosaicSizeT(value: Long = 0)"));
+        assert!(source.contains("open class MosaicBytes : Structure()"));
+        assert!(source.contains("open class MosaicBuffer : Structure()"));
+        assert!(source.contains("interface MosaicNativeApi : Library"));
+        assert!(!source.contains("private class MosaicSizeT"));
+        assert!(!source.contains("private open class MosaicBytes"));
+        assert!(!source.contains("private open class MosaicBuffer"));
+        assert!(!source.contains("private interface MosaicNativeApi"));
         for symbol in [
             "mosaic_app_create",
             "mosaic_app_dispatch",

--- a/code/packages/rust/mosaic-app-bindings/templates/compose/MosaicRuntimeHost.kt
+++ b/code/packages/rust/mosaic-app-bindings/templates/compose/MosaicRuntimeHost.kt
@@ -26,14 +26,17 @@ private const val MOSAIC_STATUS_OK = 0
 
 class MosaicRuntimeException(val status: Int, message: String) : RuntimeException(message)
 
-private class MosaicSizeT(value: Long = 0) :
+// JNA constructs ABI carrier types reflectively from its own package. These
+// classes must therefore have public JVM constructors even though applications
+// should treat them as generated implementation details.
+class MosaicSizeT(value: Long = 0) :
     IntegerType(Native.SIZE_T_SIZE, value, true) {
     override fun toByte(): Byte = toLong().toByte()
     override fun toShort(): Short = toLong().toShort()
 }
 
 @Structure.FieldOrder("ptr", "len")
-private open class MosaicBytes : Structure() {
+open class MosaicBytes : Structure() {
     @JvmField var ptr: Pointer? = null
     @JvmField var len: MosaicSizeT = MosaicSizeT()
 
@@ -47,7 +50,7 @@ private open class MosaicBytes : Structure() {
 }
 
 @Structure.FieldOrder("ptr", "len", "capacity")
-private open class MosaicBuffer : Structure() {
+open class MosaicBuffer : Structure() {
     @JvmField var ptr: Pointer? = null
     @JvmField var len: MosaicSizeT = MosaicSizeT()
     @JvmField var capacity: MosaicSizeT = MosaicSizeT()
@@ -62,7 +65,7 @@ private open class MosaicBuffer : Structure() {
     }
 }
 
-private interface MosaicNativeApi : Library {
+interface MosaicNativeApi : Library {
     fun mosaic_app_create(
         start: MosaicBytes.ByValue,
         app: PointerByReference,

--- a/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-compose/CHANGELOG.md
@@ -7,6 +7,11 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `HostTooltip` now lowers to Compose Foundation's cross-platform
+  `BasicTooltipBox`, including native overlay placement and dismissal, Material
+  surface chrome, literal/slot/expression text, and assistive-technology
+  semantics. This restores package-expanded TaskApp generation after its richer
+  Gantt introduced per-row tooltips.
 - `HostSurface ( content: slot: ... )` now accepts an
   `@Composable () -> Unit` node slot and invokes it at the shared native
   composition boundary.

--- a/code/packages/rust/mosaic-emit-compose/README.md
+++ b/code/packages/rust/mosaic-emit-compose/README.md
@@ -50,6 +50,8 @@ mosaic-compile --backend compose \
 Drop the resulting `.kt` into a project that already has
 `androidx.compose.runtime.Composable` on its classpath — Jetpack
 Compose for Android, Compose for Desktop, or Compose Multiplatform.
+Generated `HostTooltip` output requires Compose Foundation 1.11 or newer so it
+can use the common `BasicTooltipBox` API on every Compose target.
 The runtime layer (`mosaic-flux-compose`) is a separate package and
 not required for the codegen output; it's only needed if the host
 wants the strict-Flux store/dispatcher contract.
@@ -68,7 +70,7 @@ wants the strict-Flux store/dispatcher contract.
 | HostButton   | `Button(onClick) { Text(label) }`         |
 
 The emitter also lowers `For`, `If`/`Else`, table structure, buttons, checkbox
-and radio controls, number inputs, links, scroll/tooltip wrappers, and the
+and radio controls, number inputs, links, native accessible tooltip wrappers, and the
 current drag/drop degradation path. Unsupported primitives still return a
 clear `UnknownPrimitive` error instead of silently disappearing.
 
@@ -81,6 +83,6 @@ their own `MaterialTheme` for platform-level theming.
 
 ## Tests
 
-`cargo test -p mosaic-emit-compose` runs 37 focused emitter tests. The
+`cargo test -p mosaic-emit-compose` runs 39 focused emitter tests. The
 package-expanded TaskApp is also exercised as a real Compose Desktop project:
 Kotlin compilation, native macOS distribution packaging, and process launch.

--- a/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-compose/src/pipeline.rs
@@ -92,6 +92,17 @@ pub fn from_pipeline(
 
     writeln!(out, "import androidx.compose.foundation.background").unwrap();
     writeln!(out, "import androidx.compose.foundation.border").unwrap();
+    writeln!(out, "import androidx.compose.foundation.BasicTooltipBox").unwrap();
+    writeln!(
+        out,
+        "import androidx.compose.foundation.ExperimentalFoundationApi"
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "import androidx.compose.foundation.rememberBasicTooltipState"
+    )
+    .unwrap();
     writeln!(out, "import androidx.compose.foundation.layout.Box").unwrap();
     writeln!(out, "import androidx.compose.foundation.layout.Column").unwrap();
     writeln!(out, "import androidx.compose.foundation.layout.Row").unwrap();
@@ -122,17 +133,33 @@ pub fn from_pipeline(
     writeln!(out, "import androidx.compose.material.Button").unwrap();
     writeln!(out, "import androidx.compose.material.Checkbox").unwrap();
     writeln!(out, "import androidx.compose.material.RadioButton").unwrap();
+    writeln!(out, "import androidx.compose.material.Surface").unwrap();
     writeln!(out, "import androidx.compose.material.Text").unwrap();
     writeln!(out, "import androidx.compose.material.TextField").unwrap();
     writeln!(out, "import androidx.compose.runtime.Composable").unwrap();
     writeln!(out, "import androidx.compose.ui.Alignment").unwrap();
     writeln!(out, "import androidx.compose.ui.Modifier").unwrap();
+    writeln!(out, "import androidx.compose.ui.unit.IntOffset").unwrap();
+    writeln!(out, "import androidx.compose.ui.unit.IntRect").unwrap();
+    writeln!(out, "import androidx.compose.ui.unit.IntSize").unwrap();
+    writeln!(out, "import androidx.compose.ui.unit.LayoutDirection").unwrap();
+    writeln!(
+        out,
+        "import androidx.compose.ui.window.PopupPositionProvider"
+    )
+    .unwrap();
     writeln!(out, "import androidx.compose.ui.platform.testTag").unwrap();
     writeln!(out, "import androidx.compose.ui.graphics.Color").unwrap();
     writeln!(out, "import androidx.compose.ui.text.TextStyle").unwrap();
     writeln!(out, "import androidx.compose.ui.text.font.FontFamily").unwrap();
     writeln!(out, "import androidx.compose.ui.text.input.ImeAction").unwrap();
     writeln!(out, "import androidx.compose.ui.text.input.KeyboardType").unwrap();
+    writeln!(
+        out,
+        "import androidx.compose.ui.semantics.contentDescription"
+    )
+    .unwrap();
+    writeln!(out, "import androidx.compose.ui.semantics.semantics").unwrap();
     writeln!(out, "import androidx.compose.ui.unit.dp").unwrap();
     writeln!(out, "import androidx.compose.ui.unit.sp").unwrap();
     writeln!(out).unwrap();
@@ -273,6 +300,7 @@ fn emit_composable_function(
     }
 
     let mut out = String::new();
+    writeln!(out, "@OptIn(ExperimentalFoundationApi::class)").unwrap();
     writeln!(out, "@Composable").unwrap();
     writeln!(out, "fun {component_name}(").unwrap();
     for s in slots {
@@ -347,6 +375,7 @@ fn emit_split_composable_function(
 
     for (index, range) in ranges.into_iter().enumerate() {
         writeln!(out).unwrap();
+        writeln!(out, "@OptIn(ExperimentalFoundationApi::class)").unwrap();
         writeln!(out, "@Composable").unwrap();
         writeln!(out, "private fun {component_name}Section{index}(").unwrap();
         emit_composable_parameters(&mut out, slots, component_name)?;
@@ -1254,6 +1283,16 @@ fn emit_compose_tree(
         "HostNumberInput" => {
             emit_host_number_input(node, depth, component_name, emits, part_styles, text_ctx)
         }
+        "HostTooltip" => emit_host_tooltip(
+            node,
+            depth,
+            component_name,
+            emits,
+            part_styles,
+            table_ctx,
+            text_ctx,
+            for_payload,
+        ),
         // UI29 §3.1 / §3.2 — meta-primitives.
         "For" => emit_for_compose(
             node,
@@ -2414,6 +2453,96 @@ fn emit_host_number_input(
         writeln!(out, "{inner}enabled = {enabled},").unwrap();
     }
     writeln!(out, "{pad})").unwrap();
+    Ok(out)
+}
+
+/// Lower `HostTooltip` to Compose Foundation's cross-platform tooltip box.
+///
+/// `BasicTooltipBox` owns the platform input policy, overlay, focus transfer, and
+/// dismissal behavior. The generated position provider prefers the space below
+/// the target, falls back above it, and clamps the popup to the native window.
+/// The wrapper also exposes the plain-text message in the semantics tree so the
+/// annotation is available to assistive technology without app-owned glue.
+#[allow(clippy::too_many_arguments)]
+fn emit_host_tooltip(
+    node: &LayoutNode,
+    depth: usize,
+    component_name: &str,
+    emits: &[EmitDecl],
+    part_styles: &PartStyleMap,
+    table_ctx: Option<&TableContext>,
+    text_ctx: Option<&TextStyleCtx>,
+    for_payload: Option<ForPayloadScope<'_>>,
+) -> Result<String, PipelineEmitError> {
+    let pad = "    ".repeat(depth);
+    let inner = "    ".repeat(depth + 1);
+    let tooltip_inner = "    ".repeat(depth + 2);
+    let message = text_prop_expr(node, "text")?.unwrap_or_else(|| "\"\"".to_string());
+    let mut out = String::new();
+
+    writeln!(out, "{pad}BasicTooltipBox(").unwrap();
+    writeln!(
+        out,
+        "{inner}positionProvider = object : PopupPositionProvider {{"
+    )
+    .unwrap();
+    writeln!(out, "{tooltip_inner}override fun calculatePosition(").unwrap();
+    writeln!(out, "{tooltip_inner}    anchorBounds: IntRect,").unwrap();
+    writeln!(out, "{tooltip_inner}    windowSize: IntSize,").unwrap();
+    writeln!(out, "{tooltip_inner}    layoutDirection: LayoutDirection,").unwrap();
+    writeln!(out, "{tooltip_inner}    popupContentSize: IntSize,").unwrap();
+    writeln!(out, "{tooltip_inner}): IntOffset {{").unwrap();
+    writeln!(
+        out,
+        "{tooltip_inner}    val maxX = maxOf(0, windowSize.width - popupContentSize.width)"
+    )
+    .unwrap();
+    writeln!(out, "{tooltip_inner}    val preferredX = if (layoutDirection == LayoutDirection.Ltr) anchorBounds.left else anchorBounds.right - popupContentSize.width").unwrap();
+    writeln!(out, "{tooltip_inner}    val below = anchorBounds.bottom").unwrap();
+    writeln!(
+        out,
+        "{tooltip_inner}    val above = anchorBounds.top - popupContentSize.height"
+    )
+    .unwrap();
+    writeln!(out, "{tooltip_inner}    return IntOffset(").unwrap();
+    writeln!(
+        out,
+        "{tooltip_inner}        x = preferredX.coerceIn(0, maxX),"
+    )
+    .unwrap();
+    writeln!(out, "{tooltip_inner}        y = if (below + popupContentSize.height <= windowSize.height) below else maxOf(0, above),").unwrap();
+    writeln!(out, "{tooltip_inner}    )").unwrap();
+    writeln!(out, "{tooltip_inner}}}").unwrap();
+    writeln!(out, "{inner}}},").unwrap();
+    writeln!(out, "{inner}tooltip = {{").unwrap();
+    writeln!(out, "{tooltip_inner}Surface(elevation = 4.dp) {{").unwrap();
+    writeln!(
+        out,
+        "{tooltip_inner}    Text(text = {message}, modifier = Modifier.padding(8.dp))"
+    )
+    .unwrap();
+    writeln!(out, "{tooltip_inner}}}").unwrap();
+    writeln!(out, "{inner}}},").unwrap();
+    writeln!(
+        out,
+        "{inner}state = rememberBasicTooltipState(isPersistent = false),"
+    )
+    .unwrap();
+    writeln!(out, "{inner}modifier = Modifier.semantics(mergeDescendants = true) {{ contentDescription = {message} }},").unwrap();
+    writeln!(out, "{inner}focusable = true,").unwrap();
+    writeln!(out, "{pad}) {{").unwrap();
+    out.push_str(&emit_children_compose(
+        &node.children,
+        depth + 1,
+        component_name,
+        emits,
+        part_styles,
+        table_ctx,
+        text_ctx,
+        for_payload,
+        None,
+    )?);
+    writeln!(out, "{pad}}}").unwrap();
     Ok(out)
 }
 
@@ -4058,6 +4187,99 @@ mod tests {
                 >= 3,
             "expected at least 3 Column blocks (table + head + body), got:\n{out}"
         );
+    }
+
+    #[test]
+    fn host_tooltip_uses_native_overlay_and_accessible_semantics() {
+        let tooltip = node(
+            "HostTooltip",
+            vec![LayoutProp {
+                name: "text".into(),
+                value: LayoutPropValue::String("Save changes".into()),
+            }],
+            vec![node(
+                "Text",
+                vec![LayoutProp {
+                    name: "content".into(),
+                    value: LayoutPropValue::String("Save".into()),
+                }],
+                vec![],
+            )],
+        );
+        let out = from_pipeline(
+            &component("Toolbar", vec![], vec![]),
+            &layout("Toolbar", tooltip),
+            &empty_style("Toolbar"),
+        )
+        .unwrap()
+        .output;
+
+        assert!(out.contains("import androidx.compose.foundation.BasicTooltipBox"));
+        assert!(out.contains("@OptIn(ExperimentalFoundationApi::class)"));
+        assert!(out.contains("BasicTooltipBox("));
+        assert!(out.contains("Surface(elevation = 4.dp)"));
+        assert!(out.contains("Text(text = \"Save changes\", modifier = Modifier.padding(8.dp))"));
+        assert!(out.contains(
+            "Modifier.semantics(mergeDescendants = true) { contentDescription = \"Save changes\" }"
+        ));
+        assert!(out.contains("focusable = true,"));
+        assert!(out.contains("Text(text = \"Save\")"));
+    }
+
+    #[test]
+    fn host_tooltip_accepts_slot_and_loop_expression_text() {
+        let slot_tooltip = node("HostTooltip", vec![slot_prop("text", "help-text")], vec![]);
+        let slot_out = from_pipeline(
+            &component(
+                "Hint",
+                vec![slot("help-text", SlotType::Text, true)],
+                vec![],
+            ),
+            &layout("Hint", slot_tooltip),
+            &empty_style("Hint"),
+        )
+        .unwrap()
+        .output;
+        assert!(slot_out.contains("Text(text = helpText, modifier = Modifier.padding(8.dp))"));
+        assert!(slot_out.contains("contentDescription = helpText"));
+
+        let loop_tooltip = node(
+            "For",
+            vec![
+                slot_prop("each", "rows"),
+                LayoutProp {
+                    name: "as".into(),
+                    value: LayoutPropValue::Keyword("row".into()),
+                },
+            ],
+            vec![node(
+                "HostTooltip",
+                vec![expr_prop("text", "( row[1] )")],
+                vec![node(
+                    "Text",
+                    vec![expr_prop("content", "( row[0] )")],
+                    vec![],
+                )],
+            )],
+        );
+        let loop_out = from_pipeline(
+            &component(
+                "Timeline",
+                vec![slot(
+                    "rows",
+                    SlotType::List(Box::new(ListInnerType::Text)),
+                    true,
+                )],
+                vec![],
+            ),
+            &layout("Timeline", loop_tooltip),
+            &empty_style("Timeline"),
+        )
+        .unwrap()
+        .output;
+        assert!(loop_out.contains("Text(text = ( row[1] ), modifier = Modifier.padding(8.dp))"));
+        assert!(loop_out.contains("contentDescription = ( row[1] )"));
+        assert!(loop_out.contains("Text(text = ( row[0] ))"));
     }
 
     // ── UI34 Compose part-style inlining (the spreadsheet fix) ─────────

--- a/code/scripts/mosaic_compose_runtime_ci_acceptance.py
+++ b/code/scripts/mosaic_compose_runtime_ci_acceptance.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Derive the Mosaic Compose runtime conformance flag from a build plan."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+ACCEPTANCE_PACKAGES = frozenset(
+    {
+        "rust/mosaic-app-bindings",
+        "rust/mosaic-app-capi",
+        "rust/mosaic-app-conformance",
+        "rust/mosaic-app-runtime",
+        "rust/mosaic-compile",
+        "rust/mosaic-emit-compose",
+        "rust/mosaic-package-artifact-builder",
+        "rust/moslayout-compiler",
+        "rust/mosmodel-compiler",
+        "rust/mosstyle-compiler",
+        "unknown/programs/task-app",
+    }
+)
+ACCEPTANCE_PACKAGE_PREFIXES = ("unknown/mosaic-pkg-",)
+CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+
+
+def requires_mosaic_compose_runtime(
+    plan: dict[str, Any], *, workflow_changed: bool = False
+) -> bool:
+    """Return whether this plan must exercise the generated Compose binding."""
+
+    if workflow_changed:
+        return True
+    affected = plan.get("affected_packages")
+    if affected is None:
+        return True
+    if not isinstance(affected, list):
+        raise ValueError("affected_packages must be an array or null")
+    return any(
+        package in ACCEPTANCE_PACKAGES
+        or package.startswith(ACCEPTANCE_PACKAGE_PREFIXES)
+        for package in affected
+    )
+
+
+def workflow_changed(repo_root: Path, diff_base: str) -> bool:
+    """Return whether the main CI workflow differs from the selected base."""
+
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--quiet",
+            f"{diff_base}...HEAD",
+            "--",
+            CI_WORKFLOW_PATH,
+        ],
+        cwd=repo_root,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        raise RuntimeError(f"git diff exited with status {result.returncode}")
+    return result.returncode == 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("plan", type=Path)
+    parser.add_argument("--repo-root", type=Path)
+    parser.add_argument("--diff-base")
+    args = parser.parse_args()
+
+    if (args.repo_root is None) != (args.diff_base is None):
+        parser.error("--repo-root and --diff-base must be provided together")
+
+    with args.plan.open(encoding="utf-8") as handle:
+        plan = json.load(handle)
+    if not isinstance(plan, dict):
+        raise ValueError("build plan root must be an object")
+
+    changed = False
+    if args.repo_root is not None and args.diff_base is not None:
+        changed = workflow_changed(args.repo_root, args.diff_base)
+
+    required = requires_mosaic_compose_runtime(plan, workflow_changed=changed)
+    print(f"required={'true' if required else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/tests/test_mosaic_compose_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_compose_runtime_ci_acceptance.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "mosaic_compose_runtime_ci_acceptance.py"
+WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "ci.yml"
+COMPOSE_CONFORMANCE = (
+    Path(__file__).resolve().parents[2]
+    / "packages"
+    / "rust"
+    / "mosaic-app-bindings"
+    / "conformance"
+    / "compose"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "mosaic_compose_runtime_ci_acceptance", SCRIPT
+)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class MosaicComposeRuntimeCIAcceptanceTests(unittest.TestCase):
+    def test_force_plan_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_compose_runtime({"affected_packages": None})
+        )
+
+    def test_compose_emitter_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_compose_runtime(
+                {"affected_packages": ["rust/mosaic-emit-compose"]}
+            )
+        )
+
+    def test_standard_runtime_binding_requires_acceptance(self) -> None:
+        for package in (
+            "rust/mosaic-app-bindings",
+            "rust/mosaic-app-capi",
+            "rust/mosaic-app-conformance",
+            "rust/mosaic-app-runtime",
+        ):
+            with self.subTest(package=package):
+                self.assertTrue(
+                    MODULE.requires_mosaic_compose_runtime(
+                        {"affected_packages": [package]}
+                    )
+                )
+
+    def test_task_app_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_compose_runtime(
+                {"affected_packages": ["unknown/programs/task-app"]}
+            )
+        )
+
+    def test_standard_mosaic_package_requires_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_compose_runtime(
+                {"affected_packages": ["unknown/mosaic-pkg-grid"]}
+            )
+        )
+
+    def test_unrelated_plan_skips_acceptance(self) -> None:
+        self.assertFalse(
+            MODULE.requires_mosaic_compose_runtime(
+                {"affected_packages": ["rust/html-parser"]}
+            )
+        )
+
+    def test_workflow_change_self_tests_acceptance(self) -> None:
+        self.assertTrue(
+            MODULE.requires_mosaic_compose_runtime(
+                {"affected_packages": []}, workflow_changed=True
+            )
+        )
+
+    def test_invalid_affected_packages_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "array or null"):
+            MODULE.requires_mosaic_compose_runtime({"affected_packages": "all"})
+
+    def test_cli_emits_github_output_value(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            plan = Path(directory) / "build-plan.json"
+            plan.write_text(
+                '{"affected_packages":["rust/mosaic-emit-compose"]}',
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), str(plan)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.stdout, "required=true\n")
+
+    def test_workflow_routes_rust_jvm_and_acceptance(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "needs_mosaic_compose_runtime: "
+            "${{ steps.mosaic-compose-runtime.outputs.required }}",
+            workflow,
+        )
+        self.assertIn(
+            "python3 code/scripts/mosaic_compose_runtime_ci_acceptance.py",
+            workflow,
+        )
+        self.assertIn("Round-trip Rust engine through standard Compose binding", workflow)
+        self.assertIn("needs_mosaic_compose_runtime == 'true'", workflow)
+        self.assertIn("timeout-minutes: 10", workflow)
+        self.assertIn("--backend compose --output \"$output\" --emit-project", workflow)
+        self.assertIn(
+            "cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance",
+            workflow,
+        )
+        self.assertIn("compose/src/main/kotlin/MosaicRuntimeHost.kt", workflow)
+        self.assertIn("gradle --no-daemon --stacktrace -p \"$harness\" run", workflow)
+        self.assertIn("MOSAIC_APP_LIBRARY", workflow)
+
+    def test_harness_does_not_duplicate_the_generated_binding(self) -> None:
+        source = COMPOSE_CONFORMANCE / "src" / "main" / "kotlin"
+        self.assertTrue((source / "Conformance.kt").is_file())
+        self.assertFalse((source / "MosaicRuntimeHost.kt").exists())
+        gradle = (COMPOSE_CONFORMANCE / "build.gradle.kts").read_text(encoding="utf-8")
+        self.assertIn("net.java.dev.jna:jna:5.19.1", gradle)
+        self.assertIn("kotlinx-serialization-json:1.11.0", gradle)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -311,7 +311,9 @@ unblocks multiple downstream targets; never count source generation as completio
   - [x] Flutter/Dart FFI loads the shared Rust conformance library and round-trips
     startup, dispatch, snapshot/restore, notification, buffers, and teardown in
     headless Linux CI.
-  - [ ] Promote the same shared Rust fixture through the Compose standard binding.
+  - [x] Compose/JNA loads the shared Rust conformance library and round-trips
+    startup, dispatch, snapshot/restore, notification, buffers, and teardown on
+    the Linux JVM.
 - [x] Gate the complete package-expanded XAML TaskApp on GitHub-hosted Windows
   with real WinUI compilation and executable production.
   - [x] Allocate `For` row-view-model and projection names per loop rather than
@@ -330,6 +332,9 @@ unblocks multiple downstream targets; never count source generation as completio
   its lint configuration, and omit unused authored `For` bindings.
 - [x] Complete Compose TaskApp Kotlin typing: normalize Mosaic value truthiness
   in boolean positions and supply required native input commit payloads.
+- [x] Restore complete Compose TaskApp generation after package expansion added
+  per-row `HostTooltip` nodes: lower them to Compose Foundation's native overlay
+  with plain-text semantics instead of rejecting the current package graph.
 - [x] Route every compile entry point through one package-composition pipeline;
   standalone and package builds now consume the same resolved layout and merged
   dependency-style IR before selecting a backend.


### PR DESCRIPTION
## Summary
- lower `HostTooltip` to Compose Foundation native overlays with accessible semantics, restoring current package-expanded TaskApp generation
- fix generated JNA ABI carrier visibility so the Compose host can actually load a Rust application library
- add a Linux CI round trip through the exact generated binding covering startup, dispatch, snapshot/restore, notifications, buffer ownership, and teardown

## Validation
- `cargo test --manifest-path code/packages/rust/mosaic-emit-compose/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/mosaic-app-bindings/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/mosaic-package-artifact-builder/Cargo.toml`
- `cargo test --manifest-path code/packages/rust/mosaic-compile/Cargo.toml`
- `cargo clippy --manifest-path code/packages/rust/mosaic-emit-compose/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --manifest-path code/packages/rust/mosaic-app-bindings/Cargo.toml --all-targets -- -D warnings`
- package-expanded TaskApp generation + Compose 1.11.1 `compileKotlin`
- generated JNA host against `libmosaic_app_conformance.dylib`: startup, dispatch, snapshot/restore, notification, teardown
- `python3 -m unittest discover -s code/scripts/tests -p "test_mosaic_compose_runtime_ci_acceptance.py"`