### PR TITLE
Secure local password-manager host roots

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1065,4 +1065,5 @@ members = [
   "vault-pm-repository",
   "vault-pm-application",
   "vault-pm-application-storage-core",
+  "vault-pm-local-host",
 ]

--- a/code/packages/rust/vault-pm-local-host/BUILD
+++ b/code/packages/rust/vault-pm-local-host/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding_adventures_vault_pm_local_host -- --nocapture

--- a/code/packages/rust/vault-pm-local-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-local-host/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Added platform-standard configuration, local-data, and cache path resolution.
+- Added owner-only, no-link local root preparation on Unix and Windows.
+- Added a persistent owner-only lock file with non-blocking cross-process
+  single-writer exclusion.
+- Added closed, path-free diagnostics and platform security tests.

--- a/code/packages/rust/vault-pm-local-host/Cargo.toml
+++ b/code/packages/rust/vault-pm-local-host/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "coding_adventures_vault_pm_local_host"
+version = "0.1.0"
+edition = "2021"
+description = "Secure platform paths and single-writer exclusion for the local password-manager host"
+license = "MIT"
+
+[dependencies]
+directories = "6.0.0"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+] }

--- a/code/packages/rust/vault-pm-local-host/README.md
+++ b/code/packages/rust/vault-pm-local-host/README.md
@@ -1,0 +1,41 @@
+# `coding_adventures_vault_pm_local_host`
+
+This crate is the operating-system trust boundary for the local password-manager
+CLI. It resolves platform application directories, prepares owner-private roots
+without following links, and provides non-blocking cross-process writer
+exclusion before any `storage-fs` backend is opened.
+
+It deliberately does not know the vault format, keys, records, providers, or
+application use cases. The composition root receives separate paths for:
+
+- non-secret configuration;
+- owner-private application state;
+- encrypted immutable objects; and
+- disposable cache data.
+
+`LocalVaultPaths::resolve` uses the platform directory resolver rather than a
+literal `$HOME`. `LocalVaultPaths::prepare` creates or validates every root.
+Existing roots with foreign ownership, broad permissions, links, reparse
+points, or unexpected object types fail closed. It never silently repairs an
+existing root; a future explicit repair ceremony remains a separate CLI action.
+
+`PreparedLocalVault::try_acquire_writer` opens a persistent owner-only lock file
+and takes a non-blocking OS lock. The guard owns the lock until drop. Every
+Phase 1A command can acquire this guard before constructing independent
+`storage-fs` backend instances, closing the cross-process race that backend-local
+compare-and-exchange cannot close.
+
+Diagnostics and `Debug` output never include resolved paths.
+
+Eight tests cover path resolution, idempotent layout creation, native modes and
+object types, broad-root and unsafe-lock refusal, stable redaction, lock
+contention, and lock release. Tarpaulin's LLVM engine measures 187 of 196 Unix
+production lines covered (95.41%). Windows executes the same public contract in
+CI and cross-target Clippy validates its native API surface locally.
+
+## Verification
+
+```bash
+bash BUILD
+cargo clippy -p coding_adventures_vault_pm_local_host --all-targets -- -D warnings
+```

--- a/code/packages/rust/vault-pm-local-host/required_capabilities.json
+++ b/code/packages/rust/vault-pm-local-host/required_capabilities.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/vault-pm-local-host",
+  "capabilities": [
+    {
+      "category": "env",
+      "action": "read",
+      "target": "platform user-directory variables",
+      "justification": "Resolves the current user's standard configuration, local-data, and cache directories without hard-coding a home path."
+    },
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "resolved vault-pm configuration, data, cache, and lock paths",
+      "justification": "Inspects every local root and lock object without following links before exposing paths to storage adapters."
+    },
+    {
+      "category": "fs",
+      "action": "create",
+      "target": "resolved vault-pm configuration, data, cache, and lock paths",
+      "justification": "Creates missing application roots and the persistent lock file with owner-only native security metadata."
+    },
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "resolved vault-pm lock path",
+      "justification": "Acquires an operating-system advisory lock that excludes concurrent local writer processes."
+    },
+    {
+      "category": "ffi",
+      "action": "call",
+      "target": "libc openat/fstat and Windows file/token/security APIs",
+      "justification": "Uses no-follow handles, native identity and access-control inspection, and platform file locking unavailable through path-only filesystem calls."
+    }
+  ],
+  "justification": "Local CLI trust-boundary adapter for platform-standard paths, owner-private directories, and one-process-at-a-time vault access."
+}

--- a/code/packages/rust/vault-pm-local-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-local-host/src/lib.rs
@@ -1,0 +1,500 @@
+//! Secure platform roots and cross-process exclusion for the local vault host.
+
+#![deny(missing_docs)]
+
+use core::fmt::{self, Debug, Display, Formatter};
+use directories::ProjectDirs;
+use std::fs::{File, TryLockError};
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+#[path = "unix.rs"]
+mod platform;
+#[cfg(windows)]
+#[path = "windows.rs"]
+mod platform;
+
+const APPLICATION_QUALIFIER: &str = "dev";
+const APPLICATION_ORGANIZATION: &str = "Coding Adventures";
+const APPLICATION_NAME: &str = "vault-pm";
+const STATE_DIRECTORY: &str = "application-state";
+const OBJECT_DIRECTORY: &str = "objects";
+const LOCK_FILE: &str = ".writer.lock";
+const MAX_PATH_BYTES: usize = 4096;
+
+/// Stable, path-free local-host failure taxonomy.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LocalHostError {
+    /// Standard user application directories could not be resolved.
+    PlatformUnavailable,
+    /// A caller-supplied or resolved path was not bounded and absolute.
+    InvalidPath,
+    /// A parent directory could not be opened without following links.
+    ParentUnavailable,
+    /// A directory or lock object could not be created, opened, or inspected.
+    AccessFailed,
+    /// A path resolved to a link, reparse point, or unexpected object type.
+    UnsafeObjectType,
+    /// An existing private root or lock file belongs to another user.
+    InsecureOwner,
+    /// An existing private root or lock file grants access beyond its owner.
+    InsecurePermissions,
+    /// Another process currently owns the vault writer lock.
+    AlreadyLocked,
+    /// The current target has no audited local-host implementation.
+    UnsupportedPlatform,
+}
+
+impl Display for LocalHostError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::PlatformUnavailable => "vault-pm local host: platform unavailable",
+            Self::InvalidPath => "vault-pm local host: invalid path",
+            Self::ParentUnavailable => "vault-pm local host: parent unavailable",
+            Self::AccessFailed => "vault-pm local host: access failed",
+            Self::UnsafeObjectType => "vault-pm local host: unsafe object type",
+            Self::InsecureOwner => "vault-pm local host: insecure owner",
+            Self::InsecurePermissions => "vault-pm local host: insecure permissions",
+            Self::AlreadyLocked => "vault-pm local host: already locked",
+            Self::UnsupportedPlatform => "vault-pm local host: unsupported platform",
+        })
+    }
+}
+
+impl std::error::Error for LocalHostError {}
+
+/// Platform-resolved local filesystem layout for one CLI installation.
+#[derive(Clone, PartialEq, Eq)]
+pub struct LocalVaultPaths {
+    config_root: PathBuf,
+    data_root: PathBuf,
+    cache_root: PathBuf,
+    application_state_root: PathBuf,
+    object_root: PathBuf,
+    lock_file: PathBuf,
+}
+
+impl LocalVaultPaths {
+    /// Resolve the current user's standard application directories.
+    pub fn resolve() -> Result<Self, LocalHostError> {
+        let project = ProjectDirs::from(
+            APPLICATION_QUALIFIER,
+            APPLICATION_ORGANIZATION,
+            APPLICATION_NAME,
+        )
+        .ok_or(LocalHostError::PlatformUnavailable)?;
+        Self::from_roots(
+            project.config_dir(),
+            project.data_local_dir(),
+            project.cache_dir(),
+        )
+    }
+
+    /// Construct a validated layout from injected roots.
+    ///
+    /// This is the test and explicit-override seam. Every root must be an
+    /// absolute, bounded path. No filesystem access occurs until [`Self::prepare`].
+    pub fn from_roots(
+        config_root: impl Into<PathBuf>,
+        data_root: impl Into<PathBuf>,
+        cache_root: impl Into<PathBuf>,
+    ) -> Result<Self, LocalHostError> {
+        let config_root = config_root.into();
+        let data_root = data_root.into();
+        let cache_root = cache_root.into();
+        for path in [&config_root, &data_root, &cache_root] {
+            validate_path(path)?;
+        }
+        let application_state_root = data_root.join(STATE_DIRECTORY);
+        let object_root = data_root.join(OBJECT_DIRECTORY);
+        let lock_file = data_root.join(LOCK_FILE);
+        for path in [&application_state_root, &object_root, &lock_file] {
+            validate_path(path)?;
+        }
+        Ok(Self {
+            config_root,
+            data_root,
+            cache_root,
+            application_state_root,
+            object_root,
+            lock_file,
+        })
+    }
+
+    /// Return the root for non-secret CLI configuration.
+    pub fn config_root(&self) -> &Path {
+        &self.config_root
+    }
+
+    /// Return the owner-private root containing all durable local data.
+    pub fn data_root(&self) -> &Path {
+        &self.data_root
+    }
+
+    /// Return the safely disposable cache root.
+    pub fn cache_root(&self) -> &Path {
+        &self.cache_root
+    }
+
+    /// Return the root for bootstrap generations and owner-private state.
+    pub fn application_state_root(&self) -> &Path {
+        &self.application_state_root
+    }
+
+    /// Return the root for encrypted immutable repository objects.
+    pub fn object_root(&self) -> &Path {
+        &self.object_root
+    }
+
+    /// Create or verify the complete local layout without acquiring the writer lock.
+    pub fn prepare(&self) -> Result<PreparedLocalVault, LocalHostError> {
+        #[cfg(any(unix, windows))]
+        {
+            for path in self.unique_directories() {
+                platform::ensure_private_directory(path)?;
+            }
+            Ok(PreparedLocalVault {
+                paths: self.clone(),
+            })
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            Err(LocalHostError::UnsupportedPlatform)
+        }
+    }
+
+    fn unique_directories(&self) -> Vec<&Path> {
+        let mut paths = vec![
+            self.config_root(),
+            self.data_root(),
+            self.cache_root(),
+            self.application_state_root(),
+            self.object_root(),
+        ];
+        paths.sort_unstable();
+        paths.dedup();
+        paths
+    }
+}
+
+impl Debug for LocalVaultPaths {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LocalVaultPaths")
+            .field("roots", &"<redacted>")
+            .finish()
+    }
+}
+
+/// A local layout whose directories passed native owner-only checks.
+pub struct PreparedLocalVault {
+    paths: LocalVaultPaths,
+}
+
+impl PreparedLocalVault {
+    /// Borrow the verified filesystem layout for adapter construction.
+    pub const fn paths(&self) -> &LocalVaultPaths {
+        &self.paths
+    }
+
+    /// Try to acquire exclusive local-process access without waiting.
+    pub fn try_acquire_writer(&self) -> Result<LocalWriterGuard, LocalHostError> {
+        #[cfg(any(unix, windows))]
+        {
+            let file = platform::open_private_lock(&self.paths.lock_file)?;
+            match file.try_lock() {
+                Ok(()) => Ok(LocalWriterGuard { _file: file }),
+                Err(error) => Err(map_lock_error(error)),
+            }
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            Err(LocalHostError::UnsupportedPlatform)
+        }
+    }
+}
+
+fn map_lock_error(error: TryLockError) -> LocalHostError {
+    match error {
+        TryLockError::WouldBlock => LocalHostError::AlreadyLocked,
+        TryLockError::Error(_) => LocalHostError::AccessFailed,
+    }
+}
+
+impl Debug for PreparedLocalVault {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedLocalVault")
+            .field("paths", &"<redacted>")
+            .finish()
+    }
+}
+
+/// RAII ownership of the exclusive local writer lock.
+pub struct LocalWriterGuard {
+    _file: File,
+}
+
+impl Debug for LocalWriterGuard {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LocalWriterGuard")
+            .finish_non_exhaustive()
+    }
+}
+
+fn validate_path(path: &Path) -> Result<(), LocalHostError> {
+    if !path.is_absolute()
+        || path.as_os_str().is_empty()
+        || path.as_os_str().as_encoded_bytes().len() > MAX_PATH_BYTES
+        || path.as_os_str().as_encoded_bytes().contains(&0)
+        || path.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::CurDir | std::path::Component::ParentDir
+            )
+        })
+    {
+        return Err(LocalHostError::InvalidPath);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(label: &str) -> Self {
+            let sequence = NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+            let root = std::env::temp_dir().join(format!(
+                "vault-pm-local-host-{label}-{}-{sequence}",
+                std::process::id()
+            ));
+            fs::create_dir(&root).unwrap();
+            Self(fs::canonicalize(root).unwrap())
+        }
+
+        fn paths(&self) -> LocalVaultPaths {
+            LocalVaultPaths::from_roots(
+                self.0.join("config"),
+                self.0.join("data"),
+                self.0.join("cache"),
+            )
+            .unwrap()
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn resolves_absolute_platform_paths_without_touching_them() {
+        let paths = LocalVaultPaths::resolve().unwrap();
+        for path in [
+            paths.config_root(),
+            paths.data_root(),
+            paths.cache_root(),
+            paths.application_state_root(),
+            paths.object_root(),
+        ] {
+            assert!(path.is_absolute());
+        }
+    }
+
+    #[test]
+    fn prepares_separate_application_and_object_roots() {
+        let directory = TestDirectory::new("layout");
+        let paths = directory.paths();
+        let prepared = paths.prepare().unwrap();
+        for path in [
+            paths.config_root(),
+            paths.data_root(),
+            paths.cache_root(),
+            paths.application_state_root(),
+            paths.object_root(),
+        ] {
+            assert!(path.is_dir());
+        }
+        assert_eq!(prepared.paths(), &paths);
+        assert_ne!(paths.application_state_root(), paths.object_root());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for path in [
+                paths.config_root(),
+                paths.data_root(),
+                paths.cache_root(),
+                paths.application_state_root(),
+                paths.object_root(),
+            ] {
+                assert_eq!(
+                    fs::metadata(path).unwrap().permissions().mode() & 0o777,
+                    0o700
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn writer_lock_excludes_then_releases_other_openers() {
+        let directory = TestDirectory::new("lock");
+        let first = directory.paths().prepare().unwrap();
+        let second = directory.paths().prepare().unwrap();
+        let guard = first.try_acquire_writer().unwrap();
+        assert!(format!("{guard:?}").starts_with("LocalWriterGuard"));
+        assert!(matches!(
+            second.try_acquire_writer(),
+            Err(LocalHostError::AlreadyLocked)
+        ));
+        drop(guard);
+        second.try_acquire_writer().unwrap();
+        assert!(second.paths.lock_file.is_file());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&second.paths.lock_file)
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_paths_and_diagnostics_are_closed() {
+        assert_eq!(
+            LocalVaultPaths::from_roots("relative", "/absolute/data", "/absolute/cache"),
+            Err(LocalHostError::InvalidPath)
+        );
+        let too_long = PathBuf::from(format!("/{}", "x".repeat(MAX_PATH_BYTES)));
+        assert_eq!(
+            LocalVaultPaths::from_roots(&too_long, "/absolute/data", "/absolute/cache"),
+            Err(LocalHostError::InvalidPath)
+        );
+        let directory = TestDirectory::new("redaction");
+        let paths = directory.paths();
+        let rendered = format!("{paths:?}");
+        assert!(!rendered.contains(directory.0.to_string_lossy().as_ref()));
+        let prepared = paths.prepare().unwrap();
+        assert!(!format!("{prepared:?}").contains(directory.0.to_string_lossy().as_ref()));
+
+        let expected = [
+            (
+                LocalHostError::PlatformUnavailable,
+                "vault-pm local host: platform unavailable",
+            ),
+            (
+                LocalHostError::InvalidPath,
+                "vault-pm local host: invalid path",
+            ),
+            (
+                LocalHostError::ParentUnavailable,
+                "vault-pm local host: parent unavailable",
+            ),
+            (
+                LocalHostError::AccessFailed,
+                "vault-pm local host: access failed",
+            ),
+            (
+                LocalHostError::UnsafeObjectType,
+                "vault-pm local host: unsafe object type",
+            ),
+            (
+                LocalHostError::InsecureOwner,
+                "vault-pm local host: insecure owner",
+            ),
+            (
+                LocalHostError::InsecurePermissions,
+                "vault-pm local host: insecure permissions",
+            ),
+            (
+                LocalHostError::AlreadyLocked,
+                "vault-pm local host: already locked",
+            ),
+            (
+                LocalHostError::UnsupportedPlatform,
+                "vault-pm local host: unsupported platform",
+            ),
+        ];
+        for (error, message) in expected {
+            assert_eq!(error.to_string(), message);
+        }
+        assert_eq!(
+            map_lock_error(TryLockError::Error(std::io::Error::other("test"))),
+            LocalHostError::AccessFailed
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_existing_links_and_broad_private_roots() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let directory = TestDirectory::new("unix-policy");
+        let paths = directory.paths();
+        fs::create_dir(paths.config_root()).unwrap();
+        fs::set_permissions(paths.config_root(), fs::Permissions::from_mode(0o750)).unwrap();
+        assert_eq!(
+            paths.prepare().unwrap_err(),
+            LocalHostError::InsecurePermissions
+        );
+
+        fs::remove_dir(paths.config_root()).unwrap();
+        let target = directory.0.join("target");
+        fs::create_dir(&target).unwrap();
+        symlink(&target, paths.config_root()).unwrap();
+        assert_eq!(
+            paths.prepare().unwrap_err(),
+            LocalHostError::UnsafeObjectType
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_unsafe_existing_lock_objects_without_replacing_them() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let broad = TestDirectory::new("broad-lock");
+        let broad_prepared = broad.paths().prepare().unwrap();
+        fs::write(&broad_prepared.paths.lock_file, b"preserve").unwrap();
+        fs::set_permissions(
+            &broad_prepared.paths.lock_file,
+            fs::Permissions::from_mode(0o640),
+        )
+        .unwrap();
+        assert_eq!(
+            broad_prepared.try_acquire_writer().unwrap_err(),
+            LocalHostError::InsecurePermissions
+        );
+        assert_eq!(
+            fs::read(&broad_prepared.paths.lock_file).unwrap(),
+            b"preserve"
+        );
+
+        let linked = TestDirectory::new("linked-lock");
+        let linked_prepared = linked.paths().prepare().unwrap();
+        let target = linked.0.join("target.lock");
+        fs::write(&target, b"target").unwrap();
+        symlink(&target, &linked_prepared.paths.lock_file).unwrap();
+        assert_eq!(
+            linked_prepared.try_acquire_writer().unwrap_err(),
+            LocalHostError::UnsafeObjectType
+        );
+        assert_eq!(fs::read(target).unwrap(), b"target");
+    }
+}

--- a/code/packages/rust/vault-pm-local-host/src/unix.rs
+++ b/code/packages/rust/vault-pm-local-host/src/unix.rs
@@ -1,0 +1,281 @@
+use super::{LocalHostError, MAX_PATH_BYTES};
+use std::ffi::{CString, OsStr};
+use std::fs::File;
+use std::mem::MaybeUninit;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Component, Path};
+
+pub(super) fn ensure_private_directory(path: &Path) -> Result<(), LocalHostError> {
+    validate_absolute(path)?;
+    let components: Vec<_> = path.components().collect();
+    if components.len() < 2 || components[0] != Component::RootDir {
+        return Err(LocalHostError::InvalidPath);
+    }
+
+    let root = unsafe {
+        libc::open(
+            c"/".as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    let mut directory = owned_fd(root).map_err(|_| LocalHostError::ParentUnavailable)?;
+    for (index, component) in components[1..].iter().enumerate() {
+        let Component::Normal(part) = component else {
+            return Err(LocalHostError::InvalidPath);
+        };
+        let name = c_string(part)?;
+        let mut raw = unsafe {
+            libc::openat(
+                directory.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        if raw < 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ENOENT) {
+            if unsafe { libc::mkdirat(directory.as_raw_fd(), name.as_ptr(), 0o700) } != 0 {
+                let error = std::io::Error::last_os_error();
+                if error.raw_os_error() != Some(libc::EEXIST) {
+                    return Err(LocalHostError::AccessFailed);
+                }
+            }
+            raw = unsafe {
+                libc::openat(
+                    directory.as_raw_fd(),
+                    name.as_ptr(),
+                    libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                )
+            };
+        }
+        if raw < 0 {
+            return Err(match std::io::Error::last_os_error().raw_os_error() {
+                Some(libc::ELOOP) | Some(libc::ENOTDIR) => LocalHostError::UnsafeObjectType,
+                _ if index + 1 == components.len() - 1 => LocalHostError::AccessFailed,
+                _ => LocalHostError::ParentUnavailable,
+            });
+        }
+        directory = owned_fd(raw).map_err(|_| LocalHostError::AccessFailed)?;
+    }
+    verify_private_directory(&directory)
+}
+
+pub(super) fn open_private_lock(path: &Path) -> Result<File, LocalHostError> {
+    let (parent, name) = open_existing_parent(path)?;
+    let raw = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDWR | libc::O_CREAT | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            0o600,
+        )
+    };
+    if raw < 0 {
+        return Err(match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ELOOP) | Some(libc::EISDIR) => LocalHostError::UnsafeObjectType,
+            _ => LocalHostError::AccessFailed,
+        });
+    }
+    let file = File::from(owned_fd(raw).map_err(|_| LocalHostError::AccessFailed)?);
+    verify_private_file(&file)?;
+    Ok(file)
+}
+
+fn open_existing_parent(path: &Path) -> Result<(OwnedFd, CString), LocalHostError> {
+    validate_absolute(path)?;
+    let components: Vec<_> = path.components().collect();
+    if components.len() < 2 || components[0] != Component::RootDir {
+        return Err(LocalHostError::InvalidPath);
+    }
+    let name = match components.last() {
+        Some(Component::Normal(name)) => c_string(name)?,
+        _ => return Err(LocalHostError::InvalidPath),
+    };
+    let root = unsafe {
+        libc::open(
+            c"/".as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    let mut directory = owned_fd(root).map_err(|_| LocalHostError::ParentUnavailable)?;
+    for component in &components[1..components.len() - 1] {
+        let Component::Normal(part) = component else {
+            return Err(LocalHostError::InvalidPath);
+        };
+        let part = c_string(part)?;
+        let raw = unsafe {
+            libc::openat(
+                directory.as_raw_fd(),
+                part.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        if raw < 0 {
+            return Err(match std::io::Error::last_os_error().raw_os_error() {
+                Some(libc::ELOOP) | Some(libc::ENOTDIR) => LocalHostError::UnsafeObjectType,
+                _ => LocalHostError::ParentUnavailable,
+            });
+        }
+        directory = owned_fd(raw).map_err(|_| LocalHostError::ParentUnavailable)?;
+    }
+    Ok((directory, name))
+}
+
+fn validate_absolute(path: &Path) -> Result<(), LocalHostError> {
+    if !path.is_absolute()
+        || path.as_os_str().as_bytes().is_empty()
+        || path.as_os_str().as_bytes().len() > MAX_PATH_BYTES
+        || path
+            .components()
+            .any(|part| matches!(part, Component::CurDir | Component::ParentDir))
+    {
+        return Err(LocalHostError::InvalidPath);
+    }
+    Ok(())
+}
+
+fn c_string(value: &OsStr) -> Result<CString, LocalHostError> {
+    CString::new(value.as_bytes()).map_err(|_| LocalHostError::InvalidPath)
+}
+
+fn owned_fd(raw: libc::c_int) -> Result<OwnedFd, ()> {
+    if raw < 0 {
+        Err(())
+    } else {
+        Ok(unsafe { OwnedFd::from_raw_fd(raw) })
+    }
+}
+
+fn stat(raw: libc::c_int) -> Result<libc::stat, LocalHostError> {
+    let mut value = MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstat(raw, value.as_mut_ptr()) } != 0 {
+        return Err(LocalHostError::AccessFailed);
+    }
+    Ok(unsafe { value.assume_init() })
+}
+
+fn verify_private_directory(directory: &OwnedFd) -> Result<(), LocalHostError> {
+    let value = stat(directory.as_raw_fd())?;
+    if value.st_mode & libc::S_IFMT != libc::S_IFDIR {
+        return Err(LocalHostError::UnsafeObjectType);
+    }
+    verify_owner_permissions(&value, 0o700)
+}
+
+fn verify_private_file(file: &File) -> Result<(), LocalHostError> {
+    let value = stat(file.as_raw_fd())?;
+    if value.st_mode & libc::S_IFMT != libc::S_IFREG {
+        return Err(LocalHostError::UnsafeObjectType);
+    }
+    verify_owner_permissions(&value, 0o600)
+}
+
+fn verify_owner_permissions(
+    value: &libc::stat,
+    required_owner: libc::mode_t,
+) -> Result<(), LocalHostError> {
+    if value.st_uid != unsafe { libc::geteuid() } {
+        return Err(LocalHostError::InsecureOwner);
+    }
+    let permissions = value.st_mode & 0o777;
+    if permissions & 0o077 != 0 || permissions & required_owner != required_owner {
+        return Err(LocalHostError::InsecurePermissions);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, OpenOptions};
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(label: &str) -> Self {
+            let sequence = NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "vault-pm-local-host-unix-{label}-{}-{sequence}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).unwrap();
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).unwrap();
+            Self(fs::canonicalize(path).unwrap())
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::set_permissions(&self.0, fs::Permissions::from_mode(0o700));
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn low_level_validation_and_type_checks_fail_closed() {
+        assert_eq!(
+            validate_absolute(Path::new("relative")),
+            Err(LocalHostError::InvalidPath)
+        );
+        assert!(c_string(OsStr::from_bytes(b"bad\0name")).is_err());
+        assert!(owned_fd(-1).is_err());
+        assert_eq!(stat(-1).unwrap_err(), LocalHostError::AccessFailed);
+
+        let directory = TestDirectory::new("types");
+        let regular_path = directory.0.join("regular");
+        let regular = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&regular_path)
+            .unwrap();
+        fs::set_permissions(&regular_path, fs::Permissions::from_mode(0o600)).unwrap();
+        let regular_fd: OwnedFd = regular.into();
+        assert_eq!(
+            verify_private_directory(&regular_fd),
+            Err(LocalHostError::UnsafeObjectType)
+        );
+
+        let directory_file = File::open(&directory.0).unwrap();
+        assert_eq!(
+            verify_private_file(&directory_file),
+            Err(LocalHostError::UnsafeObjectType)
+        );
+
+        let mut foreign: libc::stat = unsafe { std::mem::zeroed() };
+        foreign.st_uid = unsafe { libc::geteuid() }.wrapping_add(1);
+        foreign.st_mode = 0o700;
+        assert_eq!(
+            verify_owner_permissions(&foreign, 0o700),
+            Err(LocalHostError::InsecureOwner)
+        );
+        foreign.st_uid = unsafe { libc::geteuid() };
+        foreign.st_mode = 0o500;
+        assert_eq!(
+            verify_owner_permissions(&foreign, 0o700),
+            Err(LocalHostError::InsecurePermissions)
+        );
+    }
+
+    #[test]
+    fn missing_and_unsearchable_parents_are_closed() {
+        let directory = TestDirectory::new("parents");
+        assert_eq!(
+            open_private_lock(&directory.0.join("missing/lock")).unwrap_err(),
+            LocalHostError::ParentUnavailable
+        );
+
+        let blocked = directory.0.join("blocked");
+        fs::create_dir(&blocked).unwrap();
+        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o500)).unwrap();
+        assert_eq!(
+            ensure_private_directory(&blocked.join("child")),
+            Err(LocalHostError::AccessFailed)
+        );
+        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+}

--- a/code/packages/rust/vault-pm-local-host/src/windows.rs
+++ b/code/packages/rust/vault-pm-local-host/src/windows.rs
@@ -1,0 +1,368 @@
+use super::{LocalHostError, MAX_PATH_BYTES};
+use std::ffi::c_void;
+use std::fs::File;
+use std::mem::{size_of, MaybeUninit};
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+use std::path::{Component, Path};
+use std::ptr::{addr_of, null, null_mut};
+use windows_sys::Win32::Foundation::{
+    BOOL, ERROR_ALREADY_EXISTS, HANDLE, INVALID_HANDLE_VALUE, PSID,
+};
+use windows_sys::Win32::Security::{
+    AclSizeInformation, AddAccessAllowedAce, EqualSid, GetAce, GetAclInformation,
+    GetKernelObjectSecurity, GetLengthSid, GetSecurityDescriptorControl, GetSecurityDescriptorDacl,
+    GetSecurityDescriptorOwner, GetTokenInformation, InitializeAcl, InitializeSecurityDescriptor,
+    SetSecurityDescriptorControl, SetSecurityDescriptorDacl, SetSecurityDescriptorOwner, TokenUser,
+    ACCESS_ALLOWED_ACE, ACL, ACL_REVISION, ACL_SIZE_INFORMATION, DACL_SECURITY_INFORMATION,
+    OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES, SECURITY_DESCRIPTOR,
+    SE_DACL_PROTECTED, TOKEN_QUERY, TOKEN_USER,
+};
+use windows_sys::Win32::Storage::FileSystem::{
+    CreateDirectoryW, CreateFileW, FileAttributeTagInfo, GetFileInformationByHandleEx, CREATE_NEW,
+    FILE_ALL_ACCESS, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
+    FILE_ATTRIBUTE_TAG_INFO, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+    FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE,
+    FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+};
+use windows_sys::Win32::System::SystemServices::{
+    ACCESS_ALLOWED_ACE_TYPE, SECURITY_DESCRIPTOR_REVISION,
+};
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+const MAX_SECURITY_DESCRIPTOR_BYTES: u32 = 64 * 1024;
+const MINIMUM_SID_BYTES: usize = 8;
+
+pub(super) fn ensure_private_directory(path: &Path) -> Result<(), LocalHostError> {
+    validate_absolute(path)?;
+    let mut ancestors: Vec<_> = path
+        .ancestors()
+        .filter(|ancestor| !ancestor.as_os_str().is_empty())
+        .collect();
+    ancestors.reverse();
+    let final_index = ancestors.len().saturating_sub(1);
+    for (index, ancestor) in ancestors.into_iter().enumerate() {
+        match open_directory(ancestor) {
+            Ok(handle) => {
+                if index == final_index {
+                    verify_owner_acl(handle.as_raw_handle() as HANDLE)?;
+                }
+            }
+            Err(LocalHostError::ParentUnavailable | LocalHostError::AccessFailed) => {
+                create_private_directory(ancestor)?;
+                let handle = open_directory(ancestor)?;
+                if index == final_index {
+                    verify_owner_acl(handle.as_raw_handle() as HANDLE)?;
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn open_private_lock(path: &Path) -> Result<File, LocalHostError> {
+    validate_absolute(path)?;
+    let parent = path.parent().ok_or(LocalHostError::InvalidPath)?;
+    let parent_handle = open_directory(parent)?;
+    verify_owner_acl(parent_handle.as_raw_handle() as HANDLE)?;
+    let wide = wide_path(path)?;
+    let mut security = OwnerSecurity::new(FILE_ALL_ACCESS)?;
+    let attributes = security.attributes();
+    let raw = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            &attributes,
+            CREATE_NEW,
+            FILE_FLAG_OPEN_REPARSE_POINT,
+            0,
+        )
+    };
+    let raw = if raw == INVALID_HANDLE_VALUE
+        && unsafe { windows_sys::Win32::Foundation::GetLastError() } == ERROR_ALREADY_EXISTS
+    {
+        unsafe {
+            CreateFileW(
+                wide.as_ptr(),
+                FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                null(),
+                OPEN_EXISTING,
+                FILE_FLAG_OPEN_REPARSE_POINT,
+                0,
+            )
+        }
+    } else {
+        raw
+    };
+    let handle = owned_handle(raw).map_err(|_| LocalHostError::AccessFailed)?;
+    verify_regular_file(handle.as_raw_handle() as HANDLE)?;
+    verify_owner_acl(handle.as_raw_handle() as HANDLE)?;
+    Ok(File::from(handle))
+}
+
+fn create_private_directory(path: &Path) -> Result<(), LocalHostError> {
+    let wide = wide_path(path)?;
+    let mut security = OwnerSecurity::new(FILE_ALL_ACCESS)?;
+    let attributes = security.attributes();
+    if unsafe { CreateDirectoryW(wide.as_ptr(), &attributes) } == 0 {
+        return match unsafe { windows_sys::Win32::Foundation::GetLastError() } {
+            ERROR_ALREADY_EXISTS => Ok(()),
+            _ => Err(LocalHostError::AccessFailed),
+        };
+    }
+    Ok(())
+}
+
+fn open_directory(path: &Path) -> Result<OwnedHandle, LocalHostError> {
+    let wide = wide_path(path)?;
+    let raw = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            0,
+        )
+    };
+    let handle = owned_handle(raw).map_err(|_| LocalHostError::ParentUnavailable)?;
+    let attributes = file_attributes(handle.as_raw_handle() as HANDLE)?;
+    if attributes.FileAttributes & FILE_ATTRIBUTE_DIRECTORY == 0
+        || attributes.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    {
+        return Err(LocalHostError::UnsafeObjectType);
+    }
+    Ok(handle)
+}
+
+fn validate_absolute(path: &Path) -> Result<(), LocalHostError> {
+    let encoded_units = path.as_os_str().encode_wide().count();
+    if !path.is_absolute()
+        || encoded_units == 0
+        || encoded_units > MAX_PATH_BYTES
+        || path
+            .components()
+            .any(|part| matches!(part, Component::CurDir | Component::ParentDir))
+        || path.as_os_str().encode_wide().any(|unit| unit == 0)
+    {
+        return Err(LocalHostError::InvalidPath);
+    }
+    Ok(())
+}
+
+fn wide_path(path: &Path) -> Result<Vec<u16>, LocalHostError> {
+    let mut wide: Vec<_> = path.as_os_str().encode_wide().collect();
+    if wide.is_empty() || wide.len() > MAX_PATH_BYTES || wide.contains(&0) {
+        return Err(LocalHostError::InvalidPath);
+    }
+    wide.push(0);
+    Ok(wide)
+}
+
+fn owned_handle(raw: HANDLE) -> Result<OwnedHandle, ()> {
+    if raw == INVALID_HANDLE_VALUE || raw == 0 {
+        Err(())
+    } else {
+        Ok(unsafe { OwnedHandle::from_raw_handle(raw as *mut c_void) })
+    }
+}
+
+fn file_attributes(raw: HANDLE) -> Result<FILE_ATTRIBUTE_TAG_INFO, LocalHostError> {
+    let mut information = MaybeUninit::<FILE_ATTRIBUTE_TAG_INFO>::zeroed();
+    if unsafe {
+        GetFileInformationByHandleEx(
+            raw,
+            FileAttributeTagInfo,
+            information.as_mut_ptr().cast(),
+            size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
+        )
+    } == 0
+    {
+        return Err(LocalHostError::AccessFailed);
+    }
+    Ok(unsafe { information.assume_init() })
+}
+
+fn verify_regular_file(raw: HANDLE) -> Result<(), LocalHostError> {
+    let attributes = file_attributes(raw)?;
+    if attributes.FileAttributes & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT) != 0 {
+        return Err(LocalHostError::UnsafeObjectType);
+    }
+    Ok(())
+}
+
+struct CurrentUserSid {
+    _storage: Vec<usize>,
+    sid: PSID,
+}
+
+impl CurrentUserSid {
+    fn query() -> Result<Self, LocalHostError> {
+        let mut raw_token = 0;
+        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut raw_token) } == 0 {
+            return Err(LocalHostError::AccessFailed);
+        }
+        let _token = owned_handle(raw_token).map_err(|_| LocalHostError::AccessFailed)?;
+        let mut needed = 0;
+        unsafe {
+            GetTokenInformation(raw_token, TokenUser, null_mut(), 0, &mut needed);
+        }
+        if needed == 0 || needed > MAX_SECURITY_DESCRIPTOR_BYTES {
+            return Err(LocalHostError::AccessFailed);
+        }
+        let mut storage = vec![0usize; bytes_to_words(needed)];
+        if unsafe {
+            GetTokenInformation(
+                raw_token,
+                TokenUser,
+                storage.as_mut_ptr().cast(),
+                needed,
+                &mut needed,
+            )
+        } == 0
+        {
+            return Err(LocalHostError::AccessFailed);
+        }
+        let token_user = storage.as_ptr().cast::<TOKEN_USER>();
+        let sid = unsafe { (*token_user).User.Sid };
+        if sid.is_null() || unsafe { GetLengthSid(sid) } == 0 {
+            return Err(LocalHostError::AccessFailed);
+        }
+        Ok(Self {
+            _storage: storage,
+            sid,
+        })
+    }
+}
+
+fn verify_owner_acl(raw: HANDLE) -> Result<(), LocalHostError> {
+    let current = CurrentUserSid::query()?;
+    let information = OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION;
+    let mut needed = 0;
+    unsafe {
+        GetKernelObjectSecurity(raw, information, null_mut(), 0, &mut needed);
+    }
+    if needed == 0 || needed > MAX_SECURITY_DESCRIPTOR_BYTES {
+        return Err(LocalHostError::AccessFailed);
+    }
+    let mut storage = vec![0usize; bytes_to_words(needed)];
+    let descriptor: PSECURITY_DESCRIPTOR = storage.as_mut_ptr().cast();
+    if unsafe { GetKernelObjectSecurity(raw, information, descriptor, needed, &mut needed) } == 0 {
+        return Err(LocalHostError::AccessFailed);
+    }
+    let mut owner = null_mut();
+    let mut owner_defaulted: BOOL = 0;
+    if unsafe { GetSecurityDescriptorOwner(descriptor, &mut owner, &mut owner_defaulted) } == 0 {
+        return Err(LocalHostError::AccessFailed);
+    }
+    if owner.is_null() || unsafe { EqualSid(owner, current.sid) } == 0 {
+        return Err(LocalHostError::InsecureOwner);
+    }
+    let mut control = 0;
+    let mut revision = 0;
+    if unsafe { GetSecurityDescriptorControl(descriptor, &mut control, &mut revision) } == 0 {
+        return Err(LocalHostError::AccessFailed);
+    }
+    if control & SE_DACL_PROTECTED == 0 {
+        return Err(LocalHostError::InsecurePermissions);
+    }
+    let mut present: BOOL = 0;
+    let mut dacl: *mut ACL = null_mut();
+    let mut defaulted: BOOL = 0;
+    if unsafe { GetSecurityDescriptorDacl(descriptor, &mut present, &mut dacl, &mut defaulted) }
+        == 0
+        || present == 0
+        || dacl.is_null()
+    {
+        return Err(LocalHostError::InsecurePermissions);
+    }
+    let mut acl_information = MaybeUninit::<ACL_SIZE_INFORMATION>::zeroed();
+    if unsafe {
+        GetAclInformation(
+            dacl,
+            acl_information.as_mut_ptr().cast(),
+            size_of::<ACL_SIZE_INFORMATION>() as u32,
+            AclSizeInformation,
+        )
+    } == 0
+        || unsafe { acl_information.assume_init() }.AceCount != 1
+    {
+        return Err(LocalHostError::InsecurePermissions);
+    }
+    let mut ace_pointer: *mut c_void = null_mut();
+    if unsafe { GetAce(dacl, 0, &mut ace_pointer) } == 0 || ace_pointer.is_null() {
+        return Err(LocalHostError::AccessFailed);
+    }
+    let ace = unsafe { &*ace_pointer.cast::<ACCESS_ALLOWED_ACE>() };
+    let sid_offset = size_of::<ACCESS_ALLOWED_ACE>() - size_of::<u32>();
+    if usize::from(ace.Header.AceSize) < sid_offset + MINIMUM_SID_BYTES {
+        return Err(LocalHostError::InsecurePermissions);
+    }
+    let sid = addr_of!(ace.SidStart).cast_mut().cast();
+    let sid_bytes = unsafe { GetLengthSid(sid) } as usize;
+    if u32::from(ace.Header.AceType) != ACCESS_ALLOWED_ACE_TYPE
+        || ace.Header.AceFlags != 0
+        || sid_bytes < MINIMUM_SID_BYTES
+        || usize::from(ace.Header.AceSize) < sid_offset + sid_bytes
+        || unsafe { EqualSid(sid, current.sid) } == 0
+    {
+        return Err(LocalHostError::InsecurePermissions);
+    }
+    Ok(())
+}
+
+struct OwnerSecurity {
+    _owner: CurrentUserSid,
+    _acl_storage: Vec<u32>,
+    descriptor: SECURITY_DESCRIPTOR,
+}
+
+impl OwnerSecurity {
+    fn new(access: u32) -> Result<Self, LocalHostError> {
+        let owner = CurrentUserSid::query()?;
+        let sid_bytes = unsafe { GetLengthSid(owner.sid) } as usize;
+        let acl_bytes =
+            size_of::<ACL>() + size_of::<ACCESS_ALLOWED_ACE>() - size_of::<u32>() + sid_bytes;
+        let mut acl_storage = vec![0u32; acl_bytes.div_ceil(size_of::<u32>())];
+        let acl = acl_storage.as_mut_ptr().cast::<ACL>();
+        if unsafe { InitializeAcl(acl, acl_bytes as u32, ACL_REVISION) } == 0
+            || unsafe { AddAccessAllowedAce(acl, ACL_REVISION, access, owner.sid) } == 0
+        {
+            return Err(LocalHostError::AccessFailed);
+        }
+        let mut descriptor = unsafe { MaybeUninit::<SECURITY_DESCRIPTOR>::zeroed().assume_init() };
+        let descriptor_ptr: PSECURITY_DESCRIPTOR =
+            (&mut descriptor as *mut SECURITY_DESCRIPTOR).cast();
+        if unsafe { InitializeSecurityDescriptor(descriptor_ptr, SECURITY_DESCRIPTOR_REVISION) }
+            == 0
+            || unsafe { SetSecurityDescriptorOwner(descriptor_ptr, owner.sid, 0) } == 0
+            || unsafe { SetSecurityDescriptorDacl(descriptor_ptr, 1, acl, 0) } == 0
+            || unsafe {
+                SetSecurityDescriptorControl(descriptor_ptr, SE_DACL_PROTECTED, SE_DACL_PROTECTED)
+            } == 0
+        {
+            return Err(LocalHostError::AccessFailed);
+        }
+        Ok(Self {
+            _owner: owner,
+            _acl_storage: acl_storage,
+            descriptor,
+        })
+    }
+
+    fn attributes(&mut self) -> SECURITY_ATTRIBUTES {
+        SECURITY_ATTRIBUTES {
+            nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: (&mut self.descriptor as *mut SECURITY_DESCRIPTOR).cast(),
+            bInheritHandle: 0,
+        }
+    }
+}
+
+fn bytes_to_words(bytes: u32) -> usize {
+    (bytes as usize).div_ceil(size_of::<usize>())
+}

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -806,6 +806,7 @@ code/packages/rust/vault-pm-repository   immutable DAG, publication, sync, GC
 code/packages/rust/vault-pm-application  use cases and redacted view models
 code/packages/rust/vault-pm-application-storage-core
                                          durable bootstrap/owner-state adapters
+code/packages/rust/vault-pm-local-host    secure roots and process exclusion
 code/packages/rust/vault-pm-cli          product parser/driver/renderer
 code/programs/rust/vault-pm-cli          executable composition root
 ```
@@ -1400,6 +1401,12 @@ changelog, focused build, and downstream validation.
     owns no filesystem path or platform policy; Phase 1A composes it over a
     separately permission-checked `FsStorageBackend` root and retains the
     single-writer process rule required by `storage-core` conditions.
+8b. `vault-pm-local-host`: platform-standard path resolution, owner-private
+    no-link root preparation, separate application-state/object/cache roots,
+    and a persistent owner-only non-blocking cross-process writer lock, using
+    the closed trust-boundary contract in `VLT-PM06-local-host.md`. Existing
+    broad roots fail closed; permission repair remains an explicit future CLI
+    ceremony rather than an automatic side effect.
 9. `vault-pm-cli` + real executable and pseudo-terminal E2E suite.
 10. Crash/fault matrix and local restore drill.
 

--- a/code/specs/VLT-PM06-local-host.md
+++ b/code/specs/VLT-PM06-local-host.md
@@ -1,0 +1,218 @@
+# VLT-PM06: Local Host Trust Boundary
+
+Status: Phase 1A normative contract
+
+## 1. Purpose
+
+VLT-PM01 through VLT-PM05 deliberately accept bytes, storage traits, entropy,
+and custody decisions from their caller. `storage-fs` accepts an arbitrary path
+and `storage-core` conditions are atomic only within one live backend instance.
+Those are reusable primitives, but they are not sufficient to let an executable
+safely choose a user directory or coordinate independent processes.
+
+This specification defines the smallest filesystem host boundary required
+before the local CLI composes those primitives. It owns:
+
+1. platform-standard per-user path resolution;
+2. creation and validation of owner-private local roots;
+3. separation of owner state from encrypted immutable objects;
+4. rejection of linked or substituted filesystem objects; and
+5. non-blocking cross-process single-writer exclusion.
+
+It does not parse CLI arguments, prompt for a passphrase, generate entropy,
+understand vault bytes, select a cloud provider, or repair permissions.
+
+## 2. Security objective
+
+Before a filesystem-backed command constructs any application or object-store
+adapter, the host proves that its selected roots are ordinary directories owned
+by the current user and unavailable to other users. Before a command opens any
+backend capable of mutation, it also owns the installation's process lock.
+
+The boundary prevents accidental disclosure through broad default permissions,
+link traversal into attacker-selected locations, and concurrent independent
+`FsStorageBackend` instances defeating the application adapter's exact-value
+compare-and-exchange assumptions.
+
+This boundary does not defend against another process already running as the
+same operating-system user. Such a process is inside Phase 1A's local trust
+boundary and can inspect the user's memory or replace user-owned files by other
+means.
+
+## 3. Filesystem layout
+
+The platform resolver returns application-specific roots for configuration,
+local data, and cache. The local-data root contains two disjoint subtrees:
+
+```text
+<config-root>/                    non-secret strict configuration
+<data-root>/
+  application-state/             bootstrap generations and owner-private state
+  objects/                       encrypted immutable repository objects
+  .writer.lock                   persistent process-lock identity
+<cache-root>/                     disposable derived data only
+```
+
+The exact platform prefix is selected by the operating system's application
+directory resolver. Callers must not concatenate a literal `$HOME`,
+`USERPROFILE`, drive letter, or vendor-specific cloud path.
+
+`application-state` and `objects` are separate so later storage selection can
+move or replace the object backend without silently moving the owner-private
+activation journal. Cache loss must never make the vault unrecoverable.
+
+## 4. Path contract
+
+Every resolved or explicitly injected root must be:
+
+- absolute;
+- non-empty;
+- at most 4,096 encoded bytes or code units;
+- free of `.` and `..` traversal components; and
+- representable by the target platform's native path API.
+
+The injectable constructor exists for tests and an eventual explicit
+configuration override. It performs validation only. It never reads or creates
+filesystem objects until `prepare` is called.
+
+Path-bearing values have closed `Debug` output. No error string contains a
+root, user name, volume, environment value, or lock-file path.
+
+## 5. Directory preparation
+
+Preparation is idempotent. For each required root it either creates a private
+ordinary directory or validates the existing directory. It must not silently
+replace, chmod, re-ACL, rename, delete, or migrate an existing object.
+
+### 5.1 Unix
+
+Unix traversal starts from an opened root-directory descriptor. Every path
+component is opened relative to the previously opened descriptor with
+`O_DIRECTORY`, `O_NOFOLLOW`, and `O_CLOEXEC`. Missing components are created
+relative to that descriptor with mode `0700` and immediately reopened without
+following links.
+
+The final requested root must:
+
+- be a directory according to `fstat` on the open descriptor;
+- have `st_uid` equal to the effective user ID;
+- grant no group or other permission bits; and
+- grant the owner read, write, and execute permission.
+
+This descriptor-relative sequence avoids check-then-open link substitution.
+Existing intermediate platform directories may use ordinary platform access
+modes; only newly created intermediates and each application root become
+owner-private.
+
+### 5.2 Windows
+
+Windows traversal opens every ancestor with `FILE_FLAG_OPEN_REPARSE_POINT` and
+requires the directory attribute without the reparse-point attribute. Missing
+directories are created with an explicit protected DACL, owned by the current
+process token's user SID, containing exactly one allow ACE for that SID.
+
+The final requested root is reopened and must retain that same owner and DACL
+shape. Inherited, null, absent, multi-ACE, foreign-owner, reparse-point, and
+non-directory objects fail closed.
+
+## 6. Existing insecure roots
+
+An existing final root with broad permissions or a foreign owner returns a
+coarse insecure-permissions or insecure-owner error. The library never repairs
+it automatically because changing an existing ACL or mode can revoke intended
+access, conceal compromise, or race another process.
+
+The future CLI repair ceremony must identify the exact affected logical root,
+require an interactive confirmation, revalidate through native handles, make
+the smallest permission change, synchronize it, and rerun preparation. An
+unsafe override, if ever offered, must be explicit for one invocation and may
+not become the default.
+
+## 7. Process lock
+
+After preparation, a caller may open `<data-root>/.writer.lock`. The open uses
+the same no-link and owner-only policy as the directories:
+
+- Unix: regular file, current effective user, mode `0600` or stricter owner-only
+  equivalent with owner read/write access;
+- Windows: ordinary non-reparse file with the protected single-owner DACL.
+
+The file is persistent and must not be deleted on normal unlock. Its filesystem
+identity anchors advisory locking across process lifetimes and avoids an unlink
+race in which two processes lock different inodes under the same name.
+
+Acquisition uses the operating system's exclusive advisory file lock in
+non-blocking mode. Contention returns `AlreadyLocked`; it never waits, sleeps,
+steals, truncates, or parses the lock file. The returned guard owns the open
+file and lock. Dropping the guard releases the lock even during ordinary error
+unwinding or process exit.
+
+Phase 1A commands acquire the guard before constructing `FsStorageBackend`
+instances and hold it through all reads, recovery, publication, and final
+rendering. Read-only commands may be relaxed later only after every involved
+adapter has a proven cross-process snapshot contract.
+
+## 8. Closed failures
+
+The stable local-host failure classes are:
+
+| Failure | Meaning |
+|---|---|
+| `PlatformUnavailable` | per-user standard directories could not be resolved |
+| `InvalidPath` | an injected or resolved path violated the bounded contract |
+| `ParentUnavailable` | a parent could not be traversed without following links |
+| `AccessFailed` | a native create, open, inspection, or lock operation failed |
+| `UnsafeObjectType` | a link, reparse point, or wrong object type was found |
+| `InsecureOwner` | an existing private object belongs to another user |
+| `InsecurePermissions` | an existing private object grants broader access |
+| `AlreadyLocked` | another process currently owns the writer lock |
+| `UnsupportedPlatform` | no audited native implementation exists |
+
+The executable maps invalid injected paths to exit class 2, lock contention to
+exit class 5, integrity/security-policy failures to exit class 6, unsupported
+targets to exit class 8, and unexpected native access failures to exit class
+10. Human diagnostics remain low resolution.
+
+## 9. Composition rule
+
+The initial filesystem composition is:
+
+```text
+LocalVaultPaths::resolve
+  -> prepare
+  -> try_acquire_writer
+  -> FsStorageBackend(application-state)
+     -> StorageCoreApplicationStore
+  -> FsStorageBackend(objects)
+     -> StorageCoreObjectStore
+  -> V1ApplicationRepositoryFactory
+  -> VaultAccessV1 / command driver
+```
+
+The application and object adapters do not receive the config or cache root.
+The local-host package does not receive vault IDs, locators, passphrases,
+plaintext documents, provider credentials, or serialized owner state.
+
+Replacing `FsStorageBackend(objects)` with Google Drive, WebDAV, S3, or an
+in-memory test backend does not change path preparation for local owner state
+and does not change the application contract.
+
+## 10. Acceptance tests
+
+The package is complete for Phase 1A when automated tests prove:
+
+1. resolved roots are absolute and layout subtrees are disjoint;
+2. preparation creates all required roots and is idempotent;
+3. created Unix roots are mode `0700` and Windows roots use a protected
+   single-owner DACL;
+4. existing broad-permission roots fail without mutation;
+5. final links, reparse points, and wrong object types fail closed;
+6. one guard excludes a second independently opened guard;
+7. dropping the first guard permits a later acquisition;
+8. the lock file itself is owner-only and persistent;
+9. invalid injected paths fail before filesystem access; and
+10. errors and `Debug` output contain no resolved paths.
+
+The real CLI pseudo-terminal suite must additionally run two executable
+processes against the same injected roots and observe one deterministic lock
+winner before Phase 1A is declared complete.


### PR DESCRIPTION
## Summary

- add `vault-pm-local-host`, the OS trust boundary for platform-standard paths and owner-private local roots
- enforce no-link Unix modes and protected single-owner Windows ACLs for configuration, owner state, encrypted objects, cache, and lock storage
- add persistent non-blocking cross-process writer exclusion before independent `storage-fs` backends are composed
- define VLT-PM06 and record this prerequisite in the Phase 1A roadmap without coupling application code to filesystem or future cloud providers

## Security properties

- existing foreign, broadly accessible, linked, reparse-point, and wrong-type objects fail closed and are never silently repaired
- diagnostics and `Debug` values never disclose resolved paths
- owner-private application state and encrypted immutable objects have distinct roots, so the object backend remains replaceable by Drive or another provider
- the lock file is persistent and owner-only; the RAII guard releases the OS lock on drop

## Validation

- `cargo test -p coding_adventures_vault_pm_local_host -- --nocapture` (8 passed)
- `cargo clippy -p coding_adventures_vault_pm_local_host --all-targets -- -D warnings`
- Windows GNU cross-target Clippy with warnings denied
- x86_64 Linux cross-target Clippy with warnings denied
- monorepo build tool: 974 discovered, 1 changed, 1 affected, 1 built
- Tarpaulin LLVM: 187/196 Unix production lines (95.41%)
- `git diff origin/main...HEAD --check`