### PR TITLE
feat(mosaic): require Rust in strict Flutter shells

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,6 +623,14 @@ jobs:
         if: needs.detect.outputs.needs_dart == 'true' || needs.detect.outputs.needs_mosaic_flutter_runtime == 'true'
         uses: dart-lang/setup-dart@v1
 
+      - name: Set up Flutter
+        if: runner.os == 'Linux' && needs.detect.outputs.needs_mosaic_flutter_runtime == 'true'
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.24.0'
+          channel: stable
+          cache: true
+
       - name: Set up Swift (Windows)
         if: needs.detect.outputs.needs_swift == 'true' && runner.os == 'Windows'
         shell: pwsh
@@ -1014,6 +1022,15 @@ jobs:
             dart pub get
             dart analyze
             dart run bin/conformance.dart
+          )
+
+          strict_output="$RUNNER_TEMP/mosaic-flutter-native-complete-rating-controls"
+          cargo run --manifest-path code/packages/rust/mosaic-compile/Cargo.toml -- pkg code/packages/mosaic/mosaic-pkg-rating-controls --backend flutter --output "$strict_output" --emit-project --profile native-complete
+          jq -e '.nativeComplete == true and (.degradations | length == 0)' "$strict_output/flutter/mosaic-degradations.json"
+          (
+            cd "$strict_output/flutter"
+            flutter pub get
+            dart analyze lib
           )
 
       - name: Round-trip Rust engine through standard Compose binding

--- a/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
+++ b/code/packages/rust/mosaic-app-bindings/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `MosaicHost.loadRequired()` for strict Flutter shells that must fail
+  explicitly when the Rust application runtime cannot be loaded.
 - Execute the generated Compose/JNA host against the shared Rust conformance
   library in Linux CI, covering startup, dispatch, snapshot/restore,
   notification, buffer ownership, and teardown on the JVM.

--- a/code/packages/rust/mosaic-app-bindings/README.md
+++ b/code/packages/rust/mosaic-app-bindings/README.md
@@ -38,6 +38,8 @@ semantic dispatch, revision application, buffer ownership, and teardown.
 For Flutter, set `MOSAIC_APP_LIBRARY` to the application library path. Without
 an explicit path the host checks symbols linked into the process, then the
 platform's conventional `mosaic_app` dynamic-library names.
+Strict generated shells call `MosaicHost.loadRequired()` so a missing Rust
+library fails at startup rather than silently entering preview mode.
 Linux CI runs the exact binding from a complete generated TaskApp project with
 the shared `mosaic-app-conformance` library, verifying startup, semantic
 dispatch, snapshot/restore, notification, buffer ownership, and teardown.

--- a/code/packages/rust/mosaic-app-bindings/src/lib.rs
+++ b/code/packages/rust/mosaic-app-bindings/src/lib.rs
@@ -267,6 +267,8 @@ mod tests {
         assert!(source.contains("finally {\n      _bufferFree(buffer);"));
         assert!(source.contains("void dispose()"));
         assert!(source.contains("const MosaicHost()"));
+        assert!(source.contains("static MosaicHost loadRequired()"));
+        assert!(source.contains("native-complete requires the Mosaic Rust application runtime"));
     }
 
     #[test]

--- a/code/packages/rust/mosaic-app-bindings/templates/flutter/mosaic_host.dart
+++ b/code/packages/rust/mosaic-app-bindings/templates/flutter/mosaic_host.dart
@@ -70,6 +70,16 @@ class MosaicHost {
     }
   }
 
+  static MosaicHost loadRequired() {
+    final host = load();
+    if (host == null) {
+      throw StateError(
+        'native-complete requires the Mosaic Rust application runtime',
+      );
+    }
+    return host;
+  }
+
   FutureOr<Map<String, Object?>?> props() => _runtime?.latestUpdate;
 
   FutureOr<Map<String, Object?>?> handleEvent(Map<String, Object?> event) =>

--- a/code/packages/rust/mosaic-compile/CHANGELOG.md
+++ b/code/packages/rust/mosaic-compile/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Changed - strict Flutter shells require Rust
+
+`mosaic-compile pkg --backend flutter --emit-project --profile native-complete`
+now emits a runtime-required application shell. It waits for the standard Rust
+engine's first props envelope and contains no nullable-host, event-print, or
+generated sample-value path for required props.
+
 ### Changed - strict Compose shells require Rust
 
 `mosaic-compile pkg --backend compose --emit-project --profile native-complete`

--- a/code/packages/rust/mosaic-compile/README.md
+++ b/code/packages/rust/mosaic-compile/README.md
@@ -104,9 +104,9 @@ machine-readable `<backend>/mosaic-degradations.json`. Use
 `--profile native-complete` in CI to reject known interactive, accessibility,
 effect-host, or placeholder behavior before any application artifacts are
 emitted. The first inventory is intentionally conservative and will grow as
-backend property/event coverage is audited. Compose project shells that pass the
-strict profile require the standard Rust application library at startup and do
-not include legacy-host or generated sample-prop fallbacks.
+backend property/event coverage is audited. Compose and Flutter project shells
+that pass the strict profile require the standard Rust application library at
+startup and do not include optional-host or generated sample-prop fallbacks.
 
 ## Examples
 

--- a/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-flutter/CHANGELOG.md
@@ -5,6 +5,13 @@ this file.
 
 ## [Unreleased]
 
+### Added - native-complete runtime-required shell
+
+`EmitOptions::require_runtime` now selects a fail-loud Flutter application
+shell that requires Mosaic's standard Rust host, waits for its first props
+envelope, and omits nullable-host, event-print, and generated sample-value
+fallbacks. The default remains byte-compatible permissive project emission.
+
 ### Fixed - complete TaskApp Dart compilation
 
 Generated widgets now normalize Mosaic value truthiness before values enter

--- a/code/packages/rust/mosaic-emit-flutter/README.md
+++ b/code/packages/rust/mosaic-emit-flutter/README.md
@@ -123,6 +123,12 @@ generated component. Hosts can also register a prop-change handler; native
 surface interactions use it to ask the generated shell to reproject current
 Mosaic props without creating a backend-specific state store.
 
+Project emission defaults to the permissive preview contract. Setting
+`EmitOptions::require_runtime` produces the `native-complete` shell used by the
+package builder: it requires `MosaicHost.loadRequired()`, waits for the first
+Rust props envelope, exposes an accessible startup indicator, and fails on
+missing required props instead of synthesizing sample values.
+
 Mosaic conditions pass through a generated value-truthiness helper before they
 enter Dart's statically typed boolean positions. Text-input change and commit
 handlers synthesize their declared zero- or one-value event constructors, so a

--- a/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-flutter/src/pipeline.rs
@@ -151,6 +151,12 @@ pub struct EmitOptions {
     /// alongside the component `.dart` file. Default `false`.
     pub emit_project: bool,
 
+    /// Make the generated application shell require Mosaic's standard Rust
+    /// runtime and runtime-provided props. This removes the preview/sample
+    /// paths but does not change the reusable component artifact. Default
+    /// `false` preserves permissive standalone emission.
+    pub require_runtime: bool,
+
     /// Pinned Flutter SDK constraint to write into
     /// `pubspec.yaml`'s `environment.flutter`. UI32 spec §3.6.3
     /// requires exact pinning. Default `">=3.24.0 <4.0.0"` — a
@@ -177,6 +183,7 @@ impl Default for EmitOptions {
     fn default() -> Self {
         Self {
             emit_project: false,
+            require_runtime: false,
             pinned_flutter_sdk: ">=3.24.0 <4.0.0".to_string(),
             pinned_dart_sdk: ">=3.5.0 <4.0.0".to_string(),
             package_name: None,
@@ -285,9 +292,9 @@ fn build_flutter_project_files(
 
     Ok(ProjectFiles {
         pubspec_yaml: build_pubspec_yaml(&pub_name, options),
-        main_dart: build_main_dart(name, &interface.slots),
-        mosaic_host_dart: build_mosaic_host_dart(),
-        readme: build_flutter_readme(&pub_name, name),
+        main_dart: build_main_dart(name, &interface.slots, options.require_runtime),
+        mosaic_host_dart: build_mosaic_host_dart(options.require_runtime),
+        readme: build_flutter_readme(&pub_name, name, options.require_runtime),
     })
 }
 
@@ -333,7 +340,14 @@ fn build_pubspec_yaml(pub_name: &str, options: &EmitOptions) -> String {
     )
 }
 
-fn build_main_dart(component_name: &str, slots: &[SlotDecl]) -> String {
+fn build_main_dart(component_name: &str, slots: &[SlotDecl], require_runtime: bool) -> String {
+    if require_runtime {
+        return build_runtime_required_main_dart(component_name, slots);
+    }
+    build_permissive_main_dart(component_name, slots)
+}
+
+fn build_permissive_main_dart(component_name: &str, slots: &[SlotDecl]) -> String {
     let root_widget = build_root_widget_constructor(component_name, slots);
     format!(
         concat!(
@@ -491,6 +505,384 @@ fn build_main_dart(component_name: &str, slots: &[SlotDecl]) -> String {
     )
 }
 
+fn build_runtime_required_main_dart(component_name: &str, slots: &[SlotDecl]) -> String {
+    let root_widget = build_runtime_required_root_widget_constructor(component_name, slots);
+    format!(
+        concat!(
+            "{banner}",
+            "import 'dart:async';\n",
+            "import 'package:flutter/material.dart';\n",
+            "import '{component_name}.dart';\n",
+            "import 'mosaic_host.dart';\n\n",
+            "void main() {{\n",
+            "  runApp(MosaicApp(mosaicHost: MosaicHost.loadRequired()));\n",
+            "}}\n\n",
+            "class MosaicApp extends StatefulWidget {{\n",
+            "  const MosaicApp({{super.key, required this.mosaicHost}});\n\n",
+            "  final MosaicHost mosaicHost;\n\n",
+            "  @override\n",
+            "  State<MosaicApp> createState() => _MosaicAppState();\n",
+            "}}\n\n",
+            "class _MosaicAppState extends State<MosaicApp> {{\n",
+            "  late final MosaicHost _mosaicHost;\n",
+            "  Map<String, Object?> _hostProps = const <String, Object?>{{}};\n",
+            "  bool _hostReady = false;\n\n",
+            "  @override\n",
+            "  void initState() {{\n",
+            "    super.initState();\n",
+            "    _mosaicHost = widget.mosaicHost;\n",
+            "    _mosaicHost.setPropsChangedHandler(() =>\n",
+            "        _queueMosaicResponse(_mosaicHost.props()));\n",
+            "    _queueMosaicResponse(_mosaicHost.props());\n",
+            "  }}\n\n",
+            "  @override\n",
+            "  void dispose() {{\n",
+            "    _mosaicHost.dispose();\n",
+            "    super.dispose();\n",
+            "  }}\n\n",
+            "  void _queueMosaicResponse(\n",
+            "    FutureOr<Map<String, Object?>?>? responseOrFuture,\n",
+            "  ) {{\n",
+            "    if (responseOrFuture == null) {{\n",
+            "      throw StateError('Mosaic runtime returned no response');\n",
+            "    }}\n",
+            "    Future<Map<String, Object?>?>.value(responseOrFuture).then((response) {{\n",
+            "      if (response == null) {{\n",
+            "        throw StateError('Mosaic runtime returned no response');\n",
+            "      }}\n",
+            "      _applyMosaicResponse(response);\n",
+            "    }});\n",
+            "  }}\n\n",
+            "  void _applyMosaicResponse(Map<String, Object?> response) {{\n",
+            "    if (!response.containsKey('props')) {{\n",
+            "      throw StateError('Mosaic runtime response did not include props');\n",
+            "    }}\n",
+            "    final nextProps = mosaicMap(response['props']);\n",
+            "    final hostIntent = mosaicMap(response['hostIntent']);\n",
+            "    final error = response['error'];\n",
+            "    if (!mounted) return;\n",
+            "    setState(() {{\n",
+            "      _hostProps = nextProps;\n",
+            "      _hostReady = true;\n",
+            "    }});\n",
+            "    if (hostIntent.isNotEmpty) {{\n",
+            "      debugPrint('hostIntent: $hostIntent');\n",
+            "    }}\n",
+            "    if (error != null) {{\n",
+            "      debugPrint('host error: $error');\n",
+            "    }}\n",
+            "  }}\n\n",
+            "  @override\n",
+            "  Widget build(BuildContext context) {{\n",
+            "    return MaterialApp(\n",
+            "      title: '{component_name}',\n",
+            "      home: Scaffold(\n",
+            "        appBar: AppBar(title: const Text('{component_name}')),\n",
+            "        body: Center(\n",
+            "          child: _hostReady\n",
+            "              ? {root_widget}\n",
+            "              : Semantics(\n",
+            "                  label: 'Starting {component_name}',\n",
+            "                  child: const CircularProgressIndicator(),\n",
+            "                ),\n",
+            "        ),\n",
+            "      ),\n",
+            "    );\n",
+            "  }}\n",
+            "}}\n\n",
+            "Map<String, Object?> mosaicMap(Object? value) {{\n",
+            "  if (value is Map<String, Object?>) return value;\n",
+            "  if (value is Map) {{\n",
+            "    return Map<String, Object?>.fromEntries(\n",
+            "      value.entries.where((entry) => entry.key is String).map(\n",
+            "        (entry) => MapEntry(entry.key as String, entry.value),\n",
+            "      ),\n",
+            "    );\n",
+            "  }}\n",
+            "  return const <String, Object?>{{}};\n",
+            "}}\n\n",
+            "String? mosaicOptionalString(Map<String, Object?> props, String name) {{\n",
+            "  final value = props[name];\n",
+            "  return value?.toString();\n",
+            "}}\n\n",
+            "double? mosaicOptionalDouble(Map<String, Object?> props, String name) {{\n",
+            "  final value = props[name];\n",
+            "  if (value == null) return null;\n",
+            "  if (value is num) return value.toDouble();\n",
+            "  if (value is String) {{\n",
+            "    final parsed = double.tryParse(value);\n",
+            "    if (parsed != null) return parsed;\n",
+            "  }}\n",
+            "  throw StateError(\"Mosaic runtime prop '$name' is not a number\");\n",
+            "}}\n\n",
+            "bool? mosaicOptionalBoolean(Map<String, Object?> props, String name) {{\n",
+            "  final value = props[name];\n",
+            "  if (value == null) return null;\n",
+            "  if (value is bool) return value;\n",
+            "  if (value is String) {{\n",
+            "    final lowered = value.toLowerCase();\n",
+            "    if (lowered == 'true') return true;\n",
+            "    if (lowered == 'false') return false;\n",
+            "  }}\n",
+            "  throw StateError(\"Mosaic runtime prop '$name' is not a boolean\");\n",
+            "}}\n\n",
+            "List<String>? mosaicOptionalStringList(\n",
+            "  Map<String, Object?> props,\n",
+            "  String name,\n",
+            ") {{\n",
+            "  final value = props[name];\n",
+            "  if (value == null) return null;\n",
+            "  if (value is! List) {{\n",
+            "    throw StateError(\"Mosaic runtime prop '$name' is not a list\");\n",
+            "  }}\n",
+            "  return value.map((item) {{\n",
+            "    if (item == null) {{\n",
+            "      throw StateError(\"Mosaic runtime prop '$name' contains null\");\n",
+            "    }}\n",
+            "    return item.toString();\n",
+            "  }}).toList(growable: false);\n",
+            "}}\n\n",
+            "List<double>? mosaicOptionalDoubleList(\n",
+            "  Map<String, Object?> props,\n",
+            "  String name,\n",
+            ") {{\n",
+            "  final value = props[name];\n",
+            "  if (value == null) return null;\n",
+            "  if (value is! List) {{\n",
+            "    throw StateError(\"Mosaic runtime prop '$name' is not a list\");\n",
+            "  }}\n",
+            "  return value.map((item) {{\n",
+            "    if (item is num) return item.toDouble();\n",
+            "    if (item is String) {{\n",
+            "      final parsed = double.tryParse(item);\n",
+            "      if (parsed != null) return parsed;\n",
+            "    }}\n",
+            "    throw StateError(\"Mosaic runtime prop '$name' contains a non-number\");\n",
+            "  }}).toList(growable: false);\n",
+            "}}\n\n",
+            "List<bool>? mosaicOptionalBooleanList(\n",
+            "  Map<String, Object?> props,\n",
+            "  String name,\n",
+            ") {{\n",
+            "  final value = props[name];\n",
+            "  if (value == null) return null;\n",
+            "  if (value is! List) {{\n",
+            "    throw StateError(\"Mosaic runtime prop '$name' is not a list\");\n",
+            "  }}\n",
+            "  return value.map((item) {{\n",
+            "    if (item is bool) return item;\n",
+            "    if (item is String) {{\n",
+            "      final lowered = item.toLowerCase();\n",
+            "      if (lowered == 'true') return true;\n",
+            "      if (lowered == 'false') return false;\n",
+            "    }}\n",
+            "    throw StateError(\"Mosaic runtime prop '$name' contains a non-boolean\");\n",
+            "  }}).toList(growable: false);\n",
+            "}}\n\n",
+            "Widget? mosaicOptionalWidget(Map<String, Object?> props, String name) {{\n",
+            "  final value = props[name];\n",
+            "  if (value == null) return null;\n",
+            "  if (value is Widget) return value;\n",
+            "  throw StateError(\"Mosaic runtime prop '$name' is not a Widget\");\n",
+            "}}\n\n",
+            "T? mosaicOptionalValue<T>(Map<String, Object?> props, String name) {{\n",
+            "  final value = props[name];\n",
+            "  if (value == null) return null;\n",
+            "  if (value is T) return value as T;\n",
+            "  throw StateError(\"Mosaic runtime prop '$name' has the wrong type\");\n",
+            "}}\n\n",
+            "String mosaicRequiredString(Map<String, Object?> props, String name) {{\n",
+            "  final value = props[name];\n",
+            "  if (value != null) return value.toString();\n",
+            "  throw StateError(\"Mosaic runtime omitted required prop '$name'\");\n",
+            "}}\n\n",
+            "double mosaicRequiredDouble(Map<String, Object?> props, String name) {{\n",
+            "  final value = props[name];\n",
+            "  if (value is num) return value.toDouble();\n",
+            "  if (value is String) {{\n",
+            "    final parsed = double.tryParse(value);\n",
+            "    if (parsed != null) return parsed;\n",
+            "  }}\n",
+            "  throw StateError(\"Mosaic runtime prop '$name' is not a number\");\n",
+            "}}\n\n",
+            "bool mosaicRequiredBoolean(Map<String, Object?> props, String name) {{\n",
+            "  final value = props[name];\n",
+            "  if (value is bool) return value;\n",
+            "  if (value is String) {{\n",
+            "    final lowered = value.toLowerCase();\n",
+            "    if (lowered == 'true') return true;\n",
+            "    if (lowered == 'false') return false;\n",
+            "  }}\n",
+            "  throw StateError(\"Mosaic runtime prop '$name' is not a boolean\");\n",
+            "}}\n\n",
+            "List<String> mosaicRequiredStringList(\n",
+            "  Map<String, Object?> props,\n",
+            "  String name,\n",
+            ") {{\n",
+            "  final value = props[name];\n",
+            "  if (value is! List) {{\n",
+            "    throw StateError(\"Mosaic runtime omitted required list prop '$name'\");\n",
+            "  }}\n",
+            "  return value.map((item) {{\n",
+            "    if (item == null) {{\n",
+            "      throw StateError(\"Mosaic runtime prop '$name' contains null\");\n",
+            "    }}\n",
+            "    return item.toString();\n",
+            "  }}).toList(growable: false);\n",
+            "}}\n\n",
+            "List<double> mosaicRequiredDoubleList(\n",
+            "  Map<String, Object?> props,\n",
+            "  String name,\n",
+            ") {{\n",
+            "  final value = props[name];\n",
+            "  if (value is! List) {{\n",
+            "    throw StateError(\"Mosaic runtime omitted required list prop '$name'\");\n",
+            "  }}\n",
+            "  return value.map((item) {{\n",
+            "    if (item is num) return item.toDouble();\n",
+            "    if (item is String) {{\n",
+            "      final parsed = double.tryParse(item);\n",
+            "      if (parsed != null) return parsed;\n",
+            "    }}\n",
+            "    throw StateError(\"Mosaic runtime prop '$name' contains a non-number\");\n",
+            "  }}).toList(growable: false);\n",
+            "}}\n\n",
+            "List<bool> mosaicRequiredBooleanList(\n",
+            "  Map<String, Object?> props,\n",
+            "  String name,\n",
+            ") {{\n",
+            "  final value = props[name];\n",
+            "  if (value is! List) {{\n",
+            "    throw StateError(\"Mosaic runtime omitted required list prop '$name'\");\n",
+            "  }}\n",
+            "  return value.map((item) {{\n",
+            "    if (item is bool) return item;\n",
+            "    if (item is String) {{\n",
+            "      final lowered = item.toLowerCase();\n",
+            "      if (lowered == 'true') return true;\n",
+            "      if (lowered == 'false') return false;\n",
+            "    }}\n",
+            "    throw StateError(\"Mosaic runtime prop '$name' contains a non-boolean\");\n",
+            "  }}).toList(growable: false);\n",
+            "}}\n\n",
+            "Widget mosaicRequiredWidget(Map<String, Object?> props, String name) {{\n",
+            "  final value = props[name];\n",
+            "  if (value is Widget) return value;\n",
+            "  throw StateError(\"Mosaic runtime prop '$name' is not a Widget\");\n",
+            "}}\n\n",
+            "T mosaicRequiredValue<T>(Map<String, Object?> props, String name) {{\n",
+            "  final value = props[name];\n",
+            "  if (value is T) return value as T;\n",
+            "  throw StateError(\"Mosaic runtime prop '$name' has the wrong type\");\n",
+            "}}\n"
+        ),
+        banner = BANNER_DART,
+        component_name = component_name,
+        root_widget = root_widget,
+    )
+}
+
+fn build_runtime_required_root_widget_constructor(
+    component_name: &str,
+    slots: &[SlotDecl],
+) -> String {
+    let mut out = format!("{component_name}(\n");
+    for slot in slots {
+        let field = to_camel_case_first_lower(&slot.name);
+        let value = runtime_required_host_value_for_slot(slot);
+        writeln!(out, "            {field}: {value},").unwrap();
+    }
+    out.push_str("            dispatch: (event) {\n");
+    out.push_str(
+        "              _queueMosaicResponse(_mosaicHost.handleEvent(event.mosaicEnvelope));\n",
+    );
+    out.push_str("            },\n");
+    out.push_str("          )");
+    out
+}
+
+fn runtime_required_host_value_for_slot(slot: &SlotDecl) -> String {
+    let slot_name = escape_dart_string(&slot.name);
+    if let Some(default) = &slot.default {
+        return match default {
+            SlotDefault::Text(value) => format!(
+                "mosaicOptionalString(_hostProps, \"{slot_name}\") ?? \"{}\"",
+                escape_dart_string(value)
+            ),
+            SlotDefault::Number(value) if value.is_finite() => format!(
+                "mosaicOptionalDouble(_hostProps, \"{slot_name}\") ?? {}",
+                dart_double_literal(*value)
+            ),
+            SlotDefault::Number(_) => {
+                format!("mosaicOptionalDouble(_hostProps, \"{slot_name}\") ?? 0.0")
+            }
+            SlotDefault::Bool(value) => {
+                format!("mosaicOptionalBoolean(_hostProps, \"{slot_name}\") ?? {value}")
+            }
+        };
+    }
+    if !slot.required {
+        return match &slot.r#type {
+            SlotType::Text | SlotType::Image | SlotType::Color => {
+                format!("mosaicOptionalString(_hostProps, \"{slot_name}\")")
+            }
+            SlotType::Number => {
+                format!("mosaicOptionalDouble(_hostProps, \"{slot_name}\")")
+            }
+            SlotType::Bool => {
+                format!("mosaicOptionalBoolean(_hostProps, \"{slot_name}\")")
+            }
+            SlotType::List(inner) => match inner.as_ref() {
+                ListInnerType::Text | ListInnerType::Image | ListInnerType::Color => {
+                    format!("mosaicOptionalStringList(_hostProps, \"{slot_name}\")")
+                }
+                ListInnerType::Number => {
+                    format!("mosaicOptionalDoubleList(_hostProps, \"{slot_name}\")")
+                }
+                ListInnerType::Bool => {
+                    format!("mosaicOptionalBooleanList(_hostProps, \"{slot_name}\")")
+                }
+                _ => format!(
+                    "mosaicOptionalValue<{}>(_hostProps, \"{slot_name}\")",
+                    slot_type_to_dart(&slot.r#type)
+                ),
+            },
+            SlotType::Node => format!("mosaicOptionalWidget(_hostProps, \"{slot_name}\")"),
+            SlotType::Component(_) => format!(
+                "mosaicOptionalValue<{}>(_hostProps, \"{slot_name}\")",
+                slot_type_to_dart(&slot.r#type)
+            ),
+        };
+    }
+    match &slot.r#type {
+        SlotType::Text | SlotType::Image | SlotType::Color => {
+            format!("mosaicRequiredString(_hostProps, \"{slot_name}\")")
+        }
+        SlotType::Number => format!("mosaicRequiredDouble(_hostProps, \"{slot_name}\")"),
+        SlotType::Bool => format!("mosaicRequiredBoolean(_hostProps, \"{slot_name}\")"),
+        SlotType::List(inner) => match inner.as_ref() {
+            ListInnerType::Text | ListInnerType::Image | ListInnerType::Color => {
+                format!("mosaicRequiredStringList(_hostProps, \"{slot_name}\")")
+            }
+            ListInnerType::Number => {
+                format!("mosaicRequiredDoubleList(_hostProps, \"{slot_name}\")")
+            }
+            ListInnerType::Bool => {
+                format!("mosaicRequiredBooleanList(_hostProps, \"{slot_name}\")")
+            }
+            _ => format!(
+                "mosaicRequiredValue<{}>(_hostProps, \"{slot_name}\")",
+                slot_type_to_dart(&slot.r#type)
+            ),
+        },
+        SlotType::Node => format!("mosaicRequiredWidget(_hostProps, \"{slot_name}\")"),
+        SlotType::Component(_) => format!(
+            "mosaicRequiredValue<{}>(_hostProps, \"{slot_name}\")",
+            slot_type_to_dart(&slot.r#type)
+        ),
+    }
+}
+
 fn build_root_widget_constructor(component_name: &str, slots: &[SlotDecl]) -> String {
     let mut out = format!("{component_name}(\n");
     for slot in slots {
@@ -534,12 +926,19 @@ fn host_value_for_slot(slot: &SlotDecl) -> String {
     }
 }
 
-fn build_mosaic_host_dart() -> String {
+fn build_mosaic_host_dart(require_runtime: bool) -> String {
     let mut out = String::from(BANNER_DART);
     out.push_str("import 'dart:async';\n\n");
     out.push_str("class MosaicHost {\n");
     out.push_str("  const MosaicHost();\n\n");
     out.push_str("  static MosaicHost? load() => null;\n\n");
+    if require_runtime {
+        out.push_str("  static MosaicHost loadRequired() {\n");
+        out.push_str(
+            "    throw StateError('native-complete requires the Mosaic Rust application runtime');\n",
+        );
+        out.push_str("  }\n\n");
+    }
     out.push_str("  FutureOr<Map<String, Object?>?> props() => null;\n\n");
     out.push_str(
         "  FutureOr<Map<String, Object?>?> handleEvent(Map<String, Object?> event) => null;\n\n",
@@ -598,9 +997,15 @@ fn kebab_to_pascal_case_for_label(s: &str) -> String {
     }
 }
 
-fn build_flutter_readme(pub_name: &str, component_name: &str) -> String {
-    format!(
+fn build_flutter_readme(pub_name: &str, component_name: &str, require_runtime: bool) -> String {
+    if !require_runtime {
+        return format!(
         "{BANNER_MD}# {component_name} — Flutter app shell\n\nAuto-generated by `mosaic-compile --backend flutter --emit-project`.\n\n## Prerequisites\n\n- Flutter SDK 3.24+ (run `flutter --version` to check).\n- A device target: iOS simulator, Android emulator, or desktop (`flutter config --enable-macos-desktop` / `--enable-linux-desktop` / `--enable-windows-desktop`).\n\n## Run\n\nChoose the platforms this host will ship, let Flutter add their standard runner files, then build or run normally. Flutter preserves the Mosaic-generated `lib/` sources:\n\n```sh\nflutter create --platforms=macos,windows,linux .\nflutter pub get\nflutter run -d <device-id>   # or `flutter run` to pick interactively\n```\n\n## What's in this directory\n\n| File | Purpose |\n|---|---|\n| `lib/{component_name}.dart` | The Mosaic-compiled component mounted by the app shell. |\n| `pubspec.yaml` | Dart pub manifest. Pinned Flutter + Dart SDKs per UI32 spec §3.6.3. |\n| `lib/main.dart` | MaterialApp shell that mounts `{component_name}(...)`, hydrates slot values from an optional Mosaic host, and forwards Mosaic event envelopes. |\n| `lib/mosaic_host.dart` | Default no-op Mosaic host hook. App packages can overwrite it with a real bridge. |\n| `README.md` | This file. |\n\nDart pub name: `{pub_name}`.\n\n## Editing\n\nEvery shell file carries an AUTO-GENERATED banner. Re-running `mosaic-compile --emit-project` will overwrite them. To customise the shell, remove the banner from a file and rename or relocate it; the next `--emit-project` run will recreate the original at its original name without touching your forked copy.\n"
+        );
+    }
+
+    format!(
+        "{BANNER_MD}# {component_name} — Flutter native-complete app shell\n\nAuto-generated by `mosaic-compile --backend flutter --emit-project --profile native-complete`.\n\nThis shell requires Mosaic's standard Rust application runtime at startup. It waits for the first runtime props envelope before mounting `{component_name}` and never substitutes preview/sample values for missing required props.\n\n## Prerequisites\n\n- Flutter SDK 3.24+ (run `flutter --version` to check).\n- A built Mosaic Rust application library, available through `MOSAIC_APP_LIBRARY` or the platform's conventional `mosaic_app` library name.\n- A device target: iOS simulator, Android emulator, or desktop (`flutter config --enable-macos-desktop` / `--enable-linux-desktop` / `--enable-windows-desktop`).\n\n## Run\n\nChoose the platforms this host will ship, let Flutter add their standard runner files, then build or run normally. Flutter preserves the Mosaic-generated `lib/` sources:\n\n```sh\nflutter create --platforms=macos,windows,linux .\nflutter pub get\nMOSAIC_APP_LIBRARY=/absolute/path/to/libmosaic_app.dylib flutter run -d <device-id>\n```\n\nUse the platform-appropriate library filename on Linux or Windows. Startup fails explicitly when the Rust runtime cannot be loaded or does not provide the required props envelope.\n\n## What's in this directory\n\n| File | Purpose |\n|---|---|\n| `lib/{component_name}.dart` | The Mosaic-compiled component mounted by the app shell. |\n| `pubspec.yaml` | Dart pub manifest. Pinned Flutter + Dart SDKs per UI32 spec §3.6.3. |\n| `lib/main.dart` | Runtime-required MaterialApp shell that waits for Rust-provided props and forwards Mosaic event envelopes. |\n| `lib/mosaic_host.dart` | Mosaic host contract. The package builder installs the standard Dart FFI binding here. |\n| `README.md` | This file. |\n\nDart pub name: `{pub_name}`.\n\n## Editing\n\nEvery shell file carries an AUTO-GENERATED banner. Re-running `mosaic-compile --emit-project` will overwrite them. To customise the shell, remove the banner from a file and rename or relocate it; the next `--emit-project` run will recreate the original at its original name without touching your forked copy.\n"
     )
 }
 
@@ -5141,6 +5546,64 @@ mod tests {
             r.project.is_some(),
             "emit_project: true must produce a shell"
         );
+    }
+
+    #[test]
+    fn native_complete_shell_requires_runtime_props_without_samples() {
+        let mut count = slot("count", SlotType::Number, false);
+        count.default = Some(SlotDefault::Number(3.0));
+        let m = component(
+            "Card",
+            vec![
+                slot("label", SlotType::Text, true),
+                slot("subtitle", SlotType::Text, false),
+                count,
+            ],
+            vec![],
+        );
+        let l = layout("Card", node("Box"));
+        let opts = EmitOptions {
+            emit_project: true,
+            require_runtime: true,
+            ..EmitOptions::default()
+        };
+        let project = from_pipeline_with_options(&m, &l, &empty_style("Card"), &opts)
+            .unwrap()
+            .project
+            .expect("strict project shell");
+
+        assert!(project.main_dart.contains("MosaicHost.loadRequired()"));
+        assert!(project.main_dart.contains("required this.mosaicHost"));
+        assert!(project.main_dart.contains("bool _hostReady = false"));
+        assert!(project.main_dart.contains("response.containsKey('props')"));
+        assert!(project
+            .main_dart
+            .contains("mosaicRequiredString(_hostProps, \"label\")"));
+        assert!(project
+            .main_dart
+            .contains("mosaicOptionalString(_hostProps, \"subtitle\")"));
+        assert!(project
+            .main_dart
+            .contains("mosaicOptionalDouble(_hostProps, \"count\") ?? 3.0"));
+        assert!(project.main_dart.contains("Starting Card"));
+        assert!(project
+            .main_dart
+            .contains("child: const CircularProgressIndicator()"));
+        assert!(!project.main_dart.contains(": const Semantics("));
+        assert!(project.main_dart.contains("return value as T"));
+        assert!(!project.main_dart.contains("MosaicHost?"));
+        assert!(!project.main_dart.contains("_mosaicHost?."));
+        assert!(!project.main_dart.contains("debugPrint(\"event:"));
+        assert!(!project.main_dart.contains("Sample Label"));
+        assert!(project
+            .mosaic_host_dart
+            .contains("static MosaicHost loadRequired()"));
+        assert!(project
+            .readme
+            .contains("requires Mosaic's standard Rust application runtime"));
+        assert!(project
+            .readme
+            .contains("never substitutes preview/sample values"));
     }
 
     #[test]

--- a/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased] - native-complete Flutter runtime shell
+
+- Flutter project shells emitted under `BuildProfile::NativeComplete` now
+  require Mosaic's standard Dart FFI runtime and the first props envelope before
+  mounting the generated widget.
+- Strict Flutter shells omit nullable-host, event-print, and generated sample
+  paths while permissive output remains backward-compatible.
+- Flutter runtime CI now analyzes a zero-degradation strict project in addition
+  to round-tripping the standard binding.
+
 ## [Unreleased] - native-complete Compose runtime shell
 
 - Compose project shells emitted under `BuildProfile::NativeComplete` now

--- a/code/packages/rust/mosaic-package-artifact-builder/README.md
+++ b/code/packages/rust/mosaic-package-artifact-builder/README.md
@@ -34,12 +34,12 @@ the selected backend has a known degradation.
 The initial inventory identifies passive drag/drop lowerings, native table
 lowerings without table semantics, Flutter's dialog placeholder and missing URL
 effect host, and generated native project shells that can fall back to sample
-props. Compose is the first closed shell: its strict profile requires Mosaic's
-standard Rust runtime, waits for the first props envelope, rejects missing
-required props, and omits both sample-data and package-owned reflection-host
-fallbacks. The overall native-complete milestone remains open while the other
-four native shells are closed and ignored properties, events, styles, effects,
-and accessibility metadata are added to the inventory.
+props. Compose and Flutter are the first closed shells: their strict profiles
+require Mosaic's standard Rust runtime, wait for the first props envelope,
+reject missing required props, and omit sample-data and optional-host fallbacks.
+The overall native-complete milestone remains open while the other three native
+shells are closed and ignored properties, events, styles, effects, and
+accessibility metadata are added to the inventory.
 
 `compose_component` is the canonical in-memory entry point shared by package
 builds and standalone three-file compilation. It returns the compiled model,
@@ -77,7 +77,9 @@ compatibility fallback.
 Flutter project shells replace the no-op host stub with the standard Dart FFI
 runtime while preserving `MosaicApp(mosaicHost: ...)` injection. Set
 `MOSAIC_APP_LIBRARY` to the Rust application library, or package it under the
-target platform's conventional `mosaic_app` name.
+target platform's conventional `mosaic_app` name. Permissive builds retain the
+injectable/optional preview path; `native-complete` builds require the binding
+and Rust-provided props before mounting the generated widget.
 Qt project shells install a standard QObject host backed by `QLibrary` and
 Qt JSON/variant APIs. Explicit package host assets can still replace
 `MosaicHost.h/.cpp` for specialized native surfaces and effects.

--- a/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
+++ b/code/packages/rust/mosaic-package-artifact-builder/src/lib.rs
@@ -581,8 +581,8 @@ pub fn analyze_package_degradations(
         });
     }
 
-    let runtime_required_shell =
-        profile == BuildProfile::NativeComplete && opts.backend == Backend::Compose;
+    let runtime_required_shell = profile == BuildProfile::NativeComplete
+        && matches!(opts.backend, Backend::Compose | Backend::Flutter);
     if opts.emit_project && opts.backend.is_native() && !runtime_required_shell {
         degradations.push(Degradation {
             code: "runtime.sample-fallback".to_string(),
@@ -1285,6 +1285,7 @@ fn emit_project_shell(options: ProjectShellOptions<'_>) -> Result<Vec<PathBuf>, 
         Backend::Flutter => {
             let fl_opts = mosaic_emit_flutter::pipeline::EmitOptions {
                 emit_project: true,
+                require_runtime: profile == Some(BuildProfile::NativeComplete),
                 ..Default::default()
             };
             let r = mosaic_emit_flutter::pipeline::from_pipeline_with_options(
@@ -3537,7 +3538,7 @@ layout Board {
     #[test]
     fn generated_native_shell_sample_fallback_is_reported() {
         let pkg = make_package("mosaic-pkg-card", &["Card"]);
-        for backend in [Backend::Xaml, Backend::Compose] {
+        for backend in [Backend::Xaml, Backend::Compose, Backend::Flutter] {
             let out = TempDir::new().unwrap();
             let report = analyze_package_degradations(
                 &BuildOptions {
@@ -3608,6 +3609,57 @@ layout Board {
         let readme = fs::read_to_string(out.path().join("compose/README.md")).unwrap();
         assert!(readme.contains("This `native-complete` shell requires the standard Rust runtime"));
         assert!(!readme.contains("future `native-complete` profile"));
+    }
+
+    #[test]
+    fn native_complete_flutter_shell_requires_the_standard_rust_runtime() {
+        let pkg = make_package("mosaic-pkg-card", &["Card"]);
+        fs::write(
+            pkg.path().join("src/Card.mil"),
+            "component Card { slot label : text ; }\n",
+        )
+        .unwrap();
+        fs::write(
+            pkg.path().join("src/Card.mll"),
+            "layout Card { Text [ root ] ( content : slot: label ) }\n",
+        )
+        .unwrap();
+        let out = TempDir::new().unwrap();
+        let result = build_package_with_profile(
+            &BuildOptions {
+                package_root: pkg.path().to_path_buf(),
+                output_root: out.path().to_path_buf(),
+                backend: Backend::Flutter,
+                emit_project: true,
+                theme: None,
+            },
+            BuildProfile::NativeComplete,
+        )
+        .expect("native-complete Flutter shell");
+
+        let report_path = out.path().join("flutter/mosaic-degradations.json");
+        assert!(result.artifacts.contains(&report_path));
+        let report = fs::read_to_string(report_path).unwrap();
+        assert!(report.contains("\"nativeComplete\": true"));
+
+        let main = fs::read_to_string(out.path().join("flutter/lib/main.dart")).unwrap();
+        assert!(main.contains("MosaicHost.loadRequired()"));
+        assert!(main.contains("required this.mosaicHost"));
+        assert!(main.contains("bool _hostReady = false"));
+        assert!(main.contains("response.containsKey('props')"));
+        assert!(main.contains("mosaicRequiredString(_hostProps, \"label\")"));
+        assert!(!main.contains("MosaicHost?"));
+        assert!(!main.contains("_mosaicHost?."));
+        assert!(!main.contains("debugPrint(\"event:"));
+        assert!(!main.contains("Sample Label"));
+
+        let host = fs::read_to_string(out.path().join("flutter/lib/mosaic_host.dart")).unwrap();
+        assert!(host.contains("static MosaicHost loadRequired()"));
+        assert!(host.contains("native-complete requires the Mosaic Rust application runtime"));
+
+        let readme = fs::read_to_string(out.path().join("flutter/README.md")).unwrap();
+        assert!(readme.contains("requires Mosaic's standard Rust application runtime"));
+        assert!(readme.contains("never substitutes preview/sample values"));
     }
 
     #[test]

--- a/code/scripts/tests/test_mosaic_flutter_runtime_ci_acceptance.py
+++ b/code/scripts/tests/test_mosaic_flutter_runtime_ci_acceptance.py
@@ -114,6 +114,8 @@ class MosaicFlutterRuntimeCIAcceptanceTests(unittest.TestCase):
         self.assertIn("Round-trip Rust engine through standard Flutter binding", workflow)
         self.assertIn("needs_mosaic_flutter_runtime == 'true'", workflow)
         self.assertIn("timeout-minutes: 10", workflow)
+        self.assertIn("uses: subosito/flutter-action@v2", workflow)
+        self.assertIn("flutter-version: '3.24.0'", workflow)
         self.assertIn("--backend flutter --output \"$output\" --emit-project", workflow)
         self.assertIn(
             "cargo build --manifest-path code/packages/rust/Cargo.toml -p mosaic-app-conformance",
@@ -122,6 +124,10 @@ class MosaicFlutterRuntimeCIAcceptanceTests(unittest.TestCase):
         self.assertIn("flutter/lib/mosaic_host.dart", workflow)
         self.assertIn("dart analyze", workflow)
         self.assertIn("dart run bin/conformance.dart", workflow)
+        self.assertIn("mosaic-flutter-native-complete-rating-controls", workflow)
+        self.assertIn("--profile native-complete", workflow)
+        self.assertIn(".nativeComplete == true", workflow)
+        self.assertIn("dart analyze lib", workflow)
         self.assertIn("MOSAIC_APP_LIBRARY", workflow)
 
     def test_harness_does_not_duplicate_the_generated_binding(self) -> None:

--- a/code/specs/UI38-mosaic-native-application-runtime.md
+++ b/code/specs/UI38-mosaic-native-application-runtime.md
@@ -303,12 +303,15 @@ unblocks multiple downstream targets; never count source generation as completio
 - [ ] Add `native-complete` capability/degradation analysis to the compiler.
   - [x] Add a package-builder API and CLI profile with deterministic,
     package-expanded degradation reports and pre-emission strict rejection.
-  - [x] Make Compose `native-complete` project shells require the standard Rust
-    runtime and runtime-provided props, with no legacy-host or sample-data path.
-  - [ ] Repeat the runtime-required shell policy for SwiftUI, XAML, Qt, and
-    Flutter.
+  - [x] Make Compose and Flutter `native-complete` project shells require the
+    standard Rust runtime and runtime-provided props, with no optional-host or
+    sample-data path.
+  - [ ] Repeat the runtime-required shell policy for SwiftUI, XAML, and Qt.
   - [ ] Inventory ignored properties, events, styles, effects, and accessibility
     metadata across every native emitter, and add the equivalent package setting.
+    - [ ] Define a serializable native-view reference contract for `node` and
+      component slots; Flutter's JSON runtime cannot currently materialize a
+      Dart `Widget` value for those otherwise typed composition seams.
   - [ ] Remove every reported TaskApp degradation on all five native backends.
 - [ ] Add launch-and-dispatch conformance fixtures for every native backend.
   - [x] XAML/.NET loads the shared Rust conformance DLL and round-trips startup,


### PR DESCRIPTION
## Summary
- add a native-complete Flutter shell that requires the standard Rust application runtime before mounting UI
- preserve permissive preview behavior while honoring required, optional, and defaulted MIL slot semantics in strict mode
- remove the Flutter runtime sample-fallback degradation and add a zero-degradation generated-project analyzer gate to Linux CI
- record the native-view reference contract gap for node and component slots in the UI38 backlog

## Validation
- cargo test -p mosaic-emit-flutter -p mosaic-app-bindings -p mosaic-package-artifact-builder -p mosaic-compile
- cargo clippy -p mosaic-emit-flutter -p mosaic-app-bindings -p mosaic-package-artifact-builder -p mosaic-compile --all-targets -- -D warnings
- python3 code/scripts/tests/test_mosaic_flutter_runtime_ci_acceptance.py
- generated native-complete rating-controls report is zero-degradation
- generated permissive rating-controls retains runtime.sample-fallback and sample props

## Local environment note
The installed local Dart and Flutter binaries hang even on version queries, so generated Dart analysis is delegated to the new Linux CI acceptance gate.