### PR TITLE
feat(adj-formula-stdlib): Wave 3 finale -- solve BMI=m/h^2 for body mass

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_bmi_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_bmi_e2e.rs
@@ -1,0 +1,94 @@
+//! End-to-end tests for the `clinical/bmi.adj` library — the WHO body-mass-index
+//! definition (BMI = mass/height²), plus this session's rung-0 CAS-wiring
+//! companion (ADJ-FORMULA-LIBRARIES FL-10, §3D): `body_mass_from_bmi`, solving
+//! the SAME cited WHO definition for the body mass instead of computed forward
+//! for BMI. Driven through the built CLI binary against the SHIPPED stdlib.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn shipped_bmi_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/bmi.adj")
+        .canonicalize()
+        .expect("shipped clinical/bmi.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_bmi_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_bmi_lib()).unwrap();
+    std::fs::write(dir.join("bmi.adj"), lib).unwrap();
+}
+
+#[test]
+fn imports_bmi_library_and_computes_forward_with_citation() {
+    let dir = scratch("forward");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"bmi.adj\"\n\
+         observe body_mass(70)\n\
+         observe height(1.75)\n\
+         ? bmi(body_mass, height)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    assert!(
+        s.contains("\"name\":\"bmi\"") && s.contains("\"value\":22.857142857142858"),
+        "bmi(70, 1.75) = 22.857142857142858: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("who.int"),
+        "bmi carries its WHO provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// BMI = mass/height², solved for a different unknown (ADJ-FORMULA-LIBRARIES
+// FL-10, §3D rung-0 CAS-wiring companion) — the SAME cited WHO definition as
+// `bmi` above, rearranged rather than computed forward.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn solves_for_body_mass_from_bmi_with_the_same_citation() {
+    let dir = scratch("mass_solve");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"bmi.adj\"\n\
+         observe bmi(17.5)\n\
+         observe height(2)\n\
+         ? body_mass_from_bmi(bmi, height)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 17.5 = m / 4  =>  m = 70.
+    assert!(
+        s.contains("\"name\":\"body_mass_from_bmi\"") && s.contains("\"value\":70"),
+        "body_mass_from_bmi(17.5, 2) = 70: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("who.int"),
+        "carries the same WHO citation as the forward bmi formula: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-formula-stdlib/CHANGELOG.md
@@ -185,3 +185,20 @@ landed and why, not a semver-tracked API.
   the two originally-flagged remaining candidates from the Wave 3 sweeps (gravitation, bmi is now
   the only one left, deliberately deferred as lowest priority — an isolated clinical definition,
   not part of a citable physics "family").
+- `clinical/bmi.adj` — the ELEVENTH and final Wave 3 rung-0 CAS-wiring companion (ADJ-FORMULA-
+  LIBRARIES FL-10, §3D): `body_mass_from_bmi`, solving the same cited WHO `BMI = mass/height²`
+  definition as the forward `bmi` formula for body mass — written in its equivalent multiplicative
+  form (`BMI · height² = body_mass`) so the target appears only as a linear factor. Solving for
+  height instead is deliberately absent: height is squared, quadratic, out of rung-0's linear-only
+  scope, the direct sibling of `geometry-formulas.adj`'s `square_area` boundary case. Query example
+  uses clean round numbers (BMI 17.5, height 2 m → body mass 70 kg) for an exact round trip. Like
+  `ideal-gas-law.adj`, this library had ZERO manifest.json coverage before this PR — backfilled the
+  base objective `adj.science.clinical.bmi` (domain `science`, `ngss` coverage root, mirroring the
+  convention every other Wave 3 base-science objective already uses; no dedicated clinical coverage
+  root exists yet in this manifest) so the new algebra objective had a valid prerequisite. New
+  e2e test file `formula_bmi_e2e.rs` (2 tests — this library had none before). New manifest
+  objectives `adj.science.clinical.bmi` and `adj.math.algebra.rearrange_bmi`. This closes out ALL
+  originally-flagged Wave 3 rung-0 CAS-wiring candidates (kinematics, geometry, work,
+  mechanics-force, kinetic-energy, pressure, density, electricity-current, ideal-gas-law,
+  gravitation, bmi) — eleven items across six sweep rounds. Wave 3's rung-0 sweep is now
+  genuinely complete.

--- a/code/specs/data/adj-formula-stdlib/clinical/bmi.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/bmi.adj
@@ -19,6 +19,15 @@
 % The formula (and its source) live HERE; the numbers (and their spans) come
 % from the input. Zero math is performed by the model.
 %
+% This library also carries a rung-0 CAS-wiring companion (ADJ-FORMULA-
+% LIBRARIES FL-10, §3D — a Wave 3 continuation): `body_mass_from_bmi` solves
+% the SAME cited WHO definition for the body mass instead of computed forward
+% for BMI — written in its equivalent multiplicative form
+% (`BMI · height² = body_mass`) so the target appears only as a linear factor.
+% Solving for `height` instead is deliberately absent: height is squared, which
+% is quadratic and out of rung-0's linear-only scope, the direct sibling of
+% `geometry-formulas.adj`'s `square_area` boundary case.
+%
 % Run a worked consumer (from a directory it can resolve this import from):
 %     adj-lang-cli <consumer>.adj
 % ============================================================================
@@ -37,6 +46,7 @@ dictionary bmi_vocab {
     define body_mass : finding  surface "weight", "body weight", "mass"      % mass, e.g. kg
     define height    : finding  surface "height", "stature", "body height"   % length, e.g. m
     define bmi       : finding  surface "body mass index", "BMI"             % mass / length²
+    define body_mass_from_bmi : finding  surface "missing weight", "unknown weight"
 }
 
 % ----------------------------------------------------------------------------
@@ -49,6 +59,14 @@ formulabook body_metrics {
     use bmi_vocab
 
     formula bmi(body_mass, height) = body_mass / (height * height)
+        source "BMI is a person's weight in kilograms divided by the square of height in metres. A high BMI can indicate high body fatness."
+        locator "https://www.who.int/health-topics/obesity"
+        trust authoritative
+
+    % BMI = mass/height² again, SOLVED FOR BODY MASS instead of computed
+    % forward — the same cited WHO definition, only which quantity is bound
+    % and which is unknown differs.
+    symbolic body_mass_from_bmi(bmi, height) { bmi * (height * height) == body_mass_from_bmi } for body_mass_from_bmi
         source "BMI is a person's weight in kilograms divided by the square of height in metres. A high BMI can indicate high body fatness."
         locator "https://www.who.int/health-topics/obesity"
         trust authoritative

--- a/code/specs/data/adj-formula-stdlib/clinical/bmi.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/bmi.query.adj
@@ -5,3 +5,11 @@ observe body_mass(70)
 observe height(1.75)
 
 ? bmi(body_mass, height)  % expect 22.857142857142858
+
+% --- BMI = mass/height², SOLVED FOR BODY MASS (rung-0 CAS-wiring, FL-10).
+% "A person is 2 m tall with a BMI of 17.5 -- what is their body mass?" Chosen
+% with clean round numbers so the round trip checks exactly. ---
+observe bmi(17.5)      % "…a BMI of 17.5…"  (span cited by the model)
+observe height(2)      % "…2 m tall…"        (span cited by the model)
+
+? body_mass_from_bmi(bmi, height)  % expect 70 (WHO, authoritative)

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1337,6 +1337,36 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.science.clinical.bmi",
+      "title": "Compute body mass index, BMI = mass / height^2",
+      "band": "9-12",
+      "domain": "science",
+      "competency": "compute",
+      "coverage_roots": ["ngss"],
+      "standards": [],
+      "prerequisites": ["adj.math.arithmetic.primitives"],
+      "libraries": ["code/specs/data/adj-formula-stdlib/clinical/bmi.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.math.algebra.rearrange_bmi",
+      "title": "Solve BMI = mass / height^2 for body mass, given the BMI and the height",
+      "band": "9-12",
+      "domain": "mathematics",
+      "competency": "compute",
+      "coverage_roots": ["ccss.math"],
+      "standards": [],
+      "prerequisites": ["adj.science.clinical.bmi"],
+      "libraries": ["code/specs/data/adj-formula-stdlib/clinical/bmi.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds the ELEVENTH and final Wave 3 rung-0 CAS-wiring companion (ADJ-FORMULA-LIBRARIES FL-10, §3D) to `clinical/bmi.adj`: `body_mass_from_bmi`, solving the same cited WHO `BMI = mass/height²` definition for body mass — written in its equivalent multiplicative form (`BMI · height² = body_mass`) so the target appears only as a linear factor.
- Solving for height instead is deliberately absent (quadratic, out of rung-0's linear-only scope, the sibling of `geometry-formulas.adj`'s `square_area` boundary case).
- Empirically verified via the CLI before writing (`body_mass_from_bmi(17.5, 2) = 70`, clean round numbers for an exact check).
- Like `ideal-gas-law.adj`, this library had ZERO manifest.json coverage before this PR — backfilled the base objective `adj.science.clinical.bmi` (domain `science`, `ngss` coverage root, mirroring the convention every other Wave 3 base-science objective uses; no dedicated clinical coverage root exists yet) so the new algebra objective had a valid prerequisite.
- New e2e test file `formula_bmi_e2e.rs` (2 tests — this library had none before).
- New manifest objectives `adj.science.clinical.bmi` and `adj.math.algebra.rearrange_bmi`.

**This closes out ALL originally-flagged Wave 3 rung-0 CAS-wiring candidates** (kinematics, geometry, work, mechanics-force, kinetic-energy, pressure, density, electricity-current, ideal-gas-law, gravitation, bmi) — eleven items shipped across six sweep rounds. Wave 3's rung-0 sweep is now genuinely complete.

Part of the autonomous ADJ curriculum loop (`ADJ-STDLIB-COVERAGE.md#7-delivery-order`).

## Test plan
- [x] Solve direction empirically verified via the CLI in a scratch dir before writing real content.
- [x] `cargo test -p adj-lang-cli --test formula_bmi_e2e` — 2/2 passed.
- [x] `cargo test -p adj-lang -p adj-lang-cli` — full suite green, no regressions.
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean.
- [x] `adj_stdlib_manifest.py --validate-json-schema` — 86 objectives, 0 errors, valid.
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` — exit 0, no new gaps introduced.
- [x] Python unittest suite (manifest/report subset) — 87 passed.
- [x] Security review — passed, no findings.