### PR TITLE
feat(adj-formula-stdlib): Wave 3 continuation -- solve F=Gm1m2/r^2 for mass

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_gravitation_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_gravitation_e2e.rs
@@ -115,3 +115,39 @@ fn universal_gravitation_binds_and_computes_with_nist_citation() {
         "source quotes NIST's verbatim value of G: {s}"
     );
 }
+
+/// F = G·m₁·m₂/r², solved for a different unknown (ADJ-FORMULA-LIBRARIES FL-10,
+/// §3D rung-0 CAS-wiring companion) — the SAME cited NIST relation as
+/// `gravitational_force` above, rearranged rather than computed forward. Uses
+/// clean round numbers (2 kg, 1 m) rather than inverting the Earth–Moon example,
+/// so the round trip through G checks exactly rather than approximately.
+#[test]
+fn solves_for_mass_one_from_force_with_the_same_citation() {
+    let dir = scratch("mass_solve");
+    let lib = std::fs::read_to_string(shipped_gravitation_lib()).unwrap();
+    std::fs::write(dir.join("gravitation.adj"), lib).unwrap();
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"gravitation.adj\"\n\
+         observe gravitational_force(0.00000000040045800)\n\
+         observe mass_two(2)\n\
+         observe distance(1)\n\
+         ? mass_one_from_force(gravitational_force, mass_two, distance)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // F·r² = G·m1·m2  =>  4.00458e-10 = 6.67430e-11 * m1 * 2  =>  m1 = 3.
+    assert!(
+        s.contains("\"name\":\"mass_one_from_force\"") && s.contains("\"value\":3"),
+        "mass_one_from_force(4.00458e-10, 2, 1) = 3: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("physics.nist.gov")
+            && s.contains("6.674 30 x 10-11"),
+        "carries the same NIST CODATA citation as the forward gravitational_force formula: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-formula-stdlib/CHANGELOG.md
@@ -168,3 +168,20 @@ landed and why, not a semver-tracked API.
   objectives `adj.science.chemistry.ideal_gas_law` and
   `adj.math.algebra.rearrange_ideal_gas_law`. Extended the existing `formula_idealgas_e2e.rs` with
   1 new test rather than adding a new test file.
+- `physics/gravitation.adj` — the TENTH Wave 3 rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES
+  FL-10, §3D): `mass_one_from_force`, solving the same cited NIST CODATA Newtonian gravitation
+  relation as the forward `gravitational_force` formula for one mass — written in its equivalent
+  multiplicative form (`F·r² = G·m₁·m₂`) rather than the natural quotient form. The first Wave 3
+  companion whose equation combines a grounded constant WITH a squared term in the same relation;
+  confirmed empirically before writing that `cas-solve`'s linear solver handles this shape cleanly,
+  same as every simpler product/quotient pair already shipped. Solving for `distance` is
+  deliberately absent (quadratic, out of rung-0's linear-only scope, the sibling of
+  `geometry-formulas.adj`'s `square_area` boundary case); solving for `mass_two` is symmetric and
+  left for a later pass. The query example uses clean round numbers (2 kg, 1 m) rather than
+  inverting the existing Earth–Moon example, so the round trip through G checks exactly rather than
+  approximately. New manifest objective `adj.math.algebra.rearrange_gravitation` (this library
+  already had base manifest coverage, unlike `ideal-gas-law.adj`). Extended the existing
+  `formula_gravitation_e2e.rs` with 1 new test rather than adding a new test file. This closes out
+  the two originally-flagged remaining candidates from the Wave 3 sweeps (gravitation, bmi is now
+  the only one left, deliberately deferred as lowest priority — an isolated clinical definition,
+  not part of a citable physics "family").

--- a/code/specs/data/adj-formula-stdlib/physics/gravitation.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/gravitation.adj
@@ -38,6 +38,21 @@
 % stdlib (multiply, divide) applied to the parameter leaves; only the constant
 % needs external grounding, and it is grounded to the definitive source.
 %
+% This library also carries a rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES
+% FL-10, §3D — a Wave 3 continuation): `mass_one_from_force` solves the SAME
+% cited relation for one of the masses instead of computed forward for force —
+% written in its equivalent multiplicative form (`F·r² = G·m₁·m₂`, not the
+% natural quotient form) so the target appears only as a linear factor, once the
+% OTHER two quantities (force, mass_two, distance) are bound. This is the first
+% Wave 3 companion whose equation combines a grounded constant WITH a squared
+% term in the same relation — confirmed empirically before writing that
+% `cas-solve`'s linear solver handles it cleanly, the same as every simpler
+% product/quotient pair already shipped. Solving for `distance` is deliberately
+% absent: distance is squared, which is quadratic and out of rung-0's
+% linear-only scope, the direct sibling of `geometry-formulas.adj`'s
+% `square_area` boundary case. Solving for `mass_two` is symmetric to
+% `mass_one_from_force` and left for a later pass.
+%
 % Run a worked consumer (from a directory it can resolve this import from):
 %     adj-lang-cli gravitation.query.adj
 % ============================================================================
@@ -63,6 +78,7 @@ dictionary gravitation_vocab {
     define mass_two            : finding  surface "second mass", "m2", "mass of the second body"       % mass, e.g. kg
     define distance            : finding  surface "distance", "separation", "r", "distance between centres" % length, e.g. m
     define gravitational_force : finding  surface "gravitational force", "force of gravity", "F"       % mass · length / time² (newtons)
+    define mass_one_from_force : finding  surface "missing first mass", "unknown first mass"
 }
 
 % ----------------------------------------------------------------------------
@@ -84,6 +100,17 @@ formulabook physics_gravitation {
     % 2022, the exact recommended value → authoritative).
     formula gravitational_force(mass_one, mass_two, distance) =
         6.67430e-11 * mass_one * mass_two / (distance * distance)
+        source "Newtonian constant of gravitation: Numerical value 6.674 30 x 10-11 m3 kg-1 s-2 (Standard uncertainty 0.000 15 x 10-11 m3 kg-1 s-2), CODATA 2022 recommended value."
+        locator "https://physics.nist.gov/cgi-bin/cuu/Value?bg"
+        trust authoritative
+
+    % F = G·m₁·m₂/r² again, SOLVED FOR THE FIRST MASS instead of computed
+    % forward for force — the same cited relation, written as F·r² = G·m₁·m₂ so
+    % the target appears only as a linear factor once force, mass_two, and
+    % distance are bound.
+    symbolic mass_one_from_force(gravitational_force, mass_two, distance) {
+        gravitational_force * (distance * distance) == 6.67430e-11 * mass_one_from_force * mass_two
+    } for mass_one_from_force
         source "Newtonian constant of gravitation: Numerical value 6.674 30 x 10-11 m3 kg-1 s-2 (Standard uncertainty 0.000 15 x 10-11 m3 kg-1 s-2), CODATA 2022 recommended value."
         locator "https://physics.nist.gov/cgi-bin/cuu/Value?bg"
         trust authoritative

--- a/code/specs/data/adj-formula-stdlib/physics/gravitation.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/gravitation.query.adj
@@ -26,3 +26,14 @@ observe mass_one(5.972e24)     % "…Earth's mass, 5.972×10²⁴ kg…"        
 observe mass_two(7.348e22)     % "…the Moon's mass, 7.348×10²² kg…"        (span cited by the model)
 observe distance(3.844e8)      % "…a centre-to-centre distance of 3.844×10⁸ m…" (span cited)
 ? gravitational_force(mass_one, mass_two, distance)  % engine → ≈1.98e20 N (F = G·m₁·m₂/r², NIST, authoritative)
+
+% --- F = G·m₁·m₂/r², SOLVED FOR THE FIRST MASS (rung-0 CAS-wiring, FL-10).
+% "Two point masses 1 m apart exert a mutual gravitational force of
+% 4.00458×10⁻¹⁰ N. One mass is 2 kg — what is the other?" Chosen with clean
+% round numbers (2 kg, 1 m) so the round trip through G checks exactly, rather
+% than inverting the Earth–Moon example above where float noise would obscure
+% the check. ---
+observe gravitational_force(0.00000000040045800)  % "…a mutual gravitational force of 4.00458e-10 N…" (span cited)
+observe mass_two(2)                                % "…one mass is 2 kg…"                              (span cited)
+observe distance(1)                                % "…1 m apart…"                                      (span cited)
+? mass_one_from_force(gravitational_force, mass_two, distance)  % engine → 3 kg (NIST CODATA, authoritative)

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1322,6 +1322,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.math.algebra.rearrange_gravitation",
+      "title": "Solve F = G m1 m2 / r^2 for one mass, given the force, the other mass, and the distance",
+      "band": "9-12",
+      "domain": "mathematics",
+      "competency": "compute",
+      "coverage_roots": ["ccss.math"],
+      "standards": [],
+      "prerequisites": ["adj.science.physics.gravitation"],
+      "libraries": ["code/specs/data/adj-formula-stdlib/physics/gravitation.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES FL-10, §3D — Wave 3 continuation) to `physics/gravitation.adj`: `mass_one_from_force`, solving the same cited NIST CODATA Newtonian gravitation relation for one mass — written in its equivalent multiplicative form (`F·r² = G·m₁·m₂`) rather than the natural quotient form.
- The first Wave 3 companion whose equation combines a grounded constant WITH a squared term in the same relation. Confirmed empirically before writing that `cas-solve`'s linear solver handles this shape cleanly, same as every simpler product/quotient pair already shipped.
- Solving for `distance` is deliberately absent (quadratic, out of rung-0's linear-only scope, the sibling of `geometry-formulas.adj`'s `square_area` boundary case); solving for `mass_two` is symmetric and left for a later pass.
- The query example uses clean round numbers (2 kg, 1 m) rather than inverting the existing Earth–Moon example, so the round trip through G checks exactly rather than approximately.
- New manifest objective `adj.math.algebra.rearrange_gravitation` (band 9-12).
- Extended the existing `formula_gravitation_e2e.rs` with 1 new test (2 total) rather than adding a new test file.

This closes out the originally-flagged `gravitation.adj` candidate from the Wave 3 sweeps — only `bmi.adj` remains, deliberately deferred as lowest priority (an isolated clinical definition, not part of a citable physics "family").

Part of the autonomous ADJ curriculum loop (`ADJ-STDLIB-COVERAGE.md#7-delivery-order`).

## Test plan
- [x] Solve direction empirically verified via the CLI in a scratch dir before writing real content (including the untested constant+squared-denominator equation shape).
- [x] `cargo test -p adj-lang-cli --test formula_gravitation_e2e` — 2/2 passed.
- [x] `cargo test -p adj-lang -p adj-lang-cli` — full suite green, no regressions.
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean.
- [x] `adj_stdlib_manifest.py --validate-json-schema` — 84 objectives, 0 errors, valid.
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` — exit 0, no new gaps introduced.
- [x] Python unittest suite (manifest/report subset) — 87 passed.
- [x] Security review — passed, no findings.