### PR TITLE
Add local vault bootstrap CLI

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -1068,4 +1068,5 @@ members = [
   "vault-pm-local-host",
   "vault-pm-config",
   "vault-pm-cli-host",
+  "vault-pm-cli",
 ]

--- a/code/packages/rust/vault-pm-cli/BUILD
+++ b/code/packages/rust/vault-pm-cli/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding_adventures_vault_pm_cli -- --nocapture

--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0
+
+- Added the closed `init`, `status`, and `doctor` command grammar.
+- Added stable exit classes and payload-free text/JSON rendering.
+- Composed secure local roots, exact configuration, durable application state,
+  immutable filesystem storage, fixed terminal prompts, and OS entropy.
+- Added crash-resumable generation-zero activation and restart tests.

--- a/code/packages/rust/vault-pm-cli/Cargo.toml
+++ b/code/packages/rust/vault-pm-cli/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "coding_adventures_vault_pm_cli"
+version = "0.1.0"
+edition = "2021"
+description = "Strict parser, renderer, and local composition driver for vault-pm"
+license = "MIT"
+
+[dependencies]
+coding_adventures_storage_fs = { path = "../storage-fs" }
+coding_adventures_vault_pm_application = { path = "../vault-pm-application" }
+coding_adventures_vault_pm_application_storage_core = { path = "../vault-pm-application-storage-core" }
+coding_adventures_vault_pm_cli_host = { path = "../vault-pm-cli-host" }
+coding_adventures_vault_pm_config = { path = "../vault-pm-config" }
+coding_adventures_vault_pm_local_host = { path = "../vault-pm-local-host" }
+coding_adventures_vault_pm_storage_storage_core = { path = "../vault-pm-storage-storage-core" }
+coding_adventures_zeroize = { path = "../zeroize" }
+
+[dev-dependencies]
+libc = "0.2"

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -1,0 +1,34 @@
+# `coding_adventures_vault_pm_cli`
+
+This crate is the first real composition layer for the local-first password
+manager. It owns strict parsing, stable exit classes, redacted rendering, and
+the bounded `init`, locked `status`, and locked `doctor` workflows. The
+executable is a thin caller of this package.
+
+The driver composes the existing storage-neutral application over separately
+permission-checked application-state and encrypted-object filesystem roots.
+It acquires the persistent cross-process writer lock before loading
+configuration or constructing either backend. Configuration is parsed by the
+closed VLT-PM07 codec, and the configured filesystem location must exactly
+match the prepared platform object root before storage is touched.
+
+Initialization collects a new passphrase only through the injected fixed
+secret-input boundary, fills the complete generation-zero randomness block
+from the injected OS entropy boundary, and uses a fixed production Argon2id
+floor. It durably installs the exact `PreparedInit` owner journal before
+publishing the configuration that makes the random locator discoverable. A
+restart with a prepared journal collects the existing passphrase and resumes
+the exact journal without generating new identities or ciphertext.
+
+Status and doctor do not prompt or unlock. Their text and JSON projections are
+closed labels with no paths, locators, providers, identities, or cryptographic
+details. No command accepts a passphrase through argv, stdin, environment,
+configuration, or URL.
+
+## Verification
+
+```bash
+bash BUILD
+cargo clippy -p coding_adventures_vault_pm_cli --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc -p coding_adventures_vault_pm_cli --no-deps
+```

--- a/code/packages/rust/vault-pm-cli/required_capabilities.json
+++ b/code/packages/rust/vault-pm-cli/required_capabilities.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/vault-pm-cli",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "platform-resolved owner-private vault-pm roots",
+      "justification": "Loads exact configuration, owner state, bootstrap generations, and encrypted immutable repository objects through audited adapters."
+    },
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "platform-resolved owner-private vault-pm roots",
+      "justification": "Persists atomic configuration, crash-resumable owner journals, signed bootstraps, and encrypted immutable repository objects during initialization."
+    },
+    {
+      "category": "fs",
+      "action": "create",
+      "target": "platform-resolved owner-private vault-pm roots",
+      "justification": "Creates missing private roots and first-generation durable records through the local host and storage adapters."
+    },
+    {
+      "category": "time",
+      "action": "read",
+      "target": "system wall clock",
+      "justification": "Supplies the advisory generation-zero certificate and commit timestamp."
+    }
+  ],
+  "justification": "Product composition package; terminal and entropy capabilities remain delegated to rust/vault-pm-cli-host."
+}

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -1,0 +1,869 @@
+//! Strict local CLI grammar, rendering, and product composition for vault-pm.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+use coding_adventures_storage_fs::FsStorageBackend;
+use coding_adventures_vault_pm_application::{
+    complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init, ApplicationError,
+    BootstrapLocator, GenerationZeroPolicyV1, GenerationZeroRandomness, LocalStateStore,
+    LocalStateStoreError, LocalVaultStateV1, V1ApplicationRepositoryFactory, VaultAccessV1,
+    VaultDoctorStateV1, VaultStatusStateV1, GENERATION_ZERO_RANDOM_BYTES,
+};
+use coding_adventures_vault_pm_application_storage_core::StorageCoreApplicationStore;
+use coding_adventures_vault_pm_cli_host::{
+    CliHostError, ControllingTerminal, OsEntropy, SecretPrompt,
+};
+use coding_adventures_vault_pm_config::{
+    parse_config, render_config, ConfigName, CredentialRef, StorageConfigV1, StorageKind,
+    StorageLocation, VaultConfigV1, VaultLocator as ConfigVaultLocator, VaultPmConfigV1,
+    DEFAULT_AUTO_LOCK_SECONDS, DEFAULT_CLIPBOARD_CLEAR_SECONDS,
+};
+use coding_adventures_vault_pm_local_host::{LocalHostError, LocalVaultPaths, LocalWriterGuard};
+use coding_adventures_vault_pm_storage_storage_core::StorageCoreObjectStore;
+use coding_adventures_zeroize::Zeroizing;
+use core::fmt::{self, Debug, Formatter};
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const DEFAULT_VAULT_NAME: &str = "personal";
+const DEFAULT_STORAGE_NAME: &str = "local";
+const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
+const PRODUCTION_KDF_ITERATIONS: u32 = 3;
+const PRODUCTION_KDF_LANES: u8 = 1;
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm doctor\n";
+
+/// Stable process exit classes defined by VLT-PM00.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(i32)]
+pub enum ExitCode {
+    /// The command completed successfully.
+    Success = 0,
+    /// The command or caller input was invalid.
+    InvalidInput = 2,
+    /// Authentication or an unlocked session is required.
+    Locked = 3,
+    /// A requested item or object was not found.
+    NotFound = 4,
+    /// A concurrent update or recovery conflict requires resolution.
+    Conflict = 5,
+    /// Persisted integrity, permissions, or authentication failed closed.
+    Integrity = 6,
+    /// A local or remote storage provider was unavailable.
+    Provider = 7,
+    /// The selected backend or capability is unsupported.
+    Unsupported = 8,
+    /// An internal invariant failed.
+    Internal = 10,
+}
+
+/// Complete payload-free result returned to the thin executable.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CliOutput {
+    exit_code: ExitCode,
+    stdout: String,
+    stderr: String,
+}
+
+impl CliOutput {
+    /// Return the stable process exit class.
+    pub const fn exit_code(&self) -> ExitCode {
+        self.exit_code
+    }
+
+    /// Borrow public standard output.
+    pub fn stdout(&self) -> &str {
+        &self.stdout
+    }
+
+    /// Borrow fixed, payload-free standard error.
+    pub fn stderr(&self) -> &str {
+        &self.stderr
+    }
+
+    fn success(stdout: impl Into<String>) -> Self {
+        Self {
+            exit_code: ExitCode::Success,
+            stdout: stdout.into(),
+            stderr: String::new(),
+        }
+    }
+
+    fn failure(error: CliFailure) -> Self {
+        Self {
+            exit_code: error.exit_code(),
+            stdout: String::new(),
+            stderr: format!("{}\n", error.message()),
+        }
+    }
+}
+
+/// Injected platform authorities used by the testable CLI driver.
+///
+/// Production uses [`NativeCliHost`]. Tests can replace paths, time, entropy,
+/// and fixed-prompt secret collection without adding secret-bearing CLI flags.
+pub trait CliHost {
+    /// Resolve the complete platform-local layout.
+    fn paths(&self) -> Result<LocalVaultPaths, HostError>;
+
+    /// Collect and confirm a new vault passphrase.
+    fn read_new_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError>;
+
+    /// Collect the existing passphrase for journal recovery.
+    fn read_existing_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError>;
+
+    /// Fill the entire generation-zero randomness block.
+    fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError>;
+
+    /// Return the advisory current Unix time in milliseconds.
+    fn now_ms(&self) -> Result<u64, HostError>;
+
+    /// Return the bounded Argon2id policy for a new vault.
+    fn generation_zero_kdf(&self) -> (u32, u32, u8);
+}
+
+/// Payload-free failure at an injected CLI host boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HostError {
+    /// The caller or platform returned an invalid value.
+    Invalid,
+    /// A required local authority was unavailable.
+    Unavailable,
+    /// The current platform or capability is unsupported.
+    Unsupported,
+}
+
+/// Production platform authorities for the local executable.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NativeCliHost;
+
+impl CliHost for NativeCliHost {
+    fn paths(&self) -> Result<LocalVaultPaths, HostError> {
+        LocalVaultPaths::resolve().map_err(map_native_local_host)
+    }
+
+    fn read_new_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError> {
+        ControllingTerminal
+            .read_new_passphrase()
+            .map_err(map_native_cli_host)
+    }
+
+    fn read_existing_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError> {
+        ControllingTerminal
+            .read_secret(SecretPrompt::Unlock)
+            .map_err(map_native_cli_host)
+    }
+
+    fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError> {
+        OsEntropy.fill(output).map_err(map_native_cli_host)
+    }
+
+    fn now_ms(&self) -> Result<u64, HostError> {
+        let elapsed = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| HostError::Unavailable)?;
+        u64::try_from(elapsed.as_millis()).map_err(|_| HostError::Unavailable)
+    }
+
+    fn generation_zero_kdf(&self) -> (u32, u32, u8) {
+        (
+            PRODUCTION_KDF_MEMORY_KIB,
+            PRODUCTION_KDF_ITERATIONS,
+            PRODUCTION_KDF_LANES,
+        )
+    }
+}
+
+/// Parse and execute one argument vector through an injected host.
+///
+/// `arguments` excludes the executable name. Non-Unicode arguments and every
+/// unrecognized token fail with the same bounded invalid-command class.
+pub fn run<I, S>(arguments: I, host: &dyn CliHost) -> CliOutput
+where
+    I: IntoIterator<Item = S>,
+    S: Into<OsString>,
+{
+    let command = match parse(arguments) {
+        Ok(command) => command,
+        Err(error) => return CliOutput::failure(error),
+    };
+    if matches!(command, Command::Help) {
+        return CliOutput::success(USAGE);
+    }
+    match execute(command, host) {
+        Ok(output) => output,
+        Err(error) => CliOutput::failure(error),
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Command {
+    Init {
+        vault: ConfigName,
+        storage: ConfigName,
+    },
+    Status {
+        json: bool,
+    },
+    Doctor,
+    Help,
+}
+
+fn parse<I, S>(arguments: I) -> Result<Command, CliFailure>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<OsString>,
+{
+    let values = arguments
+        .into_iter()
+        .map(|value| {
+            value
+                .into()
+                .into_string()
+                .map_err(|_| CliFailure::InvalidCommand)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let Some(name) = values.first().map(String::as_str) else {
+        return Err(CliFailure::InvalidCommand);
+    };
+    match name {
+        "--help" | "-h" | "help" if values.len() == 1 => Ok(Command::Help),
+        "init" => parse_init(&values[1..]),
+        "status" => parse_status(&values[1..]),
+        "doctor" if values.len() == 1 => Ok(Command::Doctor),
+        _ => Err(CliFailure::InvalidCommand),
+    }
+}
+
+fn parse_init(arguments: &[String]) -> Result<Command, CliFailure> {
+    let mut vault = None;
+    let mut storage = None;
+    let mut index = 0;
+    while index < arguments.len() {
+        let destination = match arguments[index].as_str() {
+            "--vault" if vault.is_none() => &mut vault,
+            "--storage" if storage.is_none() => &mut storage,
+            _ => return Err(CliFailure::InvalidCommand),
+        };
+        let value = arguments.get(index + 1).ok_or(CliFailure::InvalidCommand)?;
+        *destination =
+            Some(ConfigName::new(value.clone()).map_err(|_| CliFailure::InvalidCommand)?);
+        index += 2;
+    }
+    Ok(Command::Init {
+        vault: vault.unwrap_or(ConfigName::new(DEFAULT_VAULT_NAME).expect("fixed valid name")),
+        storage: storage
+            .unwrap_or(ConfigName::new(DEFAULT_STORAGE_NAME).expect("fixed valid name")),
+    })
+}
+
+fn parse_status(arguments: &[String]) -> Result<Command, CliFailure> {
+    match arguments {
+        [] => Ok(Command::Status { json: false }),
+        [argument] if argument == "--json" => Ok(Command::Status { json: true }),
+        _ => Err(CliFailure::InvalidCommand),
+    }
+}
+
+fn execute(command: Command, host: &dyn CliHost) -> Result<CliOutput, CliFailure> {
+    let paths = host.paths().map_err(map_host)?;
+    let prepared = paths.prepare().map_err(map_local_host)?;
+    let writer = prepared.try_acquire_writer().map_err(map_local_host)?;
+    match command {
+        Command::Init { vault, storage } => init(host, prepared.paths(), &writer, vault, storage),
+        Command::Status { json } => status(prepared.paths(), &writer, json),
+        Command::Doctor => doctor(prepared.paths(), &writer),
+        Command::Help => unreachable!("help returns before host access"),
+    }
+}
+
+fn init(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    vault_name: ConfigName,
+    storage_name: ConfigName,
+) -> Result<CliOutput, CliFailure> {
+    match writer.load_config().map_err(map_local_host)? {
+        Some(exact_config) => resume_init(host, paths, &exact_config, vault_name, storage_name),
+        None => begin_init(host, paths, writer, vault_name, storage_name),
+    }
+}
+
+fn begin_init(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    vault_name: ConfigName,
+    storage_name: ConfigName,
+) -> Result<CliOutput, CliFailure> {
+    let passphrase = host.read_new_passphrase().map_err(map_host)?;
+    let mut random_bytes = [0_u8; GENERATION_ZERO_RANDOM_BYTES];
+    host.fill_entropy(&mut random_bytes).map_err(map_host)?;
+    let (memory_kib, iterations, lanes) = host.generation_zero_kdf();
+    let policy = GenerationZeroPolicyV1::new(
+        memory_kib,
+        iterations,
+        lanes,
+        host.now_ms().map_err(map_host)?,
+    )
+    .map_err(map_application)?;
+    let prepared = prepare_generation_zero(
+        passphrase,
+        policy,
+        GenerationZeroRandomness::new(random_bytes),
+    )
+    .map_err(map_application)?;
+    let locator = prepared.bootstrap_locator();
+    let exact_prepared = prepared.owner_state().encode().map_err(map_application)?;
+    let application_store = application_store(paths);
+
+    // Install the retry journal before making its random locator discoverable.
+    // A crash before config publication therefore leaves only unreachable
+    // opaque data; a crash after publication always has exact recovery bytes.
+    application_store
+        .compare_exchange(locator, None, &exact_prepared)
+        .map_err(map_local_state)?;
+    let config = initial_config(paths, locator, vault_name, storage_name)?;
+    writer
+        .create_config(render_config(&config).as_bytes())
+        .map_err(map_local_host)?;
+
+    let repository_factory = repository_factory(paths);
+    complete_generation_zero(
+        prepared,
+        &application_store,
+        &application_store,
+        &repository_factory,
+    )
+    .map_err(map_application)?;
+    Ok(CliOutput::success("Vault initialized.\n"))
+}
+
+fn resume_init(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    exact_config: &[u8],
+    vault_name: ConfigName,
+    storage_name: ConfigName,
+) -> Result<CliOutput, CliFailure> {
+    let config = decode_config(exact_config)?;
+    if config.default_vault() != &vault_name {
+        return Err(CliFailure::AlreadyInitialized);
+    }
+    let vault = configured_vault(paths, &config)?;
+    if vault.local_store() != &storage_name {
+        return Err(CliFailure::AlreadyInitialized);
+    }
+    let locator = application_locator(vault.locator());
+    let application_store = application_store(paths);
+    let exact_state = application_store
+        .load(locator)
+        .map_err(map_local_state)?
+        .ok_or(CliFailure::Integrity)?;
+    let state = LocalVaultStateV1::decode(&exact_state).map_err(map_application)?;
+    let LocalVaultStateV1::PreparedInit(_) = state else {
+        return Err(match state {
+            LocalVaultStateV1::Active(_) => CliFailure::AlreadyInitialized,
+            LocalVaultStateV1::PendingPublication { .. } => CliFailure::Conflict,
+            LocalVaultStateV1::PreparedInit(_) => unreachable!(),
+        });
+    };
+    let passphrase = host.read_existing_passphrase().map_err(map_host)?;
+    let prepared = rehydrate_prepared_init(passphrase, state).map_err(map_application)?;
+    let repository_factory = repository_factory(paths);
+    complete_generation_zero(
+        prepared,
+        &application_store,
+        &application_store,
+        &repository_factory,
+    )
+    .map_err(map_application)?;
+    Ok(CliOutput::success("Vault initialized.\n"))
+}
+
+fn status(
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    json: bool,
+) -> Result<CliOutput, CliFailure> {
+    let Some(exact_config) = writer.load_config().map_err(map_local_host)? else {
+        return Ok(render_status_label("uninitialized", json));
+    };
+    let config = decode_config(&exact_config)?;
+    let vault = configured_vault(paths, &config)?;
+    let locator = application_locator(vault.locator());
+    let application_store = application_store(paths);
+    let access = VaultAccessV1::locked(locator);
+    let report = access.status(&application_store).map_err(map_application)?;
+    let label = match report.state() {
+        VaultStatusStateV1::Absent => "uninitialized",
+        VaultStatusStateV1::Prepared => "initializing",
+        VaultStatusStateV1::Locked => "locked",
+        VaultStatusStateV1::Unlocked => "unlocked",
+        VaultStatusStateV1::RecoveryRequired => "recovery_required",
+    };
+    Ok(render_status_label(label, json))
+}
+
+fn doctor(paths: &LocalVaultPaths, writer: &LocalWriterGuard) -> Result<CliOutput, CliFailure> {
+    let Some(exact_config) = writer.load_config().map_err(map_local_host)? else {
+        return Ok(doctor_output(
+            "initialization_required",
+            ExitCode::InvalidInput,
+        ));
+    };
+    let config = decode_config(&exact_config)?;
+    let vault = configured_vault(paths, &config)?;
+    let locator = application_locator(vault.locator());
+    let application_store = application_store(paths);
+    let access = VaultAccessV1::locked(locator);
+    let report = access.doctor(&application_store, &application_store);
+    let (label, code) = match report.state() {
+        VaultDoctorStateV1::Healthy => ("healthy", ExitCode::Success),
+        VaultDoctorStateV1::InitializationRequired => {
+            ("initialization_required", ExitCode::InvalidInput)
+        }
+        VaultDoctorStateV1::RecoveryRequired => ("recovery_required", ExitCode::Conflict),
+        VaultDoctorStateV1::LocalStateUnavailable
+        | VaultDoctorStateV1::BootstrapUnavailable
+        | VaultDoctorStateV1::RepositoryUnavailable => ("unavailable", ExitCode::Provider),
+        VaultDoctorStateV1::UnsupportedCapability => ("unsupported", ExitCode::Unsupported),
+        VaultDoctorStateV1::AuthenticationRequired => ("authentication_required", ExitCode::Locked),
+        VaultDoctorStateV1::IntegrityFailure => ("integrity_failure", ExitCode::Integrity),
+    };
+    Ok(doctor_output(label, code))
+}
+
+fn render_status_label(label: &str, json: bool) -> CliOutput {
+    if json {
+        CliOutput::success(format!("{{\"state\":\"{label}\"}}\n"))
+    } else {
+        CliOutput::success(format!("Status: {label}\n"))
+    }
+}
+
+fn doctor_output(label: &str, exit_code: ExitCode) -> CliOutput {
+    CliOutput {
+        exit_code,
+        stdout: format!("Doctor: {label}\n"),
+        stderr: String::new(),
+    }
+}
+
+fn initial_config(
+    paths: &LocalVaultPaths,
+    locator: BootstrapLocator,
+    vault_name: ConfigName,
+    storage_name: ConfigName,
+) -> Result<VaultPmConfigV1, CliFailure> {
+    let location = paths
+        .object_root()
+        .to_str()
+        .ok_or(CliFailure::Unsupported)?;
+    let storage_config = StorageConfigV1::new(
+        StorageKind::Filesystem,
+        StorageLocation::new(location).map_err(|_| CliFailure::Unsupported)?,
+        CredentialRef::none(),
+    );
+    let vault_config = VaultConfigV1::new(
+        ConfigVaultLocator::new(*locator.as_bytes()),
+        storage_name.clone(),
+        Vec::new(),
+        DEFAULT_AUTO_LOCK_SECONDS,
+        DEFAULT_CLIPBOARD_CLEAR_SECONDS,
+    )
+    .map_err(|_| CliFailure::Internal)?;
+    let mut vaults = BTreeMap::new();
+    vaults.insert(vault_name.clone(), vault_config);
+    let mut storage = BTreeMap::new();
+    storage.insert(storage_name, storage_config);
+    VaultPmConfigV1::new(vault_name, vaults, storage).map_err(|_| CliFailure::Internal)
+}
+
+fn decode_config(exact: &[u8]) -> Result<VaultPmConfigV1, CliFailure> {
+    let text = core::str::from_utf8(exact).map_err(|_| CliFailure::Integrity)?;
+    parse_config(text).map_err(|_| CliFailure::Integrity)
+}
+
+fn configured_vault<'a>(
+    paths: &LocalVaultPaths,
+    config: &'a VaultPmConfigV1,
+) -> Result<&'a VaultConfigV1, CliFailure> {
+    let vault = config.select_vault(None).ok_or(CliFailure::Integrity)?;
+    if !vault.remote_stores().is_empty() {
+        return Err(CliFailure::Unsupported);
+    }
+    let storage = config
+        .storage()
+        .get(vault.local_store())
+        .ok_or(CliFailure::Integrity)?;
+    let expected = paths
+        .object_root()
+        .to_str()
+        .ok_or(CliFailure::Unsupported)?;
+    if storage.kind() != StorageKind::Filesystem
+        || storage.location().as_str() != expected
+        || storage.credential_ref().as_str() != "none"
+    {
+        return Err(CliFailure::Unsupported);
+    }
+    Ok(vault)
+}
+
+fn application_locator(locator: ConfigVaultLocator) -> BootstrapLocator {
+    BootstrapLocator::new(*locator.as_bytes())
+}
+
+fn application_store(paths: &LocalVaultPaths) -> StorageCoreApplicationStore<FsStorageBackend> {
+    StorageCoreApplicationStore::new(FsStorageBackend::new(paths.application_state_root()))
+}
+
+fn repository_factory(
+    paths: &LocalVaultPaths,
+) -> V1ApplicationRepositoryFactory<StorageCoreObjectStore<FsStorageBackend>> {
+    V1ApplicationRepositoryFactory::new(StorageCoreObjectStore::new(FsStorageBackend::new(
+        paths.object_root(),
+    )))
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CliFailure {
+    InvalidCommand,
+    AlreadyInitialized,
+    Locked,
+    NotFound,
+    Conflict,
+    Integrity,
+    Provider,
+    Unsupported,
+    Internal,
+}
+
+impl CliFailure {
+    const fn exit_code(self) -> ExitCode {
+        match self {
+            Self::InvalidCommand | Self::AlreadyInitialized => ExitCode::InvalidInput,
+            Self::Locked => ExitCode::Locked,
+            Self::NotFound => ExitCode::NotFound,
+            Self::Conflict => ExitCode::Conflict,
+            Self::Integrity => ExitCode::Integrity,
+            Self::Provider => ExitCode::Provider,
+            Self::Unsupported => ExitCode::Unsupported,
+            Self::Internal => ExitCode::Internal,
+        }
+    }
+
+    const fn message(self) -> &'static str {
+        match self {
+            Self::InvalidCommand => "vault-pm: invalid command",
+            Self::AlreadyInitialized => "vault-pm: already initialized",
+            Self::Locked => "vault-pm: authentication required",
+            Self::NotFound => "vault-pm: not found",
+            Self::Conflict => "vault-pm: recovery or conflict required",
+            Self::Integrity => "vault-pm: integrity check failed",
+            Self::Provider => "vault-pm: storage unavailable",
+            Self::Unsupported => "vault-pm: unsupported capability",
+            Self::Internal => "vault-pm: internal invariant failed",
+        }
+    }
+}
+
+impl Debug for CliFailure {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.message())
+    }
+}
+
+fn map_application(error: ApplicationError) -> CliFailure {
+    match error {
+        ApplicationError::NotInitialized
+        | ApplicationError::AlreadyInitialized
+        | ApplicationError::InvalidInput
+        | ApplicationError::BoundExceeded => CliFailure::InvalidCommand,
+        ApplicationError::Locked | ApplicationError::AuthenticationFailed => CliFailure::Locked,
+        ApplicationError::NotFound => CliFailure::NotFound,
+        ApplicationError::ConcurrentHost | ApplicationError::ConflictRequired => {
+            CliFailure::Conflict
+        }
+        ApplicationError::IntegrityFailure => CliFailure::Integrity,
+        ApplicationError::StorageUnavailable => CliFailure::Provider,
+        ApplicationError::Unsupported => CliFailure::Unsupported,
+        ApplicationError::InternalInvariant => CliFailure::Internal,
+    }
+}
+
+fn map_local_state(error: LocalStateStoreError) -> CliFailure {
+    match error {
+        LocalStateStoreError::Unavailable => CliFailure::Provider,
+        LocalStateStoreError::ConcurrentHost => CliFailure::Conflict,
+        LocalStateStoreError::Corruption => CliFailure::Integrity,
+    }
+}
+
+fn map_local_host(error: LocalHostError) -> CliFailure {
+    match error {
+        LocalHostError::AlreadyLocked
+        | LocalHostError::ConfigAlreadyExists
+        | LocalHostError::ConfigConflict => CliFailure::Conflict,
+        LocalHostError::InsecureOwner
+        | LocalHostError::InsecurePermissions
+        | LocalHostError::UnsafeObjectType => CliFailure::Integrity,
+        LocalHostError::UnsupportedPlatform => CliFailure::Unsupported,
+        LocalHostError::PlatformUnavailable
+        | LocalHostError::ParentUnavailable
+        | LocalHostError::AccessFailed => CliFailure::Provider,
+        LocalHostError::InvalidPath | LocalHostError::InvalidConfigBytes => {
+            CliFailure::InvalidCommand
+        }
+    }
+}
+
+fn map_host(error: HostError) -> CliFailure {
+    match error {
+        HostError::Invalid => CliFailure::InvalidCommand,
+        HostError::Unavailable => CliFailure::Provider,
+        HostError::Unsupported => CliFailure::Unsupported,
+    }
+}
+
+fn map_native_cli_host(error: CliHostError) -> HostError {
+    match error {
+        CliHostError::EmptySecret
+        | CliHostError::SecretTooLong
+        | CliHostError::SecretMismatch
+        | CliHostError::InvalidEntropyRequest => HostError::Invalid,
+        CliHostError::UnsupportedPlatform => HostError::Unsupported,
+        CliHostError::TerminalUnavailable
+        | CliHostError::TerminalAccessFailed
+        | CliHostError::TerminalModeFailed
+        | CliHostError::SecretInputFailed
+        | CliHostError::EntropyUnavailable => HostError::Unavailable,
+    }
+}
+
+fn map_native_local_host(error: LocalHostError) -> HostError {
+    match error {
+        LocalHostError::UnsupportedPlatform => HostError::Unsupported,
+        LocalHostError::InvalidPath | LocalHostError::InvalidConfigBytes => HostError::Invalid,
+        _ => HostError::Unavailable,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Mutex;
+
+    static NEXT_TEMP: AtomicU64 = AtomicU64::new(1);
+
+    struct TestRoot(PathBuf);
+
+    impl TestRoot {
+        fn new() -> Self {
+            let suffix = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+            let path =
+                std::env::temp_dir().join(format!("vault-pm-cli-{}-{suffix}", std::process::id()));
+            fs::create_dir_all(&path).unwrap();
+            Self(fs::canonicalize(path).unwrap())
+        }
+
+        fn paths(&self) -> LocalVaultPaths {
+            LocalVaultPaths::from_roots(
+                self.0.join("config"),
+                self.0.join("data"),
+                self.0.join("cache"),
+            )
+            .unwrap()
+        }
+    }
+
+    impl Drop for TestRoot {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    struct TestHost {
+        paths: LocalVaultPaths,
+        secrets: Mutex<VecDeque<Vec<u8>>>,
+    }
+
+    impl TestHost {
+        fn new(paths: LocalVaultPaths, secrets: impl IntoIterator<Item = Vec<u8>>) -> Self {
+            Self {
+                paths,
+                secrets: Mutex::new(secrets.into_iter().collect()),
+            }
+        }
+
+        fn secret(&self) -> Result<Zeroizing<Vec<u8>>, HostError> {
+            self.secrets
+                .lock()
+                .unwrap()
+                .pop_front()
+                .map(Zeroizing::new)
+                .ok_or(HostError::Unavailable)
+        }
+    }
+
+    impl CliHost for TestHost {
+        fn paths(&self) -> Result<LocalVaultPaths, HostError> {
+            Ok(self.paths.clone())
+        }
+
+        fn read_new_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError> {
+            self.secret()
+        }
+
+        fn read_existing_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError> {
+            self.secret()
+        }
+
+        fn fill_entropy(&self, output: &mut [u8]) -> Result<(), HostError> {
+            for (index, byte) in output.iter_mut().enumerate() {
+                *byte = u8::try_from(index % 251).unwrap().wrapping_add(1);
+            }
+            Ok(())
+        }
+
+        fn now_ms(&self) -> Result<u64, HostError> {
+            Ok(1_700_000_000_000)
+        }
+
+        fn generation_zero_kdf(&self) -> (u32, u32, u8) {
+            (8 * 1024, 1, 1)
+        }
+    }
+
+    #[test]
+    fn parser_is_closed_and_never_accepts_secret_arguments() {
+        let root = TestRoot::new();
+        let host = TestHost::new(root.paths(), []);
+        for arguments in [
+            vec!["init", "--passphrase", "secret"],
+            vec!["init", "--vault=personal"],
+            vec!["status", "--unsafe-include-secrets"],
+            vec!["doctor", "extra"],
+            vec!["unlock"],
+        ] {
+            let output = run(arguments, &host);
+            assert_eq!(output.exit_code(), ExitCode::InvalidInput);
+            assert_eq!(output.stderr(), "vault-pm: invalid command\n");
+        }
+        assert!(!root.0.join("config").exists());
+    }
+
+    #[test]
+    fn init_survives_restart_and_locked_queries_are_redacted() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let init_host = TestHost::new(paths.clone(), [b"correct horse battery staple".to_vec()]);
+        let initialized = run(["init"], &init_host);
+        assert_eq!(
+            initialized.exit_code(),
+            ExitCode::Success,
+            "{initialized:?}"
+        );
+        assert_eq!(initialized.stdout(), "Vault initialized.\n");
+        assert!(initialized.stderr().is_empty());
+
+        let restarted = TestHost::new(paths, []);
+        let status = run(["status", "--json"], &restarted);
+        assert_eq!(status.exit_code(), ExitCode::Success);
+        assert_eq!(status.stdout(), "{\"state\":\"locked\"}\n");
+        assert!(!status.stdout().contains("personal"));
+
+        let doctor = run(["doctor"], &restarted);
+        assert_eq!(doctor.exit_code(), ExitCode::Locked);
+        assert_eq!(doctor.stdout(), "Doctor: authentication_required\n");
+        assert!(doctor.stderr().is_empty());
+    }
+
+    #[test]
+    fn repeated_init_does_not_prompt_or_replace_active_state() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let first = TestHost::new(paths.clone(), [b"first passphrase".to_vec()]);
+        let initialized = run(["init"], &first);
+        assert_eq!(
+            initialized.exit_code(),
+            ExitCode::Success,
+            "{initialized:?}"
+        );
+
+        let second = TestHost::new(paths, []);
+        let output = run(["init"], &second);
+        assert_eq!(output.exit_code(), ExitCode::InvalidInput);
+        assert_eq!(output.stderr(), "vault-pm: already initialized\n");
+    }
+
+    #[test]
+    fn prepared_init_is_rehydrated_without_new_randomness() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"resumable passphrase".to_vec();
+        let mut random_bytes = [0_u8; GENERATION_ZERO_RANDOM_BYTES];
+        for (index, byte) in random_bytes.iter_mut().enumerate() {
+            *byte = u8::try_from(index % 251).unwrap().wrapping_add(1);
+        }
+        let prepared = prepare_generation_zero(
+            Zeroizing::new(passphrase.clone()),
+            GenerationZeroPolicyV1::new(8 * 1024, 1, 1, 1_700_000_000_000).unwrap(),
+            GenerationZeroRandomness::new(random_bytes),
+        )
+        .unwrap();
+        let locator = prepared.bootstrap_locator();
+        let exact_prepared = prepared.owner_state().encode().unwrap();
+        let layout = paths.prepare().unwrap();
+        let writer = layout.try_acquire_writer().unwrap();
+        let store = application_store(&paths);
+        store
+            .compare_exchange(locator, None, &exact_prepared)
+            .unwrap();
+        let config = initial_config(
+            &paths,
+            locator,
+            ConfigName::new(DEFAULT_VAULT_NAME).unwrap(),
+            ConfigName::new(DEFAULT_STORAGE_NAME).unwrap(),
+        )
+        .unwrap();
+        writer
+            .create_config(render_config(&config).as_bytes())
+            .unwrap();
+        drop(writer);
+        drop(layout);
+        drop(prepared);
+
+        let host = TestHost::new(paths.clone(), [passphrase]);
+        let resumed = run(["init"], &host);
+        assert_eq!(resumed.exit_code(), ExitCode::Success, "{resumed:?}");
+        assert_eq!(run(["status"], &host).stdout(), "Status: locked\n");
+    }
+
+    #[test]
+    fn unconfigured_status_and_doctor_are_stable() {
+        let root = TestRoot::new();
+        let host = TestHost::new(root.paths(), []);
+        let status = run(["status"], &host);
+        assert_eq!(status.stdout(), "Status: uninitialized\n", "{status:?}");
+        let doctor = run(["doctor"], &host);
+        assert_eq!(doctor.exit_code(), ExitCode::InvalidInput);
+        assert_eq!(doctor.stdout(), "Doctor: initialization_required\n");
+    }
+
+    #[test]
+    fn help_has_no_host_side_effects() {
+        let root = TestRoot::new();
+        let host = TestHost::new(root.paths(), []);
+        let output = run(["--help"], &host);
+        assert_eq!(output.exit_code(), ExitCode::Success);
+        assert_eq!(output.stdout(), USAGE);
+        assert!(!root.0.join("config").exists());
+    }
+}

--- a/code/programs/rust/vault-pm-cli/BUILD
+++ b/code/programs/rust/vault-pm-cli/BUILD
@@ -1,0 +1,1 @@
+cargo test --manifest-path Cargo.toml -- --nocapture

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Added the `vault-pm` executable composition root.
+- Added real-process pseudo-terminal initialization and restart coverage.

--- a/code/programs/rust/vault-pm-cli/Cargo.toml
+++ b/code/programs/rust/vault-pm-cli/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "vault-pm-cli-program"
+version = "0.1.0"
+edition = "2021"
+description = "Local-first vault-pm command-line executable"
+license = "MIT"
+
+[workspace]
+
+[dependencies]
+coding_adventures_vault_pm_cli = { path = "../../../packages/rust/vault-pm-cli" }
+
+[dev-dependencies]
+libc = "0.2"
+
+[[bin]]
+name = "vault-pm"
+path = "src/main.rs"

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -1,0 +1,27 @@
+# `vault-pm`
+
+The first installable local password-manager executable. It intentionally has
+no product logic: it forwards process arguments to
+`coding_adventures_vault_pm_cli`, writes that package's bounded public output,
+and exits with its stable VLT-PM00 class.
+
+The current command surface is:
+
+```text
+vault-pm init [--vault NAME] [--storage NAME]
+vault-pm status [--json]
+vault-pm doctor
+```
+
+`init` requires a controlling terminal even when stdin is redirected. No
+passphrase flag, environment variable, config field, URL, or stdin path exists.
+Unix integration tests launch this exact binary under a fresh pseudo-terminal,
+verify the passphrase is not echoed, restart the process for status and doctor,
+and inspect the isolated filesystem tree for plaintext passphrase bytes.
+
+## Verification
+
+```bash
+bash BUILD
+cargo clippy --manifest-path Cargo.toml --all-targets -- -D warnings
+```

--- a/code/programs/rust/vault-pm-cli/required_capabilities.json
+++ b/code/programs/rust/vault-pm-cli/required_capabilities.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/vault-pm-cli-program",
+  "capabilities": [
+    {
+      "category": "fs",
+      "action": "read",
+      "target": "platform-resolved owner-private vault-pm roots",
+      "justification": "Composes the audited local host and filesystem storage adapters to read durable local vault state."
+    },
+    {
+      "category": "fs",
+      "action": "write",
+      "target": "platform-resolved owner-private vault-pm roots",
+      "justification": "Composes the audited local host and filesystem storage adapters to persist durable local vault state."
+    },
+    {
+      "category": "fs",
+      "action": "create",
+      "target": "platform-resolved owner-private vault-pm roots",
+      "justification": "Creates first-use private roots, configuration, journals, bootstraps, and encrypted immutable records."
+    },
+    {
+      "category": "ffi",
+      "action": "call",
+      "target": "controlling terminal and operating-system entropy APIs",
+      "justification": "Collects hidden passphrases from the controlling terminal and fills generation-zero randomness from the OS CSPRNG."
+    },
+    {
+      "category": "time",
+      "action": "read",
+      "target": "system wall clock",
+      "justification": "Supplies an advisory generation-zero timestamp."
+    },
+    {
+      "category": "stdout",
+      "action": "write",
+      "target": "process stdout and stderr",
+      "justification": "Writes only the bounded public output and fixed payload-free errors returned by the CLI package."
+    }
+  ],
+  "justification": "Thin executable composition root for the local-only password-manager CLI."
+}

--- a/code/programs/rust/vault-pm-cli/src/main.rs
+++ b/code/programs/rust/vault-pm-cli/src/main.rs
@@ -1,0 +1,12 @@
+use coding_adventures_vault_pm_cli::{run, ExitCode, NativeCliHost};
+use std::io::{self, Write};
+
+fn main() {
+    let output = run(std::env::args_os().skip(1), &NativeCliHost);
+    if io::stdout().write_all(output.stdout().as_bytes()).is_err()
+        || io::stderr().write_all(output.stderr().as_bytes()).is_err()
+    {
+        std::process::exit(ExitCode::Internal as i32);
+    }
+    std::process::exit(output.exit_code() as i32);
+}

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -1,0 +1,179 @@
+#![cfg(unix)]
+
+use std::fs::{self, File};
+use std::io::{self, Read, Write};
+use std::os::fd::FromRawFd;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_TEMP: AtomicU64 = AtomicU64::new(1);
+const PASSPHRASE: &[u8] = b"e2e correct horse battery staple";
+const STDIN_INJECTION: &[u8] = b"stdin injected secret\nstdin injected secret\n";
+
+struct TestHome(PathBuf);
+
+impl TestHome {
+    fn new() -> Self {
+        let sequence = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "vault-pm-program-e2e-{}-{sequence}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        let path = fs::canonicalize(path).unwrap();
+        for child in ["home", "config", "data", "cache"] {
+            fs::create_dir(path.join(child)).unwrap();
+        }
+        Self(path)
+    }
+
+    fn configure(&self, command: &mut Command) {
+        command
+            .env("HOME", self.0.join("home"))
+            .env("XDG_CONFIG_HOME", self.0.join("config"))
+            .env("XDG_DATA_HOME", self.0.join("data"))
+            .env("XDG_CACHE_HOME", self.0.join("cache"));
+    }
+}
+
+impl Drop for TestHome {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+#[test]
+fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
+    let home = TestHome::new();
+    let (status, transcript) = run_init_in_pty(&home);
+    assert!(status.success(), "init failed: {transcript}");
+    assert!(transcript.contains("New vault passphrase: "));
+    assert!(transcript.contains("Confirm vault passphrase: "));
+    assert!(transcript.contains("Vault initialized."));
+    assert!(!transcript
+        .as_bytes()
+        .windows(PASSPHRASE.len())
+        .any(|value| value == PASSPHRASE));
+    assert!(!transcript.contains("stdin injected secret"));
+
+    let status = run_plain(&home, &["status", "--json"]);
+    assert!(status.status.success());
+    assert_eq!(
+        String::from_utf8(status.stdout).unwrap(),
+        "{\"state\":\"locked\"}\n"
+    );
+    assert!(status.stderr.is_empty());
+
+    let doctor = run_plain(&home, &["doctor"]);
+    assert_eq!(doctor.status.code(), Some(3));
+    assert_eq!(
+        String::from_utf8(doctor.stdout).unwrap(),
+        "Doctor: authentication_required\n"
+    );
+    assert!(doctor.stderr.is_empty());
+
+    assert_tree_excludes(&home.0, PASSPHRASE);
+}
+
+fn run_plain(home: &TestHome, arguments: &[&str]) -> std::process::Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args(arguments);
+    home.configure(&mut command);
+    command.output().unwrap()
+}
+
+fn run_init_in_pty(home: &TestHome) -> (ExitStatus, String) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.arg("init");
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDOUT_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    drop(command);
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
+    read_until(&mut master, &mut transcript, b"New vault passphrase: ");
+    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Confirm vault passphrase: ");
+    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, b"Vault initialized.");
+    drop(master);
+    let status = child.wait().unwrap();
+    (status, String::from_utf8_lossy(&transcript).into_owned())
+}
+
+#[cfg(target_vendor = "apple")]
+fn tiocsctty_request() -> libc::c_ulong {
+    libc::TIOCSCTTY.into()
+}
+
+#[cfg(not(target_vendor = "apple"))]
+fn tiocsctty_request() -> libc::c_ulong {
+    libc::TIOCSCTTY
+}
+
+fn open_pty() -> (File, File) {
+    let mut master = -1;
+    let mut slave = -1;
+    let result = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(result, 0, "openpty failed: {}", io::Error::last_os_error());
+    unsafe { (File::from_raw_fd(master), File::from_raw_fd(slave)) }
+}
+
+fn read_until(master: &mut File, transcript: &mut Vec<u8>, pattern: &[u8]) {
+    while !transcript
+        .windows(pattern.len())
+        .any(|value| value == pattern)
+    {
+        let mut byte = [0_u8; 1];
+        match master.read(&mut byte) {
+            Ok(1) => transcript.push(byte[0]),
+            Ok(0) => panic!("pseudo-terminal closed before expected prompt"),
+            Ok(_) => unreachable!(),
+            Err(error) => panic!("pseudo-terminal read failed: {error}"),
+        }
+    }
+}
+
+fn assert_tree_excludes(root: &Path, forbidden: &[u8]) {
+    for entry in fs::read_dir(root).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if entry.file_type().unwrap().is_dir() {
+            assert_tree_excludes(&path, forbidden);
+        } else {
+            let bytes = fs::read(path).unwrap();
+            assert!(!bytes
+                .windows(forbidden.len())
+                .any(|value| value == forbidden));
+        }
+    }
+}

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1420,7 +1420,15 @@ changelog, focused build, and downstream validation.
     echo restoration, constant-time new-passphrase confirmation, and stable OS
     entropy, using the closed CLI-only trust boundary in
     `VLT-PM08-cli-host.md`.
-9. `vault-pm-cli` + real executable and pseudo-terminal E2E suite.
+9a. completed `vault-pm-cli` bootstrap composition: closed parsing/rendering,
+    stable exit classes, real `init`, locked `status`, and locked `doctor`, plus
+    a thin executable and real-process pseudo-terminal restart suite, using
+    `VLT-PM09-cli-bootstrap.md`. Generation zero installs its exact prepared
+    journal before configuration makes the random locator discoverable, and a
+    restart resumes that journal without generating replacement identities.
+9b. authenticated one-shot CLI composition for item CRUD/list, search, history,
+    portable export/import, and audit verification, followed by the foreground
+    interactive shell over the same command/use-case boundary.
 10. Crash/fault matrix and local restore drill.
 
 ### Phase 1B — daily local use
@@ -1476,8 +1484,11 @@ The following are not allowed to block Phase 1A, but each needs a later spec:
 - `VLT10-vault-sync-engine.md` — version vectors and conflict semantics.
 - `VLT11-transports.md` — current CLI transport contract.
 - `VLT-PM01-format.md`, `VLT-PM02-storage.md`, `VLT-PM03-domain.md`,
-  `VLT-PM04-repository.md`, and `VLT-PM05-application.md` — product repository
-  wire, object-store, domain, verified-DAG, and application contracts.
+  `VLT-PM04-repository.md`, `VLT-PM05-application.md`,
+  `VLT-PM06-local-host.md`, `VLT-PM07-config.md`, `VLT-PM08-cli-host.md`, and
+  `VLT-PM09-cli-bootstrap.md` — product repository wire, object-store, domain,
+  verified-DAG, application, local-host, configuration, terminal/entropy, and
+  initial executable-composition contracts.
 - `VLT12-vault-revision-history.md`, `VLT13-vault-encrypted-search.md`,
   `VLT14-vault-attachments.md`, `VLT15-vault-import-export.md`.
 - `STR01-storage-fs-backend.md` and `storage-core`.

--- a/code/specs/VLT-PM09-cli-bootstrap.md
+++ b/code/specs/VLT-PM09-cli-bootstrap.md
@@ -1,0 +1,280 @@
+# VLT-PM09 — Local CLI bootstrap composition
+
+Status: normative Phase 1A slice
+
+## 1. Purpose
+
+This specification defines the first runnable `vault-pm` product slice. It
+composes the existing provider-neutral application, durable storage adapters,
+secure local roots, strict configuration codec, controlling-terminal reader,
+and OS entropy source into one local executable.
+
+The slice proves three user-visible commands:
+
+```text
+vault-pm init [--vault NAME] [--storage NAME]
+vault-pm status [--json]
+vault-pm doctor
+```
+
+It does not redefine cryptography, repository semantics, storage wire formats,
+configuration syntax, terminal handling, or filesystem permission checks.
+Those remain owned by VLT-PM01 through VLT-PM08. This specification owns only
+command grammar, composition order, stable rendering, and real-process
+acceptance.
+
+## 2. Package and executable boundaries
+
+`code/packages/rust/vault-pm-cli` owns:
+
+- the closed command grammar;
+- stable exit-class mapping;
+- payload-free text and JSON renderers;
+- orchestration of `init`, locked `status`, and locked `doctor`;
+- validation that configured storage is safe for this local-only slice; and
+- injected path, clock, entropy, KDF-policy, and fixed-prompt secret seams.
+
+`code/programs/rust/vault-pm-cli` owns only the `vault-pm` process entry point.
+It passes `args_os().skip(1)` to the package, writes the returned bounded output,
+and exits with the returned class. It MUST NOT parse commands, collect secrets,
+construct providers, or implement application policy.
+
+The package may be reused by a later installer or foreground shell. The
+executable is replaceable without changing any persisted format.
+
+## 3. Closed command grammar
+
+### 3.1 General rules
+
+- Non-Unicode arguments fail as invalid input.
+- Unknown commands, flags, duplicates, missing values, and trailing arguments
+  fail as invalid input.
+- `--flag=value` forms are not accepted in V1.
+- `--help`, `-h`, and `help` are the only help spellings and accept no other
+  arguments.
+- Help parsing performs no path resolution or filesystem access.
+- No command accepts a passphrase, secret field, provider token, or encryption
+  key through argv.
+
+The following spellings MUST be rejected, rather than ignored:
+
+```text
+--passphrase
+--password
+--token
+--unsafe-include-secrets
+--vault=NAME
+--storage=NAME
+```
+
+Future commands extend the closed grammar deliberately. Compatibility never
+means silently accepting an unknown security-relevant option.
+
+### 3.2 `init`
+
+`init` accepts each of `--vault NAME` and `--storage NAME` at most once and in
+either order. Names use the exact bounded VLT-PM07 `ConfigName` grammar.
+Defaults are `personal` and `local`.
+
+### 3.3 `status`
+
+`status` accepts only an optional `--json`. It never prompts or unlocks in this
+slice.
+
+### 3.4 `doctor`
+
+`doctor` accepts no arguments. It never repairs, prompts, unlocks, accepts new
+pins, or changes configuration in this slice.
+
+## 4. Host acquisition order
+
+After successful parsing, every product command performs the following order:
+
+1. resolve standard platform application directories through VLT-PM06;
+2. create or validate owner-private config, data, state, object, and cache roots;
+3. acquire the non-blocking persistent writer lock;
+4. load exact configuration bytes while the lock is held;
+5. strictly decode VLT-PM07 configuration when present; and
+6. construct storage backends only after the configuration and local root have
+   both passed validation.
+
+The same lock is used for read-only commands in Phase 1A. `storage-core` does
+not provide cross-instance CAS or durable reader snapshots, so a read-only CLI
+must not race an independent writer while decoding owner state.
+
+Errors and `Debug` values MUST NOT include resolved paths.
+
+## 5. Local storage selection
+
+This slice supports one configured default vault, no remote replicas, and one
+filesystem local store. Configuration remains provider-neutral and retains a
+typed storage selection; the CLI performs the Phase 1A adapter choice.
+
+Before opening either filesystem backend, the CLI MUST prove:
+
+- the selected vault exists;
+- its local store declaration exists;
+- the storage kind is `filesystem`;
+- the credential reference is exactly `none`;
+- the remote-store list is empty; and
+- the configured filesystem location exactly equals the platform-resolved,
+  permission-checked object root.
+
+Any other valid VLT-PM07 storage selection returns `unsupported`, not a
+fallback. The CLI MUST NOT reinterpret a Google Drive, WebDAV, S3, arbitrary
+filesystem, or future storage declaration as the default local root.
+
+Application/bootstrap owner state uses the distinct permission-checked
+application-state root. Encrypted immutable repository objects use the object
+root. Both are constructed through `FsStorageBackend`, but the application
+continues to see only injected VLT-PM05 and VLT-PM02 traits.
+
+## 6. New initialization
+
+When no configuration exists, `init` performs this exact sequence while
+holding the writer lock:
+
+1. collect and constant-time confirm a new non-empty passphrase through the
+   VLT-PM08 controlling-terminal boundary;
+2. fill exactly `GENERATION_ZERO_RANDOM_BYTES` from the OS CSPRNG;
+3. read an advisory Unix-millisecond wall-clock value;
+4. construct the bounded production Argon2id policy;
+5. call the no-write VLT-PM05 `prepare_generation_zero` boundary;
+6. encode the exact returned `PreparedInit` owner state;
+7. atomically create that state at its random bootstrap locator;
+8. render and atomically create configuration containing that locator and the
+   selected filesystem store; and
+9. call `complete_generation_zero` over the injected application, bootstrap,
+   and repository stores.
+
+The production KDF floor for this slice is Argon2id with 65,536 KiB memory,
+three iterations, and one lane. Calibration and persisted policy upgrades are
+future work; a test host may inject another VLT-PM01-valid policy without
+changing production defaults.
+
+The passphrase exists only in a `Zeroizing<Vec<u8>>`. Entropy is written into a
+caller-owned fixed-size block. Neither value is cloneable through the CLI
+driver, rendered, logged, or included in an error.
+
+## 7. Crash and retry semantics
+
+The exact prepared journal is installed before configuration makes its random
+locator discoverable. This order creates two acceptable crash classes:
+
+- before config publication, no configured vault exists; any unreachable
+  opaque journal is not a partial logical vault and may be garbage-collected by
+  the Phase 1A fault/restore slice; or
+- after config publication, the configured locator resolves to the complete
+  exact `PreparedInit` journal and initialization is resumable.
+
+On a retry with existing configuration:
+
+1. the configured default vault and selected storage names must exactly match
+   the requested `init` names;
+2. the selected filesystem declaration must pass section 5;
+3. an `Active` owner state returns `already initialized` without prompting;
+4. a `PendingPublication` owner state returns `conflict/recovery required`;
+5. a missing, malformed, or mismatched owner state fails integrity; and
+6. only `PreparedInit` collects the existing passphrase, calls
+   `rehydrate_prepared_init`, and completes the exact journal.
+
+Retry MUST NOT generate a new locator, identity, key, salt, nonce, object,
+commit, or announcement. VLT-PM05 idempotence decides whether exact already
+published effects are success.
+
+## 8. Status projection
+
+With no configuration, status is `uninitialized`. With configuration, the CLI
+uses a key-free `VaultAccessV1::Locked` boundary and the exact local-state store.
+It renders only these labels:
+
+| VLT-PM05 state | CLI label |
+|---|---|
+| absent | `uninitialized` |
+| prepared | `initializing` |
+| active, no live session | `locked` |
+| live session | `unlocked` |
+| pending publication | `recovery_required` |
+
+Text output is exactly `Status: LABEL\n`. JSON output is exactly one object,
+`{"state":"LABEL"}\n`. Locked JSON never gains counts, identifiers, paths,
+or provider details merely because `--json` was supplied.
+
+## 9. Doctor projection
+
+The locked VLT-PM05 doctor report maps to one coarse label and exit class:
+
+| Doctor state | Label | Exit |
+|---|---|---:|
+| healthy | `healthy` | 0 |
+| initialization required | `initialization_required` | 2 |
+| recovery required | `recovery_required` | 5 |
+| any store unavailable | `unavailable` | 7 |
+| unsupported version/capability | `unsupported` | 8 |
+| authentication required | `authentication_required` | 3 |
+| integrity failure | `integrity_failure` | 6 |
+
+Output is exactly `Doctor: LABEL\n` on stdout, including nonzero health states.
+Stderr remains empty because this is the requested diagnostic result rather
+than an execution error.
+
+## 10. Stable execution failures
+
+Parser and orchestration failures emit one fixed line on stderr and no stdout.
+They use VLT-PM00 exit classes:
+
+| Exit | Meaning in this slice |
+|---:|---|
+| 2 | invalid command/input or already initialized |
+| 3 | passphrase authentication required/failed |
+| 4 | requested object absent |
+| 5 | writer contention, CAS conflict, or recovery required |
+| 6 | unsafe permissions/object type or persisted integrity failure |
+| 7 | local storage, terminal, entropy, clock, or platform authority unavailable |
+| 8 | unsupported platform, provider, or storage selection |
+| 10 | internal invariant failure |
+
+Failures MUST NOT interpolate an argument, name, path, OS error, passphrase,
+locator, provider identifier, or persisted payload.
+
+## 11. Real-process acceptance
+
+The executable integration suite MUST:
+
+1. create isolated platform roots;
+2. launch the exact `vault-pm` binary as a new session with a controlling
+   pseudo-terminal;
+3. connect process stdin to a pipe containing decoy secret lines and prove the
+   controlling-terminal prompts ignore them;
+4. wait for each fixed new-passphrase prompt before writing terminal input;
+5. prove the passphrase and decoy bytes do not occur in the terminal transcript;
+6. require successful generation-zero initialization;
+7. start a new process and observe exact locked JSON status;
+8. start another process and observe locked doctor authentication-required
+   output and exit 3; and
+9. recursively inspect the isolated files and prove the plaintext passphrase
+   byte string is absent.
+
+Package tests additionally cover the closed parser, unconfigured projections,
+restart behavior over injected roots, and repeated-init refusal. Native CI must
+compile the package and executable on Linux, macOS, and Windows. Unix runs the
+pseudo-terminal E2E; Windows relies on the independently tested VLT-PM08
+console adapter until the repository supplies an equivalent ConPTY harness.
+
+## 12. Explicit non-goals
+
+This slice does not implement:
+
+- an `unlock` command or resident key process;
+- item CRUD/list, search, history, conflict resolution, or restore;
+- full authenticated doctor or audit verification from a one-shot command;
+- portable export/import command parsing;
+- interactive shell, clipboard, TOTP, attachment, or password generation;
+- configuration mutation after initial creation;
+- arbitrary filesystem roots, removable-folder mode, or remote providers;
+- multiple configured vault creation; or
+- repair, garbage collection, backup, or restore drills.
+
+Those remain backlog items 9b and 10 in VLT-PM00. They must reuse the same
+application and storage seams rather than branching on filesystem or future
+Google Drive details inside command handlers.


### PR DESCRIPTION
## Summary

- specify and compose the first production CLI surface: strict `init`, `status`, and `doctor` commands over storage-neutral vault contracts
- make generation-zero initialization crash-recoverable by persisting the prepared journal before the locator config, then resuming that exact journal without fresh randomness
- add locked, payload-free status and health output plus a real standalone executable
- prove controlling-TTY passphrase handling, stdin-injection resistance, restart behavior, and plaintext exclusion in a real-process PTY test

## Validation

- `bash BUILD` in `code/packages/rust/vault-pm-cli` (6 tests)
- `bash BUILD` in `code/programs/rust/vault-pm-cli` (real-process PTY end-to-end test)
- native Clippy with warnings denied for package and program
- rustdoc with warnings denied
- cross-target Clippy for `x86_64-unknown-linux-gnu` and `x86_64-pc-windows-gnu`
- repository build tool: 4,861 packages discovered; all 44 affected packages built successfully
- capability manifests validated against their JSON schema
- `git diff --check` and clean synthetic merge with current `origin/main`