### PR TITLE
Add authenticated vault CLI verification

### DIFF
--- a/code/packages/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/packages/rust/vault-pm-cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Added one-shot authenticated `audit verify` with aggregate-only output.
+- Added opt-in full repository health verification through `doctor --unlock`.
+- Added strict parser, wrong-passphrase, synchronous re-lock, and real-process
+  controlling-terminal coverage for authenticated verification.
+
 ## 0.1.0
 
 - Added the closed `init`, `status`, and `doctor` command grammar.

--- a/code/packages/rust/vault-pm-cli/README.md
+++ b/code/packages/rust/vault-pm-cli/README.md
@@ -2,8 +2,9 @@
 
 This crate is the first real composition layer for the local-first password
 manager. It owns strict parsing, stable exit classes, redacted rendering, and
-the bounded `init`, locked `status`, and locked `doctor` workflows. The
-executable is a thin caller of this package.
+the bounded `init`, locked `status`/`doctor`, authenticated `audit verify`, and
+opt-in full `doctor --unlock` workflows. The executable is a thin caller of
+this package.
 
 The driver composes the existing storage-neutral application over separately
 permission-checked application-state and encrypted-object filesystem roots.
@@ -20,10 +21,13 @@ publishing the configuration that makes the random locator discoverable. A
 restart with a prepared journal collects the existing passphrase and resumes
 the exact journal without generating new identities or ciphertext.
 
-Status and doctor do not prompt or unlock. Their text and JSON projections are
-closed labels with no paths, locators, providers, identities, or cryptographic
-details. No command accepts a passphrase through argv, stdin, environment,
-configuration, or URL.
+Status and plain doctor do not prompt or unlock. `audit verify` and
+`doctor --unlock` collect the existing passphrase through the controlling
+terminal, open the storage-neutral repository for one read-only action, and
+synchronously drop the live session before rendering. Their projections contain
+only closed labels or aggregate verification counts, with no paths, locators,
+providers, identities, or cryptographic details. No command accepts a
+passphrase through argv, stdin, environment, configuration, or URL.
 
 ## Verification
 

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -6,9 +6,9 @@
 use coding_adventures_storage_fs::FsStorageBackend;
 use coding_adventures_vault_pm_application::{
     complete_generation_zero, prepare_generation_zero, rehydrate_prepared_init, ApplicationError,
-    BootstrapLocator, GenerationZeroPolicyV1, GenerationZeroRandomness, LocalStateStore,
-    LocalStateStoreError, LocalVaultStateV1, V1ApplicationRepositoryFactory, VaultAccessV1,
-    VaultDoctorStateV1, VaultStatusStateV1, GENERATION_ZERO_RANDOM_BYTES,
+    AuditVerificationV1, BootstrapLocator, GenerationZeroPolicyV1, GenerationZeroRandomness,
+    LocalStateStore, LocalStateStoreError, LocalVaultStateV1, V1ApplicationRepositoryFactory,
+    VaultAccessV1, VaultDoctorStateV1, VaultStatusStateV1, GENERATION_ZERO_RANDOM_BYTES,
 };
 use coding_adventures_vault_pm_application_storage_core::StorageCoreApplicationStore;
 use coding_adventures_vault_pm_cli_host::{
@@ -32,7 +32,7 @@ const DEFAULT_STORAGE_NAME: &str = "local";
 const PRODUCTION_KDF_MEMORY_KIB: u32 = 64 * 1024;
 const PRODUCTION_KDF_ITERATIONS: u32 = 3;
 const PRODUCTION_KDF_LANES: u8 = 1;
-const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm doctor\n";
+const USAGE: &str = "Usage:\n  vault-pm init [--vault NAME] [--storage NAME]\n  vault-pm status [--json]\n  vault-pm audit verify\n  vault-pm doctor [--unlock]\n";
 
 /// Stable process exit classes defined by VLT-PM00.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -110,7 +110,7 @@ pub trait CliHost {
     /// Collect and confirm a new vault passphrase.
     fn read_new_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError>;
 
-    /// Collect the existing passphrase for journal recovery.
+    /// Collect the existing passphrase for recovery or one-shot unlock.
     fn read_existing_passphrase(&self) -> Result<Zeroizing<Vec<u8>>, HostError>;
 
     /// Fill the entire generation-zero randomness block.
@@ -206,7 +206,10 @@ enum Command {
     Status {
         json: bool,
     },
-    Doctor,
+    AuditVerify,
+    Doctor {
+        unlock: bool,
+    },
     Help,
 }
 
@@ -231,7 +234,10 @@ where
         "--help" | "-h" | "help" if values.len() == 1 => Ok(Command::Help),
         "init" => parse_init(&values[1..]),
         "status" => parse_status(&values[1..]),
-        "doctor" if values.len() == 1 => Ok(Command::Doctor),
+        "audit" if values.get(1).map(String::as_str) == Some("verify") && values.len() == 2 => {
+            Ok(Command::AuditVerify)
+        }
+        "doctor" => parse_doctor(&values[1..]),
         _ => Err(CliFailure::InvalidCommand),
     }
 }
@@ -266,6 +272,14 @@ fn parse_status(arguments: &[String]) -> Result<Command, CliFailure> {
     }
 }
 
+fn parse_doctor(arguments: &[String]) -> Result<Command, CliFailure> {
+    match arguments {
+        [] => Ok(Command::Doctor { unlock: false }),
+        [argument] if argument == "--unlock" => Ok(Command::Doctor { unlock: true }),
+        _ => Err(CliFailure::InvalidCommand),
+    }
+}
+
 fn execute(command: Command, host: &dyn CliHost) -> Result<CliOutput, CliFailure> {
     let paths = host.paths().map_err(map_host)?;
     let prepared = paths.prepare().map_err(map_local_host)?;
@@ -273,7 +287,8 @@ fn execute(command: Command, host: &dyn CliHost) -> Result<CliOutput, CliFailure
     match command {
         Command::Init { vault, storage } => init(host, prepared.paths(), &writer, vault, storage),
         Command::Status { json } => status(prepared.paths(), &writer, json),
-        Command::Doctor => doctor(prepared.paths(), &writer),
+        Command::AuditVerify => audit_verify(host, prepared.paths(), &writer),
+        Command::Doctor { unlock } => doctor(host, prepared.paths(), &writer, unlock),
         Command::Help => unreachable!("help returns before host access"),
     }
 }
@@ -407,7 +422,44 @@ fn status(
     Ok(render_status_label(label, json))
 }
 
-fn doctor(paths: &LocalVaultPaths, writer: &LocalWriterGuard) -> Result<CliOutput, CliFailure> {
+fn audit_verify(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+) -> Result<CliOutput, CliFailure> {
+    let exact_config = writer
+        .load_config()
+        .map_err(map_local_host)?
+        .ok_or(CliFailure::InvalidCommand)?;
+    let config = decode_config(&exact_config)?;
+    let vault = configured_vault(paths, &config)?;
+    let locator = application_locator(vault.locator());
+    let application_store = application_store(paths);
+    let repository_factory = repository_factory(paths);
+    let mut access = VaultAccessV1::locked(locator);
+    let passphrase = host.read_existing_passphrase().map_err(map_host)?;
+    access
+        .unlock(
+            passphrase,
+            &application_store,
+            &application_store,
+            &repository_factory,
+        )
+        .map_err(map_application)?;
+    let result = access
+        .as_unlocked()
+        .and_then(|session| session.audit_verify());
+    access.lock();
+    let report = result.map_err(map_application)?;
+    Ok(render_audit(report))
+}
+
+fn doctor(
+    host: &dyn CliHost,
+    paths: &LocalVaultPaths,
+    writer: &LocalWriterGuard,
+    unlock: bool,
+) -> Result<CliOutput, CliFailure> {
     let Some(exact_config) = writer.load_config().map_err(map_local_host)? else {
         return Ok(doctor_output(
             "initialization_required",
@@ -418,8 +470,21 @@ fn doctor(paths: &LocalVaultPaths, writer: &LocalWriterGuard) -> Result<CliOutpu
     let vault = configured_vault(paths, &config)?;
     let locator = application_locator(vault.locator());
     let application_store = application_store(paths);
-    let access = VaultAccessV1::locked(locator);
+    let mut access = VaultAccessV1::locked(locator);
+    if unlock {
+        let repository_factory = repository_factory(paths);
+        let passphrase = host.read_existing_passphrase().map_err(map_host)?;
+        access
+            .unlock(
+                passphrase,
+                &application_store,
+                &application_store,
+                &repository_factory,
+            )
+            .map_err(map_application)?;
+    }
     let report = access.doctor(&application_store, &application_store);
+    access.lock();
     let (label, code) = match report.state() {
         VaultDoctorStateV1::Healthy => ("healthy", ExitCode::Success),
         VaultDoctorStateV1::InitializationRequired => {
@@ -434,6 +499,17 @@ fn doctor(paths: &LocalVaultPaths, writer: &LocalWriterGuard) -> Result<CliOutpu
         VaultDoctorStateV1::IntegrityFailure => ("integrity_failure", ExitCode::Integrity),
     };
     Ok(doctor_output(label, code))
+}
+
+fn render_audit(report: AuditVerificationV1) -> CliOutput {
+    CliOutput::success(format!(
+        "Audit: verified (announcements={} commits={} catalogs={} revisions={} items={})\n",
+        report.announcement_count(),
+        report.commit_count(),
+        report.catalog_count(),
+        report.revision_count(),
+        report.item_count(),
+    ))
 }
 
 fn render_status_label(label: &str, json: bool) -> CliOutput {
@@ -689,6 +765,21 @@ mod tests {
         }
     }
 
+    fn first_file(root: &std::path::Path) -> Option<PathBuf> {
+        for entry in fs::read_dir(root).ok()? {
+            let entry = entry.ok()?;
+            let path = entry.path();
+            if entry.file_type().ok()?.is_dir() {
+                if let Some(found) = first_file(&path) {
+                    return Some(found);
+                }
+            } else {
+                return Some(path);
+            }
+        }
+        None
+    }
+
     struct TestHost {
         paths: LocalVaultPaths,
         secrets: Mutex<VecDeque<Vec<u8>>>,
@@ -750,6 +841,9 @@ mod tests {
             vec!["init", "--vault=personal"],
             vec!["status", "--unsafe-include-secrets"],
             vec!["doctor", "extra"],
+            vec!["doctor", "--unlock", "extra"],
+            vec!["audit"],
+            vec!["audit", "verify", "extra"],
             vec!["unlock"],
         ] {
             let output = run(arguments, &host);
@@ -783,6 +877,68 @@ mod tests {
         assert_eq!(doctor.exit_code(), ExitCode::Locked);
         assert_eq!(doctor.stdout(), "Doctor: authentication_required\n");
         assert!(doctor.stderr().is_empty());
+    }
+
+    #[test]
+    fn authenticated_audit_and_doctor_unlock_for_one_operation() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"correct horse battery staple".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let audit_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        let audit = run(["audit", "verify"], &audit_host);
+        assert_eq!(audit.exit_code(), ExitCode::Success, "{audit:?}");
+        assert_eq!(
+            audit.stdout(),
+            "Audit: verified (announcements=1 commits=1 catalogs=1 revisions=0 items=0)\n"
+        );
+        assert!(audit.stderr().is_empty());
+
+        let doctor_host = TestHost::new(paths.clone(), [passphrase]);
+        let doctor = run(["doctor", "--unlock"], &doctor_host);
+        assert_eq!(doctor.exit_code(), ExitCode::Success, "{doctor:?}");
+        assert_eq!(doctor.stdout(), "Doctor: healthy\n");
+        assert!(doctor.stderr().is_empty());
+
+        let locked = TestHost::new(paths, []);
+        assert_eq!(run(["status"], &locked).stdout(), "Status: locked\n");
+    }
+
+    #[test]
+    fn authenticated_verification_rejects_the_wrong_passphrase() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let init_host = TestHost::new(paths.clone(), [b"correct passphrase".to_vec()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let wrong = TestHost::new(paths, [b"wrong passphrase".to_vec()]);
+        let output = run(["audit", "verify"], &wrong);
+        assert_eq!(output.exit_code(), ExitCode::Locked);
+        assert!(output.stdout().is_empty());
+        assert_eq!(output.stderr(), "vault-pm: authentication required\n");
+    }
+
+    #[test]
+    fn authenticated_verification_fails_closed_on_repository_tampering() {
+        let root = TestRoot::new();
+        let paths = root.paths();
+        let passphrase = b"correct passphrase".to_vec();
+        let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
+        assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
+
+        let object = first_file(paths.object_root()).expect("generation zero repository object");
+        let mut bytes = fs::read(&object).unwrap();
+        let last = bytes.last_mut().expect("non-empty storage record");
+        *last ^= 0x01;
+        fs::write(object, bytes).unwrap();
+
+        let audit_host = TestHost::new(paths, [passphrase]);
+        let output = run(["audit", "verify"], &audit_host);
+        assert_eq!(output.exit_code(), ExitCode::Integrity, "{output:?}");
+        assert!(output.stdout().is_empty());
+        assert_eq!(output.stderr(), "vault-pm: integrity check failed\n");
     }
 
     #[test]
@@ -855,6 +1011,12 @@ mod tests {
         let doctor = run(["doctor"], &host);
         assert_eq!(doctor.exit_code(), ExitCode::InvalidInput);
         assert_eq!(doctor.stdout(), "Doctor: initialization_required\n");
+        let full_doctor = run(["doctor", "--unlock"], &host);
+        assert_eq!(full_doctor.exit_code(), ExitCode::InvalidInput);
+        assert_eq!(full_doctor.stdout(), "Doctor: initialization_required\n");
+        let audit = run(["audit", "verify"], &host);
+        assert_eq!(audit.exit_code(), ExitCode::InvalidInput);
+        assert_eq!(audit.stderr(), "vault-pm: invalid command\n");
     }
 
     #[test]

--- a/code/packages/rust/vault-pm-cli/src/lib.rs
+++ b/code/packages/rust/vault-pm-cli/src/lib.rs
@@ -765,16 +765,27 @@ mod tests {
         }
     }
 
-    fn first_file(root: &std::path::Path) -> Option<PathBuf> {
+    fn first_storage_record_with_body_magic(
+        root: &std::path::Path,
+        body_magic: &[u8],
+    ) -> Option<PathBuf> {
         for entry in fs::read_dir(root).ok()? {
             let entry = entry.ok()?;
             let path = entry.path();
             if entry.file_type().ok()?.is_dir() {
-                if let Some(found) = first_file(&path) {
+                if let Some(found) = first_storage_record_with_body_magic(&path, body_magic) {
                     return Some(found);
                 }
-            } else {
-                return Some(path);
+            } else if let Ok(bytes) = fs::read(&path) {
+                let meta_len = bytes
+                    .get(5..9)
+                    .and_then(|exact| <[u8; 4]>::try_from(exact).ok())
+                    .map(u32::from_be_bytes)? as usize;
+                let body_start = 9_usize.checked_add(meta_len)?;
+                let magic_end = body_start.checked_add(body_magic.len())?;
+                if bytes.get(body_start..magic_end) == Some(body_magic) {
+                    return Some(path);
+                }
             }
         }
         None
@@ -928,7 +939,8 @@ mod tests {
         let init_host = TestHost::new(paths.clone(), [passphrase.clone()]);
         assert_eq!(run(["init"], &init_host).exit_code(), ExitCode::Success);
 
-        let object = first_file(paths.object_root()).expect("generation zero repository object");
+        let object = first_storage_record_with_body_magic(paths.object_root(), b"VPO1")
+            .expect("generation zero encrypted repository object");
         let mut bytes = fs::read(&object).unwrap();
         let last = bytes.last_mut().expect("non-empty storage record");
         *last ^= 0x01;

--- a/code/programs/rust/vault-pm-cli/CHANGELOG.md
+++ b/code/programs/rust/vault-pm-cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Exposed authenticated `audit verify` and `doctor --unlock` through the thin
+  executable.
+- Extended the real-process PTY suite across restart and redirected-stdin
+  injection for both authenticated commands.
+
 ## 0.1.0
 
 - Added the `vault-pm` executable composition root.

--- a/code/programs/rust/vault-pm-cli/README.md
+++ b/code/programs/rust/vault-pm-cli/README.md
@@ -10,13 +10,15 @@ The current command surface is:
 ```text
 vault-pm init [--vault NAME] [--storage NAME]
 vault-pm status [--json]
-vault-pm doctor
+vault-pm audit verify
+vault-pm doctor [--unlock]
 ```
 
-`init` requires a controlling terminal even when stdin is redirected. No
-passphrase flag, environment variable, config field, URL, or stdin path exists.
-Unix integration tests launch this exact binary under a fresh pseudo-terminal,
-verify the passphrase is not echoed, restart the process for status and doctor,
+`init` and authenticated verification require a controlling terminal even when
+stdin is redirected. No passphrase flag, environment variable, config field,
+URL, or stdin path exists. Unix integration tests launch this exact binary
+under fresh pseudo-terminals, verify the passphrase is not echoed, restart the
+process for locked and authenticated checks, inject decoy bytes through stdin,
 and inspect the isolated filesystem tree for plaintext passphrase bytes.
 
 ## Verification

--- a/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
+++ b/code/programs/rust/vault-pm-cli/tests/local_cli_e2e.rs
@@ -74,6 +74,27 @@ fn real_cli_initializes_through_a_hidden_tty_and_survives_restart() {
     );
     assert!(doctor.stderr.is_empty());
 
+    let (audit_status, audit_transcript) = run_unlock_in_pty(
+        &home,
+        &["audit", "verify"],
+        b"Audit: verified (announcements=1 commits=1 catalogs=1 revisions=0 items=0)",
+    );
+    assert!(audit_status.success(), "audit failed: {audit_transcript}");
+    assert!(audit_transcript.contains("Vault passphrase: "));
+    assert!(audit_transcript
+        .contains("Audit: verified (announcements=1 commits=1 catalogs=1 revisions=0 items=0)"));
+    assert_transcript_excludes_secrets(&audit_transcript);
+
+    let (doctor_status, doctor_transcript) =
+        run_unlock_in_pty(&home, &["doctor", "--unlock"], b"Doctor: healthy");
+    assert!(
+        doctor_status.success(),
+        "authenticated doctor failed: {doctor_transcript}"
+    );
+    assert!(doctor_transcript.contains("Vault passphrase: "));
+    assert!(doctor_transcript.contains("Doctor: healthy"));
+    assert_transcript_excludes_secrets(&doctor_transcript);
+
     assert_tree_excludes(&home.0, PASSPHRASE);
 }
 
@@ -120,6 +141,53 @@ fn run_init_in_pty(home: &TestHome) -> (ExitStatus, String) {
     drop(master);
     let status = child.wait().unwrap();
     (status, String::from_utf8_lossy(&transcript).into_owned())
+}
+
+fn run_unlock_in_pty(
+    home: &TestHome,
+    arguments: &[&str],
+    expected_output: &[u8],
+) -> (ExitStatus, String) {
+    let (mut master, slave) = open_pty();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vault-pm"));
+    command.args(arguments);
+    home.configure(&mut command);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(slave.try_clone().unwrap()))
+        .stderr(Stdio::from(slave));
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 || libc::ioctl(libc::STDOUT_FILENO, tiocsctty_request(), 0) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    drop(command);
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(STDIN_INJECTION)
+        .unwrap();
+    let mut transcript = Vec::new();
+    read_until(&mut master, &mut transcript, b"Vault passphrase: ");
+    master.write_all(PASSPHRASE).unwrap();
+    master.write_all(b"\n").unwrap();
+    read_until(&mut master, &mut transcript, expected_output);
+    drop(master);
+    let status = child.wait().unwrap();
+    (status, String::from_utf8_lossy(&transcript).into_owned())
+}
+
+fn assert_transcript_excludes_secrets(transcript: &str) {
+    assert!(!transcript
+        .as_bytes()
+        .windows(PASSPHRASE.len())
+        .any(|value| value == PASSPHRASE));
+    assert!(!transcript.contains("stdin injected secret"));
 }
 
 #[cfg(target_vendor = "apple")]

--- a/code/specs/VLT-PM00-local-first-password-manager.md
+++ b/code/specs/VLT-PM00-local-first-password-manager.md
@@ -1426,9 +1426,14 @@ changelog, focused build, and downstream validation.
     `VLT-PM09-cli-bootstrap.md`. Generation zero installs its exact prepared
     journal before configuration makes the random locator discoverable, and a
     restart resumes that journal without generating replacement identities.
-9b. authenticated one-shot CLI composition for item CRUD/list, search, history,
-    portable export/import, and audit verification, followed by the foreground
-    interactive shell over the same command/use-case boundary.
+9b-1. authenticated one-shot audit verification and opt-in full doctor over the
+      exact production unlock boundary, with synchronous session drop before
+      rendering, using `VLT-PM10-cli-authenticated-verification.md`.
+9b-2. redacted authenticated item list/show, search, and history reads.
+9b-3. authenticated add, replace, delete, restore, and conflict-resolution
+      mutations.
+9b-4. portable export/import CLI host composition and destination policy.
+9b-5. foreground interactive shell over the same command/use-case boundary.
 10. Crash/fault matrix and local restore drill.
 
 ### Phase 1B — daily local use

--- a/code/specs/VLT-PM10-cli-authenticated-verification.md
+++ b/code/specs/VLT-PM10-cli-authenticated-verification.md
@@ -1,0 +1,233 @@
+# VLT-PM10 - Authenticated CLI Verification
+
+Status: normative Phase 1A slice
+
+Depends on: VLT-PM05, VLT-PM06, VLT-PM07, VLT-PM08, VLT-PM09
+
+## 1. Purpose
+
+This slice proves that the standalone `vault-pm` executable can open the
+durable local vault through the production host boundaries, perform a complete
+read-only repository verification, synchronously discard the live session, and
+return only bounded public output.
+
+It adds:
+
+```text
+vault-pm audit verify
+vault-pm doctor --unlock
+```
+
+Plain `vault-pm doctor` remains the key-free health projection from VLT-PM09.
+The explicit `--unlock` flag distinguishes a potentially expensive,
+passphrase-prompting repository walk from a script-safe locked check.
+
+This ordering is intentional. Authenticated read-only verification closes the
+one-shot unlock composition before item creation, replacement, deletion,
+history restore, export, or import can mutate durable state.
+
+## 2. Locked properties
+
+1. The master passphrase is read only from the controlling terminal through
+   the fixed VLT-PM08 unlock prompt.
+2. The passphrase is never accepted through argv, process stdin, environment,
+   configuration, URL, or JSON.
+3. Both commands use the configured storage-neutral application repository
+   factory. They do not inspect filesystem objects or implement repository
+   verification in the CLI.
+4. The local process writer lock is acquired before configuration, owner state,
+   bootstrap state, or repository state is read.
+5. Unlock succeeds only after VLT-PM05 authenticates the local secret, validates
+   exact active/bootstrap binding, opens the signed repository from durable
+   pins, materializes the current catalog, and builds its wipe-on-drop search
+   projection.
+6. Audit success is rendered only after a second complete repository audit
+   succeeds from the authenticated session.
+7. Doctor success is rendered only after the unlocked doctor repeats the exact
+   local/bootstrap binding and complete audit.
+8. The live session is synchronously changed back to `Locked` before either
+   success or doctor output is constructed.
+9. Failures emit no partial counts, locators, paths, provider identifiers,
+   cryptographic identifiers, item identifiers, or item fields.
+10. This slice is read-only. It performs no recovery, repair, publication,
+    garbage collection, configuration mutation, or provider migration.
+
+## 3. Grammar
+
+The parser accepts only these new exact forms:
+
+```text
+audit verify
+doctor --unlock
+```
+
+It rejects:
+
+- `audit` without the `verify` subcommand;
+- extra audit or doctor positionals;
+- `--flag=value` spellings;
+- `--passphrase`, secret positionals, or secret-bearing JSON flags;
+- unlock aliases, environment references, and file-descriptor flags; and
+- non-Unicode arguments.
+
+`doctor` without flags preserves VLT-PM09 behavior and never prompts.
+
+## 4. Execution order
+
+### 4.1 Shared host preparation
+
+Both commands execute in this order:
+
+1. resolve platform-standard roots;
+2. prepare and permission-check the owner-private roots;
+3. acquire the persistent non-blocking process writer lock;
+4. load the exact configuration bytes;
+5. strictly parse VLT-PM07 configuration;
+6. select the default vault and its local store;
+7. reject remote stores in Phase 1A;
+8. prove that the configured filesystem location exactly equals the prepared
+   object root and that the credential reference is `none`;
+9. construct the durable owner-state/bootstrap adapter and storage-neutral
+   repository factory; and
+10. create a key-free `VaultAccessV1::Locked` boundary for the configured opaque
+    locator.
+
+An unconfigured invocation fails before a prompt. Unsupported or malformed
+configuration likewise fails before secret collection.
+
+### 4.2 One-shot unlock
+
+After host preparation:
+
+1. request the existing passphrase through the controlling terminal;
+2. pass the owned zeroizing bytes directly into `VaultAccessV1::unlock`;
+3. leave the lifecycle boundary locked on every authentication, storage,
+   unsupported-format, integrity, or repository-open failure;
+4. retain the resulting unlocked session only for this process action; and
+5. never write the passphrase or derived keys to local state, configuration,
+   repository objects, output, or diagnostics.
+
+The command does not expose a standalone `unlock` operation. A completed
+one-shot process has no resident key holder.
+
+### 4.3 Audit verification
+
+`audit verify` invokes `UnlockedVaultV1::audit_verify`. The application core:
+
+- rediscovers announcements relative to durable local pins;
+- verifies signed commits and complete bounded ancestry;
+- proves the local counter, catalog root, and device certificate anchor;
+- decrypts every distinct reachable catalog;
+- decrypts every catalog-referenced revision and validates item binding;
+- validates causal-parent item binding; and
+- rejects partial, replayed, malformed, unsupported, or cross-vault state.
+
+The CLI does not receive object identifiers or decrypted documents. On success
+it receives only aggregate counts.
+
+### 4.4 Full doctor
+
+`doctor --unlock` invokes the VLT-PM05 doctor on the authenticated lifecycle
+boundary. The doctor:
+
+- reloads and strictly decodes exact owner state;
+- proves that it equals the active state retained by the session;
+- reloads and verifies the latest signed bootstrap generation;
+- repeats the full audit; and
+- maps the result to one closed health classification.
+
+Doctor never repairs a pending journal, replaces configuration, rewrites a
+bootstrap, fetches an alternate provider, or marks corrupt data healthy.
+
+## 5. Session disposal
+
+The CLI stores the operation result, calls `VaultAccessV1::lock`, and only then
+maps or renders the result. `lock` replaces the lifecycle enum and drops the
+unlocked session, including live application keys, local private secrets,
+materialized documents, and search projection, before the function returns.
+
+Language-level drop remains a backstop for early unlock failures and process
+termination. No success path relies solely on process exit for disposal.
+
+## 6. Output contract
+
+Successful audit output is exactly:
+
+```text
+Audit: verified (announcements=A commits=C catalogs=G revisions=R items=I)
+```
+
+The five values are non-negative aggregate counts from the fully verified
+report. No output is produced until the complete audit succeeds.
+
+Successful authenticated doctor output is exactly:
+
+```text
+Doctor: healthy
+```
+
+All existing locked doctor labels remain unchanged. Prompts are emitted by the
+controlling-terminal adapter, not by standard input or the public renderer.
+
+## 7. Failure mapping
+
+| Condition | Exit | Public result |
+|---|---:|---|
+| success | 0 | exact audit or doctor line |
+| invalid or unconfigured audit invocation | 2 | fixed invalid-command error |
+| unconfigured doctor invocation | 2 | `Doctor: initialization_required` |
+| wrong passphrase/authentication failure | 3 | fixed authentication-required error |
+| pending local publication/concurrent writer | 5 | fixed recovery-or-conflict error |
+| malformed, tampered, replayed, or cross-vault state | 6 | fixed integrity error |
+| local repository unavailable | 7 | fixed storage-unavailable error |
+| unsupported configuration/format/capability | 8 | fixed unsupported error |
+| internal invariant failure | 10 | fixed internal error |
+
+Audit failures have empty stdout. Unlocked doctor uses the existing coarse
+doctor label mapping after authentication. No error includes its source value.
+
+## 8. Acceptance tests
+
+Package tests must prove:
+
+1. the parser accepts only the exact new forms;
+2. secret arguments and extra tokens are rejected without host side effects;
+3. generation zero can be initialized and reopened for a complete audit;
+4. an empty generation-zero vault reports exactly one announcement, one commit,
+   one catalog, zero revisions, and zero items;
+5. authenticated doctor reports healthy;
+6. a wrong passphrase maps to exit 3 with empty stdout and fixed stderr; and
+7. repository-object tampering maps to exit 6 with no partial audit counts; and
+8. a later command observes the vault as locked, proving no reusable session is
+   exported by the one-shot API.
+
+The real executable PTY suite must additionally:
+
+1. initialize under isolated platform roots;
+2. run `audit verify` in a new process;
+3. run `doctor --unlock` in another new process;
+4. provide decoy secret lines through redirected stdin for both commands;
+5. wait for the fixed controlling-terminal unlock prompt before providing the
+   real passphrase through the pseudo-terminal;
+6. observe exact successful public output;
+7. prove neither the passphrase nor redirected-stdin decoy occurs in either
+   transcript; and
+8. recursively prove the plaintext passphrase is absent from the isolated
+   filesystem tree.
+
+Native CI compiles and tests on Linux, macOS, and Windows. Unix executes the PTY
+suite; Windows retains the independently tested VLT-PM08 console adapter until
+an equivalent ConPTY harness is available.
+
+## 9. Explicit non-goals and backlog split
+
+This slice does not implement item list/show/search/history, item mutation,
+conflict resolution, portable export/import commands, the foreground shell,
+clipboard ownership, password generation, TOTP, attachments, or fault repair.
+
+VLT-PM00 item 9b is split after this slice into:
+
+- 9b-2: redacted item list/show, search, and history reads;
+- 9b-3: add, replace, delete, restore, and conflict-resolution mutations;
+- 9b-4: portable export/import host commands and destination policy; and
+- 9b-5: foreground interactive shell over the same command/use-case boundary.


### PR DESCRIPTION
## Summary

- add strict `audit verify` and opt-in `doctor --unlock` command forms over the existing storage-neutral application repository
- collect the existing passphrase only through the controlling terminal, perform one read-only authenticated action, and synchronously re-lock before rendering
- emit only aggregate audit counts or the coarse doctor health label, with stable authentication, integrity, and storage failure classes
- split the remaining Phase 1A command backlog into redacted reads, mutations, portable host commands, and the foreground shell
- add VLT-PM10 with the normative grammar, execution order, output, failure, disposal, and PTY acceptance contracts

## Validation

- package `bash BUILD` (9 tests, including wrong-passphrase and repository-tamper cases)
- standalone program `bash BUILD` (real-process PTY init/audit/doctor restart flow with redirected-stdin injection and plaintext scan)
- native Clippy with warnings denied for package and program
- rustdoc with warnings denied
- Linux and Windows cross-target Clippy with warnings denied for package and program
- repository build tool: 4,861 packages discovered; all 44 affected packages built successfully after rebase
- `git diff --check` and clean synthetic merge with current `origin/main`