### PR TITLE
feat(adj-formula-stdlib): Wave 3 continuation -- solve V=IR for current

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_electricity_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_electricity_e2e.rs
@@ -106,3 +106,38 @@ fn computes_electric_power_as_voltage_times_current_with_citation() {
         "electric power carries its HyperPhysics citation: {s}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Ohm's law, solved for a different unknown (ADJ-FORMULA-LIBRARIES FL-10, §3D
+// rung-0 CAS-wiring companion) — the SAME cited law as `voltage`/
+// `resistance_from_ohms_law` above, closing the one direction they leave
+// open: current.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn solves_for_current_from_voltage_with_the_same_citation() {
+    let dir = scratch("current_solve");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"electricity.adj\"\n\
+         observe voltage(6)\n\
+         observe resistance(3)\n\
+         ? current_from_voltage(voltage, resistance)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 = c * 3  =>  c = 2.
+    assert!(
+        s.contains("\"name\":\"current_from_voltage\"") && s.contains("\"value\":2"),
+        "current_from_voltage(6, 3) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("hyperphysics.gsu.edu/hbase/electric/ohmlaw.html"),
+        "carries the same HyperPhysics citation as the forward voltage/resistance formulas: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-formula-stdlib/CHANGELOG.md
@@ -149,3 +149,10 @@ landed and why, not a semver-tracked API.
   (`chemistry/ideal-gas-law.adj`, `clinical/bmi.adj`, `physics/gravitation.adj`) and turning up this
   higher-priority match instead. New manifest objective `adj.math.algebra.rearrange_density`.
   Extended the existing `formula_density_e2e.rs` with 1 new test rather than adding a new test file.
+- `physics/electricity.adj` — an eighth Wave 3 rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES
+  FL-10, §3D): `current_from_voltage`, solving the same cited HyperPhysics `V = I·R` (Ohm's law) as
+  the forward `voltage`/`resistance_from_ohms_law` pair for current — the one direction they leave
+  open. Flagged during the density sweep as a viable remaining candidate. Mirrors
+  `resistance_from_ohms_law`'s exact discipline (same equation, different target). New manifest
+  objective `adj.math.algebra.rearrange_ohms_law`. Extended the existing `formula_electricity_e2e.rs`
+  with 1 new test rather than adding a new test file.

--- a/code/specs/data/adj-formula-stdlib/physics/electricity.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/electricity.adj
@@ -41,6 +41,13 @@
 % not a second hand-written formula:
 %
 %     resistance_from_ohms_law(voltage, current) = solve[ voltage = current · resistance ] for resistance
+%
+% A second companion, `current_from_voltage`, closes the remaining direction:
+% the same cited Ohm's law solved for CURRENT instead, given the voltage and
+% resistance — the one unknown `voltage`/`resistance_from_ohms_law` leave open.
+% Mirrors the exact discipline above; its own target finding
+% (`current_from_voltage`, not `current`) avoids reusing the plain parameter
+% name, so it coexists with every other worked example in one query file.
 % ============================================================================
 
 % ----------------------------------------------------------------------------
@@ -56,6 +63,7 @@ dictionary electricity_vocab {
     define resistance : finding  surface "resistance", "R"                           % resistance, e.g. Ω
     define voltage    : finding  surface "voltage", "potential difference", "emf", "V"  % voltage, e.g. V
     define power      : finding  surface "power", "electric power", "P"              % power, e.g. W
+    define current_from_voltage : finding  surface "missing current", "unknown current"
 }
 
 % ----------------------------------------------------------------------------
@@ -90,6 +98,13 @@ formulabook electricity_laws {
     % caller-supplied knowns; `resistance` is solved for by the engine's real
     % linear-equation solver, never a second hand-written `formula`.
     symbolic resistance_from_ohms_law(voltage, current) { voltage == current * resistance } for resistance
+        source "For many conductors of electricity, the electric current which will flow through them is directly proportional to the voltage applied to them."
+        locator "https://hyperphysics.gsu.edu/hbase/electric/ohmlaw.html"
+        trust authoritative
+
+    % Ohm's law again, SOLVED FOR CURRENT — the same cited proportionality,
+    % closing the one direction `voltage`/`resistance_from_ohms_law` leave open.
+    symbolic current_from_voltage(voltage, resistance) { voltage == current_from_voltage * resistance } for current_from_voltage
         source "For many conductors of electricity, the electric current which will flow through them is directly proportional to the voltage applied to them."
         locator "https://hyperphysics.gsu.edu/hbase/electric/ohmlaw.html"
         trust authoritative

--- a/code/specs/data/adj-formula-stdlib/physics/electricity.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/electricity.query.adj
@@ -34,3 +34,9 @@ observe resistance(3)
 
 % Electric power at that same current: power = 6 * 2.
 ? power(voltage, current)          % expect 12  (electric power: P = V·I)
+
+% --- Ohm's law, SOLVED FOR CURRENT (rung-0 CAS-wiring, FL-10). The same
+% already-bound voltage(6) and resistance(3) give back the original 2 A
+% current — a second round trip, closing the one direction the forward
+% `voltage`/`resistance_from_ohms_law` pair above leave open. ---
+? current_from_voltage(voltage, resistance)   % expect 2   (I = V / R = 6 / 3)

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1277,6 +1277,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.math.algebra.rearrange_ohms_law",
+      "title": "Solve V = I R for current, given the voltage and the resistance",
+      "band": "9-12",
+      "domain": "mathematics",
+      "competency": "compute",
+      "coverage_roots": ["ccss.math"],
+      "standards": [],
+      "prerequisites": ["adj.science.physics.ohms_law"],
+      "libraries": ["code/specs/data/adj-formula-stdlib/physics/electricity.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES FL-10, §3D — Wave 3 continuation) to `physics/electricity.adj`: `current_from_voltage`, solving the same cited HyperPhysics Ohm's law (`V = I·R`) as the forward `voltage`/`resistance_from_ohms_law` pair for current — the one direction they leave open.
- Flagged during the density sweep as a viable remaining candidate. Mirrors `resistance_from_ohms_law`'s exact discipline (same equation, different target).
- Empirically verified via the CLI before writing (`current_from_voltage(6, 3) = 2`, matching the original `current(2)` bound elsewhere in the query file — a consistent round trip).
- New manifest objective `adj.math.algebra.rearrange_ohms_law` (band 9-12, prerequisite `adj.science.physics.ohms_law`).
- Extended the existing `formula_electricity_e2e.rs` with 1 new test (3 total) rather than adding a new test file.

This is Wave 3's eighth rung-0 CAS-wiring item across four sweep rounds (kinematics, geometry, work, mechanics-force, kinetic-energy, pressure, density, electricity-current).

Part of the autonomous ADJ curriculum loop (`ADJ-STDLIB-COVERAGE.md#7-delivery-order`).

## Test plan
- [x] Solve direction empirically verified via the CLI in a scratch dir before writing real content.
- [x] `cargo test -p adj-lang-cli --test formula_electricity_e2e` — 3/3 passed.
- [x] `cargo test -p adj-lang -p adj-lang-cli` — full suite green, no regressions.
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean.
- [x] `adj_stdlib_manifest.py --validate-json-schema` — 81 objectives, 0 errors, valid.
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` — exit 0, no new gaps introduced.
- [x] Python unittest suite (manifest/report subset) — 87 passed.
- [x] Security review — passed, no findings.