### PR TITLE
feat(adj-formula-stdlib): Wave 3 continuation -- solve P=F/A for area

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_pressure_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_pressure_e2e.rs
@@ -107,3 +107,37 @@ fn computes_force_as_pressure_times_area_with_citation() {
         "force carries its HyperPhysics citation: {s}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// F = P·A, solved for a different unknown (ADJ-FORMULA-LIBRARIES FL-10, §3D
+// rung-0 CAS-wiring companion) — the SAME cited HyperPhysics definition as
+// `pressure`/`force` above, closing the one direction they leave open: area.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn solves_for_area_from_pressure_with_the_same_citation() {
+    let dir = scratch("area_solve");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"pressure.adj\"\n\
+         observe force(50)\n\
+         observe pressure(25)\n\
+         ? area_from_pressure(force, pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 50 = 25 * a  =>  a = 2.
+    assert!(
+        s.contains("\"name\":\"area_from_pressure\"") && s.contains("\"value\":2"),
+        "area_from_pressure(50, 25) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("hyperphysics.gsu.edu/hbase/press.html"),
+        "carries the same HyperPhysics citation as the forward pressure/force formulas: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-formula-stdlib/CHANGELOG.md
@@ -131,3 +131,12 @@ landed and why, not a semver-tracked API.
   `geometry-formulas.adj`'s `square_area` boundary case. New manifest objective
   `adj.math.algebra.rearrange_kinetic_energy`. Extended the existing `formula_energy_work_e2e.rs`
   with 1 new test rather than adding a new test file.
+- `physics/pressure.adj` — a sixth Wave 3 rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES FL-10,
+  §3D): `area_from_pressure`, solving the same cited HyperPhysics `P = F/A` definition (via its
+  equivalent multiplicative form `F = P·A`, already hand-shipped as the `force` formula) for area —
+  the one direction `pressure`/`force` leave open. Found via a fresh sweep across every domain
+  under `adj-formula-stdlib/` (mathematics, physics, chemistry, arithmetic, clinical) confirming
+  Wave 3's original kinematics/geometry/work/mechanics-force/kinetic-energy sweep had missed this
+  library — most sibling 2-parameter libraries already hand-ship every direction, and this was the
+  one overlooked. New manifest objective `adj.math.algebra.rearrange_pressure`. Extended the
+  existing `formula_pressure_e2e.rs` with 1 new test rather than adding a new test file.

--- a/code/specs/data/adj-formula-stdlib/physics/pressure.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/pressure.adj
@@ -33,6 +33,18 @@
 % provenance envelope every shipped grounded clause carries; the linter rejects an
 % unsourced one. (See feedback_nothing_human_authored — the definitional sentence is
 % a verbatim span of the cited page, not asserted from memory.)
+%
+% This library also carries a rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES
+% FL-10, §3D — a Wave 3 continuation): `area_from_pressure` solves the SAME cited
+% HyperPhysics definition as the forward `force` formula (`F = P·A`) for area
+% instead, through `cas-solve`'s real linear-equation solver — the exact discipline
+% `electricity.adj`'s `resistance_from_ohms_law` already established. This closes
+% the one remaining direction the hand-shipped `pressure`/`force` pair left open
+% (given pressure and force, recover the area) without duplicating either existing
+% formula's citation work. The new symbolic names its OWN target finding
+% (`area_from_pressure`, not `area`) rather than reusing the plain parameter name,
+% so it coexists with the two forward examples in one query file — no target-
+% collision, no file-splitting needed.
 % ============================================================================
 
 % ----------------------------------------------------------------------------
@@ -47,6 +59,7 @@ dictionary pressure_vocab {
     define force    : finding  surface "force", "F"                     % force, e.g. N (newtons)
     define area     : finding  surface "area", "A"                      % area, e.g. m²
     define pressure : finding  surface "pressure", "P"                  % pressure, e.g. Pa (pascals)
+    define area_from_pressure : finding  surface "missing area", "unknown area"
 }
 
 % ----------------------------------------------------------------------------
@@ -68,6 +81,14 @@ formulabook pressure_laws {
     % Force — the same definition solved for the force a pressure exerts over an
     % area (F = P·A). Defended by the SAME definitional sentence, read the other way.
     formula force(pressure, area) = pressure * area
+        source "Pressure is defined as force per unit area."
+        locator "https://hyperphysics.gsu.edu/hbase/press.html"
+        trust authoritative
+
+    % F = P·A again, SOLVED FOR AREA instead of computed forward — the same cited
+    % HyperPhysics definition, only which quantity is bound and which is unknown
+    % differs. Closes the one direction `pressure`/`force` above leave open.
+    symbolic area_from_pressure(force, pressure) { force == pressure * area_from_pressure } for area_from_pressure
         source "Pressure is defined as force per unit area."
         locator "https://hyperphysics.gsu.edu/hbase/press.html"
         trust authoritative

--- a/code/specs/data/adj-formula-stdlib/physics/pressure.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/pressure.query.adj
@@ -27,3 +27,9 @@ observe area(2)
 % That 25 Pa pressure over the same 2 m² area: force = 25 * 2.
 observe pressure(25)
 ? force(pressure, area)      % expect 50   (same definition, solved for F = P·A)
+
+% --- P = F/A, SOLVED FOR AREA (rung-0 CAS-wiring, FL-10). "A 50 N force produces
+% 25 Pa of pressure. Over what area is it acting?" ---
+observe force(50)                      % "…a 50 N force…"              (span cited)
+observe pressure(25)                   % "…produces 25 Pa of pressure…" (span cited)
+? area_from_pressure(force, pressure)  % engine → 2 (HyperPhysics, authoritative)

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1247,6 +1247,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.math.algebra.rearrange_pressure",
+      "title": "Solve P = F / A for area, given the force and the pressure",
+      "band": "9-12",
+      "domain": "mathematics",
+      "competency": "compute",
+      "coverage_roots": ["ccss.math"],
+      "standards": [],
+      "prerequisites": ["adj.science.physics.pressure"],
+      "libraries": ["code/specs/data/adj-formula-stdlib/physics/pressure.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES FL-10, §3D — Wave 3 continuation) to `physics/pressure.adj`: `area_from_pressure`, solving the same cited HyperPhysics `P = F/A` definition (via its equivalent multiplicative form `F = P·A`, already hand-shipped as the `force` formula) for area — the one direction `pressure`/`force` leave open.
- Found via a fresh sweep across every domain under `adj-formula-stdlib/` (mathematics, physics, chemistry, arithmetic, clinical) confirming the original Wave 3 kinematics/geometry/work/mechanics-force/kinetic-energy sweep had missed this library — most sibling 2-parameter libraries already hand-ship every direction, and this was the one overlooked.
- Empirically verified via the CLI before writing (`area_from_pressure(50, 25) = 2`).
- New manifest objective `adj.math.algebra.rearrange_pressure` (band 9-12, prerequisite `adj.science.physics.pressure`).
- Extended the existing `formula_pressure_e2e.rs` with 1 new test (3 total) rather than adding a new test file.

Part of the autonomous ADJ curriculum loop (`ADJ-STDLIB-COVERAGE.md#7-delivery-order`).

## Test plan
- [x] Solve direction empirically verified via the CLI in a scratch dir before writing real content.
- [x] `cargo test -p adj-lang-cli --test formula_pressure_e2e` — 3/3 passed.
- [x] `cargo test -p adj-lang -p adj-lang-cli` — full suite green, no regressions.
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean.
- [x] `adj_stdlib_manifest.py --validate-json-schema` — 79 objectives, 0 errors, valid.
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` — exit 0, no new gaps introduced.
- [x] Python unittest suite (manifest/report subset) — 87 passed.
- [x] Security review — passed, no findings.