### PR TITLE
Persist local vault configuration atomically

### DIFF
--- a/code/packages/rust/vault-pm-local-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-local-host/CHANGELOG.md
@@ -6,4 +6,6 @@
 - Added owner-only, no-link local root preparation on Unix and Windows.
 - Added a persistent owner-only lock file with non-blocking cross-process
   single-writer exclusion.
+- Added exact, bounded configuration loading plus owner-only atomic initial
+  creation and compare-and-exchange through the live writer guard.
 - Added closed, path-free diagnostics and platform security tests.

--- a/code/packages/rust/vault-pm-local-host/README.md
+++ b/code/packages/rust/vault-pm-local-host/README.md
@@ -3,7 +3,9 @@
 This crate is the operating-system trust boundary for the local password-manager
 CLI. It resolves platform application directories, prepares owner-private roots
 without following links, and provides non-blocking cross-process writer
-exclusion before any `storage-fs` backend is opened.
+exclusion before any `storage-fs` backend is opened. The resulting writer guard
+also owns exact, bounded, atomic persistence for the storage-neutral VLT-PM07
+configuration bytes.
 
 It deliberately does not know the vault format, keys, records, providers, or
 application use cases. The composition root receives separate paths for:
@@ -25,13 +27,22 @@ Phase 1A command can acquire this guard before constructing independent
 `storage-fs` backend instances, closing the cross-process race that backend-local
 compare-and-exchange cannot close.
 
+The writer guard loads, initially creates, and exact-value replaces
+`vault-pm.toml`. It accepts only non-empty values through 64 KiB, never follows
+links or reparse points, validates owner-only native security, stages writes in
+the same private directory, synchronizes them, and publishes atomically.
+Initial creation never replaces an existing object; stale replacement returns a
+closed conflict. The host deliberately treats the bytes as opaque—the
+`vault-pm-config` crate remains the sole schema and canonical-rendering owner.
+
 Diagnostics and `Debug` output never include resolved paths.
 
-Eight tests cover path resolution, idempotent layout creation, native modes and
-object types, broad-root and unsafe-lock refusal, stable redaction, lock
-contention, and lock release. Tarpaulin's LLVM engine measures 187 of 196 Unix
-production lines covered (95.41%). Windows executes the same public contract in
-CI and cross-target Clippy validates its native API surface locally.
+Eleven tests cover path resolution, idempotent layout creation, native modes and
+object types, broad-root and unsafe-file refusal, stable redaction, lock
+contention, exact configuration round trips, stale-write rejection, and input
+bounds. Windows executes the same public contract in CI and cross-target Clippy
+validates its native API surface locally. Tarpaulin's LLVM engine measures 304
+of 319 Unix production lines covered (95.30%).
 
 ## Verification
 

--- a/code/packages/rust/vault-pm-local-host/required_capabilities.json
+++ b/code/packages/rust/vault-pm-local-host/required_capabilities.json
@@ -12,27 +12,27 @@
     {
       "category": "fs",
       "action": "read",
-      "target": "resolved vault-pm configuration, data, cache, and lock paths",
-      "justification": "Inspects every local root and lock object without following links before exposing paths to storage adapters."
+      "target": "resolved vault-pm configuration file, data, cache, and lock paths",
+      "justification": "Inspects every local root, lock object, and bounded configuration file without following links before returning paths or exact bytes."
     },
     {
       "category": "fs",
       "action": "create",
-      "target": "resolved vault-pm configuration, data, cache, and lock paths",
-      "justification": "Creates missing application roots and the persistent lock file with owner-only native security metadata."
+      "target": "resolved vault-pm configuration file, data, cache, and lock paths",
+      "justification": "Creates missing application roots, the persistent lock file, and same-directory configuration staging files with owner-only native security metadata."
     },
     {
       "category": "fs",
       "action": "write",
-      "target": "resolved vault-pm lock path",
-      "justification": "Acquires an operating-system advisory lock that excludes concurrent local writer processes."
+      "target": "resolved vault-pm lock and configuration paths",
+      "justification": "Acquires an operating-system advisory lock and atomically publishes synchronized exact configuration bytes."
     },
     {
       "category": "ffi",
       "action": "call",
-      "target": "libc openat/fstat and Windows file/token/security APIs",
-      "justification": "Uses no-follow handles, native identity and access-control inspection, and platform file locking unavailable through path-only filesystem calls."
+      "target": "libc descriptor-relative file APIs and Windows file/token/security APIs",
+      "justification": "Uses no-follow handles, native identity and access-control inspection, atomic publication, durable synchronization, and platform file locking unavailable through path-only filesystem calls."
     }
   ],
-  "justification": "Local CLI trust-boundary adapter for platform-standard paths, owner-private directories, and one-process-at-a-time vault access."
+  "justification": "Local CLI trust-boundary adapter for platform-standard paths, owner-private directories and configuration, and one-process-at-a-time vault access."
 }

--- a/code/packages/rust/vault-pm-local-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-local-host/src/lib.rs
@@ -1,4 +1,4 @@
-//! Secure platform roots and cross-process exclusion for the local vault host.
+//! Secure platform roots, atomic configuration, and process exclusion.
 
 #![deny(missing_docs)]
 
@@ -20,7 +20,9 @@ const APPLICATION_NAME: &str = "vault-pm";
 const STATE_DIRECTORY: &str = "application-state";
 const OBJECT_DIRECTORY: &str = "objects";
 const LOCK_FILE: &str = ".writer.lock";
+const CONFIG_FILE: &str = "vault-pm.toml";
 const MAX_PATH_BYTES: usize = 4096;
+const MAX_CONFIG_BYTES: usize = 64 * 1024;
 
 /// Stable, path-free local-host failure taxonomy.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -41,6 +43,12 @@ pub enum LocalHostError {
     InsecurePermissions,
     /// Another process currently owns the vault writer lock.
     AlreadyLocked,
+    /// A caller attempted to create configuration that already exists.
+    ConfigAlreadyExists,
+    /// Exact expected configuration did not match durable configuration.
+    ConfigConflict,
+    /// Configuration bytes were empty or exceeded the local V1 bound.
+    InvalidConfigBytes,
     /// The current target has no audited local-host implementation.
     UnsupportedPlatform,
 }
@@ -56,6 +64,9 @@ impl Display for LocalHostError {
             Self::InsecureOwner => "vault-pm local host: insecure owner",
             Self::InsecurePermissions => "vault-pm local host: insecure permissions",
             Self::AlreadyLocked => "vault-pm local host: already locked",
+            Self::ConfigAlreadyExists => "vault-pm local host: config already exists",
+            Self::ConfigConflict => "vault-pm local host: config conflict",
+            Self::InvalidConfigBytes => "vault-pm local host: invalid config bytes",
             Self::UnsupportedPlatform => "vault-pm local host: unsupported platform",
         })
     }
@@ -72,6 +83,7 @@ pub struct LocalVaultPaths {
     application_state_root: PathBuf,
     object_root: PathBuf,
     lock_file: PathBuf,
+    config_file: PathBuf,
 }
 
 impl LocalVaultPaths {
@@ -108,7 +120,13 @@ impl LocalVaultPaths {
         let application_state_root = data_root.join(STATE_DIRECTORY);
         let object_root = data_root.join(OBJECT_DIRECTORY);
         let lock_file = data_root.join(LOCK_FILE);
-        for path in [&application_state_root, &object_root, &lock_file] {
+        let config_file = config_root.join(CONFIG_FILE);
+        for path in [
+            &application_state_root,
+            &object_root,
+            &lock_file,
+            &config_file,
+        ] {
             validate_path(path)?;
         }
         Ok(Self {
@@ -118,6 +136,7 @@ impl LocalVaultPaths {
             application_state_root,
             object_root,
             lock_file,
+            config_file,
         })
     }
 
@@ -203,7 +222,10 @@ impl PreparedLocalVault {
         {
             let file = platform::open_private_lock(&self.paths.lock_file)?;
             match file.try_lock() {
-                Ok(()) => Ok(LocalWriterGuard { _file: file }),
+                Ok(()) => Ok(LocalWriterGuard {
+                    _file: file,
+                    config_file: self.paths.config_file.clone(),
+                }),
                 Err(error) => Err(map_lock_error(error)),
             }
         }
@@ -233,6 +255,60 @@ impl Debug for PreparedLocalVault {
 /// RAII ownership of the exclusive local writer lock.
 pub struct LocalWriterGuard {
     _file: File,
+    config_file: PathBuf,
+}
+
+impl LocalWriterGuard {
+    /// Load exact durable configuration bytes, or `None` when uninitialized.
+    ///
+    /// The read is capped at 65,537 bytes and rejects links, non-regular files,
+    /// foreign ownership, and broad permissions before returning bytes.
+    pub fn load_config(&self) -> Result<Option<Vec<u8>>, LocalHostError> {
+        #[cfg(any(unix, windows))]
+        {
+            platform::load_private_config(&self.config_file, MAX_CONFIG_BYTES)
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            Err(LocalHostError::UnsupportedPlatform)
+        }
+    }
+
+    /// Atomically create first configuration without replacing an existing file.
+    pub fn create_config(&self, bytes: &[u8]) -> Result<(), LocalHostError> {
+        validate_config_bytes(bytes)?;
+        #[cfg(any(unix, windows))]
+        {
+            platform::create_private_config(&self.config_file, bytes, MAX_CONFIG_BYTES)
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            Err(LocalHostError::UnsupportedPlatform)
+        }
+    }
+
+    /// Atomically replace configuration only when exact durable bytes match.
+    pub fn compare_exchange_config(
+        &self,
+        expected: &[u8],
+        replacement: &[u8],
+    ) -> Result<(), LocalHostError> {
+        validate_config_bytes(expected)?;
+        validate_config_bytes(replacement)?;
+        #[cfg(any(unix, windows))]
+        {
+            platform::compare_exchange_private_config(
+                &self.config_file,
+                expected,
+                replacement,
+                MAX_CONFIG_BYTES,
+            )
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            Err(LocalHostError::UnsupportedPlatform)
+        }
+    }
 }
 
 impl Debug for LocalWriterGuard {
@@ -258,6 +334,14 @@ fn validate_path(path: &Path) -> Result<(), LocalHostError> {
         return Err(LocalHostError::InvalidPath);
     }
     Ok(())
+}
+
+fn validate_config_bytes(bytes: &[u8]) -> Result<(), LocalHostError> {
+    if bytes.is_empty() || bytes.len() > MAX_CONFIG_BYTES {
+        Err(LocalHostError::InvalidConfigBytes)
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -376,6 +460,104 @@ mod tests {
     }
 
     #[test]
+    fn configuration_create_load_and_compare_exchange_are_exact_and_durable() {
+        let directory = TestDirectory::new("config-roundtrip");
+        let paths = directory.paths();
+        let prepared = paths.prepare().unwrap();
+        let guard = prepared.try_acquire_writer().unwrap();
+        let initial = b"version = 1\nactive_vault = \"personal\"\n";
+        let replacement = b"version = 1\nactive_vault = \"work\"\n";
+
+        assert_eq!(guard.load_config().unwrap(), None);
+        guard.create_config(initial).unwrap();
+        assert_eq!(guard.load_config().unwrap().as_deref(), Some(&initial[..]));
+        assert_eq!(
+            guard.create_config(b"do not replace").unwrap_err(),
+            LocalHostError::ConfigAlreadyExists
+        );
+        assert_eq!(guard.load_config().unwrap().as_deref(), Some(&initial[..]));
+
+        guard.compare_exchange_config(initial, replacement).unwrap();
+        assert_eq!(
+            guard.load_config().unwrap().as_deref(),
+            Some(&replacement[..])
+        );
+        assert_eq!(
+            guard
+                .compare_exchange_config(initial, b"stale replacement")
+                .unwrap_err(),
+            LocalHostError::ConfigConflict
+        );
+        assert_eq!(
+            guard.load_config().unwrap().as_deref(),
+            Some(&replacement[..])
+        );
+        assert!(
+            !fs::read_dir(paths.config_root()).unwrap().any(|entry| entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".vault-pm.toml.tmp."))
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&paths.config_file)
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+        drop(guard);
+        let reopened = prepared.try_acquire_writer().unwrap();
+        assert_eq!(
+            reopened.load_config().unwrap().as_deref(),
+            Some(&replacement[..])
+        );
+    }
+
+    #[test]
+    fn configuration_rejects_unbounded_or_missing_compare_exchange_inputs() {
+        let directory = TestDirectory::new("config-bounds");
+        let prepared = directory.paths().prepare().unwrap();
+        let guard = prepared.try_acquire_writer().unwrap();
+        let oversized = vec![b'x'; MAX_CONFIG_BYTES + 1];
+
+        assert_eq!(
+            guard.create_config(b"").unwrap_err(),
+            LocalHostError::InvalidConfigBytes
+        );
+        assert_eq!(
+            guard.create_config(&oversized).unwrap_err(),
+            LocalHostError::InvalidConfigBytes
+        );
+        assert_eq!(
+            guard
+                .compare_exchange_config(b"expected", b"replacement")
+                .unwrap_err(),
+            LocalHostError::ConfigConflict
+        );
+        assert_eq!(
+            guard
+                .compare_exchange_config(b"", b"replacement")
+                .unwrap_err(),
+            LocalHostError::InvalidConfigBytes
+        );
+        assert_eq!(
+            guard.compare_exchange_config(b"expected", b"").unwrap_err(),
+            LocalHostError::InvalidConfigBytes
+        );
+        assert_eq!(guard.load_config().unwrap(), None);
+        let maximum = vec![b'x'; MAX_CONFIG_BYTES];
+        guard.create_config(&maximum).unwrap();
+        assert_eq!(guard.load_config().unwrap(), Some(maximum));
+    }
+
+    #[test]
     fn invalid_paths_and_diagnostics_are_closed() {
         assert_eq!(
             LocalVaultPaths::from_roots("relative", "/absolute/data", "/absolute/cache"),
@@ -425,6 +607,18 @@ mod tests {
             (
                 LocalHostError::AlreadyLocked,
                 "vault-pm local host: already locked",
+            ),
+            (
+                LocalHostError::ConfigAlreadyExists,
+                "vault-pm local host: config already exists",
+            ),
+            (
+                LocalHostError::ConfigConflict,
+                "vault-pm local host: config conflict",
+            ),
+            (
+                LocalHostError::InvalidConfigBytes,
+                "vault-pm local host: invalid config bytes",
             ),
             (
                 LocalHostError::UnsupportedPlatform,
@@ -496,5 +690,77 @@ mod tests {
             LocalHostError::UnsafeObjectType
         );
         assert_eq!(fs::read(target).unwrap(), b"target");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_unsafe_existing_configuration_without_following_or_replacing_it() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let linked = TestDirectory::new("linked-config");
+        let linked_paths = linked.paths();
+        let linked_prepared = linked_paths.prepare().unwrap();
+        let linked_guard = linked_prepared.try_acquire_writer().unwrap();
+        let target = linked.0.join("outside-config");
+        fs::write(&target, b"preserve target").unwrap();
+        symlink(&target, &linked_paths.config_file).unwrap();
+        assert_eq!(
+            linked_guard.load_config().unwrap_err(),
+            LocalHostError::UnsafeObjectType
+        );
+        assert_eq!(
+            linked_guard.create_config(b"replacement").unwrap_err(),
+            LocalHostError::UnsafeObjectType
+        );
+        assert_eq!(fs::read(&target).unwrap(), b"preserve target");
+
+        let broad = TestDirectory::new("broad-config");
+        let broad_paths = broad.paths();
+        let broad_prepared = broad_paths.prepare().unwrap();
+        let broad_guard = broad_prepared.try_acquire_writer().unwrap();
+        fs::write(&broad_paths.config_file, b"preserve config").unwrap();
+        fs::set_permissions(&broad_paths.config_file, fs::Permissions::from_mode(0o640)).unwrap();
+        assert_eq!(
+            broad_guard.load_config().unwrap_err(),
+            LocalHostError::InsecurePermissions
+        );
+        assert_eq!(
+            broad_guard.create_config(b"replacement").unwrap_err(),
+            LocalHostError::InsecurePermissions
+        );
+        assert_eq!(
+            fs::read(&broad_paths.config_file).unwrap(),
+            b"preserve config"
+        );
+
+        let invalid = TestDirectory::new("invalid-config-bytes");
+        let invalid_paths = invalid.paths();
+        let invalid_prepared = invalid_paths.prepare().unwrap();
+        let invalid_guard = invalid_prepared.try_acquire_writer().unwrap();
+        fs::write(&invalid_paths.config_file, b"").unwrap();
+        fs::set_permissions(
+            &invalid_paths.config_file,
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        assert_eq!(
+            invalid_guard.load_config().unwrap_err(),
+            LocalHostError::InvalidConfigBytes
+        );
+        fs::write(&invalid_paths.config_file, vec![b'x'; MAX_CONFIG_BYTES + 1]).unwrap();
+        assert_eq!(
+            invalid_guard.load_config().unwrap_err(),
+            LocalHostError::InvalidConfigBytes
+        );
+
+        let typed = TestDirectory::new("typed-config");
+        let typed_paths = typed.paths();
+        let typed_prepared = typed_paths.prepare().unwrap();
+        let typed_guard = typed_prepared.try_acquire_writer().unwrap();
+        fs::create_dir(&typed_paths.config_file).unwrap();
+        assert_eq!(
+            typed_guard.load_config().unwrap_err(),
+            LocalHostError::UnsafeObjectType
+        );
     }
 }

--- a/code/packages/rust/vault-pm-local-host/src/unix.rs
+++ b/code/packages/rust/vault-pm-local-host/src/unix.rs
@@ -1,10 +1,15 @@
 use super::{LocalHostError, MAX_PATH_BYTES};
 use std::ffi::{CString, OsStr};
 use std::fs::File;
+use std::io::{Read, Write};
 use std::mem::MaybeUninit;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_TEMPORARY: AtomicU64 = AtomicU64::new(0);
+const MAX_TEMPORARY_ATTEMPTS: usize = 64;
 
 pub(super) fn ensure_private_directory(path: &Path) -> Result<(), LocalHostError> {
     validate_absolute(path)?;
@@ -78,6 +83,172 @@ pub(super) fn open_private_lock(path: &Path) -> Result<File, LocalHostError> {
     let file = File::from(owned_fd(raw).map_err(|_| LocalHostError::AccessFailed)?);
     verify_private_file(&file)?;
     Ok(file)
+}
+
+pub(super) fn load_private_config(
+    path: &Path,
+    max_bytes: usize,
+) -> Result<Option<Vec<u8>>, LocalHostError> {
+    let (parent, name) = open_existing_parent(path)?;
+    verify_private_directory(&parent)?;
+    read_private_file(&parent, &name, max_bytes)
+}
+
+pub(super) fn create_private_config(
+    path: &Path,
+    bytes: &[u8],
+    max_bytes: usize,
+) -> Result<(), LocalHostError> {
+    let (parent, name) = open_existing_parent(path)?;
+    verify_private_directory(&parent)?;
+    if read_private_file(&parent, &name, max_bytes)?.is_some() {
+        return Err(LocalHostError::ConfigAlreadyExists);
+    }
+    let (temporary, temporary_name) = create_temporary(&parent)?;
+    let result = (|| {
+        persist_temporary(&temporary, bytes)?;
+        if unsafe {
+            libc::linkat(
+                parent.as_raw_fd(),
+                temporary_name.as_ptr(),
+                parent.as_raw_fd(),
+                name.as_ptr(),
+                0,
+            )
+        } != 0
+        {
+            return Err(match std::io::Error::last_os_error().raw_os_error() {
+                Some(libc::EEXIST) => LocalHostError::ConfigAlreadyExists,
+                _ => LocalHostError::AccessFailed,
+            });
+        }
+        sync_directory(&parent)?;
+        verify_named_private_file(&parent, &name)?;
+        Ok(())
+    })();
+    unlink_temporary(&parent, &temporary_name);
+    if result.is_ok() {
+        sync_directory(&parent)?;
+    }
+    result
+}
+
+pub(super) fn compare_exchange_private_config(
+    path: &Path,
+    expected: &[u8],
+    replacement: &[u8],
+    max_bytes: usize,
+) -> Result<(), LocalHostError> {
+    let (parent, name) = open_existing_parent(path)?;
+    verify_private_directory(&parent)?;
+    if read_private_file(&parent, &name, max_bytes)?.as_deref() != Some(expected) {
+        return Err(LocalHostError::ConfigConflict);
+    }
+    let (temporary, temporary_name) = create_temporary(&parent)?;
+    let result = (|| {
+        persist_temporary(&temporary, replacement)?;
+        if unsafe {
+            libc::renameat(
+                parent.as_raw_fd(),
+                temporary_name.as_ptr(),
+                parent.as_raw_fd(),
+                name.as_ptr(),
+            )
+        } != 0
+        {
+            return Err(LocalHostError::AccessFailed);
+        }
+        sync_directory(&parent)?;
+        verify_named_private_file(&parent, &name)
+    })();
+    if result.is_err() {
+        unlink_temporary(&parent, &temporary_name);
+    }
+    result
+}
+
+fn read_private_file(
+    parent: &OwnedFd,
+    name: &CString,
+    max_bytes: usize,
+) -> Result<Option<Vec<u8>>, LocalHostError> {
+    let raw = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if raw < 0 {
+        return match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ENOENT) => Ok(None),
+            Some(libc::ELOOP) | Some(libc::EISDIR) => Err(LocalHostError::UnsafeObjectType),
+            _ => Err(LocalHostError::AccessFailed),
+        };
+    }
+    let file = File::from(owned_fd(raw).map_err(|_| LocalHostError::AccessFailed)?);
+    verify_private_file(&file)?;
+    let mut bytes = Vec::new();
+    file.take((max_bytes as u64).saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|_| LocalHostError::AccessFailed)?;
+    if bytes.is_empty() || bytes.len() > max_bytes {
+        return Err(LocalHostError::InvalidConfigBytes);
+    }
+    Ok(Some(bytes))
+}
+
+fn create_temporary(parent: &OwnedFd) -> Result<(File, CString), LocalHostError> {
+    for _ in 0..MAX_TEMPORARY_ATTEMPTS {
+        let sequence = NEXT_TEMPORARY.fetch_add(1, Ordering::Relaxed);
+        let name = CString::new(format!(
+            ".vault-pm.toml.tmp.{}.{}",
+            std::process::id(),
+            sequence
+        ))
+        .map_err(|_| LocalHostError::AccessFailed)?;
+        let raw = unsafe {
+            libc::openat(
+                parent.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDWR | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                0o600,
+            )
+        };
+        if raw >= 0 {
+            let file = File::from(owned_fd(raw).map_err(|_| LocalHostError::AccessFailed)?);
+            verify_private_file(&file)?;
+            return Ok((file, name));
+        }
+        if std::io::Error::last_os_error().raw_os_error() != Some(libc::EEXIST) {
+            return Err(LocalHostError::AccessFailed);
+        }
+    }
+    Err(LocalHostError::AccessFailed)
+}
+
+fn persist_temporary(mut file: &File, bytes: &[u8]) -> Result<(), LocalHostError> {
+    file.write_all(bytes)
+        .map_err(|_| LocalHostError::AccessFailed)?;
+    file.sync_all().map_err(|_| LocalHostError::AccessFailed)
+}
+
+fn verify_named_private_file(parent: &OwnedFd, name: &CString) -> Result<(), LocalHostError> {
+    read_private_file(parent, name, usize::MAX).map(|_| ())
+}
+
+fn sync_directory(parent: &OwnedFd) -> Result<(), LocalHostError> {
+    if unsafe { libc::fsync(parent.as_raw_fd()) } == 0 {
+        Ok(())
+    } else {
+        Err(LocalHostError::AccessFailed)
+    }
+}
+
+fn unlink_temporary(parent: &OwnedFd, name: &CString) {
+    unsafe {
+        libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), 0);
+    }
 }
 
 fn open_existing_parent(path: &Path) -> Result<(OwnedFd, CString), LocalHostError> {
@@ -259,6 +430,27 @@ mod tests {
             verify_owner_permissions(&foreign, 0o700),
             Err(LocalHostError::InsecurePermissions)
         );
+
+        assert_eq!(
+            ensure_private_directory(Path::new("/")),
+            Err(LocalHostError::InvalidPath)
+        );
+        let oversized_name = directory.0.join("x".repeat(300));
+        assert_eq!(
+            open_private_lock(&oversized_name).unwrap_err(),
+            LocalHostError::AccessFailed
+        );
+        assert_eq!(
+            load_private_config(&oversized_name, 64).unwrap_err(),
+            LocalHostError::AccessFailed
+        );
+
+        let mut pipe = [-1; 2];
+        assert_eq!(unsafe { libc::pipe(pipe.as_mut_ptr()) }, 0);
+        let read_end = owned_fd(pipe[0]).unwrap();
+        let write_end = owned_fd(pipe[1]).unwrap();
+        assert_eq!(sync_directory(&read_end), Err(LocalHostError::AccessFailed));
+        drop(write_end);
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-local-host/src/windows.rs
+++ b/code/packages/rust/vault-pm-local-host/src/windows.rs
@@ -1,13 +1,16 @@
 use super::{LocalHostError, MAX_PATH_BYTES};
 use std::ffi::c_void;
 use std::fs::File;
+use std::io::{Read, Write};
 use std::mem::{size_of, MaybeUninit};
 use std::os::windows::ffi::OsStrExt;
 use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
-use std::path::{Component, Path};
+use std::path::{Component, Path, PathBuf};
 use std::ptr::{addr_of, null, null_mut};
+use std::sync::atomic::{AtomicU64, Ordering};
 use windows_sys::Win32::Foundation::{
-    BOOL, ERROR_ALREADY_EXISTS, HANDLE, INVALID_HANDLE_VALUE, PSID,
+    BOOL, ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS, ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND,
+    HANDLE, INVALID_HANDLE_VALUE, PSID,
 };
 use windows_sys::Win32::Security::{
     AclSizeInformation, AddAccessAllowedAce, EqualSid, GetAce, GetAclInformation,
@@ -19,11 +22,12 @@ use windows_sys::Win32::Security::{
     SE_DACL_PROTECTED, TOKEN_QUERY, TOKEN_USER,
 };
 use windows_sys::Win32::Storage::FileSystem::{
-    CreateDirectoryW, CreateFileW, FileAttributeTagInfo, GetFileInformationByHandleEx, CREATE_NEW,
-    FILE_ALL_ACCESS, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
-    FILE_ATTRIBUTE_TAG_INFO, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
-    FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE,
-    FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    CreateDirectoryW, CreateFileW, DeleteFileW, FileAttributeTagInfo, GetFileInformationByHandleEx,
+    MoveFileExW, CREATE_NEW, FILE_ALL_ACCESS, FILE_ATTRIBUTE_DIRECTORY,
+    FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO, FILE_FLAG_BACKUP_SEMANTICS,
+    FILE_FLAG_OPEN_REPARSE_POINT, FILE_GENERIC_READ, FILE_GENERIC_WRITE, FILE_READ_ATTRIBUTES,
+    FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, MOVEFILE_REPLACE_EXISTING,
+    MOVEFILE_WRITE_THROUGH, OPEN_EXISTING,
 };
 use windows_sys::Win32::System::SystemServices::{
     ACCESS_ALLOWED_ACE_TYPE, SECURITY_DESCRIPTOR_REVISION,
@@ -32,6 +36,8 @@ use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken}
 
 const MAX_SECURITY_DESCRIPTOR_BYTES: u32 = 64 * 1024;
 const MINIMUM_SID_BYTES: usize = 8;
+const MAX_TEMPORARY_ATTEMPTS: usize = 64;
+static NEXT_TEMPORARY: AtomicU64 = AtomicU64::new(0);
 
 pub(super) fn ensure_private_directory(path: &Path) -> Result<(), LocalHostError> {
     validate_absolute(path)?;
@@ -81,8 +87,10 @@ pub(super) fn open_private_lock(path: &Path) -> Result<File, LocalHostError> {
         )
     };
     let raw = if raw == INVALID_HANDLE_VALUE
-        && unsafe { windows_sys::Win32::Foundation::GetLastError() } == ERROR_ALREADY_EXISTS
-    {
+        && matches!(
+            unsafe { windows_sys::Win32::Foundation::GetLastError() },
+            ERROR_ALREADY_EXISTS | ERROR_FILE_EXISTS
+        ) {
         unsafe {
             CreateFileW(
                 wide.as_ptr(),
@@ -90,7 +98,7 @@ pub(super) fn open_private_lock(path: &Path) -> Result<File, LocalHostError> {
                 FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                 null(),
                 OPEN_EXISTING,
-                FILE_FLAG_OPEN_REPARSE_POINT,
+                FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
                 0,
             )
         }
@@ -101,6 +109,169 @@ pub(super) fn open_private_lock(path: &Path) -> Result<File, LocalHostError> {
     verify_regular_file(handle.as_raw_handle() as HANDLE)?;
     verify_owner_acl(handle.as_raw_handle() as HANDLE)?;
     Ok(File::from(handle))
+}
+
+pub(super) fn load_private_config(
+    path: &Path,
+    max_bytes: usize,
+) -> Result<Option<Vec<u8>>, LocalHostError> {
+    validate_absolute(path)?;
+    let parent = path.parent().ok_or(LocalHostError::InvalidPath)?;
+    let parent_handle = open_directory(parent)?;
+    verify_owner_acl(parent_handle.as_raw_handle() as HANDLE)?;
+    let wide = wide_path(path)?;
+    let raw = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            FILE_GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            0,
+        )
+    };
+    if raw == INVALID_HANDLE_VALUE {
+        return match unsafe { windows_sys::Win32::Foundation::GetLastError() } {
+            ERROR_FILE_NOT_FOUND | ERROR_PATH_NOT_FOUND => Ok(None),
+            _ => Err(LocalHostError::AccessFailed),
+        };
+    }
+    let handle = owned_handle(raw).map_err(|_| LocalHostError::AccessFailed)?;
+    verify_regular_file(handle.as_raw_handle() as HANDLE)?;
+    verify_owner_acl(handle.as_raw_handle() as HANDLE)?;
+    let file = File::from(handle);
+    let mut bytes = Vec::new();
+    file.take((max_bytes as u64).saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|_| LocalHostError::AccessFailed)?;
+    if bytes.is_empty() || bytes.len() > max_bytes {
+        return Err(LocalHostError::InvalidConfigBytes);
+    }
+    Ok(Some(bytes))
+}
+
+pub(super) fn create_private_config(
+    path: &Path,
+    bytes: &[u8],
+    max_bytes: usize,
+) -> Result<(), LocalHostError> {
+    if load_private_config(path, max_bytes)?.is_some() {
+        return Err(LocalHostError::ConfigAlreadyExists);
+    }
+    verify_config_parent(path)?;
+    let (temporary, temporary_path) = create_temporary(path)?;
+    let result = (|| {
+        persist_temporary(&temporary, bytes)?;
+        let source = wide_path(&temporary_path)?;
+        let destination = wide_path(path)?;
+        if unsafe {
+            MoveFileExW(
+                source.as_ptr(),
+                destination.as_ptr(),
+                MOVEFILE_WRITE_THROUGH,
+            )
+        } == 0
+        {
+            return Err(
+                match unsafe { windows_sys::Win32::Foundation::GetLastError() } {
+                    ERROR_ALREADY_EXISTS | ERROR_FILE_EXISTS => LocalHostError::ConfigAlreadyExists,
+                    _ => LocalHostError::AccessFailed,
+                },
+            );
+        }
+        Ok(())
+    })();
+    if result.is_err() {
+        delete_temporary(&temporary_path);
+    }
+    result
+}
+
+pub(super) fn compare_exchange_private_config(
+    path: &Path,
+    expected: &[u8],
+    replacement: &[u8],
+    max_bytes: usize,
+) -> Result<(), LocalHostError> {
+    if load_private_config(path, max_bytes)?.as_deref() != Some(expected) {
+        return Err(LocalHostError::ConfigConflict);
+    }
+    let (temporary, temporary_path) = create_temporary(path)?;
+    let result = (|| {
+        persist_temporary(&temporary, replacement)?;
+        let source = wide_path(&temporary_path)?;
+        let destination = wide_path(path)?;
+        let flags = MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH;
+        if unsafe { MoveFileExW(source.as_ptr(), destination.as_ptr(), flags) } == 0 {
+            return Err(LocalHostError::AccessFailed);
+        }
+        Ok(())
+    })();
+    if result.is_err() {
+        delete_temporary(&temporary_path);
+    }
+    result
+}
+
+fn verify_config_parent(path: &Path) -> Result<(), LocalHostError> {
+    validate_absolute(path)?;
+    let parent = path.parent().ok_or(LocalHostError::InvalidPath)?;
+    let handle = open_directory(parent)?;
+    verify_owner_acl(handle.as_raw_handle() as HANDLE)
+}
+
+fn create_temporary(path: &Path) -> Result<(File, PathBuf), LocalHostError> {
+    let parent = path.parent().ok_or(LocalHostError::InvalidPath)?;
+    for _ in 0..MAX_TEMPORARY_ATTEMPTS {
+        let sequence = NEXT_TEMPORARY.fetch_add(1, Ordering::Relaxed);
+        let temporary_path = parent.join(format!(
+            ".vault-pm.toml.tmp.{}.{}",
+            std::process::id(),
+            sequence
+        ));
+        let wide = wide_path(&temporary_path)?;
+        let mut security = OwnerSecurity::new(FILE_ALL_ACCESS)?;
+        let attributes = security.attributes();
+        let raw = unsafe {
+            CreateFileW(
+                wide.as_ptr(),
+                FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                &attributes,
+                CREATE_NEW,
+                FILE_FLAG_OPEN_REPARSE_POINT,
+                0,
+            )
+        };
+        if raw != INVALID_HANDLE_VALUE {
+            let handle = owned_handle(raw).map_err(|_| LocalHostError::AccessFailed)?;
+            verify_regular_file(handle.as_raw_handle() as HANDLE)?;
+            verify_owner_acl(handle.as_raw_handle() as HANDLE)?;
+            return Ok((File::from(handle), temporary_path));
+        }
+        if !matches!(
+            unsafe { windows_sys::Win32::Foundation::GetLastError() },
+            ERROR_ALREADY_EXISTS | ERROR_FILE_EXISTS
+        ) {
+            return Err(LocalHostError::AccessFailed);
+        }
+    }
+    Err(LocalHostError::AccessFailed)
+}
+
+fn persist_temporary(mut file: &File, bytes: &[u8]) -> Result<(), LocalHostError> {
+    file.write_all(bytes)
+        .map_err(|_| LocalHostError::AccessFailed)?;
+    file.sync_all().map_err(|_| LocalHostError::AccessFailed)
+}
+
+fn delete_temporary(path: &Path) {
+    if let Ok(wide) = wide_path(path) {
+        unsafe {
+            DeleteFileW(wide.as_ptr());
+        }
+    }
 }
 
 fn create_private_directory(path: &Path) -> Result<(), LocalHostError> {

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1412,6 +1412,10 @@ changelog, focused build, and downstream validation.
     deterministic TOML rendering, using `VLT-PM07-config.md`. It persists the
     opaque bootstrap locator and typed storage selections without receiving
     passphrases, provider credentials, item metadata, or host capabilities.
+8d. `vault-pm-local-host`: exact bounded configuration loading plus atomic
+    owner-only initial creation and compare-and-exchange, guarded by the same
+    cross-process writer capability. Persistence remains schema-blind and
+    safely stores canonical bytes emitted by `vault-pm-config`.
 9. `vault-pm-cli` + real executable and pseudo-terminal E2E suite.
 10. Crash/fault matrix and local restore drill.
 

--- a/code/specs/VLT-PM06-local-host.md
+++ b/code/specs/VLT-PM06-local-host.md
@@ -16,8 +16,9 @@ before the local CLI composes those primitives. It owns:
 1. platform-standard per-user path resolution;
 2. creation and validation of owner-private local roots;
 3. separation of owner state from encrypted immutable objects;
-4. rejection of linked or substituted filesystem objects; and
-5. non-blocking cross-process single-writer exclusion.
+4. rejection of linked or substituted filesystem objects;
+5. non-blocking cross-process single-writer exclusion; and
+6. bounded, owner-private, atomic configuration persistence.
 
 It does not parse CLI arguments, prompt for a passphrase, generate entropy,
 understand vault bytes, select a cloud provider, or repair permissions.
@@ -46,6 +47,7 @@ local data, and cache. The local-data root contains two disjoint subtrees:
 
 ```text
 <config-root>/                    non-secret strict configuration
+  vault-pm.toml                   exact VLT-PM07 configuration bytes
 <data-root>/
   application-state/             bootstrap generations and owner-private state
   objects/                       encrypted immutable repository objects
@@ -152,7 +154,36 @@ instances and hold it through all reads, recovery, publication, and final
 rendering. Read-only commands may be relaxed later only after every involved
 adapter has a proven cross-process snapshot contract.
 
-## 8. Closed failures
+## 8. Configuration persistence
+
+Configuration is stored as exact non-empty bytes at
+`<config-root>/vault-pm.toml`, bounded to 65,536 bytes. The local-host package
+does not parse or render those bytes; the storage-neutral `vault-pm-config`
+package owns the VLT-PM07 schema. Load, initial create, and replacement are
+available only through the live writer guard, so every cooperating process has
+already passed native root validation and acquired cross-process exclusion.
+
+Load returns `None` only when the file is absent. An existing object must be a
+regular, non-link, current-owner file with owner-only access. Empty, oversized,
+linked, reparse, wrong-type, foreign-owner, and broadly accessible objects fail
+closed before bytes are returned.
+
+Initial create stages an owner-only file in the configuration directory,
+writes and synchronizes all bytes, and publishes it without replacing an
+existing name. Replacement is exact-value compare-and-exchange: the durable
+bytes must equal the caller's expected bytes before a same-directory staged
+file atomically replaces the name. A stale or absent value returns
+`ConfigConflict`. Unix publishes initial state with a descriptor-relative hard
+link, replaces with descriptor-relative rename, and synchronizes the directory.
+Windows uses a protected single-owner DACL and write-through move, adding the
+replace flag only for compare-and-exchange.
+
+A failed operation never truncates or partially writes the named configuration.
+A crash may leave an owner-private `.vault-pm.toml.tmp.*` staging file; loaders
+ignore such files, and a later operation uses a unique name. Automatic scanning
+or deletion of unknown residue is outside this contract.
+
+## 9. Closed failures
 
 The stable local-host failure classes are:
 
@@ -166,14 +197,18 @@ The stable local-host failure classes are:
 | `InsecureOwner` | an existing private object belongs to another user |
 | `InsecurePermissions` | an existing private object grants broader access |
 | `AlreadyLocked` | another process currently owns the writer lock |
+| `ConfigAlreadyExists` | initial creation found existing configuration |
+| `ConfigConflict` | expected bytes did not match durable configuration |
+| `InvalidConfigBytes` | configuration was empty or exceeded 65,536 bytes |
 | `UnsupportedPlatform` | no audited native implementation exists |
 
-The executable maps invalid injected paths to exit class 2, lock contention to
-exit class 5, integrity/security-policy failures to exit class 6, unsupported
-targets to exit class 8, and unexpected native access failures to exit class
-10. Human diagnostics remain low resolution.
+The executable maps invalid injected paths and duplicate initialization to exit
+class 2, lock or compare-and-exchange contention to exit class 5,
+integrity/security-policy failures (including invalid durable configuration) to
+exit class 6, unsupported targets to exit class 8, and unexpected native access
+failures to exit class 10. Human diagnostics remain low resolution.
 
-## 9. Composition rule
+## 10. Composition rule
 
 The initial filesystem composition is:
 
@@ -181,6 +216,7 @@ The initial filesystem composition is:
 LocalVaultPaths::resolve
   -> prepare
   -> try_acquire_writer
+  -> load/create/compare-exchange strict VLT-PM07 configuration bytes
   -> FsStorageBackend(application-state)
      -> StorageCoreApplicationStore
   -> FsStorageBackend(objects)
@@ -190,14 +226,15 @@ LocalVaultPaths::resolve
 ```
 
 The application and object adapters do not receive the config or cache root.
-The local-host package does not receive vault IDs, locators, passphrases,
-plaintext documents, provider credentials, or serialized owner state.
+The local-host package receives only opaque configuration bytes; it does not
+receive parsed vault IDs, locators, passphrases, plaintext documents, provider
+credentials, or serialized owner state.
 
 Replacing `FsStorageBackend(objects)` with Google Drive, WebDAV, S3, or an
 in-memory test backend does not change path preparation for local owner state
 and does not change the application contract.
 
-## 10. Acceptance tests
+## 11. Acceptance tests
 
 The package is complete for Phase 1A when automated tests prove:
 
@@ -210,8 +247,13 @@ The package is complete for Phase 1A when automated tests prove:
 6. one guard excludes a second independently opened guard;
 7. dropping the first guard permits a later acquisition;
 8. the lock file itself is owner-only and persistent;
-9. invalid injected paths fail before filesystem access; and
-10. errors and `Debug` output contain no resolved paths.
+9. invalid injected paths fail before filesystem access;
+10. errors and `Debug` output contain no resolved paths;
+11. configuration creation never replaces an existing safe or unsafe object;
+12. configuration load returns exact bounded bytes and rejects unsafe objects;
+13. compare-and-exchange rejects stale or absent expected bytes without change;
+14. successful create and replacement survive close and reopen; and
+15. created configuration uses owner-only native security metadata.
 
 The real CLI pseudo-terminal suite must additionally run two executable
 processes against the same injected roots and observe one deterministic lock


### PR DESCRIPTION
## Summary

- add guard-scoped exact loading, initial creation, and compare-and-exchange for the bounded VLT-PM07 configuration bytes
- stage owner-only writes in the configuration directory and publish atomically with Unix directory synchronization or Windows write-through moves
- reject empty, oversized, linked, reparse, wrong-type, foreign-owner, broadly accessible, duplicate, and stale configuration state without exposing paths or payloads
- correct Windows lock reopening for both documented existing-file errors and safe directory/reparse inspection
- extend VLT-PM06, the product backlog, capability declarations, README, and changelog

## Validation

- `bash vault-pm-local-host/BUILD` from `code/packages/rust`
- denied-warning Clippy on native macOS, `x86_64-unknown-linux-gnu`, and `x86_64-pc-windows-gnu`
- rustdoc with warnings denied
- Tarpaulin LLVM: 304/319 Unix production lines (95.30%)
- repository build tool: 1005 discovered, 1 changed, 1 affected, 1 built
