### PR TITLE
Add secure vault CLI host boundary

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1067,4 +1067,5 @@ members = [
   "vault-pm-application-storage-core",
   "vault-pm-local-host",
   "vault-pm-config",
+  "vault-pm-cli-host",
 ]

--- a/code/packages/rust/vault-pm-cli-host/BUILD
+++ b/code/packages/rust/vault-pm-cli-host/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding_adventures_vault_pm_cli_host -- --nocapture

--- a/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli-host/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Add fixed-prompt, bounded secret collection from the controlling terminal on
+  Unix and the attached console on Windows.
+- Add echo restoration, oversized-line draining, zeroizing ownership, and
+  constant-time new-passphrase confirmation.
+- Add a stable, payload-free OS entropy adapter over `csprng`.

--- a/code/packages/rust/vault-pm-cli-host/Cargo.toml
+++ b/code/packages/rust/vault-pm-cli-host/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "coding_adventures_vault_pm_cli_host"
+version = "0.1.0"
+edition = "2021"
+description = "Controlling-terminal secret input and OS entropy for the vault-pm CLI"
+license = "MIT"
+
+[dependencies]
+coding_adventures_csprng = { path = "../csprng" }
+coding_adventures_ct_compare = { path = "../ct-compare" }
+coding_adventures_zeroize = { path = "../zeroize" }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Console",
+] }

--- a/code/packages/rust/vault-pm-cli-host/README.md
+++ b/code/packages/rust/vault-pm-cli-host/README.md
@@ -1,0 +1,48 @@
+# `coding_adventures_vault_pm_cli_host`
+
+This crate is the native secret-input and entropy boundary for the local
+password-manager CLI. It gives the eventual `vault-pm` executable two narrow,
+auditable adapters:
+
+- `ControllingTerminal` opens `/dev/tty` on Unix or `CONIN$`/`CONOUT$` on
+  Windows, emits only fixed prompts, disables echo, reads one bounded line, and
+  restores the original terminal mode before returning; and
+- `OsEntropy` completely fills a caller-owned non-empty buffer using the
+  repository `csprng` wrapper and maps operating-system details to one stable,
+  payload-free failure.
+
+Secret input never comes from process stdin, argv, an environment variable, a
+configuration value, or a URL. Redirecting stdin therefore cannot inject a
+master passphrase. New-vault collection performs two independent terminal
+reads and compares them with the repository constant-time comparison primitive.
+Collected bytes are immediately wrapped in `Zeroizing<Vec<u8>>` and are never
+available through `Debug`.
+
+Unix opens `/dev/tty` without following links, verifies a character terminal,
+and disables `ECHO` and `ECHONL` with an RAII termios guard. Windows opens the
+attached console directly, verifies console handles, clears only
+`ENABLE_ECHO_INPUT`, and converts console UTF-16 to UTF-8 bytes. Both paths
+drain an oversized line before restoring echo, so unconsumed secret suffixes do
+not become visible terminal input. Ordinary success, error, and panic-unwind
+paths restore the captured mode; a force-kill that prevents destructors from
+running is outside an in-process library's guarantees.
+
+The accepted passphrase is non-empty and at most 1,024 bytes, matching the
+portable-export application boundary. Prompt strings and every public error
+are fixed and contain no secret, OS error, terminal path, user name, or caller
+payload. This crate deliberately does not parse commands, choose storage,
+persist configuration, calibrate Argon2id, or prepare vault bytes.
+
+Seven Unix tests exercise stable diagnostics, bounds, constant-time
+confirmation behavior, real OS entropy, pseudo-terminal hidden input and mode
+restoration, oversized-line draining, and non-terminal refusal. Windows adds
+three target-specific tests for console names and strict UTF-16 conversion;
+cross-target Clippy validates the native Windows API surface from Unix.
+
+## Verification
+
+```bash
+bash BUILD
+cargo clippy -p coding_adventures_vault_pm_cli_host --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p coding_adventures_vault_pm_cli_host --no-deps
+```

--- a/code/packages/rust/vault-pm-cli-host/required_capabilities.json
+++ b/code/packages/rust/vault-pm-cli-host/required_capabilities.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/vault-pm-cli-host",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "/dev/tty or the attached Windows console",
+      "justification": "Collects bounded passphrase bytes from the controlling terminal instead of redirectable process stdin."
+    },
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "/dev/tty or the attached Windows console",
+      "justification": "Writes fixed prompts and a post-input newline directly to the controlling terminal."
+    },
+    {
+      "category": "ffi",
+      "action": "call",
+      "target": "Unix termios and Windows console APIs",
+      "justification": "Verifies the native terminal object and disables and restores input echo using platform APIs unavailable through portable Rust I/O."
+    },
+    {
+      "category": "ffi",
+      "action": "call",
+      "target": "operating-system cryptographic random source via rust/csprng",
+      "justification": "Fills caller-owned initialization and encryption randomness without a user-space or deterministic fallback."
+    }
+  ],
+  "justification": "CLI-only host boundary for non-redirectable hidden secret input and fresh operating-system entropy; it performs no configuration, provider, network, environment, or process access."
+}

--- a/code/packages/rust/vault-pm-cli-host/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/lib.rs
@@ -1,0 +1,278 @@
+//! Controlling-terminal secret input and OS entropy for the vault-pm CLI.
+
+#![deny(missing_docs)]
+
+use coding_adventures_csprng::fill_random;
+use coding_adventures_ct_compare::ct_eq;
+use coding_adventures_zeroize::Zeroizing;
+use core::fmt::{self, Debug, Display, Formatter};
+
+#[cfg(unix)]
+#[path = "unix.rs"]
+mod platform;
+#[cfg(windows)]
+#[path = "windows.rs"]
+mod platform;
+
+/// Maximum accepted UTF-8 passphrase bytes.
+pub const MAX_SECRET_BYTES: usize = 1_024;
+
+/// Stable, payload-free native CLI host failures.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CliHostError {
+    /// The process has no usable controlling terminal or console.
+    TerminalUnavailable,
+    /// The controlling terminal could not be opened or written.
+    TerminalAccessFailed,
+    /// Echo state could not be read, disabled, or restored safely.
+    TerminalModeFailed,
+    /// Secret input ended or failed before a complete line was read.
+    SecretInputFailed,
+    /// The collected secret was empty.
+    EmptySecret,
+    /// The collected secret exceeded [`MAX_SECRET_BYTES`].
+    SecretTooLong,
+    /// Two independently collected new-passphrase values did not match.
+    SecretMismatch,
+    /// The caller requested an empty entropy buffer.
+    InvalidEntropyRequest,
+    /// The operating-system CSPRNG failed to fill a requested buffer.
+    EntropyUnavailable,
+    /// No audited implementation exists for the current target.
+    UnsupportedPlatform,
+}
+
+impl Display for CliHostError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::TerminalUnavailable => "vault-pm CLI host: terminal unavailable",
+            Self::TerminalAccessFailed => "vault-pm CLI host: terminal access failed",
+            Self::TerminalModeFailed => "vault-pm CLI host: terminal mode failed",
+            Self::SecretInputFailed => "vault-pm CLI host: secret input failed",
+            Self::EmptySecret => "vault-pm CLI host: empty secret",
+            Self::SecretTooLong => "vault-pm CLI host: secret too long",
+            Self::SecretMismatch => "vault-pm CLI host: secrets do not match",
+            Self::InvalidEntropyRequest => "vault-pm CLI host: invalid entropy request",
+            Self::EntropyUnavailable => "vault-pm CLI host: OS entropy unavailable",
+            Self::UnsupportedPlatform => "vault-pm CLI host: unsupported platform",
+        })
+    }
+}
+
+impl std::error::Error for CliHostError {}
+
+/// Fixed prompts that can never contain caller-controlled text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SecretPrompt {
+    /// Unlock an initialized local vault.
+    Unlock,
+    /// Collect the first value for a new vault passphrase.
+    NewPassphrase,
+    /// Confirm a newly collected vault passphrase.
+    ConfirmPassphrase,
+    /// Protect a portable export with a distinct passphrase.
+    ExportPassphrase,
+    /// Open a portable export using its distinct passphrase.
+    ImportPassphrase,
+}
+
+impl SecretPrompt {
+    fn message(self) -> &'static str {
+        match self {
+            Self::Unlock => "Vault passphrase: ",
+            Self::NewPassphrase => "New vault passphrase: ",
+            Self::ConfirmPassphrase => "Confirm vault passphrase: ",
+            Self::ExportPassphrase => "Export passphrase: ",
+            Self::ImportPassphrase => "Import passphrase: ",
+        }
+    }
+}
+
+/// Stateless reader that always opens the process controlling terminal.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ControllingTerminal;
+
+impl ControllingTerminal {
+    /// Read one bounded, non-empty secret with terminal echo disabled.
+    pub fn read_secret(&self, prompt: SecretPrompt) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
+        #[cfg(any(unix, windows))]
+        {
+            let secret = platform::read_secret(prompt.message(), MAX_SECRET_BYTES)?;
+            validate_secret(secret)
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = prompt;
+            Err(CliHostError::UnsupportedPlatform)
+        }
+    }
+
+    /// Read and constant-time compare a new passphrase and confirmation.
+    pub fn read_new_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
+        confirm_new_passphrase(|prompt| self.read_secret(prompt))
+    }
+}
+
+/// Stateless cryptographic entropy adapter backed by the repository OS CSPRNG.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct OsEntropy;
+
+impl OsEntropy {
+    /// Completely overwrite a non-empty caller buffer with fresh OS entropy.
+    pub fn fill(&self, output: &mut [u8]) -> Result<(), CliHostError> {
+        if output.is_empty() {
+            return Err(CliHostError::InvalidEntropyRequest);
+        }
+        fill_random(output).map_err(|_| CliHostError::EntropyUnavailable)
+    }
+}
+
+fn validate_secret(secret: Zeroizing<Vec<u8>>) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
+    if secret.is_empty() {
+        Err(CliHostError::EmptySecret)
+    } else if secret.len() > MAX_SECRET_BYTES {
+        Err(CliHostError::SecretTooLong)
+    } else {
+        Ok(secret)
+    }
+}
+
+fn confirm_new_passphrase<F>(mut read: F) -> Result<Zeroizing<Vec<u8>>, CliHostError>
+where
+    F: FnMut(SecretPrompt) -> Result<Zeroizing<Vec<u8>>, CliHostError>,
+{
+    let first = read(SecretPrompt::NewPassphrase)?;
+    let confirmation = read(SecretPrompt::ConfirmPassphrase)?;
+    if ct_eq(&first, &confirmation) {
+        Ok(first)
+    } else {
+        Err(CliHostError::SecretMismatch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_prompts_and_errors_are_payload_free() {
+        assert_eq!(SecretPrompt::Unlock.message(), "Vault passphrase: ");
+        assert_eq!(
+            SecretPrompt::NewPassphrase.message(),
+            "New vault passphrase: "
+        );
+        assert_eq!(
+            SecretPrompt::ConfirmPassphrase.message(),
+            "Confirm vault passphrase: "
+        );
+        assert_eq!(
+            SecretPrompt::ExportPassphrase.message(),
+            "Export passphrase: "
+        );
+        assert_eq!(
+            SecretPrompt::ImportPassphrase.message(),
+            "Import passphrase: "
+        );
+        let expected = [
+            (
+                CliHostError::TerminalUnavailable,
+                "vault-pm CLI host: terminal unavailable",
+            ),
+            (
+                CliHostError::TerminalAccessFailed,
+                "vault-pm CLI host: terminal access failed",
+            ),
+            (
+                CliHostError::TerminalModeFailed,
+                "vault-pm CLI host: terminal mode failed",
+            ),
+            (
+                CliHostError::SecretInputFailed,
+                "vault-pm CLI host: secret input failed",
+            ),
+            (CliHostError::EmptySecret, "vault-pm CLI host: empty secret"),
+            (
+                CliHostError::SecretTooLong,
+                "vault-pm CLI host: secret too long",
+            ),
+            (
+                CliHostError::SecretMismatch,
+                "vault-pm CLI host: secrets do not match",
+            ),
+            (
+                CliHostError::InvalidEntropyRequest,
+                "vault-pm CLI host: invalid entropy request",
+            ),
+            (
+                CliHostError::EntropyUnavailable,
+                "vault-pm CLI host: OS entropy unavailable",
+            ),
+            (
+                CliHostError::UnsupportedPlatform,
+                "vault-pm CLI host: unsupported platform",
+            ),
+        ];
+        for (error, display) in expected {
+            assert_eq!(error.to_string(), display);
+        }
+    }
+
+    #[test]
+    fn validation_enforces_nonempty_bounded_secrets() {
+        assert!(matches!(
+            validate_secret(Zeroizing::new(Vec::new())),
+            Err(CliHostError::EmptySecret)
+        ));
+        assert!(matches!(
+            validate_secret(Zeroizing::new(vec![b'x'; MAX_SECRET_BYTES + 1])),
+            Err(CliHostError::SecretTooLong)
+        ));
+        assert_eq!(
+            &*validate_secret(Zeroizing::new(vec![b'x'; MAX_SECRET_BYTES])).unwrap(),
+            &vec![b'x'; MAX_SECRET_BYTES]
+        );
+    }
+
+    #[test]
+    fn confirmation_uses_two_fixed_prompts_and_rejects_mismatch() {
+        let mut prompts = Vec::new();
+        let matched = confirm_new_passphrase(|prompt| {
+            prompts.push(prompt);
+            Ok(Zeroizing::new(b"same secret".to_vec()))
+        })
+        .unwrap();
+        assert_eq!(&*matched, b"same secret");
+        assert_eq!(
+            prompts,
+            [SecretPrompt::NewPassphrase, SecretPrompt::ConfirmPassphrase]
+        );
+
+        let mut call = 0;
+        assert!(matches!(
+            confirm_new_passphrase(|_| {
+                call += 1;
+                Ok(Zeroizing::new(if call == 1 {
+                    b"first".to_vec()
+                } else {
+                    b"second".to_vec()
+                }))
+            }),
+            Err(CliHostError::SecretMismatch)
+        ));
+    }
+
+    #[test]
+    fn os_entropy_fills_exact_caller_buffer_and_rejects_empty_requests() {
+        let entropy = OsEntropy;
+        let mut first = [0u8; 64];
+        let mut second = [0u8; 64];
+        entropy.fill(&mut first).unwrap();
+        entropy.fill(&mut second).unwrap();
+        assert!(first.iter().any(|byte| *byte != 0));
+        assert_ne!(first, second);
+        assert_eq!(
+            entropy.fill(&mut []).unwrap_err(),
+            CliHostError::InvalidEntropyRequest
+        );
+    }
+}

--- a/code/packages/rust/vault-pm-cli-host/src/unix.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/unix.rs
@@ -1,0 +1,261 @@
+use super::CliHostError;
+use coding_adventures_zeroize::Zeroizing;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::mem::MaybeUninit;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+pub(super) fn read_secret(
+    prompt: &str,
+    max_bytes: usize,
+) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
+    let raw = unsafe {
+        libc::open(
+            c"/dev/tty".as_ptr(),
+            libc::O_RDWR | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if raw < 0 {
+        return Err(match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ENXIO) | Some(libc::ENODEV) | Some(libc::ENOENT) | Some(libc::ENOTTY) => {
+                CliHostError::TerminalUnavailable
+            }
+            _ => CliHostError::TerminalAccessFailed,
+        });
+    }
+    let mut terminal = File::from(owned_fd(raw).map_err(|_| CliHostError::TerminalAccessFailed)?);
+    verify_terminal(&terminal)?;
+    read_secret_from_terminal(&mut terminal, prompt.as_bytes(), max_bytes)
+}
+
+fn read_secret_from_terminal(
+    terminal: &mut File,
+    prompt: &[u8],
+    max_bytes: usize,
+) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
+    verify_terminal(terminal)?;
+    let guard = EchoGuard::disable(terminal.as_raw_fd())?;
+    let operation = (|| {
+        terminal
+            .write_all(prompt)
+            .and_then(|()| terminal.flush())
+            .map_err(|_| CliHostError::TerminalAccessFailed)?;
+        read_bounded_line(terminal, max_bytes)
+    })();
+    let restored = guard.restore();
+    let newline = terminal
+        .write_all(b"\n")
+        .and_then(|()| terminal.flush())
+        .map_err(|_| CliHostError::TerminalAccessFailed);
+    let secret = operation?;
+    restored?;
+    newline?;
+    Ok(secret)
+}
+
+fn read_bounded_line(
+    terminal: &mut File,
+    max_bytes: usize,
+) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
+    let mut secret = Zeroizing::new(Vec::with_capacity(max_bytes));
+    let mut too_long = false;
+    loop {
+        let mut byte = Zeroizing::new([0u8; 1]);
+        match terminal.read(&mut *byte) {
+            Ok(0) => return Err(CliHostError::SecretInputFailed),
+            Ok(_) if byte[0] == b'\n' || byte[0] == b'\r' => break,
+            Ok(_) if secret.len() < max_bytes => secret.push(byte[0]),
+            Ok(_) => too_long = true,
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(_) => return Err(CliHostError::SecretInputFailed),
+        }
+    }
+    if too_long {
+        Err(CliHostError::SecretTooLong)
+    } else {
+        Ok(secret)
+    }
+}
+
+fn verify_terminal(file: &File) -> Result<(), CliHostError> {
+    if unsafe { libc::isatty(file.as_raw_fd()) } != 1 {
+        return Err(CliHostError::TerminalUnavailable);
+    }
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    if unsafe { libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) } != 0 {
+        return Err(CliHostError::TerminalAccessFailed);
+    }
+    if unsafe { stat.assume_init() }.st_mode & libc::S_IFMT != libc::S_IFCHR {
+        return Err(CliHostError::TerminalUnavailable);
+    }
+    Ok(())
+}
+
+struct EchoGuard {
+    descriptor: libc::c_int,
+    original: libc::termios,
+    active: bool,
+}
+
+impl EchoGuard {
+    fn disable(descriptor: libc::c_int) -> Result<Self, CliHostError> {
+        let mut original = MaybeUninit::<libc::termios>::uninit();
+        if unsafe { libc::tcgetattr(descriptor, original.as_mut_ptr()) } != 0 {
+            return Err(CliHostError::TerminalModeFailed);
+        }
+        let original = unsafe { original.assume_init() };
+        let mut hidden = original;
+        hidden.c_lflag &= !(libc::ECHO | libc::ECHONL);
+        if unsafe { libc::tcsetattr(descriptor, libc::TCSAFLUSH, &hidden) } != 0 {
+            return Err(CliHostError::TerminalModeFailed);
+        }
+        Ok(Self {
+            descriptor,
+            original,
+            active: true,
+        })
+    }
+
+    fn restore(mut self) -> Result<(), CliHostError> {
+        if unsafe { libc::tcsetattr(self.descriptor, libc::TCSANOW, &self.original) } != 0 {
+            return Err(CliHostError::TerminalModeFailed);
+        }
+        self.active = false;
+        Ok(())
+    }
+}
+
+impl Drop for EchoGuard {
+    fn drop(&mut self) {
+        if self.active {
+            unsafe {
+                libc::tcsetattr(self.descriptor, libc::TCSANOW, &self.original);
+            }
+        }
+    }
+}
+
+fn owned_fd(raw: libc::c_int) -> Result<OwnedFd, ()> {
+    if raw < 0 {
+        Err(())
+    } else {
+        Ok(unsafe { OwnedFd::from_raw_fd(raw) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::ErrorKind;
+    use std::sync::mpsc;
+    use std::thread;
+
+    fn pseudo_terminal() -> (File, File) {
+        let mut master = -1;
+        let mut slave = -1;
+        assert_eq!(
+            unsafe {
+                libc::openpty(
+                    &mut master,
+                    &mut slave,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                )
+            },
+            0
+        );
+        (
+            File::from(owned_fd(master).unwrap()),
+            File::from(owned_fd(slave).unwrap()),
+        )
+    }
+
+    fn terminal_mode(file: &File) -> libc::termios {
+        let mut mode = MaybeUninit::<libc::termios>::uninit();
+        assert_eq!(
+            unsafe { libc::tcgetattr(file.as_raw_fd(), mode.as_mut_ptr()) },
+            0
+        );
+        unsafe { mode.assume_init() }
+    }
+
+    #[test]
+    fn pseudo_terminal_roundtrip_hides_input_and_restores_echo() {
+        let (mut master, mut slave) = pseudo_terminal();
+        let original = terminal_mode(&slave);
+        let prompt = b"Vault passphrase: ";
+        let (prompt_seen_tx, prompt_seen_rx) = mpsc::channel();
+        let peer = thread::spawn(move || {
+            let mut seen = vec![0; prompt.len()];
+            master.read_exact(&mut seen).unwrap();
+            prompt_seen_tx.send(seen).unwrap();
+            master.write_all(b"hidden value\n").unwrap();
+            master
+        });
+
+        let secret = read_secret_from_terminal(&mut slave, prompt, 64).unwrap();
+        assert_eq!(&*secret, b"hidden value");
+        assert_eq!(prompt_seen_rx.recv().unwrap(), prompt);
+        let restored = terminal_mode(&slave);
+        assert_eq!(
+            restored.c_lflag & (libc::ECHO | libc::ECHONL),
+            original.c_lflag & (libc::ECHO | libc::ECHONL)
+        );
+
+        let mut master = peer.join().unwrap();
+        let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
+        assert!(flags >= 0);
+        assert_eq!(
+            unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) },
+            0
+        );
+        let mut output = Vec::new();
+        let mut chunk = [0u8; 128];
+        loop {
+            match master.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(count) => output.extend_from_slice(&chunk[..count]),
+                Err(error) if error.kind() == ErrorKind::WouldBlock => break,
+                Err(error) => panic!("unexpected pseudo-terminal read: {error}"),
+            }
+        }
+        assert!(!output
+            .windows(b"hidden value".len())
+            .any(|part| part == b"hidden value"));
+    }
+
+    #[test]
+    fn oversized_input_is_drained_before_echo_restoration() {
+        let (mut master, mut slave) = pseudo_terminal();
+        let original = terminal_mode(&slave);
+        let peer = thread::spawn(move || {
+            let mut prompt = [0u8; 2];
+            master.read_exact(&mut prompt).unwrap();
+            master.write_all(b"12345\n").unwrap();
+            master
+        });
+        assert!(matches!(
+            read_secret_from_terminal(&mut slave, b"> ", 4),
+            Err(CliHostError::SecretTooLong)
+        ));
+        drop(peer.join().unwrap());
+        assert_eq!(
+            terminal_mode(&slave).c_lflag & (libc::ECHO | libc::ECHONL),
+            original.c_lflag & (libc::ECHO | libc::ECHONL)
+        );
+    }
+
+    #[test]
+    fn non_terminal_descriptor_fails_closed() {
+        let mut descriptors = [-1; 2];
+        assert_eq!(unsafe { libc::pipe(descriptors.as_mut_ptr()) }, 0);
+        let mut read_end = File::from(owned_fd(descriptors[0]).unwrap());
+        let write_end = owned_fd(descriptors[1]).unwrap();
+        assert!(matches!(
+            read_secret_from_terminal(&mut read_end, b"> ", 16),
+            Err(CliHostError::TerminalUnavailable)
+        ));
+        drop(write_end);
+    }
+}

--- a/code/packages/rust/vault-pm-cli-host/src/unix.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/unix.rs
@@ -239,11 +239,12 @@ mod tests {
             read_secret_from_terminal(&mut slave, b"> ", 4),
             Err(CliHostError::SecretTooLong)
         ));
-        drop(peer.join().unwrap());
+        let master = peer.join().unwrap();
         assert_eq!(
             terminal_mode(&slave).c_lflag & (libc::ECHO | libc::ECHONL),
             original.c_lflag & (libc::ECHO | libc::ECHONL)
         );
+        drop(master);
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli-host/src/windows.rs
+++ b/code/packages/rust/vault-pm-cli-host/src/windows.rs
@@ -1,0 +1,248 @@
+use super::CliHostError;
+use coding_adventures_zeroize::{Zeroize, Zeroizing};
+use std::char::decode_utf16;
+use std::ffi::c_void;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle, RawHandle};
+use std::ptr::null;
+use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::Storage::FileSystem::{
+    CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+};
+use windows_sys::Win32::System::Console::{
+    GetConsoleMode, ReadConsoleW, SetConsoleMode, WriteConsoleW, CONSOLE_MODE, ENABLE_ECHO_INPUT,
+};
+
+const CONSOLE_INPUT: &[u16] = &[
+    b'C' as u16,
+    b'O' as u16,
+    b'N' as u16,
+    b'I' as u16,
+    b'N' as u16,
+    b'$' as u16,
+    0,
+];
+const CONSOLE_OUTPUT: &[u16] = &[
+    b'C' as u16,
+    b'O' as u16,
+    b'N' as u16,
+    b'O' as u16,
+    b'U' as u16,
+    b'T' as u16,
+    b'$' as u16,
+    0,
+];
+
+pub(super) fn read_secret(
+    prompt: &str,
+    max_bytes: usize,
+) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
+    let input = open_console(CONSOLE_INPUT, GENERIC_READ | GENERIC_WRITE)?;
+    let output = open_console(CONSOLE_OUTPUT, GENERIC_READ | GENERIC_WRITE)?;
+    verify_console(&input)?;
+    verify_console(&output)?;
+
+    let guard = ConsoleModeGuard::disable_echo(&input)?;
+    let operation = (|| {
+        write_console(&output, prompt)?;
+        read_bounded_line(&input, max_bytes)
+    })();
+    let restored = guard.restore();
+    let newline = write_console(&output, "\r\n");
+    let secret = operation?;
+    restored?;
+    newline?;
+    Ok(secret)
+}
+
+fn open_console(name: &[u16], access: u32) -> Result<OwnedHandle, CliHostError> {
+    let raw = unsafe {
+        CreateFileW(
+            name.as_ptr(),
+            access,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            null(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            0,
+        )
+    };
+    if raw == INVALID_HANDLE_VALUE {
+        Err(CliHostError::TerminalUnavailable)
+    } else {
+        Ok(unsafe { OwnedHandle::from_raw_handle(raw as RawHandle) })
+    }
+}
+
+fn verify_console(handle: &OwnedHandle) -> Result<CONSOLE_MODE, CliHostError> {
+    let mut mode = 0;
+    if unsafe { GetConsoleMode(raw_handle(handle), &mut mode) } == 0 {
+        Err(CliHostError::TerminalUnavailable)
+    } else {
+        Ok(mode)
+    }
+}
+
+fn write_console(handle: &OwnedHandle, value: &str) -> Result<(), CliHostError> {
+    let value: Vec<u16> = value.encode_utf16().collect();
+    let mut written = 0;
+    let succeeded = unsafe {
+        WriteConsoleW(
+            raw_handle(handle),
+            value.as_ptr().cast::<c_void>(),
+            value.len() as u32,
+            &mut written,
+            null(),
+        )
+    };
+    if succeeded == 0 || written as usize != value.len() {
+        Err(CliHostError::TerminalAccessFailed)
+    } else {
+        Ok(())
+    }
+}
+
+fn read_bounded_line(
+    input: &OwnedHandle,
+    max_bytes: usize,
+) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
+    let mut units = WideSecret(Vec::with_capacity(max_bytes));
+    let mut too_long = false;
+    'line: loop {
+        let mut buffer = WideBuffer([0u16; 128]);
+        let mut read = 0;
+        let succeeded = unsafe {
+            ReadConsoleW(
+                raw_handle(input),
+                buffer.0.as_mut_ptr().cast::<c_void>(),
+                buffer.0.len() as u32,
+                &mut read,
+                null(),
+            )
+        };
+        if succeeded == 0 || read == 0 {
+            return Err(CliHostError::SecretInputFailed);
+        }
+        for unit in &buffer.0[..read as usize] {
+            if *unit == b'\r' as u16 || *unit == b'\n' as u16 {
+                break 'line;
+            }
+            if units.0.len() < max_bytes {
+                units.0.push(*unit);
+            } else {
+                too_long = true;
+            }
+        }
+    }
+    if too_long {
+        finish_line(units, true)
+    } else {
+        finish_line(units, false)
+    }
+}
+
+fn finish_line(units: WideSecret, too_long: bool) -> Result<Zeroizing<Vec<u8>>, CliHostError> {
+    if too_long {
+        return Err(CliHostError::SecretTooLong);
+    }
+    let mut output = Zeroizing::new(Vec::with_capacity(units.0.len().saturating_mul(3)));
+    for decoded in decode_utf16(units.0.iter().copied()) {
+        let character = decoded.map_err(|_| CliHostError::SecretInputFailed)?;
+        let mut encoded = Zeroizing::new([0u8; 4]);
+        output.extend_from_slice(character.encode_utf8(&mut *encoded).as_bytes());
+    }
+    Ok(output)
+}
+
+struct WideSecret(Vec<u16>);
+
+impl Drop for WideSecret {
+    fn drop(&mut self) {
+        for unit in &mut self.0 {
+            unit.zeroize();
+        }
+    }
+}
+
+struct WideBuffer([u16; 128]);
+
+impl Drop for WideBuffer {
+    fn drop(&mut self) {
+        for unit in &mut self.0 {
+            unit.zeroize();
+        }
+    }
+}
+
+fn raw_handle(handle: &OwnedHandle) -> HANDLE {
+    handle.as_raw_handle() as HANDLE
+}
+
+struct ConsoleModeGuard<'handle> {
+    handle: &'handle OwnedHandle,
+    original: CONSOLE_MODE,
+    active: bool,
+}
+
+impl<'handle> ConsoleModeGuard<'handle> {
+    fn disable_echo(handle: &'handle OwnedHandle) -> Result<Self, CliHostError> {
+        let original = verify_console(handle).map_err(|_| CliHostError::TerminalModeFailed)?;
+        if unsafe { SetConsoleMode(raw_handle(handle), original & !ENABLE_ECHO_INPUT) } == 0 {
+            return Err(CliHostError::TerminalModeFailed);
+        }
+        Ok(Self {
+            handle,
+            original,
+            active: true,
+        })
+    }
+
+    fn restore(mut self) -> Result<(), CliHostError> {
+        if unsafe { SetConsoleMode(raw_handle(self.handle), self.original) } == 0 {
+            return Err(CliHostError::TerminalModeFailed);
+        }
+        self.active = false;
+        Ok(())
+    }
+}
+
+impl Drop for ConsoleModeGuard<'_> {
+    fn drop(&mut self) {
+        if self.active {
+            unsafe {
+                SetConsoleMode(raw_handle(self.handle), self.original);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn console_names_are_nul_terminated() {
+        assert_eq!(CONSOLE_INPUT.last(), Some(&0));
+        assert_eq!(CONSOLE_OUTPUT.last(), Some(&0));
+    }
+
+    #[test]
+    fn utf16_console_input_becomes_utf8_passphrase_bytes() {
+        let units: Vec<u16> = "correct horse 🐎".encode_utf16().collect();
+        assert_eq!(
+            &*finish_line(WideSecret(units), false).unwrap(),
+            "correct horse 🐎".as_bytes()
+        );
+    }
+
+    #[test]
+    fn invalid_or_oversized_console_input_fails_closed() {
+        assert!(matches!(
+            finish_line(WideSecret(vec![0xd800]), false),
+            Err(CliHostError::SecretInputFailed)
+        ));
+        assert!(matches!(
+            finish_line(WideSecret(Vec::new()), true),
+            Err(CliHostError::SecretTooLong)
+        ));
+    }
+}

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1416,6 +1416,10 @@ changelog, focused build, and downstream validation.
     owner-only initial creation and compare-and-exchange, guarded by the same
     cross-process writer capability. Persistence remains schema-blind and
     safely stores canonical bytes emitted by `vault-pm-config`.
+8e. `vault-pm-cli-host`: fixed controlling-terminal passphrase collection,
+    echo restoration, constant-time new-passphrase confirmation, and stable OS
+    entropy, using the closed CLI-only trust boundary in
+    `VLT-PM08-cli-host.md`.
 9. `vault-pm-cli` + real executable and pseudo-terminal E2E suite.
 10. Crash/fault matrix and local restore drill.
 

--- a/code/specs/VLT-PM08-cli-host.md
+++ b/code/specs/VLT-PM08-cli-host.md
@@ -1,0 +1,191 @@
+# VLT-PM08: CLI Secret Input and Entropy Host
+
+Status: Phase 1A normative contract
+
+## 1. Purpose
+
+VLT-PM05 accepts already-owned zeroizing passphrase and entropy bytes, while
+VLT-PM06 intentionally owns only paths, permissions, local persistence, and
+process exclusion. A real command must still collect a secret without exposing
+it through redirectable process inputs and must obtain fresh operating-system
+randomness without leaking platform diagnostics.
+
+This specification defines that narrow CLI-only host boundary. It owns:
+
+1. fixed passphrase prompts written to the controlling terminal;
+2. hidden, bounded line collection from that same terminal;
+3. constant-time confirmation for a newly selected vault passphrase; and
+4. exact caller-buffer filling from the operating-system CSPRNG.
+
+It does not parse commands, resolve paths, persist bytes, select storage,
+calibrate Argon2id, prepare vault state, print secrets, or implement clipboard
+policy. Web and desktop clients may reuse the same application contracts with
+their own UI secret collectors and the common CSPRNG primitive.
+
+## 2. Security objective
+
+A shell pipeline, redirected stdin, inherited environment, process listing,
+configuration reader, URL handler, or command history must not become a master
+passphrase source. The adapter opens the process's controlling terminal or
+attached console directly for every collection. If none is available, it fails
+closed rather than reading stdin or accepting an alternate source.
+
+The adapter minimizes secret lifetime and diagnostic exposure. It returns an
+owned zeroizing byte vector, never a `String`, borrowed slice, printable secret
+wrapper, or error containing input. It does not log prompts, lengths, native
+error codes, terminal paths, or collected bytes.
+
+This boundary cannot defend against another process already running as the
+same operating-system user, an administrator, kernel compromise, terminal
+emulator capture, or a force-kill that prevents in-process cleanup.
+
+## 3. Closed prompt contract
+
+The public prompt selection is a closed enum. V1 contains exactly:
+
+| Purpose | Exact text |
+|---|---|
+| unlock | `Vault passphrase: ` |
+| new vault | `New vault passphrase: ` |
+| confirmation | `Confirm vault passphrase: ` |
+| portable export | `Export passphrase: ` |
+| portable import/open | `Import passphrase: ` |
+
+The API accepts no caller-provided prompt text. This prevents an item name,
+provider string, path, locator, or other attacker-controlled value from being
+rendered beside secret collection. Prompts go to the controlling terminal, not
+stdout or stderr, so ordinary command output remains independently redirectable.
+
+## 4. Secret collection contract
+
+Each call independently opens and verifies the native terminal object, captures
+its current mode, disables input echo, writes one fixed prompt, and reads until
+the first CR or LF terminator. The terminator is not part of the secret.
+
+The resulting passphrase is:
+
+- non-empty;
+- at most 1,024 bytes after native text conversion;
+- owned by `Zeroizing<Vec<u8>>` immediately after platform collection; and
+- never exposed through ordinary `Debug` or error output.
+
+Unix retains the exact terminal input bytes. Windows reads UTF-16 console input,
+rejects an unpaired surrogate, and encodes the resulting Unicode scalar values
+as UTF-8 bytes. The maximum is measured in final bytes. A value may therefore
+fit the temporary Windows code-unit bound yet fail the byte bound after UTF-8
+encoding.
+
+An oversized line is drained through its terminator while echo remains disabled.
+This prevents a suffix from becoming the next command's visible input. EOF,
+invalid encoding, incomplete input, and native read failure fail closed.
+
+## 5. Native terminal requirements
+
+### 5.1 Unix
+
+The adapter opens `/dev/tty` read-write with close-on-exec and no-follow flags,
+then verifies both `isatty` and character-device identity. It captures termios,
+clears only `ECHO` and `ECHONL`, and applies the hidden mode before writing the
+prompt. It restores the captured mode before writing the post-input newline and
+before returning control to the caller.
+
+### 5.2 Windows
+
+The adapter opens `CONIN$` and `CONOUT$` rather than inherited standard handles.
+It verifies each with `GetConsoleMode`, captures the input mode, clears only
+`ENABLE_ECHO_INPUT`, and uses wide console reads and writes. It restores the
+exact captured input mode before writing CRLF and returning.
+
+### 5.3 Restoration
+
+Mode ownership uses a guard. Success, empty input, overflow, encoding failure,
+I/O failure after mode capture, explicit early return, and Rust panic unwinding
+all attempt restoration. An explicit restoration failure is a terminal-mode
+failure and cannot be hidden by a successful read. Abort, `SIGKILL`, kernel
+failure, and other termination that prevents destructors from executing are
+outside this library's guarantee; the eventual CLI must keep its hidden-input
+critical section minimal and install any process-wide graceful-shutdown policy
+before invoking it.
+
+## 6. New-passphrase confirmation
+
+New-vault setup performs exactly two independent collections using the fixed new
+and confirmation prompts. It compares the complete byte sequences with the
+repository constant-time equality primitive. A mismatch returns only the stable
+`secrets do not match` class. Both the confirmation and a rejected first value
+are wiped on drop. There is no normalization, trimming, case folding, retry
+loop, partial-match diagnostic, or length disclosure in this layer.
+
+Command UX may choose to call the two-read operation again after a mismatch,
+but each retry must be an explicit bounded CLI policy outside this adapter.
+
+## 7. Entropy contract
+
+The entropy adapter accepts a caller-owned mutable byte slice and either
+completely overwrites it with fresh operating-system CSPRNG output or returns a
+closed failure. Empty requests are rejected as caller errors. There is no
+partial-success result, deterministic seed, user-space pool, cache, retry with
+a weaker source, time-based fallback, or platform diagnostic in the public
+error.
+
+VLT-PM05 generation-zero initialization requests one 496-byte buffer. Portable
+export requests 40 bytes. Other application operations may request their exact
+specified lengths through the same adapter. The application layer remains
+responsible for partitioning and zeroizing caller-owned entropy.
+
+## 8. Error and redaction contract
+
+V1 errors are a closed, payload-free set:
+
+- terminal unavailable;
+- terminal access failed;
+- terminal mode failed;
+- secret input failed;
+- empty secret;
+- secret too long;
+- secrets do not match;
+- invalid entropy request;
+- OS entropy unavailable; and
+- unsupported platform.
+
+Display text is stable and low resolution. `Debug` contains only the variant.
+Native error numbers, paths, handles, input bytes, lengths, prompt payloads, and
+random bytes are never attached.
+
+## 9. Dependency and composition rules
+
+`vault-pm-cli-host` may depend on the repository CSPRNG, constant-time compare,
+and zeroize primitives plus target-specific terminal APIs. It must not depend
+on VLT-PM01 through VLT-PM07, a storage adapter, CLI parser, network SDK,
+clipboard, or OS credential store.
+
+The Phase 1A executable composes it as follows:
+
+1. parse and validate a command without accepting inline secrets;
+2. resolve and prepare VLT-PM06 roots and acquire the process guard;
+3. load and parse VLT-PM07 configuration;
+4. collect a required passphrase from this adapter;
+5. fill the exact application-requested entropy buffer when mutation requires
+   randomness; and
+6. transfer owned values into VLT-PM05 and wipe them before exit.
+
+## 10. Acceptance tests
+
+Automated tests must prove:
+
+1. prompt and error text is exact, fixed, and payload-free;
+2. empty and over-1,024-byte secrets fail;
+3. matching confirmation returns the first owned secret and mismatch fails;
+4. Unix pseudo-terminal input is not echoed and the original mode returns;
+5. an oversized Unix line is drained before mode restoration;
+6. non-terminal Unix objects are rejected;
+7. Windows console names are fixed and wide-input decoding rejects malformed
+   UTF-16;
+8. empty entropy requests fail while independent non-empty requests fill the
+   complete caller buffers; and
+9. native, Linux, and Windows target builds pass denied-warning linting.
+
+The next `vault-pm-cli` slice must add real executable pseudo-terminal or
+ConPTY tests proving redirected stdin cannot satisfy a prompt, command output
+remains redirectable, prompt failure maps to the stable CLI exit class, and
+`init -> status -> doctor` survives process restart.


### PR DESCRIPTION
## Summary

- specify the VLT-PM08 CLI-only trust boundary for fixed controlling-terminal prompts, bounded hidden passphrase input, constant-time confirmation, and OS entropy
- add `vault-pm-cli-host` with audited Unix `/dev/tty` and Windows `CONIN$`/`CONOUT$` implementations, stable payload-free errors, and zeroizing transient buffers
- place the slice in the Phase 1A backlog immediately before real `vault-pm` executable composition

## Security properties

- never accepts master passphrases from stdin, argv, environment, configuration, URLs, or caller-controlled prompt text
- drains oversized input before restoring echo and restores captured terminal mode on ordinary success, errors, and panic unwinding
- preallocates bounded secret buffers and wipes Unix bytes, Windows UTF-16 staging, UTF-8 staging, confirmation values, and rejected input on drop
- maps OS entropy and terminal failures to closed diagnostics without native error, path, handle, length, or secret payloads

## Verification

- `bash vault-pm-cli-host/BUILD`
- `cargo clippy -p coding_adventures_vault_pm_cli_host --all-targets -- -D warnings`
- Linux target Clippy with denied warnings
- Windows GNU target Clippy with denied warnings
- `RUSTDOCFLAGS="-D warnings" cargo doc -p coding_adventures_vault_pm_cli_host --no-deps`
- repository build tool: 4 affected packages built, 4,855 skipped
- fresh `git merge-tree --write-tree HEAD origin/main` succeeded