### PR TITLE
feat(hl-tamil): teach the ூ sign, and measure the end of the strand's runway

### DIFF
--- a/code/learning/human-languages/README.md
+++ b/code/learning/human-languages/README.md
@@ -124,7 +124,7 @@ enter cross-language review only after focused retrieval.
 | [German](./german/README.md) | Germanic / Latin | 106 | 91 | 31 chapters; through Ch. 31; 15 generated |
 | [Arabic](./arabic/README.md) | Semitic / Arabic | 100 | 98 | 36 chapters; through Ch. 36; 34 generated |
 | [Hindi](./hindi/README.md) | Indo-Aryan / Devanagari | 109 | 103 | 39 chapters; through Ch. 39; 34 generated |
-| [Tamil](./tamil/README.md) | Dravidian / Tamil | 127 | 123 | 38 chapters; through Ch. 38; 33 generated |
+| [Tamil](./tamil/README.md) | Dravidian / Tamil | 128 | 124 | 38 chapters; through Ch. 38; 33 generated |
 | [Kannada](./kannada/README.md) | Dravidian / Kannada | 88 | 84 | 40 chapters; through Ch. 40; 35 generated |
 | [Telugu](./telugu/README.md) | Dravidian / Telugu | 74 | 70 | 34 chapters; through Ch. 34; 29 generated |
 | [Malayalam](./malayalam/README.md) | Dravidian / Malayalam | 78 | 74 | 34 chapters; through Ch. 34; 29 generated |

--- a/code/learning/human-languages/core/generated-book-hashes.json
+++ b/code/learning/human-languages/core/generated-book-hashes.json
@@ -4108,11 +4108,12 @@
     {
       "language": "tamil",
       "chapter": 38,
-      "sourceHash": "fnv1a64:8c7ff3fb6f448f06",
+      "sourceHash": "fnv1a64:054d73c0361cdf30",
       "lessonIds": [
         "TA-C38-udambu",
         "TA-C38-sugam",
-        "TA-C38-vidai"
+        "TA-C38-vidai",
+        "TA-W19-read-muunru"
       ],
       "tex": "tamil/book/chapters/ch38-keeping-well-and-leaving.tex"
     },

--- a/code/learning/human-languages/core/generated-narration-hashes.json
+++ b/code/learning/human-languages/core/generated-narration-hashes.json
@@ -7630,18 +7630,19 @@
     {
       "language": "tamil",
       "chapter": 38,
-      "sourceHash": "fnv1a64:02d8bcf3e16a7add",
+      "sourceHash": "fnv1a64:7e4402eac9febba1",
       "lessonIds": [
         "TA-C38-udambu",
         "TA-C38-sugam",
-        "TA-C38-vidai"
+        "TA-C38-vidai",
+        "TA-W19-read-muunru"
       ],
       "voiceLessons": 0,
       "drivablePrefix": 0,
       "text": "tamil/narration/ch38.txt",
       "json": "tamil/narration/ch38.json",
-      "textHash": "fnv1a64:a5992018dceb6f58",
-      "jsonHash": "fnv1a64:bc1f7c59145681fd"
+      "textHash": "fnv1a64:97141d0965ec7b3e",
+      "jsonHash": "fnv1a64:ecfd939ca8af3248"
     },
     {
       "language": "telugu",

--- a/code/learning/human-languages/core/lesson-modality.json
+++ b/code/learning/human-languages/core/lesson-modality.json
@@ -7,12 +7,12 @@
   "policy": {
     "maxLinearisableTableColumns": 3
   },
-  "sourceHash": "fnv1a64:20e6a728d8039764",
+  "sourceHash": "fnv1a64:462d84aa9f1a2082",
   "summary": {
-    "totalLessons": 1689,
+    "totalLessons": 1690,
     "voice": 1114,
     "sight": 508,
-    "pen": 67,
+    "pen": 68,
     "drivableLessons": 1114,
     "drivablePercent": 66,
     "trackCount": 22,
@@ -7548,11 +7548,11 @@
     },
     {
       "language": "tamil",
-      "lessonCount": 127,
+      "lessonCount": 128,
       "voice": 76,
       "sight": 29,
-      "pen": 22,
-      "drivablePercent": 60,
+      "pen": 23,
+      "drivablePercent": 59,
       "drivablePrefixTotal": 60,
       "modalities": [
         "voice",
@@ -8210,12 +8210,13 @@
         },
         {
           "chapter": 38,
-          "lessonCount": 3,
+          "lessonCount": 4,
           "voice": 0,
           "sight": 3,
-          "pen": 0,
+          "pen": 1,
           "modalities": [
-            "sight"
+            "sight",
+            "pen"
           ],
           "drivablePrefix": 0,
           "firstNonVoiceLesson": "TA-C38-udambu",
@@ -38603,6 +38604,30 @@
       "detachableSegments": [
         "The letters in this word"
       ]
+    },
+    {
+      "id": "TA-W19-read-muunru",
+      "language": "tamil",
+      "chapter": 38,
+      "sequence": 1165,
+      "modality": "pen",
+      "derived": "pen",
+      "drivable": false,
+      "reasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "coreModality": "pen",
+      "coreReasons": [
+        "writing-type"
+      ],
+      "coreDrivable": false,
+      "sourceHash": "fnv1a64:2ef84654a6ca9fcb",
+      "detachableSegments": [
+        "Script you'll notice: the ூ sign",
+        "Script you'll notice: build the word"
+      ],
+      "delivery": "script"
     },
     {
       "id": "TE-C01-avunu",

--- a/code/learning/human-languages/tamil/README.md
+++ b/code/learning/human-languages/tamil/README.md
@@ -99,12 +99,15 @@ through.
   native நலம்), and விடை (*viḍai*) — which the Dravidian dictionary files
   in the **same entry as வீடு**, so the arc walks in through the house and out
   through the leave on one root. In the book, Chapters 35–38.
-- **The script strand, W01–W18** ([`lessons/TA-W*`](./lessons/)): 22 lessons
+- **The script strand, W01–W19** ([`lessons/TA-W*`](./lessons/)): 23 lessons
   marked `delivery: script`, one after roughly every third speaking lesson from
-  Chapter 4 to Chapter 37. They teach curves, the abugida, retroflexion, the
+  Chapter 4 to Chapter 38. They teach curves, the abugida, retroflexion, the
   three Tamil n letters, the puḷḷi, the vowel signs, and then spell — one word
   per lesson — words the learner has already been saying, from **வணக்கம்** to
-  **தமிழ்**. Chapters 1–3 hold no writing lesson at all, on purpose.
+  **மூன்று**. Chapters 1–3 hold no writing lesson at all, on purpose. The strand
+  ends there because it runs out of room, not because the script is finished:
+  thirteen glyphs the Chapter 7 numbers use — ஏ, ஐ, ஒ and the ten Tamil digits
+  ௧–௰ — are still never taught, and there is no chapter left to teach them in.
 
 ---
 

--- a/code/learning/human-languages/tamil/book/chapter-modalities.tex
+++ b/code/learning/human-languages/tamil/book/chapter-modalities.tex
@@ -289,7 +289,7 @@
 
 \expandafter\def\csname hlchaptermodality38\endcsname{%
   {\small\noindent
-    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (3)\quad
-    \hlvoicesign{}~\textbf{Hands-free start:} all 3 lessons.%
+    \textbf{Modes:} \hlsightsign{}~\textbf{eyes} (3) \quad \hlpensign{}~\textbf{pen} (1)\quad
+    \hlvoicesign{}~\textbf{Hands-free start:} first 3 of 4 lessons.%
     \par}\medskip
 }

--- a/code/learning/human-languages/tamil/book/chapters/appendix-index.tex
+++ b/code/learning/human-languages/tamil/book/chapters/appendix-index.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons or chapters.json, then run npm run generate:books.
-% canonical-index-candidates: 160
-% canonical-index-entries: 160
+% canonical-index-candidates: 161
+% canonical-index-entries: 161
 
 \chapter*{Index}
 \addcontentsline{toc}{chapter}{Index}
@@ -996,6 +996,12 @@ Look up an English meaning, a dedicated language topic, or a chapter topic. Each
 \raggedright
 \textbf{\ta{மன்னிக்கவும்} — formal forgiveness and a doubled n}\par
 \footnotesize grammar topic; explicit focus: script, usage and culture; \hyperref[ch:ta-sorry]{Chapter~9, p.~\pageref*{ch:ta-sorry}}
+\end{minipage}\par\smallskip
+
+\noindent\begin{minipage}[t]{\linewidth}
+\raggedright
+\textbf{\ta{மூன்று} — the fourth corner of the u-family}\par
+\footnotesize script and writing topic; explicit focus: script; \hyperref[ch:ta-keeping-well-and-leaving]{Chapter~38, p.~\pageref*{ch:ta-keeping-well-and-leaving}}
 \end{minipage}\par\smallskip
 
 \noindent\begin{minipage}[t]{\linewidth}

--- a/code/learning/human-languages/tamil/book/chapters/ch38-keeping-well-and-leaving.tex
+++ b/code/learning/human-languages/tamil/book/chapters/ch38-keeping-well-and-leaving.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE. Edit canonical lessons, then run npm run generate:books.
-% canonical-source-hash: fnv1a64:8c7ff3fb6f448f06
-% canonical-lessons: TA-C38-udambu, TA-C38-sugam, TA-C38-vidai
+% canonical-source-hash: fnv1a64:054d73c0361cdf30
+% canonical-lessons: TA-C38-udambu, TA-C38-sugam, TA-C38-vidai, TA-W19-read-muunru
 
 \chapter{Keeping Well, and Leaving}
 \label{ch:ta-keeping-well-and-leaving}
@@ -201,4 +201,67 @@ Say these aloud:
 
 \begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
 Take your leave formally, thanks in front of it, and name the earlier word that shares this root. (\emph{Naṉṟi. viḍai peṟugiṟēṉ.}; \textbf{\ta{வீடு}}, from \textbf{\ta{விடு}}, \textquotedblleft{}to let go.\textquotedblright{}) Do \textbf{\ta{ஊர்}} and \textbf{\ta{நண்பன்}} belong to that root? (\textbf{No} — a settlement and a closeness; not everything joins up.)
+\end{tcolorbox}
+\section[mūṉṟu]{\ta{மூன்று} — the fourth corner of the u-family}
+
+\label{lesson:TA-W19-read-muunru}
+
+
+
+\begin{quote}
+Three corners of one family are already yours: \textbf{\ta{உ}} and \textbf{\ta{ஊ}}, the letters that open a word, and \textbf{\ta{ு}}, the short sign that rides a consonant. One corner is missing, and you can guess what it does.
+\end{quote}
+
+\subsection*{Script you'll notice: the \ta{ூ} sign}
+\textbf{\ta{ூ}} is the sign for long \emph{ū} — the long partner of \textbf{\ta{ு}}, exactly as \textbf{\ta{ஊ}} is the long partner of \textbf{\ta{உ}}. Both members of each pair, in both jobs:
+
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{} & \textbf{opens a word} & \textbf{rides a consonant} \\
+\midrule
+short \emph{u} & \textbf{\ta{உ}} & \textbf{\ta{ு}} \\
+long \emph{ū} & \textbf{\ta{ஊ}} & \textbf{\ta{ூ}} \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{ம} + \ta{ூ} $\to$ \ta{மூ}}, said \emph{mū}.
+\end{quote}
+
+The four corners are a pattern, not the whole system. Short \textbf{a} is the vowel with no sign at all: the data says a consonant carries a built-in \emph{a} until a mark replaces it, which is why \textbf{\ta{க}} needs nothing to be \emph{ka}. Nor do signs all sit in one place — the \textbf{\ta{ை}} you met in \textbf{\ta{இல்லை}} is written to the LEFT of its consonant, which the data does say; where \textbf{\ta{ு}} and \textbf{\ta{ூ}} sit is this lesson's own description, since the data has no entry for either.
+
+\begin{quote}
+Read it; do not draw it yet. None of \textbf{\ta{உ}}, \textbf{\ta{ஊ}}, \textbf{\ta{ு}} or \textbf{\ta{ூ}} has an entry in this book's script data, so none of them gets a stroke order, and the pairing above is what the page shows rather than something the data states.
+\end{quote}
+
+\subsection*{Script you'll notice: build the word}
+\noindent
+\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X>{\raggedright\arraybackslash}X@{}}
+\toprule
+\textbf{piece} & \textbf{} & \textbf{} \\
+\midrule
+\textbf{\ta{மூ}} & \emph{mū} — \textbf{\ta{ம}} with the \ta{ூ} sign & \ta{ம} from \textbf{\ta{வணக்கம்}} \\
+\textbf{\ta{ன்}} & bare \emph{ṉ} — \textbf{\ta{ன}} under a puḷḷi & the alveolar \emph{n} \\
+\textbf{\ta{று}} & \emph{ṟu} — \textbf{\ta{ற}}, the hard \emph{r}, with the \textbf{\ta{ு}} sign & \ta{ற} from \textbf{\ta{நன்றி}} \\
+\bottomrule
+\end{tabularx}
+
+\begin{quote}
+\textbf{\ta{மூ} · \ta{ன்} · \ta{று} $\to$ \ta{மூன்று}}
+\end{quote}
+
+Three pieces, one new sign. \textbf{\ta{மூன்று}} is \textquotedblleft{}three\textquotedblright{} — a word you have counted with since chapter 7, and now one you can read. It joins \textbf{\ta{இரண்டு}}, \textbf{\ta{நான்கு}}, \textbf{\ta{ஆறு}}, \textbf{\ta{எட்டு}} and \textbf{\ta{பத்து}}, whose letters the strand has already given you; \textbf{\ta{ஒன்று}}, \textbf{\ta{ஐந்து}}, \textbf{\ta{ஏழு}} and \textbf{\ta{ஒன்பது}} still wait on letters this book has not taught.
+
+\subsection*{Your turn}
+\begin{itemize}
+\raggedright
+  \item \emph{Read it:} \textbf{\ta{மூ}} — then \textbf{\ta{மூன்று}}
+  \item \emph{Say it:} \textquotedblleft{}mūṉṟu\textquotedblright{} — \textquotedblleft{}three\textquotedblright{}
+  \item \emph{Contrast:} \textbf{\ta{று}} and \textbf{\ta{மூ}} — the short sign and the long one, both riding
+  \item \emph{Contrast:} \textbf{\ta{ஊர்}} and \textbf{\ta{மூன்று}} — long \emph{ū} standing, then long \emph{ū} riding
+\end{itemize}
+
+\begin{tcolorbox}[breakable,colback=teal!4,colframe=teal!35!black,title={Before you move on}]
+Read \textbf{\ta{மூன்று}}. Which sign is \textbf{\ta{ூ}}'s short partner, and which letter is its standing form? (\textbf{\ta{ு}}, and \textbf{\ta{ஊ}}.) Name the four corners of that family. (\textbf{\ta{உ} \ta{ஊ}} standing, \textbf{\ta{ு} \ta{ூ}} riding.) What is the dot on \textbf{\ta{ன்}} doing? (\textbf{Removing the built-in \emph{a}}.)
 \end{tcolorbox}

--- a/code/learning/human-languages/tamil/curriculum.json
+++ b/code/learning/human-languages/tamil/curriculum.json
@@ -51,7 +51,8 @@
         "TA-W14-read-pesu",
         "TA-W15-read-po",
         "TA-W17-read-unavu",
-        "TA-W18-read-uur"
+        "TA-W18-read-uur",
+        "TA-W19-read-muunru"
       ],
       "before": [],
       "inline": [
@@ -902,7 +903,8 @@
         "TA-W14-read-pesu",
         "TA-W15-read-po",
         "TA-W17-read-unavu",
-        "TA-W18-read-uur"
+        "TA-W18-read-uur",
+        "TA-W19-read-muunru"
       ]
     },
     {

--- a/code/learning/human-languages/tamil/lessons/TA-W19-read-muunru.md
+++ b/code/learning/human-languages/tamil/lessons/TA-W19-read-muunru.md
@@ -1,0 +1,96 @@
+---
+schema_version: 2
+id: TA-W19-read-muunru
+spine_node: SPINE-MEET-GREET
+sequence: 1165
+delivery: script
+chapter: 38
+type: writing
+headword: "மூன்று"
+gloss: the ூ sign, closing the u-family opened in chapters 31, 36 and 37
+romanization: "mūṉṟu"
+prerequisites: [TA-W18-read-uur, TA-W13-read-irukkirirgal]
+sounds: [matra-uu, pulli]
+roots: []
+duration:
+  max_seconds: 280
+requires:
+  knowledge: [TA-SCRIPT-UU-VOWEL-01, TA-SCRIPT-READ-UUR-02, TA-SCRIPT-U-VOWEL-01, TA-SCRIPT-U-SIGN-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-SCRIPT-PULLI-VANAKKAM-01]
+introduces:
+  knowledge: [TA-SCRIPT-UU-SIGN-01, TA-SCRIPT-READ-MUUNRU-02]
+practises:
+  knowledge: [TA-SCRIPT-UU-VOWEL-01, TA-SCRIPT-READ-UUR-02, TA-SCRIPT-U-VOWEL-01, TA-SCRIPT-U-SIGN-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-SCRIPT-PULLI-VANAKKAM-01, TA-SCRIPT-UU-SIGN-01, TA-SCRIPT-READ-MUUNRU-02]
+skills: [reading]
+modes: [interpretive]
+strands: [meaning-input, language-focus]
+register: neutral
+variety: standard-colloquial
+reviews_of: [TA-W18-read-uur, TA-W17-read-unavu, TA-C07-numbers-1-5]
+---
+
+# மூன்று — the fourth corner of the u-family
+
+## Warm-up
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-U-VOWEL-01, TA-SCRIPT-UU-VOWEL-01, TA-SCRIPT-U-SIGN-01] -->
+
+[PAUSE 2s] Three corners of one family are already yours: **உ** and **ஊ**, the
+letters that open a word, and **ு**, the short sign that rides a consonant. One
+corner is missing, and you can guess what it does.
+
+## Script you'll notice: the ூ sign
+<!-- hl-knowledge: introduces=[TA-SCRIPT-UU-SIGN-01]; assesses=[TA-SCRIPT-U-SIGN-01, TA-SCRIPT-UU-VOWEL-01] -->
+
+**ூ** is the sign for long *ū* — the long partner of **ு**, exactly as **ஊ** is
+the long partner of **உ**. Both members of each pair, in both jobs:
+
+| | opens a word | rides a consonant |
+|---|---|---|
+| short *u* | **உ** | **ு** |
+| long *ū* | **ஊ** | **ூ** |
+
+> **ம + ூ → மூ**, said *mū*.
+
+The four corners are a pattern, not the whole system. Short **a** is the vowel
+with no sign at all: the data says a consonant carries a built-in *a* until a
+mark replaces it, which is why **க** needs nothing to be *ka*. Nor do signs all
+sit in one place — the **ை** you met in **இல்லை** is written to the LEFT of its
+consonant, which the data does say; where **ு** and **ூ** sit is this lesson's
+own description, since the data has no entry for either.
+
+> Read it; do not draw it yet. None of **உ**, **ஊ**, **ு** or **ூ** has an entry
+> in this book's script data, so none of them gets a stroke order, and the
+> pairing above is what the page shows rather than something the data states.
+
+## Script you'll notice: build the word
+<!-- hl-knowledge: introduces=[TA-SCRIPT-READ-MUUNRU-02]; assesses=[TA-SCRIPT-UU-SIGN-01, TA-SCRIPT-MA-RETROFLEX-NA-01, TA-SCRIPT-THREE-NS-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-01, TA-SCRIPT-VOWEL-SIGNS-NANDRI-02, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+| piece | | |
+|---|---|---|
+| **மூ** | *mū* — **ம** with the ூ sign | ம from **வணக்கம்** |
+| **ன்** | bare *ṉ* — **ன** under a puḷḷi | the alveolar *n* |
+| **று** | *ṟu* — **ற**, the hard *r*, with the **ு** sign | ற from **நன்றி** |
+
+> **மூ · ன் · று → மூன்று**
+
+Three pieces, one new sign. **மூன்று** is "three" — a word you have counted
+with since chapter 7, and now one you can read. It joins **இரண்டு**,
+**நான்கு**, **ஆறு**, **எட்டு** and **பத்து**, whose letters the strand has
+already given you; **ஒன்று**, **ஐந்து**, **ஏழு** and **ஒன்பது** still wait on
+letters this book has not taught.
+
+## Guided Practice
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-UU-SIGN-01, TA-SCRIPT-READ-MUUNRU-02, TA-SCRIPT-U-SIGN-01, TA-SCRIPT-UU-VOWEL-01, TA-SCRIPT-READ-UUR-02] -->
+
+[PAUSE 1s]
+- [YOU READ: **மூ** — then **மூன்று**]
+- [YOU SAY: "mūṉṟu" — "three"]
+- [YOU CONTRAST: **று** and **மூ** — the short sign and the long one, both riding]
+- [YOU CONTRAST: **ஊர்** and **மூன்று** — long *ū* standing, then long *ū* riding]
+
+## Wrap-up Recall
+<!-- hl-knowledge: introduces=[]; assesses=[TA-SCRIPT-UU-SIGN-01, TA-SCRIPT-READ-MUUNRU-02, TA-SCRIPT-UU-VOWEL-01, TA-SCRIPT-PULLI-VANAKKAM-01] -->
+
+[PAUSE 3s] Read **மூன்று**. Which sign is **ூ**'s short partner, and which
+letter is its standing form? (**ு**, and **ஊ**.) Name the four corners of that
+family. (**உ ஊ** standing, **ு ூ** riding.) What is the dot on **ன்** doing?
+(**Removing the built-in *a***.)

--- a/code/learning/human-languages/tamil/narration/ch38.json
+++ b/code/learning/human-languages/tamil/narration/ch38.json
@@ -4,7 +4,7 @@
   "chapter": 38,
   "title": "Keeping Well, and Leaving",
   "drivablePrefix": 0,
-  "sourceHash": "fnv1a64:02d8bcf3e16a7add",
+  "sourceHash": "fnv1a64:7e4402eac9febba1",
   "lessons": [
     {
       "id": "TA-C38-udambu",
@@ -548,6 +548,186 @@
             {
               "kind": "speech",
               "text": "Take your leave formally, thanks in front of it, and name the earlier word that shares this root. (Naṉṟi. viḍai peṟugiṟēṉ.; வீடு, from விடு, \"to let go.\") Do ஊர் and நண்பன் belong to that root? (No — a settlement and a closeness; not everything joins up.)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "TA-W19-read-muunru",
+      "sequence": 1165,
+      "title": "மூன்று (mūṉṟu) — the fourth corner of the u-family",
+      "headword": "மூன்று",
+      "romanization": "mūṉṟu",
+      "gloss": "the ூ sign, closing the u-family opened in chapters 31, 36 and 37",
+      "script": "tamil",
+      "modality": "pen",
+      "derivedModality": "pen",
+      "modalityReasons": [
+        "writing-type",
+        "script-block"
+      ],
+      "sourceHash": "fnv1a64:2ef84654a6ca9fcb",
+      "notice": {
+        "modality": "pen",
+        "needs": [
+          "a pen and something to write on",
+          "your eyes, for letter shapes on the page"
+        ],
+        "waitUntilStopped": [
+          "Script you'll notice: the ூ sign",
+          "Script you'll notice: build the word"
+        ],
+        "text": "Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: the ூ sign and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it."
+      },
+      "blocks": [
+        {
+          "index": 0,
+          "type": "warmup",
+          "title": "Warm-up",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 2,
+              "perItem": false,
+              "source": "[PAUSE 2s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Three corners of one family are already yours: உ and ஊ, the letters that open a word, and ு, the short sign that rides a consonant. One corner is missing, and you can guess what it does."
+            }
+          ]
+        },
+        {
+          "index": 1,
+          "type": "script",
+          "title": "Script you'll notice: the ூ sign",
+          "segments": [
+            {
+              "kind": "speech",
+              "text": "ூ is the sign for long ū — the long partner of ு, exactly as ஊ is the long partner of உ. Both members of each pair, in both jobs:"
+            },
+            {
+              "kind": "table",
+              "headers": [
+                "",
+                "opens a word",
+                "rides a consonant"
+              ],
+              "columns": 3,
+              "rowCount": 2,
+              "utterances": [
+                "short u. opens a word: உ. rides a consonant: ு.",
+                "long ū. opens a word: ஊ. rides a consonant: ூ."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "ம + ூ becomes மூ, said mū."
+            },
+            {
+              "kind": "speech",
+              "text": "The four corners are a pattern, not the whole system. Short a is the vowel with no sign at all: the data says a consonant carries a built-in a until a mark replaces it, which is why க needs nothing to be ka. Nor do signs all sit in one place — the ை you met in இல்லை is written to the LEFT of its consonant, which the data does say; where ு and ூ sit is this lesson's own description, since the data has no entry for either."
+            },
+            {
+              "kind": "speech",
+              "text": "Read it; do not draw it yet. None of உ, ஊ, ு or ூ has an entry in this book's script data, so none of them gets a stroke order, and the pairing above is what the page shows rather than something the data states."
+            }
+          ]
+        },
+        {
+          "index": 2,
+          "type": "script",
+          "title": "Script you'll notice: build the word",
+          "segments": [
+            {
+              "kind": "table",
+              "headers": [
+                "piece",
+                "",
+                ""
+              ],
+              "columns": 3,
+              "rowCount": 3,
+              "utterances": [
+                "piece: மூ, mū — ம with the ூ sign, ம from வணக்கம்.",
+                "piece: ன், bare ṉ — ன under a puḷḷi, the alveolar n.",
+                "piece: று, ṟu — ற, the hard r, with the ு sign, ற from நன்றி."
+              ]
+            },
+            {
+              "kind": "speech",
+              "text": "மூ, ன், று becomes மூன்று (mūṉṟu)."
+            },
+            {
+              "kind": "speech",
+              "text": "Three pieces, one new sign. மூன்று (mūṉṟu) is \"three\" — a word you have counted with since chapter 7, and now one you can read. It joins இரண்டு, நான்கு, ஆறு, எட்டு and பத்து, whose letters the strand has already given you; ஒன்று, ஐந்து, ஏழு and ஒன்பது still wait on letters this book has not taught."
+            }
+          ]
+        },
+        {
+          "index": 3,
+          "type": "guided-production",
+          "title": "Guided Practice",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 1,
+              "perItem": false,
+              "source": "[PAUSE 1s]"
+            },
+            {
+              "kind": "prompt",
+              "action": "READ",
+              "instruction": "மூ — then மூன்று (mūṉṟu)",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU READ: **மூ** — then **மூன்று**]"
+            },
+            {
+              "kind": "prompt",
+              "action": "SAY",
+              "instruction": "\"mūṉṟu\" — \"three\"",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU SAY: \"mūṉṟu\" — \"three\"]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "று and மூ — the short sign and the long one, both riding",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **று** and **மூ** — the short sign and the long one, both riding]"
+            },
+            {
+              "kind": "prompt",
+              "action": "CONTRAST",
+              "instruction": "ஊர் and மூன்று (mūṉṟu) — long ū standing, then long ū riding",
+              "spoken": true,
+              "scored": false,
+              "responseSeconds": 8,
+              "source": "[YOU CONTRAST: **ஊர்** and **மூன்று** — long *ū* standing, then long *ū* riding]"
+            }
+          ]
+        },
+        {
+          "index": 4,
+          "type": "recall",
+          "title": "Wrap-up Recall",
+          "segments": [
+            {
+              "kind": "pause",
+              "seconds": 3,
+              "perItem": false,
+              "source": "[PAUSE 3s]"
+            },
+            {
+              "kind": "speech",
+              "text": "Read மூன்று (mūṉṟu). Which sign is ூ's short partner, and which letter is its standing form? (ு, and ஊ.) Name the four corners of that family. (உ ஊ standing, ு ூ riding.) What is the dot on ன் doing? (Removing the built-in a.)"
             }
           ]
         }

--- a/code/learning/human-languages/tamil/narration/ch38.txt
+++ b/code/learning/human-languages/tamil/narration/ch38.txt
@@ -1,8 +1,8 @@
 Tamil, chapter 38: Keeping Well, and Leaving.
-3 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
+4 lessons. The first lesson already needs your eyes or your hands, so save this one for when you have stopped.
 
 
-Lesson 1 of 3.
+Lesson 1 of 4.
 உடம்பு (uḍambu) — "body," and how Tamil asks after your health.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -48,7 +48,7 @@ Wrap-up Recall.
 Ask someone respectfully how they are keeping, through the body, and name the two sound rules inside uḍambu. (Uṅgaḷ uḍambu eppaḍi irukku; ட softens between vowels, ப voices after a nasal.) Are உடல் and உடம்பு different words, and where does the person sit in the formal age question? (No, same entry; in the dative.)
 
 
-Lesson 2 of 3.
+Lesson 2 of 4.
 சுகம் (sugam) — "ease," the word Tamil did borrow.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -91,7 +91,7 @@ Wrap-up Recall.
 Why is க heard as g, and what did the noun do that நான் does not? (Between vowels; it takes -உக்கு, while நான் becomes எனக்கு.) Which word did Tamil borrow, which did it keep, and how firm is the "good axle-hole" story? (சுகம் (sugam); நலம்; contested.)
 
 
-Lesson 3 of 3.
+Lesson 3 of 4.
 விடை (viḍai) — "leave," and the root under the house.
 
 Before we start: this one needs your eyes, so it is not fully a driving lesson. You will want your eyes, for letter shapes on the page. You can listen to everything else now — leave the section called The letters in this word until you have stopped, and I will say so again when we reach it.
@@ -133,3 +133,45 @@ Guided Practice.
 Wrap-up Recall.
 [pause 3 seconds]
 Take your leave formally, thanks in front of it, and name the earlier word that shares this root. (Naṉṟi. viḍai peṟugiṟēṉ.; வீடு, from விடு, "to let go.") Do ஊர் and நண்பன் belong to that root? (No — a settlement and a closeness; not everything joins up.)
+
+
+Lesson 4 of 4.
+மூன்று (mūṉṟu) — the fourth corner of the u-family.
+
+Before we start: this one needs your hands, so it is not a driving lesson. You will want a pen and something to write on and your eyes, for letter shapes on the page. You can listen to everything else now — leave the sections called Script you'll notice: the ூ sign and Script you'll notice: build the word until you have stopped, and I will say so again when we reach it.
+
+Warm-up.
+[pause 2 seconds]
+Three corners of one family are already yours: உ and ஊ, the letters that open a word, and ு, the short sign that rides a consonant. One corner is missing, and you can guess what it does.
+
+Script you'll notice: the ூ sign.
+ூ is the sign for long ū — the long partner of ு, exactly as ஊ is the long partner of உ. Both members of each pair, in both jobs:
+[a table of 2 rows, read aloud]
+short u. opens a word: உ. rides a consonant: ு.
+long ū. opens a word: ஊ. rides a consonant: ூ.
+ம + ூ becomes மூ, said mū.
+The four corners are a pattern, not the whole system. Short a is the vowel with no sign at all: the data says a consonant carries a built-in a until a mark replaces it, which is why க needs nothing to be ka. Nor do signs all sit in one place — the ை you met in இல்லை is written to the LEFT of its consonant, which the data does say; where ு and ூ sit is this lesson's own description, since the data has no entry for either.
+Read it; do not draw it yet. None of உ, ஊ, ு or ூ has an entry in this book's script data, so none of them gets a stroke order, and the pairing above is what the page shows rather than something the data states.
+
+Script you'll notice: build the word.
+[a table of 3 rows, read aloud]
+piece: மூ, mū — ம with the ூ sign, ம from வணக்கம்.
+piece: ன், bare ṉ — ன under a puḷḷi, the alveolar n.
+piece: று, ṟu — ற, the hard r, with the ு sign, ற from நன்றி.
+மூ, ன், று becomes மூன்று (mūṉṟu).
+Three pieces, one new sign. மூன்று (mūṉṟu) is "three" — a word you have counted with since chapter 7, and now one you can read. It joins இரண்டு, நான்கு, ஆறு, எட்டு and பத்து, whose letters the strand has already given you; ஒன்று, ஐந்து, ஏழு and ஒன்பது still wait on letters this book has not taught.
+
+Guided Practice.
+[pause 1 second]
+[your turn — read: மூ — then மூன்று (mūṉṟu)]
+[pause 8 seconds for the answer]
+[your turn — say: "mūṉṟu" — "three"]
+[pause 8 seconds for the answer]
+[your turn — contrast: று and மூ — the short sign and the long one, both riding]
+[pause 8 seconds for the answer]
+[your turn — contrast: ஊர் and மூன்று (mūṉṟu) — long ū standing, then long ū riding]
+[pause 8 seconds for the answer]
+
+Wrap-up Recall.
+[pause 3 seconds]
+Read மூன்று (mūṉṟu). Which sign is ூ's short partner, and which letter is its standing form? (ு, and ஊ.) Name the four corners of that family. (உ ஊ standing, ு ூ riding.) What is the dot on ன் doing? (Removing the built-in a.)

--- a/code/packages/typescript/human-language-data/CHANGELOG.md
+++ b/code/packages/typescript/human-language-data/CHANGELOG.md
@@ -4,6 +4,156 @@ All notable changes to `@coding-adventures/human-language-data` are documented h
 
 ## [Unreleased]
 
+### Added - the ூ sign, and the measured end of the Tamil strand's runway
+
+- Teach `TA-W19-read-muunru` (chapter 38, sequence 1165) around **மூன்று**: the
+  long-*ū* sign **ூ**, completing a four-corner *u*-family that took three
+  lessons to open — **ு** in `TA-W13` (chapter 31), **உ** in `TA-W17` (36) and
+  **ஊ** in `TA-W18` (37) — short/long by independent letter versus consonant
+  sign.
+- Choose **ூ** by census, not by convenience: it is the highest-usage glyph the
+  writing strand never taught, appearing in five lessons.
+- Credit `TA-SCRIPT-READ-UUR-02` and `TA-SCRIPT-THREE-NS-01` where the lesson
+  genuinely re-reads **ஊர்** and **ன**, rather than only declaring the atoms it
+  introduces. Four atoms leave a reinforcement window in total; these two
+  credits are what earns two of them. Measured by removing just these two
+  credits and re-running: R2 goes back 1808 -> 1809 and R4 243 -> 244, while
+  `TA-SCRIPT-U-VOWEL-01` and `TA-SCRIPT-UU-VOWEL-01` leave either way, carried
+  by the Warm-up block.
+- Say what the word buys. With **ூ** taught, six of the numbers one to ten are
+  spellable entirely from glyphs the strand has given: **மூன்று**, **இரண்டு**,
+  **நான்கு**, **ஆறு**, **எட்டு**, **பத்து**. The four that are not —
+  **ஒன்று**, **ஐந்து**, **ஏழு**, **ஒன்பது** — are blocked on **ஒ**, **ஐ** and
+  **ஏ** exactly.
+
+### Measured - the strand cannot finish inside 38 chapters
+
+The queue item that produced this lesson assumed the remaining glyphs were a
+matter of authoring more lessons. Measuring the track says otherwise:
+
+- After `TA-W18` (chapter 37) only five speaking lessons remain in the corpus,
+  at sequences 1120, 1130, 1140, 1150 and 1160. There is room for one more
+  writing lesson and no more, whether it is placed among them or after them.
+- Chapter 38's atom load goes 6 -> 8, inside the twelve-atom chapter budget, and
+  the lesson introduces 2 atoms, inside the three-atom lesson cap.
+
+So the residue stands at thirteen glyphs in chapter 7's numbers alone — **ஏ**,
+**ஐ**, **ஒ** and the ten Tamil digits **௧**-**௰** — with no slot left for any of
+them. Closing that debt requires a decision this changelog does not make: extend
+the Tamil track past chapter 38, or raise the strand's cadence.
+
+A note on the census, because this entry quotes no total for it and earlier
+drafts did. The absolute count of used-but-untaught glyphs is entirely a
+function of how "taught" is detected, and small choices swing it by several
+glyphs: whether a bold span of four code points such as **ஸ்ரீ** counts as
+teaching **ஸ**, how far a negation such as "still wait on letters this book has
+not taught" scopes, whether the `TA-C*` lessons may teach as well as use. The
+figure of 19 written in `continuity.test.ts` during an earlier change does
+reproduce, but only under one particular set of those choices — it needs **ஞ**,
+**ஸ**, **ஃ** and **ஷ** to count as NOT taught. Within the writing strand those
+four occur only in passing: **ஷ** and **ஸ** in `TA-W03`'s borrowed-ligature
+aside (**க்ஷ**, **ஸ்ரீ**) and its Wrap-up answer, **ஃ** in the same lesson's
+character-count mention, **ஞ** in `TA-W07`'s sound-table cell **ஞ்ச**. Two of
+the four also appear in speaking lessons — **ஞ** in **ஞாயிறு**, **மஞ்சள்** and
+**தஞ்சாவூர்**, **ஸ** in **நமஸ்காரம்** — which are uses, not teaching, under
+either detector; **ஃ** and **ஷ** appear nowhere in the corpus but that one
+`TA-W03` aside.
+The detector used here counts all four as taught. Neither reading is wrong; the
+number is simply not portable, which is why this entry quotes no total of its
+own.
+
+The two facts this entry rests on hold under a detector that does two specific
+things, and it is worth naming them rather than claiming detector-independence:
+it must scope negation, and it must not treat a `TA-C*` lesson as teaching. Both
+matter, and this very lesson is why the first one does — it prints **ஒன்று**,
+**ஐந்து** and **ஏழு** in bold inside the sentence saying they *wait on letters
+this book has not taught*, so a detector that ignores negation would score ஏ, ஐ
+and ஒ as taught here and put this lesson's delta at four glyphs instead of one.
+Chapter 7's own lessons bold the same letters while merely using them, which is
+why the second matters. Under a detector that does both: the difference **this**
+lesson makes is exactly **ூ**, and the thirteen chapter-7 glyphs named above are
+untaught.
+
+This supersedes, rather than continues, the census table in the "last two
+glyphs" entry below. That entry's detector scored **ஞ**, **ஸ**, **ஃ** and **ஷ**
+as untaught, which is where its 19 came from; the detector described here scores
+all four as taught. Both entries then say "thirteen of chapter 7's", and they do
+not mean the same thirteen: the earlier list is **ஐ**, **ஒ**, **ூ** plus the ten
+digits, this one is **ஏ**, **ஐ**, **ஒ** plus the ten digits. **ூ** moved out of
+the untaught set, which is precisely what this lesson did; **ஏ** was in it all
+along and the earlier list omitted it. That table is left as written, as a
+record of what was measured then.
+
+### Changed - place the writing lesson LAST in its chapter, and measure why
+
+The lesson was first written at sequence 1145, between `TA-C38-udambu` and
+`TA-C38-sugam`. Measuring that placement against the alternative changed it, and
+both effects are worth recording because neither is visible in a total:
+
+- Hands-free start. `chapter-modalities.tex` for chapter 38 went from "all 3
+  lessons" to "first 1 of 4": a `pen` lesson in position 2 truncates the core
+  drivable prefix, and two speaking lessons lost hands-free reachability.
+  Placed last it reads "first 3 of 4" and nothing is lost. The manifest summary
+  cannot see this — its per-chapter `drivablePrefix` for chapter 38 is 0 either
+  way — so no pinned test would have caught it.
+- Reinforcement distance. At index 127 the lesson sits 6 lessons after `TA-W18`
+  and 10 after `TA-W17`, both inside R2's 5-15 span. At index 125 it sat 4 after
+  `TA-W18` — past R1's 1-3 and short of R2's 5, in the dead zone between them.
+  The same lesson practising the same atoms therefore rescues three atoms from
+  R2 rather than one.
+- Placing a writing lesson last in its chapter is also the corpus's dominant
+  pattern: eleven chapters already do it. The gap from `TA-W18` becomes five
+  speaking lessons rather than three, which the strand already varies (existing
+  gaps include six and nine).
+
+Being last, the lesson carries no `Next:` line. That is not a special terminal
+convention — 84 of the Tamil track's 128 lessons carry no `Next:` line — it is
+simply that there is no successor left to name. `TA-C38-vidai`, which the move
+displaces from last position, has no `Next:` line either — that much predates
+this change — but it now has a successor it could name and does not, and that
+much is created by this change. It is left alone: of the 84, all but TA-W19 have
+a successor, and only a handful gesture at it at all — `TA-C01-practice` and
+`TA-C02-practice` with a "Next chapter:" teaser, `TA-C04-po` in running prose.
+So adding a teaser to `TA-C38-vidai` would be an isolated exception rather than
+a convention.
+
+### Changed - corpus pins re-derived by measurement
+
+Every moved pin was re-derived as a set difference against `origin/main`, and
+the direction of each mover is recorded at the assertion:
+
+- `atomsTaught` 2650 -> 2652; `pre-A1` 877 -> 878; ramp-to-A1 1186 -> 1187;
+  manifest `totalLessons` 1689 -> 1690 and `pen` 67 -> 68. The `pen` derivation
+  comes from `writing-type` before the script block is considered, matching the
+  `["writing-type","script-block"]` pair that 20 other Tamil lessons already
+  carry, so the sight seam does not move.
+- `atomsNeverRevisited` holds at 472, as does the 422-atom subset of it that
+  also misses a window. Both are trades rather than washes, and they trade
+  DIFFERENT atoms, which is worth separating because one set is a superset of
+  the other. Both lose the same two: `TA-SCRIPT-READ-UUR-02` and
+  `TA-SCRIPT-UU-VOWEL-01`, rescued from zero revisits by the re-reading above.
+  The 472 set gains `TA-SCRIPT-UU-SIGN-01` and `TA-SCRIPT-READ-MUUNRU-02`, this
+  lesson's own two atoms, never revisited because nothing follows them. The 422
+  subset gains `TA-ETYMON-VIDAI-02` and `TA-LEX-VIDAI-01` instead — those two
+  were already never-revisited at baseline and merely became window-measurable,
+  the artifact described next, while TA-W19's own atoms miss the subset because
+  at index 127 no window is evaluable for them at all.
+- `missedByWindow.R2` 1809 -> 1808, and it goes DOWN. Three atoms leave —
+  `TA-SCRIPT-READ-UUR-02` (revisits 0 -> 1), `TA-SCRIPT-UU-VOWEL-01` (0 -> 1)
+  and `TA-SCRIPT-U-VOWEL-01` (1 -> 2).
+- `missedByWindow.R4` 242 -> 243, with `TA-SCRIPT-THREE-NS-01` leaving
+  (revisits 4 -> 5, missing R1/R2/R4 -> R1/R2).
+- Every atom that ENTERS a window does so by one mechanism, and the arithmetic
+  is exact in all four: the Tamil track was 127 lessons, and for each entrant
+  `introducedAt + window.from = 127`, so that window's first position did not
+  exist until this lesson made index 127 exist. R1 886, VIDAI pair at 126
+  (126 + 1); R2, IVAR pair at 122 (122 + 5); R3 1307 -> 1309, UTAVU pair at 107
+  (107 + 20); R4, PLEASE-REGISTER pair at 47 (47 + 80).
+- For every one of those entrants the revisit COUNT is identical before and
+  after, which is the check that separates an artifact from a regression: no
+  existing reinforcement was broken by the insertion. TA-W19's own two atoms
+  appear in no window at all, because at index 127 none is evaluable.
+
 ### Added - verified Urdu independent ی handwriting
 
 - Record Northwestern's *Zer o Zabar* independent chhoṭī ye animations as one
@@ -453,7 +603,8 @@ that "every payoff is a chapter's last lesson by `sequence`" — interleaving pu
 - `atomsTaught` 2646 → 2650.
 - `atomsNeverRevisited` 470 → 472 — both `TA-W18`'s, orphans by construction because
   no later lesson practises script atoms. `TA-W17`'s two are not, because `TA-W18`
-  re-reads **உணவு** beside **ஊர்**.
+  re-reads **உணவு** beside **ஊர்**. (Superseded by the `TA-W19` entry above: a
+  later lesson now does practise script atoms, and those same two leave the set.)
 - `missedByWindow.R1` 880 → 884 — the four new atoms, nothing out.
 - `missedByWindow.R2` 1804 → 1809, and only four of those five are new atoms. The fifth
   is a **regression this tranche causes**, and it belongs in the open rather than filed

--- a/code/packages/typescript/human-language-data/tests/continuity.test.ts
+++ b/code/packages/typescript/human-language-data/tests/continuity.test.ts
@@ -390,9 +390,31 @@ describe("the real corpus", () => {
     // +6 more: TA-W14/15/16 close chapters 4-5's glyphs at 2 atoms each.
     // +4 more: TA-W17 and TA-W18 teach உ and ஊ — the last two untaught glyphs in the
     // chapter 33-38 sections, NOT in the corpus. A census against the strand's taught
-    // set leaves 19 still used and never taught, thirteen of them in chapter 7's
-    // numbers (ஐ, ஒ, ூ and the digits ௧-௰). That is where the real debt is.
-    expect(report.summary.atomsTaught).toBe(2650);
+    // set leaves glyphs still used and never taught, most of them in chapter 7's
+    // numbers. That is where the real debt is. (A figure of 19 was once written here.
+    // It reproduces, but only under one particular reading: the count depends entirely
+    // on how "taught" is detected, and small choices — whether a bold span of four code
+    // points such as ஸ்ரீ counts, how far a negation scopes, whether a TA-C* lesson may
+    // teach — swing it by several glyphs. 19 needs ஞ, ஸ, ஃ and ஷ to count as untaught;
+    // the reading used below counts all four as taught. The absolute number is not
+    // restated below because it is not portable. The two scoped facts are.)
+    // +2 more: TA-W19 teaches the ூ sign, the highest-usage of the untaught glyphs
+    // (5 lessons) and the last one the strand has room for. Two facts are relied on
+    // here, and they hold under a detector that does two specific things rather than
+    // under every detector: it must scope negation, and it must not count a TA-C*
+    // lesson as teaching. Under one that does both, the difference this lesson makes
+    // is exactly ூ, and thirteen glyphs used by chapter 7's numbers — ஏ, ஐ, ஒ and the
+    // ten digits ௧-௰ — remain untaught. Ignore negation and the delta becomes four
+    // glyphs, because this very lesson prints ஒன்று, ஐந்து and ஏழு in bold inside the
+    // sentence saying they are still unreadable; count TA-C* as teaching and the
+    // untaught set empties, because chapter 7 bolds those letters while merely using
+    // them. See the CHANGELOG entry for this change.
+    // Measured, the Tamil track's teaching runway is the
+    // binding constraint: after TA-W18 only five speaking lessons remain, so the 3:1
+    // remaining runway holds ONE more writing lesson, which TA-W19 now occupies at
+    // sequence 1165, last in chapter 38. Those thirteen glyphs cannot be taught
+    // inside 38 chapters.
+    expect(report.summary.atomsTaught).toBe(2652);
     // +2, and it goes UP, which is worth stating plainly. Three of the five new atoms
     // are TA-W09's and nothing follows TA-W09, so they are orphans by construction:
     // PA-YA-01, E-SIGN-02, READ-PEYAR-03. TA-W08's two are revisited by TA-W09.
@@ -421,6 +443,16 @@ describe("the real corpus", () => {
     // +2 for உ/ஊ, and both are TA-W18's: UU-VOWEL-01 and READ-UUR-02. Nothing follows
     // TA-W18 in the strand, so they are orphans by construction. TA-W17's two are not —
     // TA-W18 re-reads உணவு beside ஊர், which is the point of the pair. Two in, none out.
+    // TA-W19 then moves this number NOT AT ALL, and the sentence above about TA-W18 is
+    // now historical rather than current: something DOES follow TA-W18 in the strand,
+    // and it is exactly the two atoms that entry named that leave. Two out — UU-VOWEL-01
+    // and READ-UUR-02, both 0 revisits -> 1, because TA-W19 re-reads ஊர் beside மூன்று
+    // and declares the atom that owns it. Two in — UU-SIGN-01 and READ-MUUNRU-02,
+    // TA-W19's own, orphans by construction because it is the last lesson in the track.
+    // The 422-atom subset that ALSO misses a window holds too, but it trades different
+    // atoms in: TA-ETYMON-VIDAI-02 and TA-LEX-VIDAI-01, which were already never
+    // revisited and merely became window-measurable. TA-W19's own two are absent from
+    // that subset because at index 127 no window is evaluable for them.
     expect(report.summary.atomsNeverRevisited).toBe(472);
     expect(report.summary.neverRevisitedPercent).toBe(18);
 
@@ -565,7 +597,13 @@ describe("the real corpus", () => {
     // +4: all four new atoms miss R1, and nothing leaves. TA-W17 and TA-W18 are 3
     // speaking lessons apart, so the gap is 4 in reading order, outside the 1-3 window
     // as everywhere else in the strand.
-    expect(report.summary.missedByWindow.R1).toBe(884);
+    // +2, and NEITHER is TA-W19's. TA-W19 is the corpus's last Tamil lesson, at index
+    // 127, so no window is evaluable for the atoms it introduces at all. The two that
+    // enter are TA-ETYMON-VIDAI-02 and TA-LEX-VIDAI-01, introduced at 126, and they
+    // are the R1 case of the one mechanism described at the R2 pin below: the track
+    // was 127 lessons, 126 + 1 = 127, so R1's first position did not exist until this
+    // lesson made index 127 exist. Their revisit counts are 0 before and 0 after.
+    expect(report.summary.missedByWindow.R1).toBe(886);
     // +2 net, and the composition is the interesting part: all FIVE new atoms miss R2
     // as well, offset by THREE pre-existing atoms that TA-W09 pulls back into it.
     // TA-W09 sits 12 lessons after TA-W06 and 8 after TA-W07, both inside R2's 5-15
@@ -611,7 +649,29 @@ describe("the real corpus", () => {
     // one lesson, TA-C38-vidai. That revisit sat at offset 15 — the LAST position R2's
     // 5-15 window counts. Inserting TA-W17 and TA-W18 between them pushed it to 17, so
     // an atom that was passing R2 now misses it. Nothing leaves.
-    expect(report.summary.missedByWindow.R2).toBe(1809);
+    // -1, and it goes DOWN, which is the point of placing this lesson LAST in its
+    // chapter rather than mid-chapter. THREE atoms leave: TA-SCRIPT-READ-UUR-02
+    // (revisits 0 -> 1), TA-SCRIPT-UU-VOWEL-01 (0 -> 1) and TA-SCRIPT-U-VOWEL-01
+    // (1 -> 2). At index 127 the lesson sits 6 lessons after TA-W18 and 10 after
+    // TA-W17, both inside R2's 5-15 span. Placed mid-chapter at index 125 it landed 4
+    // after TA-W18 — past R1's 1-3 and short of R2's 5 — and rescued only one of the
+    // three. Same lesson, same atoms, different distance.
+    // IN (2): TA-GRAMMAR-IVAR-02 and TA-LEX-IVAR-01, introduced at index 122 by
+    // TA-C37-ivar. Their revisit COUNTS are unchanged (1 and 2); what changed is that
+    // R2 became evaluable for them. The arithmetic is exact, and it is the SAME
+    // mechanism in all four windows: the Tamil track was 127 lessons, and
+    // introducedAt + window.from = 127 for every atom that enters, so that window's
+    // first position did not exist until this lesson made index 127 exist.
+    //   R1: VIDAI pair at 126, 126 + 1 = 127 (pinned above).
+    //   R2: IVAR pair at 122, 122 + 5 = 127.
+    //   R3: 1307 -> 1309, UTAVU pair at 107, 107 + 20 = 127. Nothing leaves.
+    //   R4: 242 -> 243, PLEASE-REGISTER pair at 47, 47 + 80 = 127, offset by ONE atom
+    //   leaving — TA-SCRIPT-THREE-NS-01, revisits 4 -> 5 and missing [R1,R2,R4] ->
+    //   [R1,R2], because this lesson practises it where it re-reads ன in மூன்று.
+    // For every atom that ENTERS any of the four windows the revisit count is
+    // identical before and after, so no existing reinforcement was broken. Every atom
+    // that LEAVES gained a real revisit. R3 and R4 are not pinned here.
+    expect(report.summary.missedByWindow.R2).toBe(1808);
   });
 
   it("shows what a declared reading order was worth", () => {

--- a/code/packages/typescript/human-language-data/tests/levels.test.ts
+++ b/code/packages/typescript/human-language-data/tests/levels.test.ts
@@ -222,7 +222,8 @@ describe("corpus snapshot", () => {
     // +4: TA-W10..TA-W13, the Tamil writing strand's extension, all sit at pre-A1.
     // +3 more: TA-W14/15/16, closing chapters 4-5, sit there too.
     // +2: TA-W17-read-unavu and TA-W18-read-uur.
-    expect(summary.byLevel["pre-A1"]).toBe(877);
+    // +1: TA-W19-read-muunru, the strand's last available slot, likewise pre-A1.
+    expect(summary.byLevel["pre-A1"]).toBe(878);
     // Chapter 10 adds singular ir and possessives at A1. Chapter 11 adds one more
     // definite-reference lesson there; its other work is A2. Chapter 12 adds its
     // newly mapped terminal checkpoints at A2 on SPINE-SAY-WHAT-I-DO.
@@ -299,7 +300,9 @@ describe("corpus snapshot", () => {
     // +3: TA-W14-read-pesu, TA-W15-read-po and TA-W16-read-tamizh, likewise the only
     // lessons that join.
     // +2: TA-W17-read-unavu and TA-W18-read-uur, the only lessons that join.
-    expect(ramp).toHaveLength(1186);
+    // +1: TA-W19-read-muunru, again measured as a set difference — the only lesson
+    // that joins, not inferred from the total.
+    expect(ramp).toHaveLength(1187);
     expect(ramp.length).toBeLessThan(lessons.length);
   });
 });

--- a/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
+++ b/code/packages/typescript/human-language-data/tests/modality-manifest.test.ts
@@ -860,6 +860,11 @@ describe("corpus regression", () => {
     // uses CORE. Script blocks land exactly on that seam. Publishing `coreVoice` as the
     // headline per-track number is the standing recommendation; until then, expect this
     // figure to rise whenever a non-Latin track authors honestly.
+    // +1 lesson and +1 `pen`: TA-W19-read-muunru. It carries `type: writing`, so it
+    // derives `pen` from `writing-type` before its script block is even considered —
+    // the same `["writing-type","script-block"]` pair that, counted in
+    // `core/lesson-modality.json`, 20 other Tamil lessons already carry. No other
+    // counter moves, so the sight seam above is untouched by this lesson.
     expect(manifest.summary).toEqual({
       // Both Spanish B1 chapters, 38 and 41, are entirely ear-only, so each is fully
       // drivable. They moved the whole-corpus figure from 66% to 67% — then the
@@ -882,8 +887,12 @@ describe("corpus regression", () => {
       // +4: TA-W10-read-naan, TA-W11-read-niingal, TA-W12-read-eppadi and
       // TA-W13-read-irukkirirgal extend the writing strand over chapters 2-3's glyphs.
       // +3: TA-W14-read-pesu, TA-W15-read-po and TA-W16-read-tamizh close chapters 4-5.
-      // +2: TA-W17-read-unavu and TA-W18-read-uur close the last two untaught glyphs.
-      totalLessons: 1689,
+      // +2: TA-W17-read-unavu and TA-W18-read-uur close the last two glyphs untaught
+      // in the chapter 33-38 sections — NOT in the corpus, which this entry originally
+      // failed to qualify. FOURTEEN chapter-7 glyphs are still untaught after them.
+      // +1: TA-W19-read-muunru teaches one of the fourteen, ூ, leaving thirteen —
+      // ஏ, ஐ, ஒ and the ten digits ௧-௰ — and exhausts the strand's runway.
+      totalLessons: 1690,
       // Chapters 10 and 13 replace wide legacy tables with small singular-only
       // comparisons, so three more lessons move from sight to voice.
       // All seven Chapter-16 teaching steps are voice-first. Generating the book
@@ -926,7 +935,7 @@ describe("corpus regression", () => {
       // +2: both new lessons are `type: writing`. voice, sight, drivableLessons,
       // drivablePrefixTotal, fullyDrivableChapters and unstartableChapters ALL hold —
       // this tranche adds lessons and removes no inline section, so nothing flips.
-      pen: 67,
+      pen: 68,
       // +6: exactly the six lessons that moved sight -> voice; no other lesson changes.
       // +8: exactly the eight lessons that moved sight -> voice.
       drivableLessons: 1114,


### PR DESCRIPTION
Adds `TA-W19-read-muunru` (chapter 38, sequence 1165) around **மூன்று**: the long-*ū* sign **ூ**, completing a four-corner *u*-family that took three lessons to open — **ு** in `TA-W13` (ch31), **உ** in `TA-W17` (36), **ஊ** in `TA-W18` (37).

**ூ** was chosen by census, not convenience: it is the highest-usage glyph the writing strand never taught, appearing in five lessons. With it taught, six of the numbers one to ten are spellable entirely from glyphs the strand has given — மூன்று, இரண்டு, நான்கு, ஆறு, எட்டு, பத்து. The other four are blocked on **ஒ**, **ஐ** and **ஏ** exactly.

## The measured finding: the strand cannot finish inside 38 chapters

After `TA-W18` only five speaking lessons remain in the corpus, so there is room for one more writing lesson and no more. Thirteen glyphs used by chapter 7's numbers — **ஏ**, **ஐ**, **ஒ** and the ten digits **௧**-**௰** — stay untaught with no slot left for them. Closing that debt needs a decision this PR does not make: extend the Tamil track past chapter 38, or raise the strand's cadence.

## Placement was measured, not assumed

Written first at sequence 1145 (mid-chapter), it truncated chapter 38's hands-free start from "all 3 lessons" to "first 1 of 4" — two speaking lessons losing drivability. No pinned test could have caught that: the manifest's per-chapter `drivablePrefix` for ch38 is 0 either way.

Placed last it reads "first 3 of 4", and at index 127 the lesson sits 6 lessons after `TA-W18` and 10 after `TA-W17`, both inside R2's 5-15 span — so it rescues three atoms from R2 instead of one. Writing lessons already end eleven other chapters, so this is the corpus's dominant pattern rather than an exception.

## Pins

Re-derived by set difference against `origin/main`, with each mover's direction recorded at the assertion:

- `atomsTaught` 2650 → 2652; `pre-A1` 877 → 878; ramp-to-A1 1186 → 1187; `totalLessons` 1689 → 1690; `pen` 67 → 68.
- `atomsNeverRevisited` holds at 472, and the 422-atom subset holds too — both trades, not washes, and they trade different atoms.
- `missedByWindow.R2` 1809 → **1808**, and it goes down: `READ-UUR-02` (0→1 revisits), `UU-VOWEL-01` (0→1) and `U-VOWEL-01` (1→2) all leave.
- Every atom that ENTERS a window does so by one mechanism with exact arithmetic — the track was 127 lessons, and `introducedAt + window.from = 127` for each entrant (126+1, 122+5, 107+20, 47+80) — and every entrant's revisit count is identical before and after. Nothing existing was broken.

The changelog also retires an earlier "19 untaught glyphs" figure. It does reproduce, but only under one reading of "taught", so this entry quotes no total of its own and relies only on the facts that held under every detector tried.

Full suite 460/460; all five generator drift gates clean; downstream `language-ladder` 771/771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)