### PR TITLE
fix(gc-core): harden mark_in_progress reentrancy guard; should_collect defers during an incremental mark

### DIFF
--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this crate are documented here.
 
+## 0.24.2 - 2026-08-10 — test: `__gc_safepoint` mid-incremental-cycle regression coverage
+
+- New `safepoint_is_a_no_op_during_an_incremental_cycle` test: drives the real
+  `__gc_collect_incremental_start/step/finish` C-ABI protocol and fires `__gc_safepoint`
+  mid-cycle (with live bytes deliberately pushed over the paced-collection threshold
+  first), asserting it's a safe no-op — no panic, no collection, the live object
+  untouched — then confirms the incremental cycle completes normally and paced
+  collection isn't permanently disabled afterward. Companion coverage for the
+  `gc-core` 0.33.2 fix (`FlatHeap::should_collect` now defers during an incremental
+  mark); see that crate's changelog for the full story. No functional change in this
+  crate — `__gc_safepoint` needed no code change here, since it already gates
+  entirely through `should_collect()`.
+
 ## 0.24.1 - 2026-08-10 — fix: deterministic flaky conservative-stack-scan smoke tests
 
 - Four `stack_scan` integration tests (`stack_scan_keeps_live_local_frees_dead`,

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.24.1"
+version = "0.24.2"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/src/stack_scan.rs
+++ b/code/packages/rust/gc-core-capi/src/stack_scan.rs
@@ -1046,6 +1046,62 @@ mod tests {
         core::hint::black_box(kept);
     }
 
+    /// **Security-review finding, regression:** `__gc_safepoint` firing mid-incremental-
+    /// cycle — the intended bounded-pause usage pattern (`start` → repeated `step` at
+    /// safepoints → `finish`) can trigger this through entirely normal, sanctioned use
+    /// — must be a safe no-op, not a panic (or, before `should_collect` gained its own
+    /// `mark_in_progress` check, silent release-mode heap corruption via the
+    /// stop-the-world collectors' `debug_assert!`-only guard). Live bytes are pushed
+    /// over the paced-collection threshold *before* starting the incremental cycle, so
+    /// the live-byte half of `should_collect` alone would say yes — proving the defer
+    /// is really `mark_in_progress`-driven, not incidental.
+    #[test]
+    fn safepoint_is_a_no_op_during_an_incremental_cycle() {
+        let _guard = crate::TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        __gc_reset();
+        run_safepoint_during_incremental_case();
+        __gc_reset();
+    }
+
+    #[inline(never)]
+    fn run_safepoint_during_incremental_case() {
+        use gc_core::flat_heap::INITIAL_THRESHOLD;
+
+        let big = __gc_alloc(INITIAL_THRESHOLD as i64);
+        assert!(big != 0);
+        unsafe { *(big as *mut i64) = 0xFEED };
+        assert!(__gc_live_bytes() as usize >= INITIAL_THRESHOLD);
+
+        unsafe { __gc_collect_incremental_start() };
+
+        // A safepoint firing mid-cycle must be a safe no-op: no panic, no collection.
+        assert_eq!(unsafe { __gc_safepoint() }, 0, "safepoint must defer during an incremental mark");
+        assert_eq!(__gc_collection_count(), 0, "no stop-the-world cycle ran mid-incremental-mark");
+        assert_eq!(
+            unsafe { *(big as *const i64) },
+            0xFEED,
+            "the object survives untouched -- no sweep happened"
+        );
+
+        // Drive the cycle to completion normally -- the deferred safepoint didn't
+        // disturb it -- then confirm paced collection isn't permanently disabled.
+        let mut steps = 0;
+        while unsafe { __gc_collect_incremental_step(1) } == 0 {
+            steps += 1;
+            assert!(steps < 100_000, "incremental mark must converge");
+        }
+        let _ = unsafe { __gc_collect_incremental_finish() };
+        assert_eq!(__gc_collection_count(), 1, "the incremental cycle itself completed and counted");
+
+        let _ = unsafe { __gc_safepoint() }; // must not panic now that the flag is clear
+        assert_eq!(
+            unsafe { *(big as *const i64) },
+            0xFEED,
+            "the object -- still stack-rooted -- survives whether or not this safepoint collected again"
+        );
+        core::hint::black_box(big);
+    }
+
     /// The incremental C-ABI protocol is safe even if no phase is in progress: `step` reports
     /// "done" and `finish` reclaims nothing (the no-op cycle an untrustworthy-stack `start`
     /// produces). Nothing is swept, so no live object could be lost.

--- a/code/packages/rust/gc-core/CHANGELOG.md
+++ b/code/packages/rust/gc-core/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog — gc-core
 
+## 0.33.2 — 2026-08-10 — harden the incremental-mark reentrancy guard (security fix)
+
+- **The 11 `mark_in_progress` reentrancy guards across `flat_heap.rs` were
+  `debug_assert!`-only** — compiled out entirely under `--release`. They exist to
+  prevent any stop-the-world `collect*` call (or the internal helpers they share)
+  from running *between* `incremental_start` and `incremental_finish`: doing so would
+  `sweep` blocks still referenced by the persistent `mark_worklist`, leaving dangling
+  worklist pointers a later `incremental_step` would pop — a use-after-free. All 11
+  are now hard `assert!`s, checked in every build profile.
+- **The real gap this hardening exposed: no automatic call site checked
+  `mark_in_progress` at all.** `__gc_safepoint` (`gc-core-capi`), `vm-core`'s
+  `safepoint` opcode, and `__gc_collect`'s auto-collect all gate their stop-the-world
+  call behind `FlatHeap::should_collect()` alone — which, before this fix, consulted
+  only live-byte accounting. Two already-shipped, un-gated features made this live:
+  the incremental GC builtins (`gc_collect_incremental_start/step/finish`) and
+  `__gc_safepoint`, which fires automatically at every compiled loop-back-edge. A
+  release binary driving the intended bounded-pause pattern — `start`, repeated
+  `step` calls at safepoints, `finish` — could hit a safepoint mid-cycle and, before
+  this fix, silently corrupt the heap (the assert was compiled out); after just the
+  `assert!` hardening alone, it would instead hard-`abort()` the process (confirmed
+  empirically — see below), since a panic crossing an `extern "C"` boundary can't
+  unwind. Neither outcome is acceptable for entirely normal, sanctioned use.
+- **Fix: `should_collect()` itself now answers `false` whenever
+  `incremental_in_progress()` is true**, regardless of live bytes — the one place this
+  policy decision already lived, per its own doc comment, so every current and future
+  automatic call site is protected identically with no per-site change needed. A
+  safepoint firing mid-cycle is now a safe no-op: the incremental cycle keeps making
+  progress via its own `incremental_step` calls, and paced collection resumes
+  automatically once `incremental_finish` clears the flag.
+- 3 new regression tests: a direct `should_collect` policy test (defers while
+  `mark_in_progress`, resumes once cleared); a `#[should_panic]` test giving the
+  now-11-call-site reentrancy guard its first direct coverage (none existed before
+  this round despite the guard's presence at every stop-the-world entry); and an
+  end-to-end `gc-core-capi` test driving the real `start`/`step`/`finish` C-ABI
+  protocol with a safepoint fired mid-cycle. All three confirmed load-bearing by
+  reverting the `should_collect` fix and observing the predicted failure — notably,
+  the C-ABI test didn't just fail, it **hard-aborted the process** (`SIGABRT`),
+  empirically demonstrating the severity described above.
+- Verification: `cargo build`/`test` clean across `gc-core`, `gc-core-capi`,
+  `vm-core` (160 lib tests, up from 158; gc-core-capi 41, up from 40); `cargo clippy
+  --all-targets -- -D warnings` clean; full-crate `cargo +nightly miri test -p
+  gc-core` clean (158 passed, 2 ignored per the existing scale-test gate).
+
 ## 0.33.1 — 2026-08-10 — `find_header`: fix the one-past-the-end pointer gap (security fix)
 
 - **`FlatHeap::find_header`'s upper bound was exclusive** (`addr < payload + size`), so a

--- a/code/packages/rust/gc-core/Cargo.toml
+++ b/code/packages/rust/gc-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core"
-version = "0.33.1"
+version = "0.33.2"
 edition = "2021"
 description = "The shared GC engine (FlatHeap) for the LANG pipeline: linked directly by native-AOT backends (via gc-core-capi) and by vm-core."
 license = "MIT"

--- a/code/packages/rust/gc-core/src/flat_heap.rs
+++ b/code/packages/rust/gc-core/src/flat_heap.rs
@@ -334,13 +334,27 @@ pub const DEFAULT_TENURE_AGE: u8 = 1;
 /// small enough that old-generation garbage is never more than 8 paced cycles stale.
 pub const DEFAULT_MAX_MINOR_STREAK: u32 = 8;
 
-/// Debug-assert message for the four stop-the-world `collect*` entries: none may run
-/// *between* an [`FlatHeap::incremental_start`] and its [`FlatHeap::incremental_finish`].
-/// A full/minor collect mid-incremental-cycle would `sweep` blocks still referenced by the
-/// persistent [`FlatHeap::mark_worklist`], leaving dangling worklist pointers a later
-/// [`FlatHeap::incremental_step`] would pop (a use-after-free). One incremental cycle must
-/// run to `finish` before any other collector — a caller-contract invariant, fenced here in
-/// debug builds (AOT00-T4 §1 scope guard).
+/// Assert message for the stop-the-world `collect*` entries (and the internal helpers
+/// they share): none may run *between* an [`FlatHeap::incremental_start`] and its
+/// [`FlatHeap::incremental_finish`]. A full/minor collect mid-incremental-cycle would
+/// `sweep` blocks still referenced by the persistent [`FlatHeap::mark_worklist`],
+/// leaving dangling worklist pointers a later [`FlatHeap::incremental_step`] would pop
+/// (a use-after-free). One incremental cycle must run to `finish` before any other
+/// collector — a caller-contract invariant, fenced here as a **hard `assert!`, checked
+/// in every build profile including release** (AOT00-T4 §1 scope guard).
+///
+/// **Security-review finding, hardened here:** this was a `debug_assert!` — compiled
+/// out entirely under `--release`. Two already-shipped, un-gated features make the
+/// invariant live, reachable purely through normal, sanctioned use, no caller bug or
+/// attacker input required: `gc_collect_incremental_start/step/finish` (the incremental
+/// GC builtins) and `__gc_safepoint` (which fires automatically at every compiled
+/// loop-back-edge and, before this fix, called the stop-the-world collectors with no
+/// `mark_in_progress` check of its own — see [`FlatHeap::should_collect`]/
+/// `__gc_safepoint`'s own doc for the companion fix that makes a safepoint firing
+/// mid-cycle a safe no-op instead of ever reaching this assert). A release binary that
+/// starts an incremental cycle and then hits a safepoint before calling `finish` — the
+/// intended bounded-pause usage pattern — could previously corrupt the heap silently
+/// instead of failing loudly.
 const INCREMENTAL_MIXING_MSG: &str =
     "stop-the-world collect during an incremental mark phase — drive incremental_step/finish \
      to completion before calling collect*";
@@ -712,8 +726,25 @@ impl FlatHeap {
     /// cycle — lives with the caller (for native AOT, `gc-core-capi`'s stack scan),
     /// because only the caller knows how to enumerate its roots. A safepoint or an
     /// allocation consults this and, when true, drives a collect.
+    ///
+    /// **Security-review finding, fixed here:** answers `false` whenever an incremental
+    /// mark phase is in progress ([`Self::incremental_in_progress`]), regardless of live
+    /// bytes. Every stop-the-world `collect*` entry hard-`assert!`s this same invariant
+    /// (see [`INCREMENTAL_MIXING_MSG`]) because running one mid-cycle would sweep blocks
+    /// the persistent mark worklist still references — a use-after-free. Before this fix,
+    /// that assert was the *only* guard: every automatic call site (`__gc_safepoint`,
+    /// `vm-core`'s `safepoint` opcode, `__gc_collect`) gates its stop-the-world call
+    /// behind `should_collect()` alone, with no `mark_in_progress` check of its own — so
+    /// a release binary driving a legitimate, already-shipped bounded-pause incremental
+    /// cycle (`incremental_start` → repeated `incremental_step` at safepoints → `finish`)
+    /// could hit a safepoint mid-cycle and crash on the assert, purely through normal,
+    /// sanctioned use of two already-shipped features. Deferring here — the one place
+    /// this policy decision lives, per this method's own doc — means a safepoint firing
+    /// mid-cycle is simply a safe no-op instead: the incremental cycle keeps making
+    /// progress via its own `incremental_step` calls, and paced collection resumes
+    /// automatically once `incremental_finish` clears the flag.
     pub fn should_collect(&self) -> bool {
-        self.live_bytes >= self.collect_threshold
+        !self.mark_in_progress && self.live_bytes >= self.collect_threshold
     }
 
     /// Whether the *next* collection should also relocate objects
@@ -842,7 +873,7 @@ impl FlatHeap {
     /// reference are followed).  A false positive retains a dead object for one
     /// extra cycle; it never frees a live one.
     pub fn collect(&mut self, roots: &[usize]) -> GcCycleStats {
-        debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
         self.minor_streak = 0; // full collect: bound on consecutive minors is satisfied (AOT00-T8)
         let before = self.object_count();
         let prev_live = self.live_bytes;
@@ -909,7 +940,7 @@ impl FlatHeap {
     /// may be null iff `len == 0`). No alignment of `base`/`len` is required —
     /// scanning starts at `base` and a sub-8-byte tail is ignored.
     pub unsafe fn collect_region(&mut self, base: *const u8, len: usize) -> GcCycleStats {
-        debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
         self.minor_streak = 0; // full collect: bound on consecutive minors is satisfied (AOT00-T8)
         let before = self.object_count();
         let prev_live = self.live_bytes;
@@ -1030,7 +1061,7 @@ impl FlatHeap {
     /// object be wrongly freed. The GC upholds its half; the mutator/codegen must
     /// uphold the barrier.
     pub fn collect_minor(&mut self, roots: &[usize]) -> GcCycleStats {
-        debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
         let before = self.object_count();
         let prev_live = self.live_bytes;
         let mut work: Vec<*mut FlatHeader> = Vec::new();
@@ -1051,7 +1082,7 @@ impl FlatHeap {
     /// `[base, base + len)` must be readable (or `base` null with `len == 0`),
     /// exactly as for [`Self::collect_region`].
     pub unsafe fn collect_minor_region(&mut self, base: *const u8, len: usize) -> GcCycleStats {
-        debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
         let before = self.object_count();
         let prev_live = self.live_bytes;
         let mut work: Vec<*mut FlatHeader> = Vec::new();
@@ -1084,7 +1115,7 @@ impl FlatHeap {
         root_slots: &[usize],
         regions: &[(*const u8, usize)],
     ) -> GcCycleStats {
-        debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
         let before = self.object_count();
         let prev_live = self.live_bytes;
         let mut work: Vec<*mut FlatHeader> = Vec::new();
@@ -1215,7 +1246,7 @@ impl FlatHeap {
     /// is not a valid, readable slot is undefined behaviour — the same contract
     /// [`Self::collect_region`] places on its `[base, base + len)` span.
     pub unsafe fn collect_precise(&mut self, root_slots: &[usize]) -> GcCycleStats {
-        debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
         self.minor_streak = 0; // full collect: bound on consecutive minors is satisfied (AOT00-T8)
         let before = self.object_count();
         let prev_live = self.live_bytes;
@@ -1295,7 +1326,7 @@ impl FlatHeap {
         root_slots: &[usize],
         regions: &[(*const u8, usize)],
     ) -> GcCycleStats {
-        debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
         self.minor_streak = 0; // full collect: bound on consecutive minors is satisfied (AOT00-T8)
         let before = self.object_count();
         let prev_live = self.live_bytes;
@@ -1367,7 +1398,7 @@ impl FlatHeap {
         root_slots: &[usize],
         regions: &[(*const u8, usize)],
     ) {
-        debug_assert!(!self.mark_in_progress, "incremental cycle already in progress");
+        assert!(!self.mark_in_progress, "incremental cycle already in progress");
         // Everything white: clear the mark bit on every live block.
         // SAFETY: list walk over blocks we own / null terminator.
         let mut h = self.all;
@@ -2198,7 +2229,7 @@ impl FlatHeap {
         root_slots: &[usize],
         regions: &[(*const u8, usize)],
     ) -> (HashSet<usize>, HashSet<usize>) {
-        debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
 
         // Pin bits are a per-classification transient: clear them first.
         {
@@ -2737,7 +2768,7 @@ impl FlatHeap {
         root_slots: &[usize],
         regions: &[(*const u8, usize)],
     ) -> GcCycleStats {
-        debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
         self.minor_streak = 0; // full collect: bound on consecutive minors is satisfied (AOT00-T8)
         let before = self.object_count();
         let prev_live = self.live_bytes;
@@ -2924,7 +2955,7 @@ impl FlatHeap {
         root_slots: &[usize],
         regions: &[(*const u8, usize)],
     ) -> GcCycleStats {
-        debug_assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
+        assert!(!self.mark_in_progress, "{}", INCREMENTAL_MIXING_MSG);
         let before = self.object_count();
         let prev_live = self.live_bytes;
 
@@ -3664,6 +3695,44 @@ mod tests {
         assert!(heap.should_collect());
         heap.live_bytes = 101;
         assert!(heap.should_collect());
+    }
+
+    /// **Security-review finding, regression:** `should_collect` defers — answers
+    /// `false` — while an incremental mark is in progress, regardless of live bytes vs
+    /// threshold. Before this fix, `should_collect` only consulted live-byte
+    /// accounting, so every automatic call site (`__gc_safepoint`, `vm-core`'s
+    /// `safepoint` opcode) — none of which check `mark_in_progress` themselves — could
+    /// still be told to collect mid-cycle, reaching the stop-the-world collectors'
+    /// own `assert!(!self.mark_in_progress, ...)` (see [`INCREMENTAL_MIXING_MSG`]) —
+    /// a `debug_assert!` before this same review round, so this was a silent
+    /// release-mode heap-corruption path, not just a debug-build panic. Resumes
+    /// normally once the flag clears.
+    #[test]
+    fn should_collect_defers_during_an_incremental_mark_and_resumes_after() {
+        let mut heap = FlatHeap::new();
+        heap.collect_threshold = 100;
+        heap.live_bytes = 200; // well over threshold
+        assert!(heap.should_collect(), "sanity: over threshold, no incremental cycle in progress");
+
+        heap.mark_in_progress = true;
+        assert!(!heap.should_collect(), "must defer while an incremental mark is in progress");
+
+        heap.mark_in_progress = false;
+        assert!(heap.should_collect(), "resumes once the flag clears -- still over threshold");
+    }
+
+    /// The stop-the-world collectors' own reentrancy guard is now a hard `assert!`,
+    /// checked in every build profile (including release), not a `debug_assert!`.
+    /// This test doesn't distinguish build profiles (both panic under `cargo test`'s
+    /// debug profile) — it exists so the invariant has *some* direct coverage, since
+    /// none existed before this security-review round despite the guard being present
+    /// at 11 call sites.
+    #[test]
+    #[should_panic(expected = "stop-the-world collect during an incremental mark phase")]
+    fn collect_compacting_panics_if_called_mid_incremental_mark() {
+        let mut heap = FlatHeap::new();
+        unsafe { heap.incremental_start(&[], &[]) };
+        let _ = unsafe { heap.collect_compacting(&[], &[]) };
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The 11 `mark_in_progress` reentrancy guards across `flat_heap.rs`'s stop-the-world `collect*` entry points (and the internal helpers they share) were `debug_assert!`-only — **compiled out entirely under `--release`**. They exist to prevent any stop-the-world collect from running *between* `incremental_start` and `incremental_finish`: doing so would `sweep` blocks still referenced by the persistent `mark_worklist`, leaving dangling worklist pointers a later `incremental_step` would pop — a use-after-free.

**The real gap this hardening exposed: no automatic call site checked `mark_in_progress` at all.** `__gc_safepoint` (`gc-core-capi`), `vm-core`'s `safepoint` opcode, and `__gc_alloc_kind`'s auto-collect all gate their stop-the-world call behind `FlatHeap::should_collect()` alone, which — before this fix — consulted only live-byte accounting. Two already-shipped, un-gated features make this live: the incremental GC builtins (`gc_collect_incremental_start/step/finish`) and `__gc_safepoint`, which fires automatically at every compiled loop-back-edge. A release binary driving the intended bounded-pause pattern — `start`, repeated `step` calls at safepoints, `finish` — could hit a safepoint mid-cycle purely through normal, sanctioned use of two already-shipped features, with no caller bug or attacker input required.

## Fix

1. All 11 `debug_assert!` sites converted to `assert!` — checked in every build profile, not just debug.
2. `FlatHeap::should_collect()` itself now answers `false` whenever `incremental_in_progress()` is true, regardless of live bytes — the one place this policy decision already lives (per its own doc comment), so every current and future automatic call site is protected identically with no per-site change needed. A safepoint firing mid-cycle is now a safe no-op: the incremental cycle keeps making progress via its own `incremental_step` calls, and paced collection resumes automatically once `incremental_finish` clears the flag.

## Testing

- 3 new regression tests: a direct `should_collect` policy test (defers while `mark_in_progress`, resumes once cleared); a `#[should_panic]` test giving the reentrancy guard its first direct coverage; and an end-to-end `gc-core-capi` test driving the real `start`/`step`/`finish` C-ABI protocol with a safepoint fired mid-cycle.
- All three confirmed load-bearing by reverting the `should_collect` fix — the C-ABI test didn't just fail, it **hard-aborted the process** (`SIGABRT`), since a panic crossing an `extern "C"` boundary can't unwind. Empirical demonstration of the severity described above.
- `cargo build`/`test` clean across `gc-core`, `gc-core-capi`, `vm-core` (gc-core 160 lib tests, up from 158; gc-core-capi 41, up from 40).
- `cargo clippy --all-targets -- -D warnings` clean.
- Full-crate `cargo +nightly miri test -p gc-core` clean (158 passed, 2 ignored per the existing scale-test gate).

## Security review

Independent review, explicitly pointed at this exact worktree (to avoid a stale-file mistake made in a prior PR this session). Traced every caller of the stop-the-world `collect*` functions across the workspace, confirmed all automatic/paced sites gate through the fixed `should_collect()`, confirmed the fix cannot introduce a stuck-`mark_in_progress` DoS beyond an already-documented protocol-violation trade-off (and even then degrades to bounded OOM, not memory corruption), confirmed no `catch_unwind` anywhere in the workspace so a fired assert is a clean fail-stop, and directly verified the assert is genuinely embedded in `--release` builds. **SECURITY REVIEW PASSED — no vulnerabilities found.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)