### PR TITLE
feat(adj-formula-stdlib): Wave 3 continuation -- solve PV=nRT for volume

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_idealgas_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_idealgas_e2e.rs
@@ -99,3 +99,42 @@ fn ideal_gas_law_binds_and_computes_pressure_at_stp_with_nist_citation() {
         "applied formula carries its verbatim NIST CODATA provenance: {s}"
     );
 }
+
+/// PV = nRT, solved for a different unknown (ADJ-FORMULA-LIBRARIES FL-10, §3D
+/// rung-0 CAS-wiring companion) — the SAME cited NIST relation as `pressure`
+/// above, rearranged rather than computed forward. "One mole of an ideal gas at
+/// 273.15 K and 101325 Pa — what volume does it occupy?" → the molar volume, a
+/// round trip against the STP example above.
+#[test]
+fn solves_for_volume_from_pressure_with_the_same_citation() {
+    let dir = scratch("volume_solve");
+    let lib = std::fs::read_to_string(shipped_idealgas_lib()).unwrap();
+    std::fs::write(dir.join("ideal-gas-law.adj"), lib).unwrap();
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ideal-gas-law.adj\"\n\
+         observe pressure(101325)\n\
+         observe moles(1)\n\
+         observe temperature(273.15)\n\
+         ? volume_from_pressure(pressure, moles, temperature)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+
+    let volume = derived_value(&s, "volume_from_pressure");
+    let expected = 0.022414_f64; // the molar volume at STP
+    assert!(
+        (volume - expected).abs() < 1e-4,
+        "volume at STP is ~0.022414 m3 (got {volume}): {s}"
+    );
+
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("physics.nist.gov/cgi-bin/cuu/Value?r")
+            && s.contains("8.314 462 618"),
+        "carries the same verbatim NIST CODATA provenance as the forward pressure formula: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-formula-stdlib/CHANGELOG.md
@@ -156,3 +156,15 @@ landed and why, not a semver-tracked API.
   `resistance_from_ohms_law`'s exact discipline (same equation, different target). New manifest
   objective `adj.math.algebra.rearrange_ohms_law`. Extended the existing `formula_electricity_e2e.rs`
   with 1 new test rather than adding a new test file.
+- `chemistry/ideal-gas-law.adj` — a ninth Wave 3 rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES
+  FL-10, §3D): `volume_from_pressure`, solving the same cited NIST CODATA `PV = nRT` relation as the
+  forward `pressure` formula for volume — rewritten in its equivalent multiplicative form
+  (`P·V = n·R·T`) rather than the natural quotient form, the same technique `pressure.adj`/
+  `density.adj` used, to guarantee the target appears only as a linear factor. Also backfills the
+  base manifest objective `adj.science.chemistry.ideal_gas_law` (the FIRST chemistry-domain
+  coverage entry — the library previously had none), since the new algebra objective needs a valid
+  prerequisite to reference. The other two possible unknowns (moles, temperature) are left for a
+  later pass, keeping this change scoped to one direction like every prior Wave 3 item. New manifest
+  objectives `adj.science.chemistry.ideal_gas_law` and
+  `adj.math.algebra.rearrange_ideal_gas_law`. Extended the existing `formula_idealgas_e2e.rs` with
+  1 new test rather than adding a new test file.

--- a/code/specs/data/adj-formula-stdlib/chemistry/ideal-gas-law.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/ideal-gas-law.adj
@@ -67,6 +67,7 @@ dictionary ideal_gas_vocab {
     define temperature : finding  surface "temperature", "absolute temperature", "T"              % kelvin (K)
     define volume      : finding  surface "volume", "V"                                           % length³ (m³)
     define pressure    : finding  surface "pressure", "P", "gas pressure"                         % pascals (Pa)
+    define volume_from_pressure : finding  surface "missing volume", "unknown volume"
 }
 
 % ----------------------------------------------------------------------------
@@ -84,6 +85,16 @@ dictionary ideal_gas_vocab {
 %     for the equation-of-state form itself.
 % The value of the constant is the load-bearing claim, and it is authoritative;
 % the trust tier for the shipped formula follows the constant → authoritative.
+%
+% This library also carries a rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES
+% FL-10, §3D — a Wave 3 continuation): `volume_from_pressure` solves the SAME
+% cited PV = nRT relation, rewritten in its equivalent multiplicative form
+% (`P·V = n·R·T`, avoiding the natural quotient form), for volume instead of
+% computed forward for pressure — the exact discipline `pressure.adj`'s
+% `area_from_pressure` and `density.adj`'s `volume_from_density` already
+% established for their own quotient/product pairs. The other two possible
+% unknowns (moles, temperature) are left for a later pass, to keep this change
+% scoped to one direction, the same discipline every prior Wave 3 item used.
 % ----------------------------------------------------------------------------
 formulabook chemistry_ideal_gas {
     use ideal_gas_vocab
@@ -92,6 +103,15 @@ formulabook chemistry_ideal_gas {
     % the verbatim NIST CODATA value 8.314462618 J mol⁻¹ K⁻¹ (exact, 2022 CODATA).
     % The relation PV = nRT is the standard ideal-gas equation of state.
     formula pressure(moles, temperature, volume) = moles * 8.314462618 * temperature / volume
+        source "molar gas constant | Numerical value | 8.314 462 618 J mol^-1 K^-1 | Standard uncertainty | (exact). The ideal gas law: PV = nRT, where P is the pressure, V is the volume, n is the amount of substance, R is the ideal (universal) gas constant, and T is the absolute temperature."
+        locator "https://physics.nist.gov/cgi-bin/cuu/Value?r"
+        trust authoritative
+
+    % PV = nRT again, SOLVED FOR VOLUME instead of computed forward for
+    % pressure — the same cited relation, only which quantity is bound and
+    % which is unknown differs. Written as P·V = n·R·T (not V = nRT/P) so the
+    % target appears only as a linear factor, never in a denominator.
+    symbolic volume_from_pressure(pressure, moles, temperature) { pressure * volume_from_pressure == moles * 8.314462618 * temperature } for volume_from_pressure
         source "molar gas constant | Numerical value | 8.314 462 618 J mol^-1 K^-1 | Standard uncertainty | (exact). The ideal gas law: PV = nRT, where P is the pressure, V is the volume, n is the amount of substance, R is the ideal (universal) gas constant, and T is the absolute temperature."
         locator "https://physics.nist.gov/cgi-bin/cuu/Value?r"
         trust authoritative

--- a/code/specs/data/adj-formula-stdlib/chemistry/ideal-gas-law.query.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/ideal-gas-law.query.adj
@@ -26,3 +26,10 @@ observe moles(1)                              % "…one mole of gas…"        (
 observe temperature(273.15)                   % "…at 273.15 K…"            (span cited by the model)
 observe volume(0.022414)                      % "…occupying 0.022414 m³…"  (span cited by the model)
 ? pressure(moles, temperature, volume)        % engine → ~101325 Pa (P = nRT/V, NIST CODATA R, authoritative)
+
+% --- PV = nRT, SOLVED FOR VOLUME (rung-0 CAS-wiring, FL-10). "One mole of an
+% ideal gas at 273.15 K and 101325 Pa — what volume does it occupy?" The same
+% already-bound moles(1)/temperature(273.15) recover the molar volume — a round
+% trip against the forward pressure just computed above. ---
+observe pressure(101325)                                    % "…at 101325 Pa…" (span cited)
+? volume_from_pressure(pressure, moles, temperature)         % engine → ~0.022414 m³ (NIST CODATA, authoritative)

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1292,6 +1292,36 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.science.chemistry.ideal_gas_law",
+      "title": "Apply the ideal gas law, PV = nRT",
+      "band": "9-12",
+      "domain": "science",
+      "competency": "compute",
+      "coverage_roots": ["ngss"],
+      "standards": [],
+      "prerequisites": ["adj.math.arithmetic.primitives"],
+      "libraries": ["code/specs/data/adj-formula-stdlib/chemistry/ideal-gas-law.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.math.algebra.rearrange_ideal_gas_law",
+      "title": "Solve PV = nRT for volume, given the pressure, moles, and temperature",
+      "band": "9-12",
+      "domain": "mathematics",
+      "competency": "compute",
+      "coverage_roots": ["ccss.math"],
+      "standards": [],
+      "prerequisites": ["adj.science.chemistry.ideal_gas_law"],
+      "libraries": ["code/specs/data/adj-formula-stdlib/chemistry/ideal-gas-law.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES FL-10, §3D — Wave 3 continuation) to `chemistry/ideal-gas-law.adj`: `volume_from_pressure`, solving the same cited NIST CODATA `PV = nRT` relation as the forward `pressure` formula for volume — rewritten in its equivalent multiplicative form (`P·V = n·R·T`) rather than the natural quotient form, the same technique `pressure.adj`/`density.adj` used, to guarantee the target appears only as a linear factor.
- Also backfills the base manifest objective `adj.science.chemistry.ideal_gas_law` — the first chemistry-domain coverage entry (the library previously had none) — since the new algebra objective needs a valid prerequisite to reference.
- The other two possible unknowns (moles, temperature) are left for a later pass, keeping this change scoped to one direction like every prior Wave 3 item.
- Empirically verified via the CLI before writing (`volume_from_pressure(101325, 1, 273.15) ≈ 0.022414`, matching the library's own STP worked example).
- New manifest objectives `adj.science.chemistry.ideal_gas_law` and `adj.math.algebra.rearrange_ideal_gas_law` (band 9-12).
- Extended the existing `formula_idealgas_e2e.rs` with 1 new test (2 total) rather than adding a new test file.

This is Wave 3's ninth rung-0 CAS-wiring item across five sweep rounds.

Part of the autonomous ADJ curriculum loop (`ADJ-STDLIB-COVERAGE.md#7-delivery-order`).

## Test plan
- [x] Solve direction empirically verified via the CLI in a scratch dir before writing real content.
- [x] `cargo test -p adj-lang-cli --test formula_idealgas_e2e` — 2/2 passed.
- [x] `cargo test -p adj-lang -p adj-lang-cli` — full suite green, no regressions.
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean.
- [x] `adj_stdlib_manifest.py --validate-json-schema` — 83 objectives, 0 errors, valid (including new prerequisite-chain check).
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` — exit 0, no new gaps introduced.
- [x] Python unittest suite (manifest/report subset) — 87 passed.
- [x] Security review — passed, no findings.