### PR TITLE
feat(adj-facts-stdlib): word-families slice 2 -- add the -at family

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_wordfamilies_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_wordfamilies_e2e.rs
@@ -91,6 +91,35 @@ fn rhymes_with_is_derived_from_shared_family_membership() {
 }
 
 #[test]
+fn rhymes_with_isolates_a_second_family_with_the_same_unmodified_rule() {
+    let dir = scratch("second_family");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"word-families.adj\"\n\
+         ? rhymes_with(cat, $W)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    // Every other member of the -at family rhymes with "cat" (plus itself).
+    for w in ["cat", "bat", "fat", "sat", "rat", "pat", "mat", "hat"] {
+        assert!(
+            out.contains(&format!("\"W\":\"{w}\"")),
+            "cat rhymes with {w}: {out}"
+        );
+    }
+    // No cross-contamination: no -an family member should appear as a rhyme of "cat".
+    for w in ["pan", "fan", "ran", "man", "tan", "van"] {
+        assert!(
+            !out.contains(&format!("\"W\":\"{w}\"")),
+            "-an member {w} must NOT rhyme with -at member cat: {out}"
+        );
+    }
+}
+
+#[test]
 fn word_family_abstains_honestly_on_an_unshipped_word() {
     let dir = scratch("abstain");
     place_lib(&dir);

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -43,3 +43,17 @@ landed and why, not a semver-tracked API.
   uses the `infer` competency for a `rule`-derived fact, mirroring
   `adj.math.k2.spatial_composition`'s precedent). New e2e test `facts_heatphasechange_e2e.rs`
   (2 tests).
+- `language/word-families.adj` — extended with a SECOND word family, "-at" (cat, bat, fat, sat,
+  rat, pat, mat, hat), added as eight new rows in the existing `word_family` table alongside the
+  "-an" family shipped in the prior slice. The existing `rhymes_with` rule is reused UNCHANGED —
+  it generalizes over any `$Family` value already in the table, so this slice required zero rule
+  or engine changes, demonstrating the composition pattern scales to new vocabulary for free.
+  Quoted verbatim from a DIFFERENT Reading Rockets page than the "-an" family's (a kindergarten
+  phonological-awareness parent guide), documented in the file's header prose per the "one table,
+  one declared provenance envelope, every other row-group's real citation in prose" discipline
+  `physics/states-of-matter.adj` established. Deliberately excludes "flat" (a four-letter
+  consonant-blend word) to preserve the strict three-letter CVC scope. No new manifest objective
+  needed — extends the same already-covered library `adj.literacy.k2.rhyming_word_families`
+  already references. New e2e test `rhymes_with_isolates_a_second_family_with_the_same_unmodified_rule`
+  (4th test in `facts_wordfamilies_e2e.rs`), which also asserts NO cross-contamination between
+  the two families.

--- a/code/specs/data/adj-facts-stdlib/language/word-families.adj
+++ b/code/specs/data/adj-facts-stdlib/language/word-families.adj
@@ -17,8 +17,9 @@
 % family membership IS citable, so the rhyme relation is built from both:
 %
 %   1. `word_family($Word, $Family)` — the table below, listing each of the
-%      "-an" family's core CVC (consonant-vowel-consonant) members as named,
-%      verbatim, by Reading Rockets (a WETA/PBS literacy education nonprofit).
+%      "-an" and "-at" families' core CVC (consonant-vowel-consonant) members
+%      as named, verbatim, by Reading Rockets (a WETA/PBS literacy education
+%      nonprofit).
 %   2. The general word-family PRINCIPLE, quoted verbatim from the same page
 %      in the rule's own `source` below: words in the same family "look alike
 %      at the end" because they "sound alike at the end."
@@ -34,18 +35,34 @@
 %     import "word-families.adj"
 %     ? word_family(pan, $F)        % an        (which family "pan" belongs to)
 %     ? rhymes_with(pan, $W)        % fan, ran, man, tan, van, pan (itself too)
+%     ? rhymes_with(cat, $W)        % bat, fat, sat, rat, pat, mat, hat, cat
 %
-% Deliberately scoped to ONE family ("-an") with its SIX simple three-letter
-% CVC members, not the full 37-family phonics inventory a complete phonics
-% curriculum would need (Reading Rockets' own page also lists longer blended
-% and multi-syllable "-an" words — "plan", "scan", "bran", "began" — and this
-% library deliberately ships only the plain three-letter core, matching
-% kindergarten-level CVC scope; the blends and longer words are left for a
-% later pass, the same "keep the first slice small and citable" discipline
-% every prior curriculum item in this loop has used). `rhymes_with` includes
-% a trivial self-pair (a word "rhymes with" itself, since it shares its own
-% family) — logically consistent, left unfiltered rather than adding
-% unverified exclusion logic for a case no worked example below relies on.
+% Deliberately scoped to TWO families ("-an", "-at") with their plain
+% three-letter CVC members only, not the full 37-family phonics inventory a
+% complete phonics curriculum would need (Reading Rockets' own "-an" page also
+% lists longer blended and multi-syllable words — "plan", "scan", "bran",
+% "began" — and this library deliberately ships only the plain three-letter
+% core, matching kindergarten-level CVC scope; the "-at" family happens to be
+% ALL plain CVC in its cited source except "flat", which is excluded for the
+% same reason). The "-at" family's eight members are quoted verbatim from a
+% DIFFERENT Reading Rockets page than "-an"'s (a kindergarten phonological-
+% awareness parent guide, not "Meet the Word Families") — same organization,
+% same `consensus` trust tier, but its own real citation, documented on the
+% `word_family` table's second row block below since one `table` carries only
+% ONE declared provenance envelope (the same "one declared envelope, every
+% other row's real citation documented in prose" discipline
+% `physics/states-of-matter.adj` already established for its own six rows
+% drawn from two different LibreTexts sections). The "-at" family's citation:
+% "Then ask your child to name all the "kids" in the cat family, such as:
+% bat, fat, sat, rat, pat, mat, hat, flat." (https://www.readingrockets.org/
+% literacy-home/reading-101-guide-parents/your-kindergartener/phonological-
+% and-phonemic-awareness). Blends and longer words, and every family beyond
+% these two, are left for a later pass, the same "keep each slice small and
+% citable" discipline every prior curriculum item in this loop has used.
+% `rhymes_with` includes a trivial self-pair (a word "rhymes with" itself,
+% since it shares its own family) — logically consistent, left unfiltered
+% rather than adding unverified exclusion logic for a case no worked example
+% below relies on.
 % (See ../README.md; feedback_nothing_human_authored,
 % feedback_adj_only_shipped_artifacts.)
 % ============================================================================
@@ -59,6 +76,14 @@ table word_family {
     row (man, an)
     row (tan, an)
     row (van, an)
+    row (cat, at)
+    row (bat, at)
+    row (fat, at)
+    row (sat, at)
+    row (rat, at)
+    row (pat, at)
+    row (mat, at)
+    row (hat, at)
 
     source "pan, fan, ran, man, tan, van, plan, scan, bran, began"
     locator "https://www.readingrockets.org/topics/activities/articles/meet-word-families"

--- a/code/specs/data/adj-facts-stdlib/language/word-families.query.adj
+++ b/code/specs/data/adj-facts-stdlib/language/word-families.query.adj
@@ -16,4 +16,5 @@ import "word-families.adj"
 
 ? word_family(pan, $F)     % expect an    (direct recall: which family is "pan" in?)
 ? rhymes_with(pan, $W)     % expect fan, ran, man, tan, van, pan (derived: shares the -an family)
+? rhymes_with(cat, $W)     % expect bat, fat, sat, rat, pat, mat, hat, cat (derived: shares the -at family)
 ? word_family(dog, $F)     % expect abstain — "dog" has no shipped row, not in this family


### PR DESCRIPTION
## Summary

Extends `language/word-families.adj` (shipped in #10438) with a SECOND word family, "-at" (cat, bat, fat, sat, rat, pat, mat, hat), added as eight new rows in the existing `word_family` table alongside the "-an" family. The existing `rhymes_with` rule is reused **completely unchanged** — it generalizes over any `$Family` value already in the table — demonstrating that the family-membership -> rhyme composition pattern scales to new vocabulary with zero rule or engine changes.

- Quoted verbatim from a Reading Rockets kindergarten phonological-awareness page (a *different* Reading Rockets page than the "-an" family's, same `consensus` trust tier). Real citation documented in the file's header prose per the "one table, one declared provenance envelope, every other row-group's real citation in prose" discipline `physics/states-of-matter.adj` established.
- Deliberately excludes "flat" (a four-letter consonant-blend word) to preserve the strict three-letter CVC scope already established for this library.
- No new manifest objective needed — extends the already-covered `adj.literacy.k2.rhyming_word_families` objective.
- Verified end-to-end against the freshly-built CLI: `rhymes_with(cat, $W)` returns exactly {cat, bat, fat, sat, rat, pat, mat, hat} with correct dual citations, with no cross-contamination into the "-an" family.

Part of `wave2-k8-literacy-foundations` (intentionally `in_progress`, open-ended slice series) per `.claude/adj-curriculum-loop-state.json` and `ADJ-STDLIB-COVERAGE.md#7-delivery-order`.

## Test plan

- [x] New e2e test `rhymes_with_isolates_a_second_family_with_the_same_unmodified_rule` (4th test in `facts_wordfamilies_e2e.rs`) — asserts correct derivation for the new family AND no cross-contamination with "-an"
- [x] `cargo test -p adj-lang-cli --test facts_wordfamilies_e2e` — all 4 pass
- [x] `cargo test -p adj-lang -p adj-lang-cli` (full suite) — pass
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` — clean
- [x] `adj_stdlib_manifest.py --validate-json-schema` — 88 objectives, 0 errors
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` — exit 0
- [x] `pytest code/scripts/tests/ -k "manifest or report"` — 87 passed
- [x] Security review sub-agent — SECURITY REVIEW PASSED
- [x] Manually ran the real shipped `word-families.query.adj` through the freshly-built CLI to confirm end-to-end correctness (not just a scratch reproduction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)