### PR TITLE
fix(gc-core-capi): eliminate precise_walk's Miri Stacked/Tree-Borrows failure

### DIFF
--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to this crate are documented here.
 
+## 0.24.3 - 2026-08-10 — fix: eliminate `precise_walk`'s Miri Stacked/Tree-Borrows failure
+
+- **Root cause: test-authoring exposure ordering, not a soundness bug in
+  `build_precise_roots`/`build_precise_roots_bounded`.** Every `precise_walk` test
+  builds a synthetic stack in a `[usize; N]` array, using a helper (`addr_of`) that
+  calls `stack.as_ptr() as usize` to hand the walk-under-test real, dereferenceable
+  addresses (`Miri` calls this "exposing" a pointer's provenance — required here,
+  since the walk itself works in plain integers, exactly like real captured
+  registers/stack memory would). Every affected test computed its `sp`/`fp0`/`fp1`/
+  `base` values via `addr_of` calls positioned **before** the `stack[i] = ...` writes
+  that populate the synthetic frames. Under Stacked/Tree Borrows, a write to `stack`
+  through its owning binding invalidates any previously-exposed reborrow tags for
+  that allocation — so a later wildcard pointer read (inside the walk, dereferencing
+  one of those addresses as a real memory access) found "no exposed tags have
+  suitable permission," `precise_walk.rs:176` (`all_unmapped_frames_become_
+  conservative_regions`), reproduced identically under Stacked Borrows, Tree
+  Borrows, and permissive-provenance mode.
+- **Confirmed genuinely a test bug, not a production issue**: the failure is purely
+  an artifact of the synthetic Rust-array test harness's exposure ordering. Real
+  usage walks live captured machine registers and actual stack memory (via `asm!`),
+  which have no analogous "exposed tag invalidated by a later write through a
+  differently-typed Rust binding" concern — there is no competing safe-Rust alias to
+  the same memory doing the invalidating write.
+- **Fix: every affected test (7 of the module's 9) now computes its FINAL `sp`/
+  `fp0`/`fp1`/.../`base` values — the ones passed to `build_precise_roots` or
+  compared in assertions — only *after* every `stack[i] = ...` write is done.** An
+  `addr_of` call used only to compute a value to *write* (not to dereference later)
+  remains fine at any point, since a write doesn't care about its own right-hand
+  side's later tag validity — only the numeric address value matters there, and that
+  doesn't change based on when it's computed. `addr_of` itself gained a doc comment
+  explaining the pitfall for future tests in this style.
+- Verification: `cargo test -p gc-core-capi --lib precise_walk` — 9 passed (was
+  previously untested under Miri at all, since this crate has never been in any
+  Miri CI workflow — informational only, discovered via this session's own local
+  investigation). `cargo +nightly miri test -p gc-core-capi --lib precise_walk` —
+  **9 passed, 0 failed** (previously: 1 confirmed Stacked-Borrows UB failure on the
+  first test, aborting the run before the remaining 8 could even execute). The
+  crate's other Miri blocker (`stack_scan`'s `asm!` register-spill code — Miri
+  fundamentally does not support inline assembly) is unrelated and unaffected;
+  full-crate `cargo +nightly miri test -p gc-core-capi` still cannot run to
+  completion for that separate, pre-existing, already-documented reason.
+- `cargo build`/`test` clean across `gc-core`, `gc-core-capi`, `vm-core` (gc-core-capi
+  41 lib tests, unchanged — this is a test-quality fix with no new test count
+  change, only new pass-under-Miri coverage for the existing 9); `cargo clippy
+  --all-targets -- -D warnings` clean.
+
 ## 0.24.2 - 2026-08-10 — test: `__gc_safepoint` mid-incremental-cycle regression coverage
 
 - New `safepoint_is_a_no_op_during_an_incremental_cycle` test: drives the real

--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -25,7 +25,9 @@ All notable changes to this crate are documented here.
   which have no analogous "exposed tag invalidated by a later write through a
   differently-typed Rust binding" concern — there is no competing safe-Rust alias to
   the same memory doing the invalidating write.
-- **Fix: every affected test (7 of the module's 9) now computes its FINAL `sp`/
+- **Fix: every affected test (8 of the module's 9 — every test except
+  `degenerate_start_fp_falls_back_to_full_conservative_scan`, the only one that
+  never writes to `stack`) now computes its FINAL `sp`/
   `fp0`/`fp1`/.../`base` values — the ones passed to `build_precise_roots` or
   compared in assertions — only *after* every `stack[i] = ...` write is done.** An
   `addr_of` call used only to compute a value to *write* (not to dereference later)

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.24.2"
+version = "0.24.3"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/src/precise_walk.rs
+++ b/code/packages/rust/gc-core-capi/src/precise_walk.rs
@@ -249,6 +249,22 @@ mod tests {
     /// the base address of `stack[0]`. Frame `k` has its frame pointer at index
     /// `2*k + 2`; `[fp]` (that index) holds the next frame pointer and `[fp+8]` (the
     /// next index) holds the return address. The caller fills those in.
+    ///
+    /// **Miri/Tree-Borrows pitfall, fixed across every test below:** each call exposes
+    /// `stack`'s provenance via `.as_ptr() as usize` — required, since the walk under
+    /// test dereferences plain integers, so there is no other way to hand it real
+    /// addresses. A *subsequent* write to `stack` through the owning binding
+    /// (`stack[i] = ...`) invalidates that exposed tag under Stacked/Tree Borrows, so a
+    /// later wildcard read through an address exposed *before* the write sees "no
+    /// exposed tags have suitable permission" — a real Miri failure, confirmed
+    /// reproducible, but a test-authoring bug (wrong exposure ordering), not a
+    /// soundness bug in `build_precise_roots` itself. Every test therefore computes its
+    /// FINAL `sp`/`fp0`/`fp1`/.../`base` values (the ones passed to `build_precise_roots`
+    /// or compared in assertions) via `addr_of` only *after* every `stack[i] = ...`
+    /// write is done. An `addr_of` call used only to compute a value to *write* (not to
+    /// dereference later) is fine at any point — the write doesn't care about its own
+    /// RHS's later tag validity, only about the numeric address value, which doesn't
+    /// change based on when it's computed.
     fn addr_of(stack: &[usize], idx: usize) -> usize {
         stack.as_ptr() as usize + idx * core::mem::size_of::<usize>()
     }
@@ -265,19 +281,19 @@ mod tests {
             //   4:   fp1 → [fp1] = 0 (chain terminates)
             //   5:            [fp1+8] = ret1
             let mut stack = [0usize; 6];
-            let sp = addr_of(&stack, 0);
-            let fp0 = addr_of(&stack, 2);
-            let fp1 = addr_of(&stack, 4);
-            let base = addr_of(&stack, 6); // one past the end
-            stack[2] = fp1; // [fp0] = fp1
+            stack[2] = addr_of(&stack, 4); // [fp0] = fp1
             stack[3] = 0xaaaa; // ret0 (nothing registered → unmapped)
             stack[4] = 0; // [fp1] = 0 → terminate
             stack[5] = 0xbbbb; // ret1
 
+            // Exposed AFTER every write above — see `addr_of`'s own doc for why.
+            let sp = addr_of(&stack, 0);
+            let fp0 = addr_of(&stack, 2);
+            let fp1 = addr_of(&stack, 4);
+            let base = addr_of(&stack, 6); // one past the end
+
             let mut slots = Vec::new();
             let mut regions = Vec::new();
-            // The walk reads the synthetic frames through raw pointers the borrow
-            // checker can't see; black_box keeps every slot write live (and unelided).
             core::hint::black_box(&stack);
             unsafe { build_precise_roots(fp0, sp, base, &mut slots, &mut regions) };
 
@@ -300,14 +316,16 @@ mod tests {
     fn mapped_frame_becomes_precise_slots() {
         with_clean_registry(|| {
             let mut stack = [0usize; 6];
+            stack[2] = addr_of(&stack, 4); // [fp0] = fp1 (caller_fp)
+            stack[3] = 0x1000; // ret0 — will be mapped
+            stack[4] = 0; // terminate
+            stack[5] = 0;
+
+            // Exposed AFTER every write above — see `addr_of`'s own doc for why.
             let sp = addr_of(&stack, 0);
             let fp0 = addr_of(&stack, 2);
             let fp1 = addr_of(&stack, 4);
             let base = addr_of(&stack, 6);
-            stack[2] = fp1; // [fp0] = fp1 (caller_fp)
-            stack[3] = 0x1000; // ret0 — will be mapped
-            stack[4] = 0; // terminate
-            stack[5] = 0;
 
             // Map ret0 = 0x1000 into a function [0x1000, 0x1100) with a safepoint at
             // pc 0 naming two ref slots at offsets 0 and -8 (relative to caller_fp=fp1).
@@ -315,8 +333,6 @@ mod tests {
 
             let mut slots = Vec::new();
             let mut regions = Vec::new();
-            // The walk reads the synthetic frames through raw pointers the borrow
-            // checker can't see; black_box keeps every slot write live (and unelided).
             core::hint::black_box(&stack);
             unsafe { build_precise_roots(fp0, sp, base, &mut slots, &mut regions) };
 
@@ -342,24 +358,24 @@ mod tests {
             // Three frames: fp0 (caller ret0 unmapped), fp1 (caller ret1 mapped), then
             // terminate at fp2.
             let mut stack = [0usize; 8];
+            stack[2] = addr_of(&stack, 4); // [fp0]=fp1
+            stack[3] = 0x2222; // ret0 unmapped
+            stack[4] = addr_of(&stack, 6); // [fp1]=fp2
+            stack[5] = 0x3000; // ret1 mapped
+            stack[6] = 0; // terminate
+            stack[7] = 0;
+
+            // Exposed AFTER every write above — see `addr_of`'s own doc for why.
             let sp = addr_of(&stack, 0);
             let fp0 = addr_of(&stack, 2);
             let fp1 = addr_of(&stack, 4);
             let fp2 = addr_of(&stack, 6);
             let base = addr_of(&stack, 8);
-            stack[2] = fp1; // [fp0]=fp1
-            stack[3] = 0x2222; // ret0 unmapped
-            stack[4] = fp2; // [fp1]=fp2
-            stack[5] = 0x3000; // ret1 mapped
-            stack[6] = 0; // terminate
-            stack[7] = 0;
 
             unsafe { register(0x3000, 0x80, 0, &[16]) }; // slot at fp2 + 16
 
             let mut slots = Vec::new();
             let mut regions = Vec::new();
-            // The walk reads the synthetic frames through raw pointers the borrow
-            // checker can't see; black_box keeps every slot write live (and unelided).
             core::hint::black_box(&stack);
             unsafe { build_precise_roots(fp0, sp, base, &mut slots, &mut regions) };
 
@@ -384,17 +400,17 @@ mod tests {
     fn backward_caller_fp_scans_remainder_and_stops() {
         with_clean_registry(|| {
             let mut stack = [0usize; 6];
-            let sp = addr_of(&stack, 0);
-            let fp0 = addr_of(&stack, 2);
-            let base = addr_of(&stack, 6);
             // [fp0] points BELOW fp0 (backward) — a broken chain. (ret at stack[3] is
             // never read, because the walk breaks on the bad link before resolving it.)
             stack[2] = addr_of(&stack, 1);
 
+            // Exposed AFTER the write above — see `addr_of`'s own doc for why.
+            let sp = addr_of(&stack, 0);
+            let fp0 = addr_of(&stack, 2);
+            let base = addr_of(&stack, 6);
+
             let mut slots = Vec::new();
             let mut regions = Vec::new();
-            // The walk reads the synthetic frames through raw pointers the borrow
-            // checker can't see; black_box keeps every slot write live (and unelided).
             core::hint::black_box(&stack);
             unsafe { build_precise_roots(fp0, sp, base, &mut slots, &mut regions) };
 
@@ -411,15 +427,16 @@ mod tests {
     fn out_of_range_caller_fp_scans_remainder_and_stops() {
         with_clean_registry(|| {
             let mut stack = [0usize; 6];
+            // Planning-only exposure: only the numeric value matters for a write.
+            stack[2] = addr_of(&stack, 6) + 0x1000; // caller_fp beyond the stack base (ret unread)
+
+            // Exposed AFTER the write above — see `addr_of`'s own doc for why.
             let sp = addr_of(&stack, 0);
             let fp0 = addr_of(&stack, 2);
             let base = addr_of(&stack, 6);
-            stack[2] = base + 0x1000; // caller_fp beyond the stack base (ret unread)
 
             let mut slots = Vec::new();
             let mut regions = Vec::new();
-            // The walk reads the synthetic frames through raw pointers the borrow
-            // checker can't see; black_box keeps every slot write live (and unelided).
             core::hint::black_box(&stack);
             unsafe { build_precise_roots(fp0, sp, base, &mut slots, &mut regions) };
 
@@ -478,15 +495,16 @@ mod tests {
     fn frame_budget_exhaustion_scans_remainder() {
         with_clean_registry(|| {
             let mut stack = [0usize; 8];
+            stack[2] = addr_of(&stack, 4); // [fp0]=fp1
+            stack[3] = 0x5555; // ret0 (unmapped)
+            stack[4] = addr_of(&stack, 6); // [fp1]=fp2 — a second frame the budget won't reach
+            stack[5] = 0x6666;
+
+            // Exposed AFTER every write above — see `addr_of`'s own doc for why.
             let sp = addr_of(&stack, 0);
             let fp0 = addr_of(&stack, 2);
             let fp1 = addr_of(&stack, 4);
-            let fp2 = addr_of(&stack, 6);
             let base = addr_of(&stack, 8);
-            stack[2] = fp1; // [fp0]=fp1
-            stack[3] = 0x5555; // ret0 (unmapped)
-            stack[4] = fp2; // [fp1]=fp2 — a second frame the budget won't reach
-            stack[5] = 0x6666;
 
             let mut slots = Vec::new();
             let mut regions = Vec::new();
@@ -535,23 +553,23 @@ mod tests {
             // is NOT scanned conservatively; only the named slot (fp1-16 → `live`) is
             // rooted, so `dead` at fp1-8 is reclaimed.
             let mut stack = [0usize; 8];
-            let sp = addr_of(&stack, 0);
-            let fp0 = addr_of(&stack, 2);
-            let fp1 = addr_of(&stack, 6);
-            let base = addr_of(&stack, 8);
-            stack[2] = fp1; // [fp0] = fp1
+            stack[2] = addr_of(&stack, 6); // [fp0] = fp1
             stack[3] = 0x4000; // ret0 → mapped
             stack[4] = live; // fp1 - 16 : NAMED slot
             stack[5] = dead; // fp1 - 8  : unnamed local
             stack[6] = 0; // [fp1] = 0 → terminate (remainder [fp1, base) is zeros)
             stack[7] = 0;
 
+            // Exposed AFTER every write above — see `addr_of`'s own doc for why.
+            let sp = addr_of(&stack, 0);
+            let fp0 = addr_of(&stack, 2);
+            let fp1 = addr_of(&stack, 6);
+            let base = addr_of(&stack, 8);
+
             unsafe { register(0x4000, 0x80, 0, &[-16]) }; // names only fp1 - 16 (`live`)
 
             let mut slots = Vec::new();
             let mut regions = Vec::new();
-            // The walk reads the synthetic frames through raw pointers the borrow
-            // checker can't see; black_box keeps every slot write live (and unelided).
             core::hint::black_box(&stack);
             unsafe { build_precise_roots(fp0, sp, base, &mut slots, &mut regions) };
 
@@ -589,16 +607,18 @@ mod tests {
             //   2: fp0 → [fp0]=fp1; 3: ret0=0x4000 (mapped); 4: `live` (named fp1-16);
             //   5: `dead` (unnamed fp1-8); 6: fp1 → [fp1]=0 (terminate).
             let mut stack = [0usize; 8];
-            let sp = addr_of(&stack, 0);
-            let fp0 = addr_of(&stack, 2);
-            let fp1 = addr_of(&stack, 6);
-            let base = addr_of(&stack, 8);
-            stack[2] = fp1;
+            stack[2] = addr_of(&stack, 6);
             stack[3] = 0x4000;
             stack[4] = live; // fp1 - 16 : NAMED slot
             stack[5] = dead; // fp1 - 8  : unnamed local
             stack[6] = 0;
             stack[7] = 0;
+
+            // Exposed AFTER every write above — see `addr_of`'s own doc for why.
+            let sp = addr_of(&stack, 0);
+            let fp0 = addr_of(&stack, 2);
+            let fp1 = addr_of(&stack, 6);
+            let base = addr_of(&stack, 8);
 
             unsafe { register(0x4000, 0x80, 0, &[-16]) }; // names only fp1 - 16 (`live`)
 

--- a/code/specs/AOT00-T8-adaptive-safepoint-scheduling.md
+++ b/code/specs/AOT00-T8-adaptive-safepoint-scheduling.md
@@ -275,6 +275,12 @@ tracked separately; it is what would let an embedder responsibly call `__gc_set_
   unmodified `origin/main` in `precise_walk::tests::all_unmapped_frames_become_conservative_regions`
   (a Stacked-Borrows violation in a pre-existing synthetic-stack-walk test, `precise_walk.rs:176` —
   a file this PR does not touch). Flagged as a separate follow-up rather than fixed here.
+  **Update (gc-core-capi 0.24.3):** fixed — confirmed a test-authoring exposure-ordering bug (every
+  affected test computed its final synthetic-stack addresses via `.as_ptr()` *before* writing the
+  synthetic frames, invalidating the exposed tag under Stacked/Tree Borrows for the walk's later
+  reads), not a soundness issue in the walk itself. `cargo miri test -p gc-core-capi --lib
+  precise_walk` is now clean, 9/9. The crate's separate `asm!`-based Miri blocker in `stack_scan`
+  (inline assembly is fundamentally unsupported by Miri) is unrelated and remains.
 
 ---
 


### PR DESCRIPTION
## Summary

`cargo +nightly miri test -p gc-core-capi --lib precise_walk` failed with a confirmed Stacked-Borrows UB error (reproducible identically under Stacked Borrows, Tree Borrows, and permissive-provenance mode). This was already known and explicitly flagged as a separate follow-up in the AOT00-T8 spec, deferred at the time since it wasn't caused by that PR.

**Root cause: test-authoring exposure ordering, not a soundness bug** in `build_precise_roots`/`build_precise_roots_bounded` (both unchanged by this PR). Every `precise_walk` test builds a synthetic stack in a `[usize; N]` array using a helper (`addr_of`) that calls `stack.as_ptr() as usize` to hand the walk-under-test real, dereferenceable addresses — required, since the walk works in plain integers, exactly like real captured registers/stack memory would. 8 of the module's 9 tests computed their final `sp`/`fp0`/`fp1`/`base` values via `addr_of` **before** the `stack[i] = ...` writes that populate the synthetic frames. Under Stacked/Tree Borrows, a write to `stack` through its owning binding invalidates previously-exposed reborrow tags for that allocation, so the walk's later wildcard reads through those addresses found "no exposed tags have suitable permission."

Confirmed this is genuinely a test-harness artifact: real usage walks live captured machine registers and actual stack memory (via `asm!`), which has no analogous "exposed tag invalidated by a later write through a differently-typed Rust binding" concern — there's no competing safe-Rust alias to the same memory doing the invalidating write.

## Fix

Every affected test now computes its FINAL address values — the ones passed to `build_precise_roots` or compared in assertions — only *after* every write to the synthetic stack is done. An `addr_of` call used only to compute a value to *write* (not to dereference later) is left wherever it was, since only the numeric value matters there. `addr_of` itself gained a doc comment explaining the pitfall for future tests in this style.

## Testing

- `cargo test -p gc-core-capi --lib precise_walk` — 9 passed.
- `cargo +nightly miri test -p gc-core-capi --lib precise_walk` — **9 passed, 0 failed** (was: 1 confirmed failure aborting the run before the remaining 8 could even execute).
- The crate's separate `asm!`-based Miri blocker in `stack_scan` (inline assembly is fundamentally unsupported by Miri) is unrelated and unaffected — full-crate Miri still can't run to completion for that pre-existing, already-documented reason.
- `cargo build`/`test` clean across `gc-core`, `gc-core-capi`, `vm-core`; `cargo clippy --all-targets -- -D warnings` clean.
- AOT00-T8 spec updated to record the fix against its original follow-up note.

## Security review

Test-only change (no production code in `precise_walk.rs` touched). Independent review, explicitly pointed at this exact worktree, traced all 8 modified tests to confirm no `addr_of`-derived value used for a later dereference is still computed before an invalidating write, confirmed no accidental byte-layout/semantic change (pure reordering), confirmed the diff never touches the production `build_precise_roots`/`build_precise_roots_bounded` functions, and independently re-ran both plain tests and Miri to verify 9/9 clean. One doc-accuracy nit was caught (CHANGELOG said "7 of 9" tests, should be "8 of 9") and fixed. **SECURITY REVIEW PASSED — no vulnerabilities found.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)