### PR TITLE
feat(adj-formula-stdlib): Wave 3 continuation -- solve rho=m/V for volume

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_density_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_density_e2e.rs
@@ -107,3 +107,37 @@ fn computes_mass_as_density_times_volume_with_citation() {
         "mass carries its HyperPhysics citation: {s}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// m = ρ·V, solved for a different unknown (ADJ-FORMULA-LIBRARIES FL-10, §3D
+// rung-0 CAS-wiring companion) — the SAME cited HyperPhysics definition as
+// `density`/`mass` above, closing the one direction they leave open: volume.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn solves_for_volume_from_density_with_the_same_citation() {
+    let dir = scratch("volume_solve");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"density.adj\"\n\
+         observe mass(60)\n\
+         observe density(20)\n\
+         ? volume_from_density(mass, density)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 60 = 20 * v  =>  v = 3.
+    assert!(
+        s.contains("\"name\":\"volume_from_density\"") && s.contains("\"value\":3"),
+        "volume_from_density(60, 20) = 3: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("hyperphysics.gsu.edu/hbase/dens.html"),
+        "carries the same HyperPhysics citation as the forward density/mass formulas: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-formula-stdlib/CHANGELOG.md
@@ -140,3 +140,12 @@ landed and why, not a semver-tracked API.
   library — most sibling 2-parameter libraries already hand-ship every direction, and this was the
   one overlooked. New manifest objective `adj.math.algebra.rearrange_pressure`. Extended the
   existing `formula_pressure_e2e.rs` with 1 new test rather than adding a new test file.
+- `physics/density.adj` — a seventh Wave 3 rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES
+  FL-10, §3D): `volume_from_density`, solving the same cited HyperPhysics `ρ = m/V` definition (via
+  its equivalent multiplicative form `m = ρ·V`, already hand-shipped as the `mass` formula) for
+  volume — the one direction `density`/`mass` leave open, the exact same shape `pressure.adj`'s
+  `area_from_pressure` closed one PR earlier. Found via a targeted second confirmation sweep after
+  the pressure fix, re-checking three previously-flagged lower-priority candidates
+  (`chemistry/ideal-gas-law.adj`, `clinical/bmi.adj`, `physics/gravitation.adj`) and turning up this
+  higher-priority match instead. New manifest objective `adj.math.algebra.rearrange_density`.
+  Extended the existing `formula_density_e2e.rs` with 1 new test rather than adding a new test file.

--- a/code/specs/data/adj-formula-stdlib/physics/density.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/density.adj
@@ -33,6 +33,18 @@
 % `formula` carries the provenance envelope every shipped grounded clause carries;
 % the linter rejects an unsourced one. (See feedback_nothing_human_authored — the
 % definitional sentence is a verbatim span of the cited page, not asserted from memory.)
+%
+% This library also carries a rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES
+% FL-10, §3D — a Wave 3 continuation): `volume_from_density` solves the SAME cited
+% HyperPhysics definition as the forward `mass` formula (`m = ρ·V`) for volume
+% instead, through `cas-solve`'s real linear-equation solver — the exact discipline
+% `pressure.adj`'s `area_from_pressure` already established for its own sibling
+% quotient/product pair. This closes the one remaining direction the hand-shipped
+% `density`/`mass` pair left open (given mass and density, recover the volume)
+% without duplicating either existing formula's citation work. The new symbolic
+% names its OWN target finding (`volume_from_density`, not `volume`) rather than
+% reusing the plain parameter name, so it coexists with the two forward examples
+% in one query file — no target-collision, no file-splitting needed.
 % ============================================================================
 
 % ----------------------------------------------------------------------------
@@ -47,6 +59,7 @@ dictionary density_vocab {
     define mass    : finding  surface "mass", "m"                        % mass, e.g. kg
     define volume  : finding  surface "volume", "V"                      % volume, e.g. m³
     define density : finding  surface "density", "rho"                  % density, e.g. kg/m³
+    define volume_from_density : finding  surface "missing volume", "unknown volume"
 }
 
 % ----------------------------------------------------------------------------
@@ -68,6 +81,14 @@ formulabook density_laws {
     % Mass — the same definition solved for the mass a density fills a volume with
     % (m = ρ·V). Defended by the SAME definitional sentence, read the other way.
     formula mass(density, volume) = density * volume
+        source "Density is defined as mass per unit volume."
+        locator "https://hyperphysics.gsu.edu/hbase/dens.html"
+        trust authoritative
+
+    % m = ρ·V again, SOLVED FOR VOLUME instead of computed forward — the same
+    % cited HyperPhysics definition, only which quantity is bound and which is
+    % unknown differs. Closes the one direction `density`/`mass` above leave open.
+    symbolic volume_from_density(mass, density) { mass == density * volume_from_density } for volume_from_density
         source "Density is defined as mass per unit volume."
         locator "https://hyperphysics.gsu.edu/hbase/dens.html"
         trust authoritative

--- a/code/specs/data/adj-formula-stdlib/physics/density.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/density.query.adj
@@ -27,3 +27,9 @@ observe volume(3)
 % That 20 g/cm³ density in the same 3 cm³ volume: mass = 20 * 3.
 observe density(20)
 ? mass(density, volume)      % expect 60   (same definition, solved for m = ρ·V)
+
+% --- ρ = m/V, SOLVED FOR VOLUME (rung-0 CAS-wiring, FL-10). "A 60 g mass has a
+% density of 20 g/cm³. What volume does it occupy?" ---
+observe mass(60)                          % "…a 60 g mass…"                (span cited)
+observe density(20)                       % "…has a density of 20 g/cm³…"  (span cited)
+? volume_from_density(mass, density)      % engine → 3 (HyperPhysics, authoritative)

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1262,6 +1262,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.math.algebra.rearrange_density",
+      "title": "Solve rho = m / V for volume, given the mass and the density",
+      "band": "6-8",
+      "domain": "mathematics",
+      "competency": "compute",
+      "coverage_roots": ["ccss.math"],
+      "standards": [],
+      "prerequisites": ["adj.science.physics.density"],
+      "libraries": ["code/specs/data/adj-formula-stdlib/physics/density.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES FL-10, §3D — Wave 3 continuation) to `physics/density.adj`: `volume_from_density`, solving the same cited HyperPhysics `ρ = m/V` definition (via its equivalent multiplicative form `m = ρ·V`, already hand-shipped as the `mass` formula) for volume — the one direction `density`/`mass` leave open.
- Found via a targeted second confirmation sweep after the pressure fix, re-checking three previously-flagged lower-priority candidates (`chemistry/ideal-gas-law.adj`, `clinical/bmi.adj`, `physics/gravitation.adj`) and turning up this higher-priority match instead — the exact same shape `pressure.adj`'s `area_from_pressure` closed one PR earlier.
- Empirically verified via the CLI before writing (`volume_from_density(60, 20) = 3`).
- New manifest objective `adj.math.algebra.rearrange_density` (band 6-8, prerequisite `adj.science.physics.density`).
- Extended the existing `formula_density_e2e.rs` with 1 new test (3 total) rather than adding a new test file.

Part of the autonomous ADJ curriculum loop (`ADJ-STDLIB-COVERAGE.md#7-delivery-order`).

## Test plan
- [x] Solve direction empirically verified via the CLI in a scratch dir before writing real content.
- [x] `cargo test -p adj-lang-cli --test formula_density_e2e` — 3/3 passed.
- [x] `cargo test -p adj-lang -p adj-lang-cli` — full suite green, no regressions.
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean.
- [x] `adj_stdlib_manifest.py --validate-json-schema` — 80 objectives, 0 errors, valid.
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` — exit 0, no new gaps introduced.
- [x] Python unittest suite (manifest/report subset) — 87 passed.
- [x] Security review — passed, no findings.