### PR TITLE
feat(adj-facts-stdlib): Wave 2 literacy foundations, first slice -- rhyming word families

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_wordfamilies_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_wordfamilies_e2e.rs
@@ -1,0 +1,110 @@
+//! End-to-end test for the LANGUAGE FACTS library
+//! (`adj-facts-stdlib/language/word-families.adj`) driven through the built
+//! CLI: a native `table` of the "-an" word family's core CVC members plus a
+//! `rule` DERIVING `rhymes_with($Word1, $Word2)` from shared family
+//! membership — the first `rule`-based (composed, not just recalled) literacy
+//! fact in this loop's curriculum sweep, mirroring the discipline
+//! `shape-composition.adj` already established for geometry. Honest
+//! abstention on a word with no shipped row — 0 answer-time model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_wordfam_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place_lib(dir: &Path) {
+    let src = facts_stdlib().join("language/word-families.adj");
+    std::fs::copy(&src, dir.join("word-families.adj")).expect("copy shipped word-families.adj");
+}
+
+#[test]
+fn word_family_recall_binds_the_family_directly() {
+    let dir = scratch("family");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"word-families.adj\"\n\
+         ? word_family(pan, $F)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(out.contains("\"F\":\"an\""), "pan is in the -an family: {out}");
+    assert!(
+        out.contains("readingrockets.org") && out.contains("\"trust\":\"consensus\""),
+        "carries the Reading Rockets citation: {out}"
+    );
+}
+
+#[test]
+fn rhymes_with_is_derived_from_shared_family_membership() {
+    let dir = scratch("rhymes");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"word-families.adj\"\n\
+         ? rhymes_with(pan, $W)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    // Every other member of the -an family rhymes with "pan" (plus itself, trivially).
+    for w in ["pan", "fan", "ran", "man", "tan", "van"] {
+        assert!(
+            out.contains(&format!("\"W\":\"{w}\"")),
+            "pan rhymes with {w}: {out}"
+        );
+    }
+    // The derivation composes TWO citations: the rule's general principle AND
+    // the table's specific family-membership fact, both from the same source.
+    assert!(
+        out.contains("\"kind\":\"rule\"") && out.contains("\"kind\":\"fact\""),
+        "the rhyme is DERIVED, not a direct table row -- both a rule step and fact steps appear: {out}"
+    );
+    assert!(
+        out.contains("look alike at the end if they sound alike at the end"),
+        "the rule carries its own verbatim definitional citation: {out}"
+    );
+}
+
+#[test]
+fn word_family_abstains_honestly_on_an_unshipped_word() {
+    let dir = scratch("abstain");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"word-families.adj\"\n\
+         ? word_family(dog, $F)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "\"dog\" has no shipped row -- honest abstention, never invented: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+This directory is spec/content data, not a compiled package — entries record what content
+landed and why, not a semver-tracked API.
+
+## Unreleased
+
+- Added this `CHANGELOG.md` (a standing gap flagged during the adj-curriculum loop's Wave 2
+  literacy scoping pass, mirroring the same fix already made for `adj-formula-stdlib/`).
+- `language/word-families.adj` (new) — the FIRST literacy-domain library in the ADJ stdlib.
+  `word_family(word, family)` tables the "-an" word family's six core CVC (consonant-vowel-
+  consonant) members (pan, fan, ran, man, tan, van), quoted verbatim from Reading Rockets'
+  "Meet the Word Families." A `rule` DERIVES `rhymes_with(word1, word2)` from shared family
+  membership — composing the specific family-membership fact with the general word-family
+  principle ("words look alike at the end if they sound alike at the end"), the same
+  rule-based-inference discipline `geometry/shape-composition.adj` already established, so
+  this satisfies Wave 2's own requirement that "each tranche must include composition... not
+  only direct recall" (`ADJ-STDLIB-COVERAGE.md` §7). Grounds CCSS RF.K.2.a ("Recognize and
+  produce rhyming words"). Deliberately scoped to ONE family with its plain three-letter core
+  members only — not the full 37-family phonics inventory, nor the longer blended/multi-
+  syllable "-an" words the same source also lists (plan, scan, bran, began) — keeping this
+  first slice small and citable, the same discipline every prior curriculum item in this loop
+  has used. New manifest objective `adj.literacy.k2.rhyming_word_families` (the first
+  literacy-domain manifest entry; also introduces the `ccss.ela` coverage root and `literacy`
+  domain values, mirroring how `adj.science.clinical.bmi` introduced the first clinical-domain
+  entry one PR earlier). New e2e test `facts_wordfamilies_e2e.rs` (3 tests: direct family
+  recall, derived rhyme composition, honest abstention on an unshipped word).

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -120,6 +120,7 @@ per rotation, in parallel):
 | `geography/` | globe reference line → what it marks (equator → zero_degrees_latitude, prime_meridian → zero_degrees_longitude, tropic_of_cancer → northernmost_sun_overhead) | NOAA National Ocean Service / NESDIS (authoritative) |
 | `language/` | Greek letter → its 1-based position in the alphabet (alpha → 1, gamma → 3, pi → 16, omega → 24) | Wikipedia "Greek alphabet" (consensus) |
 | `language/` | Latin letter → its International Morse code pattern as dot/dash word-atoms (s → dot_dot_dot, o → dash_dash_dash, e → dot) | ITU-R M.1677-1 via Wikipedia "Morse code" (consensus) |
+| `language/` | **DERIVED, not looked up** — which pairs of words RHYME (`rhymes_with(word1, word2)`), by a `rule` combining a `word_family` table (the "-an" family's core CVC members: pan, fan, ran, man, tan, van) with the general word-family principle — no single source states "pan rhymes with fan" directly | Reading Rockets "Meet the Word Families" (consensus; see `word-families.adj`'s header) |
 | `music/` | movable-do solfège syllable → its 1-based major-scale degree (do → 1, sol → 5, ti → 7) | Wikipedia "Solfège" (consensus) |
 | … | *geography, physical constants, …* | *(expanding)* |
 

--- a/code/specs/data/adj-facts-stdlib/language/word-families.adj
+++ b/code/specs/data/adj-facts-stdlib/language/word-families.adj
@@ -1,0 +1,72 @@
+% ============================================================================
+% word-families — which words share a rime (word family), and which pairs of
+% words RHYME because they share one, DERIVED (not just looked up)
+% (adj-facts-stdlib, LANGUAGE). CCSS RF.K.2.a "Recognize and produce rhyming
+% words."
+% ============================================================================
+% The first LITERACY library in this loop's curriculum sweep (ADJ-STDLIB-
+% COVERAGE.md §5.1's Literacy row: alphabet/vowels/opposites/Morse/Greek
+% already ship; phonemic awareness and phonics are the still-missing majors).
+% A WORD FAMILY (also called a "rime") is the shared spelling-and-sound
+% pattern at the end of a set of words — "pan", "fan", and "ran" all end in
+% "-an". Two words that belong to the SAME family necessarily rhyme with each
+% other; that composition (family membership → rhyme) is exactly the kind of
+% DERIVED fact `shape-composition.adj` already established a pattern for in
+% this library — no single source states "pan rhymes with fan" as a citable
+% sentence, but the general word-family principle IS citable, and the specific
+% family membership IS citable, so the rhyme relation is built from both:
+%
+%   1. `word_family($Word, $Family)` — the table below, listing each of the
+%      "-an" family's core CVC (consonant-vowel-consonant) members as named,
+%      verbatim, by Reading Rockets (a WETA/PBS literacy education nonprofit).
+%   2. The general word-family PRINCIPLE, quoted verbatim from the same page
+%      in the rule's own `source` below: words in the same family "look alike
+%      at the end" because they "sound alike at the end."
+%
+% The RULE's `source` states the general principle; the TABLE's `source`
+% states which specific words the cited page names as belonging to the "-an"
+% family — so a query's `steps` trail shows BOTH citations, and a human can
+% independently check each link. `trust consensus`, not `authoritative`:
+% Reading Rockets is a respected literacy-education secondary reference, not a
+% primary/official standards body (the same tier `alphabet.adj`'s Wikipedia
+% citation and `shape-composition.adj`'s MathWorld-derived rule already use).
+%
+%     import "word-families.adj"
+%     ? word_family(pan, $F)        % an        (which family "pan" belongs to)
+%     ? rhymes_with(pan, $W)        % fan, ran, man, tan, van, pan (itself too)
+%
+% Deliberately scoped to ONE family ("-an") with its SIX simple three-letter
+% CVC members, not the full 37-family phonics inventory a complete phonics
+% curriculum would need (Reading Rockets' own page also lists longer blended
+% and multi-syllable "-an" words — "plan", "scan", "bran", "began" — and this
+% library deliberately ships only the plain three-letter core, matching
+% kindergarten-level CVC scope; the blends and longer words are left for a
+% later pass, the same "keep the first slice small and citable" discipline
+% every prior curriculum item in this loop has used). `rhymes_with` includes
+% a trivial self-pair (a word "rhymes with" itself, since it shares its own
+% family) — logically consistent, left unfiltered rather than adding
+% unverified exclusion logic for a case no worked example below relies on.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table word_family {
+    columns word, family
+
+    row (pan, an)
+    row (fan, an)
+    row (ran, an)
+    row (man, an)
+    row (tan, an)
+    row (van, an)
+
+    source "pan, fan, ran, man, tan, van, plan, scan, bran, began"
+    locator "https://www.readingrockets.org/topics/activities/articles/meet-word-families"
+    trust consensus
+}
+
+rule { head: rhymes_with($Word1, $Word2)
+       when: word_family($Word1, $Family), word_family($Word2, $Family)
+       source "Students will see how words look alike at the end if they sound alike at the end — a valuable discovery about our alphabetic writing system."
+       locator "https://www.readingrockets.org/topics/activities/articles/meet-word-families"
+       trust consensus }

--- a/code/specs/data/adj-facts-stdlib/language/word-families.query.adj
+++ b/code/specs/data/adj-facts-stdlib/language/word-families.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% word-families.query.adj — worked recall over the word-family / rhyme library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what family is this word
+% in?" or "what rhymes with this word?" — it states no fact of its own — it
+% only `import`s the grounded table+rule and asks binding queries. Family
+% lookup is a direct table recall; the rhyme relation is DERIVED by the rule,
+% composing family membership with the general word-family principle — so
+% every rhyme answer carries BOTH citations in its `steps` trail.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli word-families.query.adj
+% ============================================================================
+
+import "word-families.adj"
+
+? word_family(pan, $F)     % expect an    (direct recall: which family is "pan" in?)
+? rhymes_with(pan, $W)     % expect fan, ran, man, tan, van, pan (derived: shares the -an family)
+? word_family(dog, $F)     % expect abstain — "dog" has no shipped row, not in this family

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1367,6 +1367,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.literacy.k2.rhyming_word_families",
+      "title": "Recognize rhyming words via shared word-family (rime) membership",
+      "band": "K-2",
+      "domain": "literacy",
+      "competency": "classify",
+      "coverage_roots": ["ccss.ela"],
+      "standards": [],
+      "prerequisites": [],
+      "libraries": ["code/specs/data/adj-facts-stdlib/language/word-families.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary

The first content PR after Wave 3's rung-0 CAS-wiring sweep completed. This is a **scoping-pass decision**, not another algebra item: with Wave 3 fully shipped, the only two remaining backlog items (`wave2-k8-literacy-foundations`, `wave2-k8-science-foundations`) needed genuine design/scoping work before any content could be written. This PR is the outcome of that scoping pass for the literacy gap.

### Scoping rationale
- Read `ADJ-STDLIB-COVERAGE.md` §5.1's Literacy row in full: existing coverage is alphabet/vowels/opposites/Morse/Greek-alphabet lookup tables; the major gaps are phonemic awareness, phonics, decoding, morphology, vocabulary-in-context, grammar, sentence meaning, comprehension, evidence use, writing, and speaking/listening.
- Found direct prior art: `adj-facts-stdlib/language/alphabet.adj` (a `table` pattern) and `adj-facts-stdlib/geometry/shape-composition.adj` (a `rule`-derived composition over a table, established during an earlier Wave 2 item).
- Confirmed phonological-awareness content is fully **text-representable** via `table`/`rule` (word-family/rhyme membership is an orthographic relation, same as how `alphabet_position` encodes letter order) — **no audio-modality engine gap**, so this doesn't require new engine capability.
- Grounded the ordering choice in CCSS's own Reading Foundational Skills strand (phonological awareness before comprehension) — the same standards-based default the math track has used throughout (arithmetic primitives before algebra), not an invented pedagogical stance on the phonics-vs-whole-language debate.

### What shipped
- **`language/word-families.adj`** (new) — the FIRST literacy-domain library. A `word_family(word, family)` table grounds the "-an" word family's six core CVC members (pan, fan, ran, man, tan, van), quoted verbatim from [Reading Rockets' "Meet the Word Families"](https://www.readingrockets.org/topics/activities/articles/meet-word-families). A `rule` **derives** `rhymes_with(word1, word2)` from shared family membership — composing the specific fact with the general word-family principle, satisfying Wave 2's own requirement that "each tranche must include composition... not only direct recall."
- Grounds **CCSS RF.K.2.a** ("Recognize and produce rhyming words") — verbatim standard text verified via a California Dept. of Education (.gov) mirror.
- Deliberately scoped to ONE family with its plain three-letter core members only (not the full 37-family phonics inventory, nor the longer blended/multi-syllable "-an" words the same source also lists) — keeping the first slice small and citable.
- New manifest objective `adj.literacy.k2.rhyming_word_families` (the first literacy-domain manifest entry; the `ccss.ela` coverage root was already pre-declared in the manifest schema, unused until now).
- New e2e test `facts_wordfamilies_e2e.rs` (3 tests: direct family recall, derived rhyme composition with dual citations, honest abstention on an unshipped word).
- New `CHANGELOG.md` for `adj-facts-stdlib/` (didn't exist before — mirroring the earlier gap-fill already done for `adj-formula-stdlib/`).

Part of the autonomous ADJ curriculum loop (`ADJ-STDLIB-COVERAGE.md#7-delivery-order`).

## Test plan
- [x] Multi-premise `rule { ... when: a(...), b(...) ... }` syntax empirically verified via the CLI in a scratch dir before writing real content.
- [x] Real query file (`word-families.query.adj`) executed end-to-end: direct recall, derived rhyme composition (dual citations in `steps`), honest abstention all confirmed.
- [x] `cargo test -p adj-lang-cli --test facts_wordfamilies_e2e` — 3/3 passed.
- [x] `cargo test -p adj-lang -p adj-lang-cli` — full suite green, no regressions.
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean.
- [x] `adj_stdlib_manifest.py --validate-json-schema` — 87 objectives, 0 errors, valid.
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` — exit 0, no new gaps introduced.
- [x] Python unittest suite (manifest/report subset) — 87 passed.
- [x] Security review — passed, no findings.