### PR TITLE
feat(adj-facts-stdlib): science slice 2 -- force causes acceleration

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_forcecausesacceleration_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_forcecausesacceleration_e2e.rs
@@ -1,0 +1,114 @@
+//! End-to-end test for the physics FACTS library
+//! (`adj-facts-stdlib/physics/force-causes-acceleration.adj`) driven through
+//! the built CLI: a `rule` composing Newton's second law's own general
+//! statement (from the sibling `newton-laws.adj`) with a specific
+//! force->example fact (from the sibling `forces.adj`) to DERIVE
+//! `force_causes_acceleration($Force, $Example)` -- the second `rule`-based
+//! CAUSAL-EXPLANATION fact in this loop's science curriculum sweep, mirroring
+//! the discipline `heat-causes-phase-change.adj` already established. 0
+//! answer-time model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_forceaccel_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy ALL THREE shipped libraries beside the entry program:
+/// `force-causes-acceleration.adj` transitively imports both sibling
+/// `newton-laws.adj` and `forces.adj`, so the CLI's sandbox-checked relative
+/// import needs all three present.
+fn place_libs(dir: &Path) {
+    let physics = facts_stdlib().join("physics");
+    for name in ["newton-laws.adj", "forces.adj", "force-causes-acceleration.adj"] {
+        std::fs::copy(physics.join(name), dir.join(name))
+            .unwrap_or_else(|e| panic!("copy shipped physics/{name}: {e}"));
+    }
+}
+
+#[test]
+fn gravity_derives_acceleration_of_its_own_waterfall_example_with_dual_citations() {
+    let dir = scratch("gravity");
+    place_libs(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"force-causes-acceleration.adj\"\n\
+         ? force_causes_acceleration(gravity, $Ex)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    assert!(
+        out.contains("\"Ex\":\"waterfall\""),
+        "gravity causes the waterfall's acceleration: {out}"
+    );
+    // The derivation composes citations from BOTH sibling libraries: the
+    // rule's own second-law statement AND forces.adj's specific example fact.
+    assert!(
+        out.contains("\"kind\":\"rule\"") && out.contains("\"kind\":\"fact\""),
+        "the causal fact is DERIVED, not a direct table row -- both a rule step and fact steps appear: {out}"
+    );
+    assert!(
+        out.contains("imagine.gsfc.nasa.gov") && out.contains("www1.grc.nasa.gov"),
+        "carries citations from BOTH composed libraries (forces.adj and newton-laws.adj): {out}"
+    );
+}
+
+#[test]
+fn wheels_reverse_binds_to_friction() {
+    let dir = scratch("wheels");
+    place_libs(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"force-causes-acceleration.adj\"\n\
+         ? force_causes_acceleration($F, wheels)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"F\":\"friction\""),
+        "the wheels example illustrates friction: {out}"
+    );
+}
+
+#[test]
+fn magnetism_abstains_honestly_as_not_one_of_the_five_tabled_forces() {
+    let dir = scratch("abstain");
+    place_libs(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"force-causes-acceleration.adj\"\n\
+         ? force_causes_acceleration(magnetism, $Ex)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "magnetism has no shipped row in forces.adj -- honest abstention, never invented: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/CHANGELOG.md
+++ b/code/specs/data/adj-facts-stdlib/CHANGELOG.md
@@ -57,3 +57,15 @@ landed and why, not a semver-tracked API.
   already references. New e2e test `rhymes_with_isolates_a_second_family_with_the_same_unmodified_rule`
   (4th test in `facts_wordfamilies_e2e.rs`), which also asserts NO cross-contamination between
   the two families.
+- `physics/force-causes-acceleration.adj` (new) — the SECOND causal-explanation library in the
+  ADJ stdlib's science domain, following `heat-causes-phase-change.adj`'s precedent. A `rule`
+  composes Newton's second law's own general statement (from the already-shipped
+  `newton-laws.adj`) with a specific force→example fact (from the already-shipped `forces.adj`)
+  to DERIVE `force_causes_acceleration(force, example)` — a genuine CROSS-FILE composition
+  reusing TWO already-verified NASA citations with zero new sourcing work. Grounds NGSS MS-PS2-2.
+  Deliberately scoped to the second law only (F = m·a governs any force's relationship to
+  acceleration) — the first law (inertia) and third law (action-reaction) describe different
+  causal relationships, left for a later pass. New manifest objective
+  `adj.science.6to8.force_causes_acceleration` (band 6-8, uses the `infer` competency for a
+  rule-derived fact). New e2e test `facts_forcecausesacceleration_e2e.rs` (3 tests: direct
+  derivation with dual citations, reverse binding, honest abstention on an untabled force).

--- a/code/specs/data/adj-facts-stdlib/physics/force-causes-acceleration.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/force-causes-acceleration.adj
@@ -1,0 +1,71 @@
+% ============================================================================
+% force-causes-acceleration — Newton's SECOND LAW's own general principle,
+% applied to every named force this library already knows an everyday example
+% of, DERIVED (not just looked up) (adj-facts-stdlib, PHYSICS). NGSS MS-PS2-2.
+% ============================================================================
+% A causal explanation, not a lookup: `newton-laws.adj` already tables WHICH
+% law is numbered 2 and names it "force"; `forces.adj` already tables five
+% named forces and the everyday NASA scene that illustrates each one. Neither
+% file states outright "gravity causes the waterfall to accelerate" as its own
+% row — but Newton's second law's own general statement ("the acceleration of
+% an object depends on... the amount of force applied") applies to ANY force
+% acting on ANY object, and `forces.adj`'s gravity row already quotes NASA's
+% own causal sentence for its specific example ("gravity... causes it to
+% accelerate downward"). So the general LAW (cited once, from `newton-laws.adj`)
+% composed with each SPECIFIC force->example fact (cited once each, from
+% `forces.adj`) DERIVES a `force_causes_acceleration(force, example)` relation
+% for all five — exactly the same "general principle + specific fact ->
+% derived, dual-cited conclusion" composition discipline
+% `geometry/shape-composition.adj` and `language/word-families.adj` already
+% established, applied here to a genuinely CROSS-FILE pair of ALREADY-SHIPPED
+% physics tables (mirroring `heat-causes-phase-change.adj`'s precedent).
+%
+%     import "force-causes-acceleration.adj"
+%     ? force_causes_acceleration(gravity, $Ex)   % waterfall
+%     ? force_causes_acceleration($F, wheels)     % friction
+%     ? force_causes_acceleration(magnetism, $Ex) % abstain -- not a tabled force
+%
+% This is a native `rule` (ADJ-TABLES RS-6): its body binds `$Force`/`$Example`
+% through the already-shipped `force_example` table, then GUARDS on the
+% already-shipped `newton_law(2, force)` fact (a fully-bound check, not a
+% binding premise -- confirms we are actually invoking the SECOND law before
+% deriving anything). A query's `steps` trail therefore shows THREE entries:
+% the rule's own citation (the general law), the `force_example` fact's
+% citation (the specific example), and the `newton_law` fact's citation --
+% so a human can independently verify each link. Honest abstention on any
+% force `forces.adj` does not table (magnetism, the normal force, air
+% resistance) -- the rule only derives what its premises can ground.
+%
+% Deliberately scoped to Newton's SECOND law only (F = m·a governs any force's
+% relationship to acceleration) -- the first law (inertia: an object's motion
+% does NOT change without a net force) and third law (action-reaction pairs)
+% describe different causal relationships and are left for a later pass, the
+% same "keep each slice small and citable" discipline every prior curriculum
+% item in this loop has used. Grounds NGSS MS-PS2-2 ("the change in an
+% object's motion depends on the sum of forces on the object and the mass of
+% the object"), a direct qualitative statement of the same second-law
+% relationship this rule derives.
+%
+% ---------------------------------------------------------------------------
+% Provenance: this file adds NO new fact rows and needs no fresh sourcing --
+% it composes two citations already WebFetch-verified and shipped in this
+% repo. The rule's own `source`/`locator`/`trust` below quote the SAME NASA
+% Beginner's Guide to Aeronautics sentence `newton-laws.adj`'s header already
+% documents for law 2 ("The acceleration of an object depends on the mass of
+% the object and the amount of force applied."), `trust authoritative` (a
+% primary U.S. government NASA source, matching both composed tables' own
+% trust tier). Each specific force->example fact keeps ITS OWN citation from
+% `forces.adj` (the NASA Goddard Swift mission poster), visible in every
+% query's `steps` trail.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+import "newton-laws.adj"
+import "forces.adj"
+
+rule { head: force_causes_acceleration($Force, $Example)
+       when: force_example($Force, $Example), newton_law(2, force)
+       source "The acceleration of an object depends on the mass of the object and the amount of force applied."
+       locator "https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/newtons-laws-of-motion/"
+       trust authoritative }

--- a/code/specs/data/adj-facts-stdlib/physics/force-causes-acceleration.query.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/force-causes-acceleration.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% force-causes-acceleration.query.adj — worked recall over the force/Newton's-
+% second-law causal library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "why does this force
+% matter?" — it states no physics fact of its own — it only `import`s the
+% grounded rule and asks binding queries. The answer is DERIVED, composing
+% Newton's second law's own general statement with a specific force->example
+% fact, so every answer carries the law's citation AND the example's citation
+% in its `steps` trail.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli force-causes-acceleration.query.adj
+% ============================================================================
+
+import "force-causes-acceleration.adj"
+
+? force_causes_acceleration(gravity, $Ex)      % expect waterfall (direct: gravity's own NASA example)
+? force_causes_acceleration($F, wheels)        % expect friction (reverse: which force is illustrated by "wheels"?)
+? force_causes_acceleration(magnetism, $Ex)    % expect abstain -- not one of the five tabled forces

--- a/code/specs/data/adj-stdlib-coverage/manifest.json
+++ b/code/specs/data/adj-stdlib-coverage/manifest.json
@@ -1397,6 +1397,21 @@
       "source_cas_hashes": [],
       "benchmark_paths": [],
       "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
+    },
+    {
+      "id": "adj.science.6to8.force_causes_acceleration",
+      "title": "Derive that a named force causes acceleration of its everyday example, by combining Newton's second law with the already-shipped force-example table",
+      "band": "6-8",
+      "domain": "science",
+      "competency": "infer",
+      "coverage_roots": ["ngss"],
+      "standards": [],
+      "prerequisites": [],
+      "libraries": ["code/specs/data/adj-facts-stdlib/physics/force-causes-acceleration.adj"],
+      "modalities": ["text"],
+      "source_cas_hashes": [],
+      "benchmark_paths": [],
+      "status": {"implementation": "present", "provenance": "source_labeled", "tests": "present", "benchmark": "missing", "crosswalk": "unmapped"}
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds the SECOND causal-explanation library in the ADJ stdlib's science domain, `physics/force-causes-acceleration.adj`, following `heat-causes-phase-change.adj`'s precedent (#10441).

A `rule` composes Newton's second law's own general statement (from the already-shipped `newton-laws.adj`) with a specific force→example fact (from the already-shipped `forces.adj`) to DERIVE `force_causes_acceleration(force, example)` -- a genuine **cross-file composition** reusing two already-verified NASA citations, with zero new sourcing work required.

- Grounds NGSS MS-PS2-2 ("the change in an object's motion depends on the sum of forces on the object and the mass of the object").
- Deliberately scoped to Newton's second law only (F = m·a) -- the first law (inertia) and third law (action-reaction) describe different causal relationships, left for a later pass.
- Honest abstention on any force `forces.adj` doesn't table (e.g. magnetism).
- New manifest objective `adj.science.6to8.force_causes_acceleration` (band 6-8, `infer` competency for a rule-derived fact).
- Verified end-to-end against the freshly-built CLI running the real shipped query file before pushing.

Part of `wave2-k8-science-foundations` (intentionally `in_progress`, open-ended slice series) per `.claude/adj-curriculum-loop-state.json` and `ADJ-STDLIB-COVERAGE.md#7-delivery-order`.

## Test plan

- [x] New e2e test `facts_forcecausesacceleration_e2e.rs` (3 tests: direct derivation with dual citations, reverse binding, honest abstention on an untabled force)
- [x] `cargo test -p adj-lang-cli --test facts_forcecausesacceleration_e2e` -- all 3 pass
- [x] `cargo test -p adj-lang -p adj-lang-cli` (full suite) -- pass
- [x] `cargo clippy -p adj-lang-cli --all-targets -- -D warnings` -- clean
- [x] `adj_stdlib_manifest.py --validate-json-schema` -- 89 objectives, 0 errors
- [x] `adj_stdlib_report.py --fail-on-unreferenced-tests` -- exit 0
- [x] `pytest code/scripts/tests/ -k "manifest or report"` -- 87 passed
- [x] Security review sub-agent -- SECURITY REVIEW PASSED
- [x] Manually ran the real shipped `force-causes-acceleration.query.adj` through the freshly-built CLI to confirm end-to-end correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)